### PR TITLE
fix: loading historic with clean state

### DIFF
--- a/block-node/block-providers/files.historic/src/main/java/module-info.java
+++ b/block-node/block-providers/files.historic/src/main/java/module-info.java
@@ -11,12 +11,12 @@ module org.hiero.block.node.blocks.files.historic {
             com.swirlds.config.extensions,
             org.hiero.block.node.app;
 
-    requires com.hedera.pbj.runtime;
-    requires org.hiero.block.stream;
     requires transitive com.swirlds.config.api;
     requires transitive org.hiero.block.node.base;
     requires transitive org.hiero.block.node.spi;
+    requires com.hedera.pbj.runtime;
     requires org.hiero.block.common;
+    requires org.hiero.block.stream;
     requires com.github.luben.zstd_jni;
     requires com.github.spotbugs.annotations;
 

--- a/block-node/spi/src/main/java/org/hiero/block/node/spi/historicalblocks/LongRange.java
+++ b/block-node/spi/src/main/java/org/hiero/block/node/spi/historicalblocks/LongRange.java
@@ -26,17 +26,21 @@ public record LongRange(long start, long end) implements Comparable<LongRange> {
      *                                  or if start is greater than end
      */
     public LongRange {
-        if (start < 0) {
-            throw new IllegalArgumentException("Range start must be non-negative: " + start);
-        }
-        if (end < 0) {
-            throw new IllegalArgumentException("Range end must be non-negative: " + end);
-        }
-        if (start > end) {
-            throw new IllegalArgumentException("Range start must be less than or equal to end: " + start + " > " + end);
-        }
-        if (end > Long.MAX_VALUE - 1) {
-            throw new IllegalArgumentException("Range end must be less than or equal to Long.MAX_VALUE-1: " + end);
+        // Special case: allow both start and end to be -1 for clean state initialization
+        if (!(start == -1 && end == -1)) {
+            if (start < 0) {
+                throw new IllegalArgumentException("Range start must be non-negative: " + start);
+            }
+            if (end < 0) {
+                throw new IllegalArgumentException("Range end must be non-negative: " + end);
+            }
+            if (start > end) {
+                throw new IllegalArgumentException(
+                        "Range start must be less than or equal to end: " + start + " > " + end);
+            }
+            if (end > Long.MAX_VALUE - 1) {
+                throw new IllegalArgumentException("Range end must be less than or equal to Long.MAX_VALUE-1: " + end);
+            }
         }
     }
 

--- a/block-node/spi/src/test/java/org/hiero/block/node/spi/historicalblocks/LongRangeTest.java
+++ b/block-node/spi/src/test/java/org/hiero/block/node/spi/historicalblocks/LongRangeTest.java
@@ -37,6 +37,11 @@ class LongRangeTest {
         assertEquals(10, range3.start());
         assertEquals(10, range3.end());
 
+        // Test special case for clean state initialization
+        final LongRange cleanStateRange = new LongRange(-1, -1);
+        assertEquals(-1, cleanStateRange.start());
+        assertEquals(-1, cleanStateRange.end());
+
         // Test validation failures
         assertThrows(IllegalArgumentException.class, () -> new LongRange(-1, 5));
         assertThrows(IllegalArgumentException.class, () -> new LongRange(5, -1));


### PR DESCRIPTION
## Reviewer Notes
This PR fixes the recently introduced LongRange class to take into consideration the case, when we pass start as -1 and end as -1. This means that we are starting on clean state with no blocks. Otherwise application throws exception and fails to load rest of the plugins.
```
Exception in thread "main" java.lang.IllegalArgumentException: Range start must be non-negative: -1
	at org.hiero.block.node.spi@0.9.0-SNAPSHOT/org.hiero.block.node.spi.historicalblocks.LongRange.<init>(LongRange.java:32)
	at org.hiero.block.node.base@0.9.0-SNAPSHOT/org.hiero.block.node.base.ranges.ConcurrentLongRangeSet.add(ConcurrentLongRangeSet.java:164)
	at org.hiero.block.node.blocks.files.historic@0.9.0-SNAPSHOT/org.hiero.block.node.blocks.files.historic.BlocksFilesHistoricPlugin.init(BlocksFilesHistoricPlugin.java:69)
	at org.hiero.block.node.app@0.9.0-SNAPSHOT/org.hiero.block.node.app.BlockNodeApp.<init>(BlockNodeApp.java:168)
	at org.hiero.block.node.app@0.9.0-SNAPSHOT/org.hiero.block.node.app.BlockNodeApp.main(BlockNodeApp.java:259)
```
## Related Issue(s)
 Use keywords `Fix, Fixes, Fixed, Close, Closes, Closed, Resolve, Resolves, Resolved`
to connect an issue to be closed by this pull request.
