### PR TITLE
 chore: Set on pull_request_target for PR formatting check GHA

### DIFF
--- a/.github/workflows/pr-formatting.yaml
+++ b/.github/workflows/pr-formatting.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 name: "PR Formatting Checks"
 on:
-  pull_request:
+  pull_request_target:
     types:
       - assigned
       - unassigned


### PR DESCRIPTION
## Reviewer Notes
Forked PRs were failing on title check. By setting `pull_request_target` the GHA can run in the needed context

## Related Issue(s)
Fixes #819 

