### PR TITLE
chore: remove sleep on completeStreaming() in Simulator

### DIFF
--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
@@ -151,14 +151,10 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
     /**
      * Sends a onCompleted message to the server and waits for a short period of
      * time to ensure the message is sent.
-     *
-     * @throws InterruptedException if the thread is interrupted
      */
     @Override
-    public void completeStreaming() throws InterruptedException {
+    public void completeStreaming() {
         requestStreamObserver.onCompleted();
-        // todo(352) Find a suitable solution for removing the sleep
-        Thread.sleep(100);
     }
 
     /**


### PR DESCRIPTION
## Reviewer Notes
1. Added test `testStreamBlock_RejectsAfterShutdown` to verify proper shutdown behavior:
   - Verifies that client rejects new messages after shutdown
   - Validates correct error message "Stream is already completed, no further calls are allowed"
   - Added flag to prevent double shutdown in test teardown

2. Removed unnecessary sleep in `PublishStreamGrpcClientImpl.completeStreaming()`:
   - Simplified the method to just call `onCompleted()`
   - Removed redundant wait time that was causing potential delays
  
## Related Issue(s)
Fixes #352 
