### PR TITLE
fix: restart recovery race condition

### DIFF
--- a/block-node/base/src/main/java/org/hiero/block/server/ack/AckHandlerImpl.java
+++ b/block-node/base/src/main/java/org/hiero/block/server/ack/AckHandlerImpl.java
@@ -74,6 +74,10 @@ public class AckHandlerImpl implements AckHandler {
             // @todo(147) we need to handle new instances that need to start from a different block than 0.
             lastAcknowledgedBlockNumber = -1;
         }
+
+        LOGGER.log(
+                System.Logger.Level.INFO,
+                "AckHandler initialized with lastAcknowledgedBlockNumber: " + lastAcknowledgedBlockNumber);
     }
 
     @Override

--- a/block-node/base/src/main/java/org/hiero/block/server/ack/AckHandlerImpl.java
+++ b/block-node/base/src/main/java/org/hiero/block/server/ack/AckHandlerImpl.java
@@ -32,7 +32,7 @@ import org.hiero.block.server.service.ServiceStatus;
 public class AckHandlerImpl implements AckHandler {
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
     private final Map<Long, BlockInfo> blockInfo = new ConcurrentHashMap<>();
-    private volatile long lastAcknowledgedBlockNumber;
+    private volatile long lastAcknowledgedBlockNumber = -1;
     private final Notifier notifier;
     private final boolean skipAcknowledgement;
     private final ServiceStatus serviceStatus;
@@ -56,8 +56,14 @@ public class AckHandlerImpl implements AckHandler {
         this.serviceStatus = Objects.requireNonNull(serviceStatus);
         this.blockRemover = Objects.requireNonNull(blockRemover);
         this.metricsService = metricsService;
+    }
+
+    @Override
+    public void registerPersistence(@NonNull final StreamPersistenceHandlerImpl streamPersistenceHandler) {
+        this.streamPersistenceHandler = Objects.requireNonNull(streamPersistenceHandler);
 
         // Initialize lastAcknowledgedBlockNumber from the service status if available
+        // When Persistence registers itself, it means it has already calculated is last persisted block.
         final BlockInfo latestAckedBlock = serviceStatus.getLatestAckedBlock();
         if (latestAckedBlock != null) {
             lastAcknowledgedBlockNumber = latestAckedBlock.getBlockNumber();
@@ -68,11 +74,6 @@ public class AckHandlerImpl implements AckHandler {
             // @todo(147) we need to handle new instances that need to start from a different block than 0.
             lastAcknowledgedBlockNumber = -1;
         }
-    }
-
-    @Override
-    public void registerPersistence(@NonNull final StreamPersistenceHandlerImpl streamPersistenceHandler) {
-        this.streamPersistenceHandler = Objects.requireNonNull(streamPersistenceHandler);
     }
 
     @Override

--- a/block-node/base/src/test/java/org/hiero/block/server/ack/AckHandlerImplTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/server/ack/AckHandlerImplTest.java
@@ -297,6 +297,26 @@ class AckHandlerImplTest {
         verifyNoMoreInteractions(notifier);
     }
 
+    @Test
+    @DisplayName("Verify that latestAckedBlock is initialized correctly")
+    void latestAckedBlockInitialized() {
+        // given
+        when(serviceStatus.getLatestAckedBlock()).thenReturn(new BlockInfo(50));
+        ackHandler = new AckHandlerImpl(notifier, false, serviceStatus, blockRemover, metricsService);
+        ackHandler.registerPersistence(persistenceHandlerMock);
+
+        // given
+        final long block = 51L;
+        final Bytes hash = Bytes.wrap("hash51".getBytes());
+
+        ackHandler.blockPersisted(new BlockPersistenceResult(block, BlockPersistenceStatus.SUCCESS));
+        ackHandler.blockVerified(block, hash);
+
+        // Expect the second ACK
+        verify(notifier, times(1)).sendAck(eq(block), eq(hash), anyBoolean());
+        verifyNoMoreInteractions(notifier);
+    }
+
     /**
      * Edge condition #1:
      * If only block 2 is processed (i.e. block 1 is missing)


### PR DESCRIPTION
## Reviewer Notes
This issue was found on `0.6.0-rc2` after 233K blocks have been persisted, GCP restarted everything and the block-node was unable to recover sucessfully, while Persistence and Verification were continue to function properly, the ACK handler was initialized in a bad state.

Fixes #874 
