### PR TITLE
feat: add unverified blocks root

### DIFF
--- a/common/src/test/java/com/hedera/block/common/CommonsTestUtility.java
+++ b/common/src/test/java/com/hedera/block/common/CommonsTestUtility.java
@@ -327,7 +327,7 @@ public final class CommonsTestUtility {
                 Arguments.of(-1_000_000_000));
     }
 
-    // @todo(517) add 0 and MIN MAX values here as well, also, make the same logic to test for longs as well
+    // @todo(713) add 0 and MIN MAX values here as well, also, make the same logic to test for longs as well
     public static Stream<Arguments> nonPowersOf10() {
         return Stream.of(
                 Arguments.of(2),

--- a/server/src/main/java/com/hedera/block/server/Constants.java
+++ b/server/src/main/java/com/hedera/block/server/Constants.java
@@ -3,12 +3,6 @@ package com.hedera.block.server;
 
 /** Constants used in the BlockNode service. */
 public final class Constants {
-    /** Constant mapped to the semantic name of the Block Node live root directory */
-    public static final String BLOCK_NODE_LIVE_ROOT_DIRECTORY_SEMANTIC_NAME = "Block Node Live Root Directory";
-
-    /** Constant mapped to the semantic name of the Block Node archive root directory */
-    public static final String BLOCK_NODE_ARCHIVE_ROOT_DIRECTORY_SEMANTIC_NAME = "Block Node Archive Root Directory";
-
     /** Constant mapped to PbjProtocolProvider.CONFIG_NAME in the PBJ Helidon Plugin */
     public static final String PBJ_PROTOCOL_PROVIDER_CONFIG_NAME = "pbj";
 
@@ -29,12 +23,6 @@ public final class Constants {
 
     /** Constant defining the block file extension */
     public static final String BLOCK_FILE_EXTENSION = ".blk";
-
-    /** Constant defining the unverified block file extension */
-    public static final String UNVERIFIED_BLOCK_FILE_EXTENSION = ".blk.unverified";
-
-    /** Constant defining the compressed file extension */
-    public static final String COMPRESSED_FILE_EXTENSION = ".zstd";
 
     /** Constant defining zip file extension */
     public static final String ZIP_FILE_EXTENSION = ".zip";

--- a/server/src/main/java/com/hedera/block/server/ack/AckHandler.java
+++ b/server/src/main/java/com/hedera/block/server/ack/AckHandler.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.ack;
 
+import com.hedera.block.server.persistence.StreamPersistenceHandlerImpl;
 import com.hedera.block.server.persistence.storage.write.BlockPersistenceResult;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -10,6 +11,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Responsible for sending Block Acknowledgements to the producer.
  */
 public interface AckHandler {
+    /**
+     * Register the persistence handler. Temporary solution due to lack of
+     * critical infrastructure. This should be removed as soon as architectural
+     * changes, which would allow us to publish results which would then be
+     * picked up, are implemented.
+     */
+    void registerPersistence(@NonNull final StreamPersistenceHandlerImpl persistence);
 
     /**
      * Called when we receive a "persistence" result.

--- a/server/src/main/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializer.java
+++ b/server/src/main/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializer.java
@@ -40,6 +40,7 @@ public final class ServerMappedConfigSourceInitializer {
             new ConfigMapping("persistence.storage.liveRootPath", "PERSISTENCE_STORAGE_LIVE_ROOT_PATH"),
             new ConfigMapping("persistence.storage.type", "PERSISTENCE_STORAGE_TYPE"),
             new ConfigMapping("persistence.storage.archiveGroupSize", "PERSISTENCE_STORAGE_ARCHIVE_GROUP_SIZE"),
+            new ConfigMapping("persistence.storage.unverifiedRootPath", "PERSISTENCE_STORAGE_UNVERIFIED_ROOT_PATH"),
 
             // Producer Config
             new ConfigMapping("producer.type", "PRODUCER_TYPE"),

--- a/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
@@ -154,6 +154,7 @@ public interface PersistenceInjectionModule {
     @Singleton
     static LocalBlockArchiver providesLocalBlockArchiver(
             @NonNull final PersistenceStorageConfig config, @NonNull final BlockPathResolver blockPathResolver) {
+        // @todo(740) allow for configurable executor for the archiver
         return new BlockAsLocalFileArchiver(config, blockPathResolver, Executors.newFixedThreadPool(5));
     }
 
@@ -176,6 +177,7 @@ public interface PersistenceInjectionModule {
             @NonNull final ServiceStatus serviceStatus,
             @NonNull final AckHandler ackHandler,
             @NonNull final AsyncBlockWriterFactory asyncBlockWriterFactory,
+            @NonNull final BlockPathResolver blockPathResolver,
             @NonNull final PersistenceStorageConfig persistenceStorageConfig,
             @NonNull final LocalBlockArchiver localBlockArchiver) {
         try {
@@ -188,6 +190,7 @@ public interface PersistenceInjectionModule {
                     asyncBlockWriterFactory,
                     Executors.newFixedThreadPool(5),
                     localBlockArchiver,
+                    blockPathResolver,
                     persistenceStorageConfig);
         } catch (final IOException e) {
             throw new UncheckedIOException(e);

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 public record PersistenceStorageConfig(
         @Loggable @ConfigProperty(defaultValue = "/opt/hashgraph/blocknode/data/live") Path liveRootPath,
         @Loggable @ConfigProperty(defaultValue = "/opt/hashgraph/blocknode/data/archive") Path archiveRootPath,
+        @Loggable @ConfigProperty(defaultValue = "/opt/hashgraph/blocknode/data/unverified") Path unverifiedRootPath,
         @Loggable @ConfigProperty(defaultValue = "BLOCK_AS_LOCAL_FILE") StorageType type,
         @Loggable @ConfigProperty(defaultValue = "ZSTD") CompressionType compression,
         @Loggable @ConfigProperty(defaultValue = "3") @Min(0) @Max(20) int compressionLevel,
@@ -35,8 +36,11 @@ public record PersistenceStorageConfig(
     public PersistenceStorageConfig {
         Objects.requireNonNull(liveRootPath);
         Objects.requireNonNull(archiveRootPath);
+        Objects.requireNonNull(unverifiedRootPath);
         Objects.requireNonNull(type);
         compression.verifyCompressionLevel(compressionLevel);
+        // @todo(742) verify that the group size has not changed once it has
+        //    been set initially
         Preconditions.requireGreaterOrEqual(
                 archiveGroupSize,
                 10,

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/archive/BlockAsLocalFileArchiver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/archive/BlockAsLocalFileArchiver.java
@@ -58,7 +58,7 @@ public final class BlockAsLocalFileArchiver implements LocalBlockArchiver {
         while ((completionResult = completionService.poll()) != null) {
             try {
                 if (completionResult.isCancelled()) {
-                    // @todo(517) when we have infrastructure for publishing
+                    // @todo(713) when we have infrastructure for publishing
                     //    results, we should do so
                 } else {
                     // We call get here to verify that the task has run to completion
@@ -69,7 +69,7 @@ public final class BlockAsLocalFileArchiver implements LocalBlockArchiver {
                     // The result should be the number of actual block items
                     // archived.
                     final long result = completionResult.get();
-                    // @todo(517) this is a good place to do some metrics
+                    // @todo(713) this is a good place to do some metrics
                     LOGGER.log(TRACE, "Archived [{0}] BlockFiles", result);
                 }
             } catch (final ExecutionException e) {
@@ -77,7 +77,7 @@ public final class BlockAsLocalFileArchiver implements LocalBlockArchiver {
                 // either a bug in the archiving task, or an unhandled case
                 throw new BlockArchivingException(e.getCause());
             } catch (final InterruptedException e) {
-                // @todo(517) What shall we do here? How to handle?
+                // @todo(713) What shall we do here? How to handle?
                 Thread.currentThread().interrupt();
             }
         }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/ArchiveBlockPath.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/ArchiveBlockPath.java
@@ -1,16 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.path;
 
+import com.hedera.block.common.utils.Preconditions;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.CompressionType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.Path;
+import java.util.Objects;
 
 /**
- * TODO: add documentation
+ * A record that represents a detailed path to a Block that is stored under the
+ * archive storage root.
  */
 public record ArchiveBlockPath(
         @NonNull Path dirPath,
         @NonNull String zipFileName,
         @NonNull String zipEntryName,
         @NonNull CompressionType compressionType,
-        long blockNumber) {}
+        long blockNumber) {
+    public ArchiveBlockPath {
+        Objects.requireNonNull(dirPath);
+        Objects.requireNonNull(zipFileName);
+        Objects.requireNonNull(zipEntryName);
+        Objects.requireNonNull(compressionType);
+        Preconditions.requireWhole(blockNumber);
+    }
+}

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockPathResolver.java
@@ -2,7 +2,6 @@
 package com.hedera.block.server.persistence.storage.path;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -40,18 +39,16 @@ public interface BlockPathResolver {
      * This method resolves the fs {@link Path} to a Block by a given input
      * number. This method does not guarantee that the returned {@link Path}
      * exists! This method is guaranteed to return a {@code non-null}
-     * {@link Path}. The Unverified Block File extension
-     * {@value com.hedera.block.server.Constants#UNVERIFIED_BLOCK_FILE_EXTENSION} is
-     * appended to the resolved Block path. No compression extension is appended
+     * {@link Path}. No compression extension is appended
      * to the file name. No other file extension is appended to the file name.
-     * The provided path is the raw resolved path to the Block inside the live
-     * root storage.
+     * The provided path is the raw resolved path to the Block inside the
+     * unverified root storage.
      * <br/>
      * <br/>
      * E.G. (illustrative example, actual path may vary):
      * <pre>
      *     If the blockNumber is 10, the resolved path will be:
-     *     <b>/path/to/live/block/storage/0.../1/0000000000000000010.blk.unverified</b>
+     *     <b>/path/to/unverified/block/storage/0000000000000000010.blk</b>
      * </pre>
      *
      * @param blockNumber to be resolved the path for
@@ -117,8 +114,8 @@ public interface BlockPathResolver {
      * This method attempts to find a Block by a given number under the
      * persistence storage archive. This method will ONLY check for
      * ARCHIVED persisted Blocks. Unverified Blocks cannot be archived, so it is
-     * inferred that all Blocks, found in the are verified. If the Block is
-     * found, the method returns a non-empty {@link Optional} of
+     * inferred that all Blocks, found under the archive root are verified.
+     * If the Block is found, the method returns a non-empty {@link Optional} of
      * {@link ArchiveBlockPath}, else an empty {@link Optional} is returned.
      *
      * @param blockNumber to be resolved the path for
@@ -127,6 +124,19 @@ public interface BlockPathResolver {
      */
     @NonNull
     Optional<ArchiveBlockPath> findArchivedBlock(final long blockNumber);
+
+    /**
+     * This method attempts to find an UNVERIFIED Block by a given number under
+     * the persistence storage unverified root. If the Block is found, the method
+     * returns a non-empty {@link Optional} of {@link UnverifiedBlockPath}, else
+     * an empty {@link Optional} is returned.
+     *
+     * @param blockNumber to be resolved the path for
+     * @return an {@link Optional} of {@link UnverifiedBlockPath} if the block is found
+     * @throws IllegalArgumentException if the blockNumber IS NOT a whole number
+     */
+    @NonNull
+    Optional<UnverifiedBlockPath> findUnverifiedBlock(final long blockNumber);
 
     /**
      * This method attempts to find a VERIFIED Block by a given number under the
@@ -139,18 +149,4 @@ public interface BlockPathResolver {
      * @throws IllegalArgumentException if the blockNumber IS NOT a whole number
      */
     boolean existsVerifiedBlock(final long blockNumber);
-
-    /**
-     * This method marks a Block as verified. The Block is identified by the
-     * given block number. The method will attempt to find the unverified Block
-     * under the live root storage, and if found, it will mark it as verified.
-     * If the Block is found under the archive storage, it will be marked as
-     * verified. If the unverified Block is not found under the live root
-     * storage,the method will do nothing.
-     *
-     * @param blockNumber to be marked as verified
-     * @throws IOException when failing to mark a block as verified
-     * @throws IllegalArgumentException if the blockNumber IS NOT a whole number
-     */
-    void markVerified(final long blockNumber) throws IOException;
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolver.java
@@ -70,18 +70,20 @@ public final class NoOpBlockPathResolver implements BlockPathResolver {
     }
 
     /**
+     * No-op resolver. Does nothing and always returns an empty optional.
+     * No preconditions check also.
+     */
+    @NonNull
+    @Override
+    public Optional<UnverifiedBlockPath> findUnverifiedBlock(final long blockNumber) {
+        return Optional.empty();
+    }
+
+    /**
      * No-op resolver. Does nothing and always returns false.
      */
     @Override
     public boolean existsVerifiedBlock(final long blockNumber) {
         return false;
-    }
-
-    /**
-     * No-op resolver. Does nothing.
-     */
-    @Override
-    public void markVerified(final long blockNumber) {
-        // no-op
     }
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/UnverifiedBlockPath.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/UnverifiedBlockPath.java
@@ -8,15 +8,15 @@ import java.nio.file.Path;
 import java.util.Objects;
 
 /**
- * A record that represents a detailed path to a Block that is stored under the
- * live storage root.
+ * A record that represents a detailed path to an unverified Block that is
+ * stored under the unverified storage root.
  */
-public record LiveBlockPath(
+public record UnverifiedBlockPath(
         long blockNumber,
         @NonNull Path dirPath,
         @NonNull String blockFileName,
         @NonNull CompressionType compressionType) {
-    public LiveBlockPath {
+    public UnverifiedBlockPath {
         Preconditions.requireWhole(blockNumber);
         Objects.requireNonNull(dirPath);
         Objects.requireNonNull(blockFileName);

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReader.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReader.java
@@ -71,6 +71,7 @@ public final class BlockAsLocalFileReader implements LocalBlockReader<BlockUnpar
                 final ArchiveBlockPath archiveBlockPath = optArchivedBlock.get();
                 final Path zipFilePath = archiveBlockPath.dirPath().resolve(archiveBlockPath.zipFileName());
                 final BlockUnparsed value;
+                // @todo(741) update reader to use zipfs to read blocks
                 try (final ZipFile zipFile = new ZipFile(zipFilePath.toFile())) {
                     final ZipEntry entry = zipFile.getEntry(archiveBlockPath.zipEntryName());
                     final InputStream in = zipFile.getInputStream(entry);

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/remove/BlockRemover.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/remove/BlockRemover.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 /** The BlockRemover interface defines the contract for removing a block from storage. */
 public interface BlockRemover {
     /**
-     * Remove an unverified block under the live root with the given block
+     * Remove an unverified block under the unverified root with the given block
      * number.
      *
      * @param blockNumber the block number of the block to remove
@@ -14,5 +14,5 @@ public interface BlockRemover {
      * @throws IOException when failing to remove a block
      * @throws IllegalArgumentException if the blockNumber IS NOT a whole number
      */
-    boolean removeLiveUnverified(final long blockNumber) throws IOException;
+    boolean removeUnverified(final long blockNumber) throws IOException;
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/remove/NoOpBlockRemover.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/remove/NoOpBlockRemover.java
@@ -24,7 +24,7 @@ public final class NoOpBlockRemover implements BlockRemover {
      * check also.
      */
     @Override
-    public boolean removeLiveUnverified(final long blockNumber) {
+    public boolean removeUnverified(final long blockNumber) {
         return false;
     }
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/AsyncNoOpWriter.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/AsyncNoOpWriter.java
@@ -73,7 +73,7 @@ final class AsyncNoOpWriter implements AsyncBlockWriter {
                     }
                 }
             } catch (final InterruptedException e) {
-                // @todo(545) is this the proper handling here?
+                // @todo(713) is this the proper handling here?
                 LOGGER.log(
                         Level.ERROR,
                         "Interrupted while waiting for next block item for block [%d]".formatted(blockNumber));

--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -64,6 +64,7 @@ class ServerMappedConfigSourceInitializerTest {
         new ConfigMapping("persistence.storage.liveRootPath", "PERSISTENCE_STORAGE_LIVE_ROOT_PATH"),
         new ConfigMapping("persistence.storage.type", "PERSISTENCE_STORAGE_TYPE"),
         new ConfigMapping("persistence.storage.archiveGroupSize", "PERSISTENCE_STORAGE_ARCHIVE_GROUP_SIZE"),
+        new ConfigMapping("persistence.storage.unverifiedRootPath", "PERSISTENCE_STORAGE_UNVERIFIED_ROOT_PATH"),
 
         // Producer Config
         new ConfigMapping("producer.type", "PRODUCER_TYPE"),

--- a/server/src/test/java/com/hedera/block/server/config/logging/ConfigurationLoggingImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/logging/ConfigurationLoggingImplTest.java
@@ -25,7 +25,7 @@ public class ConfigurationLoggingImplTest {
         final ConfigurationLoggingImpl configurationLogging = new ConfigurationLoggingImpl(configuration);
         final Map<String, Object> config = configurationLogging.collectConfig(configuration);
         assertNotNull(config);
-        assertEquals(34, config.size());
+        assertEquals(35, config.size());
 
         for (Map.Entry<String, Object> entry : config.entrySet()) {
             String value = entry.getValue().toString();
@@ -42,7 +42,7 @@ public class ConfigurationLoggingImplTest {
         final ConfigurationLoggingImpl configurationLogging = new ConfigurationLoggingImpl(configuration);
         final Map<String, Object> config = configurationLogging.collectConfig(configuration);
         assertNotNull(config);
-        assertEquals(36, config.size());
+        assertEquals(37, config.size());
 
         assertEquals("*****", config.get("test.secret").toString());
         assertEquals("", config.get("test.emptySecret").toString());

--- a/server/src/test/java/com/hedera/block/server/grpc/BlockAccessServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/grpc/BlockAccessServiceTest.java
@@ -51,7 +51,7 @@ class BlockAccessServiceTest {
     private ServiceStatus serviceStatus;
 
     @TempDir
-    private Path testLiveRootPath;
+    private Path testTempDir;
 
     private BlockNodeContext blockNodeContext;
     private PersistenceStorageConfig testConfig;
@@ -59,14 +59,13 @@ class BlockAccessServiceTest {
 
     @BeforeEach
     void setUp() throws IOException {
+        final Path testLiveRootPath = testTempDir.resolve("live");
         blockNodeContext = TestConfigUtil.getTestBlockNodeContext(
                 Map.of(PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY, testLiveRootPath.toString()));
         testConfig = blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
-
-        blockAccessService = new PbjBlockAccessServiceProxy(serviceStatus, blockReader, blockNodeContext);
-
         final Path testConfigLiveRootPath = testConfig.liveRootPath();
         assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath);
+        blockAccessService = new PbjBlockAccessServiceProxy(serviceStatus, blockReader, blockNodeContext);
     }
 
     @Test

--- a/server/src/test/java/com/hedera/block/server/manager/AckHandlerInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/manager/AckHandlerInjectionModuleTest.java
@@ -35,6 +35,7 @@ class AckHandlerInjectionModuleTest {
         final PersistenceStorageConfig persistenceStorageConfig = new PersistenceStorageConfig(
                 Path.of(""),
                 Path.of(""),
+                Path.of(""),
                 PersistenceStorageConfig.StorageType.BLOCK_AS_LOCAL_FILE,
                 PersistenceStorageConfig.CompressionType.NONE,
                 0,

--- a/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
@@ -154,6 +154,7 @@ class PersistenceInjectionModuleTest {
     void testProvidesBlockPathResolver(final StorageType storageType) {
         lenient().when(persistenceStorageConfigMock.liveRootPath()).thenReturn(testLiveRootPath);
         lenient().when(persistenceStorageConfigMock.archiveRootPath()).thenReturn(testLiveRootPath);
+        lenient().when(persistenceStorageConfigMock.unverifiedRootPath()).thenReturn(testLiveRootPath);
         lenient().when(persistenceStorageConfigMock.archiveGroupSize()).thenReturn(10);
         when(persistenceStorageConfigMock.type()).thenReturn(storageType);
 
@@ -218,6 +219,7 @@ class PersistenceInjectionModuleTest {
         final BlockNodeContext blockNodeContext = TestConfigUtil.getTestBlockNodeContext();
         when(persistenceStorageConfigMock.liveRootPath()).thenReturn(testLiveRootPath);
         when(persistenceStorageConfigMock.archiveRootPath()).thenReturn(testLiveRootPath);
+        when(persistenceStorageConfigMock.unverifiedRootPath()).thenReturn(testLiveRootPath);
         // Call the method under test
         final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> streamVerifier =
                 new StreamPersistenceHandlerImpl(
@@ -229,6 +231,7 @@ class PersistenceInjectionModuleTest {
                         asyncBlockWriterFactoryMock,
                         executorMock,
                         archiverMock,
+                        blockPathResolverMock,
                         persistenceStorageConfigMock);
         assertNotNull(streamVerifier);
     }

--- a/server/src/test/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImplTest.java
@@ -5,11 +5,14 @@ import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.Strea
 import static com.hedera.block.server.util.PersistTestUtils.*;
 import static com.hedera.block.server.util.PersistTestUtils.PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY;
 import static com.hedera.block.server.util.PersistTestUtils.generateBlockItemsUnparsed;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.hedera.block.common.utils.FileUtilities;
 import com.hedera.block.server.ack.AckHandler;
 import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.events.ObjectEvent;
@@ -17,15 +20,21 @@ import com.hedera.block.server.mediator.SubscriptionHandler;
 import com.hedera.block.server.metrics.MetricsService;
 import com.hedera.block.server.notifier.Notifier;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.CompressionType;
 import com.hedera.block.server.persistence.storage.archive.LocalBlockArchiver;
+import com.hedera.block.server.persistence.storage.path.BlockPathResolver;
+import com.hedera.block.server.persistence.storage.path.UnverifiedBlockPath;
 import com.hedera.block.server.persistence.storage.write.AsyncBlockWriterFactory;
 import com.hedera.block.server.service.ServiceStatus;
 import com.hedera.hapi.block.BlockItemUnparsed;
+import com.hedera.hapi.block.BlockUnparsed;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,22 +43,26 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+/**
+ * Test class for {@link StreamPersistenceHandlerImpl}.
+ */
+@SuppressWarnings("FieldCanBeLocal")
 @ExtendWith(MockitoExtension.class)
 class StreamPersistenceHandlerImplTest {
     @Mock
     private SubscriptionHandler<List<BlockItemUnparsed>> subscriptionHandler;
 
     @Mock
-    private Notifier notifier;
+    private Notifier notifierMock;
 
     @Mock
-    private BlockNodeContext blockNodeContext;
+    private BlockNodeContext blockNodeContextMock;
 
     @Mock
-    private ServiceStatus serviceStatus;
+    private ServiceStatus serviceStatusMock;
 
     @Mock
-    private MetricsService metricsService;
+    private MetricsService metricsServiceMock;
 
     @Mock
     private AckHandler ackHandlerMock;
@@ -63,45 +76,132 @@ class StreamPersistenceHandlerImplTest {
     @Mock
     private Executor executorMock;
 
+    @Mock
+    private BlockPathResolver pathResolverMock;
+
     @TempDir
     private Path testTempDir;
 
+    private Path testLiveRootPath;
+    private Path testUnverifiedRootPath;
     private PersistenceStorageConfig persistenceStorageConfig;
+    private StreamPersistenceHandlerImpl toTest;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws IOException {
         final ConfigurationBuilder configBuilder = ConfigurationBuilder.create().autoDiscoverExtensions();
-        configBuilder.withValue(PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY, testTempDir.toString());
-        configBuilder.withValue(PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH_KEY, testTempDir.toString());
+        testLiveRootPath = testTempDir.resolve("live");
+        final Path testArchiveRootPath = testTempDir.resolve("archive");
+        testUnverifiedRootPath = testTempDir.resolve("unverified");
+        configBuilder.withValue(PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY, testLiveRootPath.toString());
+        configBuilder.withValue(PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH_KEY, testArchiveRootPath.toString());
+        configBuilder.withValue(PERSISTENCE_STORAGE_UNVERIFIED_ROOT_PATH_KEY, testUnverifiedRootPath.toString());
         final Configuration config = configBuilder.build();
         persistenceStorageConfig = config.getConfigData(PersistenceStorageConfig.class);
-    }
-
-    @Test
-    void testOnEventWhenServiceIsNotRunning() throws IOException {
-        when(blockNodeContext.metricsService()).thenReturn(metricsService);
-        when(serviceStatus.isRunning()).thenReturn(false);
-
-        final StreamPersistenceHandlerImpl streamPersistenceHandler = new StreamPersistenceHandlerImpl(
+        final Path testConfigLiveRootPath = persistenceStorageConfig.liveRootPath();
+        assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath);
+        final Path testConfigArchiveRootPath = persistenceStorageConfig.archiveRootPath();
+        assertThat(testConfigArchiveRootPath).isEqualTo(testArchiveRootPath);
+        final Path testConfigUnverifiedRootPath = persistenceStorageConfig.unverifiedRootPath();
+        assertThat(testConfigUnverifiedRootPath).isEqualTo(testUnverifiedRootPath);
+        toTest = new StreamPersistenceHandlerImpl(
                 subscriptionHandler,
-                notifier,
-                blockNodeContext,
-                serviceStatus,
+                notifierMock,
+                blockNodeContextMock,
+                serviceStatusMock,
                 ackHandlerMock,
                 asyncBlockWriterFactoryMock,
                 executorMock,
                 archiverMock,
+                pathResolverMock,
                 persistenceStorageConfig);
+    }
+
+    /**
+     * This test aims to assert that the method
+     * {@link StreamPersistenceHandlerImpl#onEvent(ObjectEvent, long, boolean)}
+     * correctly handles the event when the service is not running.
+     */
+    @Test
+    void testOnEventWhenServiceIsNotRunning() throws IOException {
+        when(serviceStatusMock.isRunning()).thenReturn(false);
 
         final List<BlockItemUnparsed> blockItems = generateBlockItemsUnparsed(1);
         final ObjectEvent<List<BlockItemUnparsed>> event = new ObjectEvent<>();
         event.set(blockItems);
 
-        streamPersistenceHandler.onEvent(event, 0, false);
+        toTest.onEvent(event, 0, false);
 
         // Indirectly confirm the branch we're in by verifying
         // these methods were not called.
-        verify(notifier, never()).publish(any());
-        verify(metricsService, never()).get(StreamPersistenceHandlerError);
+        verify(notifierMock, never()).publish(any());
+        verify(metricsServiceMock, never()).get(StreamPersistenceHandlerError);
+    }
+
+    /**
+     * This test aims to assert that the method
+     * {@link StreamPersistenceHandlerImpl#moveVerified(long)} correctly moves
+     * a block from the unverified root to the live root.
+     */
+    @Test
+    void testSuccessfulMoveToVerified() throws IOException {
+        // Given a block number
+        final long blockNumber = 1;
+        final String blockFileName = blockNumber + ".blk";
+        final Path expectedInLive = testLiveRootPath.resolve(blockFileName);
+        when(pathResolverMock.resolveLiveRawPathToBlock(blockNumber)).thenReturn(expectedInLive);
+        when(pathResolverMock.findUnverifiedBlock(blockNumber))
+                .thenReturn(Optional.of(new UnverifiedBlockPath(
+                        blockNumber, testUnverifiedRootPath, blockFileName, CompressionType.NONE)));
+
+        // Generate an empty block file and persist it to where it would be in unverified root
+        final Path blockInUnverified = testUnverifiedRootPath.resolve(blockFileName);
+        FileUtilities.createFile(blockInUnverified);
+
+        // Assert that the file is in unverified root and not in live root
+        assertThat(blockInUnverified).isNotNull().isRegularFile().exists();
+        assertThat(expectedInLive).isNotNull().doesNotExist();
+
+        // Call actual method && assert that the file is moved to live root
+        toTest.moveVerified(blockNumber);
+        assertThat(expectedInLive).isNotNull().isRegularFile().exists();
+        assertThat(blockInUnverified).isNotNull().doesNotExist();
+    }
+
+    /**
+     * This test aims to assert that the method
+     * {@link StreamPersistenceHandlerImpl#moveVerified(long)} a file moved by
+     * the method will have the same binary content.
+     */
+    @Test
+    void testSuccessfulMoveToVerifiedBinContent() throws IOException {
+        // Given a block number
+        final long blockNumber = 1;
+        final String blockFileName = blockNumber + ".blk";
+        final Path expectedInLive = testLiveRootPath.resolve(blockFileName);
+        when(pathResolverMock.resolveLiveRawPathToBlock(blockNumber)).thenReturn(expectedInLive);
+        when(pathResolverMock.findUnverifiedBlock(blockNumber))
+                .thenReturn(Optional.of(new UnverifiedBlockPath(
+                        blockNumber, testUnverifiedRootPath, blockFileName, CompressionType.NONE)));
+
+        // Generate && persist Block
+        final List<BlockItemUnparsed> blockWithNumber1 = generateBlockItemsUnparsedForWithBlockNumber(blockNumber);
+        final BlockUnparsed block =
+                BlockUnparsed.newBuilder().blockItems(blockWithNumber1).build();
+        final byte[] blockAsBytes = BlockUnparsed.PROTOBUF.toBytes(block).toByteArray();
+        final Path blockInUnverified = testUnverifiedRootPath.resolve(blockFileName);
+        FileUtilities.createFile(blockInUnverified);
+        Files.write(blockInUnverified, blockAsBytes);
+
+        // Call actual method && assert
+        toTest.moveVerified(blockNumber);
+        assertThat(expectedInLive).isNotNull().hasBinaryContent(blockAsBytes);
+    }
+
+    @Test
+    void testThrowsWhenNonExistingSource() throws IOException {
+        final long blockNumber = 1;
+        // Call actual method && assert
+        assertThatIOException().isThrownBy(() -> toTest.moveVerified(blockNumber));
     }
 }

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
@@ -70,6 +70,7 @@ class PersistenceStorageConfigTest {
         final PersistenceStorageConfig actual = new PersistenceStorageConfig(
                 Path.of(""),
                 Path.of(""),
+                Path.of(""),
                 storageType,
                 CompressionType.NONE,
                 DEFAULT_COMPRESSION_LEVEL,
@@ -97,6 +98,7 @@ class PersistenceStorageConfigTest {
         final PersistenceStorageConfig actual = new PersistenceStorageConfig(
                 liveRootPathToTest,
                 archiveRootPathToTest,
+                archiveRootPathToTest, // @todo(582) add unverified paths
                 StorageType.BLOCK_AS_LOCAL_FILE,
                 CompressionType.NONE,
                 DEFAULT_COMPRESSION_LEVEL,
@@ -117,6 +119,7 @@ class PersistenceStorageConfigTest {
     void testPersistenceStorageConfigValidCompressionLevel(
             final CompressionType compressionType, final int compressionLevel) {
         final PersistenceStorageConfig actual = new PersistenceStorageConfig(
+                Path.of(""),
                 Path.of(""),
                 Path.of(""),
                 StorageType.BLOCK_AS_LOCAL_FILE,
@@ -141,6 +144,7 @@ class PersistenceStorageConfigTest {
                 .isThrownBy(() -> new PersistenceStorageConfig(
                         Path.of(""),
                         Path.of(""),
+                        Path.of(""),
                         StorageType.BLOCK_AS_LOCAL_FILE,
                         compressionType,
                         compressionLevel,
@@ -157,6 +161,7 @@ class PersistenceStorageConfigTest {
     @EnumSource(CompressionType.class)
     void testPersistenceStorageConfigCompressionTypes(final CompressionType compressionType) {
         final PersistenceStorageConfig actual = new PersistenceStorageConfig(
+                Path.of(""),
                 Path.of(""),
                 Path.of(""),
                 StorageType.NO_OP,
@@ -178,6 +183,7 @@ class PersistenceStorageConfigTest {
         final PersistenceStorageConfig actual = new PersistenceStorageConfig(
                 Path.of(""),
                 Path.of(""),
+                Path.of(""),
                 StorageType.NO_OP,
                 CompressionType.NONE,
                 DEFAULT_COMPRESSION_LEVEL,
@@ -197,6 +203,7 @@ class PersistenceStorageConfigTest {
     void testPersistenceStorageConfigInvalidArchiveGroupSizes(final int archiveGroupSize) {
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> new PersistenceStorageConfig(
+                        Path.of(""),
                         Path.of(""),
                         Path.of(""),
                         StorageType.NO_OP,

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/archive/LocalGroupZipArchiveTaskTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/archive/LocalGroupZipArchiveTaskTest.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.archive;
 
-import static com.hedera.block.server.util.PersistTestUtils.PERSISTENCE_STORAGE_ARCHIVE_BATCH_SIZE;
+import static com.hedera.block.server.util.PersistTestUtils.PERSISTENCE_STORAGE_ARCHIVE_GROUP_SIZE;
 import static com.hedera.block.server.util.PersistTestUtils.PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH_KEY;
 import static com.hedera.block.server.util.PersistTestUtils.PERSISTENCE_STORAGE_COMPRESSION_TYPE;
 import static com.hedera.block.server.util.PersistTestUtils.PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY;
@@ -53,20 +53,20 @@ class LocalGroupZipArchiveTaskTest {
 
     @BeforeEach
     void setUp() throws IOException {
-
+        final Path testLiveRootPath = testTempDir.resolve("live");
+        final Path testArchiveRootPath = testTempDir.resolve("archive");
         final Configuration config = ConfigurationBuilder.create()
-                .autoDiscoverExtensions()
+                .withConfigDataType(PersistenceStorageConfig.class)
                 .withValue(PERSISTENCE_STORAGE_COMPRESSION_TYPE, "NONE")
-                .withValue(PERSISTENCE_STORAGE_ARCHIVE_BATCH_SIZE, String.valueOf(ARCHIVE_GROUP_SIZE))
-                .withValue(
-                        PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY,
-                        testTempDir.resolve("live").toString())
-                .withValue(
-                        PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH_KEY,
-                        testTempDir.resolve("archive").toString())
+                .withValue(PERSISTENCE_STORAGE_ARCHIVE_GROUP_SIZE, String.valueOf(ARCHIVE_GROUP_SIZE))
+                .withValue(PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY, testLiveRootPath.toString())
+                .withValue(PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH_KEY, testArchiveRootPath.toString())
                 .build();
-
         persistenceStorageConfig = config.getConfigData(PersistenceStorageConfig.class);
+        final Path testConfigLiveRootPath = persistenceStorageConfig.liveRootPath();
+        assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath);
+        final Path testConfigArchiveRootPath = persistenceStorageConfig.archiveRootPath();
+        assertThat(testConfigArchiveRootPath).isEqualTo(testArchiveRootPath);
         // using spy for path resolver because we should test with actual logic for path resolution
         // also asserts would be based on the findLive/findArchive methods, which are unit tested themselves
         // in the respective test class

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolverTest.java
@@ -2,9 +2,7 @@
 package com.hedera.block.server.persistence.storage.path;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
-import com.hedera.block.server.Constants;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -130,28 +128,6 @@ class NoOpBlockPathResolverTest {
     @MethodSource({"validBlockNumbers", "invalidBlockNumbers"})
     void testSuccessfulExistsVerified(final long toResolve) {
         assertThat(toTest.existsVerifiedBlock(toResolve)).isFalse();
-    }
-
-    /**
-     * This test aims to verify that the
-     * {@link NoOpBlockPathResolver#markVerified(long)} does nothing.
-     *
-     * @param toResolve parameterized, block number
-     */
-    @ParameterizedTest
-    @MethodSource({"validBlockNumbers", "invalidBlockNumbers"})
-    void testSuccessfulMarkVerified(final long toResolve, final String blockPath) {
-        final Path verifiedBlockPath = Path.of(blockPath);
-        final Path unverifiedBlockPath =
-                Path.of(blockPath.replace(Constants.BLOCK_FILE_EXTENSION, Constants.UNVERIFIED_BLOCK_FILE_EXTENSION));
-
-        assertThat(verifiedBlockPath).doesNotExist();
-        assertThat(unverifiedBlockPath).doesNotExist();
-
-        assertThatCode(() -> toTest.markVerified(toResolve)).doesNotThrowAnyException();
-
-        assertThat(verifiedBlockPath).doesNotExist();
-        assertThat(unverifiedBlockPath).doesNotExist();
     }
 
     /**

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/remove/NoOpBlockRemoverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/remove/NoOpBlockRemoverTest.java
@@ -22,7 +22,7 @@ class NoOpBlockRemoverTest {
 
     /**
      * This test aims to verify that the
-     * {@link NoOpBlockRemover#removeLiveUnverified(long)} does nothing and
+     * {@link NoOpBlockRemover#removeUnverified(long)} does nothing and
      * returns false always. The no-op remover has no preconditions check as well.
      *
      * @param toRemove parameterized, block number
@@ -30,7 +30,7 @@ class NoOpBlockRemoverTest {
     @ParameterizedTest
     @MethodSource({"validBlockNumbers", "invalidBlockNumbers"})
     void testSuccessfulBlockDeletion(final long toRemove) {
-        final boolean actual = toTest.removeLiveUnverified(toRemove);
+        final boolean actual = toTest.removeUnverified(toRemove);
         assertThat(actual).isFalse();
     }
 

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/write/AsyncBlockAsLocalFileWriterTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/write/AsyncBlockAsLocalFileWriterTest.java
@@ -24,6 +24,7 @@ import com.hedera.hapi.block.BlockUnparsed;
 import com.swirlds.metrics.api.Counter;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -103,6 +104,67 @@ class AsyncBlockAsLocalFileWriterTest {
         when(metricsServiceMock.get(BlocksPersisted)).thenReturn(successfulPersistenceCounterMock);
 
         // then
+        toTest.call();
+        assertThat(expectedWrittenBlockFile)
+                .exists()
+                .isRegularFile()
+                .isReadable()
+                .hasBinaryContent(generateByteArrayOfTestBlock(validBlock));
+        final BlockPersistenceResult expectedResult =
+                new BlockPersistenceResult(validBlockNumber, BlockPersistenceStatus.SUCCESS);
+        verifySuccessfulPersistencePublish(expectedResult);
+    }
+
+    /**
+     * This test aims to verify that the {@link AsyncBlockAsLocalFileWriter#call()}
+     * correctly overwrites an already existing block if the call is executed.
+     * It is important to assert this since the writer writes blocks as
+     * unverified. These blocks are ephemeral and can be overwritten if they
+     * fail verification. This test ensures that the writer can overwrite an
+     * existing  unverified block. No duplicate is found and no problems arose
+     * during write.
+     *
+     * @param validBlockNumber parameterized, valid block number
+     */
+    @Timeout(value = TEST_TIMEOUT_MILLIS, unit = TimeUnit.MILLISECONDS)
+    @ParameterizedTest
+    @MethodSource("validBlockNumbers")
+    void testSuccessfulWriteOverwriteExisting(final long validBlockNumber) throws Exception {
+        // setup
+        final List<BlockItemUnparsed> validBlock =
+                PersistTestUtils.generateBlockItemsUnparsedForWithBlockNumber(validBlockNumber);
+        final AsyncBlockWriter toTest = new AsyncBlockAsLocalFileWriter(
+                validBlockNumber,
+                blockPathResolverMock,
+                blockRemoverMock,
+                compressionMock,
+                ackHandlerMock,
+                metricsServiceMock);
+        final TransferQueue<BlockItemUnparsed> q = toTest.getQueue();
+        validBlock.forEach(q::offer);
+
+        // when
+        final Path expectedWrittenBlockFile = testTempDir.resolve(validBlockNumber + Constants.BLOCK_FILE_EXTENSION);
+        when(blockPathResolverMock.resolveLiveRawUnverifiedPathToBlock(validBlockNumber))
+                .thenReturn(expectedWrittenBlockFile);
+        when(blockPathResolverMock.existsVerifiedBlock(validBlockNumber)).thenReturn(false);
+        when(compressionMock.getCompressionFileExtension()).thenReturn("");
+        when(compressionMock.wrap(any(OutputStream.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(metricsServiceMock.get(BlocksPersisted)).thenReturn(successfulPersistenceCounterMock);
+
+        // before call, create the expected file and pollute it with some data
+        // we expect that the writer will overwrite this file as it is writing
+        // to an unverified block file path that is permitted, since unverified
+        // blocks could fail verification so they need to be able to be overwritten
+        final String pollution = "block file is polluted";
+        Files.writeString(expectedWrittenBlockFile, pollution);
+        assertThat(expectedWrittenBlockFile)
+                .exists()
+                .isRegularFile()
+                .isReadable()
+                .hasContent(pollution);
+
+        // then (we expect overwrite to happen)
         toTest.call();
         assertThat(expectedWrittenBlockFile)
                 .exists()

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/write/AsyncBlockAsLocalFileWriterTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/write/AsyncBlockAsLocalFileWriterTest.java
@@ -95,7 +95,8 @@ class AsyncBlockAsLocalFileWriterTest {
 
         // when
         final Path expectedWrittenBlockFile = testTempDir.resolve(validBlockNumber + Constants.BLOCK_FILE_EXTENSION);
-        when(blockPathResolverMock.resolveLiveRawPathToBlock(validBlockNumber)).thenReturn(expectedWrittenBlockFile);
+        when(blockPathResolverMock.resolveLiveRawUnverifiedPathToBlock(validBlockNumber))
+                .thenReturn(expectedWrittenBlockFile);
         when(blockPathResolverMock.existsVerifiedBlock(validBlockNumber)).thenReturn(false);
         when(compressionMock.getCompressionFileExtension()).thenReturn("");
         when(compressionMock.wrap(any(OutputStream.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -139,7 +140,8 @@ class AsyncBlockAsLocalFileWriterTest {
 
         // when
         final Path expectedWrittenBlockFile = testTempDir.resolve(validBlockNumber + Constants.BLOCK_FILE_EXTENSION);
-        when(blockPathResolverMock.resolveLiveRawPathToBlock(validBlockNumber)).thenReturn(expectedWrittenBlockFile);
+        when(blockPathResolverMock.resolveLiveRawUnverifiedPathToBlock(validBlockNumber))
+                .thenReturn(expectedWrittenBlockFile);
         when(blockPathResolverMock.existsVerifiedBlock(validBlockNumber)).thenReturn(false);
         when(compressionMock.getCompressionFileExtension()).thenReturn("");
         when(compressionMock.wrap(any(OutputStream.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -179,7 +181,8 @@ class AsyncBlockAsLocalFileWriterTest {
         // when
         final Path expectedWrittenBlockFile = testTempDir.resolve(validBlockNumber + Constants.BLOCK_FILE_EXTENSION);
         when(metricsServiceMock.get(BlockPersistenceError)).thenReturn(persistenceErrorCounterMock);
-        when(blockPathResolverMock.resolveLiveRawPathToBlock(validBlockNumber)).thenReturn(expectedWrittenBlockFile);
+        when(blockPathResolverMock.resolveLiveRawUnverifiedPathToBlock(validBlockNumber))
+                .thenReturn(expectedWrittenBlockFile);
         when(blockPathResolverMock.existsVerifiedBlock(validBlockNumber)).thenReturn(false);
         when(compressionMock.getCompressionFileExtension()).thenReturn("");
         when(compressionMock.wrap(any(OutputStream.class))).thenThrow(IOException.class);
@@ -218,11 +221,12 @@ class AsyncBlockAsLocalFileWriterTest {
 
         // when
         final Path expectedWrittenBlockFile = testTempDir.resolve(validBlockNumber + Constants.BLOCK_FILE_EXTENSION);
-        when(blockPathResolverMock.resolveLiveRawPathToBlock(validBlockNumber)).thenReturn(expectedWrittenBlockFile);
+        when(blockPathResolverMock.resolveLiveRawUnverifiedPathToBlock(validBlockNumber))
+                .thenReturn(expectedWrittenBlockFile);
         when(blockPathResolverMock.existsVerifiedBlock(validBlockNumber)).thenReturn(false);
         when(compressionMock.getCompressionFileExtension()).thenReturn("");
         when(compressionMock.wrap(any(OutputStream.class))).thenThrow(IOException.class);
-        when(blockRemoverMock.removeLiveUnverified(validBlockNumber)).thenThrow(IOException.class);
+        when(blockRemoverMock.removeUnverified(validBlockNumber)).thenThrow(IOException.class);
         when(metricsServiceMock.get(BlockPersistenceError)).thenReturn(persistenceErrorCounterMock);
 
         // then

--- a/server/src/test/java/com/hedera/block/server/util/PersistTestUtils.java
+++ b/server/src/test/java/com/hedera/block/server/util/PersistTestUtils.java
@@ -14,9 +14,10 @@ import java.util.List;
 public final class PersistTestUtils {
     public static final String PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY = "persistence.storage.liveRootPath";
     public static final String PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH_KEY = "persistence.storage.archiveRootPath";
+    public static final String PERSISTENCE_STORAGE_UNVERIFIED_ROOT_PATH_KEY = "persistence.storage.unverifiedRootPath";
     public static final String PERSISTENCE_STORAGE_COMPRESSION_TYPE = "persistence.storage.compressionType";
     public static final String PERSISTENCE_STORAGE_COMPRESSION_LEVEL = "persistence.storage.compressionLevel";
-    public static final String PERSISTENCE_STORAGE_ARCHIVE_BATCH_SIZE = "persistence.storage.archiveGroupSize";
+    public static final String PERSISTENCE_STORAGE_ARCHIVE_GROUP_SIZE = "persistence.storage.archiveGroupSize";
 
     private PersistTestUtils() {}
 


### PR DESCRIPTION
## Reviewer Notes

- add a new unverified blocks root
- persistence will first persist blocks under the unverfied root
- after successful persistence under unverified && successful verification, persistence should move the block to live
- due to unavaliable critical infrastructure, a method call has to be made to persistence to move the block

## Related Issue(s)

Closes #582 
