### PR TITLE
feat: added block stream simulator mid-block sending failure

### DIFF
--- a/simulator/src/main/java/org/hiero/block/simulator/config/SimulatorMappedConfigSourceInitializer.java
+++ b/simulator/src/main/java/org/hiero/block/simulator/config/SimulatorMappedConfigSourceInitializer.java
@@ -24,6 +24,8 @@ public final class SimulatorMappedConfigSourceInitializer {
             new ConfigMapping("blockStream.streamingMode", "BLOCK_STREAM_STREAMING_MODE"),
             new ConfigMapping("blockStream.millisecondsPerBlock", "BLOCK_STREAM_MILLISECONDS_PER_BLOCK"),
             new ConfigMapping("blockStream.blockItemsBatchSize", "BLOCK_STREAM_BLOCK_ITEMS_BATCH_SIZE"),
+            new ConfigMapping("blockStream.midBlockFailType", "BLOCK_STREAM_MID_BLOCK_FAIL_TYPE"),
+            new ConfigMapping("blockStream.midBlockFailOffset", "BLOCK_STREAM_MID_BLOCK_FAIL_OFFSET"),
 
             // Block consumer configuration
             new ConfigMapping("consumer.startBlockNumber", "CONSUMER_START_BLOCK_NUMBER"),

--- a/simulator/src/main/java/org/hiero/block/simulator/config/data/BlockStreamConfig.java
+++ b/simulator/src/main/java/org/hiero/block/simulator/config/data/BlockStreamConfig.java
@@ -4,6 +4,7 @@ package org.hiero.block.simulator.config.data;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 import org.hiero.block.simulator.config.logging.Loggable;
+import org.hiero.block.simulator.config.types.MidBlockFailType;
 import org.hiero.block.simulator.config.types.SimulatorMode;
 import org.hiero.block.simulator.config.types.StreamingMode;
 
@@ -26,7 +27,9 @@ public record BlockStreamConfig(
         @Loggable @ConfigProperty(defaultValue = "100_000") int maxBlockItemsToStream,
         @Loggable @ConfigProperty(defaultValue = "MILLIS_PER_BLOCK") StreamingMode streamingMode,
         @Loggable @ConfigProperty(defaultValue = "1000") int millisecondsPerBlock,
-        @Loggable @ConfigProperty(defaultValue = "1000") int blockItemsBatchSize) {
+        @Loggable @ConfigProperty(defaultValue = "1000") int blockItemsBatchSize,
+        @Loggable @ConfigProperty(defaultValue = "NONE") MidBlockFailType midBlockFailType,
+        @Loggable @ConfigProperty(defaultValue = "0") long midBlockFailOffset) {
 
     /**
      * Creates a new {@link Builder} instance for constructing a {@code BlockStreamConfig}.
@@ -48,6 +51,8 @@ public record BlockStreamConfig(
         private StreamingMode streamingMode = StreamingMode.MILLIS_PER_BLOCK;
         private int millisecondsPerBlock = 1000;
         private int blockItemsBatchSize = 1000;
+        private MidBlockFailType midBlockFailType = MidBlockFailType.NONE;
+        private long midBlockFailOffset = 0;
 
         /**
          * Creates a new instance of the {@code Builder} class with default configuration values.
@@ -134,6 +139,28 @@ public record BlockStreamConfig(
         }
 
         /**
+         * Sets a failure type to occur while streaming.
+         *
+         * @param midBlockFailType the failure type
+         * @return this {@code Builder} instance
+         */
+        public Builder midBlockFailType(MidBlockFailType midBlockFailType) {
+            this.midBlockFailType = midBlockFailType;
+            return this;
+        }
+
+        /**
+         * Sets the index of the failing block.
+         *
+         * @param midBlockFailOffset the index of the failing block
+         * @return this {@code Builder} instance
+         */
+        public Builder midBlockFailOffset(long midBlockFailOffset) {
+            this.midBlockFailOffset = midBlockFailOffset;
+            return this;
+        }
+
+        /**
          * Builds a new {@link BlockStreamConfig} instance with the configured values.
          *
          * @return a new {@code BlockStreamConfig}
@@ -146,7 +173,9 @@ public record BlockStreamConfig(
                     maxBlockItemsToStream,
                     streamingMode,
                     millisecondsPerBlock,
-                    blockItemsBatchSize);
+                    blockItemsBatchSize,
+                    midBlockFailType,
+                    midBlockFailOffset);
         }
     }
 }

--- a/simulator/src/main/java/org/hiero/block/simulator/config/types/MidBlockFailType.java
+++ b/simulator/src/main/java/org/hiero/block/simulator/config/types/MidBlockFailType.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.simulator.config.types;
+
+/** The MidBlockFailType enum defines the type of failure in the process of block streaming.
+ * Failure will occur randomly between the header and the proof of the block. */
+public enum MidBlockFailType {
+    /**
+     * The NONE value indicates no failure will be simulated during streaming.
+     */
+    NONE,
+    /**
+     * The ABRUPT value indicates that an abrupt disconnection will occur while streaming
+     * (without closing the connection or sending an EndOfStream message).
+     */
+    ABRUPT,
+    /**
+     * The EOS value indicates that an EndOfStream message will be sent before the final item of the block.
+     * Currently, onError is called, as the client is not able to send actual EOS message
+     */
+    EOS
+}

--- a/simulator/src/main/java/org/hiero/block/simulator/grpc/PublishStreamGrpcClient.java
+++ b/simulator/src/main/java/org/hiero/block/simulator/grpc/PublishStreamGrpcClient.java
@@ -2,7 +2,6 @@
 package org.hiero.block.simulator.grpc;
 
 import com.hedera.hapi.block.stream.protoc.Block;
-import com.hedera.hapi.block.stream.protoc.BlockItem;
 import java.util.List;
 
 /**
@@ -13,14 +12,6 @@ public interface PublishStreamGrpcClient {
      * Initialize, opens a gRPC channel and creates the needed stubs with the passed configuration.
      */
     void init();
-
-    /**
-     * Streams the block item.
-     *
-     * @param blockItems list of the block item to be streamed
-     * @return true if the block item is streamed successfully, false otherwise
-     */
-    boolean streamBlockItem(List<BlockItem> blockItems);
 
     /**
      * Streams the block.

--- a/simulator/src/main/resources/app.properties
+++ b/simulator/src/main/resources/app.properties
@@ -36,6 +36,10 @@ prometheus.endpointPortNumber=9998
 #blockStream.millisecondsPerBlock=500
 #blockStream.blockItemsBatchSize=1_000
 #blockStream.delayBetweenBlockItems=3_000_000
+# When this property is active it causes an abrupt disconnect or sending EndOfStream message (NONE/ABRUPT/EOS)
+#blockStream.midBlockFailType=NONE
+# The number of blocks streamed before the failure
+#blockStream.midBlockFailOffset=0
 
 # ----------------------------------------------
 

--- a/simulator/src/test/java/org/hiero/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
+++ b/simulator/src/test/java/org/hiero/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
@@ -47,6 +47,8 @@ class SimulatorMappedConfigSourceInitializerTest {
         new ConfigMapping("blockStream.streamingMode", "BLOCK_STREAM_STREAMING_MODE"),
         new ConfigMapping("blockStream.millisecondsPerBlock", "BLOCK_STREAM_MILLISECONDS_PER_BLOCK"),
         new ConfigMapping("blockStream.blockItemsBatchSize", "BLOCK_STREAM_BLOCK_ITEMS_BATCH_SIZE"),
+        new ConfigMapping("blockStream.midBlockFailType", "BLOCK_STREAM_MID_BLOCK_FAIL_TYPE"),
+        new ConfigMapping("blockStream.midBlockFailOffset", "BLOCK_STREAM_MID_BLOCK_FAIL_OFFSET"),
 
         // Block consumer configuration
         new ConfigMapping("consumer.startBlockNumber", "CONSUMER_START_BLOCK_NUMBER"),

--- a/simulator/src/test/java/org/hiero/block/simulator/config/logging/SimulatorConfigurationLoggerTest.java
+++ b/simulator/src/test/java/org/hiero/block/simulator/config/logging/SimulatorConfigurationLoggerTest.java
@@ -26,7 +26,7 @@ class SimulatorConfigurationLoggerTest {
         final SimulatorConfigurationLogger configurationLogging = new SimulatorConfigurationLogger(configuration);
         final Map<String, Object> config = configurationLogging.collectConfig(configuration);
         assertNotNull(config);
-        assertEquals(36, config.size());
+        assertEquals(38, config.size());
         for (final Map.Entry<String, Object> entry : config.entrySet()) {
             String value = entry.getValue().toString();
             if (value.contains("*")) {
@@ -42,7 +42,7 @@ class SimulatorConfigurationLoggerTest {
         final SimulatorConfigurationLogger configurationLogging = new SimulatorConfigurationLogger(configuration);
         final Map<String, Object> config = configurationLogging.collectConfig(configuration);
         assertNotNull(config);
-        assertEquals(38, config.size());
+        assertEquals(40, config.size());
         assertEquals("*****", config.get("test.secret").toString());
         assertEquals("", config.get("test.emptySecret").toString());
     }


### PR DESCRIPTION
## Reviewer Notes
Mid-block sending failure can be triggered by setting blockStream.midBlockFailType and blockStream.midBlockFailOffset in app.properties. midBlockFailType takes NONE/ABRUPT/EOS as values. NONE is the default value which disables the feature. ABRUPT causes a runtime exception after sending the header and a random amount of items (without the proof). Currently, EOS (end of stream) causes calling of onError after sending the header and a random amount of items because PublishStreamRequest does not support end of stream messages, only a BlockItemSet.
midBlockFailOffset takes a numeric value and sets the amount on blocks to be sent before the failing block.
Test methods for the new functionality are added.
The streamBlockItem method is removed as it was redundant.

## Related Issue(s)
 Closes #523
