### PR TITLE
ci: Fix triggers for e2e-tests, smoke-test, and pr-checks

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -6,8 +6,10 @@ on:
       - main
       - release/*
   pull_request:
-    branches:
-      - "*"
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 defaults:
   run:

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -6,8 +6,10 @@ on:
       - main
       - release/*
   pull_request:
-    branches:
-      - "*"
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 defaults:
   run:

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -6,8 +6,10 @@ on:
       - main
       - release/*
   pull_request:
-    branches:
-      - "*"
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 defaults:
   run:


### PR DESCRIPTION
**Description**:

- update e2e-tests.yml, smoke-test.yml, and pr-checks.yml `on`-triggers to use pull_request: types per standard pull_request triggers.

**Related Issue(s)**:

Fixes #833
