### PR TITLE
chore: named injection for components with a common interface

### DIFF
--- a/block-node/base/src/main/java/module-info.java
+++ b/block-node/base/src/main/java/module-info.java
@@ -27,6 +27,7 @@ module org.hiero.block.base {
     exports org.hiero.block.server.verification.signature;
     exports org.hiero.block.server.verification.service;
     exports org.hiero.block.server.block;
+    exports org.hiero.block.server.utils;
 
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.common;

--- a/block-node/base/src/main/java/org/hiero/block/server/persistence/PersistenceInjectionModule.java
+++ b/block-node/base/src/main/java/org/hiero/block/server/persistence/PersistenceInjectionModule.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import org.hiero.block.server.ack.AckHandler;
 import org.hiero.block.server.events.BlockNodeEventHandler;
@@ -41,6 +42,7 @@ import org.hiero.block.server.persistence.storage.write.AsyncBlockWriterFactory;
 import org.hiero.block.server.persistence.storage.write.AsyncNoOpWriterFactory;
 import org.hiero.block.server.persistence.storage.write.AsyncWriterExecutorFactory;
 import org.hiero.block.server.service.ServiceStatus;
+import org.hiero.block.server.utils.InjectionConstants;
 
 /** A Dagger module for providing dependencies for Persistence Module. */
 @Module
@@ -172,6 +174,7 @@ public interface PersistenceInjectionModule {
      */
     @Provides
     @Singleton
+    @Named(InjectionConstants.PERSISTENCE_HANDLER)
     static BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> providesBlockNodeEventHandler(
             @NonNull final SubscriptionHandler<List<BlockItemUnparsed>> subscriptionHandler,
             @NonNull final Notifier notifier,

--- a/block-node/base/src/main/java/org/hiero/block/server/utils/InjectionConstants.java
+++ b/block-node/base/src/main/java/org/hiero/block/server/utils/InjectionConstants.java
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.server.utils;
+
+public final class InjectionConstants {
+    public static final String PERSISTENCE_HANDLER = "PersistenceHandler";
+    public static final String VERIFICATION_HANDLER = "VerificationHandler";
+
+    private InjectionConstants() {}
+}

--- a/block-node/base/src/main/java/org/hiero/block/server/verification/StreamVerificationHandlerImpl.java
+++ b/block-node/base/src/main/java/org/hiero/block/server/verification/StreamVerificationHandlerImpl.java
@@ -7,7 +7,6 @@ import com.hedera.hapi.block.BlockItemUnparsed;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Objects;
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.hiero.block.server.events.BlockNodeEventHandler;
 import org.hiero.block.server.events.ObjectEvent;
@@ -39,7 +38,6 @@ public class StreamVerificationHandlerImpl implements BlockNodeEventHandler<Obje
      * @param serviceStatus           the service status
      * @param blockVerificationService the block verification service
      */
-    @Inject
     public StreamVerificationHandlerImpl(
             @NonNull final SubscriptionHandler<List<BlockItemUnparsed>> subscriptionHandler,
             @NonNull final Notifier notifier,

--- a/block-node/base/src/main/java/org/hiero/block/server/verification/VerificationInjectionModule.java
+++ b/block-node/base/src/main/java/org/hiero/block/server/verification/VerificationInjectionModule.java
@@ -1,15 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.server.verification;
 
+import com.hedera.hapi.block.BlockItemUnparsed;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import org.hiero.block.server.ack.AckHandler;
+import org.hiero.block.server.events.BlockNodeEventHandler;
+import org.hiero.block.server.events.ObjectEvent;
+import org.hiero.block.server.mediator.SubscriptionHandler;
 import org.hiero.block.server.metrics.MetricsService;
+import org.hiero.block.server.notifier.Notifier;
+import org.hiero.block.server.service.ServiceStatus;
+import org.hiero.block.server.utils.InjectionConstants;
 import org.hiero.block.server.verification.service.BlockVerificationService;
 import org.hiero.block.server.verification.service.BlockVerificationServiceImpl;
 import org.hiero.block.server.verification.service.NoOpBlockVerificationService;
@@ -73,5 +82,18 @@ public interface VerificationInjectionModule {
         final ExecutorService executorService = ForkJoinPool.commonPool();
         return new BlockVerificationSessionFactory(
                 verificationConfig, metricsService, signatureVerifier, executorService);
+    }
+
+    @Provides
+    @Singleton
+    @Named(InjectionConstants.VERIFICATION_HANDLER)
+    static BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> providesBlockNodeEventHandler(
+            @NonNull final SubscriptionHandler<List<BlockItemUnparsed>> subscriptionHandler,
+            @NonNull final Notifier notifier,
+            @NonNull final MetricsService metricsService,
+            @NonNull final ServiceStatus serviceStatus,
+            @NonNull final BlockVerificationService blockVerificationService) {
+        return new StreamVerificationHandlerImpl(
+                subscriptionHandler, notifier, metricsService, serviceStatus, blockVerificationService);
     }
 }

--- a/block-node/server/src/main/java/org/hiero/block/server/pbj/PbjBlockStreamServiceProxy.java
+++ b/block-node/server/src/main/java/org/hiero/block/server/pbj/PbjBlockStreamServiceProxy.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.inject.Inject;
+import javax.inject.Named;
 import org.hiero.block.server.block.BlockInfo;
 import org.hiero.block.server.consumer.ClosedRangeHistoricStreamEventHandlerBuilder;
 import org.hiero.block.server.consumer.ConsumerConfig;
@@ -37,7 +38,7 @@ import org.hiero.block.server.producer.ProducerBlockItemObserver;
 import org.hiero.block.server.producer.ProducerConfig;
 import org.hiero.block.server.service.Constants;
 import org.hiero.block.server.service.ServiceStatus;
-import org.hiero.block.server.verification.StreamVerificationHandlerImpl;
+import org.hiero.block.server.utils.InjectionConstants;
 
 /**
  * PbjBlockStreamServiceProxy is the runtime binding between the PBJ Helidon Plugin and the
@@ -75,8 +76,10 @@ public class PbjBlockStreamServiceProxy implements PbjBlockStreamService {
     public PbjBlockStreamServiceProxy(
             @NonNull final LiveStreamMediator streamMediator,
             @NonNull final ServiceStatus serviceStatus,
-            @NonNull final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> streamPersistenceHandler,
-            @NonNull final StreamVerificationHandlerImpl streamVerificationHandler,
+            @NonNull @Named(InjectionConstants.PERSISTENCE_HANDLER)
+                    final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> streamPersistenceHandler,
+            @NonNull @Named(InjectionConstants.VERIFICATION_HANDLER)
+                    final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> streamVerificationHandler,
             @NonNull final BlockReader<BlockUnparsed> blockReader,
             @NonNull final Notifier notifier,
             @NonNull final MetricsService metricsService,


### PR DESCRIPTION
## Reviewer Notes
- Implemented named injection for StreamPersistenceHandlerImpl and StreamVerificationHandlerImpl.
- Scanned the project for similar cases but didn't find any. Other interfaces with multiple implementations rely on configuration-based injection managed by Dagger.

## Related Issue(s)
Closes #628