### PR TITLE
feat: Configured Observability stack to use PVC on Helm Charts

### DIFF
--- a/charts/block-node-server/templates/deployment.yaml
+++ b/charts/block-node-server/templates/deployment.yaml
@@ -48,12 +48,12 @@ spec:
             - sh
             - -c
             - |
-              mkdir -p /live-pvc/live-data && \
-              chown 2000:2000 /live-pvc/live-data && \
-              chmod 700 /live-pvc/live-data && \
-              mkdir -p /archive-pvc/archive-data && \
-              chown 2000:2000 /archive-pvc/archive-data && \
-              chmod 700 /archive-pvc/archive-data
+              mkdir -p /live-pvc/{{ .Values.blockNode.persistence.live.subPath }} && \
+              chown 2000:2000 /live-pvc/{{ .Values.blockNode.persistence.live.subPath }} && \
+              chmod 700 /live-pvc/{{ .Values.blockNode.persistence.live.subPath }} && \
+              mkdir -p /archive-pvc/{{ .Values.blockNode.persistence.archive.subPath }} && \
+              chown 2000:2000 /archive-pvc/{{ .Values.blockNode.persistence.archive.subPath }} && \
+              chmod 700 /archive-pvc/{{ .Values.blockNode.persistence.archive.subPath }}
           volumeMounts:
             - name: live-storage
               mountPath: /live-pvc
@@ -83,10 +83,10 @@ spec:
             readOnly: true
           - name: archive-storage
             mountPath: {{ .Values.blockNode.persistence.archive.mountPath }}
-            subPath: archive-data
+            subPath: {{ .Values.blockNode.persistence.archive.subPath }}
           - name: live-storage
             mountPath: {{ .Values.blockNode.persistence.live.mountPath }}
-            subPath: live-data
+            subPath: {{ .Values.blockNode.persistence.live.subPath }}
           - name: unverified-ephemeral-storage
             mountPath: {{ .Values.blockNode.persistence.unverified.mountPath }}
         {{- with  .Values.resources }}

--- a/charts/block-node-server/values-overrides/mini.yaml
+++ b/charts/block-node-server/values-overrides/mini.yaml
@@ -19,3 +19,21 @@ blockNode:
       size: 6Gi
     live:
       size: 1Gi
+
+# Setting the PVC size for the Observability stack to mini claims of 1 Gigabyte
+kubepromstack:
+  prometheus:
+    prometheusSpec:
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            resources:
+              requests:
+                storage: 1Gi
+  grafana:
+    persistence:
+      size: 1Gi
+
+loki:
+  persistence:
+    size: 1Gi

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -161,7 +161,7 @@ kubepromstack:
       storageSpec:
         volumeClaimTemplate:
           spec:
-            accessModes: [ "ReadWriteOnce" ]
+            accessModes: ["ReadWriteOnce"]
             resources:
               requests:
                 storage: 20Gi

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -86,6 +86,8 @@ blockNode:
       create: true
       # Name of the externally provided PVC
       existingClaim: ""
+      # Name of the subPath in the PVC to mount to mountPath in the container
+      subPath: "archive-data"
       # If create is true, the following values are used to create the PVC
       # should match PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH, leave as is for default.
       mountPath: "/opt/hashgraph/blocknode/data/archive"
@@ -97,6 +99,8 @@ blockNode:
       create: true
       # Name of the externally provided PVC
       existingClaim: ""
+      # Name of the subPath in the PVC to mount to mountPath in the container
+      subPath: "live-data"
       # If create is true, the following values are used to create the PVC
       # should match PERSISTENCE_STORAGE_LIVE_ROOT_PATH, leave as is for default.
       mountPath: "/opt/hashgraph/blocknode/data/live"
@@ -152,6 +156,15 @@ blockNode:
 
 kubepromstack:
   enabled: true
+  prometheus:
+    prometheusSpec:
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            accessModes: [ "ReadWriteOnce" ]
+            resources:
+              requests:
+                storage: 20Gi
   prometheusOperator:
     namespaces:
       releaseNamespace: true
@@ -171,6 +184,10 @@ kubepromstack:
       datasources:
         enabled: true
         label: grafana_datasource
+    persistence:
+      enabled: true
+      type: pvc
+      size: 10Gi
 
   nodeExporter:
     enabled: true
@@ -192,6 +209,10 @@ loki:
   datasource:
     jsonData: "{}"
     uid: ""
+  persistence:
+    enabled: true
+    size: 20Gi
+    # storageClassName: ""
 
 promtail:
   enabled: true


### PR DESCRIPTION
## Reviewer Notes
- Configuring all observability stack to use Persistent PVC instead of ephemeral disks.
- Set `subPath` for `archive-data` and `live-data` configurable via chart values.
- Added override for mini deployments

## Related Issue(s)
Fixes #831 
Fixes #847 