### PR TITLE
chore: Add UTs for Recent BlockFileBlockAccessor exception handling

### DIFF
--- a/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileBlockAccessorTest.java
+++ b/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileBlockAccessorTest.java
@@ -21,7 +21,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-
 import org.assertj.core.api.Assertions;
 import org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder;
 import org.hiero.block.node.base.CompressionType;
@@ -236,7 +235,8 @@ class BlockFileBlockAccessorTest {
             final Block expected = new Block(List.of(blockItems));
             final Bytes protoBytes = Block.PROTOBUF.toBytes(expected);
             // create instance to test
-            final BlockFileBlockAccessor toTest = createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
+            final BlockFileBlockAccessor toTest =
+                    createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
             // test accessor.block()
             final Block actual = toTest.block();
             assertThat(actual).isEqualTo(expected);
@@ -257,7 +257,8 @@ class BlockFileBlockAccessorTest {
             final Block expected = new Block(List.of(blockItems));
             final Bytes protoBytes = Block.PROTOBUF.toBytes(expected);
             // create instance to test
-            final BlockFileBlockAccessor toTest = createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
+            final BlockFileBlockAccessor toTest =
+                    createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
 
             // delete the file to simulate NoSuchFileException IOException
             Files.delete(blockFilePath);
@@ -286,7 +287,8 @@ class BlockFileBlockAccessorTest {
             // provide empty byte array to simulate parse exception
             final Bytes protoBytes = Bytes.wrap(new byte[48]);
             // create instance to test
-            final BlockFileBlockAccessor toTest = createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
+            final BlockFileBlockAccessor toTest =
+                    createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
 
             // test accessor.block() expecting IOException
             try {
@@ -313,7 +315,8 @@ class BlockFileBlockAccessorTest {
             final BlockUnparsed expected = new BlockUnparsed(List.of(blockItems));
             final Bytes protoBytes = BlockUnparsed.PROTOBUF.toBytes(expected);
             // create instance to test
-            final BlockFileBlockAccessor toTest = createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
+            final BlockFileBlockAccessor toTest =
+                    createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
             // test accessor.blockUnparsed()
             final BlockUnparsed actual = toTest.blockUnparsed();
             assertThat(actual).isEqualTo(expected);
@@ -334,7 +337,8 @@ class BlockFileBlockAccessorTest {
             final Block expected = new Block(List.of(blockItems));
             final Bytes protoBytes = Block.PROTOBUF.toBytes(expected);
             // create instance to test
-            final BlockFileBlockAccessor toTest = createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
+            final BlockFileBlockAccessor toTest =
+                    createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
 
             // delete the file to simulate NoSuchFileException IOException
             Files.delete(blockFilePath);
@@ -363,7 +367,8 @@ class BlockFileBlockAccessorTest {
             // provide empty byte array to simulate parse exception
             final Bytes protoBytes = Bytes.wrap(new byte[48]);
             // create instance to test
-            final BlockFileBlockAccessor toTest = createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
+            final BlockFileBlockAccessor toTest =
+                    createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
 
             // test accessor.block() expecting IOException
             try {
@@ -386,7 +391,8 @@ class BlockFileBlockAccessorTest {
             // create block file path before call
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
             // create instance to test
-            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            final BlockFileBlockAccessor toTest =
+                    buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
             // test accessor.blockBytes()
             final Format format =
                     switch (compressionType) {
@@ -410,7 +416,8 @@ class BlockFileBlockAccessorTest {
             // create block file path before call
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
             // create instance to test
-            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            final BlockFileBlockAccessor toTest =
+                    buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
             // test accessor.blockBytes()
             final Format format =
                     switch (compressionType) {
@@ -443,7 +450,8 @@ class BlockFileBlockAccessorTest {
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
 
             // create instance to test
-            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            final BlockFileBlockAccessor toTest =
+                    buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
 
             // delete the file to simulate NoSuchFileException IOException
             Files.delete(blockFilePath);
@@ -469,7 +477,8 @@ class BlockFileBlockAccessorTest {
             // create block file path before call
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
             // create instance to test
-            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            final BlockFileBlockAccessor toTest =
+                    buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
             // test accessor.writeBytesTo(OutputStream)
             final Format format =
                     switch (compressionType) {
@@ -495,7 +504,8 @@ class BlockFileBlockAccessorTest {
             // create block file path before call
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
             // create instance to test
-            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            final BlockFileBlockAccessor toTest =
+                    buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
             // test accessor.writeBytesTo(OutputStream)
             final Format format =
                     switch (compressionType) {
@@ -523,13 +533,15 @@ class BlockFileBlockAccessorTest {
          * handle an IOException when the format is protobuf zstd but the compression is none.
          */
         @Test
-        @DisplayName("Test writeBytesTo method will correctly handle IOException flows on taret OutputStream ZSTF protobuf but no compression")
+        @DisplayName(
+                "Test writeBytesTo method will correctly handle IOException flows on taret OutputStream ZSTF protobuf but no compression")
         void testWriteBytesToOutputStreamZSTDIOException() throws IOException {
             // create block file path before call
             final CompressionType compressionType = CompressionType.NONE;
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
             // create instance to test
-            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            final BlockFileBlockAccessor toTest =
+                    buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
 
             final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
 
@@ -558,7 +570,8 @@ class BlockFileBlockAccessorTest {
             // create block file path before call
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
             // create instance to test
-            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            final BlockFileBlockAccessor toTest =
+                    buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
             // test accessor.writeBytesTo(BufferedData)
             final Format format =
                     switch (compressionType) {
@@ -580,11 +593,13 @@ class BlockFileBlockAccessorTest {
         @ParameterizedTest
         @EnumSource(CompressionType.class)
         @DisplayName("Test writeBytesTo method will correctly handle IOException in the WritableSequentialData paths")
-        void testWriteBytesToWritableSequentialDataIOException(final CompressionType compressionType) throws IOException {
+        void testWriteBytesToWritableSequentialDataIOException(final CompressionType compressionType)
+                throws IOException {
             // create block file path before call
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
             // create instance to test
-            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            final BlockFileBlockAccessor toTest =
+                    buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
             // test accessor.writeBytesTo(BufferedData)
             final Format format =
                     switch (compressionType) {
@@ -612,13 +627,15 @@ class BlockFileBlockAccessorTest {
          * will correctly handle an IOException when the format is protobuf zstd but the compression is none.
          */
         @Test
-        @DisplayName("Test writeBytesTo method will correctly handle IOException in the WritableSequentialData paths on ZSTF protobuf but no compression")
+        @DisplayName(
+                "Test writeBytesTo method will correctly handle IOException in the WritableSequentialData paths on ZSTF protobuf but no compression")
         void testWriteBytesToWritableSequentialDataZSTDIOException() throws IOException {
             // create block file path before call
             final CompressionType compressionType = CompressionType.NONE;
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
             // create instance to test
-            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            final BlockFileBlockAccessor toTest =
+                    buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
             // test accessor.writeBytesTo(BufferedData)
             final Bytes expectedFileBytes = Bytes.wrap(Files.readAllBytes(blockFilePath));
             final BufferedData bufferedData = BufferedData.allocate((int) expectedFileBytes.length());
@@ -648,7 +665,8 @@ class BlockFileBlockAccessorTest {
             // create block file path before call
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
             // create instance to test
-            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            final BlockFileBlockAccessor toTest =
+                    buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
             // test accessor.writeTo(Path)
             final Format format =
                     switch (compressionType) {
@@ -675,7 +693,8 @@ class BlockFileBlockAccessorTest {
             // create block file path before call
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
             // create instance to test
-            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            final BlockFileBlockAccessor toTest =
+                    buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
             // test accessor.delete()
             toTest.delete();
             assertThat(blockFilePath).doesNotExist();
@@ -692,12 +711,14 @@ class BlockFileBlockAccessorTest {
             // create 1st block file at depth 2, leaving depth 1 empty
             final Path blockFile1Path = depth2Dir.resolve("7.blk".concat(compressionType.extension()));
             // create instance to test
-            final BlockFileBlockAccessor toTest1 = buildAndCreateBlockAndGetAssociatedAccessor(blockFile1Path, compressionType, 2);
+            final BlockFileBlockAccessor toTest1 =
+                    buildAndCreateBlockAndGetAssociatedAccessor(blockFile1Path, compressionType, 2);
 
             // create 2nd block file at depth 3
             final Path blockFile2Path = depth3Dir.resolve("8.blk".concat(compressionType.extension()));
             // create instance to test
-            final BlockFileBlockAccessor toTest2 = buildAndCreateBlockAndGetAssociatedAccessor(blockFile2Path, compressionType, 3);
+            final BlockFileBlockAccessor toTest2 =
+                    buildAndCreateBlockAndGetAssociatedAccessor(blockFile2Path, compressionType, 3);
 
             // test accessor2.delete() expecting depth 1 and 2 contents to remain but 3 to be removed
             toTest2.delete();
@@ -715,8 +736,7 @@ class BlockFileBlockAccessorTest {
         }
 
         private BlockFileBlockAccessor createBlockAndGetAssociatedAccessor(
-                final Path blockFilePath, final CompressionType compressionType, Bytes protoBytes)
-                throws IOException {
+                final Path blockFilePath, final CompressionType compressionType, Bytes protoBytes) throws IOException {
 
             // create & assert existing block file path before call
             Files.createFile(blockFilePath);
@@ -733,7 +753,8 @@ class BlockFileBlockAccessorTest {
         private BlockFileBlockAccessor buildAndCreateBlockAndGetAssociatedAccessor(
                 final Path blockFilePath, final CompressionType compressionType, final int numberOfBlocks)
                 throws IOException {
-            final BlockItemUnparsed[] blockItems1 = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocksUnparsed(numberOfBlocks);
+            final BlockItemUnparsed[] blockItems1 =
+                    SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocksUnparsed(numberOfBlocks);
             final BlockUnparsed expected1 = new BlockUnparsed(List.of(blockItems1));
             final Bytes protoBytes = BlockUnparsed.PROTOBUF.toBytes(expected1);
 

--- a/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileBlockAccessorTest.java
+++ b/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileBlockAccessorTest.java
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.blocks.files.recent;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;

--- a/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileBlockAccessorTest.java
+++ b/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileBlockAccessorTest.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.blocks.files.recent;
 
+import static org.assertj.core.api.Assertions.*;
+
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.hedera.hapi.block.stream.Block;
@@ -16,7 +18,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder;
 import org.hiero.block.node.base.CompressionType;
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor.Format;
@@ -29,8 +30,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-
-import static org.assertj.core.api.Assertions.*;
 
 /**
  * Test class for {@link BlockFileBlockAccessor}.
@@ -424,7 +423,8 @@ class BlockFileBlockAccessorTest {
             Files.delete(blockFilePath);
 
             // test accessor.blockBytes() expecting IOException
-            assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> toTest.blockBytes(Format.ZSTD_PROTOBUF));
+            assertThatExceptionOfType(UncheckedIOException.class)
+                    .isThrownBy(() -> toTest.blockBytes(Format.ZSTD_PROTOBUF));
         }
 
         /**
@@ -480,7 +480,8 @@ class BlockFileBlockAccessorTest {
             Files.delete(blockFilePath);
 
             // test accessor.writeBytesTo() expecting IOException
-            assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> toTest.writeBytesTo(format, byteArrayOutputStream));
+            assertThatExceptionOfType(UncheckedIOException.class)
+                    .isThrownBy(() -> toTest.writeBytesTo(format, byteArrayOutputStream));
         }
 
         /**
@@ -504,7 +505,8 @@ class BlockFileBlockAccessorTest {
             Files.delete(blockFilePath);
 
             // test accessor.writeBytesTo() expecting IOException
-            assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> toTest.writeBytesTo(Format.ZSTD_PROTOBUF, byteArrayOutputStream));
+            assertThatExceptionOfType(UncheckedIOException.class)
+                    .isThrownBy(() -> toTest.writeBytesTo(Format.ZSTD_PROTOBUF, byteArrayOutputStream));
         }
 
         /**
@@ -562,7 +564,8 @@ class BlockFileBlockAccessorTest {
             Files.delete(blockFilePath);
 
             // test accessor.writeBytesTo() expecting IOException
-            assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> toTest.writeBytesTo(format, bufferedData));
+            assertThatExceptionOfType(UncheckedIOException.class)
+                    .isThrownBy(() -> toTest.writeBytesTo(format, bufferedData));
         }
 
         /**
@@ -587,7 +590,8 @@ class BlockFileBlockAccessorTest {
             Files.delete(blockFilePath);
 
             // test accessor.writeBytesTo() expecting IOException
-            assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> toTest.writeBytesTo(Format.ZSTD_PROTOBUF, bufferedData));
+            assertThatExceptionOfType(UncheckedIOException.class)
+                    .isThrownBy(() -> toTest.writeBytesTo(Format.ZSTD_PROTOBUF, bufferedData));
         }
 
         /**

--- a/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileBlockAccessorTest.java
+++ b/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileBlockAccessorTest.java
@@ -10,15 +10,19 @@ import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.pbj.runtime.UncheckedParseException;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+
+import org.assertj.core.api.Assertions;
 import org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder;
 import org.hiero.block.node.base.CompressionType;
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor.Format;
@@ -232,10 +236,66 @@ class BlockFileBlockAccessorTest {
             final Block expected = new Block(List.of(blockItems));
             final Bytes protoBytes = Block.PROTOBUF.toBytes(expected);
             // create instance to test
-            final BlockFileBlockAccessor toTest = createInstanceToTest(blockFilePath, compressionType, protoBytes);
+            final BlockFileBlockAccessor toTest = createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
             // test accessor.block()
             final Block actual = toTest.block();
             assertThat(actual).isEqualTo(expected);
+        }
+
+        /**
+         * This test aims to verify that the {@link BlockFileBlockAccessor#block()} will correctly handle
+         * IOExceptions encountered when attempting to persist blocks.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test block() method correctly handles an IOException")
+        void testBlockIOException(final CompressionType compressionType) throws IOException {
+            // create block file path before call
+            final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
+            // build a test block
+            final BlockItem[] blockItems = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocks(1);
+            final Block expected = new Block(List.of(blockItems));
+            final Bytes protoBytes = Block.PROTOBUF.toBytes(expected);
+            // create instance to test
+            final BlockFileBlockAccessor toTest = createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
+
+            // delete the file to simulate NoSuchFileException IOException
+            Files.delete(blockFilePath);
+
+            // test accessor.block() expecting IOException
+            try {
+                toTest.block();
+                assertThat(false).isTrue(); // exception should have been thrown
+            } catch (Throwable e) {
+                // expected
+                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
+            }
+        }
+
+        /**
+         * This test aims to verify that the {@link BlockFileBlockAccessor#block()} will correctly handle
+         * protobuf parse exception encountered when attempting to persist blocks.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test block() method correctly handles proto parse exception")
+        void testBlockParseException(final CompressionType compressionType) throws IOException {
+            // create block file path before call
+            final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
+
+            // provide empty byte array to simulate parse exception
+            final Bytes protoBytes = Bytes.wrap(new byte[48]);
+            // create instance to test
+            final BlockFileBlockAccessor toTest = createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
+
+            // test accessor.block() expecting IOException
+            try {
+                toTest.block();
+                assertThat(false).isTrue(); // exception should have been thrown
+            } catch (Throwable e) {
+                // expected
+                Assertions.assertThat(e).isInstanceOf(UncheckedParseException.class);
+            }
         }
 
         /**
@@ -253,10 +313,66 @@ class BlockFileBlockAccessorTest {
             final BlockUnparsed expected = new BlockUnparsed(List.of(blockItems));
             final Bytes protoBytes = BlockUnparsed.PROTOBUF.toBytes(expected);
             // create instance to test
-            final BlockFileBlockAccessor toTest = createInstanceToTest(blockFilePath, compressionType, protoBytes);
+            final BlockFileBlockAccessor toTest = createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
             // test accessor.blockUnparsed()
             final BlockUnparsed actual = toTest.blockUnparsed();
             assertThat(actual).isEqualTo(expected);
+        }
+
+        /**
+         * This test aims to verify that the {@link BlockFileBlockAccessor#blockUnparsed()} will correctly handle
+         * IOException encountered when attempting to persist blocks.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test blockUnparsed() method correctly handles an IOException")
+        void testBlockUnparsedIOException(final CompressionType compressionType) throws IOException {
+            // create block file path before call
+            final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
+            // build a test block
+            final BlockItem[] blockItems = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocks(1);
+            final Block expected = new Block(List.of(blockItems));
+            final Bytes protoBytes = Block.PROTOBUF.toBytes(expected);
+            // create instance to test
+            final BlockFileBlockAccessor toTest = createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
+
+            // delete the file to simulate NoSuchFileException IOException
+            Files.delete(blockFilePath);
+
+            // test accessor.block() expecting IOException
+            try {
+                toTest.blockUnparsed();
+                assertThat(false).isTrue(); // exception should have been thrown
+            } catch (Throwable e) {
+                // expected
+                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
+            }
+        }
+
+        /**
+         * This test aims to verify that the {@link BlockFileBlockAccessor#blockUnparsed()} will correctly handle
+         * protobuf parse exceptions encountered when attempting to persist blocks.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test blockUnparsed() method correctly handles proto parse exception")
+        void testBlockUnparseException(final CompressionType compressionType) throws IOException {
+            // create block file path before call
+            final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
+
+            // provide empty byte array to simulate parse exception
+            final Bytes protoBytes = Bytes.wrap(new byte[48]);
+            // create instance to test
+            final BlockFileBlockAccessor toTest = createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
+
+            // test accessor.block() expecting IOException
+            try {
+                toTest.blockUnparsed();
+                assertThat(false).isTrue(); // exception should have been thrown
+            } catch (Throwable e) {
+                // expected
+                Assertions.assertThat(e).isInstanceOf(UncheckedParseException.class);
+            }
         }
 
         /**
@@ -269,12 +385,8 @@ class BlockFileBlockAccessorTest {
         void testBlockBytes(final CompressionType compressionType) throws IOException {
             // create block file path before call
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
-            // build a test block
-            final BlockItemUnparsed[] blockItems = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocksUnparsed(1);
-            final BlockUnparsed block = new BlockUnparsed(List.of(blockItems));
-            final Bytes protoBytes = BlockUnparsed.PROTOBUF.toBytes(block);
             // create instance to test
-            final BlockFileBlockAccessor toTest = createInstanceToTest(blockFilePath, compressionType, protoBytes);
+            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
             // test accessor.blockBytes()
             final Format format =
                     switch (compressionType) {
@@ -288,6 +400,65 @@ class BlockFileBlockAccessorTest {
         }
 
         /**
+         * This test aims to verify that the {@link BlockFileBlockAccessor#blockBytes(Format)} will correctly
+         * handle IOExceptions encountered.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test blockBytes method correctly handles an IOException")
+        void testBlockBytesIOException(final CompressionType compressionType) throws IOException {
+            // create block file path before call
+            final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
+            // create instance to test
+            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            // test accessor.blockBytes()
+            final Format format =
+                    switch (compressionType) {
+                        case ZSTD -> Format.ZSTD_PROTOBUF;
+                        case NONE -> Format.PROTOBUF;
+                    };
+
+            // delete the file to simulate NoSuchFileException IOException
+            Files.delete(blockFilePath);
+
+            // test accessor.blockBytes() expecting IOException
+            try {
+                toTest.blockBytes(format);
+                assertThat(false).isTrue(); // exception should have been thrown
+            } catch (Throwable e) {
+                // expected
+                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
+            }
+        }
+
+        /**
+         * This test aims to verify that the {@link BlockFileBlockAccessor#blockBytes(Format)} will correctly
+         * handle an IOException when the format is protobuf zstd but the compression is none.
+         */
+        @Test
+        @DisplayName("Test blockBytes method correctly handles an IOException on ZSTF protobuf but no compression")
+        void testBlockBytesZSTDIOException() throws IOException {
+            // create block file path before call
+            final CompressionType compressionType = CompressionType.NONE;
+            final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
+
+            // create instance to test
+            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+
+            // delete the file to simulate NoSuchFileException IOException
+            Files.delete(blockFilePath);
+
+            // test accessor.blockBytes() expecting IOException
+            try {
+                toTest.blockBytes(Format.ZSTD_PROTOBUF);
+                assertThat(false).isTrue(); // exception should have been thrown
+            } catch (Throwable e) {
+                // expected
+                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
+            }
+        }
+
+        /**
          * This test aims to verify that the {@link BlockFileBlockAccessor#writeBytesTo(Format, OutputStream)}
          * will correctly write bytes to the target {@link OutputStream}.
          */
@@ -297,12 +468,8 @@ class BlockFileBlockAccessorTest {
         void testWriteBytesToOutputStream(final CompressionType compressionType) throws IOException {
             // create block file path before call
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
-            // build a test block
-            final BlockItemUnparsed[] blockItems = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocksUnparsed(1);
-            final BlockUnparsed block = new BlockUnparsed(List.of(blockItems));
-            final Bytes protoBytes = BlockUnparsed.PROTOBUF.toBytes(block);
             // create instance to test
-            final BlockFileBlockAccessor toTest = createInstanceToTest(blockFilePath, compressionType, protoBytes);
+            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
             // test accessor.writeBytesTo(OutputStream)
             final Format format =
                     switch (compressionType) {
@@ -318,6 +485,68 @@ class BlockFileBlockAccessorTest {
         }
 
         /**
+         * This test aims to verify that the {@link BlockFileBlockAccessor#writeBytesTo(Format, OutputStream)}
+         * will correctly manage IOExceptions.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test writeBytesTo method will correctly handle IOException flows")
+        void testWriteBytesToOutputStreamIOException(final CompressionType compressionType) throws IOException {
+            // create block file path before call
+            final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
+            // create instance to test
+            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            // test accessor.writeBytesTo(OutputStream)
+            final Format format =
+                    switch (compressionType) {
+                        case ZSTD -> Format.ZSTD_PROTOBUF;
+                        case NONE -> Format.PROTOBUF;
+                    };
+
+            final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+            // delete the file to simulate NoSuchFileException IOException
+            Files.delete(blockFilePath);
+
+            // test accessor.writeBytesTo() expecting IOException
+            try {
+                toTest.writeBytesTo(format, byteArrayOutputStream);
+                assertThat(false).isTrue(); // exception should have been thrown
+            } catch (Throwable e) {
+                // expected
+                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
+            }
+        }
+
+        /**
+         * This test aims to verify that the {@link BlockFileBlockAccessor#writeBytesTo(Format, OutputStream)} will correctly
+         * handle an IOException when the format is protobuf zstd but the compression is none.
+         */
+        @Test
+        @DisplayName("Test writeBytesTo method will correctly handle IOException flows on taret OutputStream ZSTF protobuf but no compression")
+        void testWriteBytesToOutputStreamZSTDIOException() throws IOException {
+            // create block file path before call
+            final CompressionType compressionType = CompressionType.NONE;
+            final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
+            // create instance to test
+            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+
+            final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+            // delete the file to simulate NoSuchFileException IOException
+            Files.delete(blockFilePath);
+
+            // test accessor.writeBytesTo() expecting IOException
+            try {
+                toTest.writeBytesTo(Format.ZSTD_PROTOBUF, byteArrayOutputStream);
+                assertThat(false).isTrue(); // exception should have been thrown
+            } catch (Throwable e) {
+                // expected
+                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
+            }
+        }
+
+        /**
          * This test aims to verify that the
          * {@link BlockFileBlockAccessor#writeBytesTo(Format, com.hedera.pbj.runtime.io.WritableSequentialData)}
          * will correctly write bytes to the target {@link com.hedera.pbj.runtime.io.WritableSequentialData}.
@@ -328,12 +557,8 @@ class BlockFileBlockAccessorTest {
         void testWriteBytesToWritableSequentialData(final CompressionType compressionType) throws IOException {
             // create block file path before call
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
-            // build a test block
-            final BlockItemUnparsed[] blockItems = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocksUnparsed(1);
-            final BlockUnparsed block = new BlockUnparsed(List.of(blockItems));
-            final Bytes protoBytes = BlockUnparsed.PROTOBUF.toBytes(block);
             // create instance to test
-            final BlockFileBlockAccessor toTest = createInstanceToTest(blockFilePath, compressionType, protoBytes);
+            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
             // test accessor.writeBytesTo(BufferedData)
             final Format format =
                     switch (compressionType) {
@@ -349,6 +574,69 @@ class BlockFileBlockAccessorTest {
         }
 
         /**
+         * This test aims to verify that the {@link BlockFileBlockAccessor#writeBytesTo(Format, com.hedera.pbj.runtime.io.WritableSequentialData)}
+         * will correctly manage IOExceptions.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test writeBytesTo method will correctly handle IOException in the WritableSequentialData paths")
+        void testWriteBytesToWritableSequentialDataIOException(final CompressionType compressionType) throws IOException {
+            // create block file path before call
+            final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
+            // create instance to test
+            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            // test accessor.writeBytesTo(BufferedData)
+            final Format format =
+                    switch (compressionType) {
+                        case ZSTD -> Format.ZSTD_PROTOBUF;
+                        case NONE -> Format.PROTOBUF;
+                    };
+            final Bytes expectedFileBytes = Bytes.wrap(Files.readAllBytes(blockFilePath));
+            final BufferedData bufferedData = BufferedData.allocate((int) expectedFileBytes.length());
+
+            // delete the file to simulate NoSuchFileException IOException
+            Files.delete(blockFilePath);
+
+            // test accessor.blockBytes() expecting IOException
+            try {
+                toTest.writeBytesTo(format, bufferedData);
+                assertThat(false).isTrue(); // exception should have been thrown
+            } catch (Throwable e) {
+                // expected
+                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
+            }
+        }
+
+        /**
+         * This test aims to verify that the {@link BlockFileBlockAccessor#writeBytesTo(Format, com.hedera.pbj.runtime.io.WritableSequentialData)}
+         * will correctly handle an IOException when the format is protobuf zstd but the compression is none.
+         */
+        @Test
+        @DisplayName("Test writeBytesTo method will correctly handle IOException in the WritableSequentialData paths on ZSTF protobuf but no compression")
+        void testWriteBytesToWritableSequentialDataZSTDIOException() throws IOException {
+            // create block file path before call
+            final CompressionType compressionType = CompressionType.NONE;
+            final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
+            // create instance to test
+            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
+            // test accessor.writeBytesTo(BufferedData)
+            final Bytes expectedFileBytes = Bytes.wrap(Files.readAllBytes(blockFilePath));
+            final BufferedData bufferedData = BufferedData.allocate((int) expectedFileBytes.length());
+
+            // delete the file to simulate NoSuchFileException IOException
+            Files.delete(blockFilePath);
+
+            // test accessor.blockBytes() expecting IOException
+            try {
+                toTest.writeBytesTo(Format.ZSTD_PROTOBUF, bufferedData);
+                assertThat(false).isTrue(); // exception should have been thrown
+            } catch (Throwable e) {
+                // expected
+                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
+            }
+        }
+
+        /**
          * This test aims to verify that the
          * {@link BlockFileBlockAccessor#writeTo(Format, Path)}
          * will correctly write bytes to the target {@link Path}.
@@ -359,12 +647,8 @@ class BlockFileBlockAccessorTest {
         void testWriteToPath(final CompressionType compressionType) throws IOException {
             // create block file path before call
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
-            // build a test block
-            final BlockItemUnparsed[] blockItems = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocksUnparsed(1);
-            final BlockUnparsed block = new BlockUnparsed(List.of(blockItems));
-            final Bytes protoBytes = BlockUnparsed.PROTOBUF.toBytes(block);
             // create instance to test
-            final BlockFileBlockAccessor toTest = createInstanceToTest(blockFilePath, compressionType, protoBytes);
+            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
             // test accessor.writeTo(Path)
             final Format format =
                     switch (compressionType) {
@@ -390,20 +674,50 @@ class BlockFileBlockAccessorTest {
         void testBlockDelete(final CompressionType compressionType) throws IOException {
             // create block file path before call
             final Path blockFilePath = testBasePath.resolve("0.blk".concat(compressionType.extension()));
-            // build a test block
-            final BlockItemUnparsed[] blockItems = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocksUnparsed(1);
-            final BlockUnparsed expected = new BlockUnparsed(List.of(blockItems));
-            final Bytes protoBytes = BlockUnparsed.PROTOBUF.toBytes(expected);
             // create instance to test
-            final BlockFileBlockAccessor toTest = createInstanceToTest(blockFilePath, compressionType, protoBytes);
+            final BlockFileBlockAccessor toTest = buildAndCreateBlockAndGetAssociatedAccessor(blockFilePath, compressionType, 1);
             // test accessor.delete()
             toTest.delete();
             assertThat(blockFilePath).doesNotExist();
         }
 
-        private BlockFileBlockAccessor createInstanceToTest(
-                final Path blockFilePath, final CompressionType compressionType, final Bytes protoBytes)
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        void testDeleteNestedEmptyParentDirectory(final CompressionType compressionType) throws IOException {
+            // create parents dirs
+            final Path depth1Dir = Files.createDirectories(Path.of(testBasePath + "/depth1"));
+            final Path depth2Dir = Files.createDirectories(Path.of(testBasePath + "/depth1/depth2"));
+            final Path depth3Dir = Files.createDirectories(Path.of(testBasePath + "/depth1/depth2/depth3"));
+
+            // create 1st block file at depth 2, leaving depth 1 empty
+            final Path blockFile1Path = depth2Dir.resolve("7.blk".concat(compressionType.extension()));
+            // create instance to test
+            final BlockFileBlockAccessor toTest1 = buildAndCreateBlockAndGetAssociatedAccessor(blockFile1Path, compressionType, 2);
+
+            // create 2nd block file at depth 3
+            final Path blockFile2Path = depth3Dir.resolve("8.blk".concat(compressionType.extension()));
+            // create instance to test
+            final BlockFileBlockAccessor toTest2 = buildAndCreateBlockAndGetAssociatedAccessor(blockFile2Path, compressionType, 3);
+
+            // test accessor2.delete() expecting depth 1 and 2 contents to remain but 3 to be removed
+            toTest2.delete();
+            assertThat(blockFile2Path).doesNotExist();
+            assertThat(depth3Dir).doesNotExist();
+            assertThat(depth2Dir).exists();
+            assertThat(blockFile1Path).exists();
+            assertThat(depth1Dir).exists();
+
+            // test accessor1.delete() expecting depth 1 and 2 contents to be removed
+            toTest1.delete();
+            assertThat(depth2Dir).doesNotExist();
+            assertThat(depth1Dir).doesNotExist();
+            assertThat(blockFile1Path).doesNotExist();
+        }
+
+        private BlockFileBlockAccessor createBlockAndGetAssociatedAccessor(
+                final Path blockFilePath, final CompressionType compressionType, Bytes protoBytes)
                 throws IOException {
+
             // create & assert existing block file path before call
             Files.createFile(blockFilePath);
             assertThat(blockFilePath).exists().isEmptyFile();
@@ -414,6 +728,16 @@ class BlockFileBlockAccessorTest {
             // assert the test block file is populated
             assertThat(blockFilePath).isNotEmptyFile();
             return new BlockFileBlockAccessor(testBasePath, blockFilePath, compressionType);
+        }
+
+        private BlockFileBlockAccessor buildAndCreateBlockAndGetAssociatedAccessor(
+                final Path blockFilePath, final CompressionType compressionType, final int numberOfBlocks)
+                throws IOException {
+            final BlockItemUnparsed[] blockItems1 = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocksUnparsed(numberOfBlocks);
+            final BlockUnparsed expected1 = new BlockUnparsed(List.of(blockItems1));
+            final Bytes protoBytes = BlockUnparsed.PROTOBUF.toBytes(expected1);
+
+            return createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
         }
     }
 }

--- a/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileBlockAccessorTest.java
+++ b/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileBlockAccessorTest.java
@@ -1,11 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.blocks.files.recent;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.hedera.hapi.block.stream.Block;
@@ -34,6 +29,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Test class for {@link BlockFileBlockAccessor}.
@@ -264,13 +261,7 @@ class BlockFileBlockAccessorTest {
             Files.delete(blockFilePath);
 
             // test accessor.block() expecting IOException
-            try {
-                toTest.block();
-                assertThat(false).isTrue(); // exception should have been thrown
-            } catch (Throwable e) {
-                // expected
-                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
-            }
+            assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(toTest::block);
         }
 
         /**
@@ -290,14 +281,8 @@ class BlockFileBlockAccessorTest {
             final BlockFileBlockAccessor toTest =
                     createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
 
-            // test accessor.block() expecting IOException
-            try {
-                toTest.block();
-                assertThat(false).isTrue(); // exception should have been thrown
-            } catch (Throwable e) {
-                // expected
-                Assertions.assertThat(e).isInstanceOf(UncheckedParseException.class);
-            }
+            // test accessor.block() expecting ParseException
+            assertThatExceptionOfType(UncheckedParseException.class).isThrownBy(toTest::block);
         }
 
         /**
@@ -343,14 +328,8 @@ class BlockFileBlockAccessorTest {
             // delete the file to simulate NoSuchFileException IOException
             Files.delete(blockFilePath);
 
-            // test accessor.block() expecting IOException
-            try {
-                toTest.blockUnparsed();
-                assertThat(false).isTrue(); // exception should have been thrown
-            } catch (Throwable e) {
-                // expected
-                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
-            }
+            // test accessor.blockUnparsed() expecting IOException
+            assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(toTest::blockUnparsed);
         }
 
         /**
@@ -370,14 +349,8 @@ class BlockFileBlockAccessorTest {
             final BlockFileBlockAccessor toTest =
                     createBlockAndGetAssociatedAccessor(blockFilePath, compressionType, protoBytes);
 
-            // test accessor.block() expecting IOException
-            try {
-                toTest.blockUnparsed();
-                assertThat(false).isTrue(); // exception should have been thrown
-            } catch (Throwable e) {
-                // expected
-                Assertions.assertThat(e).isInstanceOf(UncheckedParseException.class);
-            }
+            // test accessor.blockUnparsed() expecting ParseException
+            assertThatExceptionOfType(UncheckedParseException.class).isThrownBy(toTest::blockUnparsed);
         }
 
         /**
@@ -429,13 +402,7 @@ class BlockFileBlockAccessorTest {
             Files.delete(blockFilePath);
 
             // test accessor.blockBytes() expecting IOException
-            try {
-                toTest.blockBytes(format);
-                assertThat(false).isTrue(); // exception should have been thrown
-            } catch (Throwable e) {
-                // expected
-                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
-            }
+            assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> toTest.blockBytes(format));
         }
 
         /**
@@ -457,13 +424,7 @@ class BlockFileBlockAccessorTest {
             Files.delete(blockFilePath);
 
             // test accessor.blockBytes() expecting IOException
-            try {
-                toTest.blockBytes(Format.ZSTD_PROTOBUF);
-                assertThat(false).isTrue(); // exception should have been thrown
-            } catch (Throwable e) {
-                // expected
-                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
-            }
+            assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> toTest.blockBytes(Format.ZSTD_PROTOBUF));
         }
 
         /**
@@ -519,13 +480,7 @@ class BlockFileBlockAccessorTest {
             Files.delete(blockFilePath);
 
             // test accessor.writeBytesTo() expecting IOException
-            try {
-                toTest.writeBytesTo(format, byteArrayOutputStream);
-                assertThat(false).isTrue(); // exception should have been thrown
-            } catch (Throwable e) {
-                // expected
-                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
-            }
+            assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> toTest.writeBytesTo(format, byteArrayOutputStream));
         }
 
         /**
@@ -549,13 +504,7 @@ class BlockFileBlockAccessorTest {
             Files.delete(blockFilePath);
 
             // test accessor.writeBytesTo() expecting IOException
-            try {
-                toTest.writeBytesTo(Format.ZSTD_PROTOBUF, byteArrayOutputStream);
-                assertThat(false).isTrue(); // exception should have been thrown
-            } catch (Throwable e) {
-                // expected
-                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
-            }
+            assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> toTest.writeBytesTo(Format.ZSTD_PROTOBUF, byteArrayOutputStream));
         }
 
         /**
@@ -612,14 +561,8 @@ class BlockFileBlockAccessorTest {
             // delete the file to simulate NoSuchFileException IOException
             Files.delete(blockFilePath);
 
-            // test accessor.blockBytes() expecting IOException
-            try {
-                toTest.writeBytesTo(format, bufferedData);
-                assertThat(false).isTrue(); // exception should have been thrown
-            } catch (Throwable e) {
-                // expected
-                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
-            }
+            // test accessor.writeBytesTo() expecting IOException
+            assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> toTest.writeBytesTo(format, bufferedData));
         }
 
         /**
@@ -643,14 +586,8 @@ class BlockFileBlockAccessorTest {
             // delete the file to simulate NoSuchFileException IOException
             Files.delete(blockFilePath);
 
-            // test accessor.blockBytes() expecting IOException
-            try {
-                toTest.writeBytesTo(Format.ZSTD_PROTOBUF, bufferedData);
-                assertThat(false).isTrue(); // exception should have been thrown
-            } catch (Throwable e) {
-                // expected
-                Assertions.assertThat(e).isInstanceOf(UncheckedIOException.class);
-            }
+            // test accessor.writeBytesTo() expecting IOException
+            assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> toTest.writeBytesTo(Format.ZSTD_PROTOBUF, bufferedData));
         }
 
         /**


### PR DESCRIPTION
## Reviewer Notes
Add additional UTs for exception handling cases in BlockFileBlockAccessor
- Add nested depth test for additional `delete()` confidence
- Add logic to handle IOException and ParseException in block()
- Add logic to handle IOException and ParseException in blockUnparsed()
- Add logic to handle IOException in blockBytes() 
- Add logic to handle IOException in writeBytesTo() 
- Add logic to handle IOException in writeBytesTo() 
- Move shared setup logic from `createInstanceToTest()` into `buildAndCreateBlockAndGetAssociatedAccessor()` and `createBlockAndGetAssociatedAccessor()`

## Related Issue(s)
Fixes #969 