### PR TITLE
fix: Simulator Helm Chart Deployment in Consumer Mode

### DIFF
--- a/charts/blockstream-simulator/templates/deployment.yaml
+++ b/charts/blockstream-simulator/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - name: data-storage
           persistentVolumeClaim:
             claimName: {{ if .Values.simulator.persistence.data.create }}{{ include "blockstream-simulator-chart.fullname" . }}-data{{ else }}{{ .Values.simulator.persistence.data.existingClaim }}{{ end }}
-      {{- if eq .Values.simulator.config.BLOCK_STREAM_SIMULATOR_MODE "PUBLISER_MODE" }}
+      {{- if eq .Values.simulator.config.BLOCK_STREAM_SIMULATOR_MODE "PUBLISHER_CLIENT" }}
       initContainers:
         - name: init-storage-dirs
           image: busybox
@@ -62,7 +62,7 @@ spec:
               name: {{ include "blockstream-simulator-chart.fullname" . }}-config
           - secretRef:
               name: {{ include "blockstream-simulator-chart.fullname" . }}-secret
-        {{- if eq .Values.simulator.config.BLOCK_STREAM_SIMULATOR_MODE "PUBLISER_MODE" }}
+        {{- if eq .Values.simulator.config.BLOCK_STREAM_SIMULATOR_MODE "PUBLISHER_CLIENT" }}
         volumeMounts:
           - name: data-storage
             mountPath: {{ .Values.simulator.persistence.data.mountPath }}

--- a/charts/blockstream-simulator/templates/deployment.yaml
+++ b/charts/blockstream-simulator/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         - name: data-storage
           persistentVolumeClaim:
             claimName: {{ if .Values.simulator.persistence.data.create }}{{ include "blockstream-simulator-chart.fullname" . }}-data{{ else }}{{ .Values.simulator.persistence.data.existingClaim }}{{ end }}
+      {{- if eq .Values.simulator.config.BLOCK_STREAM_SIMULATOR_MODE "PUBLISER_MODE" }}
       initContainers:
         - name: init-storage-dirs
           image: busybox
@@ -45,6 +46,7 @@ spec:
           volumeMounts:
             - name: data-storage
               mountPath: /data-pvc
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         securityContext:
@@ -60,10 +62,12 @@ spec:
               name: {{ include "blockstream-simulator-chart.fullname" . }}-config
           - secretRef:
               name: {{ include "blockstream-simulator-chart.fullname" . }}-secret
+        {{- if eq .Values.simulator.config.BLOCK_STREAM_SIMULATOR_MODE "PUBLISER_MODE" }}
         volumeMounts:
           - name: data-storage
             mountPath: {{ .Values.simulator.persistence.data.mountPath }}
             subPath: {{ .Values.simulator.persistence.data.subPath }}
+        {{- end }}
         {{- with .Values.resources }}
         resources:
           requests:


### PR DESCRIPTION
- Only adding PVC to mounting to container when deploying in Publisher Mode.

## Reviewer Notes

This can be cherry-picked and added to `rc2` then to `0.8.0` GA version.

## Related Issue(s)
Fixes #963
