### PR TITLE
chore: Add HealthServicePlugin UTs

### DIFF
--- a/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
@@ -12,11 +12,9 @@ import org.hiero.block.node.spi.health.HealthFacility;
 /** Provides implementation for the health endpoints of the server. */
 public class HealthServicePlugin implements BlockNodePlugin {
 
-    // TODO maybe these want to be package protected so they can be used in tests, as they are never module exported
-    // then that is fine
-    private static final String HEALTH_PATH = "/healthz";
-    private static final String LIVEZ_PATH = "/livez";
-    private static final String READYZ_PATH = "/readyz";
+    protected static final String HEALTHZ_PATH = "/healthz";
+    protected static final String LIVEZ_PATH = "/livez";
+    protected static final String READYZ_PATH = "/readyz";
 
     /** The health facility, used for getting server status */
     private HealthFacility healthFacility;
@@ -28,7 +26,7 @@ public class HealthServicePlugin implements BlockNodePlugin {
     public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
         healthFacility = context.serverHealth();
         serviceBuilder.registerHttpService(
-                HEALTH_PATH,
+                HEALTHZ_PATH,
                 httpRules -> httpRules.get(LIVEZ_PATH, this::handleLivez).get(READYZ_PATH, this::handleReadyz));
     }
 

--- a/block-node/health/src/test/java/org/hiero/block/node/health/HealthServiceTest.java
+++ b/block-node/health/src/test/java/org/hiero/block/node/health/HealthServiceTest.java
@@ -1,107 +1,140 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.health;
 
-import static org.mockito.Mockito.*;
-
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.HttpService;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import org.hiero.block.node.spi.BlockNodeContext;
+import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.health.HealthFacility;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hiero.block.node.health.HealthServicePlugin.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(MockitoExtension.class)
 class HealthServiceTest {
-    // TODO: Uncomment the following lines and fix the test cases
-    //
-    //    private static final String READINESS_PATH = "/readyz";
-    //    private static final String LIVENESS_PATH = "/livez";
-    //    private static final String HEALTH_PATH = "/healthz";
-    //
-    //    @Mock
-    //    private ServiceStatus serviceStatus;
-    //
-    //    @Mock
-    //    ServerRequest serverRequest;
-    //
-    //    @Mock
-    //    ServerResponse serverResponse;
-    //
-    //    @Test
-    //    public void testHandleLivez() {
-    //        // given
-    //        Mockito.when(serviceStatus.isRunning()).thenReturn(true);
-    //        Mockito.when(serverResponse.status(200)).thenReturn(serverResponse);
-    //        Mockito.doNothing().when(serverResponse).send("OK");
-    //        HealthService healthService = new HealthServiceImpl(serviceStatus);
-    //
-    //        // when
-    //        healthService.handleLivez(serverRequest, serverResponse);
-    //
-    //        // then
-    //        Mockito.verify(serverResponse, Mockito.times(1)).status(200);
-    //        Mockito.verify(serverResponse, Mockito.times(1)).send("OK");
-    //    }
-    //
-    //    @Test
-    //    public void testHandleLivez_notRunning() {
-    //        // given
-    //        Mockito.when(serviceStatus.isRunning()).thenReturn(false);
-    //        Mockito.when(serverResponse.status(503)).thenReturn(serverResponse);
-    //        Mockito.doNothing().when(serverResponse).send("Service is not running");
-    //        HealthService healthService = new HealthServiceImpl(serviceStatus);
-    //
-    //        // when
-    //        healthService.handleLivez(serverRequest, serverResponse);
-    //
-    //        // then
-    //        Mockito.verify(serverResponse, Mockito.times(1)).status(503);
-    //        Mockito.verify(serverResponse, Mockito.times(1)).send("Service is not running");
-    //    }
-    //
-    //    @Test
-    //    public void testHandleReadyz() {
-    //        // given
-    //        Mockito.when(serviceStatus.isRunning()).thenReturn(true);
-    //        Mockito.when(serverResponse.status(200)).thenReturn(serverResponse);
-    //        Mockito.doNothing().when(serverResponse).send("OK");
-    //        HealthService healthService = new HealthServiceImpl(serviceStatus);
-    //
-    //        // when
-    //        healthService.handleReadyz(serverRequest, serverResponse);
-    //
-    //        // then
-    //        Mockito.verify(serverResponse, Mockito.times(1)).status(200);
-    //        Mockito.verify(serverResponse, Mockito.times(1)).send("OK");
-    //    }
-    //
-    //    @Test
-    //    public void testHandleReadyz_notRunning() {
-    //        // given
-    //        Mockito.when(serviceStatus.isRunning()).thenReturn(false);
-    //        Mockito.when(serverResponse.status(503)).thenReturn(serverResponse);
-    //        Mockito.doNothing().when(serverResponse).send("Service is not running");
-    //        HealthService healthService = new HealthServiceImpl(serviceStatus);
-    //
-    //        // when
-    //        healthService.handleReadyz(serverRequest, serverResponse);
-    //
-    //        // then
-    //        Mockito.verify(serverResponse, Mockito.times(1)).status(503);
-    //        Mockito.verify(serverResponse, Mockito.times(1)).send("Service is not running");
-    //    }
-    //
-    //    @Test
-    //    public void testRouting() {
-    //        // given
-    //        HealthService healthService = new HealthServiceImpl(serviceStatus);
-    //        HttpRules httpRules = Mockito.mock(HttpRules.class);
-    //        Mockito.when(httpRules.get(ArgumentMatchers.anyString(), ArgumentMatchers.any())).thenReturn(httpRules);
-    //
-    //        // when
-    //        healthService.routing(httpRules);
-    //
-    //        // then
-    //        Mockito.verify(httpRules, Mockito.times(1)).get(ArgumentMatchers.eq(LIVENESS_PATH),
-    // ArgumentMatchers.any());
-    //        Mockito.verify(httpRules, Mockito.times(1)).get(ArgumentMatchers.eq(READINESS_PATH),
-    // ArgumentMatchers.any());
-    //        assertEquals(HEALTH_PATH, healthService.getHealthRootPath());
-    //    }
+
+    @Mock
+    ServerRequest serverRequest;
+
+    @Mock
+    ServerResponse serverResponse;
+
+    @Mock
+    ServiceBuilder serviceBuilder;
+
+    @Test
+    public void testHandleLivez() {
+        // given
+        Mockito.when(serverResponse.status(200)).thenReturn(serverResponse);
+        Mockito.doNothing().when(serverResponse).send("OK");
+
+        BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
+        HealthFacility healthFacility = Mockito.mock(HealthFacility.class);
+        Mockito.when(healthFacility.isRunning()).thenReturn(true);
+        Mockito.when(context.serverHealth()).thenReturn(healthFacility);
+
+        // when
+        HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
+        healthServicePlugin.init(context, serviceBuilder);
+        healthServicePlugin.handleLivez(serverRequest, serverResponse);
+
+        // then
+        Mockito.verify(serverResponse, Mockito.times(1)).status(200);
+        Mockito.verify(serverResponse, Mockito.times(1)).send("OK");
+    }
+
+    @Test
+    public void testHandleLivez_notRunning() {
+        // given
+        Mockito.when(serverResponse.status(503)).thenReturn(serverResponse);
+
+        BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
+        HealthFacility healthFacility = Mockito.mock(HealthFacility.class);
+        Mockito.when(healthFacility.isRunning()).thenReturn(false);
+        Mockito.when(context.serverHealth()).thenReturn(healthFacility);
+
+        // when
+        HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
+        healthServicePlugin.init(context, serviceBuilder);
+        healthServicePlugin.handleLivez(serverRequest, serverResponse);
+
+        // then
+        Mockito.verify(serverResponse, Mockito.times(1)).status(503);
+        Mockito.verify(serverResponse, Mockito.times(1)).send("Service is not running");
+    }
+
+    @Test
+    public void testHandleReadyz() {
+        // given
+        Mockito.when(serverResponse.status(200)).thenReturn(serverResponse);
+        Mockito.doNothing().when(serverResponse).send("OK");
+
+        BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
+        HealthFacility healthFacility = Mockito.mock(HealthFacility.class);
+        Mockito.when(healthFacility.isRunning()).thenReturn(true);
+        Mockito.when(context.serverHealth()).thenReturn(healthFacility);
+
+        // when
+        HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
+        healthServicePlugin.init(context, serviceBuilder);
+        healthServicePlugin.handleReadyz(serverRequest, serverResponse);
+
+        // then
+        Mockito.verify(serverResponse, Mockito.times(1)).status(200);
+        Mockito.verify(serverResponse, Mockito.times(1)).send("OK");
+    }
+
+    @Test
+    public void testHandleReadyz_notRunning() {
+        // given
+        Mockito.when(serverResponse.status(503)).thenReturn(serverResponse);
+
+        BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
+        HealthFacility healthFacility = Mockito.mock(HealthFacility.class);
+        Mockito.when(healthFacility.isRunning()).thenReturn(false);
+        Mockito.when(context.serverHealth()).thenReturn(healthFacility);
+
+        // when
+        HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
+        healthServicePlugin.init(context, serviceBuilder);
+        healthServicePlugin.handleLivez(serverRequest, serverResponse);
+
+        // then
+        Mockito.verify(serverResponse, Mockito.times(1)).status(503);
+        Mockito.verify(serverResponse, Mockito.times(1)).send("Service is not running");
+    }
+
+    @Test
+    public void testRouting() {
+        // given
+        ArgumentCaptor<HttpService> httpServiceArgumentCaptor = ArgumentCaptor.forClass(HttpService.class);
+        HttpRules httpRules = Mockito.mock(HttpRules.class);
+        Mockito.when(httpRules.get(ArgumentMatchers.anyString(), ArgumentMatchers.any())).thenReturn(httpRules);
+        BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
+
+        // when
+        HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
+        healthServicePlugin.init(context, serviceBuilder);
+
+        // then
+        Mockito.verify(serviceBuilder, Mockito.times(1))
+                .registerHttpService(ArgumentMatchers.eq(HEALTHZ_PATH), httpServiceArgumentCaptor.capture());
+        HttpService httpService = httpServiceArgumentCaptor.getValue();
+        assertNotNull(httpService);
+
+        // healthServicePlugin used a functionalInterface to define HttpService so we have to confirm
+        // healthServicePlugin.routing() will apply the expected routing paths
+        // confirm that httRules.get(..) is called twice, once for READINESS_PATH and then once for LIVENESS_PATH
+        httpService.routing(httpRules);
+        Mockito.verify(httpRules, Mockito.times(1))
+                .get(ArgumentMatchers.eq(READYZ_PATH), ArgumentMatchers.any());
+        Mockito.verify(httpRules, Mockito.times(1))
+                .get(ArgumentMatchers.eq(LIVEZ_PATH), ArgumentMatchers.any());
+    }
 }


### PR DESCRIPTION
## Reviewer Notes
New `HealthServicePlugin` was missing UTs and `HealthServiceTest` had UTs from prior to refactor that needed refactoring themselves

- Update `HEALTHZ_PATH` strings to be protected 
- Refactor lives and readyz tests in `HealthServiceTest` with mock considerations `BlockNodeContext` and `HealthFacility`
- Refactor testRouting test with capture logic to manage functional interface usage for HttpService to expose routes

## Related Issue(s)
Fixes #925 