### PR TITLE
feat: allow for configuration of the async writers executors

### DIFF
--- a/server/docs/configuration.md
+++ b/server/docs/configuration.md
@@ -9,21 +9,27 @@ The default configuration allows users to quickly get up and running without hav
 ease of use at the trade-off of some insecure default configuration. Most configuration settings have appropriate
 defaults and can be left unchanged. It is recommended to browse the properties below and adjust to your needs.
 
-| Environment Variable                   | Description                                                                                  | Default Value                         |
-|:---------------------------------------|:---------------------------------------------------------------------------------------------|:--------------------------------------|
-| PERSISTENCE_STORAGE_LIVE_ROOT_PATH     | The root path for the live storage.                                                          | /opt/hashgraph/blocknode/data/live    |
-| PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH  | The root path for the archive storage.                                                       | /opt/hashgraph/blocknode/data/archive |
-| PERSISTENCE_STORAGE_TYPE               | Type of the persistence storage                                                              | BLOCK_AS_LOCAL_FILE                   |
-| PERSISTENCE_STORAGE_COMPRESSION        | Compression algorithm used during persistence (could be none as well)                        | ZSTD                                  |
-| PERSISTENCE_STORAGE_COMPRESSION_LEVEL  | Compression level to be used by the compression algorithm                                    | 3                                     |
-| PERSISTENCE_STORAGE_ARCHIVE_GROUP_SIZE | The size of the group of blocks to be archived at once                                       | 1_000                                 |
-| CONSUMER_MAX_BLOCK_ITEM_BATCH_SIZE     | Maximum size of block item batches streamed to a client for closed-range historical requests | 1000                                  |
-| CONSUMER_TIMEOUT_THRESHOLD_MILLIS      | Time to wait for subscribers before disconnecting in milliseconds                            | 1500                                  |
-| SERVICE_DELAY_MILLIS                   | Service shutdown delay in milliseconds                                                       | 500                                   |
-| MEDIATOR_RING_BUFFER_SIZE              | Size of the ring buffer used by the mediator (must be a power of 2)                          | 67108864                              |
-| NOTIFIER_RING_BUFFER_SIZE              | Size of the ring buffer used by the notifier (must be a power of 2)                          | 2048                                  |
-| SERVER_PORT                            | The port the server will listen on                                                           | 8080                                  |
-| SERVER_MAX_MESSAGE_SIZE_BYTES          | The maximum size of a message frame in bytes                                                 | 1048576                               |
-| VERIFICATION_ENABLED                   | Enables or disables the block verification process                                           | true                                  |
-| VERIFICATION_SESSION_TYPE              | The type of BlockVerificationSession to use, either `ASYNC` or `SYNC`                        | ASYNC                                 |
-| VERIFICATION_HASH_COMBINE_BATCH_SIZE   | The number of hashes to combine into a single hash during verification                       | 32                                    |
+| Environment Variable                       | Description                                                                                  | Default Value                         |
+|:-------------------------------------------|:---------------------------------------------------------------------------------------------|:--------------------------------------|
+| PERSISTENCE_STORAGE_LIVE_ROOT_PATH         | The root path for the live storage.                                                          | /opt/hashgraph/blocknode/data/live    |
+| PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH      | The root path for the archive storage.                                                       | /opt/hashgraph/blocknode/data/archive |
+| PERSISTENCE_STORAGE_TYPE                   | Type of the persistence storage                                                              | BLOCK_AS_LOCAL_FILE                   |
+| PERSISTENCE_STORAGE_COMPRESSION            | Compression algorithm used during persistence (could be none as well)                        | ZSTD                                  |
+| PERSISTENCE_STORAGE_COMPRESSION_LEVEL      | Compression level to be used by the compression algorithm                                    | 3                                     |
+| PERSISTENCE_STORAGE_ARCHIVE_ENABLED        | Whether to enable archiving of blocks                                                        | true                                  |
+| PERSISTENCE_STORAGE_ARCHIVE_GROUP_SIZE     | The size of the group of blocks to be archived at once                                       | 1_000                                 |
+| PERSISTENCE_STORAGE_EXECUTOR_TYPE          | Type of executor for async writers (THREAD_POOL, SINGLE_THREAD, FORK_JOIN)                   | THREAD_POOL                           |
+| PERSISTENCE_STORAGE_THREAD_COUNT           | Number of threads for thread pool executor (1-16)                                            | 6                                     |
+| PERSISTENCE_STORAGE_THREAD_KEEP_ALIVE_TIME | Keep-alive time in seconds for idle threads in thread pool                                   | 60                                    |
+| PERSISTENCE_STORAGE_USE_VIRTUAL_THREADS    | Whether to use virtual threads (Java 21 feature) instead of platform threads                 | false                                 |
+| PERSISTENCE_STORAGE_EXECUTION_QUEUE_LIMIT  | Maximum queue size for pending tasks (64-2048)                                               | 1024                                  |
+| CONSUMER_MAX_BLOCK_ITEM_BATCH_SIZE         | Maximum size of block item batches streamed to a client for closed-range historical requests | 1000                                  |
+| CONSUMER_TIMEOUT_THRESHOLD_MILLIS          | Time to wait for subscribers before disconnecting in milliseconds                            | 1500                                  |
+| SERVICE_DELAY_MILLIS                       | Service shutdown delay in milliseconds                                                       | 500                                   |
+| MEDIATOR_RING_BUFFER_SIZE                  | Size of the ring buffer used by the mediator (must be a power of 2)                          | 67108864                              |
+| NOTIFIER_RING_BUFFER_SIZE                  | Size of the ring buffer used by the notifier (must be a power of 2)                          | 2048                                  |
+| SERVER_PORT                                | The port the server will listen on                                                           | 8080                                  |
+| SERVER_MAX_MESSAGE_SIZE_BYTES              | The maximum size of a message frame in bytes                                                 | 1048576                               |
+| VERIFICATION_ENABLED                       | Enables or disables the block verification process                                           | true                                  |
+| VERIFICATION_SESSION_TYPE                  | The type of BlockVerificationSession to use, either `ASYNC` or `SYNC`                        | ASYNC                                 |
+| VERIFICATION_HASH_COMBINE_BATCH_SIZE       | The number of hashes to combine into a single hash during verification                       | 32                                    |

--- a/server/src/main/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializer.java
+++ b/server/src/main/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializer.java
@@ -41,6 +41,11 @@ public final class ServerMappedConfigSourceInitializer {
             new ConfigMapping("persistence.storage.type", "PERSISTENCE_STORAGE_TYPE"),
             new ConfigMapping("persistence.storage.archiveGroupSize", "PERSISTENCE_STORAGE_ARCHIVE_GROUP_SIZE"),
             new ConfigMapping("persistence.storage.unverifiedRootPath", "PERSISTENCE_STORAGE_UNVERIFIED_ROOT_PATH"),
+            new ConfigMapping("persistence.storage.executionQueueLimit", "PERSISTENCE_STORAGE_EXECUTION_QUEUE_LIMIT"),
+            new ConfigMapping("persistence.storage.executorType", "PERSISTENCE_STORAGE_EXECUTOR_TYPE"),
+            new ConfigMapping("persistence.storage.threadCount", "PERSISTENCE_STORAGE_THREAD_COUNT"),
+            new ConfigMapping("persistence.storage.threadKeepAliveTime", "PERSISTENCE_STORAGE_THREAD_KEEP_ALIVE_TIME"),
+            new ConfigMapping("persistence.storage.useVirtualThreads", "PERSISTENCE_STORAGE_USE_VIRTUAL_THREADS"),
 
             // Producer Config
             new ConfigMapping("producer.type", "PRODUCER_TYPE"),

--- a/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
@@ -27,6 +27,7 @@ import com.hedera.block.server.persistence.storage.remove.NoOpBlockRemover;
 import com.hedera.block.server.persistence.storage.write.AsyncBlockAsLocalFileWriterFactory;
 import com.hedera.block.server.persistence.storage.write.AsyncBlockWriterFactory;
 import com.hedera.block.server.persistence.storage.write.AsyncNoOpWriterFactory;
+import com.hedera.block.server.persistence.storage.write.AsyncWriterExecutorFactory;
 import com.hedera.block.server.service.ServiceStatus;
 import com.hedera.hapi.block.BlockItemUnparsed;
 import com.hedera.hapi.block.BlockUnparsed;
@@ -37,7 +38,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Executor;
 import javax.inject.Singleton;
 
 /** A Dagger module for providing dependencies for Persistence Module. */
@@ -181,6 +182,7 @@ public interface PersistenceInjectionModule {
             @NonNull final PersistenceStorageConfig persistenceStorageConfig,
             @NonNull final LocalBlockArchiver localBlockArchiver) {
         try {
+            final Executor executor = AsyncWriterExecutorFactory.createExecutor(persistenceStorageConfig);
             return new StreamPersistenceHandlerImpl(
                     subscriptionHandler,
                     notifier,
@@ -188,7 +190,7 @@ public interface PersistenceInjectionModule {
                     serviceStatus,
                     ackHandler,
                     asyncBlockWriterFactory,
-                    Executors.newFixedThreadPool(5),
+                    executor,
                     localBlockArchiver,
                     blockPathResolver,
                     persistenceStorageConfig);

--- a/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
@@ -39,6 +39,7 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import javax.inject.Singleton;
 
 /** A Dagger module for providing dependencies for Persistence Module. */

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
@@ -29,7 +29,12 @@ public record PersistenceStorageConfig(
         @Loggable @ConfigProperty(defaultValue = "BLOCK_AS_LOCAL_FILE") StorageType type,
         @Loggable @ConfigProperty(defaultValue = "ZSTD") CompressionType compression,
         @Loggable @ConfigProperty(defaultValue = "3") @Min(0) @Max(20) int compressionLevel,
-        @Loggable @ConfigProperty(defaultValue = "1_000") @Min(10) int archiveGroupSize) {
+        @Loggable @ConfigProperty(defaultValue = "1_000") @Min(10) int archiveGroupSize,
+        @Loggable @ConfigProperty(defaultValue = "true") boolean archiveEnabled,
+        @Loggable @ConfigProperty(defaultValue = "THREAD_POOL") ExecutorType executorType,
+        @Loggable @ConfigProperty(defaultValue = "6") @Min(1) @Max(16) int threadCount,
+        @Loggable @ConfigProperty(defaultValue = "false") boolean useVirtualThreads,
+        @Loggable @ConfigProperty(defaultValue = "1024") @Min(64) @Max(2048) int executionQueueLimit) {
     /**
      * Constructor.
      */
@@ -72,6 +77,39 @@ public record PersistenceStorageConfig(
          * This type of storage does nothing.
          */
         NO_OP
+    }
+
+    /**
+     * An enum that defines the type of executor to use for async writers.
+     * <p>
+     * Different executor types have different performance characteristics and are suitable
+     * for different workloads and deployment environments.
+     */
+    public enum ExecutorType {
+        /**
+         * A fixed-size thread pool executor that maintains a specified number of threads.
+         * Recommended for environments where consistent performance and resource usage are important.
+         */
+        THREAD_POOL,
+
+        /**
+         * An executor with a single worker thread.
+         * Suitable for low-throughput environments or when strict ordering of task execution is required.
+         */
+        SINGLE_THREAD,
+
+        /**
+         * Uses the common ForkJoinPool for task execution.
+         * Best for compute-intensive workloads that benefit from work-stealing and when
+         * you want to share thread resources with other components in the application.
+         */
+        FORK_JOIN,
+
+        /**
+         * Executes tasks directly in the calling thread without creating additional threads.
+         * Useful for testing, debugging, or when immediate execution in the current thread is desired.
+         */
+        CALLING_THREAD
     }
 
     /**

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/AsyncWriterExecutorFactory.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/AsyncWriterExecutorFactory.java
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.server.persistence.storage.write;
+
+import static java.lang.System.Logger.Level.TRACE;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.ExecutorType;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Factory for creating executor instances for async writers based on configuration.
+ * <p>
+ * This factory creates different types of executors with specific configurations
+ * to optimize performance for different workloads and deployment environments.
+ * <p>
+ * The factory supports creating:
+ * <ul>
+ *   <li>Thread pool executors with configurable thread count and queue size
+ *   <li>Single-threaded executors for sequential processing
+ *   <li>Fork-join pool executors for work-stealing parallelism
+ * </ul>
+ */
+public final class AsyncWriterExecutorFactory {
+    private static final System.Logger LOGGER = System.getLogger(AsyncWriterExecutorFactory.class.getName());
+    private static final int BASE_THREADS = 4;
+
+    // Private constructor to prevent instantiation
+    private AsyncWriterExecutorFactory() {}
+
+    /**
+     * Creates an executor based on the provided configuration.
+     * <p>
+     * This method creates the appropriate executor type with the specified parameters
+     * depending on the configuration.
+     *
+     * @param config the persistence storage configuration containing executor settings
+     * @return an executor configured according to the settings
+     * @throws NullPointerException if config is null
+     */
+    @NonNull
+    public static Executor createExecutor(@NonNull final PersistenceStorageConfig config) {
+        requireNonNull(config);
+
+        LOGGER.log(TRACE, "Creating async writer executor of type: {0}", config.executorType());
+        final ExecutorType executorType = config.executorType();
+        return switch (executorType) {
+            case THREAD_POOL -> createThreadPoolExecutor(config);
+            case SINGLE_THREAD -> createSingleThreadExecutor();
+            case FORK_JOIN -> createForkJoinExecutor(config);
+        };
+    }
+
+    /**
+     * Creates a thread pool executor with the specified configuration.
+     * <p>
+     * The thread pool uses:
+     * <ul>
+     *   <li>Fixed number of threads as specified in the configuration
+     *   <li>Custom thread factory that creates named daemon threads
+     *   <li>Configurable keep alive time for threads
+     *   <li>Bounded queue with the specified capacity
+     *   <li>Custom rejection handler that implements a caller-runs policy
+     * </ul>
+     *
+     * @param config the configuration containing thread pool settings
+     * @return a configured thread pool executor
+     */
+    @NonNull
+    private static Executor createThreadPoolExecutor(@NonNull final PersistenceStorageConfig config) {
+        final int threadCount = config.threadCount();
+        final long threadKeepAliveTime = config.threadKeepAliveTime();
+        final int queueLimit = config.executionQueueLimit();
+        final boolean useVirtualThreads = config.useVirtualThreads();
+
+        LOGGER.log(
+                TRACE,
+                "Creating thread pool executor with {0} threads and queue limit of {1}",
+                threadCount,
+                queueLimit);
+
+        return new ThreadPoolExecutor(
+                threadCount,
+                threadCount,
+                threadKeepAliveTime,
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingDeque<>(queueLimit),
+                new AsyncWriterThreadFactory(useVirtualThreads),
+                new CallerRunsPolicy());
+    }
+
+    /**
+     * Creates a single-threaded executor.
+     * <p>
+     * This executor processes tasks sequentially using a single worker thread.
+     *
+     * @return a single-threaded executor
+     */
+    @NonNull
+    private static ExecutorService createSingleThreadExecutor() {
+        LOGGER.log(TRACE, "Creating single thread executor");
+        return Executors.newSingleThreadExecutor(new AsyncWriterThreadFactory(false));
+    }
+
+    /**
+     * Creates a fork-join pool executor.
+     * <p>
+     * This method creates a dedicated ForkJoinPool with configurable parallelism and thread limits.
+     * The maximum number of threads is calculated based on the thread count configuration plus a base value.
+     *
+     * @param config the configuration containing executor settings
+     * @return a configured fork-join pool
+     */
+    @NonNull
+    private static ForkJoinPool createForkJoinExecutor(@NonNull final PersistenceStorageConfig config) {
+        final int threadCount = config.threadCount();
+        final long threadKeepAliveTime = config.threadKeepAliveTime();
+        int maxThreads = threadCount + BASE_THREADS;
+
+        LOGGER.log(TRACE, "Creating fork-join pool with parallelism: {0}, max threads: {1}", threadCount, maxThreads);
+
+        return new ForkJoinPool(
+                threadCount,
+                ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+                null,
+                true,
+                maxThreads,
+                maxThreads,
+                0,
+                null,
+                threadKeepAliveTime,
+                TimeUnit.MILLISECONDS);
+    }
+
+    private static class AsyncWriterThreadFactory implements ThreadFactory {
+        private final AtomicInteger threadNumber = new AtomicInteger(1);
+        private final boolean useVirtualThreads;
+
+        public AsyncWriterThreadFactory(final boolean useVirtualThreads) {
+            this.useVirtualThreads = useVirtualThreads;
+        }
+
+        @Override
+        public Thread newThread(@NonNull final Runnable r) {
+            if (useVirtualThreads) {
+                return Thread.ofVirtual()
+                        .name("async-writer-" + threadNumber.getAndIncrement())
+                        .unstarted(r);
+            }
+            return new Thread(r, "async-writer-" + threadNumber.getAndIncrement());
+        }
+    }
+}

--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -65,6 +65,11 @@ class ServerMappedConfigSourceInitializerTest {
         new ConfigMapping("persistence.storage.type", "PERSISTENCE_STORAGE_TYPE"),
         new ConfigMapping("persistence.storage.archiveGroupSize", "PERSISTENCE_STORAGE_ARCHIVE_GROUP_SIZE"),
         new ConfigMapping("persistence.storage.unverifiedRootPath", "PERSISTENCE_STORAGE_UNVERIFIED_ROOT_PATH"),
+        new ConfigMapping("persistence.storage.executionQueueLimit", "PERSISTENCE_STORAGE_EXECUTION_QUEUE_LIMIT"),
+        new ConfigMapping("persistence.storage.executorType", "PERSISTENCE_STORAGE_EXECUTOR_TYPE"),
+        new ConfigMapping("persistence.storage.threadCount", "PERSISTENCE_STORAGE_THREAD_COUNT"),
+        new ConfigMapping("persistence.storage.threadKeepAliveTime", "PERSISTENCE_STORAGE_THREAD_KEEP_ALIVE_TIME"),
+        new ConfigMapping("persistence.storage.useVirtualThreads", "PERSISTENCE_STORAGE_USE_VIRTUAL_THREADS"),
 
         // Producer Config
         new ConfigMapping("producer.type", "PRODUCER_TYPE"),

--- a/server/src/test/java/com/hedera/block/server/config/logging/ConfigurationLoggingImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/logging/ConfigurationLoggingImplTest.java
@@ -25,7 +25,7 @@ public class ConfigurationLoggingImplTest {
         final ConfigurationLoggingImpl configurationLogging = new ConfigurationLoggingImpl(configuration);
         final Map<String, Object> config = configurationLogging.collectConfig(configuration);
         assertNotNull(config);
-        assertEquals(35, config.size());
+        assertEquals(40, config.size());
 
         for (Map.Entry<String, Object> entry : config.entrySet()) {
             String value = entry.getValue().toString();
@@ -42,7 +42,7 @@ public class ConfigurationLoggingImplTest {
         final ConfigurationLoggingImpl configurationLogging = new ConfigurationLoggingImpl(configuration);
         final Map<String, Object> config = configurationLogging.collectConfig(configuration);
         assertNotNull(config);
-        assertEquals(37, config.size());
+        assertEquals(42, config.size());
 
         assertEquals("*****", config.get("test.secret").toString());
         assertEquals("", config.get("test.emptySecret").toString());

--- a/server/src/test/java/com/hedera/block/server/manager/AckHandlerInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/manager/AckHandlerInjectionModuleTest.java
@@ -39,7 +39,12 @@ class AckHandlerInjectionModuleTest {
                 PersistenceStorageConfig.StorageType.BLOCK_AS_LOCAL_FILE,
                 PersistenceStorageConfig.CompressionType.NONE,
                 0,
-                10);
+                10,
+                1024,
+                PersistenceStorageConfig.ExecutorType.THREAD_POOL,
+                6,
+                60000,
+                true);
         final VerificationConfig verificationConfig = mock(VerificationConfig.class);
         when(verificationConfig.type()).thenReturn(VerificationConfig.VerificationServiceType.PRODUCTION);
 

--- a/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
@@ -209,8 +209,6 @@ class PersistenceInjectionModuleTest {
     @ParameterizedTest
     @EnumSource(StorageType.class)
     void testProvidesLocalBlockArchiver(final StorageType type) {
-        when(persistenceStorageConfigMock.executorType())
-                .thenReturn(PersistenceStorageConfig.ExecutorType.SINGLE_THREAD);
         final LocalBlockArchiver actual = PersistenceInjectionModule.providesLocalBlockArchiver(
                 persistenceStorageConfigMock, blockPathResolverMock);
         assertThat(actual).isNotNull().isExactlyInstanceOf(BlockAsLocalFileArchiver.class);
@@ -224,7 +222,6 @@ class PersistenceInjectionModuleTest {
         when(persistenceStorageConfigMock.unverifiedRootPath()).thenReturn(testLiveRootPath);
         // Call the method under test
         // Given
-        final BlockNodeContext blockNodeContext = TestConfigUtil.getTestBlockNodeContext();
         when(persistenceStorageConfigMock.liveRootPath()).thenReturn(testLiveRootPath);
         when(persistenceStorageConfigMock.archiveRootPath()).thenReturn(testLiveRootPath);
         when(persistenceStorageConfigMock.executorType())
@@ -239,8 +236,6 @@ class PersistenceInjectionModuleTest {
                         serviceStatusMock,
                         ackHandlerMock,
                         asyncBlockWriterFactoryMock,
-                        executorMock,
-                        archiverMock,
                         blockPathResolverMock,
                         persistenceStorageConfigMock,
                         archiverMock);

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
@@ -529,7 +529,9 @@ class PersistenceStorageConfigTest {
                 Arguments.of(10_000),
                 Arguments.of(100_000),
                 Arguments.of(1_000_000),
-                Arguments.of(10_000_000));
+                Arguments.of(10_000_000),
+                Arguments.of(100_000_000),
+                Arguments.of(1_000_000_000));
     }
 
     private static Stream<Arguments> invalidArchiveGroupSizes() {
@@ -546,7 +548,9 @@ class PersistenceStorageConfigTest {
                 Arguments.of(-10_000),
                 Arguments.of(-100_000),
                 Arguments.of(-1_000_000),
-                Arguments.of(-10_000_000));
+                Arguments.of(-10_000_000),
+                Arguments.of(-100_000_000),
+                Arguments.of(-1_000_000_000));
     }
 
     private static Stream<Arguments> validExecutionQueueLimits() {

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
@@ -39,6 +39,13 @@ class PersistenceStorageConfigTest {
     private static final int UPPER_BOUNDARY_FOR_ZSTD_COMPRESSION = 20;
     // Archiving defaults
     private static final int DEFAULT_ARCHIVE_BATCH_SIZE = 1000;
+    // Concurrency defaults
+    private static final int DEFAULT_EXECUTION_QUEUE_LIMIT = 1024;
+    private static final PersistenceStorageConfig.ExecutorType DEFAULT_EXECUTOR_TYPE =
+            PersistenceStorageConfig.ExecutorType.THREAD_POOL;
+    private static final int DEFAULT_THREAD_COUNT = 6;
+    private static final int DEFAULT_THREAD_KEEP_ALIVE_TIME = 60000;
+    private static final boolean DEFAULT_USE_VIRTUAL_THREADS = false;
 
     @AfterEach
     void tearDown() {
@@ -74,7 +81,12 @@ class PersistenceStorageConfigTest {
                 storageType,
                 CompressionType.NONE,
                 DEFAULT_COMPRESSION_LEVEL,
-                DEFAULT_ARCHIVE_BATCH_SIZE);
+                DEFAULT_ARCHIVE_BATCH_SIZE,
+                DEFAULT_EXECUTION_QUEUE_LIMIT,
+                DEFAULT_EXECUTOR_TYPE,
+                DEFAULT_THREAD_COUNT,
+                DEFAULT_THREAD_KEEP_ALIVE_TIME,
+                DEFAULT_USE_VIRTUAL_THREADS);
         assertThat(actual).returns(storageType, from(PersistenceStorageConfig::type));
     }
 
@@ -102,7 +114,12 @@ class PersistenceStorageConfigTest {
                 StorageType.BLOCK_AS_LOCAL_FILE,
                 CompressionType.NONE,
                 DEFAULT_COMPRESSION_LEVEL,
-                DEFAULT_ARCHIVE_BATCH_SIZE);
+                DEFAULT_ARCHIVE_BATCH_SIZE,
+                DEFAULT_EXECUTION_QUEUE_LIMIT,
+                DEFAULT_EXECUTOR_TYPE,
+                DEFAULT_THREAD_COUNT,
+                DEFAULT_THREAD_KEEP_ALIVE_TIME,
+                DEFAULT_USE_VIRTUAL_THREADS);
         assertThat(actual)
                 .returns(expectedLiveRootPathToTest, from(PersistenceStorageConfig::liveRootPath))
                 .returns(expectedArchiveRootPathToTest, from(PersistenceStorageConfig::archiveRootPath));
@@ -125,7 +142,12 @@ class PersistenceStorageConfigTest {
                 StorageType.BLOCK_AS_LOCAL_FILE,
                 compressionType,
                 compressionLevel,
-                DEFAULT_ARCHIVE_BATCH_SIZE);
+                DEFAULT_ARCHIVE_BATCH_SIZE,
+                DEFAULT_EXECUTION_QUEUE_LIMIT,
+                DEFAULT_EXECUTOR_TYPE,
+                DEFAULT_THREAD_COUNT,
+                DEFAULT_THREAD_KEEP_ALIVE_TIME,
+                DEFAULT_USE_VIRTUAL_THREADS);
         assertThat(actual).returns(compressionLevel, from(PersistenceStorageConfig::compressionLevel));
     }
 
@@ -148,7 +170,12 @@ class PersistenceStorageConfigTest {
                         StorageType.BLOCK_AS_LOCAL_FILE,
                         compressionType,
                         compressionLevel,
-                        DEFAULT_ARCHIVE_BATCH_SIZE));
+                        DEFAULT_ARCHIVE_BATCH_SIZE,
+                        DEFAULT_EXECUTION_QUEUE_LIMIT,
+                        DEFAULT_EXECUTOR_TYPE,
+                        DEFAULT_THREAD_COUNT,
+                        DEFAULT_THREAD_KEEP_ALIVE_TIME,
+                        DEFAULT_USE_VIRTUAL_THREADS));
     }
 
     /**
@@ -167,7 +194,12 @@ class PersistenceStorageConfigTest {
                 StorageType.NO_OP,
                 compressionType,
                 DEFAULT_COMPRESSION_LEVEL,
-                DEFAULT_ARCHIVE_BATCH_SIZE);
+                DEFAULT_ARCHIVE_BATCH_SIZE,
+                DEFAULT_EXECUTION_QUEUE_LIMIT,
+                DEFAULT_EXECUTOR_TYPE,
+                DEFAULT_THREAD_COUNT,
+                DEFAULT_THREAD_KEEP_ALIVE_TIME,
+                DEFAULT_USE_VIRTUAL_THREADS);
         assertThat(actual).returns(compressionType, from(PersistenceStorageConfig::compression));
     }
 
@@ -187,7 +219,12 @@ class PersistenceStorageConfigTest {
                 StorageType.NO_OP,
                 CompressionType.NONE,
                 DEFAULT_COMPRESSION_LEVEL,
-                archiveGroupSize);
+                archiveGroupSize,
+                DEFAULT_EXECUTION_QUEUE_LIMIT,
+                DEFAULT_EXECUTOR_TYPE,
+                DEFAULT_THREAD_COUNT,
+                DEFAULT_THREAD_KEEP_ALIVE_TIME,
+                DEFAULT_USE_VIRTUAL_THREADS);
         assertThat(actual).returns(archiveGroupSize, from(PersistenceStorageConfig::archiveGroupSize));
     }
 
@@ -209,7 +246,183 @@ class PersistenceStorageConfigTest {
                         StorageType.NO_OP,
                         CompressionType.NONE,
                         DEFAULT_COMPRESSION_LEVEL,
-                        archiveGroupSize));
+                        archiveGroupSize,
+                        DEFAULT_EXECUTION_QUEUE_LIMIT,
+                        DEFAULT_EXECUTOR_TYPE,
+                        DEFAULT_THREAD_COUNT,
+                        DEFAULT_THREAD_KEEP_ALIVE_TIME,
+                        DEFAULT_USE_VIRTUAL_THREADS));
+    }
+
+    /**
+     * This test aims to verify that the {@link PersistenceStorageConfig} class
+     * correctly returns the execution queue limit that was set in the constructor.
+     *
+     * @param executionQueueLimit parameterized, the execution queue limit to test
+     */
+    @ParameterizedTest
+    @MethodSource("validExecutionQueueLimits")
+    void testPersistenceStorageConfigValidExecutionQueueLimits(final int executionQueueLimit) {
+        final PersistenceStorageConfig actual = new PersistenceStorageConfig(
+                Path.of(""),
+                Path.of(""),
+                StorageType.NO_OP,
+                CompressionType.NONE,
+                DEFAULT_COMPRESSION_LEVEL,
+                DEFAULT_ARCHIVE_BATCH_SIZE,
+                executionQueueLimit,
+                DEFAULT_EXECUTOR_TYPE,
+                DEFAULT_THREAD_COUNT,
+                DEFAULT_THREAD_KEEP_ALIVE_TIME,
+                DEFAULT_USE_VIRTUAL_THREADS);
+        assertThat(actual).returns(executionQueueLimit, from(PersistenceStorageConfig::executionQueueLimit));
+    }
+
+    /**
+     * This test aims to verify that the {@link PersistenceStorageConfig} class
+     * correctly throws an {@link IllegalArgumentException} when the execution queue
+     * limit is invalid.
+     *
+     * @param executionQueueLimit parameterized, the execution queue limit to test
+     */
+    @ParameterizedTest
+    @MethodSource("invalidExecutionQueueLimits")
+    void testPersistenceStorageConfigInvalidExecutionQueueLimits(final int executionQueueLimit) {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new PersistenceStorageConfig(
+                        Path.of(""),
+                        Path.of(""),
+                        StorageType.NO_OP,
+                        CompressionType.NONE,
+                        DEFAULT_COMPRESSION_LEVEL,
+                        DEFAULT_ARCHIVE_BATCH_SIZE,
+                        executionQueueLimit,
+                        DEFAULT_EXECUTOR_TYPE,
+                        DEFAULT_THREAD_COUNT,
+                        DEFAULT_THREAD_KEEP_ALIVE_TIME,
+                        DEFAULT_USE_VIRTUAL_THREADS));
+    }
+
+    /**
+     * This test aims to verify that the {@link PersistenceStorageConfig} class
+     * correctly returns the thread count that was set in the constructor.
+     *
+     * @param threadCount parameterized, the thread count to test
+     */
+    @ParameterizedTest
+    @MethodSource("validThreadCounts")
+    void testPersistenceStorageConfigValidThreadCounts(final int threadCount) {
+        final PersistenceStorageConfig actual = new PersistenceStorageConfig(
+                Path.of(""),
+                Path.of(""),
+                StorageType.NO_OP,
+                CompressionType.NONE,
+                DEFAULT_COMPRESSION_LEVEL,
+                DEFAULT_ARCHIVE_BATCH_SIZE,
+                DEFAULT_EXECUTION_QUEUE_LIMIT,
+                DEFAULT_EXECUTOR_TYPE,
+                threadCount,
+                DEFAULT_THREAD_KEEP_ALIVE_TIME,
+                DEFAULT_USE_VIRTUAL_THREADS);
+        assertThat(actual).returns(threadCount, from(PersistenceStorageConfig::threadCount));
+    }
+
+    /**
+     * This test aims to verify that the {@link PersistenceStorageConfig} class
+     * correctly throws an {@link IllegalArgumentException} when the thread count
+     * is invalid.
+     *
+     * @param threadCount parameterized, the thread count to test
+     */
+    @ParameterizedTest
+    @MethodSource("invalidThreadCounts")
+    void testPersistenceStorageConfigInvalidThreadCounts(final int threadCount) {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new PersistenceStorageConfig(
+                        Path.of(""),
+                        Path.of(""),
+                        StorageType.NO_OP,
+                        CompressionType.NONE,
+                        DEFAULT_COMPRESSION_LEVEL,
+                        DEFAULT_ARCHIVE_BATCH_SIZE,
+                        DEFAULT_EXECUTION_QUEUE_LIMIT,
+                        DEFAULT_EXECUTOR_TYPE,
+                        threadCount,
+                        DEFAULT_THREAD_KEEP_ALIVE_TIME,
+                        DEFAULT_USE_VIRTUAL_THREADS));
+    }
+
+    /**
+     * This test aims to verify that the {@link PersistenceStorageConfig} class
+     * correctly returns the thread keep alive time that was set in the constructor.
+     *
+     * @param threadKeepAliveTime parameterized, the thread keep alive time to test
+     */
+    @ParameterizedTest
+    @MethodSource("validThreadKeepAliveTimes")
+    void testPersistenceStorageConfigValidThreadKeepAliveTimes(final long threadKeepAliveTime) {
+        final PersistenceStorageConfig actual = new PersistenceStorageConfig(
+                Path.of(""),
+                Path.of(""),
+                StorageType.NO_OP,
+                CompressionType.NONE,
+                DEFAULT_COMPRESSION_LEVEL,
+                DEFAULT_ARCHIVE_BATCH_SIZE,
+                DEFAULT_EXECUTION_QUEUE_LIMIT,
+                DEFAULT_EXECUTOR_TYPE,
+                DEFAULT_THREAD_COUNT,
+                threadKeepAliveTime,
+                DEFAULT_USE_VIRTUAL_THREADS);
+        assertThat(actual).returns(threadKeepAliveTime, from(PersistenceStorageConfig::threadKeepAliveTime));
+    }
+
+    /**
+     * This test aims to verify that the {@link PersistenceStorageConfig} class
+     * correctly throws an {@link IllegalArgumentException} when the thread keep
+     * alive time is invalid.
+     *
+     * @param threadKeepAliveTime parameterized, the thread keep alive time to test
+     */
+    @ParameterizedTest
+    @MethodSource("invalidThreadKeepAliveTimes")
+    void testPersistenceStorageConfigInvalidThreadKeepAliveTimes(final int threadKeepAliveTime) {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new PersistenceStorageConfig(
+                        Path.of(""),
+                        Path.of(""),
+                        StorageType.NO_OP,
+                        CompressionType.NONE,
+                        DEFAULT_COMPRESSION_LEVEL,
+                        DEFAULT_ARCHIVE_BATCH_SIZE,
+                        DEFAULT_EXECUTION_QUEUE_LIMIT,
+                        DEFAULT_EXECUTOR_TYPE,
+                        DEFAULT_THREAD_COUNT,
+                        threadKeepAliveTime,
+                        DEFAULT_USE_VIRTUAL_THREADS));
+    }
+
+    /**
+     * This test aims to verify that the {@link PersistenceStorageConfig} class
+     * correctly returns the use virtual threads flag that was set in the constructor.
+     *
+     * @param useVirtualThreads parameterized, the use virtual threads flag to test
+     */
+    @ParameterizedTest
+    @MethodSource("validUseVirtualThreads")
+    void testPersistenceStorageConfigValidUseVirtualThreads(final boolean useVirtualThreads) {
+        final PersistenceStorageConfig actual = new PersistenceStorageConfig(
+                Path.of(""),
+                Path.of(""),
+                StorageType.NO_OP,
+                CompressionType.NONE,
+                DEFAULT_COMPRESSION_LEVEL,
+                DEFAULT_ARCHIVE_BATCH_SIZE,
+                DEFAULT_EXECUTION_QUEUE_LIMIT,
+                DEFAULT_EXECUTOR_TYPE,
+                DEFAULT_THREAD_COUNT,
+                DEFAULT_THREAD_KEEP_ALIVE_TIME,
+                useVirtualThreads);
+        assertThat(actual).returns(useVirtualThreads, from(PersistenceStorageConfig::useVirtualThreads));
     }
 
     /**
@@ -316,9 +529,7 @@ class PersistenceStorageConfigTest {
                 Arguments.of(10_000),
                 Arguments.of(100_000),
                 Arguments.of(1_000_000),
-                Arguments.of(10_000_000),
-                Arguments.of(100_000_000),
-                Arguments.of(1_000_000_000));
+                Arguments.of(10_000_000));
     }
 
     private static Stream<Arguments> invalidArchiveGroupSizes() {
@@ -335,8 +546,72 @@ class PersistenceStorageConfigTest {
                 Arguments.of(-10_000),
                 Arguments.of(-100_000),
                 Arguments.of(-1_000_000),
-                Arguments.of(-10_000_000),
-                Arguments.of(-100_000_000),
-                Arguments.of(-1_000_000_000));
+                Arguments.of(-10_000_000));
+    }
+
+    private static Stream<Arguments> validExecutionQueueLimits() {
+        return Stream.of(Arguments.of(100), Arguments.of(1_000));
+    }
+
+    private static Stream<Arguments> invalidExecutionQueueLimits() {
+        return Stream.of(
+                Arguments.of(0),
+                Arguments.of(-1),
+                Arguments.of(-2),
+                Arguments.of(-10),
+                Arguments.of(-20),
+                Arguments.of(-50),
+                Arguments.of(-100),
+                Arguments.of(-1_000),
+                Arguments.of(-10_000),
+                Arguments.of(-100_000),
+                Arguments.of(-1_000_000),
+                Arguments.of(-10_000_000));
+    }
+
+    private static Stream<Arguments> validThreadCounts() {
+        return Stream.of(Arguments.of(1), Arguments.of(2), Arguments.of(4), Arguments.of(8), Arguments.of(16));
+    }
+
+    private static Stream<Arguments> invalidThreadCounts() {
+        return Stream.of(
+                Arguments.of(0),
+                Arguments.of(-1),
+                Arguments.of(-2),
+                Arguments.of(-4),
+                Arguments.of(-8),
+                Arguments.of(-16));
+    }
+
+    private static Stream<Arguments> validThreadKeepAliveTimes() {
+        return Stream.of(
+                Arguments.of(0),
+                Arguments.of(1000),
+                Arguments.of(5000),
+                Arguments.of(10000),
+                Arguments.of(30000),
+                Arguments.of(60000),
+                Arguments.of(120000),
+                Arguments.of(300000),
+                Arguments.of(600000),
+                Arguments.of(3600000));
+    }
+
+    private static Stream<Arguments> invalidThreadKeepAliveTimes() {
+        return Stream.of(
+                Arguments.of(-1),
+                Arguments.of(-1000),
+                Arguments.of(-5000),
+                Arguments.of(-10000),
+                Arguments.of(-30000),
+                Arguments.of(-60000),
+                Arguments.of(-120000),
+                Arguments.of(-300000),
+                Arguments.of(-600000),
+                Arguments.of(-3600000));
+    }
+
+    private static Stream<Arguments> validUseVirtualThreads() {
+        return Stream.of(Arguments.of(true), Arguments.of(false));
     }
 }

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 class PersistenceStorageConfigTest {
     private static final Path HASHGRAPH_ROOT_ABSOLUTE_PATH =
-            Path.of("/opt/hashgraph/").toAbsolutePath();
+            Path.of("./opt/hashgraph/").toAbsolutePath();
     private static final Path PERSISTENCE_STORAGE_ROOT_ABSOLUTE_PATH =
             HASHGRAPH_ROOT_ABSOLUTE_PATH.resolve("blocknode/data/");
     // Default compression level (as set in the config annotation)
@@ -266,6 +266,7 @@ class PersistenceStorageConfigTest {
         final PersistenceStorageConfig actual = new PersistenceStorageConfig(
                 Path.of(""),
                 Path.of(""),
+                Path.of(""),
                 StorageType.NO_OP,
                 CompressionType.NONE,
                 DEFAULT_COMPRESSION_LEVEL,
@@ -292,6 +293,7 @@ class PersistenceStorageConfigTest {
                 .isThrownBy(() -> new PersistenceStorageConfig(
                         Path.of(""),
                         Path.of(""),
+                        Path.of(""),
                         StorageType.NO_OP,
                         CompressionType.NONE,
                         DEFAULT_COMPRESSION_LEVEL,
@@ -313,6 +315,7 @@ class PersistenceStorageConfigTest {
     @MethodSource("validThreadCounts")
     void testPersistenceStorageConfigValidThreadCounts(final int threadCount) {
         final PersistenceStorageConfig actual = new PersistenceStorageConfig(
+                Path.of(""),
                 Path.of(""),
                 Path.of(""),
                 StorageType.NO_OP,
@@ -341,6 +344,7 @@ class PersistenceStorageConfigTest {
                 .isThrownBy(() -> new PersistenceStorageConfig(
                         Path.of(""),
                         Path.of(""),
+                        Path.of(""),
                         StorageType.NO_OP,
                         CompressionType.NONE,
                         DEFAULT_COMPRESSION_LEVEL,
@@ -362,6 +366,7 @@ class PersistenceStorageConfigTest {
     @MethodSource("validThreadKeepAliveTimes")
     void testPersistenceStorageConfigValidThreadKeepAliveTimes(final long threadKeepAliveTime) {
         final PersistenceStorageConfig actual = new PersistenceStorageConfig(
+                Path.of(""),
                 Path.of(""),
                 Path.of(""),
                 StorageType.NO_OP,
@@ -390,6 +395,7 @@ class PersistenceStorageConfigTest {
                 .isThrownBy(() -> new PersistenceStorageConfig(
                         Path.of(""),
                         Path.of(""),
+                        Path.of(""),
                         StorageType.NO_OP,
                         CompressionType.NONE,
                         DEFAULT_COMPRESSION_LEVEL,
@@ -411,6 +417,7 @@ class PersistenceStorageConfigTest {
     @MethodSource("validUseVirtualThreads")
     void testPersistenceStorageConfigValidUseVirtualThreads(final boolean useVirtualThreads) {
         final PersistenceStorageConfig actual = new PersistenceStorageConfig(
+                Path.of(""),
                 Path.of(""),
                 Path.of(""),
                 StorageType.NO_OP,

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/write/AsyncWriterExecutorFactoryTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/write/AsyncWriterExecutorFactoryTest.java
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.server.persistence.storage.write;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.ExecutorType;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * Test class that tests the functionality of the
+ * {@link AsyncWriterExecutorFactory}
+ */
+class AsyncWriterExecutorFactoryTest {
+
+    /**
+     * This test verifies that the factory throws a NullPointerException when
+     * null config is provided.
+     */
+    @Test
+    void testCreateExecutorWithNullConfig() {
+        assertThrows(NullPointerException.class, () -> AsyncWriterExecutorFactory.createExecutor(null));
+    }
+
+    /**
+     * This test verifies that the factory creates the correct executor type
+     * based on the configuration.
+     *
+     * @param executorType the executor type to test
+     */
+    @ParameterizedTest
+    @EnumSource(ExecutorType.class)
+    void testCreateExecutorWithDifferentTypes(final ExecutorType executorType) {
+        // Given
+        final PersistenceStorageConfig config = createConfig(executorType, false, 4, 60L, 100);
+
+        // When
+        final Executor executor = AsyncWriterExecutorFactory.createExecutor(config);
+
+        // Then
+        assertNotNull(executor);
+
+        switch (executorType) {
+            case THREAD_POOL -> assertTrue(executor instanceof ThreadPoolExecutor);
+            case SINGLE_THREAD -> assertTrue(executor instanceof ExecutorService);
+            case FORK_JOIN -> assertTrue(executor instanceof ForkJoinPool);
+        }
+    }
+
+    /**
+     * This test verifies that the factory creates a virtual thread executor
+     * when virtual threads are enabled.
+     */
+    @Test
+    void testCreateThreadPoolExecutorWithVirtualThreads() {
+        // Given
+        final PersistenceStorageConfig config = createConfig(ExecutorType.THREAD_POOL, true, 4, 60L, 100);
+
+        // When
+        final Executor executor = AsyncWriterExecutorFactory.createExecutor(config);
+
+        // Then
+        assertNotNull(executor);
+        System.out.println(executor.getClass().getName());
+        // Virtual thread executor invokes underneath ThreadPerTaskExecutor with specific factory for virtual
+        assertTrue(executor.getClass().getName().contains("ThreadPerTaskExecutor"));
+    }
+
+    /**
+     * This test verifies that the factory creates a thread pool executor with
+     * the correct configuration when virtual threads are disabled.
+     */
+    @Test
+    void testCreateThreadPoolExecutorWithPlatformThreads() {
+        // Given
+        final int threadCount = 6;
+        final long keepAliveTime = 120L;
+        final int queueLimit = 200;
+        final PersistenceStorageConfig config =
+                createConfig(ExecutorType.THREAD_POOL, false, threadCount, keepAliveTime, queueLimit);
+
+        // When
+        final Executor executor = AsyncWriterExecutorFactory.createExecutor(config);
+
+        // Then
+        assertNotNull(executor);
+        assertTrue(executor instanceof ThreadPoolExecutor);
+
+        final ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executor;
+        assertTrue(threadPoolExecutor.getCorePoolSize() == threadCount);
+        assertTrue(threadPoolExecutor.getMaximumPoolSize() == threadCount);
+        assertTrue(threadPoolExecutor.getKeepAliveTime(java.util.concurrent.TimeUnit.SECONDS) == keepAliveTime);
+        assertTrue(threadPoolExecutor.getQueue().remainingCapacity() == queueLimit);
+        assertTrue(threadPoolExecutor.getRejectedExecutionHandler() instanceof ThreadPoolExecutor.CallerRunsPolicy);
+    }
+
+    /**
+     * Creates a test configuration with the specified parameters.
+     */
+    private PersistenceStorageConfig createConfig(
+            final ExecutorType executorType,
+            final boolean useVirtualThreads,
+            final int threadCount,
+            final long threadKeepAliveTime,
+            final int executionQueueLimit) {
+        return new PersistenceStorageConfig(
+                java.nio.file.Path.of(""),
+                java.nio.file.Path.of(""),
+                PersistenceStorageConfig.StorageType.BLOCK_AS_LOCAL_FILE,
+                PersistenceStorageConfig.CompressionType.NONE,
+                3, // Default compression level
+                1000, // Default archive batch size
+                executionQueueLimit,
+                executorType,
+                threadCount,
+                threadKeepAliveTime,
+                useVirtualThreads);
+    }
+}


### PR DESCRIPTION
This PR adds a configurable executor for async writers in the persistence storage module. The implementation allows for different executor types and configurations to optimize performance for various workloads and deployment environments.
#### Key Changes:
- Added `ExecutorType` enum to `PersistenceStorageConfig` with options for `THREAD_POOL`, `SINGLE_THREAD`, and `FORK_JOIN` executors
- Added configuration properties for thread count, thread keep-alive time, virtual threads support, and execution queue limit
- Implemented `AsyncWriterExecutorFactory` to create appropriate executor instances based on configuration
- Updated `PersistenceInjectionModule` to use the factory for creating executors
- Added unit tests for all new components


## Reviewer Notes
#### Configuration Options:
- `persistence.storage.executionQueueLimit`: Maximum queue size for pending tasks (64-2048)
- `persistence.storage.executorType`: Type of executor (THREAD_POOL, SINGLE_THREAD, FORK_JOIN)
- `persistence.storage.threadCount`: Number of threads for thread pool (1-16)
- `persistence.storage.threadKeepAliveTime`: Keep-alive time in seconds for idle threads
- `persistence.storage.useVirtualThreads`: Whether to use virtual threads (boolean)
## Related Issue(s)
Fixes #587 
