### PR TITLE
feat: added block stream simulator out-of-order streaming

### DIFF
--- a/simulator/src/main/java/org/hiero/block/simulator/config/ConfigInjectionModule.java
+++ b/simulator/src/main/java/org/hiero/block/simulator/config/ConfigInjectionModule.java
@@ -11,6 +11,7 @@ import org.hiero.block.simulator.config.data.BlockStreamConfig;
 import org.hiero.block.simulator.config.data.ConsumerConfig;
 import org.hiero.block.simulator.config.data.GrpcConfig;
 import org.hiero.block.simulator.config.data.SimulatorStartupDataConfig;
+import org.hiero.block.simulator.config.data.UnorderedStreamConfig;
 import org.hiero.block.simulator.config.logging.ConfigurationLogging;
 import org.hiero.block.simulator.config.logging.SimulatorConfigurationLogger;
 
@@ -100,5 +101,17 @@ public interface ConfigInjectionModule {
     @Provides
     static SimulatorStartupDataConfig providesSimulatorStartupDataConfig(final Configuration configuration) {
         return configuration.getConfigData(SimulatorStartupDataConfig.class);
+    }
+
+    /**
+     * Provides the unordered stream configuration.
+     *
+     * @param configuration the configuration to be used by the unordered stream
+     * @return the unordered stream configuration
+     */
+    @Singleton
+    @Provides
+    static UnorderedStreamConfig provideUnorderedStreamConfig(final Configuration configuration) {
+        return configuration.getConfigData(UnorderedStreamConfig.class);
     }
 }

--- a/simulator/src/main/java/org/hiero/block/simulator/config/SimulatorConfigExtension.java
+++ b/simulator/src/main/java/org/hiero/block/simulator/config/SimulatorConfigExtension.java
@@ -12,6 +12,7 @@ import org.hiero.block.simulator.config.data.BlockStreamConfig;
 import org.hiero.block.simulator.config.data.ConsumerConfig;
 import org.hiero.block.simulator.config.data.GrpcConfig;
 import org.hiero.block.simulator.config.data.SimulatorStartupDataConfig;
+import org.hiero.block.simulator.config.data.UnorderedStreamConfig;
 
 /** Sets up configuration for services. */
 @AutoService(ConfigurationExtension.class)
@@ -27,6 +28,7 @@ public class SimulatorConfigExtension implements ConfigurationExtension {
     public Set<Class<? extends Record>> getConfigDataTypes() {
         return Set.of(
                 BlockStreamConfig.class,
+                UnorderedStreamConfig.class,
                 ConsumerConfig.class,
                 GrpcConfig.class,
                 BlockGeneratorConfig.class,

--- a/simulator/src/main/java/org/hiero/block/simulator/config/SimulatorMappedConfigSourceInitializer.java
+++ b/simulator/src/main/java/org/hiero/block/simulator/config/SimulatorMappedConfigSourceInitializer.java
@@ -56,7 +56,13 @@ public final class SimulatorMappedConfigSourceInitializer {
                     "SIMULATOR_STARTUP_DATA_LATEST_ACK_BLOCK_NUMBER_PATH"),
             new ConfigMapping(
                     "simulator.startup.data.latestAckBlockHashPath",
-                    "SIMULATOR_STARTUP_DATA_LATEST_ACK_BLOCK_HASH_PATH"));
+                    "SIMULATOR_STARTUP_DATA_LATEST_ACK_BLOCK_HASH_PATH"),
+
+            // Block stream configuration
+            new ConfigMapping("unorderedStream.enabled", "UNORDERED_STREAM_ENABLED"),
+            new ConfigMapping("unorderedStream.availableBlocks", "UNORDERED_STREAM_AVAILABLE_BLOCKS"),
+            new ConfigMapping("unorderedStream.sequenceScrambleLevel", "UNORDERED_STREAM_SEQUENCE_SCRAMBLE_LEVEL"),
+            new ConfigMapping("unorderedStream.fixedStreamingSequence", "UNORDERED_STREAM_FIXED_STREAMING_SEQUENCE"));
 
     private SimulatorMappedConfigSourceInitializer() {}
 

--- a/simulator/src/main/java/org/hiero/block/simulator/config/data/UnorderedStreamConfig.java
+++ b/simulator/src/main/java/org/hiero/block/simulator/config/data/UnorderedStreamConfig.java
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.simulator.config.data;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import java.util.regex.Pattern;
+import org.hiero.block.common.utils.Preconditions;
+import org.hiero.block.simulator.config.logging.Loggable;
+
+/**
+ * Defines the configuration data for the unordered block streaming in the Hedera Block Simulator.
+ *
+ * @param enabled                indicates whether to enable the unordered streaming mode
+ * @param availableBlocks        the numbers of the blocks which will be considered available for sending
+ * @param sequenceScrambleLevel  the coefficient used to randomly scramble the stream
+ * @param fixedStreamingSequence the numbers of the blocks which will form the steam (could be from availableBlocks or not)
+ */
+@ConfigData("unorderedStream")
+public record UnorderedStreamConfig(
+        @Loggable @ConfigProperty(defaultValue = "false") boolean enabled,
+        @Loggable @ConfigProperty(defaultValue = "[1-10]") String availableBlocks,
+        @Loggable @ConfigProperty(defaultValue = "0") int sequenceScrambleLevel,
+        @Loggable @ConfigProperty(defaultValue = "1,2,4,3") String fixedStreamingSequence) {
+
+    public UnorderedStreamConfig {
+        availableBlocks = availableBlocks.trim();
+        fixedStreamingSequence = fixedStreamingSequence.trim();
+        final Pattern pattern = Pattern.compile("^(\\[(\\d+)-(\\d+)\\]|\\d+)(,\\s*(\\[(\\d+)-(\\d+)\\]|\\d+))*$");
+
+        Preconditions.requireInRange(sequenceScrambleLevel, 0, 10, "sequenceScrambleLevel must be between 0 and 10");
+        Preconditions.requireNotBlank(
+                fixedStreamingSequence, "fixedStreamingSequence must not be blank when sequenceScrambleLevel is 0");
+        if (!pattern.matcher(fixedStreamingSequence).matches()) {
+            throw new IllegalArgumentException(fixedStreamingSequence + " does not match the expected format");
+        }
+        Preconditions.requireNotBlank(
+                availableBlocks, "availableBlocks must not be blank when sequenceScrambleLevel is larger than 0");
+        if (!pattern.matcher(availableBlocks).matches()) {
+            throw new IllegalArgumentException(availableBlocks + " does not match the expected format");
+        }
+    }
+}

--- a/simulator/src/main/java/org/hiero/block/simulator/generator/CraftBlockStreamManager.java
+++ b/simulator/src/main/java/org/hiero/block/simulator/generator/CraftBlockStreamManager.java
@@ -2,7 +2,10 @@
 package org.hiero.block.simulator.generator;
 
 import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
+import static java.lang.System.Logger.Level.WARNING;
+import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.block.stream.BlockProof;
 import com.hedera.hapi.block.stream.protoc.Block;
@@ -12,14 +15,23 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.lang.System.Logger;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.hiero.block.common.hasher.Hashes;
 import org.hiero.block.common.hasher.HashingUtilities;
 import org.hiero.block.common.hasher.NaiveStreamingTreeHasher;
 import org.hiero.block.common.hasher.StreamingTreeHasher;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.simulator.config.data.BlockGeneratorConfig;
+import org.hiero.block.simulator.config.data.UnorderedStreamConfig;
 import org.hiero.block.simulator.config.types.GenerationMode;
 import org.hiero.block.simulator.exception.BlockSimulatorParsingException;
 import org.hiero.block.simulator.generator.itemhandler.BlockHeaderHandler;
@@ -56,17 +68,22 @@ public class CraftBlockStreamManager implements BlockStreamManager {
     private StreamingTreeHasher inputTreeHasher;
     private StreamingTreeHasher outputTreeHasher;
 
+    // Unordered streaming
+    private final boolean unorderedStreamingEnabled;
+    private Iterator<Block> unorderedStreamIterator;
+
     /**
      * Constructs a new CraftBlockStreamManager with the specified configuration.
      *
      * @param blockGeneratorConfig Configuration parameters for block generation
-     * including event and transaction counts
+     *                             including event and transaction counts
      * @param simulatorStartupData simulator startup data used for initialization
      * @throws NullPointerException if blockGeneratorConfig is null
      */
     public CraftBlockStreamManager(
             @NonNull final BlockGeneratorConfig blockGeneratorConfig,
-            @NonNull final SimulatorStartupData simulatorStartupData) {
+            @NonNull final SimulatorStartupData simulatorStartupData,
+            @NonNull final UnorderedStreamConfig unorderedStreamConfig) {
         this.generationMode = blockGeneratorConfig.generationMode();
         this.minEventsPerBlock = blockGeneratorConfig.minEventsPerBlock();
         this.maxEventsPerBlock = blockGeneratorConfig.maxEventsPerBlock();
@@ -81,6 +98,39 @@ public class CraftBlockStreamManager implements BlockStreamManager {
         this.currentBlockNumber = simulatorStartupData.getLatestAckBlockNumber() + 1L;
         this.previousBlockHash = simulatorStartupData.getLatestAckBlockHash();
         LOGGER.log(INFO, "Block Stream Simulator will use Craft mode for block management");
+
+        // Unordered streaming
+        unorderedStreamingEnabled = unorderedStreamConfig.enabled();
+        if (unorderedStreamingEnabled) {
+            initUnorderedStreaming(simulatorStartupData, unorderedStreamConfig);
+        }
+    }
+
+    private void initUnorderedStreaming(
+            SimulatorStartupData simulatorStartupData, UnorderedStreamConfig unorderedStreamConfig) {
+
+        if (simulatorStartupData.isEnabled()) {
+            throw new IllegalStateException("Unordered streaming does not support start-up data enabled");
+        }
+        this.currentBlockNumber = 0;
+        final List<Block> blockStreamList;
+        final int scrambleLevel = unorderedStreamConfig.sequenceScrambleLevel();
+        if (scrambleLevel == 0) {
+            // use a predefined order of streaming from the properties file
+            final LinkedHashSet<Long> fixedStreamingSequence =
+                    parseRangeSet(unorderedStreamConfig.fixedStreamingSequence());
+            blockStreamList = getBlockStreamList(fixedStreamingSequence);
+        } else {
+            // put the predefined available blocks in a list and scramble by the provided coefficient
+            final Set<Long> availableBlocks = parseRangeSet(unorderedStreamConfig.availableBlocks());
+            blockStreamList = getBlockStreamList(availableBlocks);
+            scrambleBlocks(blockStreamList, scrambleLevel);
+        }
+        if (blockStreamList.isEmpty()) {
+            throw new IllegalStateException("No blocks are available for streaming with the current configuration");
+        }
+        unorderedStreamIterator = blockStreamList.iterator();
+        LOGGER.log(INFO, "Unordered streaming is enabled");
     }
 
     /**
@@ -109,11 +159,22 @@ public class CraftBlockStreamManager implements BlockStreamManager {
      * Each block includes a header, events with their transactions and results, and a proof.
      *
      * @return A newly generated Block
-     * @throws IOException if there is an error processing block items
+     * @throws IOException                    if there is an error processing block items
      * @throws BlockSimulatorParsingException if there is an error parsing block components
      */
     @Override
     public Block getNextBlock() throws IOException, BlockSimulatorParsingException {
+        if (unorderedStreamingEnabled) {
+            if (unorderedStreamIterator.hasNext()) {
+                return unorderedStreamIterator.next();
+            }
+            return null;
+        } else {
+            return createNextBlock();
+        }
+    }
+
+    private Block createNextBlock() throws BlockSimulatorParsingException {
         LOGGER.log(DEBUG, "Started creation of block number %s.".formatted(currentBlockNumber));
         // todo(683) Refactor common hasher to accept protoc types, in order to avoid the additional overhead of keeping
         // and unparsing.
@@ -187,5 +248,105 @@ public class CraftBlockStreamManager implements BlockStreamManager {
         outputTreeHasher = new NaiveStreamingTreeHasher();
         currentBlockNumber++;
         previousBlockHash = currentBlockHash;
+    }
+
+    private List<Block> getBlockStreamList(Set<Long> blockSequence) {
+        requireNonNull(blockSequence);
+        final Map<Long, Block> craftedBlocksMap = new HashMap<>();
+        final List<Block> blockStreamList = new ArrayList<>();
+        if (!blockSequence.isEmpty()) {
+            try {
+                for (int i = 0; i <= Collections.max(blockSequence); i++) {
+                    final Block block = createNextBlock();
+                    final long blockNbr = block.getItems(block.getItemsCount() - 1)
+                            .getBlockProof()
+                            .getBlock();
+                    craftedBlocksMap.put(blockNbr, block);
+                }
+            } catch (Exception e) {
+                LOGGER.log(ERROR, e.getMessage(), e);
+                throw new RuntimeException(e);
+            }
+            for (Long blockNbr : blockSequence) {
+                if (craftedBlocksMap.containsKey(blockNbr)) {
+                    blockStreamList.add(craftedBlocksMap.get(blockNbr));
+                }
+            }
+        }
+        return blockStreamList;
+    }
+
+    private void scrambleBlocks(List<Block> list, int coefficient) {
+        requireNonNull(list);
+        final int size = list.size();
+        if (size > 1) {
+            final List<Block> originalList = new ArrayList<>(list);
+            final Random random = new Random();
+            final int maxAttempts = 10;
+            int attempt = 0;
+
+            // The number of swaps is proportional to the coefficient
+            final int swapCount = (int) ((coefficient / 10.0) * (size * 2));
+
+            while (list.equals(originalList) && attempt++ < maxAttempts) {
+                for (int i = 0; i < swapCount; i++) {
+                    final int index1 = random.nextInt(size - 1);
+                    final int index2;
+                    if (coefficient <= 5) {
+                        // When coefficient is low, swap with a neighbor
+                        index2 = index1 + 1;
+                    } else {
+                        // Higher coefficient allows more distant swaps
+                        index2 = random.nextInt(size);
+                    }
+                    Collections.swap(list, index1, index2);
+                }
+            }
+
+            // this condition is not supposed to be met when valid configurations are provided
+            // maxAttempts variable serves for endless loop prevention in case of inaccurate config inputs
+            if (list.equals(originalList)) {
+                LOGGER.log(WARNING, "Scramble unsuccessful after " + maxAttempts + " attempts");
+            }
+        }
+    }
+
+    private LinkedHashSet<Long> parseRangeSet(String input) {
+        requireNonNull(input);
+        final LinkedHashSet<Long> result = new LinkedHashSet<>();
+        if (!input.isBlank()) {
+            try {
+                final Matcher matcher =
+                        Pattern.compile("\\[(\\d+)-(\\d+)\\]|(\\d+)").matcher(input);
+                while (matcher.find()) {
+                    if (matcher.group(1) != null && matcher.group(2) != null) {
+                        final long start = Long.parseLong(matcher.group(1));
+                        final long end = Long.parseLong(matcher.group(2));
+                        if (start <= 0 || end <= 0) {
+                            throw new IllegalArgumentException(input
+                                    + " does not match the expected format. Range values must be positive and non-zero: ["
+                                    + start + "-" + end + "]");
+                        }
+                        if (start >= end) {
+                            throw new IllegalArgumentException(
+                                    input + " does not match the expected format. Invalid range: start >= end in ["
+                                            + start + "-" + end + "]");
+                        }
+                        for (long i = start; i <= end; i++) {
+                            result.add(i);
+                        }
+                    } else if (matcher.group(3) != null) {
+                        final long value = Long.parseLong(matcher.group(3));
+                        if (value <= 0) {
+                            throw new IllegalArgumentException("Values must be positive and non-zero: " + value);
+                        }
+                        result.add(value);
+                    }
+                }
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Exception in parsing input: " + input, e);
+            }
+        }
+        return result;
     }
 }

--- a/simulator/src/main/java/org/hiero/block/simulator/generator/GeneratorInjectionModule.java
+++ b/simulator/src/main/java/org/hiero/block/simulator/generator/GeneratorInjectionModule.java
@@ -6,6 +6,7 @@ import dagger.Provides;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Singleton;
 import org.hiero.block.simulator.config.data.BlockGeneratorConfig;
+import org.hiero.block.simulator.config.data.UnorderedStreamConfig;
 import org.hiero.block.simulator.config.types.GenerationMode;
 import org.hiero.block.simulator.startup.SimulatorStartupData;
 
@@ -29,7 +30,8 @@ public interface GeneratorInjectionModule {
     @Provides
     static BlockStreamManager providesBlockStreamManager(
             @NonNull final BlockGeneratorConfig generatorConfig,
-            @NonNull final SimulatorStartupData simulatorStartupData) {
+            @NonNull final SimulatorStartupData simulatorStartupData,
+            @NonNull final UnorderedStreamConfig unorderedStreamConfig) {
         final String managerImpl = generatorConfig.managerImplementation();
         final GenerationMode generationMode = generatorConfig.generationMode();
         return switch (generationMode) {
@@ -39,7 +41,7 @@ public interface GeneratorInjectionModule {
                 }
                 yield new BlockAsFileBlockStreamManager(generatorConfig);
             }
-            case CRAFT -> new CraftBlockStreamManager(generatorConfig, simulatorStartupData);
+            case CRAFT -> new CraftBlockStreamManager(generatorConfig, simulatorStartupData, unorderedStreamConfig);
         };
     }
 }

--- a/simulator/src/main/java/org/hiero/block/simulator/startup/SimulatorStartupData.java
+++ b/simulator/src/main/java/org/hiero/block/simulator/startup/SimulatorStartupData.java
@@ -59,4 +59,6 @@ public interface SimulatorStartupData {
      */
     @NonNull
     byte[] getLatestAckBlockHash();
+
+    boolean isEnabled();
 }

--- a/simulator/src/main/java/org/hiero/block/simulator/startup/impl/SimulatorStartupDataImpl.java
+++ b/simulator/src/main/java/org/hiero/block/simulator/startup/impl/SimulatorStartupDataImpl.java
@@ -98,6 +98,11 @@ public final class SimulatorStartupDataImpl implements SimulatorStartupData {
     }
 
     @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
     public void updateLatestAckBlockStartupData(
             final long blockNumber, final byte[] blockHash, final boolean alreadyExists) throws IOException {
         if (enabled && !alreadyExists) {

--- a/simulator/src/main/resources/app.properties
+++ b/simulator/src/main/resources/app.properties
@@ -46,3 +46,26 @@ prometheus.endpointPortNumber=9998
 
 # Simulator startup data
 #simulator.startup.data.enabled=true
+
+# ----------------------------------------------
+# Unordered Stream Configuration
+# ----------------------------------------------
+
+# Enables the unordered stream mode. (values: true/false)
+#unorderedStream.enabled=false
+
+# Defines which of the crafted blocks are considered available for streaming.
+# Ranges are expanded, e.g., [2-4], [6-9], 13 -> 2, 3, 4, 6, 7, 8, 9, 13.
+# All blocks up to the latest listed will be generated in CRAFT mode to keep the hashes realistic
+#unorderedStream.availableBlocks=[2-4], [6-9], 13
+
+# Coefficient that determines how scrambled the stream sequence will be (range: 0 to 10).
+# - 0 -> The sequence follows unorderedStream.fixedStreamingSequence exactly.
+# - 1-5 -> Minor sequence variations.
+# - 6-10 -> Major sequence changes.
+#unorderedStream.sequenceScrambleLevel=10
+
+# Defines the exact streaming sequence when sequenceScrambleLevel is 0.
+# Ranges are expanded, e.g., [1-3], 99, [5-6], 4, 55 -> 1, 2, 3, 99, 5, 6, 4, 55.
+# Only the elements that exist in both
+#unorderedStream.fixedStreamingSequence=[1-3], 99, [5-6], 4, 55

--- a/simulator/src/test/java/org/hiero/block/simulator/config/ConfigInjectionModuleTest.java
+++ b/simulator/src/test/java/org/hiero/block/simulator/config/ConfigInjectionModuleTest.java
@@ -14,6 +14,7 @@ import org.hiero.block.simulator.config.data.BlockGeneratorConfig;
 import org.hiero.block.simulator.config.data.BlockStreamConfig;
 import org.hiero.block.simulator.config.data.GrpcConfig;
 import org.hiero.block.simulator.config.data.SimulatorStartupDataConfig;
+import org.hiero.block.simulator.config.data.UnorderedStreamConfig;
 import org.hiero.block.simulator.config.logging.ConfigurationLogging;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -108,5 +109,17 @@ class ConfigInjectionModuleTest {
         assertEquals(
                 "/opt/simulator/data/latestAckBlockHash",
                 startupDataConfig.latestAckBlockHashPath().toString());
+    }
+
+    /**
+     * Verifies that the {@link ConfigInjectionModule#provideUnorderedStreamConfig} method
+     * successfully returns a non-null {@link UnorderedStreamConfig} instance when provided
+     * with a valid configuration.
+     */
+    @Test
+    void provideUnorderedStreamConfig() {
+        final UnorderedStreamConfig unorderedStreamConfig =
+                ConfigInjectionModule.provideUnorderedStreamConfig(configuration);
+        assertNotNull(unorderedStreamConfig);
     }
 }

--- a/simulator/src/test/java/org/hiero/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
+++ b/simulator/src/test/java/org/hiero/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
@@ -78,7 +78,13 @@ class SimulatorMappedConfigSourceInitializerTest {
                 "simulator.startup.data.latestAckBlockNumberPath",
                 "SIMULATOR_STARTUP_DATA_LATEST_ACK_BLOCK_NUMBER_PATH"),
         new ConfigMapping(
-                "simulator.startup.data.latestAckBlockHashPath", "SIMULATOR_STARTUP_DATA_LATEST_ACK_BLOCK_HASH_PATH")
+                "simulator.startup.data.latestAckBlockHashPath", "SIMULATOR_STARTUP_DATA_LATEST_ACK_BLOCK_HASH_PATH"),
+
+        // Block stream configuration
+        new ConfigMapping("unorderedStream.enabled", "UNORDERED_STREAM_ENABLED"),
+        new ConfigMapping("unorderedStream.availableBlocks", "UNORDERED_STREAM_AVAILABLE_BLOCKS"),
+        new ConfigMapping("unorderedStream.sequenceScrambleLevel", "UNORDERED_STREAM_SEQUENCE_SCRAMBLE_LEVEL"),
+        new ConfigMapping("unorderedStream.fixedStreamingSequence", "UNORDERED_STREAM_FIXED_STREAMING_SEQUENCE")
     };
 
     /**

--- a/simulator/src/test/java/org/hiero/block/simulator/config/data/UnorderedStreamConfigTest.java
+++ b/simulator/src/test/java/org/hiero/block/simulator/config/data/UnorderedStreamConfigTest.java
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.simulator.config.data;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link UnorderedStreamConfig} class.
+ * <p>
+ * This test suite verifies configuration parsing, validation logic, and
+ * correct transformation of input strings into ordered sets of block numbers.
+ */
+class UnorderedStreamConfigTest {
+
+    /**
+     * Verifies that scramble levels outside the accepted range (0–10)
+     * throw an {@link IllegalArgumentException}.
+     */
+    @Test
+    void testInvalidScrambleLevelInvalid() {
+        assertThrows(IllegalArgumentException.class, () -> new UnorderedStreamConfig(true, "[1-3]", -1, ""));
+        assertThrows(IllegalArgumentException.class, () -> new UnorderedStreamConfig(true, "[1-3]", 11, ""));
+    }
+
+    /**
+     * Ensures that a fixed streaming sequence is required when
+     * scramble level is 0; an empty or blank input should fail.
+     */
+    @Test
+    void testMissingFixedStreamingSequenceWhenLevel0() {
+        assertThrows(IllegalArgumentException.class, () -> new UnorderedStreamConfig(true, "", 0, "   "));
+    }
+
+    /**
+     * Ensures that available blocks must be provided when scrambling is enabled.
+     */
+    @Test
+    void testMissingAvailableBlocksWhenScrambleEnabled() {
+        assertThrows(IllegalArgumentException.class, () -> new UnorderedStreamConfig(true, "   ", 5, ""));
+    }
+
+    /**
+     * Ensures that an empty string for available blocks throws an exception
+     * if scrambling is enabled.
+     */
+    @Test
+    void testAvailableBlocksEmptyInputThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new UnorderedStreamConfig(true, " ", 5, ""));
+    }
+
+    /**
+     * Verifies that improperly formatted {@code availableBlocks} values
+     * result in an {@link IllegalArgumentException} when scrambling is enabled.
+     * These inputs do not conform to the expected format and should trigger validation failures.
+     */
+    @Test
+    void testInvalidAvailableBlocksFormatThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> new UnorderedStreamConfig(true, "abc", 5, "1,2,3"));
+        assertThrows(IllegalArgumentException.class, () -> new UnorderedStreamConfig(true, "1--3", 5, "1,2,3"));
+        assertThrows(IllegalArgumentException.class, () -> new UnorderedStreamConfig(true, "[1-]", 5, "1,2,3"));
+    }
+
+    /**
+     * Ensures that a correctly formatted configuration does not throw any exception.
+     * <p>
+     * This test verifies that a combination of valid range and single values in
+     * both {@code availableBlocks} and {@code fixedStreamingSequence} passes validation.
+     */
+    @Test
+    void testValidConfigurationDoesNotThrow() {
+        assertDoesNotThrow(() -> new UnorderedStreamConfig(true, "[1-3],5,7", 5, "1,2,[3-4]"));
+    }
+}

--- a/simulator/src/test/java/org/hiero/block/simulator/config/logging/SimulatorConfigurationLoggerTest.java
+++ b/simulator/src/test/java/org/hiero/block/simulator/config/logging/SimulatorConfigurationLoggerTest.java
@@ -26,7 +26,7 @@ class SimulatorConfigurationLoggerTest {
         final SimulatorConfigurationLogger configurationLogging = new SimulatorConfigurationLogger(configuration);
         final Map<String, Object> config = configurationLogging.collectConfig(configuration);
         assertNotNull(config);
-        assertEquals(39, config.size());
+        assertEquals(43, config.size());
         for (final Map.Entry<String, Object> entry : config.entrySet()) {
             String value = entry.getValue().toString();
             if (value.contains("*")) {
@@ -42,7 +42,7 @@ class SimulatorConfigurationLoggerTest {
         final SimulatorConfigurationLogger configurationLogging = new SimulatorConfigurationLogger(configuration);
         final Map<String, Object> config = configurationLogging.collectConfig(configuration);
         assertNotNull(config);
-        assertEquals(41, config.size());
+        assertEquals(45, config.size());
         assertEquals("*****", config.get("test.secret").toString());
         assertEquals("", config.get("test.emptySecret").toString());
     }

--- a/simulator/src/test/java/org/hiero/block/simulator/generator/CraftBlockStreamManagerTest.java
+++ b/simulator/src/test/java/org/hiero/block/simulator/generator/CraftBlockStreamManagerTest.java
@@ -5,8 +5,14 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.hedera.hapi.block.stream.protoc.Block;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import org.hiero.block.common.hasher.StreamingTreeHasher;
 import org.hiero.block.simulator.config.data.BlockGeneratorConfig;
+import org.hiero.block.simulator.config.data.UnorderedStreamConfig;
 import org.hiero.block.simulator.config.types.GenerationMode;
 import org.hiero.block.simulator.exception.BlockSimulatorParsingException;
 import org.hiero.block.simulator.startup.SimulatorStartupData;
@@ -17,27 +23,40 @@ import org.mockito.Mockito;
 class CraftBlockStreamManagerTest {
     private static final int START_BLOCK_NUMBER = 1;
     private BlockGeneratorConfig generatorConfigMock;
+    private UnorderedStreamConfig unorderedStreamConfigMock;
     private SimulatorStartupData startupDataMock;
     private CraftBlockStreamManager manager;
 
     @BeforeEach
     void setUp() {
         generatorConfigMock = Mockito.mock(BlockGeneratorConfig.class);
+        unorderedStreamConfigMock = Mockito.mock(UnorderedStreamConfig.class);
         Mockito.when(generatorConfigMock.generationMode()).thenReturn(GenerationMode.CRAFT);
         Mockito.when(generatorConfigMock.startBlockNumber()).thenReturn(START_BLOCK_NUMBER);
         Mockito.when(generatorConfigMock.minEventsPerBlock()).thenReturn(1);
         Mockito.when(generatorConfigMock.maxEventsPerBlock()).thenReturn(3);
         Mockito.when(generatorConfigMock.minTransactionsPerEvent()).thenReturn(1);
         Mockito.when(generatorConfigMock.maxTransactionsPerEvent()).thenReturn(2);
+        Mockito.when(unorderedStreamConfigMock.enabled()).thenReturn(false);
         startupDataMock = Mockito.mock(SimulatorStartupData.class);
         Mockito.when(startupDataMock.getLatestAckBlockNumber()).thenReturn((long) START_BLOCK_NUMBER);
         Mockito.when(startupDataMock.getLatestAckBlockHash()).thenReturn(new byte[StreamingTreeHasher.HASH_LENGTH]);
-        manager = new CraftBlockStreamManager(generatorConfigMock, startupDataMock);
+        manager = new CraftBlockStreamManager(generatorConfigMock, startupDataMock, unorderedStreamConfigMock);
     }
 
+    /**
+     * Verifies that the {@link CraftBlockStreamManager} constructor throws a
+     * {@link NullPointerException} when passed a {@code null} configuration or
+     * a {@code null} unordered stream config.
+     */
     @Test
     void testConstructorNullConfig() {
-        assertThrows(NullPointerException.class, () -> new CraftBlockStreamManager(null, startupDataMock));
+        assertThrows(
+                NullPointerException.class,
+                () -> new CraftBlockStreamManager(null, startupDataMock, unorderedStreamConfigMock));
+        assertThrows(
+                NullPointerException.class,
+                () -> new CraftBlockStreamManager(generatorConfigMock, startupDataMock, null));
     }
 
     @Test
@@ -76,10 +95,190 @@ class CraftBlockStreamManagerTest {
         Mockito.when(generatorConfigMock.maxEventsPerBlock()).thenReturn(4);
         Mockito.when(generatorConfigMock.minTransactionsPerEvent()).thenReturn(2);
         Mockito.when(generatorConfigMock.maxTransactionsPerEvent()).thenReturn(3);
-        manager = new CraftBlockStreamManager(generatorConfigMock, startupDataMock);
+        manager = new CraftBlockStreamManager(generatorConfigMock, startupDataMock, unorderedStreamConfigMock);
         final Block block = manager.getNextBlock();
         // We expect at least:
         // 1 block header + (3 events * (1 header + 2 transactions * 2 items)) + 1 proof = 17
         assertTrue(block.getItemsCount() >= 17);
+    }
+
+    /**
+     * Verifies that an {@link IllegalStateException} is thrown when both
+     * unordered block generation and startup data are enabled simultaneously.
+     * This configuration is invalid as they are mutually exclusive sources.
+     */
+    @Test
+    void testUnorderedBlockGenerationWithActiveStartupData() {
+        Mockito.when(unorderedStreamConfigMock.enabled()).thenReturn(true);
+        Mockito.when(startupDataMock.isEnabled()).thenReturn(true);
+        assertThrows(
+                IllegalStateException.class,
+                () -> new CraftBlockStreamManager(generatorConfigMock, startupDataMock, unorderedStreamConfigMock));
+    }
+
+    /**
+     * Verifies that an {@link IllegalStateException} is thrown when
+     * unordered stream is enabled with a non-zero scramble level,
+     * but the available block set is empty.
+     */
+    @Test
+    void testUnorderedBlockGenerationWithEmptyStreamList() {
+        Mockito.when(unorderedStreamConfigMock.enabled()).thenReturn(true);
+        Mockito.when(unorderedStreamConfigMock.availableBlocks()).thenReturn("");
+        Mockito.when(unorderedStreamConfigMock.sequenceScrambleLevel()).thenReturn(3);
+        assertThrows(
+                IllegalStateException.class,
+                () -> new CraftBlockStreamManager(generatorConfigMock, startupDataMock, unorderedStreamConfigMock));
+    }
+
+    /**
+     * Tests unordered block generation with a valid block set and a
+     * non-zero scramble level. Verifies that the resulting block stream
+     * has the same size but a different order from the input.
+     */
+    @Test
+    void testUnorderedBlockGenerationWithScrambleLevelMoreThanZero()
+            throws IOException, BlockSimulatorParsingException {
+        Set<Long> availableBlockNumbers = Set.of(2L, 3L, 4L, 6L, 7L, 8L, 9L, 13L);
+
+        Mockito.when(unorderedStreamConfigMock.enabled()).thenReturn(true);
+        Mockito.when(unorderedStreamConfigMock.availableBlocks()).thenReturn("2, 3, 4, 6, 7, 8, 9, 13");
+        Mockito.when(unorderedStreamConfigMock.sequenceScrambleLevel()).thenReturn(3);
+        manager = new CraftBlockStreamManager(generatorConfigMock, startupDataMock, unorderedStreamConfigMock);
+
+        List<Long> expectedStreamBlockNumbers = getExpectedStreamBlockNumbers();
+
+        assertEquals(availableBlockNumbers.size(), expectedStreamBlockNumbers.size());
+        assertNotEquals(new ArrayList<>(availableBlockNumbers), expectedStreamBlockNumbers);
+    }
+
+    /**
+     * Similar to {@link #testUnorderedBlockGenerationWithScrambleLevelMoreThanZero()},
+     * this test validates scrambling behavior when scramble level is > 5.
+     */
+    @Test
+    void testUnorderedBlockGenerationWithScrambleLevelMoreThanFive()
+            throws IOException, BlockSimulatorParsingException {
+        Set<Long> availableBlockNumbers = Set.of(2L, 3L, 4L, 6L, 7L, 8L, 9L, 13L);
+
+        Mockito.when(unorderedStreamConfigMock.enabled()).thenReturn(true);
+        Mockito.when(unorderedStreamConfigMock.availableBlocks()).thenReturn("2, 3, 4, 6, 7, 8, 9, 13");
+        Mockito.when(unorderedStreamConfigMock.sequenceScrambleLevel()).thenReturn(7);
+        manager = new CraftBlockStreamManager(generatorConfigMock, startupDataMock, unorderedStreamConfigMock);
+
+        List<Long> expectedStreamBlockNumbers = getExpectedStreamBlockNumbers();
+
+        assertEquals(availableBlockNumbers.size(), expectedStreamBlockNumbers.size());
+        assertNotEquals(new ArrayList<>(availableBlockNumbers), expectedStreamBlockNumbers);
+    }
+
+    /**
+     * Verifies that when the scramble level is 0, the generated block stream
+     * matches the exact order and content of the {@code fixedStreamingSequence}.
+     */
+    @Test
+    void testUnorderedBlockGenerationWithScrambleLevelZero() throws IOException, BlockSimulatorParsingException {
+        LinkedHashSet<Long> fixedStreamingSequence = new LinkedHashSet<>();
+        fixedStreamingSequence.add(1L);
+        fixedStreamingSequence.add(2L);
+        fixedStreamingSequence.add(3L);
+        fixedStreamingSequence.add(99L);
+        fixedStreamingSequence.add(5L);
+        fixedStreamingSequence.add(6L);
+        fixedStreamingSequence.add(4L);
+        fixedStreamingSequence.add(55L);
+
+        Mockito.when(unorderedStreamConfigMock.enabled()).thenReturn(true);
+        Mockito.when(unorderedStreamConfigMock.fixedStreamingSequence()).thenReturn("1, 2, 3, 99, 5, 6, 4, 55");
+        Mockito.when(unorderedStreamConfigMock.sequenceScrambleLevel()).thenReturn(0);
+        manager = new CraftBlockStreamManager(generatorConfigMock, startupDataMock, unorderedStreamConfigMock);
+
+        List<Long> expectedStreamBlockNumbers = getExpectedStreamBlockNumbers();
+
+        assertEquals(fixedStreamingSequence.size(), expectedStreamBlockNumbers.size());
+        assertEquals(new ArrayList<>(fixedStreamingSequence), new ArrayList<>(expectedStreamBlockNumbers));
+    }
+
+    /**
+     * Verifies that an IllegalArgumentException is thrown when the `availableBlocks`
+     * configuration string contains an invalid range where the start of the range is greater
+     * than the end (e.g., "[5-3]"). This is considered an invalid configuration and should be rejected.
+     */
+    @Test
+    void testInvalidGroupInAvailableBlocksBeginningBiggerThanEnd() {
+        Mockito.when(unorderedStreamConfigMock.enabled()).thenReturn(true);
+        Mockito.when(unorderedStreamConfigMock.availableBlocks()).thenReturn("[5-3]");
+        Mockito.when(unorderedStreamConfigMock.sequenceScrambleLevel()).thenReturn(2);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new CraftBlockStreamManager(generatorConfigMock, startupDataMock, unorderedStreamConfigMock));
+    }
+
+    /**
+     * Verifies that an IllegalArgumentException is thrown when the `availableBlocks`
+     * configuration string contains a range that includes zero (e.g., "[0-5]").
+     * Zero is not allowed as a valid block number and should trigger validation failure.
+     */
+    @Test
+    void testInvalidGroupInAvailableBlocksContainingZero() {
+        Mockito.when(unorderedStreamConfigMock.enabled()).thenReturn(true);
+        Mockito.when(unorderedStreamConfigMock.availableBlocks()).thenReturn("[0-5]");
+        Mockito.when(unorderedStreamConfigMock.sequenceScrambleLevel()).thenReturn(2);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new CraftBlockStreamManager(generatorConfigMock, startupDataMock, unorderedStreamConfigMock));
+    }
+
+    /**
+     * Verifies that an IllegalArgumentException is thrown when the `availableBlocks`
+     * configuration contains a range where the start and end values are the same (e.g., "[5-5]").
+     * This is an invalid case since ranges must have strictly increasing bounds.
+     */
+    @Test
+    void testInvalidGroupInAvailableBlocksEqualBeginningAndEnding() {
+        Mockito.when(unorderedStreamConfigMock.enabled()).thenReturn(true);
+        Mockito.when(unorderedStreamConfigMock.availableBlocks()).thenReturn("[5-5]");
+        Mockito.when(unorderedStreamConfigMock.sequenceScrambleLevel()).thenReturn(2);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new CraftBlockStreamManager(generatorConfigMock, startupDataMock, unorderedStreamConfigMock));
+    }
+
+    /**
+     * Verifies that an IllegalArgumentException is thrown when the `availableBlocks`
+     * configuration string contains a single invalid block number "0".
+     * Since block numbers must be positive and non-zero, this input is invalid.
+     */
+    @Test
+    void testInvalidGroupInAvailableBlocksSingleZero() {
+        Mockito.when(unorderedStreamConfigMock.enabled()).thenReturn(true);
+        Mockito.when(unorderedStreamConfigMock.availableBlocks()).thenReturn("0");
+        Mockito.when(unorderedStreamConfigMock.sequenceScrambleLevel()).thenReturn(2);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new CraftBlockStreamManager(generatorConfigMock, startupDataMock, unorderedStreamConfigMock));
+    }
+
+    /**
+     * Helper method to extract all block numbers from the generated stream.
+     *
+     * @return a list of block numbers in the order they appear in the stream
+     * @throws IOException if an I/O error occurs while reading a block
+     * @throws BlockSimulatorParsingException if a parsing error occurs
+     */
+    private List<Long> getExpectedStreamBlockNumbers() throws IOException, BlockSimulatorParsingException {
+        List<Long> expectedBlockNumbers = new ArrayList<>();
+        while (true) {
+            Block block = manager.getNextBlock();
+            if (Objects.nonNull(block)) {
+                long blockNbr = block.getItems(block.getItemsCount() - 1)
+                        .getBlockProof()
+                        .getBlock();
+                expectedBlockNumbers.add(blockNbr);
+            } else {
+                break;
+            }
+        }
+        return expectedBlockNumbers;
     }
 }

--- a/simulator/src/test/java/org/hiero/block/simulator/generator/GeneratorInjectionModuleTest.java
+++ b/simulator/src/test/java/org/hiero/block/simulator/generator/GeneratorInjectionModuleTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.Map;
 import org.hiero.block.simulator.TestUtils;
 import org.hiero.block.simulator.config.data.BlockGeneratorConfig;
+import org.hiero.block.simulator.config.data.UnorderedStreamConfig;
 import org.hiero.block.simulator.startup.SimulatorStartupData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +19,13 @@ class GeneratorInjectionModuleTest {
     @Mock
     private SimulatorStartupData startupDataMock;
 
+    private final UnorderedStreamConfig unorderedStreamConfig;
+
+    public GeneratorInjectionModuleTest() throws IOException {
+        this.unorderedStreamConfig = TestUtils.getTestConfiguration(Map.of("unorderedStream.enabled", "false"))
+                .getConfigData(UnorderedStreamConfig.class);
+    }
+
     @Test
     void providesBlockStreamManager_AsFileLargeDataSets() throws IOException {
         final BlockGeneratorConfig blockGeneratorConfig = TestUtils.getTestConfiguration(Map.of(
@@ -27,8 +35,8 @@ class GeneratorInjectionModuleTest {
                         "BlockAsFileLargeDataSets"))
                 .getConfigData(BlockGeneratorConfig.class);
 
-        final BlockStreamManager blockStreamManager =
-                GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig, startupDataMock);
+        final BlockStreamManager blockStreamManager = GeneratorInjectionModule.providesBlockStreamManager(
+                blockGeneratorConfig, startupDataMock, unorderedStreamConfig);
 
         assertEquals(blockStreamManager.getClass().getName(), BlockAsFileLargeDataSets.class.getName());
     }
@@ -44,8 +52,8 @@ class GeneratorInjectionModuleTest {
                         ""))
                 .getConfigData(BlockGeneratorConfig.class);
 
-        final BlockStreamManager blockStreamManager =
-                GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig, startupDataMock);
+        final BlockStreamManager blockStreamManager = GeneratorInjectionModule.providesBlockStreamManager(
+                blockGeneratorConfig, startupDataMock, unorderedStreamConfig);
 
         assertEquals(blockStreamManager.getClass().getName(), BlockAsFileBlockStreamManager.class.getName());
     }
@@ -61,8 +69,8 @@ class GeneratorInjectionModuleTest {
                         ""))
                 .getConfigData(BlockGeneratorConfig.class);
 
-        final BlockStreamManager blockStreamManager =
-                GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig, startupDataMock);
+        final BlockStreamManager blockStreamManager = GeneratorInjectionModule.providesBlockStreamManager(
+                blockGeneratorConfig, startupDataMock, unorderedStreamConfig);
 
         assertEquals(blockStreamManager.getClass().getName(), BlockAsFileBlockStreamManager.class.getName());
     }
@@ -73,8 +81,8 @@ class GeneratorInjectionModuleTest {
                         Map.of("generator.generationMode", "CRAFT"))
                 .getConfigData(BlockGeneratorConfig.class);
 
-        final BlockStreamManager blockStreamManager =
-                GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig, startupDataMock);
+        final BlockStreamManager blockStreamManager = GeneratorInjectionModule.providesBlockStreamManager(
+                blockGeneratorConfig, startupDataMock, unorderedStreamConfig);
 
         assertEquals(blockStreamManager.getClass().getName(), CraftBlockStreamManager.class.getName());
     }

--- a/simulator/src/test/java/org/hiero/block/simulator/mode/PublisherClientModeHandlerTest.java
+++ b/simulator/src/test/java/org/hiero/block/simulator/mode/PublisherClientModeHandlerTest.java
@@ -81,7 +81,7 @@ public class PublisherClientModeHandlerTest {
 
         verify(publishStreamGrpcClient).streamBlock(block1);
         verify(publishStreamGrpcClient).streamBlock(block2);
-        verifyNoMoreInteractions(publishStreamGrpcClient);
+        verify(publishStreamGrpcClient).shutdown();
         verify(blockStreamManager, times(3)).getNextBlock();
     }
 
@@ -175,7 +175,7 @@ public class PublisherClientModeHandlerTest {
 
         verify(publishStreamGrpcClient).streamBlock(block1);
         verify(publishStreamGrpcClient).streamBlock(block2);
-        verifyNoMoreInteractions(publishStreamGrpcClient);
+        verify(publishStreamGrpcClient).shutdown();
         verify(blockStreamManager, times(3)).getNextBlock();
     }
 
@@ -220,7 +220,7 @@ public class PublisherClientModeHandlerTest {
         verify(publishStreamGrpcClient).streamBlock(block1);
         verify(publishStreamGrpcClient).streamBlock(block2);
         verify(publishStreamGrpcClient).streamBlock(block3);
-        verifyNoMoreInteractions(publishStreamGrpcClient);
+        verify(publishStreamGrpcClient).shutdown();
         verify(blockStreamManager, times(3)).getNextBlock();
     }
 
@@ -251,7 +251,7 @@ public class PublisherClientModeHandlerTest {
 
         verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
         verify(blockStreamManager).getNextBlock();
-        verifyNoMoreInteractions(publishStreamGrpcClient);
+        verify(publishStreamGrpcClient).shutdown();
         verifyNoMoreInteractions(blockStreamManager);
     }
 
@@ -278,7 +278,7 @@ public class PublisherClientModeHandlerTest {
 
         verify(publishStreamGrpcClient).streamBlock(block1);
         verify(publishStreamGrpcClient).streamBlock(block2);
-        verifyNoMoreInteractions(publishStreamGrpcClient);
+        verify(publishStreamGrpcClient).shutdown();
         verify(blockStreamManager, times(2)).getNextBlock();
     }
 
@@ -312,7 +312,7 @@ public class PublisherClientModeHandlerTest {
 
         verify(publishStreamGrpcClient).streamBlock(block1);
         verify(publishStreamGrpcClient).streamBlock(block2);
-        verifyNoMoreInteractions(publishStreamGrpcClient);
+        verify(publishStreamGrpcClient).shutdown();
         verify(blockStreamManager, times(2)).getNextBlock();
     }
 }

--- a/simulator/src/test/java/org/hiero/block/simulator/startup/impl/SimulatorStartupDataImplTest.java
+++ b/simulator/src/test/java/org/hiero/block/simulator/startup/impl/SimulatorStartupDataImplTest.java
@@ -207,6 +207,7 @@ class SimulatorStartupDataImplTest {
         assertThat(latestAckBlockHashPath).doesNotExist();
         assertThat(latestAckBlockNumberPath).doesNotExist();
         final SimulatorStartupDataImpl toTest = newInstanceToTest(false);
+        assertThat(toTest.isEnabled()).isFalse();
         // @todo(904) we need the correct response code
         toTest.updateLatestAckBlockStartupData(1L, validSimulatedBlockHash, false);
         assertThat(latestAckBlockHashPath).doesNotExist();
@@ -223,6 +224,7 @@ class SimulatorStartupDataImplTest {
         assertThat(latestAckBlockHashPath).doesNotExist();
         assertThat(latestAckBlockNumberPath).doesNotExist();
         final SimulatorStartupDataImpl toTest = newInstanceToTest(true);
+        assertThat(toTest.isEnabled()).isTrue();
         assertThat(latestAckBlockNumberPath)
                 .exists()
                 .isRegularFile()


### PR DESCRIPTION
## Reviewer Notes
Implemented unordered block streaming in the simulator, configurable via app.properties.
The feature can be enabled by setting unorderedStream.enabled=true.
Two sub-modes are supported:
- Automatic Scrambling: Generates an unordered stream of blocks based on a specified block range and a scrambling coefficient.
- Fixed Sequence: Streams blocks in a predefined order specified in unorderedStream.fixedStreamingSequence.
Added unit tests to cover both sub-modes and the new configuration logic.

## Related Issue(s)
Closes #522
