### PR TITLE
feat: BN server Helm various improvements

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -60,4 +60,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --config ct.yaml --helm-extra-args "-f charts/block-node-server/values-overrides/mini.yaml"
+        run: ct install --config ct.yaml

--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -60,4 +60,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --config ct.yaml
+        run: ct install --config ct.yaml --helm-extra-args "-f values-overrides/mini.yaml"

--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -60,4 +60,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --config ct.yaml --helm-extra-args "-f values-overrides/mini.yaml"
+        run: ct install --config ct.yaml --helm-extra-args "-f charts/block-node-server/values-overrides/mini.yaml"

--- a/charts/block-node-server/templates/NOTES.txt
+++ b/charts/block-node-server/templates/NOTES.txt
@@ -1,7 +1,7 @@
 1. **Get the application URL** by running the following commands:
 
 ```bash
-kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{.Release.Name}}-hiero-block-node 8080:{{ .Values.service.port }}
+kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{.Release.Name}}-{{.Chart.Name}} 8080:{{ .Values.service.port }}
 echo "Visit http://127.0.0.1:8080 to use your application"
 ```
 

--- a/charts/block-node-server/templates/NOTES.txt
+++ b/charts/block-node-server/templates/NOTES.txt
@@ -1,7 +1,7 @@
 1. **Get the application URL** by running the following commands:
 
 ```bash
-kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{.Release.Name}}-hedera-block-node 8080:{{ .Values.service.port }}
+kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{.Release.Name}}-hiero-block-node 8080:{{ .Values.service.port }}
 echo "Visit http://127.0.0.1:8080 to use your application"
 ```
 

--- a/charts/block-node-server/templates/_helpers.tpl
+++ b/charts/block-node-server/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "hedera-block-node.name" -}}
+{{- define "hiero-block-node.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "hedera-block-node.fullname" -}}
+{{- define "hiero-block-node.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "hedera-block-node.chart" -}}
+{{- define "hiero-block-node.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "hedera-block-node.labels" -}}
-helm.sh/chart: {{ include "hedera-block-node.chart" . }}
-{{ include "hedera-block-node.selectorLabels" . }}
+{{- define "hiero-block-node.labels" -}}
+helm.sh/chart: {{ include "hiero-block-node.chart" . }}
+{{ include "hiero-block-node.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -45,17 +45,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "hedera-block-node.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "hedera-block-node.name" . }}
+{{- define "hiero-block-node.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hiero-block-node.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "hedera-block-node.serviceAccountName" -}}
+{{- define "hiero-block-node.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "hedera-block-node.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "hiero-block-node.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
@@ -66,16 +66,16 @@ This function returns the image tag from the values.yaml file if provided.
 If the tag is not provided, it defaults to the AppVersion specified in the Chart.yaml file.
 Usage: {{ include "image.AppVersion" . }}
 */}}
-{{- define "hedera-block-node.image.tag" -}}
+{{- define "hiero-block-node.image.tag" -}}
 {{- default .Chart.AppVersion .Values.image.tag -}}
 {{- end -}}
 
 {{/*
 This function returns the image tag from the values.yaml file if provided.
 If the tag is not provided, it defaults to the AppVersion specified in the Chart.yaml file.
-Usage: {{ include "hedera-block-node.app.version" . }}
+Usage: {{ include "hiero-block-node.app.version" . }}
 */}}
-{{- define "hedera-block-node.appVersion" -}}
+{{- define "hiero-block-node.appVersion" -}}
 {{- default .Chart.AppVersion .Values.blockNode.version -}}
 {{- end -}}
 

--- a/charts/block-node-server/templates/configmap-logging.yaml
+++ b/charts/block-node-server/templates/configmap-logging.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "hedera-block-node.fullname" . }}-logging-config
+  name: {{ include "hiero-block-node.fullname" . }}-logging-config
 data:
   logging.properties: |
     # Log properties

--- a/charts/block-node-server/templates/configmap.yaml
+++ b/charts/block-node-server/templates/configmap.yaml
@@ -5,9 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "hedera-block-node.fullname" . }}-config
+  name: {{ include "hiero-block-node.fullname" . }}-config
 data:
-  VERSION: {{ include "hedera-block-node.appVersion" .  | quote }}
+  VERSION: {{ include "hiero-block-node.appVersion" .  | quote }}
 {{- range $key, $value := .Values.blockNode.config }}
   {{ $key }}: {{ $value | quote }}
 {{- end }}

--- a/charts/block-node-server/templates/deployment.yaml
+++ b/charts/block-node-server/templates/deployment.yaml
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "hedera-block-node.fullname" . }}
+  name: {{ include "hiero-block-node.fullname" . }}
   labels:
-    {{- include "hedera-block-node.labels" . | nindent 4 }}
+    {{- include "hiero-block-node.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "hedera-block-node.selectorLabels" . | nindent 6 }}
+      {{- include "hiero-block-node.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -20,19 +20,19 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "hedera-block-node.selectorLabels" . | nindent 8 }}
+        {{- include "hiero-block-node.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "hedera-block-node.serviceAccountName" . }}
+      serviceAccountName: {{ include "hiero-block-node.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
         - name: logging-config
           configMap:
-            name: {{ include "hedera-block-node.fullname" . }}-logging-config
+            name: {{ include "hiero-block-node.fullname" . }}-logging-config
       containers:
       - name: {{ .Chart.Name }}
         securityContext:
@@ -48,9 +48,9 @@ spec:
             protocol: TCP
         envFrom:
           - configMapRef:
-              name: {{ include "hedera-block-node.fullname" . }}-config
+              name: {{ include "hiero-block-node.fullname" . }}-config
           - secretRef:
-              name: {{ include "hedera-block-node.fullname" . }}-secret
+              name: {{ include "hiero-block-node.fullname" . }}-secret
         volumeMounts:
           - name: logging-config
             mountPath: /app/logs/config

--- a/charts/block-node-server/templates/deployment.yaml
+++ b/charts/block-node-server/templates/deployment.yaml
@@ -33,6 +33,12 @@ spec:
         - name: logging-config
           configMap:
             name: {{ include "hiero-block-node.fullname" . }}-logging-config
+        - name: archive-storage
+          persistentVolumeClaim:
+            claimName: {{ if .Values.blockNode.persistence.archive.create }}{{ include "hiero-block-node.fullname" . }}-archive{{ else }}{{ .Values.blockNode.persistence.archive.existingClaim }}{{ end }}
+        - name: live-storage
+          persistentVolumeClaim:
+            claimName: {{ if .Values.blockNode.persistence.live.create }}{{ include "hiero-block-node.fullname" . }}-live{{ else }}{{ .Values.blockNode.persistence.live.existingClaim }}{{ end }}
       containers:
       - name: {{ .Chart.Name }}
         securityContext:
@@ -55,6 +61,10 @@ spec:
           - name: logging-config
             mountPath: /app/logs/config
             readOnly: true
+          - name: archive-storage
+            mountPath: {{ .Values.blockNode.persistence.archive.mountPath }}
+          - name: live-storage
+            mountPath: {{ .Values.blockNode.persistence.live.mountPath }}
         {{- with  .Values.resources }}
         resources:
           requests:

--- a/charts/block-node-server/templates/deployment.yaml
+++ b/charts/block-node-server/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
         - name: live-storage
           persistentVolumeClaim:
             claimName: {{ if .Values.blockNode.persistence.live.create }}{{ include "hiero-block-node.fullname" . }}-live{{ else }}{{ .Values.blockNode.persistence.live.existingClaim }}{{ end }}
+        - name: unverified-ephemeral-storage
+          emptyDir: {}
       containers:
       - name: {{ .Chart.Name }}
         securityContext:
@@ -65,6 +67,8 @@ spec:
             mountPath: {{ .Values.blockNode.persistence.archive.mountPath }}
           - name: live-storage
             mountPath: {{ .Values.blockNode.persistence.live.mountPath }}
+          - name: unverified-ephemeral-storage
+            mountPath: {{ .Values.blockNode.persistence.unverified.mountPath }}
         {{- with  .Values.resources }}
         resources:
           requests:

--- a/charts/block-node-server/templates/grafana-datasource.yaml
+++ b/charts/block-node-server/templates/grafana-datasource.yaml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "hedera-block-node.fullname" . }}-grafana-datasource
+  name: {{ include "hiero-block-node.fullname" . }}-grafana-datasource
   labels:
     grafana_datasource: "1"
 data:

--- a/charts/block-node-server/templates/ingress.yaml
+++ b/charts/block-node-server/templates/ingress.yaml
@@ -3,7 +3,7 @@ SPDX-License-Identifier: Apache-2.0
 */}}
 
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "hedera-block-node.fullname" . -}}
+{{- $fullName := include "hiero-block-node.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
@@ -21,7 +21,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "hedera-block-node.labels" . | nindent 4 }}
+    {{- include "hiero-block-node.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/block-node-server/templates/pvc-archive.yaml
+++ b/charts/block-node-server/templates/pvc-archive.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.blockNode.persistence.archive.create }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "hiero-block-node.fullname" . }}-archive
+  labels:
+    {{- include "hiero-block-node.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.blockNode.persistence.archive.size }}
+  {{- if .Values.blockNode.persistence.archive.storageClass }}
+  storageClassName: {{ .Values.blockNode.persistence.archive.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/block-node-server/templates/pvc-live.yaml
+++ b/charts/block-node-server/templates/pvc-live.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.blockNode.persistence.live.create }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "hiero-block-node.fullname" . }}-live
+  labels:
+    {{- include "hiero-block-node.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.blockNode.persistence.live.size }}
+  {{- if .Values.blockNode.persistence.live.storageClass }}
+  storageClassName: {{ .Values.blockNode.persistence.live.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/block-node-server/templates/secret.yaml
+++ b/charts/block-node-server/templates/secret.yaml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "hedera-block-node.fullname" . }}-secret
+  name: {{ include "hiero-block-node.fullname" . }}-secret
 type: Opaque
 data:
 {{- range $key, $value := .Values.blockNode.secret }}

--- a/charts/block-node-server/templates/service.yaml
+++ b/charts/block-node-server/templates/service.yaml
@@ -5,10 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "hedera-block-node.fullname" . }}
+  name: {{ include "hiero-block-node.fullname" . }}
   labels:
-    app: {{ include "hedera-block-node.name" . }}
-    {{- include "hedera-block-node.labels" . | nindent 4 }}
+    app: {{ include "hiero-block-node.name" . }}
+    {{- include "hiero-block-node.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -20,4 +20,4 @@ spec:
       port: {{ .Values.blockNode.health.metrics.port }}
       targetPort: metrics
   selector:
-    {{- include "hedera-block-node.selectorLabels" . | nindent 4 }}
+    {{- include "hiero-block-node.selectorLabels" . | nindent 4 }}

--- a/charts/block-node-server/templates/serviceaccount.yaml
+++ b/charts/block-node-server/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "hedera-block-node.serviceAccountName" . }}
+  name: {{ include "hiero-block-node.serviceAccountName" . }}
   labels:
-    {{- include "hedera-block-node.labels" . | nindent 4 }}
+    {{- include "hiero-block-node.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/block-node-server/templates/servicemonitor.yaml
+++ b/charts/block-node-server/templates/servicemonitor.yaml
@@ -6,15 +6,15 @@ SPDX-License-Identifier: Apache-2.0
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "hedera-block-node.fullname" . }}
+  name: {{ include "hiero-block-node.fullname" . }}
   labels:
-    app: {{ include "hedera-block-node.name" . }}
+    app: {{ include "hiero-block-node.name" . }}
     release: {{ .Release.Name }}
-    {{- include "hedera-block-node.labels" . | nindent 4 }}
+    {{- include "hiero-block-node.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "hedera-block-node.name" . }}
+      app: {{ include "hiero-block-node.name" . }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/block-node-server/values-overrides/mini.yaml
+++ b/charts/block-node-server/values-overrides/mini.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This override values for the block-node-server chart to deploy a mini version of the block-node-server.
+# This is useful for testing and development purposes with limited resources.
+# ie: minikube
+
+resources:
+  requests:
+    cpu: "3"
+    memory: "8Gi"
+
+blockNode:
+  config:
+    JAVA_TOOL_OPTIONS: "-Djava.util.logging.config.file=/app/logs/config/logging.properties"
+    JAVA_OPTS: "-Xms5G -Xmx5G"
+    MEDIATOR_RING_BUFFER_SIZE: "2048"
+  persistence:
+    archive:
+      size: 2Gi
+    live:
+      size: 5Gi

--- a/charts/block-node-server/values-overrides/mini.yaml
+++ b/charts/block-node-server/values-overrides/mini.yaml
@@ -16,6 +16,6 @@ blockNode:
     MEDIATOR_RING_BUFFER_SIZE: "2048"
   persistence:
     archive:
-      size: 2Gi
+      size: 6Gi
     live:
-      size: 5Gi
+      size: 1Gi

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -80,7 +80,29 @@ blockNode:
     # VERIFICATION_TYPE: "NO_OP"
     # MEDIATOR_TYPE: "NO_OP"
     MEDIATOR_RING_BUFFER_SIZE: "4096"
-
+  persistence:
+    archive:
+      # If false, the chart expects an externally provided PVC
+      create: true
+      # Name of the externally provided PVC
+      existingClaim: ""
+      # If create is true, the following values are used to create the PVC
+      # should match PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH, leave as is for default.
+      mountPath: "/opt/hashgraph/blocknode/data/archive"
+      size: 2Gi
+      # Optionally add a storage class name if needed
+      # storageClass: "your-storage-class"
+    live:
+      # If false, the chart expects an externally provided PVC
+      create: true
+      # Name of the externally provided PVC
+      existingClaim: ""
+      # If create is true, the following values are used to create the PVC
+      # should match PERSISTENCE_STORAGE_LIVE_ROOT_PATH, leave as is for default.
+      mountPath: "/opt/hashgraph/blocknode/data/live"
+      size: 5Gi
+      # Optionally add a storage class name if needed
+      # storageClass: "your-storage-class"
   secret:
     PRIVATE_KEY: "fake_private_key"
   health:

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Default values for hedera-block-node.
+# Default values for a production hiero block-node-server deployment
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -100,7 +100,7 @@ blockNode:
       # If create is true, the following values are used to create the PVC
       # should match PERSISTENCE_STORAGE_LIVE_ROOT_PATH, leave as is for default.
       mountPath: "/opt/hashgraph/blocknode/data/live"
-      size: 10Gi
+      size: 20Gi
       # Optionally add a storage class name if needed
       # storageClass: "your-storage-class"
   secret:

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -89,7 +89,7 @@ blockNode:
       # If create is true, the following values are used to create the PVC
       # should match PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH, leave as is for default.
       mountPath: "/opt/hashgraph/blocknode/data/archive"
-      size: 200Gi
+      size: 800Gi
       # Optionally add a storage class name if needed
       # storageClass: "your-storage-class"
     live:
@@ -100,7 +100,7 @@ blockNode:
       # If create is true, the following values are used to create the PVC
       # should match PERSISTENCE_STORAGE_LIVE_ROOT_PATH, leave as is for default.
       mountPath: "/opt/hashgraph/blocknode/data/live"
-      size: 500Gi
+      size: 10Gi
       # Optionally add a storage class name if needed
       # storageClass: "your-storage-class"
   secret:

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -103,6 +103,11 @@ blockNode:
       size: 20Gi
       # Optionally add a storage class name if needed
       # storageClass: "your-storage-class"
+    unverified:
+      # unverified does a hard-coded emptyDir and is ephemeral, however needs to be mounted
+      # this does not create a PVC.
+      # should match PERSISTENCE_STORAGE_UNVERIFIED_ROOT_PATH, leave as is for default.
+      mountPath: "/opt/hashgraph/blocknode/data/unverified"
   secret:
     PRIVATE_KEY: "fake_private_key"
   health:

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -58,8 +58,8 @@ ingress:
 
 resources:
   requests:
-    cpu: "8"
-    memory: "24Gi"
+    cpu: "3"
+    memory: "12Gi"
 
 nodeSelector: {}
 
@@ -74,7 +74,7 @@ blockNode:
     # Add any additional env configuration here
     # key: value
     JAVA_TOOL_OPTIONS: "-Djava.util.logging.config.file=/app/logs/config/logging.properties"
-    JAVA_OPTS: "-Xms16G -Xmx16G"
+    JAVA_OPTS: "-Xms8G -Xmx8G"
     # PRODUCER_TYPE: "NO_OP"
     # PERSISTENCE_STORAGE_TYPE: "NO_OP"
     # VERIFICATION_TYPE: "NO_OP"

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -58,8 +58,8 @@ ingress:
 
 resources:
   requests:
-    cpu: "3"
-    memory: "12Gi"
+    cpu: "8"
+    memory: "24Gi"
 
 nodeSelector: {}
 
@@ -74,12 +74,12 @@ blockNode:
     # Add any additional env configuration here
     # key: value
     JAVA_TOOL_OPTIONS: "-Djava.util.logging.config.file=/app/logs/config/logging.properties"
-    JAVA_OPTS: "-Xms8G -Xmx8G"
+    JAVA_OPTS: "-Xms16G -Xmx16G"
     # PRODUCER_TYPE: "NO_OP"
     # PERSISTENCE_STORAGE_TYPE: "NO_OP"
     # VERIFICATION_TYPE: "NO_OP"
     # MEDIATOR_TYPE: "NO_OP"
-    MEDIATOR_RING_BUFFER_SIZE: "4096"
+    MEDIATOR_RING_BUFFER_SIZE: "8192"
   persistence:
     archive:
       # If false, the chart expects an externally provided PVC
@@ -89,7 +89,7 @@ blockNode:
       # If create is true, the following values are used to create the PVC
       # should match PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH, leave as is for default.
       mountPath: "/opt/hashgraph/blocknode/data/archive"
-      size: 2Gi
+      size: 200Gi
       # Optionally add a storage class name if needed
       # storageClass: "your-storage-class"
     live:
@@ -100,7 +100,7 @@ blockNode:
       # If create is true, the following values are used to create the PVC
       # should match PERSISTENCE_STORAGE_LIVE_ROOT_PATH, leave as is for default.
       mountPath: "/opt/hashgraph/blocknode/data/live"
-      size: 5Gi
+      size: 500Gi
       # Optionally add a storage class name if needed
       # storageClass: "your-storage-class"
   secret:


### PR DESCRIPTION
## Reviewer Notes
- Fixed notes command for correct `port-forward` tunnel into the `block-node-server` using default port of `8080`
- changed all instances were resources were named with the `hedera` prefix and updated them for `hiero` prefix.
- Added Archive and Live PVC
  - given flexibility to use existing external PVC instead of creating one.
- optimized `default` **Values.yaml** file for Production recommendations, and created a mini version that is intended to run on a minikube or similar environment for small tests.
- 


## Related Issue(s)
Fixes #793 
Fixes #792 
Fixes #791 
