### PR TITLE
chore: Improve PR Gradle Checks GHA definition (0.8)

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "PR Gradle Checks"
+name: "PR Checks"
 on:
   push:
     branches:
@@ -26,6 +26,7 @@ permissions:
 jobs:
   check-gradle:
     name: Gradle
+    if: ${{ github.base_ref == 'main' || startsWith(github.base_ref, 'release/') }}
     uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
     with:
       ref: ${{ github.event.inputs.ref || '' }}
@@ -34,7 +35,7 @@ jobs:
 
   compile:
     timeout-minutes: 20
-    name: "Gradle Checks"
+    name: "Quality Checks and UTs"
     runs-on: hiero-block-node-linux-medium
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Reviewer Notes
Cherry pick of  #962 
Update PR Gradle Checks
- name to not be gradle specific
- `check-gradle` job to only run against main or release branches
- `compile` job name to make quality and UT run explicit

## Related Issue(s)
Fixes #951 in release/0.8