### PR TITLE
chore: change the liverootpath and archiverootpath to absolute paths as default

### DIFF
--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -86,7 +86,7 @@ COPY logging.properties /app/logs/config/logging.properties
 WORKDIR /
 
 # Ensure proper file permissions
-RUN chown -R 2000:2000 /app
+RUN chown -R 2000:2000 /app /opt
 
 ########################################
 ####    Deterministic Build Hack    ####

--- a/server/docs/configuration.md
+++ b/server/docs/configuration.md
@@ -9,20 +9,21 @@ The default configuration allows users to quickly get up and running without hav
 ease of use at the trade-off of some insecure default configuration. Most configuration settings have appropriate
 defaults and can be left unchanged. It is recommended to browse the properties below and adjust to your needs.
 
-| Environment Variable                  | Description                                                                                  |       Default Value |
-|:--------------------------------------|:---------------------------------------------------------------------------------------------|--------------------:|
-| PERSISTENCE_STORAGE_LIVE_ROOT_PATH    | The root path for the live storage.                                                          |                     |
-| PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH | The root path for the archive storage.                                                       |                     |
-| PERSISTENCE_STORAGE_TYPE              | Type of the persistence storage                                                              | BLOCK_AS_LOCAL_FILE |
-| PERSISTENCE_STORAGE_COMPRESSION       | Compression algorithm used during persistence (could be none as well)                        |                ZSTD |
-| PERSISTENCE_STORAGE_COMPRESSION_LEVEL | Compression level to be used by the compression algorithm                                    |                   3 |
-| CONSUMER_MAX_BLOCK_ITEM_BATCH_SIZE    | Maximum size of block item batches streamed to a client for closed-range historical requests |                1000 |
-| CONSUMER_TIMEOUT_THRESHOLD_MILLIS     | Time to wait for subscribers before disconnecting in milliseconds                            |                1500 |
-| SERVICE_DELAY_MILLIS                  | Service shutdown delay in milliseconds                                                       |                 500 |
-| MEDIATOR_RING_BUFFER_SIZE             | Size of the ring buffer used by the mediator (must be a power of 2)                          |            67108864 |
-| NOTIFIER_RING_BUFFER_SIZE             | Size of the ring buffer used by the notifier (must be a power of 2)                          |                2048 |
-| SERVER_PORT                           | The port the server will listen on                                                           |                8080 |
-| SERVER_MAX_MESSAGE_SIZE_BYTES         | The maximum size of a message frame in bytes                                                 |             1048576 |
-| VERIFICATION_ENABLED                  | Enables or disables the block verification process                                           |                true |
-| VERIFICATION_SESSION_TYPE             | The type of BlockVerificationSession to use, either `ASYNC` or `SYNC`                        |               ASYNC |
-| VERIFICATION_HASH_COMBINE_BATCH_SIZE  | The number of hashes to combine into a single hash during verification                       |                  32 |
+| Environment Variable                   | Description                                                                                  | Default Value                         |
+|:---------------------------------------|:---------------------------------------------------------------------------------------------|:--------------------------------------|
+| PERSISTENCE_STORAGE_LIVE_ROOT_PATH     | The root path for the live storage.                                                          | /opt/hashgraph/blocknode/data/live    |
+| PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH  | The root path for the archive storage.                                                       | /opt/hashgraph/blocknode/data/archive |
+| PERSISTENCE_STORAGE_TYPE               | Type of the persistence storage                                                              | BLOCK_AS_LOCAL_FILE                   |
+| PERSISTENCE_STORAGE_COMPRESSION        | Compression algorithm used during persistence (could be none as well)                        | ZSTD                                  |
+| PERSISTENCE_STORAGE_COMPRESSION_LEVEL  | Compression level to be used by the compression algorithm                                    | 3                                     |
+| PERSISTENCE_STORAGE_ARCHIVE_GROUP_SIZE | The size of the group of blocks to be archived at once                                       | 1_000                                 |
+| CONSUMER_MAX_BLOCK_ITEM_BATCH_SIZE     | Maximum size of block item batches streamed to a client for closed-range historical requests | 1000                                  |
+| CONSUMER_TIMEOUT_THRESHOLD_MILLIS      | Time to wait for subscribers before disconnecting in milliseconds                            | 1500                                  |
+| SERVICE_DELAY_MILLIS                   | Service shutdown delay in milliseconds                                                       | 500                                   |
+| MEDIATOR_RING_BUFFER_SIZE              | Size of the ring buffer used by the mediator (must be a power of 2)                          | 67108864                              |
+| NOTIFIER_RING_BUFFER_SIZE              | Size of the ring buffer used by the notifier (must be a power of 2)                          | 2048                                  |
+| SERVER_PORT                            | The port the server will listen on                                                           | 8080                                  |
+| SERVER_MAX_MESSAGE_SIZE_BYTES          | The maximum size of a message frame in bytes                                                 | 1048576                               |
+| VERIFICATION_ENABLED                   | Enables or disables the block verification process                                           | true                                  |
+| VERIFICATION_SESSION_TYPE              | The type of BlockVerificationSession to use, either `ASYNC` or `SYNC`                        | ASYNC                                 |
+| VERIFICATION_HASH_COMBINE_BATCH_SIZE   | The number of hashes to combine into a single hash during verification                       | 32                                    |

--- a/server/src/main/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializer.java
+++ b/server/src/main/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializer.java
@@ -32,7 +32,7 @@ public final class ServerMappedConfigSourceInitializer {
             new ConfigMapping("persistence.storage.liveRootPath", "PERSISTENCE_STORAGE_LIVE_ROOT_PATH"),
             new ConfigMapping("persistence.storage.type", "PERSISTENCE_STORAGE_TYPE"),
             new ConfigMapping("persistence.storage.archiveEnabled", "PERSISTENCE_STORAGE_ARCHIVE_ENABLED"),
-            new ConfigMapping("persistence.storage.archiveBatchSize", "PERSISTENCE_STORAGE_ARCHIVE_BATCH_SIZE"),
+            new ConfigMapping("persistence.storage.archiveGroupSize", "PERSISTENCE_STORAGE_ARCHIVE_BATCH_SIZE"),
 
             // Producer Config
             new ConfigMapping("producer.type", "PRODUCER_TYPE"),

--- a/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
@@ -31,6 +31,8 @@ import com.hedera.hapi.block.BlockUnparsed;
 import dagger.Module;
 import dagger.Provides;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Executors;
@@ -119,10 +121,14 @@ public interface PersistenceInjectionModule {
     @Singleton
     static BlockPathResolver providesPathResolver(@NonNull final PersistenceStorageConfig config) {
         final StorageType persistenceType = config.type();
-        return switch (persistenceType) {
-            case BLOCK_AS_LOCAL_FILE -> BlockAsLocalFilePathResolver.of(config);
-            case NO_OP -> NoOpBlockPathResolver.newInstance();
-        };
+        try {
+            return switch (persistenceType) {
+                case BLOCK_AS_LOCAL_FILE -> new BlockAsLocalFilePathResolver(config);
+                case NO_OP -> new NoOpBlockPathResolver();
+            };
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     /**

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
@@ -1,20 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage;
 
-import static com.hedera.block.server.Constants.BLOCK_NODE_ARCHIVE_ROOT_DIRECTORY_SEMANTIC_NAME;
-import static com.hedera.block.server.Constants.BLOCK_NODE_LIVE_ROOT_DIRECTORY_SEMANTIC_NAME;
+import static com.hedera.block.common.utils.StringUtilities.isBlank;
 
 import com.hedera.block.common.utils.Preconditions;
-import com.hedera.block.common.utils.StringUtilities;
 import com.hedera.block.server.config.logging.Loggable;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 import com.swirlds.config.api.validation.annotation.Max;
 import com.swirlds.config.api.validation.annotation.Min;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 
@@ -30,89 +24,25 @@ import java.util.Objects;
  */
 @ConfigData("persistence.storage")
 public record PersistenceStorageConfig(
-        // @todo(#371) - the default life/archive root path must be absolute starting from /opt
-        @Loggable @ConfigProperty(defaultValue = "") String liveRootPath,
-        // @todo(#371) - the default life/archive root path must be absolute starting from /opt
-        @Loggable @ConfigProperty(defaultValue = "") String archiveRootPath,
+        @Loggable @ConfigProperty(defaultValue = DEFAULT_LIVE_ROOT_PATH) Path liveRootPath,
+        @Loggable @ConfigProperty(defaultValue = DEFAULT_ARCHIVE_ROOT_PATH) Path archiveRootPath,
         @Loggable @ConfigProperty(defaultValue = "BLOCK_AS_LOCAL_FILE") StorageType type,
         @Loggable @ConfigProperty(defaultValue = "ZSTD") CompressionType compression,
         @Loggable @ConfigProperty(defaultValue = "3") @Min(0) @Max(20) int compressionLevel,
         @Loggable @ConfigProperty(defaultValue = "true") boolean archiveEnabled,
-        @Loggable @ConfigProperty(defaultValue = "1_000")
-                int archiveBatchSize) { // @todo(517) rename batch to group size
-    // @todo(#371) - the default life/archive root path must be absolute starting from /opt
-    private static final String LIVE_ROOT_PATH =
-            Path.of("hashgraph/blocknode/data/live/").toAbsolutePath().toString();
-    // @todo(#371) - the default life/archive root path must be absolute starting from /opt
-    private static final String ARCHIVE_ROOT_PATH =
-            Path.of("hashgraph/blocknode/data/archive/").toAbsolutePath().toString();
+        @Loggable @ConfigProperty(defaultValue = "1_000") int archiveGroupSize) {
+    private static final String DEFAULT_LIVE_ROOT_PATH = "/opt/hashgraph/blocknode/data/live";
+    private static final String DEFAULT_ARCHIVE_ROOT_PATH = "/opt/hashgraph/blocknode/data/archive";
 
     /**
      * Constructor.
      */
     public PersistenceStorageConfig {
         Objects.requireNonNull(type);
-        Preconditions.requirePositivePowerOf10(archiveBatchSize);
+        Preconditions.requirePositivePowerOf10(archiveGroupSize);
         compression.verifyCompressionLevel(compressionLevel);
-        liveRootPath = resolvePath(liveRootPath, LIVE_ROOT_PATH, BLOCK_NODE_LIVE_ROOT_DIRECTORY_SEMANTIC_NAME);
-        archiveRootPath =
-                resolvePath(archiveRootPath, ARCHIVE_ROOT_PATH, BLOCK_NODE_ARCHIVE_ROOT_DIRECTORY_SEMANTIC_NAME);
-    }
-
-    /**
-     * This method attempts to resolve a given configured path. If the input
-     * path is blank, a default path is used. The resolved path must be
-     * absolute! If the path resolution is successful, at attempt is made to
-     * create the directory path. If the directory path cannot be created, an
-     * {@link UncheckedIOException} is thrown.
-     *
-     * @param pathToResolve the path to resolve
-     * @param defaultIfBlank the default path if the path to resolve is blank
-     * @param semanticPathName the semantic name of the path used for logging
-     * @return the resolved path
-     * @throws IllegalArgumentException if the resolved path is not absolute
-     * @throws UncheckedIOException if the resolved path cannot be created
-     */
-    @NonNull
-    private String resolvePath(
-            final String pathToResolve, @NonNull final String defaultIfBlank, @NonNull final String semanticPathName) {
-        final Path normalized = getNormalizedPath(pathToResolve, defaultIfBlank);
-        createDirectoryPath(normalized, semanticPathName);
-        return normalized.toString();
-    }
-
-    /**
-     * This method normalizes a given path. If the path to normalize is blank,
-     * a default path is used. The normalized path must be absolute!
-     *
-     * @param pathToNormalize the path to normalize
-     * @param defaultIfBlank the default path if the path to normalize is blank
-     * @throws IllegalArgumentException if the path to normalize is not absolute
-     */
-    @NonNull
-    private Path getNormalizedPath(final String pathToNormalize, @NonNull final String defaultIfBlank) {
-        final String actualToNormalize = StringUtilities.isBlank(pathToNormalize) ? defaultIfBlank : pathToNormalize;
-        return Path.of(actualToNormalize).normalize().toAbsolutePath();
-    }
-
-    /**
-     * This method creates a directory path at the given target path. If the
-     * directory path cannot be created, an {@link UncheckedIOException} is
-     * thrown.
-     *
-     * @param targetPath the target path to create the directory path
-     * @param semanticPathName the semantic name of the path used for logging
-     * @throws UncheckedIOException if the directory path cannot be created
-     */
-    private void createDirectoryPath(@NonNull final Path targetPath, @NonNull final String semanticPathName) {
-        try {
-            Files.createDirectories(targetPath);
-        } catch (final IOException e) {
-            final String classname = this.getClass().getName();
-            final String message = "Unable to instantiate [%s]! Unable to create the [%s] path that was provided!"
-                    .formatted(classname, semanticPathName);
-            throw new UncheckedIOException(message, e);
-        }
+        liveRootPath = isBlank(liveRootPath.toString()) ? Path.of(DEFAULT_LIVE_ROOT_PATH) : liveRootPath;
+        archiveRootPath = isBlank(archiveRootPath.toString()) ? Path.of(DEFAULT_ARCHIVE_ROOT_PATH) : archiveRootPath;
     }
 
     /**

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage;
 
-import static com.hedera.block.common.utils.StringUtilities.isBlank;
-
 import com.hedera.block.common.utils.Preconditions;
 import com.hedera.block.server.config.logging.Loggable;
 import com.swirlds.config.api.ConfigData;
@@ -21,28 +19,27 @@ import java.util.Objects;
  * @param compression compression type to use for the storage
  * @param compressionLevel compression level used by the compression algorithm
  * Non-PRODUCTION values should only be used for troubleshooting and development purposes.
+ * @param archiveEnabled whether to enable archiving
+ * @param archiveGroupSize the number of blocks to archive in a single group
  */
 @ConfigData("persistence.storage")
 public record PersistenceStorageConfig(
-        @Loggable @ConfigProperty(defaultValue = DEFAULT_LIVE_ROOT_PATH) Path liveRootPath,
-        @Loggable @ConfigProperty(defaultValue = DEFAULT_ARCHIVE_ROOT_PATH) Path archiveRootPath,
+        @Loggable @ConfigProperty(defaultValue = "/opt/hashgraph/blocknode/data/live") Path liveRootPath,
+        @Loggable @ConfigProperty(defaultValue = "/opt/hashgraph/blocknode/data/archive") Path archiveRootPath,
         @Loggable @ConfigProperty(defaultValue = "BLOCK_AS_LOCAL_FILE") StorageType type,
         @Loggable @ConfigProperty(defaultValue = "ZSTD") CompressionType compression,
         @Loggable @ConfigProperty(defaultValue = "3") @Min(0) @Max(20) int compressionLevel,
         @Loggable @ConfigProperty(defaultValue = "true") boolean archiveEnabled,
         @Loggable @ConfigProperty(defaultValue = "1_000") int archiveGroupSize) {
-    private static final String DEFAULT_LIVE_ROOT_PATH = "/opt/hashgraph/blocknode/data/live";
-    private static final String DEFAULT_ARCHIVE_ROOT_PATH = "/opt/hashgraph/blocknode/data/archive";
-
     /**
      * Constructor.
      */
     public PersistenceStorageConfig {
+        Objects.requireNonNull(liveRootPath);
+        Objects.requireNonNull(archiveRootPath);
         Objects.requireNonNull(type);
-        Preconditions.requirePositivePowerOf10(archiveGroupSize);
         compression.verifyCompressionLevel(compressionLevel);
-        liveRootPath = isBlank(liveRootPath.toString()) ? Path.of(DEFAULT_LIVE_ROOT_PATH) : liveRootPath;
-        archiveRootPath = isBlank(archiveRootPath.toString()) ? Path.of(DEFAULT_ARCHIVE_ROOT_PATH) : archiveRootPath;
+        Preconditions.requirePositivePowerOf10(archiveGroupSize);
     }
 
     /**

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
@@ -33,24 +33,13 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
      * @param config valid, {@code non-null} instance of
      * {@link PersistenceStorageConfig} used for initializing the resolver
      */
-    private BlockAsLocalFilePathResolver(@NonNull final PersistenceStorageConfig config) {
-        this.liveRootPath = Path.of(config.liveRootPath());
-        this.archiveGroupSize = config.archiveBatchSize();
+    public BlockAsLocalFilePathResolver(@NonNull final PersistenceStorageConfig config) throws IOException {
+        this.liveRootPath = Objects.requireNonNull(config.liveRootPath());
+        Files.createDirectories(liveRootPath);
+        this.archiveGroupSize = config.archiveGroupSize();
         this.archiveDirDepth = MAX_LONG_DIGITS - (int) Math.log10(this.archiveGroupSize);
         this.longLeadingZeroesFormat = new DecimalFormat("0".repeat(MAX_LONG_DIGITS));
         this.blockDirDepthFormat = new DecimalFormat("0".repeat(archiveDirDepth));
-    }
-
-    /**
-     * This method creates and returns a new instance of
-     * {@link BlockAsLocalFilePathResolver}.
-     *
-     * @param config valid, {@code non-null} instance of
-     * {@link PersistenceStorageConfig} used for initializing the resolver
-     * @return a new, fully initialized instance of {@link BlockAsLocalFilePathResolver}
-     */
-    public static BlockAsLocalFilePathResolver of(@NonNull final PersistenceStorageConfig config) {
-        return new BlockAsLocalFilePathResolver(config);
     }
 
     @NonNull

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolver.java
@@ -10,22 +10,6 @@ import java.util.Optional;
  */
 public final class NoOpBlockPathResolver implements BlockPathResolver {
     /**
-     * Constructor.
-     */
-    private NoOpBlockPathResolver() {}
-
-    /**
-     * This method creates and returns a new instance of
-     * {@link NoOpBlockPathResolver}.
-     *
-     * @return a new, fully initialized instance of
-     * {@link NoOpBlockPathResolver}
-     */
-    public static NoOpBlockPathResolver newInstance() {
-        return new NoOpBlockPathResolver();
-    }
-
-    /**
      * No-op resolver. Does nothing and always returns a path under '/tmp' that
      * resolves to 'blockNumber.tmp.blk'. No preconditions check also.
      */

--- a/server/src/main/resources/app.properties
+++ b/server/src/main/resources/app.properties
@@ -16,4 +16,4 @@ prometheus.endpointPortNumber=9999
 #persistence.storage.compression=NONE
 #persistence.storage.archiveEnabled=false
 # @todo(517) - enable default batch size
-persistence.storage.archiveBatchSize=10
+persistence.storage.archiveGroupSize=10

--- a/server/src/test/java/com/hedera/block/server/config/ConfigInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ConfigInjectionModuleTest.java
@@ -16,142 +16,105 @@ import com.swirlds.common.metrics.config.MetricsConfig;
 import com.swirlds.common.metrics.platform.prometheus.PrometheusConfig;
 import com.swirlds.config.api.Configuration;
 import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ConfigInjectionModuleTest {
+    private BlockNodeContext testContext;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        testContext = TestConfigUtil.getTestBlockNodeContext();
+    }
 
     @Test
-    void testProvidePersistenceStorageConfig() throws IOException {
-
-        BlockNodeContext context = TestConfigUtil.getTestBlockNodeContext();
-        Configuration configuration = context.configuration();
-        PersistenceStorageConfig persistenceStorageConfig = configuration.getConfigData(PersistenceStorageConfig.class);
-
-        // Call the method under test
-        PersistenceStorageConfig providedConfig = ConfigInjectionModule.providePersistenceStorageConfig(configuration);
-
-        // Verify that the correct config data is returned
+    void testProvidePersistenceStorageConfig() {
+        final Configuration configuration = testContext.configuration();
+        final PersistenceStorageConfig persistenceStorageConfig =
+                configuration.getConfigData(PersistenceStorageConfig.class);
+        final PersistenceStorageConfig providedConfig =
+                ConfigInjectionModule.providePersistenceStorageConfig(configuration);
         assertNotNull(providedConfig);
         assertSame(persistenceStorageConfig, providedConfig);
     }
 
     @Test
-    void testProvideMetricsConfig() throws IOException {
-
-        BlockNodeContext context = TestConfigUtil.getTestBlockNodeContext();
-        Configuration configuration = context.configuration();
-        MetricsConfig metricsConfig = configuration.getConfigData(MetricsConfig.class);
-
-        // Call the method under test
-        MetricsConfig providedConfig = ConfigInjectionModule.provideMetricsConfig(configuration);
-
-        // Verify that the correct config data is returned
+    void testProvideMetricsConfig() {
+        final Configuration configuration = testContext.configuration();
+        final MetricsConfig metricsConfig = configuration.getConfigData(MetricsConfig.class);
+        final MetricsConfig providedConfig = ConfigInjectionModule.provideMetricsConfig(configuration);
         assertNotNull(providedConfig);
         assertSame(metricsConfig, providedConfig);
     }
 
     @Test
-    void testProvidePrometheusConfig() throws IOException {
-
-        BlockNodeContext context = TestConfigUtil.getTestBlockNodeContext();
-        Configuration configuration = context.configuration();
-        PrometheusConfig prometheusConfig = configuration.getConfigData(PrometheusConfig.class);
-
-        // Call the method under test
-        PrometheusConfig providedConfig = ConfigInjectionModule.providePrometheusConfig(configuration);
-
-        // Verify that the correct config data is returned
+    void testProvidePrometheusConfig() {
+        final Configuration configuration = testContext.configuration();
+        final PrometheusConfig prometheusConfig = configuration.getConfigData(PrometheusConfig.class);
+        final PrometheusConfig providedConfig = ConfigInjectionModule.providePrometheusConfig(configuration);
         assertNotNull(providedConfig);
         assertSame(prometheusConfig, providedConfig);
     }
 
     @Test
-    void testProvideConsumerConfig() throws IOException {
-
-        BlockNodeContext context = TestConfigUtil.getTestBlockNodeContext();
-        Configuration configuration = context.configuration();
-        ConsumerConfig consumerConfig = configuration.getConfigData(ConsumerConfig.class);
-
-        // Call the method under test
-        ConsumerConfig providedConfig = ConfigInjectionModule.provideConsumerConfig(configuration);
-
-        // Verify that the correct config data is returned
+    void testProvideConsumerConfig() {
+        final Configuration configuration = testContext.configuration();
+        final ConsumerConfig consumerConfig = configuration.getConfigData(ConsumerConfig.class);
+        final ConsumerConfig providedConfig = ConfigInjectionModule.provideConsumerConfig(configuration);
         assertNotNull(providedConfig);
         assertSame(consumerConfig, providedConfig);
     }
 
     @Test
-    void testProvideMediatorConfig() throws IOException {
-        BlockNodeContext context = TestConfigUtil.getTestBlockNodeContext();
-        Configuration configuration = context.configuration();
-        MediatorConfig mediatorConfig = configuration.getConfigData(MediatorConfig.class);
-
-        MediatorConfig providedConfig = ConfigInjectionModule.provideMediatorConfig(configuration);
-
-        // Verify the config
+    void testProvideMediatorConfig() {
+        final Configuration configuration = testContext.configuration();
+        final MediatorConfig mediatorConfig = configuration.getConfigData(MediatorConfig.class);
+        final MediatorConfig providedConfig = ConfigInjectionModule.provideMediatorConfig(configuration);
         assertNotNull(providedConfig);
         assertSame(mediatorConfig, providedConfig);
     }
 
     @Test
-    void testProvideNotifierConfig() throws IOException {
-        BlockNodeContext context = TestConfigUtil.getTestBlockNodeContext();
-        Configuration configuration = context.configuration();
-        NotifierConfig notifierConfig = configuration.getConfigData(NotifierConfig.class);
-
-        NotifierConfig providedConfig = ConfigInjectionModule.provideNotifierConfig(configuration);
-
-        // Verify the config
+    void testProvideNotifierConfig() {
+        final Configuration configuration = testContext.configuration();
+        final NotifierConfig notifierConfig = configuration.getConfigData(NotifierConfig.class);
+        final NotifierConfig providedConfig = ConfigInjectionModule.provideNotifierConfig(configuration);
         assertNotNull(providedConfig);
         assertSame(notifierConfig, providedConfig);
     }
 
     @Test
-    void testServerConfig() throws IOException {
-        BlockNodeContext context = TestConfigUtil.getTestBlockNodeContext();
-        Configuration configuration = context.configuration();
-        ServerConfig serverConfig = configuration.getConfigData(ServerConfig.class);
-
-        ServerConfig providedConfig = ConfigInjectionModule.provideServerConfig(configuration);
-
-        // Verify the config
+    void testServerConfig() {
+        final Configuration configuration = testContext.configuration();
+        final ServerConfig serverConfig = configuration.getConfigData(ServerConfig.class);
+        final ServerConfig providedConfig = ConfigInjectionModule.provideServerConfig(configuration);
         assertNotNull(providedConfig);
         assertSame(serverConfig, providedConfig);
     }
 
     @Test
-    void testVerificationConfig() throws IOException {
-        BlockNodeContext context = TestConfigUtil.getTestBlockNodeContext();
-        Configuration configuration = context.configuration();
-        VerificationConfig verificationConfig = configuration.getConfigData(VerificationConfig.class);
-
-        VerificationConfig providedConfig = ConfigInjectionModule.provideVerificationConfig(configuration);
-
-        // Verify the config
+    void testVerificationConfig() {
+        final Configuration configuration = testContext.configuration();
+        final VerificationConfig verificationConfig = configuration.getConfigData(VerificationConfig.class);
+        final VerificationConfig providedConfig = ConfigInjectionModule.provideVerificationConfig(configuration);
         assertNotNull(providedConfig);
         assertSame(verificationConfig, providedConfig);
     }
 
     @Test
-    void testProducerConfig() throws IOException {
-        BlockNodeContext context = TestConfigUtil.getTestBlockNodeContext();
-        Configuration configuration = context.configuration();
-        ProducerConfig producerConfig = configuration.getConfigData(ProducerConfig.class);
-
-        ProducerConfig providedConfig = ConfigInjectionModule.provideProducerConfig(configuration);
-
-        // Verify the config
+    void testProducerConfig() {
+        final Configuration configuration = testContext.configuration();
+        final ProducerConfig producerConfig = configuration.getConfigData(ProducerConfig.class);
+        final ProducerConfig providedConfig = ConfigInjectionModule.provideProducerConfig(configuration);
         assertNotNull(providedConfig);
         assertSame(producerConfig, providedConfig);
     }
 
     @Test
-    void testConfigurationLogging() throws IOException {
-        BlockNodeContext context = TestConfigUtil.getTestBlockNodeContext();
-        Configuration configuration = context.configuration();
-        ConfigurationLogging providedConfigurationLogging =
+    void testConfigurationLogging() {
+        final Configuration configuration = testContext.configuration();
+        final ConfigurationLogging providedConfigurationLogging =
                 ConfigInjectionModule.provideConfigurationLogging(configuration);
-
         assertNotNull(providedConfigurationLogging);
     }
 }

--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -58,7 +58,7 @@ class ServerMappedConfigSourceInitializerTest {
         new ConfigMapping("persistence.storage.liveRootPath", "PERSISTENCE_STORAGE_LIVE_ROOT_PATH"),
         new ConfigMapping("persistence.storage.type", "PERSISTENCE_STORAGE_TYPE"),
         new ConfigMapping("persistence.storage.archiveEnabled", "PERSISTENCE_STORAGE_ARCHIVE_ENABLED"),
-        new ConfigMapping("persistence.storage.archiveBatchSize", "PERSISTENCE_STORAGE_ARCHIVE_BATCH_SIZE"),
+        new ConfigMapping("persistence.storage.archiveGroupSize", "PERSISTENCE_STORAGE_ARCHIVE_BATCH_SIZE"),
 
         // Producer Config
         new ConfigMapping("producer.type", "PRODUCER_TYPE"),

--- a/server/src/test/java/com/hedera/block/server/config/TestConfigBuilder.java
+++ b/server/src/test/java/com/hedera/block/server/config/TestConfigBuilder.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.config;
 
-import com.swirlds.common.config.singleton.ConfigurationHolder;
 import com.swirlds.common.threading.locks.AutoClosableLock;
 import com.swirlds.common.threading.locks.Locks;
 import com.swirlds.common.threading.locks.locked.Locked;
@@ -154,7 +153,6 @@ public class TestConfigBuilder {
         try (final Locked ignore = configLock.lock()) {
             if (configuration == null) {
                 configuration = builder.build();
-                ConfigurationHolder.getInstance().setConfiguration(configuration);
             }
             return configuration;
         }

--- a/server/src/test/java/com/hedera/block/server/grpc/BlockAccessServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/grpc/BlockAccessServiceTest.java
@@ -65,8 +65,8 @@ class BlockAccessServiceTest {
 
         blockAccessService = new PbjBlockAccessServiceProxy(serviceStatus, blockReader, blockNodeContext);
 
-        final String testConfigLiveRootPath = testConfig.liveRootPath();
-        assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath.toString());
+        final Path testConfigLiveRootPath = testConfig.liveRootPath();
+        assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath);
     }
 
     @Test

--- a/server/src/test/java/com/hedera/block/server/manager/AckHandlerInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/manager/AckHandlerInjectionModuleTest.java
@@ -14,6 +14,7 @@ import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
 import com.hedera.block.server.persistence.storage.remove.BlockRemover;
 import com.hedera.block.server.service.ServiceStatus;
 import com.hedera.block.server.verification.VerificationConfig;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -32,8 +33,8 @@ class AckHandlerInjectionModuleTest {
         final ServiceStatus serviceStatus = mock(ServiceStatus.class);
         final BlockRemover blockRemover = mock(BlockRemover.class);
         final PersistenceStorageConfig persistenceStorageConfig = new PersistenceStorageConfig(
-                "",
-                "",
+                Path.of(""),
+                Path.of(""),
                 PersistenceStorageConfig.StorageType.BLOCK_AS_LOCAL_FILE,
                 PersistenceStorageConfig.CompressionType.NONE,
                 0,

--- a/server/src/test/java/com/hedera/block/server/pbj/PbjBlockStreamServiceIntegrationTest.java
+++ b/server/src/test/java/com/hedera/block/server/pbj/PbjBlockStreamServiceIntegrationTest.java
@@ -145,8 +145,8 @@ class PbjBlockStreamServiceIntegrationTest {
         blockNodeContext = TestConfigUtil.getTestBlockNodeContext(properties);
         testConfig = blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
 
-        final String testConfigLiveRootPath = testConfig.liveRootPath();
-        assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath.toString());
+        final Path testConfigLiveRootPath = testConfig.liveRootPath();
+        assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath);
     }
 
     @Disabled("@todo(642) make test deterministic via correct executor injection")

--- a/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
@@ -90,7 +90,7 @@ class PersistenceInjectionModuleTest {
     @ParameterizedTest
     @EnumSource(StorageType.class)
     void testProvidesBlockReader(final StorageType storageType) {
-        lenient().when(persistenceStorageConfigMock.liveRootPath()).thenReturn(testLiveRootPath.toString());
+        lenient().when(persistenceStorageConfigMock.liveRootPath()).thenReturn(testLiveRootPath);
         when(persistenceStorageConfigMock.type()).thenReturn(storageType);
 
         final BlockReader<BlockUnparsed> actual = PersistenceInjectionModule.providesBlockReader(
@@ -147,9 +147,9 @@ class PersistenceInjectionModuleTest {
     @ParameterizedTest
     @EnumSource(StorageType.class)
     void testProvidesBlockPathResolver(final StorageType storageType) {
-        lenient().when(persistenceStorageConfigMock.liveRootPath()).thenReturn(testLiveRootPath.toString());
-        lenient().when(persistenceStorageConfigMock.archiveRootPath()).thenReturn(testLiveRootPath.toString());
-        lenient().when(persistenceStorageConfigMock.archiveBatchSize()).thenReturn(10);
+        lenient().when(persistenceStorageConfigMock.liveRootPath()).thenReturn(testLiveRootPath);
+        lenient().when(persistenceStorageConfigMock.archiveRootPath()).thenReturn(testLiveRootPath);
+        lenient().when(persistenceStorageConfigMock.archiveGroupSize()).thenReturn(10);
         when(persistenceStorageConfigMock.type()).thenReturn(storageType);
 
         final BlockPathResolver actual = PersistenceInjectionModule.providesPathResolver(persistenceStorageConfigMock);

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
@@ -200,7 +200,7 @@ class PersistenceStorageConfigTest {
 
         // blank liveRootPath results in the default liveRootPath to be used
         final String liveToTest2 = "";
-        final String liveExpected2 = defaultLiveRootAbsolutePath.toString();
+        final String liveExpected2 = liveToTest2;
         final String archiveToTest2 = defaultArchiveRootAbsolutePath.toString();
         final String archiveExpected2 = defaultArchiveRootAbsolutePath.toString();
 
@@ -208,13 +208,13 @@ class PersistenceStorageConfigTest {
         final String liveToTest3 = defaultLiveRootAbsolutePath.toString();
         final String liveExpected3 = defaultLiveRootAbsolutePath.toString();
         final String archiveToTest3 = "";
-        final String archiveExpected3 = defaultArchiveRootAbsolutePath.toString();
+        final String archiveExpected3 = archiveToTest3;
 
         // blank liveRootPath and archiveRootPath results in the default liveRootPath and archiveRootPath to be used
         final String liveToTest6 = "";
-        final String liveExpected6 = defaultLiveRootAbsolutePath.toString();
+        final String liveExpected6 = liveToTest6;
         final String archiveToTest6 = "";
-        final String archiveExpected6 = defaultArchiveRootAbsolutePath.toString();
+        final String archiveExpected6 = archiveToTest6;
 
         return Stream.of(
                 Arguments.of(liveToTest1, liveExpected1, archiveToTest1, archiveExpected1),

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
@@ -2,14 +2,12 @@
 package com.hedera.block.server.persistence.storage;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.from;
 
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.CompressionType;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.StorageType;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -18,6 +16,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
@@ -26,7 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 class PersistenceStorageConfigTest {
     private static final Path HASHGRAPH_ROOT_ABSOLUTE_PATH =
-            Path.of("hashgraph/").toAbsolutePath();
+            Path.of("/opt/hashgraph/").toAbsolutePath();
     private static final Path PERSISTENCE_STORAGE_ROOT_ABSOLUTE_PATH =
             HASHGRAPH_ROOT_ABSOLUTE_PATH.resolve("blocknode/data/");
     // Default compression level (as set in the config annotation)
@@ -68,11 +67,11 @@ class PersistenceStorageConfigTest {
      * @param storageType parameterized, the storage type to test
      */
     @ParameterizedTest
-    @MethodSource("storageTypes")
+    @EnumSource(StorageType.class)
     void testPersistenceStorageConfigStorageTypes(final StorageType storageType) {
         final PersistenceStorageConfig actual = new PersistenceStorageConfig(
-                "",
-                "",
+                Path.of(""),
+                Path.of(""),
                 storageType,
                 CompressionType.NONE,
                 DEFAULT_COMPRESSION_LEVEL,
@@ -94,10 +93,10 @@ class PersistenceStorageConfigTest {
     @ParameterizedTest
     @MethodSource({"validAbsoluteDefaultRootPaths", "validAbsoluteNonDefaultRootPaths"})
     void testPersistenceStorageConfigHappyPaths(
-            final String liveRootPathToTest,
-            final String expectedLiveRootPathToTest,
-            final String archiveRootPathToTest,
-            final String expectedArchiveRootPathToTest) {
+            final Path liveRootPathToTest,
+            final Path expectedLiveRootPathToTest,
+            final Path archiveRootPathToTest,
+            final Path expectedArchiveRootPathToTest) {
         final PersistenceStorageConfig actual = new PersistenceStorageConfig(
                 liveRootPathToTest,
                 archiveRootPathToTest,
@@ -113,31 +112,6 @@ class PersistenceStorageConfigTest {
 
     /**
      * This test aims to verify that the {@link PersistenceStorageConfig} class
-     * correctly throws an {@link UncheckedIOException} when either the live or
-     * archive root paths are invalid.
-     *
-     * @param invalidLiveRootPathToTest parameterized, the invalid live root
-     * path to test
-     * @param invalidArchiveRootPathToTest parameterized, the invalid archive
-     * root path to test
-     */
-    @ParameterizedTest
-    @MethodSource({"invalidRootPaths"})
-    void testPersistenceStorageConfigInvalidRootPaths(
-            final String invalidLiveRootPathToTest, final String invalidArchiveRootPathToTest) {
-        assertThatExceptionOfType(UncheckedIOException.class)
-                .isThrownBy(() -> new PersistenceStorageConfig(
-                        invalidLiveRootPathToTest,
-                        invalidArchiveRootPathToTest,
-                        StorageType.BLOCK_AS_LOCAL_FILE,
-                        CompressionType.NONE,
-                        DEFAULT_COMPRESSION_LEVEL,
-                        DEFAULT_ARCHIVE_ENABLED,
-                        DEFAULT_ARCHIVE_BATCH_SIZE));
-    }
-
-    /**
-     * This test aims to verify that the {@link PersistenceStorageConfig} class
      * correctly returns the compression level that was set in the constructor.
      *
      * @param compressionLevel parameterized, the compression level to test
@@ -147,8 +121,8 @@ class PersistenceStorageConfigTest {
     void testPersistenceStorageConfigValidCompressionLevel(
             final CompressionType compressionType, final int compressionLevel) {
         final PersistenceStorageConfig actual = new PersistenceStorageConfig(
-                "",
-                "",
+                Path.of(""),
+                Path.of(""),
                 StorageType.BLOCK_AS_LOCAL_FILE,
                 compressionType,
                 compressionLevel,
@@ -170,8 +144,8 @@ class PersistenceStorageConfigTest {
             final CompressionType compressionType, final int compressionLevel) {
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> new PersistenceStorageConfig(
-                        "",
-                        "",
+                        Path.of(""),
+                        Path.of(""),
                         StorageType.BLOCK_AS_LOCAL_FILE,
                         compressionType,
                         compressionLevel,
@@ -186,24 +160,17 @@ class PersistenceStorageConfigTest {
      * @param compressionType parameterized, the compression type to test
      */
     @ParameterizedTest
-    @MethodSource("compressionTypes")
+    @EnumSource(CompressionType.class)
     void testPersistenceStorageConfigCompressionTypes(final CompressionType compressionType) {
         final PersistenceStorageConfig actual = new PersistenceStorageConfig(
-                "",
-                "",
+                Path.of(""),
+                Path.of(""),
                 StorageType.NO_OP,
                 compressionType,
                 DEFAULT_COMPRESSION_LEVEL,
                 DEFAULT_ARCHIVE_ENABLED,
                 DEFAULT_ARCHIVE_BATCH_SIZE);
         assertThat(actual).returns(compressionType, from(PersistenceStorageConfig::compression));
-    }
-
-    /**
-     * All storage types dynamically provided.
-     */
-    private static Stream<Arguments> storageTypes() {
-        return Arrays.stream(StorageType.values()).map(Arguments::of);
     }
 
     /**
@@ -243,38 +210,17 @@ class PersistenceStorageConfigTest {
         final String archiveToTest3 = "";
         final String archiveExpected3 = defaultArchiveRootAbsolutePath.toString();
 
-        // null liveRootPath results in the default liveRootPath to be used
-        final String liveToTest4 = null;
-        final String liveExpected4 = defaultLiveRootAbsolutePath.toString();
-        final String archiveToTest4 = defaultArchiveRootAbsolutePath.toString();
-        final String archiveExpected4 = defaultArchiveRootAbsolutePath.toString();
-
-        // null archiveRootPath results in the default archiveRootPath to be used
-        final String liveToTest5 = defaultLiveRootAbsolutePath.toString();
-        final String liveExpected5 = defaultLiveRootAbsolutePath.toString();
-        final String archiveToTest5 = null;
-        final String archiveExpected5 = defaultArchiveRootAbsolutePath.toString();
-
         // blank liveRootPath and archiveRootPath results in the default liveRootPath and archiveRootPath to be used
         final String liveToTest6 = "";
         final String liveExpected6 = defaultLiveRootAbsolutePath.toString();
         final String archiveToTest6 = "";
         final String archiveExpected6 = defaultArchiveRootAbsolutePath.toString();
 
-        // null liveRootPath and archiveRootPath results in the default liveRootPath and archiveRootPath to be used
-        final String liveToTest7 = null;
-        final String liveExpected7 = defaultLiveRootAbsolutePath.toString();
-        final String archiveToTest7 = null;
-        final String archiveExpected7 = defaultArchiveRootAbsolutePath.toString();
-
         return Stream.of(
                 Arguments.of(liveToTest1, liveExpected1, archiveToTest1, archiveExpected1),
                 Arguments.of(liveToTest2, liveExpected2, archiveToTest2, archiveExpected2),
                 Arguments.of(liveToTest3, liveExpected3, archiveToTest3, archiveExpected3),
-                Arguments.of(liveToTest4, liveExpected4, archiveToTest4, archiveExpected4),
-                Arguments.of(liveToTest5, liveExpected5, archiveToTest5, archiveExpected5),
-                Arguments.of(liveToTest6, liveExpected6, archiveToTest6, archiveExpected6),
-                Arguments.of(liveToTest7, liveExpected7, archiveToTest7, archiveExpected7));
+                Arguments.of(liveToTest6, liveExpected6, archiveToTest6, archiveExpected6));
     }
 
     /**
@@ -300,17 +246,6 @@ class PersistenceStorageConfigTest {
         return Stream.of(
                 Arguments.of(liveToTest1, liveToTest1, archiveToTest1, archiveToTest1),
                 Arguments.of(liveToTest2, liveToTest2, archiveToTest2, archiveToTest2));
-    }
-
-    /**
-     * Supplying blank is valid, both must be valid paths in order to be able
-     * to create the config instance. If either liveRootPath or archiveRootPath
-     * is invalid, we expect to fail. There cannot be invalid paths supplied.
-     */
-    private static Stream<Arguments> invalidRootPaths() {
-        final String invalidPath = "/invalid_path/:invalid_directory";
-        return Stream.of(
-                Arguments.of("", invalidPath), Arguments.of(invalidPath, ""), Arguments.of(invalidPath, invalidPath));
     }
 
     private static Stream<Arguments> validCompressionLevels() {

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolverTest.java
@@ -49,9 +49,9 @@ class BlockAsLocalFilePathResolverTest {
                 "10"));
         testConfig = blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
 
-        final String testConfigLiveRootPath = testConfig.liveRootPath();
-        assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath.toString());
-        toTest = BlockAsLocalFilePathResolver.of(testConfig);
+        final Path testConfigLiveRootPath = testConfig.liveRootPath();
+        assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath);
+        toTest = new BlockAsLocalFilePathResolver(testConfig);
     }
 
     /**

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolverTest.java
@@ -20,7 +20,7 @@ class NoOpBlockPathResolverTest {
 
     @BeforeEach
     void setUp() {
-        toTest = NoOpBlockPathResolver.newInstance();
+        toTest = new NoOpBlockPathResolver();
     }
 
     /**

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReaderTest.java
@@ -53,11 +53,11 @@ class BlockAsLocalFileReaderTest {
         final PersistenceStorageConfig testConfig =
                 blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
 
-        final String testConfigLiveRootPath = testConfig.liveRootPath();
-        assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath.toString());
+        final Path testConfigLiveRootPath = testConfig.liveRootPath();
+        assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath);
 
         compressionMock = spy(NoOpCompression.newInstance());
-        blockPathResolverMock = spy(BlockAsLocalFilePathResolver.of(testConfig));
+        blockPathResolverMock = spy(new BlockAsLocalFilePathResolver(testConfig));
         toTest = BlockAsLocalFileReader.of(compressionMock, blockPathResolverMock);
     }
 

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/remove/BlockAsLocalFileRemoverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/remove/BlockAsLocalFileRemoverTest.java
@@ -40,8 +40,8 @@ class BlockAsLocalFileRemoverTest {
         final PersistenceStorageConfig testConfig =
                 blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
 
-        final String testConfigLiveRootPath = testConfig.liveRootPath();
-        assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath.toString());
+        final Path testConfigLiveRootPath = testConfig.liveRootPath();
+        assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath);
 
         blockPathResolverMock = mock(BlockPathResolver.class);
         toTest = new BlockAsLocalFileRemover(blockPathResolverMock);

--- a/server/src/test/java/com/hedera/block/server/util/PersistTestUtils.java
+++ b/server/src/test/java/com/hedera/block/server/util/PersistTestUtils.java
@@ -20,8 +20,9 @@ import java.util.List;
 public final class PersistTestUtils {
     private static final Logger LOGGER = System.getLogger(PersistTestUtils.class.getName());
     public static final String PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY = "persistence.storage.liveRootPath";
+    public static final String PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH_KEY = "persistence.storage.archiveRootPath";
     public static final String PERSISTENCE_STORAGE_COMPRESSION_LEVEL = "persistence.storage.compressionLevel";
-    public static final String PERSISTENCE_STORAGE_ARCHIVE_BATCH_SIZE = "persistence.storage.archiveBatchSize";
+    public static final String PERSISTENCE_STORAGE_ARCHIVE_BATCH_SIZE = "persistence.storage.archiveGroupSize";
 
     private PersistTestUtils() {}
 


### PR DESCRIPTION
## Reviewer Notes

- change persistence config liveRootPath default to /opt/hashgraph/blocknode/data/live
- change persistence config archiveRootPath default to /opt/hashgraph/blocknode/data/archive
- both configs now use Path instead of String for their type
- docker user now has access to /opt
- change persistence config key archiveBatchSize to archiveGroup size for improved semantics (todo left from the past)
- config record no longer creates roots, it is just a value holder, it has no logic and is no decision maker
- remove deprecated usage of ConfigrationHolder (it also caused issues for tests)
- updated tests to pass with the new default paths
- updated documentation

## Related Issue(s)

Closes #371 
