### PR TITLE
chore: Improve PR Gradle Checks GHA definition

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   check-gradle:
     name: Gradle
-    if: github.base_ref != 'main' && !startsWith(github.base_ref, 'release/')
+    if: github.base_ref == 'main' && startsWith(github.base_ref, 'release/')
     uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
     with:
       ref: ${{ github.event.inputs.ref || '' }}

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -24,6 +24,18 @@ permissions:
   packages: write
 
 jobs:
+  refs-test:
+    timeout-minutes: 10
+    name: "Check PR refs"
+    steps:
+      - name: Check PR refs
+        id: check-refs
+        run: |
+          echo "github.base_ref branch=$(github.base_ref)"
+          echo "GITHUB_BASE_REF branch=$(GITHUB_BASE_REF)"
+          echo "github.ref branch=$(github.ref)"
+          echo "GITHUB_REF branch=$(GITHUB_REF)"
+
   check-gradle:
     name: Gradle
     if: github.base_ref == 'main' && startsWith(github.base_ref, 'release/')

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -32,10 +32,10 @@ jobs:
       - name: Check PR refs
         id: check-refs
         run: |
-          echo "github.base_ref branch=$(github.base_ref)"
-          echo "GITHUB_BASE_REF branch=$(GITHUB_BASE_REF)"
-          echo "github.ref branch=$(github.ref)"
-          echo "GITHUB_REF branch=$(GITHUB_REF)"
+          echo "github.base_ref branch=${{ github.base_ref }}"
+          echo "GITHUB_BASE_REF branch=${{ GITHUB_BASE_REF }}"
+          echo "github.ref branch=${{ github.ref }}"
+          echo "GITHUB_REF branch=${{ GITHUB_REF }}"
 
   check-gradle:
     name: Gradle

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -26,10 +26,7 @@ permissions:
 jobs:
   check-gradle:
     name: Gradle
-    if: contains('
-      refs/heads/main
-      refs/heads/release/**
-      ', github.base_ref)
+    if: github.base_ref != 'main' && !startsWith(github.base_ref, 'release/')
     uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
     with:
       ref: ${{ github.event.inputs.ref || '' }}

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -33,13 +33,11 @@ jobs:
         id: check-refs
         run: |
           echo "github.base_ref branch=${{ github.base_ref }}"
-          echo "GITHUB_BASE_REF branch=${{ GITHUB_BASE_REF }}"
           echo "github.ref branch=${{ github.ref }}"
-          echo "GITHUB_REF branch=${{ GITHUB_REF }}"
 
   check-gradle:
     name: Gradle
-    if: github.base_ref == 'main' && startsWith(github.base_ref, 'release/')
+    if: ${{ github.base_ref == 'main' && startsWith(github.base_ref, 'release/') }}
     uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
     with:
       ref: ${{ github.event.inputs.ref || '' }}

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "PR Gradle Checks"
+name: "PR Checks"
 on:
   push:
     branches:

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -26,6 +26,11 @@ permissions:
 jobs:
   check-gradle:
     name: Gradle
+    if:
+      contains('
+      refs/heads/main
+      refs/heads/release/**
+      ', github.ref)
     uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
     with:
       ref: ${{ github.event.inputs.ref || '' }}
@@ -34,7 +39,7 @@ jobs:
 
   compile:
     timeout-minutes: 20
-    name: "Gradle Checks"
+    name: "Quality Checks and UTs"
     runs-on: hiero-block-node-linux-medium
     steps:
       - name: Harden Runner

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -27,6 +27,7 @@ jobs:
   refs-test:
     timeout-minutes: 10
     name: "Check PR refs"
+    runs-on: hiero-block-node-linux-medium
     steps:
       - name: Check PR refs
         id: check-refs

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -26,8 +26,7 @@ permissions:
 jobs:
   check-gradle:
     name: Gradle
-    if:
-      contains('
+    if: contains('
       refs/heads/main
       refs/heads/release/**
       ', github.ref)

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -29,7 +29,7 @@ jobs:
     if: contains('
       refs/heads/main
       refs/heads/release/**
-      ', github.ref)
+      ', github.base_ref)
     uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
     with:
       ref: ${{ github.event.inputs.ref || '' }}


### PR DESCRIPTION
## Reviewer Notes
Update PR Gradle Checks
- name to not be gradle specific
- `check-gradle` job to only run against main or release branches
- `compile` job name to make quality and UT run explicit

## Related Issue(s)
Fixes #951 
