### PR TITLE
chore: follow-up for hiero package move

### DIFF
--- a/block-node/base/build.gradle.kts
+++ b/block-node/base/build.gradle.kts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins { id("org.hiero.gradle.module.library") }
 
-description = "Hedera Block Node Base"
+description = "Hiero Block Node Base"
 
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.

--- a/block-node/base/src/main/java/module-info.java
+++ b/block-node/base/src/main/java/module-info.java
@@ -28,13 +28,13 @@ module org.hiero.block.base {
     exports org.hiero.block.server.verification.service;
     exports org.hiero.block.server.block;
 
-    requires transitive com.hedera.block.stream;
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.common;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.config.extensions;
     requires transitive com.swirlds.metrics.api;
     requires transitive org.hiero.block.common;
+    requires transitive org.hiero.block.stream;
     requires transitive com.lmax.disruptor;
     requires transitive dagger;
     requires transitive io.helidon.webserver;

--- a/block-node/server/src/main/java/module-info.java
+++ b/block-node/server/src/main/java/module-info.java
@@ -2,7 +2,6 @@
 module org.hiero.block.server {
     exports org.hiero.block.server;
 
-    requires com.hedera.block.stream;
     requires com.hedera.pbj.grpc.helidon.config;
     requires com.hedera.pbj.grpc.helidon;
     requires com.hedera.pbj.runtime;
@@ -11,6 +10,7 @@ module org.hiero.block.server {
     requires com.swirlds.metrics.api;
     requires org.hiero.block.base;
     requires org.hiero.block.common;
+    requires org.hiero.block.stream;
     requires dagger;
     requires io.helidon.common;
     requires io.helidon.webserver;

--- a/common/src/main/java/module-info.java
+++ b/common/src/main/java/module-info.java
@@ -4,8 +4,8 @@ module org.hiero.block.common {
     exports org.hiero.block.common.utils;
     exports org.hiero.block.common.hasher;
 
-    requires transitive com.hedera.block.stream;
     requires transitive com.hedera.pbj.runtime;
+    requires transitive org.hiero.block.stream;
     requires com.swirlds.common;
     requires static com.github.spotbugs.annotations;
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,7 @@ rootProject.name = "hiero-block-node"
 
 javaModules {
     directory(".") {
-        group = "com.hedera.block"
+        group = "org.hiero.block"
         module("tools") // no 'module-info' yet
         module("suites")
         module("simulator")
@@ -13,7 +13,7 @@ javaModules {
         module("stream")
     }
     directory("block-node") {
-        group = "com.hedera.block"
+        group = "org.hiero.block"
         module("server") { artifact = "block-node-server" }
         module("base") { artifact = "block-node-base" }
         // module("persistence") { artifact = "service-persistence" }

--- a/simulator/src/main/java/module-info.java
+++ b/simulator/src/main/java/module-info.java
@@ -14,13 +14,13 @@ module org.hiero.block.simulator {
     exports org.hiero.block.simulator.mode;
     exports org.hiero.block.simulator.mode.impl;
 
-    requires com.hedera.block.stream;
     requires com.hedera.pbj.runtime;
     requires com.swirlds.common;
     requires com.swirlds.config.api;
     requires com.swirlds.config.extensions;
     requires com.swirlds.metrics.api;
     requires org.hiero.block.common;
+    requires org.hiero.block.stream;
     requires com.google.protobuf;
     requires dagger;
     requires io.grpc.stub;

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("com.hedera.pbj.pbj-compiler") version "0.9.17"
 }
 
-description = "Hedera API"
+description = "Hiero API"
 
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.

--- a/stream/src/main/java/module-info.java
+++ b/stream/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-module com.hedera.block.stream {
+module org.hiero.block.stream {
     exports com.hedera.hapi.block;
     exports com.hedera.hapi.block.protoc;
     exports com.hedera.hapi.block.stream.protoc;

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -11,7 +11,7 @@ description = "Hiero Block Stream Tools"
 application { mainClass = "org.hiero.block.tools.BlockStreamTool" }
 
 mainModuleInfo {
-    requires("com.hedera.block.stream") // use streams module to access protobuf generated classes
+    requires("org.hiero.block.stream")
     requires("com.hedera.pbj.runtime")
     requires("com.github.luben.zstd_jni")
     requires("com.google.api.gax")


### PR DESCRIPTION
- Moved the base package for all modules to `org.hiero` in the main build settings
   - Fixed all the references as needed (mostly just the "stream" module name changed).
