### PR TITLE
ci: Update ubuntu runners to 24.04 and 22.04

### DIFF
--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -142,8 +142,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - ubuntu-24.04
           - ubuntu-22.04
-          - ubuntu-20.04
           - hiero-block-node-linux-medium
     steps:
       - name: Harden Runner


### PR DESCRIPTION
**Description**:
Update version of Ubuntu in the verify-artifacts job to be 24.04 and 22.04 instead of 22.04 and 20.04

**Related Issue(s)**:
Fixes #769 
