### PR TITLE
chore: Remove unneeded dependency on slf4j

### DIFF
--- a/block-node/base/build.gradle.kts
+++ b/block-node/base/build.gradle.kts
@@ -11,7 +11,6 @@ mainModuleInfo {
     annotationProcessor("dagger.compiler")
     annotationProcessor("com.google.auto.service.processor")
     runtimeOnly("com.swirlds.config.impl")
-    runtimeOnly("org.apache.logging.log4j.slf4j2.impl")
     runtimeOnly("io.helidon.logging.jul")
     runtimeOnly("com.hedera.pbj.grpc.helidon.config")
 }

--- a/block-node/messaging/build.gradle.kts
+++ b/block-node/messaging/build.gradle.kts
@@ -11,7 +11,6 @@ mainModuleInfo {
     annotationProcessor("dagger.compiler")
     annotationProcessor("com.google.auto.service.processor")
     runtimeOnly("com.swirlds.config.impl")
-    runtimeOnly("org.apache.logging.log4j.slf4j2.impl")
     runtimeOnly("io.helidon.logging.jul")
     runtimeOnly("com.hedera.pbj.grpc.helidon.config")
 }

--- a/block-node/server/build.gradle.kts
+++ b/block-node/server/build.gradle.kts
@@ -19,7 +19,6 @@ mainModuleInfo {
     annotationProcessor("dagger.compiler")
     annotationProcessor("com.google.auto.service.processor")
     runtimeOnly("com.swirlds.config.impl")
-    runtimeOnly("org.apache.logging.log4j.slf4j2.impl")
     runtimeOnly("io.helidon.logging.jul")
     runtimeOnly("com.hedera.pbj.grpc.helidon.config")
 }

--- a/common/src/main/java/module-info.java
+++ b/common/src/main/java/module-info.java
@@ -6,6 +6,5 @@ module org.hiero.block.common {
 
     requires transitive com.hedera.pbj.runtime;
     requires transitive org.hiero.block.stream;
-    requires com.swirlds.common;
     requires static com.github.spotbugs.annotations;
 }

--- a/common/src/main/java/org/hiero/block/common/hasher/HashingUtilities.java
+++ b/common/src/main/java/org/hiero/block/common/hasher/HashingUtilities.java
@@ -4,7 +4,6 @@ package org.hiero.block.common.hasher;
 import com.hedera.hapi.block.BlockItemUnparsed;
 import com.hedera.hapi.block.stream.BlockProof;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.common.crypto.DigestType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
@@ -21,9 +20,18 @@ public final class HashingUtilities {
     }
 
     /**
-     * The size of an SHA-384 hash in bytes.
+     * The size of a SHA-384 hash, in bytes.
      */
-    public static final int HASH_SIZE = DigestType.SHA_384.digestLength();
+    public static final int HASH_SIZE = 48;
+
+    /**
+     * The standard name of the SHA2 384-bit hash algorithm.
+     *
+     * This value must match what is declared for the
+     * <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/security/standard-names.html#messagedigest-algorithms">
+     * standard message digest names</a>.
+     */
+    public static final String HASH_ALGORITHM = "SHA-384";
 
     /**
      * Returns the SHA-384 hash of the given bytes.
@@ -41,7 +49,7 @@ public final class HashingUtilities {
      */
     public static byte[] noThrowSha384HashOf(@NonNull final byte[] byteArray) {
         try {
-            return MessageDigest.getInstance(DigestType.SHA_384.algorithmName()).digest(byteArray);
+            return MessageDigest.getInstance(HASH_ALGORITHM).digest(byteArray);
         } catch (final NoSuchAlgorithmException fatal) {
             throw new IllegalStateException(fatal);
         }
@@ -54,7 +62,7 @@ public final class HashingUtilities {
      */
     public static MessageDigest sha384DigestOrThrow() {
         try {
-            return MessageDigest.getInstance(DigestType.SHA_384.algorithmName());
+            return MessageDigest.getInstance(HASH_ALGORITHM);
         } catch (final NoSuchAlgorithmException fatal) {
             throw new IllegalStateException(fatal);
         }
@@ -78,7 +86,7 @@ public final class HashingUtilities {
      */
     public static byte[] combine(@NonNull final byte[] leftHash, @NonNull final byte[] rightHash) {
         try {
-            final var digest = MessageDigest.getInstance(DigestType.SHA_384.algorithmName());
+            final var digest = MessageDigest.getInstance(HASH_ALGORITHM);
             digest.update(leftHash);
             digest.update(rightHash);
             return digest.digest();

--- a/common/src/main/java/org/hiero/block/common/hasher/StreamingTreeHasher.java
+++ b/common/src/main/java/org/hiero/block/common/hasher/StreamingTreeHasher.java
@@ -2,7 +2,6 @@
 package org.hiero.block.common.hasher;
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.common.crypto.DigestType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -17,7 +16,7 @@ public interface StreamingTreeHasher {
     /**
      * The length of the hash produced by this hasher.
      */
-    int HASH_LENGTH = DigestType.SHA_384.digestLength();
+    int HASH_LENGTH = 48;
 
     /**
      * Describes the status of the tree hash computation.

--- a/simulator/build.gradle.kts
+++ b/simulator/build.gradle.kts
@@ -19,7 +19,6 @@ mainModuleInfo {
     annotationProcessor("dagger.compiler")
     annotationProcessor("com.google.auto.service.processor")
     runtimeOnly("com.swirlds.config.impl")
-    runtimeOnly("org.apache.logging.log4j.slf4j2.impl")
     runtimeOnly("io.grpc.netty")
 }
 

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -21,7 +21,6 @@ mainModuleInfo {
     requires("com.google.gson")
     requires("info.picocli")
     runtimeOnly("com.swirlds.config.impl")
-    runtimeOnly("org.apache.logging.log4j.slf4j2.impl")
     runtimeOnly("io.grpc.netty")
 }
 


### PR DESCRIPTION
* Removed dependency from Common to swirlds-common that only provided 2 constants.
* Removed slf4j from build "runtime" dependencies.
* Verified that gradle checks do not require the dependency

## Reviewer Notes
Just a quick PR to remove an unused runtime dependency from the gradle build files.
This also cleans up an unnecessary dependency in the Common module.  Much as `com.swirlds.common` might seem basic from the name, it is actually a _very_ large module, with a vast dependency tree.

## Related Issue(s)
 Fixes #870.
