### PR TITLE
fix: Publisher plugin fixes and tests

### DIFF
--- a/block-node/publisher/build.gradle.kts
+++ b/block-node/publisher/build.gradle.kts
@@ -18,4 +18,6 @@ testModuleInfo {
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
     requires("org.hiero.block.node.app.test.fixtures")
+    requires("org.mockito")
+    requires("org.mockito.junit.jupiter")
 }

--- a/block-node/publisher/build.gradle.kts
+++ b/block-node/publisher/build.gradle.kts
@@ -16,5 +16,6 @@ mainModuleInfo {
 
 testModuleInfo {
     requires("org.junit.jupiter.api")
+    requires("org.junit.jupiter.params")
     requires("org.hiero.block.node.app.test.fixtures")
 }

--- a/block-node/publisher/src/main/java/module-info.java
+++ b/block-node/publisher/src/main/java/module-info.java
@@ -16,6 +16,7 @@ module org.hiero.block.node.publisher {
     requires transitive com.swirlds.metrics.api;
     requires transitive org.hiero.block.node.spi;
     requires transitive org.hiero.block.stream;
+    requires org.hiero.block.common;
     requires org.hiero.block.node.base;
     requires com.github.spotbugs.annotations;
 

--- a/block-node/publisher/src/main/java/org/hiero/block/node/publisher/BlockStreamProducerSession.java
+++ b/block-node/publisher/src/main/java/org/hiero/block/node/publisher/BlockStreamProducerSession.java
@@ -136,7 +136,9 @@ public final class BlockStreamProducerSession implements Pipeline<List<BlockItem
      *
      * @return the current session ID.
      */
-    long sessionId() { return sessionId; }
+    long sessionId() {
+        return sessionId;
+    }
 
     /**
      * Make this session the primary session for the block stream. This means that we are now the primary session and

--- a/block-node/publisher/src/main/java/org/hiero/block/node/publisher/BlockStreamProducerSession.java
+++ b/block-node/publisher/src/main/java/org/hiero/block/node/publisher/BlockStreamProducerSession.java
@@ -132,6 +132,13 @@ public final class BlockStreamProducerSession implements Pipeline<List<BlockItem
     }
 
     /**
+     * Get the ID of the current session.
+     *
+     * @return the current session ID.
+     */
+    long sessionId() { return sessionId; }
+
+    /**
      * Make this session the primary session for the block stream. This means that we are now the primary session and
      * will send block items to the block messaging service. This is called when we are in the new state and have
      * received the first block item for the new block. It is trusted that this is always called with the stateLock
@@ -240,7 +247,7 @@ public final class BlockStreamProducerSession implements Pipeline<List<BlockItem
             // update the live block items received metric
             liveBlockItemsReceived.add(items.size());
             // check items to see if we are entering a new block
-            final boolean newBlock = items.size() == 1 && items.getFirst().hasBlockHeader();
+            final boolean newBlock = items.getFirst().hasBlockHeader();
             if (newBlock) {
                 try {
                     long newBlockNumber = BlockHeader.PROTOBUF
@@ -285,7 +292,9 @@ public final class BlockStreamProducerSession implements Pipeline<List<BlockItem
             }
             // call the onUpdate method to notify the block messaging service that we have received data and updated our
             // state, check if we are starting or ending a block
-            if (items.size() == 1 && items.getFirst().hasBlockProof()) {
+            if (newBlock && items.getLast().hasBlockProof()) {
+                onUpdate.update(this, UpdateType.WHOLE_BLOCK, currentBlockNumber);
+            } else if (items.getLast().hasBlockProof()) {
                 // send end block update
                 onUpdate.update(this, UpdateType.END_BLOCK, currentBlockNumber);
                 // change state back to NEW as we have finished the current block

--- a/block-node/publisher/src/main/java/org/hiero/block/node/publisher/PublisherConfig.java
+++ b/block-node/publisher/src/main/java/org/hiero/block/node/publisher/PublisherConfig.java
@@ -3,10 +3,10 @@ package org.hiero.block.node.publisher;
 
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
+import com.swirlds.config.api.validation.annotation.Min;
+import java.util.Objects;
 import org.hiero.block.common.utils.Preconditions;
 import org.hiero.block.node.base.Loggable;
-
-import java.util.Objects;
 
 /**
  * Use this configuration across the producer package
@@ -17,7 +17,7 @@ import java.util.Objects;
 @ConfigData("producer")
 public record PublisherConfig(
         @Loggable @ConfigProperty(defaultValue = "PRODUCTION") PublisherType type,
-        @Loggable @ConfigProperty(defaultValue = "1500") int timeoutThresholdMillis) {
+        @Loggable @ConfigProperty(defaultValue = "1500") @Min(1) int timeoutThresholdMillis) {
     /**
      * The type of the publisher service to use - PRODUCTION or NO_OP.
      */

--- a/block-node/publisher/src/main/java/org/hiero/block/node/publisher/PublisherConfig.java
+++ b/block-node/publisher/src/main/java/org/hiero/block/node/publisher/PublisherConfig.java
@@ -3,7 +3,10 @@ package org.hiero.block.node.publisher;
 
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
+import org.hiero.block.common.utils.Preconditions;
 import org.hiero.block.node.base.Loggable;
+
+import java.util.Objects;
 
 /**
  * Use this configuration across the producer package
@@ -27,5 +30,13 @@ public record PublisherConfig(
          * No-op mode. Does not send any block items to the block messaging service. Just updates the metrics
          */
         NO_OP,
+    }
+
+    /**
+     * Constructs a new {@code PublisherConfig} instance with validation.
+     */
+    public PublisherConfig {
+        Objects.requireNonNull(type);
+        Preconditions.requirePositive(timeoutThresholdMillis);
     }
 }

--- a/block-node/publisher/src/main/java/org/hiero/block/node/publisher/PublisherServicePlugin.java
+++ b/block-node/publisher/src/main/java/org/hiero/block/node/publisher/PublisherServicePlugin.java
@@ -204,7 +204,8 @@ public final class PublisherServicePlugin implements BlockNodePlugin, ServiceInt
                     LOGGER.log(INFO, "onSessionUpdate: newPrimarySession was found {0}", newPrimarySession);
                     if (newPrimarySession.isPresent()) {
                         final BlockStreamProducerSession openSession = newPrimarySession.get();
-                        // skip setting currentPrimarySession, because this is a whole block and setting here as primary is not necessary, as we are going to search for new primary for next block
+                        // skip setting currentPrimarySession, because this is a whole block and setting here as primary
+                        // is not necessary, as we are going to search for new primary for next block
                         if (updateType != UpdateType.WHOLE_BLOCK) {
                             // set the current primary session
                             currentPrimarySession = openSession;
@@ -212,10 +213,10 @@ public final class PublisherServicePlugin implements BlockNodePlugin, ServiceInt
                         openSession.switchToPrimary();
                         // tell all other sessions to switch to behind
                         openSessions.stream()
-                                .filter(otherSession -> otherSession != currentPrimarySession && otherSession.sessionId() != openSession.sessionId())
+                                .filter(otherSession -> otherSession != currentPrimarySession
+                                        && otherSession.sessionId() != openSession.sessionId())
                                 .forEach(BlockStreamProducerSession::switchToBehind);
-                    }
-                    else {
+                    } else {
                         // no primary session, set to null
                         currentPrimarySession = null;
                         // this can happen if all sessions are behind or ahead, so lets check if they

--- a/block-node/publisher/src/main/java/org/hiero/block/node/publisher/UpdateCallback.java
+++ b/block-node/publisher/src/main/java/org/hiero/block/node/publisher/UpdateCallback.java
@@ -11,6 +11,7 @@ public interface UpdateCallback {
         BLOCK_ITEMS_RECEIVED,
         START_BLOCK,
         END_BLOCK,
+        WHOLE_BLOCK,
         SESSION_ADDED,
         SESSION_CLOSED,
     }

--- a/block-node/publisher/src/test/java/org/hiero/block/node/publisher/BlockStreamProducerSessionTest.java
+++ b/block-node/publisher/src/test/java/org/hiero/block/node/publisher/BlockStreamProducerSessionTest.java
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.publisher;
+
+import static org.hiero.block.node.spi.BlockNodePlugin.UNKNOWN_BLOCK_NUMBER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.metrics.api.Counter;
+import java.util.List;
+import java.util.concurrent.Flow;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.hapi.block.node.BlockItemUnparsed;
+import org.hiero.hapi.block.node.PublishStreamResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link BlockStreamProducerSession}.
+ * Tests cover session state management, block processing, and response handling.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Block Stream Producer Session Tests")
+public class BlockStreamProducerSessionTest {
+
+    @Mock
+    private UpdateCallback onUpdate;
+
+    @Mock
+    private Consumer<BlockItems> sendToBlockMessaging;
+
+    @Mock
+    private Counter liveBlockItemsReceived;
+
+    private BlockStreamProducerSession session;
+
+    private PublishStreamResponse lastResponse;
+
+    private Bytes BLOCK_HEADER = Bytes.fromHex(
+            "0a0210011202100122300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a0608c3e6b0bf06");
+    private Bytes TRANSACTION_RESULT = Bytes.fromHex(
+            "0816120608c4e6b0bf063a120a070a0218161085030a070a02183610860342160a02185112070a02180310f10112070a02180610f201");
+    private Bytes BLOCK_PROOF = Bytes.fromHex(
+            "12300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001a300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002230e21453939fb461d46ae919bfdd0ceb945d4ccc76e15e591fc0588533fd201635b545d62cff07732e34deaedfc81c1f6a");
+
+    @BeforeEach
+    void setUp() {
+        final ReentrantLock stateLock = new ReentrantLock();
+        Pipeline<? super PublishStreamResponse> responsePipeline = new ResponsePipeline();
+        session = new BlockStreamProducerSession(
+                1L, // sessionId
+                responsePipeline,
+                onUpdate,
+                liveBlockItemsReceived,
+                stateLock,
+                sendToBlockMessaging);
+    }
+
+    /**
+     * Tests the initial state of a new session.
+     * Verifies that the session starts with correct default values.
+     */
+    @Test
+    @DisplayName("Should initialize with correct default values")
+    void testInitialState() {
+        assertEquals(1L, session.sessionId());
+        assertEquals(BlockStreamProducerSession.BlockState.NEW, session.currentBlockState());
+        assertEquals(UNKNOWN_BLOCK_NUMBER, session.currentBlockNumber());
+        assertEquals(0L, session.startTimeOfCurrentBlock());
+    }
+
+    /**
+     * Tests the state transition from NEW to PRIMARY.
+     * Verifies that the session correctly handles becoming the primary session.
+     */
+    @Test
+    @DisplayName("Should transition from NEW to PRIMARY state")
+    void testSwitchToPrimary() {
+        // Initial state should be NEW
+        assertEquals(BlockStreamProducerSession.BlockState.NEW, session.currentBlockState());
+
+        // Switch to primary
+        session.switchToPrimary();
+
+        // Verify state change
+        assertEquals(BlockStreamProducerSession.BlockState.PRIMARY, session.currentBlockState());
+    }
+
+    /**
+     * Tests the state transition from NEW to BEHIND.
+     * Verifies that the session correctly handles becoming a behind session.
+     */
+    @Test
+    @DisplayName("Should transition from NEW to BEHIND state")
+    void testSwitchToBehind() {
+        // Initial state should be NEW
+        assertEquals(BlockStreamProducerSession.BlockState.NEW, session.currentBlockState());
+
+        // Switch to behind
+        session.switchToBehind();
+
+        // Verify state change
+        assertEquals(BlockStreamProducerSession.BlockState.BEHIND, session.currentBlockState());
+        assertNotNull(lastResponse);
+        assertEquals(
+                PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT,
+                lastResponse.response().kind());
+    }
+
+    /**
+     * Tests handling of block items in different states.
+     * Verifies that the session correctly processes items based on its current state.
+     */
+    @Test
+    @DisplayName("Should handle block items correctly in different states")
+    void testBlockItemProcessing() {
+        // Test processing in NEW state with block header
+        session.onNext(
+                List.of(BlockItemUnparsed.newBuilder().blockHeader(BLOCK_HEADER).build()));
+        assertEquals(BlockStreamProducerSession.BlockState.NEW, session.currentBlockState());
+        assertEquals(0L, session.currentBlockNumber());
+
+        // Test processing in NEW state with transaction result
+        session.onNext(List.of(BlockItemUnparsed.newBuilder()
+                .transactionResult(TRANSACTION_RESULT)
+                .build()));
+        assertEquals(BlockStreamProducerSession.BlockState.NEW, session.currentBlockState());
+
+        // Test processing in PRIMARY state with transaction result
+        session.switchToPrimary();
+        session.onNext(List.of(BlockItemUnparsed.newBuilder()
+                .transactionResult(TRANSACTION_RESULT)
+                .build()));
+        assertEquals(BlockStreamProducerSession.BlockState.PRIMARY, session.currentBlockState());
+    }
+
+    /**
+     * Tests handling of block header parsing and state transitions.
+     * Verifies that the session correctly handles block headers and updates state accordingly.
+     */
+    @Test
+    @DisplayName("Should handle block header parsing and state transitions")
+    void testBlockHeaderParsing() {
+        // Test with valid block header
+        session.onNext(
+                List.of(BlockItemUnparsed.newBuilder().blockHeader(BLOCK_HEADER).build()));
+        assertEquals(BlockStreamProducerSession.BlockState.NEW, session.currentBlockState());
+        assertEquals(0L, session.currentBlockNumber());
+
+        // Test with invalid block header (should throw ParseException)
+        assertThrows(
+                RuntimeException.class,
+                () -> session.onNext(List.of(BlockItemUnparsed.newBuilder()
+                        .blockHeader(Bytes.fromHex("invalid"))
+                        .build())));
+    }
+
+    /**
+     * Tests handling of block proof and state transitions.
+     * Verifies that the session correctly handles block proofs and updates state accordingly.
+     */
+    @Test
+    @DisplayName("Should handle block proof and state transitions")
+    void testBlockProofHandling() {
+        // Start with block header
+        session.onNext(
+                List.of(BlockItemUnparsed.newBuilder().blockHeader(BLOCK_HEADER).build()));
+
+        // Add transaction result
+        session.onNext(List.of(BlockItemUnparsed.newBuilder()
+                .transactionResult(TRANSACTION_RESULT)
+                .build()));
+
+        // Add block proof
+        session.onNext(
+                List.of(BlockItemUnparsed.newBuilder().blockProof(BLOCK_PROOF).build()));
+
+        // Verify state transition back to NEW after block proof
+        assertEquals(BlockStreamProducerSession.BlockState.NEW, session.currentBlockState());
+    }
+
+    /**
+     * Tests handling of block items in WAITING_FOR_RESEND state.
+     * Verifies that the session correctly ignores items while waiting for resend.
+     */
+    @Test
+    @DisplayName("Should handle block items in WAITING_FOR_RESEND state")
+    void testWaitingForResendState() {
+        // Set up waiting for resend state
+        session.requestResend(100L);
+
+        // Send items while waiting for resend
+        session.onNext(List.of(BlockItemUnparsed.newBuilder()
+                .transactionResult(TRANSACTION_RESULT)
+                .build()));
+
+        // Verify state remains WAITING_FOR_RESEND
+        assertEquals(BlockStreamProducerSession.BlockState.WAITING_FOR_RESEND, session.currentBlockState());
+        assertEquals(100L, session.currentBlockNumber());
+    }
+
+    /**
+     * Tests handling of block items in DISCONNECTED state.
+     * Verifies that the session correctly handles items while disconnected.
+     */
+    @Test
+    @DisplayName("Should handle block items in DISCONNECTED state")
+    void testDisconnectedState() {
+        // Set up disconnected state
+        session.close();
+
+        // Send items while disconnected
+        session.onNext(List.of(BlockItemUnparsed.newBuilder()
+                .transactionResult(TRANSACTION_RESULT)
+                .build()));
+
+        // Verify state remains DISCONNECTED
+        assertEquals(BlockStreamProducerSession.BlockState.DISCONNECTED, session.currentBlockState());
+    }
+
+    /**
+     * Tests handling of complete block processing sequence.
+     * Verifies that the session correctly processes a complete block from start to finish.
+     */
+    @Test
+    @DisplayName("Should handle complete block processing sequence")
+    void testCompleteBlockProcessing() {
+        // Start block with header
+        session.onNext(
+                List.of(BlockItemUnparsed.newBuilder().blockHeader(BLOCK_HEADER).build()));
+        assertEquals(BlockStreamProducerSession.BlockState.NEW, session.currentBlockState());
+
+        // Switch to primary
+        session.switchToPrimary();
+
+        // Add transaction results
+        session.onNext(List.of(BlockItemUnparsed.newBuilder()
+                .transactionResult(TRANSACTION_RESULT)
+                .build()));
+        assertEquals(BlockStreamProducerSession.BlockState.PRIMARY, session.currentBlockState());
+
+        // End block with proof
+        session.onNext(
+                List.of(BlockItemUnparsed.newBuilder().blockProof(BLOCK_PROOF).build()));
+
+        // Verify final state
+        assertEquals(BlockStreamProducerSession.BlockState.NEW, session.currentBlockState());
+    }
+
+    /**
+     * Tests the session's response to block resend requests.
+     * Verifies that the session correctly handles requests to resend blocks.
+     */
+    @Test
+    @DisplayName("Should handle block resend requests")
+    void testRequestResend() {
+        // Request resend of block 100
+        session.requestResend(100L);
+
+        // Verify state change
+        assertEquals(BlockStreamProducerSession.BlockState.WAITING_FOR_RESEND, session.currentBlockState());
+        assertEquals(100L, session.currentBlockNumber());
+        assertNotNull(lastResponse);
+        assertEquals(
+                PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK,
+                lastResponse.response().kind());
+    }
+
+    /**
+     * Tests session cleanup and disconnection.
+     * Verifies that the session properly cleans up resources when closed.
+     */
+    @Test
+    @DisplayName("Should clean up resources on close")
+    void testClose() {
+        // Create a mock subscription
+        Flow.Subscription mockSubscription = new Flow.Subscription() {
+            @Override
+            public void request(long n) {}
+
+            @Override
+            public void cancel() {}
+        };
+
+        // Set up subscription
+        session.onSubscribe(mockSubscription);
+
+        // Close the session
+        session.close();
+
+        // Verify state change
+        assertEquals(BlockStreamProducerSession.BlockState.DISCONNECTED, session.currentBlockState());
+        assertNotNull(lastResponse);
+        assertEquals(
+                PublishStreamResponse.ResponseOneOfType.END_STREAM,
+                lastResponse.response().kind());
+    }
+
+    /**
+     * Tests handling of block persistence notifications.
+     * Verifies that the session correctly sends acknowledgments when blocks are persisted.
+     */
+    @Test
+    @DisplayName("Should handle block persistence notifications")
+    void testSendBlockPersisted() {
+        // Create a mock block hash
+        Bytes blockHash = Bytes.fromHex("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+        // Send block persisted notification
+        session.sendBlockPersisted(100L, blockHash);
+
+        assertNotNull(lastResponse);
+        assertEquals(
+                PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT,
+                lastResponse.response().kind());
+    }
+
+    /**
+     * Tests error handling in the session.
+     * Verifies that the session properly handles errors and updates its state accordingly.
+     */
+    @Test
+    @DisplayName("Should handle errors gracefully")
+    void testErrorHandling() {
+        // Simulate an error
+        session.onError(new RuntimeException("Test error"));
+
+        assertEquals(BlockStreamProducerSession.BlockState.DISCONNECTED, session.currentBlockState());
+        assertNotNull(lastResponse);
+        assertEquals(
+                PublishStreamResponse.ResponseOneOfType.END_STREAM,
+                lastResponse.response().kind());
+    }
+
+    /**
+     * Tests handling of stream completion.
+     * Verifies that the session properly handles stream completion events.
+     */
+    @Test
+    @DisplayName("Should handle stream completion")
+    void testStreamCompletion() {
+        // Simulate stream completion
+        session.onComplete();
+
+        // Verify state change
+        assertEquals(BlockStreamProducerSession.BlockState.DISCONNECTED, session.currentBlockState());
+    }
+
+    private class ResponsePipeline implements Pipeline<PublishStreamResponse> {
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            throw new UnsupportedOperationException("This pipeline does not support subscriptions.");
+        }
+
+        @Override
+        public void clientEndStreamReceived() {
+            Pipeline.super.clientEndStreamReceived();
+        }
+
+        @Override
+        public void onNext(PublishStreamResponse item) throws RuntimeException {
+            BlockStreamProducerSessionTest.this.lastResponse = item;
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            // Not used
+        }
+
+        @Override
+        public void onComplete() {
+            // Not used
+        }
+    }
+}

--- a/block-node/publisher/src/test/java/org/hiero/block/node/publisher/PublisherConfigTest.java
+++ b/block-node/publisher/src/test/java/org/hiero/block/node/publisher/PublisherConfigTest.java
@@ -1,10 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.publisher;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -114,9 +115,7 @@ public class PublisherConfigTest {
     @DisplayName("Should reject null publisher type")
     void testNullType() {
         // Test that null type is not allowed
-        assertThrows(NullPointerException.class, () ->
-                new PublisherConfig(null, 1500)
-        );
+        assertThrows(NullPointerException.class, () -> new PublisherConfig(null, 1500));
     }
 
     /**
@@ -130,9 +129,9 @@ public class PublisherConfigTest {
     @DisplayName("Should reject invalid timeout threshold values")
     void testInvalidTimeoutThreshold(int invalidTimeout) {
         // Test that negative or zero timeout is not allowed
-        assertThrows(IllegalArgumentException.class, () ->
-                new PublisherConfig(PublisherConfig.PublisherType.PRODUCTION, invalidTimeout)
-        );
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new PublisherConfig(PublisherConfig.PublisherType.PRODUCTION, invalidTimeout));
     }
 
     /**

--- a/block-node/publisher/src/test/java/org/hiero/block/node/publisher/PublisherConfigTest.java
+++ b/block-node/publisher/src/test/java/org/hiero/block/node/publisher/PublisherConfigTest.java
@@ -1,0 +1,155 @@
+package org.hiero.block.node.publisher;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit tests for the {@link PublisherConfig} class.
+ * Tests cover configuration creation, validation, and behavior of the publisher configuration.
+ */
+@DisplayName("Publisher Configuration Tests")
+public class PublisherConfigTest {
+
+    /**
+     * Tests the creation of a PublisherConfig with default values.
+     * Verifies that the default publisher type is PRODUCTION and timeout is 1500ms.
+     */
+    @Test
+    @DisplayName("Should create configuration with default values")
+    void testDefaultConfiguration() {
+        // Create config with default values
+        final PublisherConfig config = new PublisherConfig(PublisherConfig.PublisherType.PRODUCTION, 1500);
+
+        // Verify default values
+        assertEquals(PublisherConfig.PublisherType.PRODUCTION, config.type());
+        assertEquals(1500, config.timeoutThresholdMillis());
+    }
+
+    /**
+     * Tests the creation of PublisherConfig with custom values.
+     * Verifies that both publisher type and timeout can be customized.
+     */
+    @Test
+    @DisplayName("Should create configuration with custom values")
+    void testCustomConfiguration() {
+        // Test NO_OP type
+        final PublisherConfig noOpConfig = new PublisherConfig(PublisherConfig.PublisherType.NO_OP, 2000);
+        assertEquals(PublisherConfig.PublisherType.NO_OP, noOpConfig.type());
+        assertEquals(2000, noOpConfig.timeoutThresholdMillis());
+
+        // Test custom timeout
+        final PublisherConfig customTimeoutConfig = new PublisherConfig(PublisherConfig.PublisherType.PRODUCTION, 3000);
+        assertEquals(PublisherConfig.PublisherType.PRODUCTION, customTimeoutConfig.type());
+        assertEquals(3000, customTimeoutConfig.timeoutThresholdMillis());
+    }
+
+    /**
+     * Tests the PublisherType enum values and their properties.
+     * Verifies the number of enum values, their existence, names, and string representation.
+     */
+    @Test
+    @DisplayName("Should have valid publisher type enum values")
+    void testPublisherTypeEnum() {
+        // Verify enum has exactly two values
+        assertEquals(2, PublisherConfig.PublisherType.values().length);
+
+        // Verify enum values
+        assertNotNull(PublisherConfig.PublisherType.PRODUCTION);
+        assertNotNull(PublisherConfig.PublisherType.NO_OP);
+
+        // Verify enum names
+        assertEquals("PRODUCTION", PublisherConfig.PublisherType.PRODUCTION.name());
+        assertEquals("NO_OP", PublisherConfig.PublisherType.NO_OP.name());
+
+        // Verify toString behavior
+        assertEquals("PRODUCTION", PublisherConfig.PublisherType.PRODUCTION.toString());
+        assertEquals("NO_OP", PublisherConfig.PublisherType.NO_OP.toString());
+    }
+
+    /**
+     * Tests the record behavior of PublisherConfig including equals, hashCode, and toString methods.
+     * Verifies that identical configurations are equal and different configurations are not.
+     */
+    @Test
+    @DisplayName("Should have correct record behavior")
+    void testRecordBehavior() {
+        // Create two identical configs
+        final PublisherConfig config1 = new PublisherConfig(PublisherConfig.PublisherType.PRODUCTION, 1500);
+        final PublisherConfig config2 = new PublisherConfig(PublisherConfig.PublisherType.PRODUCTION, 1500);
+
+        // Create a different config
+        final PublisherConfig config3 = new PublisherConfig(PublisherConfig.PublisherType.NO_OP, 1500);
+
+        // Test equals
+        assertEquals(config1, config2);
+        assertNotEquals(config1, config3);
+
+        // Test hashCode
+        assertEquals(config1.hashCode(), config2.hashCode());
+        assertNotEquals(config1.hashCode(), config3.hashCode());
+
+        // Test toString
+        final String toString = config1.toString();
+        assertTrue(toString.contains("PRODUCTION"));
+        assertTrue(toString.contains("1500"));
+
+        // Test immutability by creating new instances
+        final PublisherConfig newConfig = new PublisherConfig(PublisherConfig.PublisherType.NO_OP, 2000);
+        assertNotEquals(config1, newConfig);
+    }
+
+    /**
+     * Tests that PublisherConfig rejects null publisher type.
+     * Verifies that attempting to create a configuration with null type throws NullPointerException.
+     */
+    @Test
+    @DisplayName("Should reject null publisher type")
+    void testNullType() {
+        // Test that null type is not allowed
+        assertThrows(NullPointerException.class, () ->
+                new PublisherConfig(null, 1500)
+        );
+    }
+
+    /**
+     * Tests that PublisherConfig rejects invalid timeout threshold values.
+     * Verifies that zero or negative timeout values are rejected with IllegalArgumentException.
+     *
+     * @param invalidTimeout The invalid timeout value to test
+     */
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1, -100})
+    @DisplayName("Should reject invalid timeout threshold values")
+    void testInvalidTimeoutThreshold(int invalidTimeout) {
+        // Test that negative or zero timeout is not allowed
+        assertThrows(IllegalArgumentException.class, () ->
+                new PublisherConfig(PublisherConfig.PublisherType.PRODUCTION, invalidTimeout)
+        );
+    }
+
+    /**
+     * Tests that PublisherConfig remains immutable after creation.
+     * Verifies that the configuration values cannot be modified after instantiation.
+     */
+    @Test
+    @DisplayName("Should remain immutable after creation")
+    void testConfigImmutability() {
+        // Create initial config
+        final PublisherConfig config = new PublisherConfig(PublisherConfig.PublisherType.PRODUCTION, 1500);
+
+        // Attempt to modify the config (should not be possible as it's a record)
+        // This is a compile-time check, but we can verify the values remain unchanged
+        final PublisherConfig modifiedConfig = new PublisherConfig(PublisherConfig.PublisherType.NO_OP, 2000);
+        assertNotEquals(config, modifiedConfig);
+        assertEquals(PublisherConfig.PublisherType.PRODUCTION, config.type());
+        assertEquals(1500, config.timeoutThresholdMillis());
+    }
+}


### PR DESCRIPTION
## Reviewer Notes
This PR aims to:
- Fix session handling of newly received items.
- Handle items where there are multiple items in the batch, including header in the beginning and proof at the end. 
- Plugin changes onSessionUpdate, where the session that called is chosen as primary and is handling whole block.
- Added unit tests for `PublisherConfig` and `BlockStreamProducerSession`.

## Related Issue(s)
 Use keywords `Fix, Fixes, Fixed, Close, Closes, Closed, Resolve, Resolves, Resolved`
to connect an issue to be closed by this pull request.
