### PR TITLE
ci: Updated CODEOWNERS and self hosted runners for hiero-block-node

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 ##### Global Protection Rule ######
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below
-*                                               @hashgraph/block-node
+*                                               @hiero-ledger/hiero-block-node-maintainers @hiero-ledger/hiero-block-node-committers
 
 #########################
 #####  Core Files  ######
@@ -11,24 +11,24 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/release-engineering-managers @hashgraph/block-node
-/.github/workflows/                             @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
+/.github/                                       @hiero-ledger/github-maintainers @hiero-ledger/hiero-block-node-maintainers @hiero-ledger/hiero-block-node-committers
+/.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/github-committers
 
 # Codacy Tool Configurations
-/config/                                        @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/block-node
-.remarkrc                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/block-node
+/config/                                        @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-block-node-maintainers @hiero-ledger/hiero-block-node-committers
+.remarkrc                                       @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-block-node-maintainers @hiero-ledger/hiero-block-node-committers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
-/CODEOWNERS                                     @hashgraph/release-engineering-managers
+/CODEOWNERS                                     @hiero-ledger/github-maintainers
 
 # Protect the repository root files
-/README.md                                      @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/block-node
-**/LICENSE                                      @hashgraph/release-engineering-managers
+/README.md                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-block-node-maintainers @hiero-ledger/hiero-block-node-committers
+**/LICENSE                                      @hiero-ledger/github-maintainers
 
 # CodeCov configuration
-**/codecov.yml                                  @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/block-node
+**/codecov.yml                                  @hiero-ledger/github-maintainers @hiero-ledger/hiero-block-node-maintainers @hiero-ledger/hiero-block-node-committers
 
 # Git Ignore definitions
-**/.gitignore                                   @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/block-node
-**/.gitignore.*                                 @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/block-node
+**/.gitignore                                   @hiero-ledger/github-maintainers @hiero-ledger/hiero-block-node-maintainers @hiero-ledger/hiero-block-node-committers
+**/.gitignore.*                                 @hiero-ledger/github-maintainers @hiero-ledger/hiero-block-node-maintainers @hiero-ledger/hiero-block-node-committers
 

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   e2e-tests:
-    runs-on: block-node-linux-medium
+    runs-on: hiero-block-node-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   lint-install-test:
     name: Lint and Install Charts
-    runs-on: block-node-linux-medium
+    runs-on: hiero-block-node-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -40,7 +40,7 @@ jobs:
 
   compile:
     name: "Gradle Checks"
-    runs-on: block-node-linux-medium
+    runs-on: hiero-block-node-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/pr-formatting.yaml
+++ b/.github/workflows/pr-formatting.yaml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   pr-formatting-checks:
     name: PR Formatting Checks
-    runs-on: block-node-linux-medium
+    runs-on: hiero-block-node-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -19,7 +19,7 @@ defaults:
 jobs:
   release:
     name: Release
-    runs-on: block-node-linux-medium
+    runs-on: hiero-block-node-linux-medium
     env:
       RELEASE_NOTES_FILENAME: release_notes
     outputs:
@@ -140,7 +140,7 @@ jobs:
 
   create_pr:
     name: Create PR
-    runs-on: block-node-linux-medium
+    runs-on: hiero-block-node-linux-medium
     needs: release
     if: ${{ needs.release.outputs.create_pr == 'true' }}
     env:

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -48,7 +48,7 @@ jobs:
 
   publish:
     needs: [check-gradle, check-docker]
-    runs-on: block-node-linux-medium
+    runs-on: hiero-block-node-linux-medium
 
     steps:
       - name: Harden Runner
@@ -137,7 +137,7 @@ jobs:
 
   helm-chart-release:
     needs: publish
-    runs-on: block-node-linux-medium
+    runs-on: hiero-block-node-linux-medium
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   smoke-test:
     name: "Smoke Tests"
-    runs-on: block-node-linux-medium
+    runs-on: hiero-block-node-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -62,7 +62,7 @@ env:
 jobs:
   generate-baseline:
     name: Generate Baseline
-    runs-on: block-node-linux-medium
+    runs-on: hiero-block-node-linux-medium
     outputs:
       sha: ${{ steps.commit.outputs.sha }}
       sha-abbrev: ${{ steps.commit.outputs.sha-abbrev }}
@@ -223,7 +223,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - block-node-linux-medium
+          - hiero-block-node-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -57,7 +57,7 @@ env:
 jobs:
   generate-baseline:
     name: Generate Baseline
-    runs-on: block-node-linux-medium
+    runs-on: hiero-block-node-linux-medium
     outputs:
       sha: ${{ steps.commit.outputs.sha }}
       path: ${{ steps.baseline.outputs.path }}
@@ -144,7 +144,7 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-20.04
-          - block-node-linux-medium
+          - hiero-block-node-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0


### PR DESCRIPTION
**Description**:

Updated the CODEOWNERS teams to reflect block node syntax Updated the self-hosted runners to use the new runner image: `hiero-block-node-linux-medium`

**Related Issue(s)**:

Fixes #667
