### PR TITLE
chore: improvements for test repeatability

### DIFF
--- a/server/src/test/java/com/hedera/block/server/util/BlockingExecutorService.java
+++ b/server/src/test/java/com/hedera/block/server/util/BlockingExecutorService.java
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.server.util;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class BlockingExecutorService extends ThreadPoolExecutor {
+    // Useful for testing async logic. Blocks the test thread when waitTasksToComplete() is called.
+    // Takes as param the expected number of tasks to finish before continuing the test thread.
+    // (Additional tasks, if any, are executed before releasing, the queue should be empty)
+    // Takes the pool size as a second parameter
+    private final int expectedTasks;
+    private int completedTasks = 0;
+    private final CountDownLatch countDownLatch;
+
+    public BlockingExecutorService(int expectedTasks, int poolSize) {
+        super(poolSize, poolSize, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
+        this.expectedTasks = expectedTasks;
+        this.countDownLatch = new CountDownLatch(1);
+    }
+
+    @Override
+    protected void afterExecute(Runnable r, Throwable t) {
+        completedTasks++;
+        if (getQueue().isEmpty() && completedTasks >= expectedTasks) {
+            countDownLatch.countDown();
+        }
+    }
+
+    public void waitTasksToComplete() throws InterruptedException {
+        countDownLatch.await();
+    }
+}

--- a/server/src/test/java/com/hedera/block/server/util/TestUtils.java
+++ b/server/src/test/java/com/hedera/block/server/util/TestUtils.java
@@ -6,6 +6,8 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import org.mockito.stubbing.Answer;
 
 public final class TestUtils {
     private TestUtils() {}
@@ -42,5 +44,15 @@ public final class TestUtils {
 
     public static FileAttribute<Set<PosixFilePermission>> getNoWrite() {
         return PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString(NO_WRITE));
+    }
+
+    public static Answer<Void> onEventLatchCountdown(CountDownLatch latch) {
+        return invocation -> {
+            if (latch.getCount() == 0) {
+                throw new IllegalStateException("Event calls exceeded");
+            }
+            latch.countDown();
+            return null;
+        };
     }
 }


### PR DESCRIPTION
## Reviewer Notes
- Added a custom BlockingExecutorService to ensure async logic in tests executes and completes before assertions begin.
- Used CountDownLatch technique to synchronize execution in cases where BlockingExecutorService cannot be properly injected.
- Modified PbjBlockStreamServiceProxy to enable custom executor injection for test purposes.


## Related Issue(s)
 Fixes #642 
