### PR TITLE
Fixed Dockerfile to use new artifact name

### DIFF
--- a/block-node/app/docker/Dockerfile
+++ b/block-node/app/docker/Dockerfile
@@ -76,10 +76,10 @@ WORKDIR /app
 # Copy Distribution TAR file
 # Ignore Codacy, the `distributions` context is set on command line and
 # _must be_ so set in order to work with the wonky CI setup.
-COPY --from=distributions block-node-server-${VERSION}.tar .
+COPY --from=distributions block-node-app-${VERSION}.tar .
 
 # Extract the TAR file
-RUN tar -xvf block-node-server-${VERSION}.tar
+RUN tar -xvf block-node-app-${VERSION}.tar
 
 # Create a log directory
 RUN mkdir -p /app/logs/config
@@ -145,5 +145,5 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=3s --retries=3 \
   CMD curl -f http://localhost:8080/healthz/livez || exit 1 && \
       curl -f http://localhost:8080/healthz/readyz || exit 1
 
-# RUN the bin script for starting the server
-ENTRYPOINT ["/bin/bash", "-c", "/app/block-node-server-${VERSION}/bin/block-node-server"]
+# RUN the bin script for starting the server app
+ENTRYPOINT ["/bin/bash", "-c", "/app/block-node-app-${VERSION}/bin/block-node-app"]


### PR DESCRIPTION
## Reviewer Notes

This makes the docker related processes work and allows the app to run successfully inside a container along the rest of the stack.

However the `ccontainer image` created intentionally stayed the same/old name `block-node-server` instead of `block-node-app`, this decision was to unblock testing on docker while minimizing conflicts with the rest of the system.

In the future we can discuss if we want to rename the container image to `block-node-app` to keep consistency. 
in any case such a change would break, smoke tests, test suites, CI workflows (publish and release), local docker-compose env, observability integrations and possible more stuff.... so for now, I intentionally prefer to keep the name to `block-node-server` at the container image level. :)


![image](https://github.com/user-attachments/assets/bc8a2e54-2277-49b3-af1d-120d82117656)
![image](https://github.com/user-attachments/assets/c37348b4-6ceb-4e30-a5e4-a3ba7d32e8fc)

