### PR TITLE
feat: Simple Persistence startup data

### DIFF
--- a/server/src/main/java/com/hedera/block/server/ack/AckHandlerImpl.java
+++ b/server/src/main/java/com/hedera/block/server/ack/AckHandlerImpl.java
@@ -32,7 +32,7 @@ import javax.inject.Inject;
 public class AckHandlerImpl implements AckHandler {
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
     private final Map<Long, BlockInfo> blockInfo = new ConcurrentHashMap<>();
-    private volatile long lastAcknowledgedBlockNumber = -1;
+    private volatile long lastAcknowledgedBlockNumber;
     private final Notifier notifier;
     private final boolean skipAcknowledgement;
     private final ServiceStatus serviceStatus;
@@ -56,6 +56,18 @@ public class AckHandlerImpl implements AckHandler {
         this.serviceStatus = Objects.requireNonNull(serviceStatus);
         this.blockRemover = Objects.requireNonNull(blockRemover);
         this.metricsService = metricsService;
+
+        // Initialize lastAcknowledgedBlockNumber from the service status if available
+        final BlockInfo latestAckedBlock = serviceStatus.getLatestAckedBlock();
+        if (latestAckedBlock != null) {
+            lastAcknowledgedBlockNumber = latestAckedBlock.getBlockNumber();
+        } else {
+            // if it enters here the service is starting for the first time
+            // since we don't have a `first_intended_block_number` value that should come from config
+            // we will assume that we expect 0 to be the next block.
+            // @todo(147) we need to handle new instances that need to start from a different block than 0.
+            lastAcknowledgedBlockNumber = -1;
+        }
     }
 
     @Override
@@ -126,17 +138,6 @@ public class AckHandlerImpl implements AckHandler {
      * It ACKs all blocks in sequence that are both persisted and verified.
      */
     private void attemptAcks() {
-        // Temporarily if lastAcknowledgedBlockNumber is -1, we get the first block in the map
-        if (lastAcknowledgedBlockNumber == -1) {
-            // @todo(147): once we have a way to get the last acknowledged block from the store we should use that
-            final BlockInfo latestAckedBlock = serviceStatus.getLatestAckedBlock();
-            if (latestAckedBlock != null) {
-                lastAcknowledgedBlockNumber = latestAckedBlock.getBlockNumber();
-            } else {
-                lastAcknowledgedBlockNumber = 0;
-            }
-        }
-
         // Keep ACK-ing starting from the next block in sequence
         while (true) {
             long nextBlock = lastAcknowledgedBlockNumber + 1;

--- a/server/src/main/java/com/hedera/block/server/ack/AckHandlerImpl.java
+++ b/server/src/main/java/com/hedera/block/server/ack/AckHandlerImpl.java
@@ -129,7 +129,12 @@ public class AckHandlerImpl implements AckHandler {
         // Temporarily if lastAcknowledgedBlockNumber is -1, we get the first block in the map
         if (lastAcknowledgedBlockNumber == -1) {
             // @todo(147): once we have a way to get the last acknowledged block from the store we should use that
-            lastAcknowledgedBlockNumber = 0;
+            final BlockInfo latestAckedBlock = serviceStatus.getLatestAckedBlock();
+            if (latestAckedBlock != null) {
+                lastAcknowledgedBlockNumber = latestAckedBlock.getBlockNumber();
+            } else {
+                lastAcknowledgedBlockNumber = 0;
+            }
         }
 
         // Keep ACK-ing starting from the next block in sequence

--- a/server/src/main/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImpl.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImpl.java
@@ -6,6 +6,7 @@ import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 
 import com.hedera.block.common.utils.FileUtilities;
+import com.hedera.block.server.ack.AckBlockStatus;
 import com.hedera.block.server.ack.AckHandler;
 import com.hedera.block.server.block.BlockInfo;
 import com.hedera.block.server.events.BlockNodeEventHandler;
@@ -129,12 +130,13 @@ public class StreamPersistenceHandlerImpl implements BlockNodeEventHandler<Objec
         final Optional<Long> latestAvailableBlockNumberOpt = pathResolver.getLatestAvailableBlockNumber();
         if (latestAvailableBlockNumberOpt.isPresent()) {
             final long latestAvailableBlockNumber = latestAvailableBlockNumberOpt.get();
-            serviceStatus.setLatestReceivedBlockNumber(latestAvailableBlockNumber);
             final BlockInfo latestAckedBlockInfo = new BlockInfo(latestAvailableBlockNumber);
-            latestAckedBlockInfo.getBlockStatus().setPersisted();
-            latestAckedBlockInfo.getBlockStatus().setVerified();
-            latestAckedBlockInfo.getBlockStatus().markAckSentIfNotAlready();
+            final AckBlockStatus blockStatus = latestAckedBlockInfo.getBlockStatus();
+            blockStatus.setPersisted();
+            blockStatus.setVerified();
+            blockStatus.markAckSentIfNotAlready();
             serviceStatus.setLatestAckedBlock(latestAckedBlockInfo);
+            serviceStatus.setLatestReceivedBlockNumber(latestAvailableBlockNumber);
         }
 
         // It is indeed a very bad idea to expose `this` to the outside world

--- a/server/src/main/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImpl.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImpl.java
@@ -121,13 +121,13 @@ public class StreamPersistenceHandlerImpl implements BlockNodeEventHandler<Objec
         //   initial one, so we know that if we get it, nothing has ever set
         //   changed the value yet.
 
-        final Optional<Long> firstAvailableBlockNumberOpt = pathResolver.getFirstAvailableBlockNumber();
+        final Optional<Long> firstAvailableBlockNumberOpt = pathResolver.findFirstAvailableBlockNumber();
         if (firstAvailableBlockNumberOpt.isPresent()) {
             final long firstAvailableBlockNumber = firstAvailableBlockNumberOpt.get();
             serviceStatus.setFirstAvailableBlockNumber(firstAvailableBlockNumber);
         }
 
-        final Optional<Long> latestAvailableBlockNumberOpt = pathResolver.getLatestAvailableBlockNumber();
+        final Optional<Long> latestAvailableBlockNumberOpt = pathResolver.findLatestAvailableBlockNumber();
         if (latestAvailableBlockNumberOpt.isPresent()) {
             final long latestAvailableBlockNumber = latestAvailableBlockNumberOpt.get();
             final BlockInfo latestAckedBlockInfo = new BlockInfo(latestAvailableBlockNumber);

--- a/server/src/main/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImpl.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImpl.java
@@ -7,6 +7,7 @@ import static java.lang.System.Logger.Level.ERROR;
 
 import com.hedera.block.common.utils.FileUtilities;
 import com.hedera.block.server.ack.AckHandler;
+import com.hedera.block.server.block.BlockInfo;
 import com.hedera.block.server.events.BlockNodeEventHandler;
 import com.hedera.block.server.events.ObjectEvent;
 import com.hedera.block.server.exception.BlockStreamProtocolException;
@@ -110,6 +111,30 @@ public class StreamPersistenceHandlerImpl implements BlockNodeEventHandler<Objec
             // Clean up the unverified directory at startup. Any files under the
             // unverified root at startup are to be considered unreliable
             blockFilesInUnverified.map(Path::toFile).forEach(File::delete);
+        }
+
+        // @todo(796) default value for long is a 0, so this means that if no
+        //   value is set to the service status for these numbers, the default
+        //   in the beginning will be 0, which is a valid number for us. This
+        //   maybe makes it erroneous. Maybe we should have a value of -1 as
+        //   initial one, so we know that if we get it, nothing has ever set
+        //   changed the value yet.
+
+        final Optional<Long> firstAvailableBlockNumberOpt = pathResolver.getFirstAvailableBlockNumber();
+        if (firstAvailableBlockNumberOpt.isPresent()) {
+            final long firstAvailableBlockNumber = firstAvailableBlockNumberOpt.get();
+            serviceStatus.setFirstAvailableBlockNumber(firstAvailableBlockNumber);
+        }
+
+        final Optional<Long> latestAvailableBlockNumberOpt = pathResolver.getLatestAvailableBlockNumber();
+        if (latestAvailableBlockNumberOpt.isPresent()) {
+            final long latestAvailableBlockNumber = latestAvailableBlockNumberOpt.get();
+            serviceStatus.setLatestReceivedBlockNumber(latestAvailableBlockNumber);
+            final BlockInfo latestAckedBlockInfo = new BlockInfo(latestAvailableBlockNumber);
+            latestAckedBlockInfo.getBlockStatus().setPersisted();
+            latestAckedBlockInfo.getBlockStatus().setVerified();
+            latestAckedBlockInfo.getBlockStatus().markAckSentIfNotAlready();
+            serviceStatus.setLatestAckedBlock(latestAckedBlockInfo);
         }
 
         // It is indeed a very bad idea to expose `this` to the outside world

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/archive/LocalGroupZipArchiveTask.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/archive/LocalGroupZipArchiveTask.java
@@ -75,7 +75,7 @@ public final class LocalGroupZipArchiveTask implements Callable<Long> {
      * @param config valid, non-null {@link PersistenceStorageConfig} instance
      * @param pathResolver valid, non-null {@link BlockPathResolver} instance
      */
-    LocalGroupZipArchiveTask(
+    public LocalGroupZipArchiveTask(
             final long blockNumberThreshold,
             @NonNull final PersistenceStorageConfig config,
             @NonNull final BlockPathResolver pathResolver) {

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.path;
 
-import static java.lang.System.Logger.Level.INFO;
-
 import com.hedera.block.common.utils.FileUtilities;
 import com.hedera.block.common.utils.Preconditions;
 import com.hedera.block.server.Constants;
@@ -12,7 +10,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.lang.System.Logger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.DecimalFormat;
@@ -27,7 +24,6 @@ import java.util.zip.ZipFile;
  * A Block path resolver for block-as-file.
  */
 public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
-    private static final Logger LOGGER = System.getLogger(BlockAsLocalFilePathResolver.class.getName());
     private static final int MAX_LONG_DIGITS = 19;
     private final Path liveRootPath;
     private final Path archiveRootPath;
@@ -175,10 +171,8 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
             try (final Stream<Path> list = Files.list(root)) {
                 final Optional<Path> nextPath = list.sorted().findAny();
                 if (nextPath.isPresent()) {
-                    LOGGER.log(INFO, "traversing first dfs - " + nextPath.get().toString());
                     return dfsFindFistLive(nextPath.get());
                 } else {
-                    LOGGER.log(INFO, "traversing first dfs - empty");
                     return Optional.empty();
                 }
             }
@@ -201,10 +195,7 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
                     try (final ZipFile zipFile = new ZipFile(pathToBlock.toFile())) {
                         return zipFile.stream()
                                 .sorted(Comparator.comparing(ZipEntry::getName))
-                                .filter(e -> {
-                                    LOGGER.log(INFO, "first available from zip - " + e.getName());
-                                    return !e.isDirectory();
-                                })
+                                .filter(e -> !e.isDirectory())
                                 .findAny()
                                 .map(ze -> {
                                     final String entryName = ze.getName();
@@ -230,10 +221,8 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
                 final Optional<Path> nextPath =
                         list.sorted(Comparator.reverseOrder()).findAny();
                 if (nextPath.isPresent()) {
-                    LOGGER.log(INFO, "traversing last dfs - " + nextPath.get().toString());
                     return dfsFindLatestLive(nextPath.get());
                 } else {
-                    LOGGER.log(INFO, "traversing last dfs - empty");
                     return Optional.empty();
                 }
             }
@@ -256,10 +245,7 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
                     try (final ZipFile zipFile = new ZipFile(pathToBlock.toFile())) {
                         return zipFile.stream()
                                 .sorted(Comparator.comparing(ZipEntry::getName).reversed())
-                                .filter(e -> {
-                                    LOGGER.log(INFO, "last available from zip - " + e.getName());
-                                    return !e.isDirectory();
-                                })
+                                .filter(e -> !e.isDirectory())
                                 .findAny()
                                 .map(ze -> {
                                     final String entryName = ze.getName();

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
@@ -195,8 +195,14 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
                                     return !e.isDirectory();
                                 })
                                 .findAny()
-                                .map(ze -> Long.parseLong(
-                                        ze.getName().substring(0, ze.getName().indexOf('.'))))
+                                .map(ze -> {
+                                    final String entryName = ze.getName();
+                                    // remove leading dir as part of the zip entry name
+                                    final String rawEntryName = entryName.substring(entryName.lastIndexOf('/') + 1);
+                                    // remove extensions
+                                    final String toParse = rawEntryName.substring(0, rawEntryName.indexOf('.'));
+                                    return Long.parseLong(toParse);
+                                })
                                 .orElse(-1L)
                                 .describeConstable();
                     }
@@ -235,8 +241,14 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
                                     return !e.isDirectory();
                                 })
                                 .findAny()
-                                .map(ze -> Long.parseLong(
-                                        ze.getName().substring(0, ze.getName().indexOf('.'))))
+                                .map(ze -> {
+                                    final String entryName = ze.getName();
+                                    // remove leading dir as part of the zip entry name
+                                    final String rawEntryName = entryName.substring(entryName.lastIndexOf('/') + 1);
+                                    // remove extensions
+                                    final String toParse = rawEntryName.substring(0, rawEntryName.indexOf('.'));
+                                    return Long.parseLong(toParse);
+                                })
                                 .orElse(-1L)
                                 .describeConstable();
                     }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
@@ -188,7 +188,7 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
 
     @NonNull
     @Override
-    public Optional<Long> getFirstAvailableBlockNumber() throws IOException {
+    public Optional<Long> findFirstAvailableBlockNumber() throws IOException {
         final Optional<Path> blockOpt = dfsFindFistLive(liveRootPath);
         if (blockOpt.isPresent()) {
             final Path pathToBlock = blockOpt.get();
@@ -239,7 +239,7 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
 
     @NonNull
     @Override
-    public Optional<Long> getLatestAvailableBlockNumber() throws IOException {
+    public Optional<Long> findLatestAvailableBlockNumber() throws IOException {
         final Optional<Path> blockOpt = dfsFindLatestLive(liveRootPath);
         if (blockOpt.isPresent()) {
             final Path pathToBlock = blockOpt.get();

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
@@ -172,8 +172,9 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
     @NonNull
     @Override
     public Optional<Long> getFirstAvailableBlockNumber() throws IOException {
+        final Optional<Path> blockOpt;
         try (final Stream<Path> tree = Files.walk(liveRootPath)) {
-            final Optional<Path> blockOpt = tree.sorted()
+            blockOpt = tree.sorted()
                     .filter(f -> {
                         final String fileName = f.getFileName().toString();
                         LOGGER.log(INFO, "first available - " + fileName);
@@ -183,43 +184,44 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
                         return false;
                     })
                     .findAny();
-            if (blockOpt.isPresent()) {
-                final Path pathToBlock = blockOpt.get();
-                final String fileName = pathToBlock.getFileName().toString();
-                if (fileName.endsWith(Constants.ZIP_FILE_EXTENSION)) {
-                    try (final ZipFile zipFile = new ZipFile(pathToBlock.toFile())) {
-                        return zipFile.stream()
-                                .sorted(Comparator.comparing(ZipEntry::getName))
-                                .filter(e -> {
-                                    LOGGER.log(INFO, "first available from zip - " + e.getName());
-                                    return !e.isDirectory();
-                                })
-                                .findAny()
-                                .map(ze -> {
-                                    final String entryName = ze.getName();
-                                    // remove leading dir as part of the zip entry name
-                                    final String rawEntryName = entryName.substring(entryName.lastIndexOf('/') + 1);
-                                    // remove extensions
-                                    final String toParse = rawEntryName.substring(0, rawEntryName.indexOf('.'));
-                                    return Long.parseLong(toParse);
-                                })
-                                .orElse(-1L)
-                                .describeConstable();
-                    }
-                } else {
-                    return Optional.of(Long.parseLong(fileName.substring(0, fileName.indexOf('.'))));
+        }
+        if (blockOpt.isPresent()) {
+            final Path pathToBlock = blockOpt.get();
+            final String fileName = pathToBlock.getFileName().toString();
+            if (fileName.endsWith(Constants.ZIP_FILE_EXTENSION)) {
+                try (final ZipFile zipFile = new ZipFile(pathToBlock.toFile())) {
+                    return zipFile.stream()
+                            .sorted(Comparator.comparing(ZipEntry::getName))
+                            .filter(e -> {
+                                LOGGER.log(INFO, "first available from zip - " + e.getName());
+                                return !e.isDirectory();
+                            })
+                            .findAny()
+                            .map(ze -> {
+                                final String entryName = ze.getName();
+                                // remove leading dir as part of the zip entry name
+                                final String rawEntryName = entryName.substring(entryName.lastIndexOf('/') + 1);
+                                // remove extensions
+                                final String toParse = rawEntryName.substring(0, rawEntryName.indexOf('.'));
+                                return Long.parseLong(toParse);
+                            })
+                            .orElse(-1L)
+                            .describeConstable();
                 }
             } else {
-                return Optional.empty();
+                return Optional.of(Long.parseLong(fileName.substring(0, fileName.indexOf('.'))));
             }
+        } else {
+            return Optional.empty();
         }
     }
 
     @NonNull
     @Override
     public Optional<Long> getLatestAvailableBlockNumber() throws IOException {
+        final Optional<Path> blockOpt;
         try (final Stream<Path> tree = Files.walk(liveRootPath)) {
-            final Optional<Path> blockOpt = tree.sorted(Comparator.reverseOrder())
+            blockOpt = tree.sorted(Comparator.reverseOrder())
                     .filter(f -> {
                         final String fileName = f.getFileName().toString();
                         LOGGER.log(INFO, "last available - " + fileName);
@@ -229,35 +231,35 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
                         return false;
                     })
                     .findAny();
-            if (blockOpt.isPresent()) {
-                final Path pathToBlock = blockOpt.get();
-                final String fileName = pathToBlock.getFileName().toString();
-                if (fileName.endsWith(Constants.ZIP_FILE_EXTENSION)) {
-                    try (final ZipFile zipFile = new ZipFile(pathToBlock.toFile())) {
-                        return zipFile.stream()
-                                .sorted(Comparator.comparing(ZipEntry::getName).reversed())
-                                .filter(e -> {
-                                    LOGGER.log(INFO, "last available from zip - " + e.getName());
-                                    return !e.isDirectory();
-                                })
-                                .findAny()
-                                .map(ze -> {
-                                    final String entryName = ze.getName();
-                                    // remove leading dir as part of the zip entry name
-                                    final String rawEntryName = entryName.substring(entryName.lastIndexOf('/') + 1);
-                                    // remove extensions
-                                    final String toParse = rawEntryName.substring(0, rawEntryName.indexOf('.'));
-                                    return Long.parseLong(toParse);
-                                })
-                                .orElse(-1L)
-                                .describeConstable();
-                    }
-                } else {
-                    return Optional.of(Long.parseLong(fileName.substring(0, fileName.indexOf('.'))));
+        }
+        if (blockOpt.isPresent()) {
+            final Path pathToBlock = blockOpt.get();
+            final String fileName = pathToBlock.getFileName().toString();
+            if (fileName.endsWith(Constants.ZIP_FILE_EXTENSION)) {
+                try (final ZipFile zipFile = new ZipFile(pathToBlock.toFile())) {
+                    return zipFile.stream()
+                            .sorted(Comparator.comparing(ZipEntry::getName).reversed())
+                            .filter(e -> {
+                                LOGGER.log(INFO, "last available from zip - " + e.getName());
+                                return !e.isDirectory();
+                            })
+                            .findAny()
+                            .map(ze -> {
+                                final String entryName = ze.getName();
+                                // remove leading dir as part of the zip entry name
+                                final String rawEntryName = entryName.substring(entryName.lastIndexOf('/') + 1);
+                                // remove extensions
+                                final String toParse = rawEntryName.substring(0, rawEntryName.indexOf('.'));
+                                return Long.parseLong(toParse);
+                            })
+                            .orElse(-1L)
+                            .describeConstable();
                 }
             } else {
-                return Optional.empty();
+                return Optional.of(Long.parseLong(fileName.substring(0, fileName.indexOf('.'))));
             }
+        } else {
+            return Optional.empty();
         }
     }
 

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
@@ -177,6 +177,7 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
                     LOGGER.log(INFO, "traversing first dfs - " + nextPath.get().toString());
                     return dfsFindFistLive(nextPath.get());
                 } else {
+                    LOGGER.log(INFO, "traversing first dfs - empty");
                     return Optional.empty();
                 }
             }
@@ -194,6 +195,7 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
                     LOGGER.log(INFO, "traversing last dfs - " + nextPath.get().toString());
                     return dfsFindLatestLive(nextPath.get());
                 } else {
+                    LOGGER.log(INFO, "traversing last dfs - empty");
                     return Optional.empty();
                 }
             }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
@@ -162,6 +162,18 @@ public final class BlockAsLocalFilePathResolver implements BlockPathResolver {
                 || findArchivedBlock(blockNumber).isPresent();
     }
 
+    @NonNull
+    @Override
+    public Optional<Long> getFirstAvailableBlockNumber() {
+        return Optional.empty();
+    }
+
+    @NonNull
+    @Override
+    public Optional<Long> getLatestAvailableBlockNumber() {
+        return Optional.empty();
+    }
+
     /**
      * This method resolves the path to where an archived block would reside. No
      * compression extension is appended to the file name.

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockPathResolver.java
@@ -151,9 +151,31 @@ public interface BlockPathResolver {
      */
     boolean existsVerifiedBlock(final long blockNumber);
 
+    /**
+     * This method attempts to find the first available Block Number. A Block
+     * that is considered available is one that is PERSISTED and VERIFIED!
+     * If the Block is found, the method returns a non-empty
+     * {@link Optional} of {@link Long}, else an empty {@link Optional} is
+     * returned.
+     *
+     * @return a {@link Optional} of {@link Long} with the first available Block
+     * Number if it is found, else an empty {@link Optional}
+     * @throws IOException if an I/O error occurs
+     */
     @NonNull
     Optional<Long> findFirstAvailableBlockNumber() throws IOException;
 
+    /**
+     * This method attempts to find the latest available Block Number. A Block
+     * that is considered available is one that is PERSISTED and VERIFIED!
+     * If the Block is found, the method returns a non-empty
+     * {@link Optional} of {@link Long}, else an empty {@link Optional} is
+     * returned.
+     *
+     * @return a {@link Optional} of {@link Long} with the latest available
+     * Block Number if it is found, else an empty {@link Optional}
+     * @throws IOException if an I/O error occurs
+     */
     @NonNull
     Optional<Long> findLatestAvailableBlockNumber() throws IOException;
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockPathResolver.java
@@ -149,4 +149,10 @@ public interface BlockPathResolver {
      * @throws IllegalArgumentException if the blockNumber IS NOT a whole number
      */
     boolean existsVerifiedBlock(final long blockNumber);
+
+    @NonNull
+    Optional<Long> getFirstAvailableBlockNumber();
+
+    @NonNull
+    Optional<Long> getLatestAvailableBlockNumber();
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockPathResolver.java
@@ -152,8 +152,8 @@ public interface BlockPathResolver {
     boolean existsVerifiedBlock(final long blockNumber);
 
     @NonNull
-    Optional<Long> getFirstAvailableBlockNumber() throws IOException;
+    Optional<Long> findFirstAvailableBlockNumber() throws IOException;
 
     @NonNull
-    Optional<Long> getLatestAvailableBlockNumber() throws IOException;
+    Optional<Long> findLatestAvailableBlockNumber() throws IOException;
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockPathResolver.java
@@ -2,6 +2,7 @@
 package com.hedera.block.server.persistence.storage.path;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -151,8 +152,8 @@ public interface BlockPathResolver {
     boolean existsVerifiedBlock(final long blockNumber);
 
     @NonNull
-    Optional<Long> getFirstAvailableBlockNumber();
+    Optional<Long> getFirstAvailableBlockNumber() throws IOException;
 
     @NonNull
-    Optional<Long> getLatestAvailableBlockNumber();
+    Optional<Long> getLatestAvailableBlockNumber() throws IOException;
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolver.java
@@ -86,4 +86,22 @@ public final class NoOpBlockPathResolver implements BlockPathResolver {
     public boolean existsVerifiedBlock(final long blockNumber) {
         return false;
     }
+
+    /**
+     * No-op resolver. Does nothing and always returns an empty optional.
+     */
+    @NonNull
+    @Override
+    public Optional<Long> getFirstAvailableBlockNumber() {
+        return Optional.empty();
+    }
+
+    /**
+     * No-op resolver. Does nothing and always returns an empty optional.
+     */
+    @NonNull
+    @Override
+    public Optional<Long> getLatestAvailableBlockNumber() {
+        return Optional.empty();
+    }
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolver.java
@@ -92,7 +92,7 @@ public final class NoOpBlockPathResolver implements BlockPathResolver {
      */
     @NonNull
     @Override
-    public Optional<Long> getFirstAvailableBlockNumber() {
+    public Optional<Long> findFirstAvailableBlockNumber() {
         return Optional.empty();
     }
 
@@ -101,7 +101,7 @@ public final class NoOpBlockPathResolver implements BlockPathResolver {
      */
     @NonNull
     @Override
-    public Optional<Long> getLatestAvailableBlockNumber() {
+    public Optional<Long> findLatestAvailableBlockNumber() {
         return Optional.empty();
     }
 }

--- a/server/src/main/java/com/hedera/block/server/service/ServiceStatus.java
+++ b/server/src/main/java/com/hedera/block/server/service/ServiceStatus.java
@@ -68,4 +68,8 @@ public interface ServiceStatus {
      * @param latestReceivedBlockNumber the latest received block number
      */
     void setLatestReceivedBlockNumber(long latestReceivedBlockNumber);
+
+    long getFirstAvailableBlockNumber();
+
+    void setFirstAvailableBlockNumber(long firstAvailableBlockNumber);
 }

--- a/server/src/main/java/com/hedera/block/server/service/ServiceStatus.java
+++ b/server/src/main/java/com/hedera/block/server/service/ServiceStatus.java
@@ -69,7 +69,19 @@ public interface ServiceStatus {
      */
     void setLatestReceivedBlockNumber(long latestReceivedBlockNumber);
 
+    /**
+     * Gets the first available block number. The first available Block Number
+     * is the number of the first Block that is both PERSISTED and VERIFIED.
+     *
+     * @return the first available block number
+     */
     long getFirstAvailableBlockNumber();
 
+    /**
+     * Sets the first available block number. The first available Block Number
+     * must be the number of the first Block that is both PERSISTED and VERIFIED.
+     *
+     * @param firstAvailableBlockNumber the first available block number
+     */
     void setFirstAvailableBlockNumber(long firstAvailableBlockNumber);
 }

--- a/server/src/main/java/com/hedera/block/server/service/ServiceStatusImpl.java
+++ b/server/src/main/java/com/hedera/block/server/service/ServiceStatusImpl.java
@@ -17,14 +17,13 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class ServiceStatusImpl implements ServiceStatus {
-
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
-
     private final AtomicBoolean isRunning = new AtomicBoolean(true);
+    private final int delayMillis;
     private WebServer webServer;
     private volatile BlockInfo latestAckedBlock;
     private volatile long latestReceivedBlockNumber;
-    private final int delayMillis;
+    private volatile long firstAvailableBlockNumber;
 
     /**
      * Use the ServiceStatusImpl to check the status of the block node server and to shut it down if
@@ -109,5 +108,15 @@ public class ServiceStatusImpl implements ServiceStatus {
     @Override
     public void setLatestReceivedBlockNumber(long latestReceivedBlockNumber) {
         this.latestReceivedBlockNumber = latestReceivedBlockNumber;
+    }
+
+    @Override
+    public long getFirstAvailableBlockNumber() {
+        return firstAvailableBlockNumber;
+    }
+
+    @Override
+    public void setFirstAvailableBlockNumber(final long firstAvailableBlockNumber) {
+        this.firstAvailableBlockNumber = firstAvailableBlockNumber;
     }
 }

--- a/server/src/main/java/com/hedera/block/server/service/ServiceStatusImpl.java
+++ b/server/src/main/java/com/hedera/block/server/service/ServiceStatusImpl.java
@@ -23,7 +23,7 @@ public class ServiceStatusImpl implements ServiceStatus {
     private WebServer webServer;
     private volatile BlockInfo latestAckedBlock;
     private volatile long latestReceivedBlockNumber;
-    private volatile long firstAvailableBlockNumber;
+    private volatile long firstAvailableBlockNumber = Long.MIN_VALUE;
 
     /**
      * Use the ServiceStatusImpl to check the status of the block node server and to shut it down if

--- a/server/src/test/java/com/hedera/block/server/ack/AckHandlerInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/ack/AckHandlerInjectionModuleTest.java
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.hedera.block.server.manager;
+package com.hedera.block.server.ack;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.hedera.block.server.ack.AckHandler;
-import com.hedera.block.server.ack.AckHandlerImpl;
-import com.hedera.block.server.ack.AckHandlerInjectionModule;
 import com.hedera.block.server.metrics.MetricsService;
 import com.hedera.block.server.notifier.Notifier;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;

--- a/server/src/test/java/com/hedera/block/server/manager/AckHandlerImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/manager/AckHandlerImplTest.java
@@ -331,7 +331,7 @@ class AckHandlerImplTest {
         assertTrue(doneLatch.await(60, TimeUnit.SECONDS), "Tasks did not complete in time");
         executor.shutdown();
         // Wait a bit to ensure all ACKs are processed.
-        Thread.sleep(100);
+        Thread.sleep(1_000);
 
         final ArgumentCaptor<Long> blockNumberCaptor = ArgumentCaptor.forClass(Long.class);
         final ArgumentCaptor<Bytes> blockHashCaptor = ArgumentCaptor.forClass(Bytes.class);

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolverTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -128,6 +129,26 @@ class NoOpBlockPathResolverTest {
     @MethodSource({"validBlockNumbers", "invalidBlockNumbers"})
     void testSuccessfulExistsVerified(final long toResolve) {
         assertThat(toTest.existsVerifiedBlock(toResolve)).isFalse();
+    }
+
+    /**
+     * This test aims to verify that the
+     * {@link NoOpBlockPathResolver#findFirstAvailableBlockNumber()}
+     * always returns an empty optional.
+     */
+    @Test
+    void testFindFirstAvailableBlockNumber() {
+        assertThat(toTest.findFirstAvailableBlockNumber()).isNotNull().isEmpty();
+    }
+
+    /**
+     * This test aims to verify that the
+     * {@link NoOpBlockPathResolver#findLatestAvailableBlockNumber()}
+     * always returns an empty optional.
+     */
+    @Test
+    void testFindLatestAvailableBlockNumber() {
+        assertThat(toTest.findLatestAvailableBlockNumber()).isNotNull().isEmpty();
     }
 
     /**

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockGeneratorConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockGeneratorConfig.java
@@ -32,7 +32,7 @@ public record BlockGeneratorConfig(
         @ConfigProperty(defaultValue = "36") int paddedLength,
         @ConfigProperty(defaultValue = ".blk.gz") String fileExtension,
         // Optional block number range for the BlockAsFileLargeDataSets manager
-        @ConfigProperty(defaultValue = "1") @Min(0) int startBlockNumber,
+        @ConfigProperty(defaultValue = "0") @Min(0) int startBlockNumber,
         @ConfigProperty(defaultValue = "-1") int endBlockNumber) {
 
     /**

--- a/simulator/src/main/resources/app.properties
+++ b/simulator/src/main/resources/app.properties
@@ -28,7 +28,7 @@ prometheus.endpointPortNumber=9998
 #generator.managerImplementation=BlockAsFileLargeDataSets
 
 # Optional range configuration
-#generator.startBlockNumber=1
+#generator.startBlockNumber=0
 #generator.endBlockNumber=2000
 
 #blockStream.maxBlockItemsToStream=100_000_000


### PR DESCRIPTION
## Reviewer Notes
- Changed the default start block generated from `1` to `0`
- Changed the assumption that Genesis block number was `1` on BN to `0`.
- Persistence will `traverse` the files and provide to `serviceStatus` the `lastBlock` persisted, so that BN can resume streaming from the last received block and not having to start always from genesis.
- Improved AckHandler init process due to now receiving the `lastAckedBlock` from persistence.
- Added UT with coverage for new functionality

The goal of this PR is to enable a simple and partial, but functional way for the BN to **Recover from restarts** so that persisted blocks are truly used and persisted across restarts.

## Related Issue(s)
Closes #796 
