### PR TITLE
chore: Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-Story-Template.yml
+++ b/.github/ISSUE_TEMPLATE/01-Story-Template.yml
@@ -1,31 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 name: Agile Task or Feature
 description: Create a new task or feature
-title: "-"
-projects: "hiero-ledger/9"
+projects:
+  - "hiero-ledger/9"
+type: feature
 body:
-  - type: input
-    id: as-a-line
+  - type: textarea
+    id: Story-Form
     attributes:
-      label: Persona
-      description: As a "Persona"
-      value: "As a ?"
-    validations:
-      required: true
-  - type: input
-    id: i-want-to-line
-    attributes:
-      label: Request
-      description: I want to "Request"
-      value: "I want to ?"
-    validations:
-      required: true
-  - type: input
-    id: so-that-line
-    attributes:
-      label: Goal
-      description: So that "Goal"
-      value: "So that ?"
+      label: Story Form
+      description: |
+        As a "Persona"
+        I want to "Request"
+        So that "Goal"
+      value: |
+        As a ?
+        I want to ?
+        So that ?
     validations:
       required: true
   - type: textarea
@@ -33,7 +24,7 @@ body:
     attributes:
       label: Technical Notes
       description: Add any additional detail to describe this story.
-      value: |
+      placeholder: |
         Technical details, notes, suggestions, etc...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/02-Epic-Template.yml
+++ b/.github/ISSUE_TEMPLATE/02-Epic-Template.yml
@@ -1,15 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 name: Epic
 description: Create a new Epic
-title: "-"
-projects: "hiero-ledger/9"
+projects:
+  - "hiero-ledger/9"
+type: "epic"
 body:
   - type: textarea
     id: epic-goal
     attributes:
       label: Goal
       description: Describe the goal of this epic in one or two sentences
-      value: |
+      placeholder: |
         Make the block node spectacular.
     validations:
       required: true
@@ -18,7 +19,7 @@ body:
     attributes:
       label: Intention
       description: Three to five sentences about what the team intends to accomplish in order to meet the epic goal.
-      value: |
+      placeholder: |
         Three to five sentences about what the team intends to accomplish in order to meet the epic goal.
     validations:
       required: true
@@ -27,21 +28,21 @@ body:
     attributes:
       label: Considerations
       description: A list of considerations that affect the completion of this epic.
-      value: |
+      placeholder: |
         A list of considerations that affect the completion of this epic.  This includes alternatives already considered before arriving at the intention above.
-        - Consideration
+        - Consideration 1
            - Added details
-        - Consideration
+        - Consideration 2
            - Added details
         - ...
     validations:
-      required: true
+      required: false
   - type: textarea
     id: epic-detail
     attributes:
       label: Technical Details
       description: Add any additional detail to describe this epic.
-      value: |
+      placeholder: |
         Technical details, notes, customer stories, etc...
     validations:
       required: false
@@ -50,10 +51,10 @@ body:
     attributes:
       label: Tasks and Features
       description: List features and tasks needed to complete this epic
-      value: |
+      placeholder: |
         - [ ] feature 1
         - [ ] feature 2
         - [ ] task 1
         - [ ] ...
     validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/03-Bug-Template.yml
+++ b/.github/ISSUE_TEMPLATE/03-Bug-Template.yml
@@ -1,0 +1,46 @@
+#·SPDX-License-Identifier:·Apache-2.0
+name: Block Node Bug Report
+description: Create a report to help us improve
+labels:
+  - bug
+type: Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Thanks for submitting a bug report!
+
+        Before submitting:
+        1. Try searching the existing issues and discussions to see if your issue has already been reported
+        2. If you're reporting a security vulnerability, please disclose responsibly via our [bug bounty program](https://hedera.com/bounty)
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened and what you did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Run the block node
+        2. Send a '...' request
+        3. Response is '...'
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Attach any logs or screenshots relevant to the problem.
+      placeholder: |
+        ![Screenshot](bug.png)
+
+        ```bash
+        2021-06-29T13:50:45.008-0600 INFO thread-1 Some logs
+        ```
+    validations:
+      required: false


### PR DESCRIPTION
* Added type to both forms
* Moved most values to placeholders
* Changed 3 separate questions to one text area for feature/task
   * This improves readability versus the 3 separate headers github inserts
* Removed titles so that is entered more easily
* Fixed projects assignment

Small updates based on user feedback to make the template forms easier to use and less intrusive.