### PR TITLE
fix: downgrade of upgrade found to be the culprit of Build broke.

### DIFF
--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("org.hiero.gradle.check.spotless-kotlin")
 }
 
-dependencies { api(platform("com.google.cloud:libraries-bom:26.55.0")) }
+dependencies { api(platform("com.google.cloud:libraries-bom:26.54.0")) }
 
 dependencies.constraints {
     val daggerVersion = "2.55"


### PR DESCRIPTION
## Reviewer Notes

This PR aims to rollback dependency upgrade: https://github.com/hiero-ledger/hiero-block-node/pull/695

To allow the Build process in `main` to be fixed/unblocked, while a deeper investigation on why exactly this dependency upgrade has broken the build process, specifically for `Hedera-Protobuf` stream package.

Pending: another Issue to continue with the investigation and if possible, re-upgrade to newest version.
