### PR TITLE
fix: Exclude `suites` and `tools` from CodeCov Coverage report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -24,3 +24,5 @@ ignore:
   - "server/src/main/java/com/hedera/block/server/producer/NoOpProducerObserver.java"
   - "server/src/main/java/com/hedera/block/server/persistence/storage/write/NoOpBlockWriter.java"
   - "simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulator.java"
+  - "suites/**"
+  - "tools/**"


### PR DESCRIPTION
## Reviewer Notes
Exclude `suites` and `tools` from CodeCov Coverage Report


## Related Issue(s)
Fixes #717 
