### PR TITLE
fix: Various Bugs found on `0.6.0-rc1` deployment.

### DIFF
--- a/charts/block-node-server/templates/deployment.yaml
+++ b/charts/block-node-server/templates/deployment.yaml
@@ -41,6 +41,24 @@ spec:
             claimName: {{ if .Values.blockNode.persistence.live.create }}{{ include "hiero-block-node.fullname" . }}-live{{ else }}{{ .Values.blockNode.persistence.live.existingClaim }}{{ end }}
         - name: unverified-ephemeral-storage
           emptyDir: {}
+      initContainers:
+        - name: init-storage-dirs
+          image: busybox
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /live-pvc/live-data && \
+              chown 2000:2000 /live-pvc/live-data && \
+              chmod 700 /live-pvc/live-data && \
+              mkdir -p /archive-pvc/archive-data && \
+              chown 2000:2000 /archive-pvc/archive-data && \
+              chmod 700 /archive-pvc/archive-data
+          volumeMounts:
+            - name: live-storage
+              mountPath: /live-pvc
+            - name: archive-storage
+              mountPath: /archive-pvc
       containers:
       - name: {{ .Chart.Name }}
         securityContext:
@@ -65,8 +83,10 @@ spec:
             readOnly: true
           - name: archive-storage
             mountPath: {{ .Values.blockNode.persistence.archive.mountPath }}
+            subPath: archive-data
           - name: live-storage
             mountPath: {{ .Values.blockNode.persistence.live.mountPath }}
+            subPath: live-data
           - name: unverified-ephemeral-storage
             mountPath: {{ .Values.blockNode.persistence.unverified.mountPath }}
         {{- with  .Values.resources }}

--- a/server/src/main/java/org/hiero/block/server/producer/ProducerBlockItemObserver.java
+++ b/server/src/main/java/org/hiero/block/server/producer/ProducerBlockItemObserver.java
@@ -309,8 +309,8 @@ public class ProducerBlockItemObserver
      */
     private Optional<Bytes> getBlockHash(final long blockNumber) {
         final BlockInfo latestAckedBlockNumber = serviceStatus.getLatestAckedBlock();
-        if (latestAckedBlockNumber.getBlockNumber() == blockNumber) {
-            return Optional.of(latestAckedBlockNumber.getBlockHash());
+        if (latestAckedBlockNumber != null && latestAckedBlockNumber.getBlockNumber() == blockNumber) {
+            return Optional.ofNullable(latestAckedBlockNumber.getBlockHash());
         }
         // if the block is older than the latest acked block, we don't have the hash on hand
         return Optional.empty();

--- a/server/src/test/java/org/hiero/block/server/producer/ProducerBlockItemObserverTest.java
+++ b/server/src/test/java/org/hiero/block/server/producer/ProducerBlockItemObserverTest.java
@@ -345,7 +345,8 @@ public class ProducerBlockItemObserverTest {
         when(serviceStatus.getLatestAckedBlock()).thenReturn(latestAckedBlock);
         when(serviceStatus.getLatestReceivedBlockNumber()).thenReturn(latestReceivedBlockNumber);
 
-        final List<BlockItemUnparsed> blockItems = generateBlockItemsUnparsedForWithBlockNumber(latestReceivedBlockNumber);
+        final List<BlockItemUnparsed> blockItems =
+                generateBlockItemsUnparsedForWithBlockNumber(latestReceivedBlockNumber);
         final ProducerBlockItemObserver producerBlockItemObserver = new ProducerBlockItemObserver(
                 testClock,
                 publisher,

--- a/server/src/test/java/org/hiero/block/server/producer/ProducerBlockItemObserverTest.java
+++ b/server/src/test/java/org/hiero/block/server/producer/ProducerBlockItemObserverTest.java
@@ -332,6 +332,52 @@ public class ProducerBlockItemObserverTest {
     }
 
     @Test
+    @DisplayName("Test duplicate block items with different ACK number variation")
+    public void testDuplicateBlockReceived_DiffAckNumberVariation() {
+
+        // given
+        when(serviceStatus.isRunning()).thenReturn(true);
+        long latestAckedBlockNumber = 10L;
+        long latestReceivedBlockNumber = 11L;
+        Bytes fakeHash = Bytes.wrap("fake_hash");
+        BlockInfo latestAckedBlock = new BlockInfo(latestAckedBlockNumber);
+        latestAckedBlock.setBlockHash(fakeHash);
+        when(serviceStatus.getLatestAckedBlock()).thenReturn(latestAckedBlock);
+        when(serviceStatus.getLatestReceivedBlockNumber()).thenReturn(latestReceivedBlockNumber);
+
+        final List<BlockItemUnparsed> blockItems = generateBlockItemsUnparsedForWithBlockNumber(latestReceivedBlockNumber);
+        final ProducerBlockItemObserver producerBlockItemObserver = new ProducerBlockItemObserver(
+                testClock,
+                publisher,
+                subscriptionHandler,
+                helidonPublishPipeline,
+                serviceStatus,
+                consumerConfig,
+                metricsService);
+
+        // when
+        producerBlockItemObserver.onNext(blockItems);
+
+        // then
+        final BlockAcknowledgement blockAcknowledgement = BlockAcknowledgement.newBuilder()
+                .blockNumber(latestReceivedBlockNumber)
+                .blockAlreadyExists(true)
+                .build();
+
+        final Acknowledgement acknowledgement =
+                Acknowledgement.newBuilder().blockAck(blockAcknowledgement).build();
+
+        final PublishStreamResponse publishStreamResponse = PublishStreamResponse.newBuilder()
+                .acknowledgement(acknowledgement)
+                .build();
+
+        // verify helidonPublishPipeline.onNext() is called once with publishStreamResponse
+        verify(helidonPublishPipeline, timeout(testTimeout).times(1)).onNext(publishStreamResponse);
+        // verify that the duplicate block is not published
+        verify(publisher, never()).publish(any());
+    }
+
+    @Test
     @DisplayName("Test future (ahead of expected) block received")
     public void testFutureBlockReceived() {
         // given


### PR DESCRIPTION
## Reviewer Notes

At the beginning of the sprint we decided to include a first/simple mechanism to recover from restarts, so that we can keep re-using `metrics, logs and data` from the next deployment forward. This meant adding a `Internal Memory` feature and Helm PVCs and its corresponding mappings and values so that both `archive` and `live` data were pesisted.

However, 3 bugs were found with the first `rc` version:

1. [Lost+Found directory present on created PVC](https://github.com/hiero-ledger/hiero-block-node/issues/815)
2. [PVC For Live and Archive Permissions](https://github.com/hiero-ledger/hiero-block-node/issues/816)
3. [Issue when restarted the BN](https://github.com/hiero-ledger/hiero-block-node/issues/814)

Fixes #815 
Fixes #816 
Fixes #814 
