### PR TITLE
ci: Change frequency of running LocalNode test GHA WF to just after merge

### DIFF
--- a/.github/workflows/local-node-test.yaml
+++ b/.github/workflows/local-node-test.yaml
@@ -2,12 +2,6 @@
 name: "Local Node E2E Tests"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-    branches: [main]
   push:
     branches: [main]
     tags: ["v*"]


### PR DESCRIPTION
## Reviewer Notes

Changing the GHA trigger to run only after a PR is merged to `main` since this one is taking `~40mins` and we don't need to run it that often.