### PR TITLE
chore: Cherry picks for `0.5.0-rc2`

### DIFF
--- a/server/docker/logging.properties
+++ b/server/docker/logging.properties
@@ -50,7 +50,7 @@ handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
 ################################################################################
 # ConsoleHandler configuration
 ################################################################################
-java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
 ################################################################################
@@ -69,7 +69,7 @@ java.util.logging.FileHandler.limit = 5_000_000
 # Then it cycles back over the oldest.
 java.util.logging.FileHandler.count = 5
 # Log level for the FileHandler
-java.util.logging.FileHandler.level = FINE
+java.util.logging.FileHandler.level = ALL
 # Use your SimpleFormatter, or a custom format
 java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
 

--- a/simulator/build.gradle.kts
+++ b/simulator/build.gradle.kts
@@ -29,7 +29,7 @@ testModuleInfo {
     requires("org.mockito")
     requires("org.mockito.junit.jupiter")
     requires("org.assertj.core")
-    requires("com.google.protobuf")
+    runtimeOnly("com.google.protobuf")
 }
 
 // Task to run simulator in Publisher mode

--- a/simulator/src/main/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializer.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializer.java
@@ -31,6 +31,10 @@ public final class SimulatorMappedConfigSourceInitializer {
 
             // Block generator configuration
             new ConfigMapping("generator.generationMode", "GENERATOR_GENERATION_MODE"),
+            new ConfigMapping("generator.minEventsPerBlock", "GENERATOR_MIN_EVENTS_PER_BLOCK"),
+            new ConfigMapping("generator.maxEventsPerBlock", "GENERATOR_MAX_EVENTS_PER_BLOCK"),
+            new ConfigMapping("generator.minTransactionsPerEvent", "GENERATOR_MIN_TRANSACTIONS_PER_EVENT"),
+            new ConfigMapping("generator.maxTransactionsPerEvent", "GENERATOR_MAX_TRANSACTIONS_PER_EVENT"),
             new ConfigMapping("generator.folderRootPath", "GENERATOR_FOLDER_ROOT_PATH"),
             new ConfigMapping("generator.managerImplementation", "GENERATOR_MANAGER_IMPLEMENTATION"),
             new ConfigMapping("generator.paddedLength", "GENERATOR_PADDED_LENGTH"),

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockGeneratorConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockGeneratorConfig.java
@@ -22,13 +22,17 @@ import java.nio.file.Paths;
  */
 @ConfigData("generator")
 public record BlockGeneratorConfig(
-        @ConfigProperty(defaultValue = "DIR") GenerationMode generationMode,
+        @ConfigProperty(defaultValue = "CRAFT") GenerationMode generationMode,
+        @ConfigProperty(defaultValue = "1") @Min(1) int minEventsPerBlock,
+        @ConfigProperty(defaultValue = "10") int maxEventsPerBlock,
+        @ConfigProperty(defaultValue = "1") @Min(1) int minTransactionsPerEvent,
+        @ConfigProperty(defaultValue = "10") int maxTransactionsPerEvent,
         @ConfigProperty(defaultValue = "") String folderRootPath,
         @ConfigProperty(defaultValue = "BlockAsFileBlockStreamManager") String managerImplementation,
         @ConfigProperty(defaultValue = "36") int paddedLength,
         @ConfigProperty(defaultValue = ".blk.gz") String fileExtension,
         // Optional block number range for the BlockAsFileLargeDataSets manager
-        @ConfigProperty(defaultValue = "1") @Min(1) int startBlockNumber,
+        @ConfigProperty(defaultValue = "1") @Min(0) int startBlockNumber,
         @ConfigProperty(defaultValue = "-1") int endBlockNumber) {
 
     /**
@@ -74,6 +78,10 @@ public record BlockGeneratorConfig(
      */
     public static class Builder {
         private GenerationMode generationMode = GenerationMode.DIR;
+        private int minEventsPerBlock = 1;
+        private int maxEventsPerBlock = 10;
+        private int minTransactionsPerEvent = 1;
+        private int maxTransactionsPerEvent = 10;
         private String folderRootPath = "";
         private String managerImplementation = "BlockAsFileBlockStreamManager";
         private int paddedLength = 36;
@@ -96,6 +104,50 @@ public record BlockGeneratorConfig(
          */
         public Builder generationMode(GenerationMode generationMode) {
             this.generationMode = generationMode;
+            return this;
+        }
+
+        /**
+         * Sets the minimum number of events per block.
+         *
+         * @param minEventsPerBlock the minimum number of events per block
+         * @return this {@code Builder} instance
+         */
+        public Builder minEventsPerBlock(int minEventsPerBlock) {
+            this.minEventsPerBlock = minEventsPerBlock;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of events per block.
+         *
+         * @param maxEventsPerBlock the maximum number of events per block
+         * @return this {@code Builder} instance
+         */
+        public Builder maxEventsPerBlock(int maxEventsPerBlock) {
+            this.maxEventsPerBlock = maxEventsPerBlock;
+            return this;
+        }
+
+        /**
+         * Sets the minimum number of transactions per event.
+         *
+         * @param minTransactionsPerEvent the minimum number of transactions per event
+         * @return this {@code Builder} instance
+         */
+        public Builder minTransactionsPerEvent(int minTransactionsPerEvent) {
+            this.minTransactionsPerEvent = minTransactionsPerEvent;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of transactions per event.
+         *
+         * @param maxTransactionsPerEvent the maximum number of transactions per event
+         * @return this {@code Builder} instance
+         */
+        public Builder maxTransactionsPerEvent(int maxTransactionsPerEvent) {
+            this.maxTransactionsPerEvent = maxTransactionsPerEvent;
             return this;
         }
 
@@ -175,6 +227,10 @@ public record BlockGeneratorConfig(
         public BlockGeneratorConfig build() {
             return new BlockGeneratorConfig(
                     generationMode,
+                    minEventsPerBlock,
+                    maxEventsPerBlock,
+                    minTransactionsPerEvent,
+                    maxTransactionsPerEvent,
                     folderRootPath,
                     managerImplementation,
                     paddedLength,

--- a/simulator/src/main/java/com/hedera/block/simulator/config/types/GenerationMode.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/types/GenerationMode.java
@@ -6,5 +6,5 @@ public enum GenerationMode {
     /** Reads Blocks from a Folder. */
     DIR,
     /** Generates Blocks from rules */
-    ADHOC
+    CRAFT
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/CraftBlockStreamManager.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/CraftBlockStreamManager.java
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator;
+
+import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.INFO;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.block.common.hasher.Hashes;
+import com.hedera.block.common.hasher.HashingUtilities;
+import com.hedera.block.common.hasher.NaiveStreamingTreeHasher;
+import com.hedera.block.common.hasher.StreamingTreeHasher;
+import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
+import com.hedera.block.simulator.config.types.GenerationMode;
+import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
+import com.hedera.block.simulator.generator.itemhandler.BlockHeaderHandler;
+import com.hedera.block.simulator.generator.itemhandler.BlockProofHandler;
+import com.hedera.block.simulator.generator.itemhandler.EventHeaderHandler;
+import com.hedera.block.simulator.generator.itemhandler.EventTransactionHandler;
+import com.hedera.block.simulator.generator.itemhandler.ItemHandler;
+import com.hedera.block.simulator.generator.itemhandler.TransactionResultHandler;
+import com.hedera.hapi.block.BlockItemUnparsed;
+import com.hedera.hapi.block.stream.protoc.Block;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Implementation of BlockStreamManager that crafts blocks from scratch rather than reading from an existing stream.
+ * This manager generates synthetic blocks with random events and transactions based on configured parameters.
+ */
+public class CraftBlockStreamManager implements BlockStreamManager {
+    private final System.Logger LOGGER = System.getLogger(getClass().getName());
+
+    // Service
+    private final Random random;
+
+    // Configuration
+    private final int minEventsPerBlock;
+    private final int maxEventsPerBlock;
+    private final int minTransactionsPerEvent;
+    private final int maxTransactionsPerEvent;
+
+    // State
+    private final GenerationMode generationMode;
+    private final byte[] previousStateRootHash;
+    private byte[] previousBlockHash;
+    private byte[] currentBlockHash;
+    private long currentBlockNumber;
+    private StreamingTreeHasher inputTreeHasher;
+    private StreamingTreeHasher outputTreeHasher;
+
+    /**
+     * Constructs a new CraftBlockStreamManager with the specified configuration.
+     *
+     * @param blockGeneratorConfig Configuration parameters for block generation including event and transaction counts
+     * @throws NullPointerException if blockGeneratorConfig is null
+     */
+    public CraftBlockStreamManager(@NonNull BlockGeneratorConfig blockGeneratorConfig) {
+        final BlockGeneratorConfig blockGeneratorConfig1 = requireNonNull(blockGeneratorConfig);
+        this.generationMode = blockGeneratorConfig1.generationMode();
+        this.currentBlockNumber = blockGeneratorConfig1.startBlockNumber();
+        this.minEventsPerBlock = blockGeneratorConfig1.minEventsPerBlock();
+        this.maxEventsPerBlock = blockGeneratorConfig1.maxEventsPerBlock();
+        this.minTransactionsPerEvent = blockGeneratorConfig1.minTransactionsPerEvent();
+        this.maxTransactionsPerEvent = blockGeneratorConfig1.maxTransactionsPerEvent();
+
+        this.random = new Random();
+        this.previousStateRootHash = new byte[StreamingTreeHasher.HASH_LENGTH];
+
+        this.previousBlockHash = new byte[StreamingTreeHasher.HASH_LENGTH];
+        this.currentBlockHash = new byte[StreamingTreeHasher.HASH_LENGTH];
+
+        this.inputTreeHasher = new NaiveStreamingTreeHasher();
+        this.outputTreeHasher = new NaiveStreamingTreeHasher();
+
+        LOGGER.log(INFO, "Block Stream Simulator will use Craft mode for block management.");
+    }
+
+    /**
+     * Returns the generation mode of this block stream manager.
+     *
+     * @return The GenerationMode enum value representing the current generation mode
+     */
+    @Override
+    public GenerationMode getGenerationMode() {
+        return generationMode;
+    }
+
+    /**
+     * This operation is not supported in Craft mode.
+     *
+     * @throws UnsupportedOperationException always, as Craft mode does not support getting individual block items
+     */
+    @Override
+    public BlockItem getNextBlockItem() {
+        throw new UnsupportedOperationException("Craft mode does not support getting block items.");
+    }
+
+    /**
+     * Generates and returns the next synthetic block.
+     * Creates a block with a random number of events and transactions within configured bounds.
+     * Each block includes a header, events with their transactions and results, and a proof.
+     *
+     * @return A newly generated Block
+     * @throws IOException if there is an error processing block items
+     * @throws BlockSimulatorParsingException if there is an error parsing block components
+     */
+    @Override
+    public Block getNextBlock() throws IOException, BlockSimulatorParsingException {
+        LOGGER.log(DEBUG, "Started creation of block number %s.".formatted(currentBlockNumber));
+        // todo(683) Refactor common hasher to accept protoc types, in order to avoid the additional overhead of keeping
+        // and unparsing.
+        final List<BlockItemUnparsed> blockItemsUnparsed = new ArrayList<>();
+        final List<ItemHandler> items = new ArrayList<>();
+
+        final ItemHandler headerItemHandler = new BlockHeaderHandler(previousBlockHash, currentBlockNumber);
+        items.add(headerItemHandler);
+        blockItemsUnparsed.add(headerItemHandler.unparseBlockItem());
+
+        final int eventsNumber = random.nextInt(minEventsPerBlock, maxEventsPerBlock);
+        for (int i = 0; i < eventsNumber; i++) {
+            final ItemHandler eventHeaderHandler = new EventHeaderHandler();
+            items.add(eventHeaderHandler);
+            blockItemsUnparsed.add(eventHeaderHandler.unparseBlockItem());
+
+            final int transactionsNumber = random.nextInt(minTransactionsPerEvent, maxTransactionsPerEvent);
+            for (int j = 0; j < transactionsNumber; j++) {
+                final ItemHandler eventTransactionHandler = new EventTransactionHandler();
+                items.add(eventTransactionHandler);
+                blockItemsUnparsed.add(eventTransactionHandler.unparseBlockItem());
+
+                final ItemHandler transactionResultHandler = new TransactionResultHandler();
+                items.add(transactionResultHandler);
+                blockItemsUnparsed.add(transactionResultHandler.unparseBlockItem());
+            }
+        }
+
+        LOGGER.log(DEBUG, "Appending %s number of block items in this block.".formatted(items.size()));
+
+        processBlockItems(blockItemsUnparsed);
+        updateCurrentBlockHash();
+
+        ItemHandler proofItemHandler = new BlockProofHandler(previousBlockHash, currentBlockHash, currentBlockNumber);
+        items.add(proofItemHandler);
+        resetState();
+        return Block.newBuilder()
+                .addAllItems(items.stream().map(ItemHandler::getItem).toList())
+                .build();
+    }
+
+    private void updateCurrentBlockHash() {
+        com.hedera.hapi.block.stream.BlockProof unfinishedBlockProof =
+                com.hedera.hapi.block.stream.BlockProof.newBuilder()
+                        .previousBlockRootHash(Bytes.wrap(previousBlockHash))
+                        .startOfBlockStateRootHash(Bytes.wrap(previousStateRootHash))
+                        .build();
+
+        currentBlockHash = HashingUtilities.computeFinalBlockHash(
+                        unfinishedBlockProof, inputTreeHasher, outputTreeHasher)
+                .toByteArray();
+    }
+
+    private void processBlockItems(List<BlockItemUnparsed> blockItems) {
+        Hashes hashes = HashingUtilities.getBlockHashes(blockItems);
+        while (hashes.inputHashes().hasRemaining()) {
+            inputTreeHasher.addLeaf(hashes.inputHashes());
+        }
+        while (hashes.outputHashes().hasRemaining()) {
+            outputTreeHasher.addLeaf(hashes.outputHashes());
+        }
+    }
+
+    private void resetState() {
+        inputTreeHasher = new NaiveStreamingTreeHasher();
+        outputTreeHasher = new NaiveStreamingTreeHasher();
+        currentBlockNumber++;
+        previousBlockHash = currentBlockHash;
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/GeneratorInjectionModule.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/GeneratorInjectionModule.java
@@ -2,6 +2,7 @@
 package com.hedera.block.simulator.generator;
 
 import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
+import com.hedera.block.simulator.config.types.GenerationMode;
 import dagger.Module;
 import dagger.Provides;
 import javax.inject.Singleton;
@@ -11,24 +12,34 @@ import javax.inject.Singleton;
 public interface GeneratorInjectionModule {
 
     /**
-     * Provides the block stream manager based on the configuration, either
-     * BlockAsFileBlockStreamManager or BlockAsDirBlockStreamManager. by default, it will be
-     * BlockAsFileBlockStreamManager.
+     * Provides the block stream manager based on the configuration settings.
+     * For DIR generation mode:
+     * - BlockAsDirBlockStreamManager if explicitly configured
+     * - BlockAsFileLargeDataSets if explicitly configured
+     * - BlockAsFileBlockStreamManager as default
+     * For CRAFT generation mode:
+     * - CraftBlockStreamManager
      *
      * @param config the block stream configuration
-     * @return the block stream manager
+     * @return the appropriate BlockStreamManager implementation based on configuration
      */
     @Singleton
     @Provides
     static BlockStreamManager providesBlockStreamManager(BlockGeneratorConfig config) {
 
         final String managerImpl = config.managerImplementation();
-        if ("BlockAsDirBlockStreamManager".equalsIgnoreCase(managerImpl)) {
-            return new BlockAsDirBlockStreamManager(config);
-        } else if ("BlockAsFileLargeDataSets".equalsIgnoreCase(managerImpl)) {
-            return new BlockAsFileLargeDataSets(config);
-        }
+        final GenerationMode generationMode = config.generationMode();
 
-        return new BlockAsFileBlockStreamManager(config);
+        return switch (generationMode) {
+            case DIR -> {
+                if ("BlockAsDirBlockStreamManager".equalsIgnoreCase(managerImpl)) {
+                    yield new BlockAsDirBlockStreamManager(config);
+                } else if ("BlockAsFileLargeDataSets".equalsIgnoreCase(managerImpl)) {
+                    yield new BlockAsFileLargeDataSets(config);
+                }
+                yield new BlockAsFileBlockStreamManager(config);
+            }
+            case CRAFT -> new CraftBlockStreamManager(config);
+        };
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/itemhandler/AbstractBlockItemHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/itemhandler/AbstractBlockItemHandler.java
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator.itemhandler;
+
+import com.hedera.block.common.utils.Preconditions;
+import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
+import com.hedera.hapi.block.BlockItemUnparsed;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hederahashgraph.api.proto.java.SemanticVersion;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import java.util.Random;
+
+/**
+ * Abstract base class for block item handlers providing common functionality.
+ * Implements core methods and utilities used by specific item handlers.
+ */
+abstract class AbstractBlockItemHandler implements ItemHandler {
+    protected BlockItem blockItem;
+
+    @Override
+    public BlockItem getItem() {
+        return blockItem;
+    }
+
+    @Override
+    public BlockItemUnparsed unparseBlockItem() throws BlockSimulatorParsingException {
+        try {
+            return BlockItemUnparsed.PROTOBUF.parse(Bytes.wrap(getItem().toByteArray()));
+        } catch (ParseException e) {
+            throw new BlockSimulatorParsingException(e);
+        }
+    }
+
+    /**
+     * Creates a timestamp representing the current time.
+     *
+     * @return A Timestamp protobuf object
+     */
+    protected Timestamp getTimestamp() {
+        return Timestamp.newBuilder()
+                .setSeconds(System.currentTimeMillis() / 1000)
+                .build();
+    }
+
+    /**
+     * Creates a semantic version object with default values.
+     *
+     * @return A SemanticVersion protobuf object
+     */
+    protected SemanticVersion getSemanticVersion() {
+        return SemanticVersion.newBuilder().setMajor(0).setMinor(1).setPatch(0).build();
+    }
+
+    /**
+     * Generates a random value within the specified range.
+     *
+     * @param min The minimum value (inclusive)
+     * @param max The maximum value (exclusive)
+     * @return A random long value between min and max
+     * @throws IllegalArgumentException if min or max is negative
+     */
+    protected long generateRandomValue(long min, long max) {
+        Preconditions.requirePositive(min);
+        Preconditions.requirePositive(max);
+
+        return new Random().nextLong(min, max);
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/itemhandler/BlockHeaderHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/itemhandler/BlockHeaderHandler.java
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator.itemhandler;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.protobuf.ByteString;
+import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hederahashgraph.api.proto.java.BlockHashAlgorithm;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Handler for block headers in the block stream.
+ * Creates and manages block header items containing metadata about the block.
+ */
+public class BlockHeaderHandler extends AbstractBlockItemHandler {
+    private final byte[] previousBlockHash;
+    private final long currentBlockNumber;
+
+    /**
+     * Constructs a new BlockHeaderHandler.
+     *
+     * @param previousBlockHash Hash of the previous block in the chain
+     * @param currentBlockNumber Number of the current block
+     * @throws NullPointerException if previousBlockHash is null
+     */
+    public BlockHeaderHandler(@NonNull final byte[] previousBlockHash, final long currentBlockNumber) {
+        this.previousBlockHash = requireNonNull(previousBlockHash);
+        this.currentBlockNumber = currentBlockNumber;
+    }
+
+    @Override
+    public BlockItem getItem() {
+        if (blockItem == null) {
+            blockItem =
+                    BlockItem.newBuilder().setBlockHeader(createBlockHeader()).build();
+        }
+        return blockItem;
+    }
+
+    private BlockHeader createBlockHeader() {
+        return BlockHeader.newBuilder()
+                .setHapiProtoVersion(getSemanticVersion())
+                .setSoftwareVersion(getSemanticVersion())
+                .setHashAlgorithm(BlockHashAlgorithm.SHA2_384)
+                .setFirstTransactionConsensusTime(getTimestamp())
+                .setPreviousBlockHash(ByteString.copyFrom(previousBlockHash))
+                .setNumber(currentBlockNumber)
+                .build();
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/itemhandler/BlockProofHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/itemhandler/BlockProofHandler.java
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator.itemhandler;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.protobuf.ByteString;
+import com.hedera.block.common.hasher.HashingUtilities;
+import com.hedera.block.common.hasher.StreamingTreeHasher;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hedera.hapi.block.stream.protoc.BlockProof;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Handler for block proofs in the block stream.
+ * Creates and manages block proof items containing cryptographic proof of block validity.
+ */
+public class BlockProofHandler extends AbstractBlockItemHandler {
+    private final byte[] previousBlockHash;
+    private final byte[] currentBlockHash;
+    private final byte[] previousStateRootHash;
+    private final long currentBlockNumber;
+
+    /**
+     * Constructs a new BlockProofHandler.
+     *
+     * @param previousBlockHash Hash of the previous block
+     * @param currentBlockHash Hash of the current block
+     * @param currentBlockNumber Number of the current block
+     * @throws NullPointerException if previousBlockHash or currentBlockHash is null
+     */
+    public BlockProofHandler(
+            @NonNull final byte[] previousBlockHash,
+            @NonNull final byte[] currentBlockHash,
+            final long currentBlockNumber) {
+        this.previousBlockHash = requireNonNull(previousBlockHash);
+        this.currentBlockHash = requireNonNull(currentBlockHash);
+        this.currentBlockNumber = currentBlockNumber;
+        this.previousStateRootHash = new byte[StreamingTreeHasher.HASH_LENGTH];
+    }
+
+    @Override
+    public BlockItem getItem() {
+        if (blockItem == null) {
+            blockItem = BlockItem.newBuilder().setBlockProof(createBlockProof()).build();
+        }
+        return blockItem;
+    }
+
+    private BlockProof createBlockProof() {
+        return BlockProof.newBuilder()
+                .setBlock(currentBlockNumber)
+                .setPreviousBlockRootHash(ByteString.copyFrom(previousBlockHash))
+                .setStartOfBlockStateRootHash(ByteString.copyFrom(previousStateRootHash))
+                .setBlockSignature(produceSignature())
+                .build();
+    }
+
+    private ByteString produceSignature() {
+        return ByteString.copyFrom(HashingUtilities.noThrowSha384HashOf(currentBlockHash));
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/itemhandler/EventHeaderHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/itemhandler/EventHeaderHandler.java
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator.itemhandler;
+
+import com.hedera.hapi.block.stream.input.protoc.EventHeader;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hedera.hapi.platform.event.legacy.EventCore;
+
+/**
+ * Handler for event headers in the block stream.
+ * Creates and manages event header items containing metadata about events.
+ */
+public class EventHeaderHandler extends AbstractBlockItemHandler {
+    @Override
+    public BlockItem getItem() {
+        if (blockItem == null) {
+            blockItem =
+                    BlockItem.newBuilder().setEventHeader(createEventHeader()).build();
+        }
+        return blockItem;
+    }
+
+    private EventHeader createEventHeader() {
+        return EventHeader.newBuilder().setEventCore(createEventCore()).build();
+    }
+
+    private EventCore createEventCore() {
+        return EventCore.newBuilder()
+                .setCreatorNodeId(generateRandomValue(1, 32))
+                .setVersion(getSemanticVersion())
+                .build();
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/itemhandler/EventTransactionHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/itemhandler/EventTransactionHandler.java
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator.itemhandler;
+
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hedera.hapi.platform.event.legacy.EventTransaction;
+
+/**
+ * Handler for event transactions in the block stream.
+ * Creates and manages event transaction items representing blockchain transactions.
+ */
+public class EventTransactionHandler extends AbstractBlockItemHandler {
+    @Override
+    public BlockItem getItem() {
+        if (blockItem == null) {
+            blockItem = BlockItem.newBuilder()
+                    .setEventTransaction(createEventTransaction())
+                    .build();
+        }
+        return blockItem;
+    }
+
+    private EventTransaction createEventTransaction() {
+        // For now, we stick with empty EventTransaction, because otherwise we need to provide encoded transaction,
+        // which we don't have.
+        // This transaction data should correspond with the results in the transaction result item and others.
+        return EventTransaction.newBuilder().build();
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/itemhandler/ItemHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/itemhandler/ItemHandler.java
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator.itemhandler;
+
+import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
+import com.hedera.hapi.block.BlockItemUnparsed;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+
+/**
+ * Interface defining the contract for handling different types of block items.
+ * Implementations handle specific types of items like block headers, proofs, events, and transactions.
+ */
+public interface ItemHandler {
+    /**
+     * Returns the block item in its protobuf format.
+     *
+     * @return The constructed BlockItem
+     */
+    BlockItem getItem();
+
+    /**
+     * Converts the block item to its unparsed format.
+     *
+     * @return The block item in unparsed format
+     * @throws BlockSimulatorParsingException if there is an error parsing the block item
+     */
+    BlockItemUnparsed unparseBlockItem() throws BlockSimulatorParsingException;
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/itemhandler/TransactionResultHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/itemhandler/TransactionResultHandler.java
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator.itemhandler;
+
+import com.hedera.block.common.utils.Preconditions;
+import com.hedera.hapi.block.stream.output.protoc.TransactionResult;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hederahashgraph.api.proto.java.AccountAmount;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TokenTransferList;
+import com.hederahashgraph.api.proto.java.TransferList;
+
+/**
+ * Handler for transaction results in the block stream.
+ * Creates and manages transaction result items containing the outcome of transactions,
+ * including transfer lists and token transfers.
+ */
+public class TransactionResultHandler extends AbstractBlockItemHandler {
+    @Override
+    public BlockItem getItem() {
+        if (blockItem == null) {
+            blockItem = BlockItem.newBuilder()
+                    .setTransactionResult(createTransactionResult())
+                    .build();
+        }
+        return blockItem;
+    }
+
+    private TransactionResult createTransactionResult() {
+        return TransactionResult.newBuilder()
+                .setStatus(ResponseCodeEnum.SUCCESS)
+                .setTransferList(createTransferList())
+                .addTokenTransferLists(createTokenTransferList())
+                .setConsensusTimestamp(getTimestamp())
+                .build();
+    }
+
+    private TransferList createTransferList() {
+        long creditAccount = generateRandomValue(1, 100);
+        long debitAccount = generateRandomValue(1, 100);
+        long amount = generateRandomValue(100, 200);
+
+        return TransferList.newBuilder()
+                .addAccountAmounts(createAccountAmount(creditAccount, -amount))
+                .addAccountAmounts(createAccountAmount(debitAccount, amount))
+                .build();
+    }
+
+    private AccountAmount createAccountAmount(long accountNum, long accountAmount) {
+        Preconditions.requirePositive(accountNum);
+        // todo(700) Add support for non-zero shard/realm entity
+        return AccountAmount.newBuilder()
+                .setAccountID(AccountID.newBuilder()
+                        .setRealmNum(0)
+                        .setShardNum(0)
+                        .setAccountNum(accountNum)
+                        .build())
+                .setAmount(accountAmount)
+                .build();
+    }
+
+    private TokenTransferList createTokenTransferList() {
+        long tokenId = generateRandomValue(1, 100);
+        long creditAccount = generateRandomValue(1, 100);
+        long debitAccount = generateRandomValue(1, 100);
+        long amount = generateRandomValue(100, 200);
+
+        return TokenTransferList.newBuilder()
+                .setToken(TokenID.newBuilder().setRealmNum(0).setShardNum(0).setTokenNum(tokenId))
+                .addTransfers(createAccountAmount(creditAccount, -amount))
+                .addTransfers(createAccountAmount(debitAccount, amount))
+                .build();
+    }
+}

--- a/simulator/src/main/java/module-info.java
+++ b/simulator/src/main/java/module-info.java
@@ -21,6 +21,7 @@ module com.hedera.block.simulator {
     requires com.swirlds.config.api;
     requires com.swirlds.config.extensions;
     requires com.swirlds.metrics.api;
+    requires com.google.protobuf;
     requires dagger;
     requires io.grpc.stub;
     requires io.grpc;

--- a/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
@@ -51,6 +51,10 @@ class SimulatorMappedConfigSourceInitializerTest {
 
         // Block generator configuration
         new ConfigMapping("generator.generationMode", "GENERATOR_GENERATION_MODE"),
+        new ConfigMapping("generator.minEventsPerBlock", "GENERATOR_MIN_EVENTS_PER_BLOCK"),
+        new ConfigMapping("generator.maxEventsPerBlock", "GENERATOR_MAX_EVENTS_PER_BLOCK"),
+        new ConfigMapping("generator.minTransactionsPerEvent", "GENERATOR_MIN_TRANSACTIONS_PER_EVENT"),
+        new ConfigMapping("generator.maxTransactionsPerEvent", "GENERATOR_MAX_TRANSACTIONS_PER_EVENT"),
         new ConfigMapping("generator.folderRootPath", "GENERATOR_FOLDER_ROOT_PATH"),
         new ConfigMapping("generator.managerImplementation", "GENERATOR_MANAGER_IMPLEMENTATION"),
         new ConfigMapping("generator.paddedLength", "GENERATOR_PADDED_LENGTH"),

--- a/simulator/src/test/java/com/hedera/block/simulator/config/data/BlockStreamConfigTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/data/BlockStreamConfigTest.java
@@ -161,7 +161,7 @@ class BlockStreamConfigTest {
     void testGenerationModeNonDirDoesNotCheckFolderExistence() {
         // Setup a non-existent folder path but with a generation mode that is not DIR
         String folderRootPath = "/non/existent/path/to/blocks";
-        GenerationMode generationMode = GenerationMode.ADHOC;
+        GenerationMode generationMode = GenerationMode.CRAFT;
 
         // No exception should be thrown because generation mode is not DIR
         BlockGeneratorConfig config = getBlockGeneratorConfigBuilder()
@@ -171,6 +171,6 @@ class BlockStreamConfigTest {
 
         // Verify that the configuration was created successfully
         assertEquals(folderRootPath, config.folderRootPath());
-        assertEquals(GenerationMode.ADHOC, config.generationMode());
+        assertEquals(GenerationMode.CRAFT, config.generationMode());
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/config/types/GenerationModeTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/types/GenerationModeTest.java
@@ -11,7 +11,7 @@ class GenerationModeTest {
     void testGenerationMode() {
         GenerationMode mode = GenerationMode.DIR;
         assertEquals(GenerationMode.DIR, mode);
-        mode = GenerationMode.ADHOC;
-        assertEquals(GenerationMode.ADHOC, mode);
+        mode = GenerationMode.CRAFT;
+        assertEquals(GenerationMode.CRAFT, mode);
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManagerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManagerTest.java
@@ -57,7 +57,7 @@ class BlockAsDirBlockStreamManagerTest {
 
     private BlockStreamManager getBlockAsDirBlockStreamManager(String rootFolder) {
         final BlockGeneratorConfig blockGeneratorConfig = new BlockGeneratorConfig(
-                GenerationMode.DIR, rootFolder, "BlockAsDirBlockStreamManager", 36, ".blk", 0, 0);
+                GenerationMode.DIR, 1, 10, 1, 10, rootFolder, "BlockAsDirBlockStreamManager", 36, ".blk", 0, 0);
         final BlockStreamManager blockStreamManager = new BlockAsDirBlockStreamManager(blockGeneratorConfig);
         blockStreamManager.init();
         return blockStreamManager;

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/CraftBlockStreamManagerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/CraftBlockStreamManagerTest.java
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
+import com.hedera.block.simulator.config.types.GenerationMode;
+import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
+import com.hedera.hapi.block.stream.protoc.Block;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class CraftBlockStreamManagerTest {
+    private BlockGeneratorConfig mockConfig;
+    private CraftBlockStreamManager manager;
+
+    @BeforeEach
+    void setUp() {
+        mockConfig = Mockito.mock(BlockGeneratorConfig.class);
+        Mockito.when(mockConfig.generationMode()).thenReturn(GenerationMode.CRAFT);
+        Mockito.when(mockConfig.startBlockNumber()).thenReturn(1);
+        Mockito.when(mockConfig.minEventsPerBlock()).thenReturn(1);
+        Mockito.when(mockConfig.maxEventsPerBlock()).thenReturn(3);
+        Mockito.when(mockConfig.minTransactionsPerEvent()).thenReturn(1);
+        Mockito.when(mockConfig.maxTransactionsPerEvent()).thenReturn(2);
+
+        manager = new CraftBlockStreamManager(mockConfig);
+    }
+
+    @Test
+    void testConstructorNullConfig() {
+        assertThrows(NullPointerException.class, () -> new CraftBlockStreamManager(null));
+    }
+
+    @Test
+    void testGetGenerationMode() {
+        assertEquals(GenerationMode.CRAFT, manager.getGenerationMode());
+    }
+
+    @Test
+    void testGetNextBlockItem() {
+        assertThrows(UnsupportedOperationException.class, () -> manager.getNextBlockItem());
+    }
+
+    @Test
+    void testGetNextBlock() throws IOException, BlockSimulatorParsingException {
+        Block block = manager.getNextBlock();
+        assertNotNull(block);
+        assertTrue(block.getItemsCount() > 0);
+
+        // Each block should have at least:
+        // 1 block header + 1 event header + 1 transaction + 1 result + 1 proof
+        assertTrue(block.getItemsCount() >= 5);
+    }
+
+    @Test
+    void testMultipleBlockGeneration() throws IOException, BlockSimulatorParsingException {
+        Block block1 = manager.getNextBlock();
+        Block block2 = manager.getNextBlock();
+
+        assertNotNull(block1);
+        assertNotNull(block2);
+        assertNotEquals(0, block1.getItemsCount());
+        assertNotEquals(0, block2.getItemsCount());
+    }
+
+    @Test
+    void testBlockGenerationWithCustomValues() throws IOException, BlockSimulatorParsingException {
+        Mockito.when(mockConfig.minEventsPerBlock()).thenReturn(3);
+        Mockito.when(mockConfig.maxEventsPerBlock()).thenReturn(4);
+        Mockito.when(mockConfig.minTransactionsPerEvent()).thenReturn(2);
+        Mockito.when(mockConfig.maxTransactionsPerEvent()).thenReturn(3);
+
+        manager = new CraftBlockStreamManager(mockConfig);
+        Block block = manager.getNextBlock();
+
+        // We expect at least:
+        // 1 block header + (3 events * (1 header + 2 transactions * 2 items)) + 1 proof = 17
+        assertTrue(block.getItemsCount() >= 17);
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/GeneratorInjectionModuleTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/GeneratorInjectionModuleTest.java
@@ -14,8 +14,11 @@ class GeneratorInjectionModuleTest {
     @Test
     void providesBlockStreamManager_AsFileLargeDataSets() throws IOException {
 
-        BlockGeneratorConfig blockGeneratorConfig = TestUtils.getTestConfiguration(
-                        Map.of("generator.managerImplementation", "BlockAsFileLargeDataSets"))
+        BlockGeneratorConfig blockGeneratorConfig = TestUtils.getTestConfiguration(Map.of(
+                        "generator.generationMode",
+                        "DIR",
+                        "generator.managerImplementation",
+                        "BlockAsFileLargeDataSets"))
                 .getConfigData(BlockGeneratorConfig.class);
 
         BlockStreamManager blockStreamManager =
@@ -27,6 +30,8 @@ class GeneratorInjectionModuleTest {
     @Test
     void providesBlockStreamManager_AsFile() throws IOException {
         BlockGeneratorConfig blockGeneratorConfig = TestUtils.getTestConfiguration(Map.of(
+                        "generator.generationMode",
+                        "DIR",
                         "generator.managerImplementation",
                         "BlockAsFileBlockStreamManager",
                         "generator.folderRootPath",
@@ -41,8 +46,11 @@ class GeneratorInjectionModuleTest {
 
     @Test
     void providesBlockStreamManager_AsDir() throws IOException {
-        BlockGeneratorConfig blockGeneratorConfig = TestUtils.getTestConfiguration(
-                        Map.of("generator.managerImplementation", "BlockAsDirBlockStreamManager"))
+        BlockGeneratorConfig blockGeneratorConfig = TestUtils.getTestConfiguration(Map.of(
+                        "generator.generationMode",
+                        "DIR",
+                        "generator.managerImplementation",
+                        "BlockAsDirBlockStreamManager"))
                 .getConfigData(BlockGeneratorConfig.class);
 
         BlockStreamManager blockStreamManager =
@@ -55,13 +63,30 @@ class GeneratorInjectionModuleTest {
 
     @Test
     void providesBlockStreamManager_default() throws IOException {
-        BlockGeneratorConfig blockGeneratorConfig = TestUtils.getTestConfiguration(
-                        Map.of("generator.managerImplementation", "", "generator.folderRootPath", ""))
+        BlockGeneratorConfig blockGeneratorConfig = TestUtils.getTestConfiguration(Map.of(
+                        "generator.generationMode",
+                        "DIR",
+                        "generator.managerImplementation",
+                        "",
+                        "generator.folderRootPath",
+                        ""))
                 .getConfigData(BlockGeneratorConfig.class);
 
         BlockStreamManager blockStreamManager =
                 GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig);
 
         assertEquals(blockStreamManager.getClass().getName(), BlockAsFileBlockStreamManager.class.getName());
+    }
+
+    @Test
+    void providesBlockStreamManager_asCraft() throws IOException {
+        BlockGeneratorConfig blockGeneratorConfig = TestUtils.getTestConfiguration(
+                        Map.of("generator.generationMode", "CRAFT"))
+                .getConfigData(BlockGeneratorConfig.class);
+
+        BlockStreamManager blockStreamManager =
+                GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig);
+
+        assertEquals(blockStreamManager.getClass().getName(), CraftBlockStreamManager.class.getName());
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/itemhandler/AbstractBlockItemHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/itemhandler/AbstractBlockItemHandlerTest.java
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator.itemhandler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
+import com.hedera.hapi.block.BlockItemUnparsed;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hederahashgraph.api.proto.java.SemanticVersion;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class AbstractBlockItemHandlerTest {
+
+    private TestBlockItemHandler handler;
+
+    // Concrete implementation for testing abstract class
+    private static class TestBlockItemHandler extends AbstractBlockItemHandler {
+        public TestBlockItemHandler() {
+            this.blockItem = BlockItem.newBuilder().build();
+        }
+
+        // Expose protected methods for testing
+        public Timestamp getTestTimestamp() {
+            return getTimestamp();
+        }
+
+        public SemanticVersion getTestSemanticVersion() {
+            return getSemanticVersion();
+        }
+
+        public long generateTestRandomValue(long min, long max) {
+            return generateRandomValue(min, max);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        handler = new TestBlockItemHandler();
+    }
+
+    @Test
+    void testGetItem() {
+        BlockItem item = handler.getItem();
+        assertNotNull(item);
+    }
+
+    @Test
+    void testUnparseBlockItem() throws BlockSimulatorParsingException {
+        BlockItemUnparsed unparsed = handler.unparseBlockItem();
+        assertNotNull(unparsed);
+    }
+
+    @Test
+    void testGetTimestamp() {
+        Timestamp timestamp = handler.getTestTimestamp();
+        assertNotNull(timestamp);
+
+        // Timestamp should be recent (within last minute)
+        long currentTimeSeconds = System.currentTimeMillis() / 1000;
+        assertTrue(Math.abs(currentTimeSeconds - timestamp.getSeconds()) < 60);
+
+        // Nanos should be 0 as per implementation
+        assertEquals(0, timestamp.getNanos());
+    }
+
+    @Test
+    void testGetSemanticVersion() {
+        SemanticVersion version = handler.getTestSemanticVersion();
+        assertNotNull(version);
+        assertEquals(0, version.getMajor());
+        assertEquals(1, version.getMinor());
+        assertEquals(0, version.getPatch());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"1, 10", "1, 1000", "100, 200", "1, 2"})
+    void testGenerateRandomValue(long min, long max) {
+        for (int i = 0; i < 100; i++) { // Test multiple times to ensure range
+            long value = handler.generateTestRandomValue(min, max);
+            assertTrue(value >= min);
+            assertTrue(value < max);
+        }
+    }
+
+    @Test
+    void testGenerateRandomValueWithEqualMinMax() {
+        long min = 5;
+        long max = 5;
+        assertThrows(IllegalArgumentException.class, () -> handler.generateTestRandomValue(min, max));
+    }
+
+    @Test
+    void testGenerateRandomValueWithNegativeMin() {
+        assertThrows(IllegalArgumentException.class, () -> handler.generateTestRandomValue(-1, 10));
+    }
+
+    @Test
+    void testGenerateRandomValueWithNegativeMax() {
+        assertThrows(IllegalArgumentException.class, () -> handler.generateTestRandomValue(1, -10));
+    }
+
+    @Test
+    void testGenerateRandomValueWithMinGreaterThanMax() {
+        assertThrows(IllegalArgumentException.class, () -> handler.generateTestRandomValue(10, 5));
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/itemhandler/BlockHeaderHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/itemhandler/BlockHeaderHandlerTest.java
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator.itemhandler;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hederahashgraph.api.proto.java.BlockHashAlgorithm;
+import org.junit.jupiter.api.Test;
+
+class BlockHeaderHandlerTest {
+
+    private final byte[] previousBlockHash = new byte[32];
+    private final long blockNumber = 1L;
+
+    @Test
+    void testConstructorWithNullHash() {
+        assertThrows(NullPointerException.class, () -> new BlockHeaderHandler(null, blockNumber));
+    }
+
+    @Test
+    void testGetItem() {
+        BlockHeaderHandler handler = new BlockHeaderHandler(previousBlockHash, blockNumber);
+        BlockItem item = handler.getItem();
+
+        assertNotNull(item);
+        assertTrue(item.hasBlockHeader());
+
+        BlockHeader header = item.getBlockHeader();
+        assertEquals(BlockHashAlgorithm.SHA2_384, header.getHashAlgorithm());
+        assertEquals(blockNumber, header.getNumber());
+        assertArrayEquals(previousBlockHash, header.getPreviousBlockHash().toByteArray());
+        assertNotNull(header.getFirstTransactionConsensusTime());
+        assertNotNull(header.getHapiProtoVersion());
+        assertNotNull(header.getSoftwareVersion());
+    }
+
+    @Test
+    void testGetItemCaching() {
+        BlockHeaderHandler handler = new BlockHeaderHandler(previousBlockHash, blockNumber);
+        BlockItem item1 = handler.getItem();
+        BlockItem item2 = handler.getItem();
+
+        assertSame(item1, item2, "getItem should return cached instance");
+    }
+
+    @Test
+    void testSemanticVersions() {
+        BlockHeaderHandler handler = new BlockHeaderHandler(previousBlockHash, blockNumber);
+        BlockHeader header = handler.getItem().getBlockHeader();
+
+        assertEquals(0, header.getHapiProtoVersion().getMajor());
+        assertEquals(1, header.getHapiProtoVersion().getMinor());
+        assertEquals(0, header.getHapiProtoVersion().getPatch());
+
+        assertEquals(0, header.getSoftwareVersion().getMajor());
+        assertEquals(1, header.getSoftwareVersion().getMinor());
+        assertEquals(0, header.getSoftwareVersion().getPatch());
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/itemhandler/BlockProofHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/itemhandler/BlockProofHandlerTest.java
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator.itemhandler;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.block.common.hasher.StreamingTreeHasher;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hedera.hapi.block.stream.protoc.BlockProof;
+import org.junit.jupiter.api.Test;
+
+class BlockProofHandlerTest {
+
+    private final byte[] previousBlockHash = new byte[StreamingTreeHasher.HASH_LENGTH];
+    private final byte[] currentBlockHash = new byte[StreamingTreeHasher.HASH_LENGTH];
+    private final long blockNumber = 1L;
+
+    @Test
+    void testConstructorWithNullPreviousHash() {
+        assertThrows(NullPointerException.class, () -> new BlockProofHandler(null, currentBlockHash, blockNumber));
+    }
+
+    @Test
+    void testConstructorWithNullCurrentHash() {
+        assertThrows(NullPointerException.class, () -> new BlockProofHandler(previousBlockHash, null, blockNumber));
+    }
+
+    @Test
+    void testGetItem() {
+        BlockProofHandler handler = new BlockProofHandler(previousBlockHash, currentBlockHash, blockNumber);
+        BlockItem item = handler.getItem();
+
+        assertNotNull(item);
+        assertTrue(item.hasBlockProof());
+
+        BlockProof proof = item.getBlockProof();
+        assertEquals(blockNumber, proof.getBlock());
+        assertArrayEquals(previousBlockHash, proof.getPreviousBlockRootHash().toByteArray());
+        assertNotNull(proof.getBlockSignature());
+        assertFalse(proof.getBlockSignature().isEmpty());
+    }
+
+    @Test
+    void testGetItemCaching() {
+        BlockProofHandler handler = new BlockProofHandler(previousBlockHash, currentBlockHash, blockNumber);
+        BlockItem item1 = handler.getItem();
+        BlockItem item2 = handler.getItem();
+
+        assertSame(item1, item2, "getItem should return cached instance");
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/itemhandler/EventHeaderHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/itemhandler/EventHeaderHandlerTest.java
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator.itemhandler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hapi.block.stream.input.protoc.EventHeader;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hedera.hapi.platform.event.legacy.EventCore;
+import org.junit.jupiter.api.Test;
+
+class EventHeaderHandlerTest {
+
+    @Test
+    void testGetItem() {
+        EventHeaderHandler handler = new EventHeaderHandler();
+        BlockItem item = handler.getItem();
+
+        assertNotNull(item);
+        assertTrue(item.hasEventHeader());
+
+        EventHeader header = item.getEventHeader();
+        assertNotNull(header.getEventCore());
+
+        EventCore core = header.getEventCore();
+        assertTrue(core.getCreatorNodeId() >= 1 && core.getCreatorNodeId() < 32);
+        assertNotNull(core.getVersion());
+    }
+
+    @Test
+    void testGetItemCaching() {
+        EventHeaderHandler handler = new EventHeaderHandler();
+        BlockItem item1 = handler.getItem();
+        BlockItem item2 = handler.getItem();
+
+        assertSame(item1, item2, "getItem should return cached instance");
+    }
+
+    @Test
+    void testSemanticVersion() {
+        EventHeaderHandler handler = new EventHeaderHandler();
+        EventCore core = handler.getItem().getEventHeader().getEventCore();
+
+        assertEquals(0, core.getVersion().getMajor());
+        assertEquals(1, core.getVersion().getMinor());
+        assertEquals(0, core.getVersion().getPatch());
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/itemhandler/EventTransactionHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/itemhandler/EventTransactionHandlerTest.java
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator.itemhandler;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hedera.hapi.platform.event.legacy.EventTransaction;
+import org.junit.jupiter.api.Test;
+
+class EventTransactionHandlerTest {
+
+    @Test
+    void testGetItem() {
+        EventTransactionHandler handler = new EventTransactionHandler();
+        BlockItem item = handler.getItem();
+
+        assertNotNull(item);
+        assertTrue(item.hasEventTransaction());
+
+        EventTransaction transaction = item.getEventTransaction();
+        assertNotNull(transaction);
+    }
+
+    @Test
+    void testGetItemCaching() {
+        EventTransactionHandler handler = new EventTransactionHandler();
+        BlockItem item1 = handler.getItem();
+        BlockItem item2 = handler.getItem();
+
+        assertSame(item1, item2, "getItem should return cached instance");
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/itemhandler/TransactionResultHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/itemhandler/TransactionResultHandlerTest.java
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.simulator.generator.itemhandler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hapi.block.stream.output.protoc.TransactionResult;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hederahashgraph.api.proto.java.AccountAmount;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenTransferList;
+import com.hederahashgraph.api.proto.java.TransferList;
+import org.junit.jupiter.api.Test;
+
+class TransactionResultHandlerTest {
+
+    @Test
+    void testGetItem() {
+        TransactionResultHandler handler = new TransactionResultHandler();
+        BlockItem item = handler.getItem();
+
+        assertNotNull(item);
+        assertTrue(item.hasTransactionResult());
+
+        TransactionResult result = item.getTransactionResult();
+        assertEquals(ResponseCodeEnum.SUCCESS, result.getStatus());
+        assertNotNull(result.getConsensusTimestamp());
+        assertNotNull(result.getTransferList());
+        assertEquals(1, result.getTokenTransferListsCount());
+    }
+
+    @Test
+    void testGetItemCaching() {
+        TransactionResultHandler handler = new TransactionResultHandler();
+        BlockItem item1 = handler.getItem();
+        BlockItem item2 = handler.getItem();
+
+        assertSame(item1, item2, "getItem should return cached instance");
+    }
+
+    @Test
+    void testTransferList() {
+        TransactionResultHandler handler = new TransactionResultHandler();
+        TransferList transferList = handler.getItem().getTransactionResult().getTransferList();
+
+        assertEquals(2, transferList.getAccountAmountsCount());
+
+        AccountAmount debit = transferList.getAccountAmounts(0);
+        AccountAmount credit = transferList.getAccountAmounts(1);
+
+        assertTrue(debit.getAmount() < 0);
+        assertTrue(credit.getAmount() > 0);
+        assertEquals(-debit.getAmount(), credit.getAmount());
+
+        assertTrue(debit.getAccountID().getAccountNum() >= 1);
+        assertTrue(debit.getAccountID().getAccountNum() <= 100);
+        assertTrue(credit.getAccountID().getAccountNum() >= 1);
+        assertTrue(credit.getAccountID().getAccountNum() <= 100);
+    }
+
+    @Test
+    void testTokenTransferList() {
+        TransactionResultHandler handler = new TransactionResultHandler();
+        TokenTransferList tokenTransfers =
+                handler.getItem().getTransactionResult().getTokenTransferLists(0);
+
+        assertNotNull(tokenTransfers.getToken());
+        assertTrue(tokenTransfers.getToken().getTokenNum() >= 1);
+        assertTrue(tokenTransfers.getToken().getTokenNum() <= 100);
+
+        assertEquals(2, tokenTransfers.getTransfersCount());
+
+        AccountAmount debit = tokenTransfers.getTransfers(0);
+        AccountAmount credit = tokenTransfers.getTransfers(1);
+
+        assertTrue(debit.getAmount() < 0);
+        assertTrue(credit.getAmount() > 0);
+        assertEquals(-debit.getAmount(), credit.getAmount());
+
+        assertTrue(debit.getAccountID().getAccountNum() >= 1);
+        assertTrue(debit.getAccountID().getAccountNum() <= 100);
+        assertTrue(credit.getAccountID().getAccountNum() >= 1);
+        assertTrue(credit.getAccountID().getAccountNum() <= 100);
+    }
+}


### PR DESCRIPTION
## Reviewer Notes

We need to include these 2 PRs as part of the `0.5.0` release, since they are needed for the **Long Term K8 Testing**

needed to release  a `0.5.0-rc2`

