### PR TITLE
Fixing GRPC Services Methods not found.

### DIFF
--- a/block-node/publisher/src/main/java/org/hiero/block/node/publisher/PublisherServicePlugin.java
+++ b/block-node/publisher/src/main/java/org/hiero/block/node/publisher/PublisherServicePlugin.java
@@ -352,7 +352,7 @@ public class PublisherServicePlugin implements BlockNodePlugin, ServiceInterface
      */
     @NonNull
     public String serviceName() {
-        return "BlockStreamPublisherService";
+        return "BlockStreamService";
     }
 
     /**
@@ -360,7 +360,7 @@ public class PublisherServicePlugin implements BlockNodePlugin, ServiceInterface
      */
     @NonNull
     public String fullName() {
-        return "com.hedera.hapi.block.node." + serviceName();
+        return "com.hedera.hapi.block." + serviceName();
     }
 
     /**
@@ -413,6 +413,10 @@ public class PublisherServicePlugin implements BlockNodePlugin, ServiceInterface
                     onSessionUpdate(null, UpdateType.SESSION_ADDED, UNKNOWN_BLOCK_NUMBER);
                     // return the pipeline
                     yield pipe;
+
+                /*case subscribeBlockStream:
+                    // we do not support this method
+                    throw new RuntimeException();*/
             };
         } finally {
             stateLock.unlock();

--- a/block-node/subscriber/src/main/java/org/hiero/block/node/subscriber/SubscriberServicePlugin.java
+++ b/block-node/subscriber/src/main/java/org/hiero/block/node/subscriber/SubscriberServicePlugin.java
@@ -78,7 +78,7 @@ public class SubscriberServicePlugin implements BlockNodePlugin, ServiceInterfac
      */
     @NonNull
     public String serviceName() {
-        return "BlockStreamSubscriberService";
+        return "BlockStreamService";
     }
 
     /**
@@ -86,7 +86,7 @@ public class SubscriberServicePlugin implements BlockNodePlugin, ServiceInterfac
      */
     @NonNull
     public String fullName() {
-        return "com.hedera.hapi.block.node." + serviceName();
+        return "com.hedera.hapi.block." + serviceName();
     }
 
     /**


### PR DESCRIPTION
## Reviewer Notes

Previous to this fix, we were getting NOT FOUND status code from helidon.

Now connections are stablished and logic of consumer and publisher plugins is being executed.

Block-Node-App (Server)
![image](https://github.com/user-attachments/assets/a3c73b13-acba-4b7b-b169-0ab9adbcb49f)


Simulator on Publisher Mode
![image](https://github.com/user-attachments/assets/f41f9e61-2660-4ab6-a6fc-c499c2577832)

Simulator on Consumer Mode
![image](https://github.com/user-attachments/assets/820baece-3949-4282-8c0a-50886230eaee)
