### PR TITLE
test: Files Historic Plugin Unit Tests Pt 2

### DIFF
--- a/block-node/base/build.gradle.kts
+++ b/block-node/base/build.gradle.kts
@@ -16,5 +16,6 @@ mainModuleInfo {
 testModuleInfo {
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
+    requires("org.assertj.core")
     requires("org.mockito")
 }

--- a/block-node/base/src/main/java/org/hiero/block/node/base/CompressionType.java
+++ b/block-node/base/src/main/java/org/hiero/block/node/base/CompressionType.java
@@ -91,4 +91,18 @@ public enum CompressionType {
             case NONE -> data;
         };
     }
+
+    /**
+     * Decompresses the given data using the appropriate compression type.
+     *
+     * @param data the data to decompress
+     * @return the decompressed data
+     */
+    public byte[] decompress(@NonNull final byte[] data) {
+        Objects.requireNonNull(data);
+        return switch (this) {
+            case ZSTD -> Zstd.decompress(data, data.length);
+            case NONE -> data;
+        };
+    }
 }

--- a/block-node/base/src/main/java/org/hiero/block/node/base/CompressionType.java
+++ b/block-node/base/src/main/java/org/hiero/block/node/base/CompressionType.java
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.base;
 
+import com.github.luben.zstd.Zstd;
+import com.github.luben.zstd.ZstdInputStream;
+import com.github.luben.zstd.ZstdOutputStream;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Objects;
 
 /**
  * An enum that reflects the type of compression that is used to compress the blocks that are stored within the
@@ -20,6 +25,8 @@ public enum CompressionType {
      */
     NONE("");
 
+    /** The default compression level for Zstandard compression. */
+    private static final int DEFAULT_ZSTD_COMPRESSION_LEVEL = 3;
     /** The file extension for this compression type. */
     private final String fileExtension;
 
@@ -48,9 +55,10 @@ public enum CompressionType {
      * @return the wrapped input stream
      * @throws IOException if an I/O error occurs
      */
-    public InputStream wrapStream(InputStream streamToWrap) throws IOException {
+    public InputStream wrapStream(@NonNull final InputStream streamToWrap) throws IOException {
+        Objects.requireNonNull(streamToWrap);
         return switch (this) {
-            case ZSTD -> new com.github.luben.zstd.ZstdInputStream(streamToWrap);
+            case ZSTD -> new ZstdInputStream(streamToWrap);
             case NONE -> streamToWrap;
         };
     }
@@ -62,10 +70,25 @@ public enum CompressionType {
      * @return the wrapped output stream
      * @throws IOException if an I/O error occurs
      */
-    public OutputStream wrapStream(OutputStream streamToWrap) throws IOException {
+    public OutputStream wrapStream(@NonNull final OutputStream streamToWrap) throws IOException {
+        Objects.requireNonNull(streamToWrap);
         return switch (this) {
-            case ZSTD -> new com.github.luben.zstd.ZstdOutputStream(streamToWrap, 3);
+            case ZSTD -> new ZstdOutputStream(streamToWrap, DEFAULT_ZSTD_COMPRESSION_LEVEL);
             case NONE -> streamToWrap;
+        };
+    }
+
+    /**
+     * Compresses the given data using the appropriate compression type.
+     *
+     * @param data the data to compress
+     * @return the compressed data
+     */
+    public byte[] compress(@NonNull final byte[] data) {
+        Objects.requireNonNull(data);
+        return switch (this) {
+            case ZSTD -> Zstd.compress(data, DEFAULT_ZSTD_COMPRESSION_LEVEL);
+            case NONE -> data;
         };
     }
 }

--- a/block-node/base/src/test/java/org/hiero/block/node/base/CompressionTypeTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/CompressionTypeTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.base;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.github.luben.zstd.ZstdInputStream;
@@ -10,43 +11,128 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 /**
- * Unit tests for the CompressionType enum.
+ * Unit tests for the {@link CompressionType} enum.
  */
-public class CompressionTypeTest {
+@DisplayName("CompressionType Tests")
+class CompressionTypeTest {
+    /**
+     * Functionality tests for the {@link CompressionType} enum.
+     */
+    @Nested
+    @DisplayName("Functionality Tests")
+    final class FunctionalityTests {
+        /**
+         * This test aims to verify the correct file extension is returned for
+         * each compression type.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test extension() correctly returns the file extension based on the compression type")
+        void testExtension(final CompressionType compressionType) {
+            final String expected = compressionType.extension();
+            switch (compressionType) {
+                case ZSTD -> assertThat(".zstd").isEqualTo(expected);
+                case NONE -> assertThat("").isEqualTo(expected);
+            }
+        }
 
-    @Test
-    void testExtension() {
-        assertEquals(".zstd", CompressionType.ZSTD.extension());
-        assertEquals("", CompressionType.NONE.extension());
+        /**
+         * This test aims to verify that a given input stream is correctly
+         * wrapped based on the compression type.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test wrapStream(InputStream) correctly wraps the input stream based on the compression type")
+        void testWrapStreamInputStream(final CompressionType compressionType) throws IOException {
+            final ByteArrayInputStream original = new ByteArrayInputStream(new byte[0]);
+            final InputStream actual = compressionType.wrapStream(original);
+            switch (compressionType) {
+                case ZSTD -> assertThat(actual)
+                        .isNotNull()
+                        .isExactlyInstanceOf(ZstdInputStream.class)
+                        .isNotSameAs(original);
+                case NONE -> assertThat(actual)
+                        .isNotNull()
+                        .isExactlyInstanceOf(original.getClass())
+                        .isSameAs(original);
+            }
+        }
+
+        /**
+         * This test aims to verify that a given output stream is correctly
+         * wrapped based on the compression type.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test wrapStream(OutputStream) correctly wraps the output stream based on the compression type")
+        void testWrapStreamOutputStream(final CompressionType compressionType) throws IOException {
+            final ByteArrayOutputStream original = new ByteArrayOutputStream();
+            final OutputStream actual = compressionType.wrapStream(original);
+            switch (compressionType) {
+                case ZSTD -> assertThat(actual)
+                        .isNotNull()
+                        .isExactlyInstanceOf(ZstdOutputStream.class)
+                        .isNotSameAs(original);
+                case NONE -> assertThat(actual)
+                        .isNotNull()
+                        .isExactlyInstanceOf(ByteArrayOutputStream.class)
+                        .isSameAs(original);
+            }
+        }
+
+        /**
+         * This test aims to verify that the compression works correctly for the
+         * wrapped output stream.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test writeStream() correctly compresses the data written to the output stream")
+        void testWriteStream(final CompressionType compressionType) throws IOException {
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            final OutputStream wrappedBaos = compressionType.wrapStream(baos);
+            final byte[] expected = "test expected data".getBytes();
+            wrappedBaos.write(expected);
+            wrappedBaos.close(); // close always because otherwise some footers may not be written
+            // decompress the data using the input compression type in order to be able to compare
+            final byte[] actual = compressionType.decompress(baos.toByteArray());
+            assertArrayEquals(expected, actual);
+        }
+
+        /**
+         * This test aims to verify that the decompression works correctly for the
+         * wrapped input stream.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test readStream() correctly decompresses the data read from the input stream")
+        void testReadStream(final CompressionType compressionType) throws IOException {
+            final byte[] expected = "test expected data".getBytes();
+            // make sure to compress the data that will be read through the wrapped input stream
+            final ByteArrayInputStream bais = new ByteArrayInputStream(compressionType.compress(expected));
+            final InputStream wrappedBais = compressionType.wrapStream(bais);
+            final byte[] actual = wrappedBais.readAllBytes();
+            wrappedBais.close();
+            assertArrayEquals(expected, actual);
+        }
     }
 
-    @Test
-    void testWrapStreamInputStream() throws IOException {
-        byte[] data = "test data".getBytes();
-        InputStream inputStream = new ByteArrayInputStream(data);
-
-        InputStream zstdStream = CompressionType.ZSTD.wrapStream(inputStream);
-        assertNotNull(zstdStream);
-        assertInstanceOf(ZstdInputStream.class, zstdStream);
-
-        InputStream noneStream = CompressionType.NONE.wrapStream(inputStream);
-        assertNotNull(noneStream);
-        assertFalse(noneStream instanceof com.github.luben.zstd.ZstdInputStream);
-    }
-
-    @Test
-    void testWrapStreamOutputStream() throws IOException {
-        OutputStream outputStream = new ByteArrayOutputStream();
-
-        OutputStream zstdStream = CompressionType.ZSTD.wrapStream(outputStream);
-        assertNotNull(zstdStream);
-        assertInstanceOf(ZstdOutputStream.class, zstdStream);
-
-        OutputStream noneStream = CompressionType.NONE.wrapStream(outputStream);
-        assertNotNull(noneStream);
-        assertFalse(noneStream instanceof com.github.luben.zstd.ZstdOutputStream);
+    /**
+     * This test aims to verify that the compression and decompression methods
+     * work correctly for the compression type.
+     */
+    @ParameterizedTest
+    @EnumSource(CompressionType.class)
+    @DisplayName("Test compress() and decompress() methods")
+    void testCompressAndDecompress(final CompressionType compressionType) {
+        final byte[] expected = "test expected data".getBytes();
+        final byte[] compressed = compressionType.compress(expected);
+        final byte[] actual = compressionType.decompress(compressed);
+        assertThat(actual).isEqualTo(expected).containsExactly(expected);
     }
 }

--- a/block-node/block-providers/files.historic/build.gradle.kts
+++ b/block-node/block-providers/files.historic/build.gradle.kts
@@ -19,4 +19,5 @@ testModuleInfo {
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
     requires("org.assertj.core")
+    requires("org.hiero.block.node.app.test.fixtures")
 }

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockPath.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockPath.java
@@ -53,17 +53,16 @@ record BlockPath(Path dirPath, Path zipFilePath, String blockNumStr, String bloc
         final String blockNumberStr = blockNumberFormated(blockNumber);
         // split string into digits for zip and for directories
         // offsetToZip is the number of digits in the block number that will be split into directories
-        final int offsetToZip = blockNumberStr.length() - DIGITS_PER_ZIP_FILE_NAME - config.powersOfTenPerZipFileContents();
+        final int offsetToZip =
+                blockNumberStr.length() - DIGITS_PER_ZIP_FILE_NAME - config.powersOfTenPerZipFileContents();
         // slice the block number string, directory part
         final String directoryDigits = blockNumberStr.substring(0, offsetToZip);
         // slice the block number string, zip file part, with DIGITS_PER_ZIP_FILE_NAME = 1 this is always 1 digit
-        final String zipFileNameDigits =
-                blockNumberStr.substring(offsetToZip, offsetToZip + DIGITS_PER_ZIP_FILE_NAME);
+        final String zipFileNameDigits = blockNumberStr.substring(offsetToZip, offsetToZip + DIGITS_PER_ZIP_FILE_NAME);
         // start building directory path to zip file, by slicing directoryDigits by DIGITS_PER_DIR
         Path dirPath = config.rootPath();
         for (int i = 0; i < directoryDigits.length(); i += DIGITS_PER_DIR) {
-            final String dirName =
-                    directoryDigits.substring(i, Math.min(i + DIGITS_PER_DIR, directoryDigits.length()));
+            final String dirName = directoryDigits.substring(i, Math.min(i + DIGITS_PER_DIR, directoryDigits.length()));
             dirPath = dirPath.resolve(dirName);
         }
         // create zip file name, there are always 10 zip files in each base directory as DIGITS_PER_ZIP_FILE_NAME = 1

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockPath.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockPath.java
@@ -18,6 +18,11 @@ import org.hiero.block.common.utils.Preconditions;
  * @param blockFileName The name of the block file in the zip file
  */
 record BlockPath(Path dirPath, Path zipFilePath, String blockNumStr, String blockFileName) {
+    /** The number of block number digits per directory level. For example 3 = 1000 directories in each directory */
+    public static final int DIGITS_PER_DIR = 3;
+    /** The number of digits of zip files in bottom level directory, For example 1 = 10 zip files in each directory */
+    public static final int DIGITS_PER_ZIP_FILE_NAME = 1;
+
     /**
      * Constructor.
      *
@@ -47,21 +52,30 @@ record BlockPath(Path dirPath, Path zipFilePath, String blockNumStr, String bloc
         // convert block number to string
         final String blockNumberStr = blockNumberFormated(blockNumber);
         // split string into digits for zip and for directories
-        final int offsetToZip = blockNumberStr.length() - config.digitsPerZipFileName() - config.digitsPerDir();
+        // offsetToZip is the number of digits in the block number that will be split into directories
+        final int offsetToZip = blockNumberStr.length() - DIGITS_PER_ZIP_FILE_NAME - config.powersOfTenPerZipFileContents();
+        // slice the block number string, directory part
         final String directoryDigits = blockNumberStr.substring(0, offsetToZip);
+        // slice the block number string, zip file part, with DIGITS_PER_ZIP_FILE_NAME = 1 this is always 1 digit
         final String zipFileNameDigits =
-                blockNumberStr.substring(offsetToZip, offsetToZip + config.digitsPerZipFileName());
-        // start building path to zip file
+                blockNumberStr.substring(offsetToZip, offsetToZip + DIGITS_PER_ZIP_FILE_NAME);
+        // start building directory path to zip file, by slicing directoryDigits by DIGITS_PER_DIR
         Path dirPath = config.rootPath();
-        for (int i = 0; i < directoryDigits.length(); i += config.digitsPerDir()) {
+        for (int i = 0; i < directoryDigits.length(); i += DIGITS_PER_DIR) {
             final String dirName =
-                    directoryDigits.substring(i, Math.min(i + config.digitsPerDir(), directoryDigits.length()));
+                    directoryDigits.substring(i, Math.min(i + DIGITS_PER_DIR, directoryDigits.length()));
             dirPath = dirPath.resolve(dirName);
         }
-        // create zip file name
-        final String zipFileName = zipFileNameDigits + "000s.zip";
+        // create zip file name, there are always 10 zip files in each base directory as DIGITS_PER_ZIP_FILE_NAME = 1
+        // the name of the zip file is the set of values stored in the zip. So if there are 1000 files in a zip file
+        // the zip file names will be 0000s.zip, 1000s.zip, 2000s.zip, 3000s.zip etc.
+        final String zipFileName = zipFileNameDigits + "0".repeat(config.powersOfTenPerZipFileContents()) + "s.zip";
+        // create the block file name, this is always the block number with the BLOCK_FILE_EXTENSION it is always the
+        // whole number so if the file is manually expanded the blocks always have the full block number so there are
+        // no duplicates or confusion.
         final String fileName =
                 blockNumberStr + BLOCK_FILE_EXTENSION + config.compression().extension();
+        // assemble the BlockPath from all the components
         return new BlockPath(dirPath, dirPath.resolve(zipFileName), blockNumberStr, fileName);
     }
 }

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
@@ -63,7 +63,7 @@ public class BlocksFilesHistoricPlugin implements BlockProviderPlugin, BlockNoti
         }
         // register to listen to block notifications
         context.blockMessaging().registerBlockNotificationHandler(this, false, "Blocks Files Historic");
-        numberOfBlocksPerZipFile = (int) Math.pow(10, config.digitsPerZipFileContents());
+        numberOfBlocksPerZipFile = (int) Math.pow(10, config.powersOfTenPerZipFileContents());
         zipBlockArchive = new ZipBlockArchive(context, config);
         // get the first and last block numbers from the zipBlockArchive
         availableBlocks.add(zipBlockArchive.minStoredBlockNumber(), zipBlockArchive.maxStoredBlockNumber());

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
@@ -17,27 +17,22 @@ import org.hiero.block.node.base.Loggable;
  * @param rootPath provides the root path for saving historic blocks
  * @param compression compression type to use for the storage. It is assumed this never changes while a node is running
  *                    and has existing files.
- * @param digitsPerDir the number of block number digits per directory level. For example 3 = 1000 directories in each
- *                     directory
- * @param digitsPerZipFileName the number of digits of zip files in bottom level directory, For example 1 = 10 zip files
- *                             in each directory
- * @param digitsPerZipFileContents the number of digits of files in the zip file. For example 4 = 1000 files in each zip
+ * @param powersOfTenPerZipFileContents the number files in a zip file specified in powers of ten. Can can be one of
+ *                                 1 = 10, 2 = 100, 3 = 1000, 4 = 10,000, 5 = 100,000, or 6 = 1,000,000 files per
+ *                                 zip. Changing this is handy for testing, as having to wait for 10,000 blocks to be
+ *                                 created is a long time.
  */
 @ConfigData("files.historic")
 public record FilesHistoricConfig(
         @Loggable @ConfigProperty(defaultValue = "/opt/hashgraph/blocknode/data/historic") Path rootPath,
         @Loggable @ConfigProperty(defaultValue = "ZSTD") CompressionType compression,
-        @Loggable @ConfigProperty(defaultValue = "3") @Min(1) @Max(6) int digitsPerDir,
-        @Loggable @ConfigProperty(defaultValue = "1") @Min(1) @Max(10) int digitsPerZipFileName,
-        @Loggable @ConfigProperty(defaultValue = "4") @Min(1) @Max(10) int digitsPerZipFileContents) {
+        @Loggable @ConfigProperty(defaultValue = "4") @Min(1) @Max(6) int powersOfTenPerZipFileContents) {
     /**
      * Constructor.
      */
     public FilesHistoricConfig {
         Objects.requireNonNull(rootPath);
         Objects.requireNonNull(compression);
-        Preconditions.requireInRange(digitsPerDir, 1, 6);
-        Preconditions.requireInRange(digitsPerZipFileName, 1, 10);
-        Preconditions.requireInRange(digitsPerZipFileContents, 1, 10);
+        Preconditions.requireInRange(powersOfTenPerZipFileContents, 1, 6);
     }
 }

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
@@ -81,7 +81,12 @@ public class ZipBlockArchive {
             zipOutputStream.setMethod(ZipOutputStream.STORED);
             for (long blockNumber = firstBlockNumber; blockNumber < lastBlockNumber; blockNumber++) {
                 // compute block filename
-                final String blockFileName = BlockFile.blockFileName(blockNumber);
+                // todo should we also not append the compression extension to the filename?
+                // todo I feel like the accessor should generally be getting us the block file name
+                //   what if the file is zstd compressed but the current runtime compression is none?
+                //   then the file name would be wrong?
+                final String blockFileName = BlockFile.blockFileName(blockNumber)
+                        .concat(config.compression().extension());
                 // get block accessor
                 final BlockAccessor blockAccessor = blockAccessors.get((int) (blockNumber - firstBlockNumber));
                 // get the bytes to write, we have to do this as we need to know the size
@@ -115,7 +120,8 @@ public class ZipBlockArchive {
         final BlockPath blockPath = computeBlockPath(config, blockNumber);
         if (Files.exists(blockPath.zipFilePath())) {
             return new ZipBlockAccessor(blockPath);
-        }
+        } // todo should we also not check if the entry exists so that we know
+        //     for sure that the block exists?
         return null;
     }
 

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
@@ -49,7 +49,7 @@ public class ZipBlockArchive {
         this.context = context;
         this.historicalBlockFacility = context.historicalBlockProvider();
         this.config = historicConfig;
-        numberOfBlocksPerZipFile = (int) Math.pow(10, historicConfig.digitsPerZipFileContents());
+        numberOfBlocksPerZipFile = (int) Math.pow(10, historicConfig.powersOfTenPerZipFileContents());
         format = switch (historicConfig.compression()) {
             case ZSTD -> Format.ZSTD_PROTOBUF;
             case NONE -> Format.PROTOBUF;};

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
@@ -403,10 +403,10 @@ class BlockPathTest {
                     Arguments.of(
                             "0000000000000000000",
                             "0000000000000000000.blk"+ compressionType.extension(),
-                            "/000/000/000/000/000/0000s.zip",
+                            "/000/000/000/000/0000000s.zip",
                             0L,
                             compressionType,
-                            3),
+                            6),
                     Arguments.of(
                             "0000000000000000010",
                             "0000000000000000010.blk"+ compressionType.extension(),

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
@@ -62,13 +62,21 @@ class BlockPathTest {
          * valid inputs.
          */
         @ParameterizedTest
-        @MethodSource("org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsDefaultConfig")
+        @MethodSource({
+            "org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsDefaultConfig",
+            "org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsConfigVariation1"
+        })
         @DisplayName("Test constructor throws no exceptions with valid inputs")
-        void testConstructorValidInput(final String blockNumStr, final String blockFileName, final String zipFilePath) {
+        void testConstructorValidInput(final ArgumentsAccessor argAccessor) {
+            final String blockNumStr = argAccessor.getString(0);
+            final String blockFileName = argAccessor.getString(1);
+            final String zipFilePath = argAccessor.getString(2);
+            final CompressionType compressionType = argAccessor.get(4, CompressionType.class);
             final Path resolvedZipFilePath = jimfs.getPath(zipFilePath);
             final Path resolvedDirPath = resolvedZipFilePath.getParent();
             assertThatNoException()
-                    .isThrownBy(() -> new BlockPath(resolvedDirPath, resolvedZipFilePath, blockNumStr, blockFileName));
+                    .isThrownBy(() -> new BlockPath(
+                            resolvedDirPath, resolvedZipFilePath, blockNumStr, blockFileName, compressionType));
         }
 
         /**
@@ -77,17 +85,23 @@ class BlockPathTest {
          * valid inputs.
          */
         @ParameterizedTest
-        @MethodSource("org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsDefaultConfig")
+        @MethodSource({
+            "org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsDefaultConfig",
+            "org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsConfigVariation1"
+        })
         @DisplayName("Test constructor does not create any paths with valid inputs")
-        void testConstructorValidInputNoCreatePaths(
-                final String blockNumStr, final String blockFileName, final String zipFilePath) {
+        void testConstructorValidInputNoCreatePaths(final ArgumentsAccessor argAccessor) {
+            final String blockNumStr = argAccessor.getString(0);
+            final String blockFileName = argAccessor.getString(1);
+            final String zipFilePath = argAccessor.getString(2);
+            final CompressionType compressionType = argAccessor.get(4, CompressionType.class);
             final Path resolvedZipFilePath = jimfs.getPath(zipFilePath);
             final Path resolvedDirPath = resolvedZipFilePath.getParent();
             // Check that the directory and zip file paths do not exist pre call
             assertThat(resolvedDirPath).doesNotExist();
             assertThat(resolvedZipFilePath).doesNotExist();
             // call
-            new BlockPath(resolvedDirPath, resolvedZipFilePath, blockNumStr, blockFileName);
+            new BlockPath(resolvedDirPath, resolvedZipFilePath, blockNumStr, blockFileName, compressionType);
             // Check that the directory and zip file paths are not created post call
             assertThat(resolvedDirPath).doesNotExist();
             assertThat(resolvedZipFilePath).doesNotExist();
@@ -99,13 +113,20 @@ class BlockPathTest {
          * the directory path is null.
          */
         @ParameterizedTest
-        @MethodSource("org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsDefaultConfig")
+        @MethodSource({
+            "org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsDefaultConfig",
+            "org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsConfigVariation1"
+        })
         @DisplayName("Test constructor throws NullPointerException when dirPath is null")
-        void testConstructorDirPathNull(
-                final String blockNumStr, final String blockFileName, final String zipFilePath) {
+        void testConstructorDirPathNull(final ArgumentsAccessor argAccessor) {
+            final String blockNumStr = argAccessor.getString(0);
+            final String blockFileName = argAccessor.getString(1);
+            final String zipFilePath = argAccessor.getString(2);
+            final CompressionType compressionType = argAccessor.get(4, CompressionType.class);
             final Path resolvedZipFilePath = jimfs.getPath(zipFilePath);
             assertThatNullPointerException()
-                    .isThrownBy(() -> new BlockPath(null, resolvedZipFilePath, blockNumStr, blockFileName));
+                    .isThrownBy(() ->
+                            new BlockPath(null, resolvedZipFilePath, blockNumStr, blockFileName, compressionType));
         }
 
         /**
@@ -114,13 +135,20 @@ class BlockPathTest {
          * the zip file path is null.
          */
         @ParameterizedTest
-        @MethodSource("org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsDefaultConfig")
+        @MethodSource({
+            "org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsDefaultConfig",
+            "org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsConfigVariation1"
+        })
         @DisplayName("Test constructor throws NullPointerException when zipFilePath is null")
-        void testConstructorZipFilePathNull(
-                final String blockNumStr, final String blockFileName, final String zipFilePath) {
+        void testConstructorZipFilePathNull(final ArgumentsAccessor argAccessor) {
+            final String blockNumStr = argAccessor.getString(0);
+            final String blockFileName = argAccessor.getString(1);
+            final String zipFilePath = argAccessor.getString(2);
+            final CompressionType compressionType = argAccessor.get(4, CompressionType.class);
             final Path resolvedDirPath = jimfs.getPath(zipFilePath).getParent();
             assertThatNullPointerException()
-                    .isThrownBy(() -> new BlockPath(resolvedDirPath, null, blockNumStr, blockFileName));
+                    .isThrownBy(
+                            () -> new BlockPath(resolvedDirPath, null, blockNumStr, blockFileName, compressionType));
         }
 
         /**
@@ -129,15 +157,20 @@ class BlockPathTest {
          * the block number string is blank.
          */
         @ParameterizedTest
-        @MethodSource("org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsDefaultConfig")
+        @MethodSource({
+            "org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsDefaultConfig",
+            "org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsConfigVariation1"
+        })
         @DisplayName("Test constructor throws IllegalArgumentException when blockNumStr is blank")
         void testConstructorBlockNumStrBlank(final ArgumentsAccessor argAccessor) {
             final String blockFileName = argAccessor.getString(1);
             final String zipFilePath = argAccessor.getString(2);
+            final CompressionType compressionType = argAccessor.get(4, CompressionType.class);
             final Path resolvedZipFilePath = jimfs.getPath(zipFilePath);
             final Path resolvedDirPath = resolvedZipFilePath.getParent();
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> new BlockPath(resolvedDirPath, resolvedZipFilePath, "", blockFileName));
+                    .isThrownBy(() ->
+                            new BlockPath(resolvedDirPath, resolvedZipFilePath, "", blockFileName, compressionType));
         }
 
         /**
@@ -146,15 +179,20 @@ class BlockPathTest {
          * the block file name is blank.
          */
         @ParameterizedTest
-        @MethodSource("org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsDefaultConfig")
+        @MethodSource({
+            "org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsDefaultConfig",
+            "org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsConfigVariation1"
+        })
         @DisplayName("Test constructor throws IllegalArgumentException when blockFileName is blank")
         void testConstructorBlockFileNameBlank(final ArgumentsAccessor argAccessor) {
             final String blockNumStr = argAccessor.getString(0);
             final String zipFilePath = argAccessor.getString(2);
+            final CompressionType compressionType = argAccessor.get(4, CompressionType.class);
             final Path resolvedZipFilePath = jimfs.getPath(zipFilePath);
             final Path resolvedDirPath = resolvedZipFilePath.getParent();
             assertThatIllegalArgumentException()
-                    .isThrownBy(() -> new BlockPath(resolvedDirPath, resolvedZipFilePath, blockNumStr, ""));
+                    .isThrownBy(() ->
+                            new BlockPath(resolvedDirPath, resolvedZipFilePath, blockNumStr, "", compressionType));
         }
     }
 
@@ -180,20 +218,21 @@ class BlockPathTest {
                 final String expectedBlockFileName,
                 final String expectedRelativeZipFilePathStr,
                 final long blockNumber,
-                final CompressionType compressionType,
+                final CompressionType expectedCompressionType,
                 final int digitsPerZipFileContents) {
             final Path expectedZipFilePath = jimfs.getPath(ROOT_PATH + expectedRelativeZipFilePathStr);
             final Path expectedDirPath = expectedZipFilePath.getParent();
             // create the config to use for the test, resolve paths with jimfs
-            final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(jimfs.getPath(ROOT_PATH), compressionType, digitsPerZipFileContents);
+            final FilesHistoricConfig testConfig = new FilesHistoricConfig(
+                    jimfs.getPath(ROOT_PATH), expectedCompressionType, digitsPerZipFileContents);
             final BlockPath actual = BlockPath.computeBlockPath(testConfig, blockNumber);
             assertThat(actual)
                     .isNotNull()
                     .returns(expectedBlockNumStr, from(BlockPath::blockNumStr))
                     .returns(expectedBlockFileName, from(BlockPath::blockFileName))
                     .returns(expectedZipFilePath, from(BlockPath::zipFilePath))
-                    .returns(expectedDirPath, from(BlockPath::dirPath));
+                    .returns(expectedDirPath, from(BlockPath::dirPath))
+                    .returns(expectedCompressionType, from(BlockPath::compressionType));
         }
     }
 

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
@@ -166,7 +166,10 @@ class BlockPathTest {
          * number and default configuration.
          */
         @ParameterizedTest
-        @MethodSource("org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsDefaultConfig")
+        @MethodSource({
+            //            "org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsDefaultConfig",
+            "org.hiero.block.node.blocks.files.historic.BlockPathTest#validBlockPathsConfigVariation1"
+        })
         @DisplayName("Test computeBlockPath with valid inputs")
         void testComputeBlockPath(
                 final String expectedBlockNumStr,
@@ -194,7 +197,7 @@ class BlockPathTest {
     }
 
     /**
-     * Stream of arguments of valid block paths.
+     * Stream of arguments of valid block paths with default config.
      */
     private static Stream<Arguments> validBlockPathsDefaultConfig() {
         // default configuration
@@ -209,6 +212,147 @@ class BlockPathTest {
                         "0000000000123456789",
                         "0000000000123456789.blk.zstd",
                         configRootPath.concat("/000/000/000/012/345/6000s.zip"),
+                        123_456_789L,
+                        baseConfig),
+                Arguments.of(
+                        "1234567890123456789",
+                        "1234567890123456789.blk.zstd",
+                        configRootPath.concat("/123/456/789/012/345/6000s.zip"),
+                        1_234_567_890_123_456_789L,
+                        baseConfig),
+                Arguments.of(
+                        "0000000000000000000",
+                        "0000000000000000000.blk.zstd",
+                        configRootPath.concat("/000/000/000/000/000/0000s.zip"),
+                        0L,
+                        baseConfig),
+                Arguments.of(
+                        "0000000000000000010",
+                        "0000000000000000010.blk.zstd",
+                        configRootPath.concat("/000/000/000/000/000/0000s.zip"),
+                        10L,
+                        baseConfig),
+                Arguments.of(
+                        "0000000000000000100",
+                        "0000000000000000100.blk.zstd",
+                        configRootPath.concat("/000/000/000/000/000/0000s.zip"),
+                        100L,
+                        baseConfig),
+                Arguments.of(
+                        "0000000000000001000",
+                        "0000000000000001000.blk.zstd",
+                        configRootPath.concat("/000/000/000/000/000/1000s.zip"),
+                        1_000L,
+                        baseConfig),
+                Arguments.of(
+                        "0000000000000010000",
+                        "0000000000000010000.blk.zstd",
+                        configRootPath.concat("/000/000/000/000/001/0000s.zip"),
+                        10_000L,
+                        baseConfig),
+                Arguments.of(
+                        "0000000000000100000",
+                        "0000000000000100000.blk.zstd",
+                        configRootPath.concat("/000/000/000/000/010/0000s.zip"),
+                        100_000L,
+                        baseConfig),
+                Arguments.of(
+                        "0000000000001000000",
+                        "0000000000001000000.blk.zstd",
+                        configRootPath.concat("/000/000/000/000/100/0000s.zip"),
+                        1_000_000L,
+                        baseConfig),
+                Arguments.of(
+                        "0000000000010000000",
+                        "0000000000010000000.blk.zstd",
+                        configRootPath.concat("/000/000/000/001/000/0000s.zip"),
+                        10_000_000L,
+                        baseConfig),
+                Arguments.of(
+                        "0000000000100000000",
+                        "0000000000100000000.blk.zstd",
+                        configRootPath.concat("/000/000/000/010/000/0000s.zip"),
+                        100_000_000L,
+                        baseConfig),
+                Arguments.of(
+                        "0000000001000000000",
+                        "0000000001000000000.blk.zstd",
+                        configRootPath.concat("/000/000/000/100/000/0000s.zip"),
+                        1_000_000_000L,
+                        baseConfig),
+                Arguments.of(
+                        "0000000010000000000",
+                        "0000000010000000000.blk.zstd",
+                        configRootPath.concat("/000/000/001/000/000/0000s.zip"),
+                        10_000_000_000L,
+                        baseConfig),
+                Arguments.of(
+                        "0000000100000000000",
+                        "0000000100000000000.blk.zstd",
+                        configRootPath.concat("/000/000/010/000/000/0000s.zip"),
+                        100_000_000_000L,
+                        baseConfig),
+                Arguments.of(
+                        "0000001000000000000",
+                        "0000001000000000000.blk.zstd",
+                        configRootPath.concat("/000/000/100/000/000/0000s.zip"),
+                        1_000_000_000_000L,
+                        baseConfig),
+                Arguments.of(
+                        "0000010000000000000",
+                        "0000010000000000000.blk.zstd",
+                        configRootPath.concat("/000/001/000/000/000/0000s.zip"),
+                        10_000_000_000_000L,
+                        baseConfig),
+                Arguments.of(
+                        "0000100000000000000",
+                        "0000100000000000000.blk.zstd",
+                        configRootPath.concat("/000/010/000/000/000/0000s.zip"),
+                        100_000_000_000_000L,
+                        baseConfig),
+                Arguments.of(
+                        "0001000000000000000",
+                        "0001000000000000000.blk.zstd",
+                        configRootPath.concat("/000/100/000/000/000/0000s.zip"),
+                        1_000_000_000_000_000L,
+                        baseConfig),
+                Arguments.of(
+                        "0010000000000000000",
+                        "0010000000000000000.blk.zstd",
+                        configRootPath.concat("/001/000/000/000/000/0000s.zip"),
+                        10_000_000_000_000_000L,
+                        baseConfig),
+                Arguments.of(
+                        "0100000000000000000",
+                        "0100000000000000000.blk.zstd",
+                        configRootPath.concat("/010/000/000/000/000/0000s.zip"),
+                        100_000_000_000_000_000L,
+                        baseConfig),
+                Arguments.of(
+                        "9223372036854775807",
+                        "9223372036854775807.blk.zstd",
+                        configRootPath.concat("/922/337/203/685/477/5000s.zip"),
+                        Long.MAX_VALUE,
+                        baseConfig));
+    }
+
+    /**
+     * Stream of arguments of valid block paths with config variation 1.
+     */
+    private static Stream<Arguments> validBlockPathsConfigVariation1() {
+        // default configuration
+        final FilesHistoricConfig baseConfig = ConfigurationBuilder.create()
+                .withConfigDataType(FilesHistoricConfig.class)
+                .withValue("files.historic.digitsPerDir", "1")
+                .build()
+                .getConfigData(FilesHistoricConfig.class);
+        // root path from config, to use below to create the zip file path (concat)
+        final String configRootPath = baseConfig.rootPath().toString();
+        return Stream.of(
+                Arguments.of(
+                        "0000000000123456789",
+                        "0000000000123456789.blk.zstd",
+                        configRootPath.concat("/0/0/0/0/0/0/0/0/0/0/1/2/3/4/5/6000s.zip"),
                         123_456_789L,
                         baseConfig),
                 Arguments.of(

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
@@ -185,10 +185,8 @@ class BlockPathTest {
             final Path expectedZipFilePath = jimfs.getPath(ROOT_PATH + expectedRelativeZipFilePathStr);
             final Path expectedDirPath = expectedZipFilePath.getParent();
             // create the config to use for the test, resolve paths with jimfs
-            final FilesHistoricConfig testConfig = new FilesHistoricConfig(
-                    jimfs.getPath(ROOT_PATH),
-                    compressionType,
-                    digitsPerZipFileContents);
+            final FilesHistoricConfig testConfig =
+                    new FilesHistoricConfig(jimfs.getPath(ROOT_PATH), compressionType, digitsPerZipFileContents);
             final BlockPath actual = BlockPath.computeBlockPath(testConfig, blockNumber);
             assertThat(actual)
                     .isNotNull()
@@ -363,177 +361,176 @@ class BlockPathTest {
      */
     private static Stream<Arguments> validBlockPathsConfigVariation1() {
         final List<Arguments> argumentsList = new ArrayList<>();
-        for(CompressionType compressionType : CompressionType.values()) {
+        for (final CompressionType compressionType : CompressionType.values()) {
             argumentsList.addAll(List.of(
                     Arguments.of(
                             "0000000000123456789",
-                            "0000000000123456789.blk"+ compressionType.extension(),
+                            "0000000000123456789.blk" + compressionType.extension(),
                             "/000/000/000/012/345/67/80s.zip",
                             123_456_789L,
                             compressionType,
                             1),
                     Arguments.of(
                             "0000000000123456789",
-                            "0000000000123456789.blk"+ compressionType.extension(),
+                            "0000000000123456789.blk" + compressionType.extension(),
                             "/000/000/000/012/345/6/700s.zip",
                             123_456_789L,
                             compressionType,
                             2),
                     Arguments.of(
                             "0000000000123456789",
-                            "0000000000123456789.blk"+ compressionType.extension(),
+                            "0000000000123456789.blk" + compressionType.extension(),
                             "/000/000/000/012/345/6000s.zip",
                             123_456_789L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0000000000123456789",
-                            "0000000000123456789.blk"+ compressionType.extension(),
+                            "0000000000123456789.blk" + compressionType.extension(),
                             "/000/000/000/012/34/50000s.zip",
                             123_456_789L,
                             compressionType,
                             4),
                     Arguments.of(
                             "0000000000123456789",
-                            "0000000000123456789.blk"+ compressionType.extension(),
+                            "0000000000123456789.blk" + compressionType.extension(),
                             "/000/000/000/012/3/400000s.zip",
                             123_456_789L,
                             compressionType,
                             5),
                     Arguments.of(
                             "0000000000000000000",
-                            "0000000000000000000.blk"+ compressionType.extension(),
+                            "0000000000000000000.blk" + compressionType.extension(),
                             "/000/000/000/000/0000000s.zip",
                             0L,
                             compressionType,
                             6),
                     Arguments.of(
                             "0000000000000000010",
-                            "0000000000000000010.blk"+ compressionType.extension(),
+                            "0000000000000000010.blk" + compressionType.extension(),
                             "/000/000/000/000/000/0000s.zip",
                             10L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0000000000000000100",
-                            "0000000000000000100.blk"+ compressionType.extension(),
+                            "0000000000000000100.blk" + compressionType.extension(),
                             "/000/000/000/000/000/0000s.zip",
                             100L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0000000000000001000",
-                            "0000000000000001000.blk"+ compressionType.extension(),
+                            "0000000000000001000.blk" + compressionType.extension(),
                             "/000/000/000/000/000/1000s.zip",
                             1_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0000000000000010000",
-                            "0000000000000010000.blk"+ compressionType.extension(),
+                            "0000000000000010000.blk" + compressionType.extension(),
                             "/000/000/000/000/001/0000s.zip",
                             10_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0000000000000100000",
-                            "0000000000000100000.blk"+ compressionType.extension(),
+                            "0000000000000100000.blk" + compressionType.extension(),
                             "/000/000/000/000/010/0000s.zip",
                             100_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0000000000001000000",
-                            "0000000000001000000.blk"+ compressionType.extension(),
+                            "0000000000001000000.blk" + compressionType.extension(),
                             "/000/000/000/000/100/0000s.zip",
                             1_000_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0000000000010000000",
-                            "0000000000010000000.blk"+ compressionType.extension(),
+                            "0000000000010000000.blk" + compressionType.extension(),
                             "/000/000/000/001/000/0000s.zip",
                             10_000_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0000000000100000000",
-                            "0000000000100000000.blk"+ compressionType.extension(),
+                            "0000000000100000000.blk" + compressionType.extension(),
                             "/000/000/000/010/000/0000s.zip",
                             100_000_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0000000001000000000",
-                            "0000000001000000000.blk"+ compressionType.extension(),
+                            "0000000001000000000.blk" + compressionType.extension(),
                             "/000/000/000/100/000/0000s.zip",
                             1_000_000_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0000000010000000000",
-                            "0000000010000000000.blk"+ compressionType.extension(),
+                            "0000000010000000000.blk" + compressionType.extension(),
                             "/000/000/001/000/000/0000s.zip",
                             10_000_000_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0000000100000000000",
-                            "0000000100000000000.blk"+ compressionType.extension(),
+                            "0000000100000000000.blk" + compressionType.extension(),
                             "/000/000/010/000/000/0000s.zip",
                             100_000_000_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0000001000000000000",
-                            "0000001000000000000.blk"+ compressionType.extension(),
+                            "0000001000000000000.blk" + compressionType.extension(),
                             "/000/000/100/000/000/0000s.zip",
                             1_000_000_000_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0000010000000000000",
-                            "0000010000000000000.blk"+ compressionType.extension(),
+                            "0000010000000000000.blk" + compressionType.extension(),
                             "/000/001/000/000/000/0000s.zip",
                             10_000_000_000_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0000100000000000000",
-                            "0000100000000000000.blk"+ compressionType.extension(),
+                            "0000100000000000000.blk" + compressionType.extension(),
                             "/000/010/000/000/000/0000s.zip",
                             100_000_000_000_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0001000000000000000",
-                            "0001000000000000000.blk"+ compressionType.extension(),
+                            "0001000000000000000.blk" + compressionType.extension(),
                             "/000/100/000/000/000/0000s.zip",
                             1_000_000_000_000_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0010000000000000000",
-                            "0010000000000000000.blk"+ compressionType.extension(),
+                            "0010000000000000000.blk" + compressionType.extension(),
                             "/001/000/000/000/000/0000s.zip",
                             10_000_000_000_000_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "0100000000000000000",
-                            "0100000000000000000.blk"+ compressionType.extension(),
+                            "0100000000000000000.blk" + compressionType.extension(),
                             "/010/000/000/000/000/0000s.zip",
                             100_000_000_000_000_000L,
                             compressionType,
                             3),
                     Arguments.of(
                             "9223372036854775807",
-                            "9223372036854775807.blk"+ compressionType.extension(),
+                            "9223372036854775807.blk" + compressionType.extension(),
                             "/922/337/203/685/477/5000s.zip",
                             Long.MAX_VALUE,
                             compressionType,
-                            3)
-            ));
+                            3)));
         }
         return argumentsList.stream();
     }

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfigTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfigTest.java
@@ -11,6 +11,7 @@ import com.google.common.jimfs.Jimfs;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.hiero.block.node.base.CompressionType;
 import org.junit.jupiter.api.AfterEach;
@@ -30,8 +31,6 @@ class FilesHistoricConfigTest {
     private FileSystem jimfs;
     private Path defaultRootPath;
     private CompressionType defaultCompression;
-    private int defaultDigitsPerDir;
-    private int defaultDigitsPerZipFileName;
     private int defaultDigitsPerZipFileContents;
 
     /**
@@ -42,8 +41,6 @@ class FilesHistoricConfigTest {
         jimfs = Jimfs.newFileSystem(Configuration.unix());
         defaultRootPath = jimfs.getPath("/opt/hashgraph/blocknode/data/historic");
         defaultCompression = CompressionType.ZSTD;
-        defaultDigitsPerDir = 3;
-        defaultDigitsPerZipFileName = 1;
         defaultDigitsPerZipFileContents = 4;
     }
 
@@ -75,8 +72,6 @@ class FilesHistoricConfigTest {
                     .isThrownBy(() -> new FilesHistoricConfig(
                             null,
                             defaultCompression,
-                            defaultDigitsPerDir,
-                            defaultDigitsPerZipFileName,
                             defaultDigitsPerZipFileContents));
         }
 
@@ -92,118 +87,40 @@ class FilesHistoricConfigTest {
                     .isThrownBy(() -> new FilesHistoricConfig(
                             defaultRootPath,
                             null,
-                            defaultDigitsPerDir,
-                            defaultDigitsPerZipFileName,
                             defaultDigitsPerZipFileContents));
         }
 
         /**
          * This test aims to verify that the constructor of
          * {@link FilesHistoricConfig} does not throw an exception when the
-         * digitsPerDir is in range.
-         */
-        @ParameterizedTest
-        @MethodSource("org.hiero.block.node.blocks.files.historic.FilesHistoricConfigTest#validDigitsPerDir")
-        @DisplayName("Test that no exception is thrown when digitsPerDir is in range")
-        void testValidDigitsPerDir(final int validDigitsPerDir) {
-            assertThatNoException()
-                    .isThrownBy(() -> new FilesHistoricConfig(
-                            defaultRootPath,
-                            defaultCompression,
-                            validDigitsPerDir,
-                            defaultDigitsPerZipFileName,
-                            defaultDigitsPerZipFileContents));
-        }
-
-        /**
-         * This test aims to verify that the constructor of
-         * {@link FilesHistoricConfig} throws a {@link IllegalArgumentException}
-         * if the digitsPerDir is out of range.
-         */
-        @ParameterizedTest
-        @MethodSource("org.hiero.block.node.blocks.files.historic.FilesHistoricConfigTest#invalidDigitsPerDir")
-        @DisplayName("Test that IllegalArgumentException is thrown when digitsPerDir is out of range")
-        void testInvalidDigitsPerDir(final int invalidDigitsPerDir) {
-            assertThatIllegalArgumentException()
-                    .isThrownBy(() -> new FilesHistoricConfig(
-                            defaultRootPath,
-                            defaultCompression,
-                            invalidDigitsPerDir,
-                            defaultDigitsPerZipFileName,
-                            defaultDigitsPerZipFileContents));
-        }
-
-        /**
-         * This test aims to verify that the constructor of
-         * {@link FilesHistoricConfig} does not throw an exception when the
-         * digitsPerZipFileName is in range.
-         */
-        @ParameterizedTest
-        @MethodSource("org.hiero.block.node.blocks.files.historic.FilesHistoricConfigTest#validDigitsPerZipFileName")
-        @DisplayName("Test that no exception is thrown when digitsPerZipFileName is in range")
-        void testValidDigitsPerZipFileName(final int validDigitsPerZipFileName) {
-            assertThatNoException()
-                    .isThrownBy(() -> new FilesHistoricConfig(
-                            defaultRootPath,
-                            defaultCompression,
-                            defaultDigitsPerDir,
-                            validDigitsPerZipFileName,
-                            defaultDigitsPerZipFileContents));
-        }
-
-        /**
-         * This test aims to verify that the constructor of
-         * {@link FilesHistoricConfig} throws a {@link IllegalArgumentException}
-         * if the digitsPerZipFileName is out of range.
-         */
-        @ParameterizedTest
-        @MethodSource("org.hiero.block.node.blocks.files.historic.FilesHistoricConfigTest#invalidDigitsPerZipFileName")
-        @DisplayName("Test that IllegalArgumentException is thrown when digitsPerZipFileName is out of range")
-        void testInvalidDigitsPerZipFileName(final int invalidDigitsPerZipFileName) {
-            assertThatIllegalArgumentException()
-                    .isThrownBy(() -> new FilesHistoricConfig(
-                            defaultRootPath,
-                            defaultCompression,
-                            defaultDigitsPerDir,
-                            invalidDigitsPerZipFileName,
-                            defaultDigitsPerZipFileContents));
-        }
-
-        /**
-         * This test aims to verify that the constructor of
-         * {@link FilesHistoricConfig} does not throw an exception when the
-         * digitsPerZipFileContents is in range.
+         * powersOfTenPerZipFileContents is in range.
          */
         @ParameterizedTest
         @MethodSource(
                 "org.hiero.block.node.blocks.files.historic.FilesHistoricConfigTest#validDigitsPerZipFileContents")
-        @DisplayName("Test that no exception is thrown when digitsPerZipFileContents is in range")
+        @DisplayName("Test that no exception is thrown when powersOfTenPerZipFileContents is in range")
         void testValidDigitsPerZipFileContents(final int validDigitsPerZipFileContents) {
             assertThatNoException()
                     .isThrownBy(() -> new FilesHistoricConfig(
                             defaultRootPath,
                             defaultCompression,
-                            defaultDigitsPerDir,
-                            defaultDigitsPerZipFileName,
                             validDigitsPerZipFileContents));
         }
 
         /**
          * This test aims to verify that the constructor of
          * {@link FilesHistoricConfig} throws a {@link IllegalArgumentException}
-         * if the digitsPerZipFileContents is out of range.
+         * if the powersOfTenPerZipFileContents is out of range.
          */
         @ParameterizedTest
         @MethodSource(
                 "org.hiero.block.node.blocks.files.historic.FilesHistoricConfigTest#invalidDigitsPerZipFileContents")
-        @DisplayName("Test that IllegalArgumentException is thrown when digitsPerZipFileContents is out of range")
+        @DisplayName("Test that IllegalArgumentException is thrown when powersOfTenPerZipFileContents is out of range")
         void testInvalidDigitsPerZipFileContents(final int invalidDigitsPerZipFileContents) {
             assertThatIllegalArgumentException()
                     .isThrownBy(() -> new FilesHistoricConfig(
                             defaultRootPath,
                             defaultCompression,
-                            defaultDigitsPerDir,
-                            defaultDigitsPerZipFileName,
                             invalidDigitsPerZipFileContents));
         }
 
@@ -219,8 +136,6 @@ class FilesHistoricConfigTest {
                     .isThrownBy(() -> new FilesHistoricConfig(
                             defaultRootPath.resolve("valid"),
                             CompressionType.NONE,
-                            defaultDigitsPerDir + 1,
-                            defaultDigitsPerZipFileName + 1,
                             defaultDigitsPerZipFileContents + 1));
         }
 
@@ -236,8 +151,6 @@ class FilesHistoricConfigTest {
                     .isThrownBy(() -> new FilesHistoricConfig(
                             defaultRootPath,
                             defaultCompression,
-                            defaultDigitsPerDir,
-                            defaultDigitsPerZipFileName,
                             defaultDigitsPerZipFileContents));
         }
 
@@ -252,64 +165,13 @@ class FilesHistoricConfigTest {
             new FilesHistoricConfig(
                     defaultRootPath,
                     defaultCompression,
-                    defaultDigitsPerDir,
-                    defaultDigitsPerZipFileName,
                     defaultDigitsPerZipFileContents);
             assertThat(defaultRootPath).doesNotExist();
         }
     }
 
     /**
-     * Stream of valid digitsPerDir values.
-     */
-    private static Stream<Arguments> validDigitsPerDir() {
-        return Stream.of(
-                Arguments.of(1), Arguments.of(2), Arguments.of(3), Arguments.of(4), Arguments.of(5), Arguments.of(6));
-    }
-
-    /**
-     * Stream of invalid digitsPerDir values.
-     */
-    private static Stream<Arguments> invalidDigitsPerDir() {
-        return Stream.of(
-                Arguments.of(Integer.MAX_VALUE),
-                Arguments.of(7),
-                Arguments.of(0),
-                Arguments.of(-1),
-                Arguments.of(Integer.MIN_VALUE));
-    }
-
-    /**
-     * Stream of valid digitsPerZipFileName values.
-     */
-    private static Stream<Arguments> invalidDigitsPerZipFileName() {
-        return Stream.of(
-                Arguments.of(Integer.MAX_VALUE),
-                Arguments.of(11),
-                Arguments.of(0),
-                Arguments.of(-1),
-                Arguments.of(Integer.MIN_VALUE));
-    }
-
-    /**
-     * Stream of valid digitsPerZipFileName values.
-     */
-    private static Stream<Arguments> validDigitsPerZipFileName() {
-        return Stream.of(
-                Arguments.of(1),
-                Arguments.of(2),
-                Arguments.of(3),
-                Arguments.of(4),
-                Arguments.of(5),
-                Arguments.of(6),
-                Arguments.of(7),
-                Arguments.of(8),
-                Arguments.of(9),
-                Arguments.of(10));
-    }
-
-    /**
-     * Stream of valid digitsPerZipFileContents values.
+     * Stream of valid powersOfTenPerZipFileContents values.
      */
     private static Stream<Arguments> invalidDigitsPerZipFileContents() {
         return Stream.of(
@@ -321,19 +183,9 @@ class FilesHistoricConfigTest {
     }
 
     /**
-     * Stream of valid digitsPerZipFileContents values.
+     * Stream of valid powersOfTenPerZipFileContents values.
      */
     private static Stream<Arguments> validDigitsPerZipFileContents() {
-        return Stream.of(
-                Arguments.of(1),
-                Arguments.of(2),
-                Arguments.of(3),
-                Arguments.of(4),
-                Arguments.of(5),
-                Arguments.of(6),
-                Arguments.of(7),
-                Arguments.of(8),
-                Arguments.of(9),
-                Arguments.of(10));
+        return IntStream.range(1,6).mapToObj(Arguments::of);
     }
 }

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfigTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfigTest.java
@@ -31,7 +31,7 @@ class FilesHistoricConfigTest {
     private FileSystem jimfs;
     private Path defaultRootPath;
     private CompressionType defaultCompression;
-    private int defaultDigitsPerZipFileContents;
+    private int powersOfTenPerZipFileContents;
 
     /**
      * Environment setup before each test.
@@ -41,7 +41,7 @@ class FilesHistoricConfigTest {
         jimfs = Jimfs.newFileSystem(Configuration.unix());
         defaultRootPath = jimfs.getPath("/opt/hashgraph/blocknode/data/historic");
         defaultCompression = CompressionType.ZSTD;
-        defaultDigitsPerZipFileContents = 4;
+        powersOfTenPerZipFileContents = 4;
     }
 
     /**
@@ -69,10 +69,7 @@ class FilesHistoricConfigTest {
         @DisplayName("Test that NullPointerException is thrown when rootPath is null")
         void testNullRootPath() {
             assertThatNullPointerException()
-                    .isThrownBy(() -> new FilesHistoricConfig(
-                            null,
-                            defaultCompression,
-                            defaultDigitsPerZipFileContents));
+                    .isThrownBy(() -> new FilesHistoricConfig(null, defaultCompression, powersOfTenPerZipFileContents));
         }
 
         /**
@@ -84,10 +81,7 @@ class FilesHistoricConfigTest {
         @DisplayName("Test that NullPointerException is thrown when compression is null")
         void testNullCompression() {
             assertThatNullPointerException()
-                    .isThrownBy(() -> new FilesHistoricConfig(
-                            defaultRootPath,
-                            null,
-                            defaultDigitsPerZipFileContents));
+                    .isThrownBy(() -> new FilesHistoricConfig(defaultRootPath, null, powersOfTenPerZipFileContents));
         }
 
         /**
@@ -102,9 +96,7 @@ class FilesHistoricConfigTest {
         void testValidDigitsPerZipFileContents(final int validDigitsPerZipFileContents) {
             assertThatNoException()
                     .isThrownBy(() -> new FilesHistoricConfig(
-                            defaultRootPath,
-                            defaultCompression,
-                            validDigitsPerZipFileContents));
+                            defaultRootPath, defaultCompression, validDigitsPerZipFileContents));
         }
 
         /**
@@ -114,14 +106,12 @@ class FilesHistoricConfigTest {
          */
         @ParameterizedTest
         @MethodSource(
-                "org.hiero.block.node.blocks.files.historic.FilesHistoricConfigTest#invalidDigitsPerZipFileContents")
+                "org.hiero.block.node.blocks.files.historic.FilesHistoricConfigTest#powersOfTenPerZipFileContents")
         @DisplayName("Test that IllegalArgumentException is thrown when powersOfTenPerZipFileContents is out of range")
-        void testInvalidDigitsPerZipFileContents(final int invalidDigitsPerZipFileContents) {
+        void testInvalidPowersOfTenPerZipFileContents(final int invalidPowersOfTenPerZipFileContents) {
             assertThatIllegalArgumentException()
                     .isThrownBy(() -> new FilesHistoricConfig(
-                            defaultRootPath,
-                            defaultCompression,
-                            invalidDigitsPerZipFileContents));
+                            defaultRootPath, defaultCompression, invalidPowersOfTenPerZipFileContents));
         }
 
         /**
@@ -134,9 +124,7 @@ class FilesHistoricConfigTest {
         void testValidConstructor() {
             assertThatNoException()
                     .isThrownBy(() -> new FilesHistoricConfig(
-                            defaultRootPath.resolve("valid"),
-                            CompressionType.NONE,
-                            defaultDigitsPerZipFileContents + 1));
+                            defaultRootPath.resolve("valid"), CompressionType.NONE, powersOfTenPerZipFileContents + 1));
         }
 
         /**
@@ -149,9 +137,7 @@ class FilesHistoricConfigTest {
         void testValidConstructorWithDefaults() {
             assertThatNoException()
                     .isThrownBy(() -> new FilesHistoricConfig(
-                            defaultRootPath,
-                            defaultCompression,
-                            defaultDigitsPerZipFileContents));
+                            defaultRootPath, defaultCompression, powersOfTenPerZipFileContents));
         }
 
         /**
@@ -162,10 +148,7 @@ class FilesHistoricConfigTest {
         @DisplayName("Test that constructor does not create any paths or directories")
         void testNoPathCreation() {
             assertThat(defaultRootPath).doesNotExist();
-            new FilesHistoricConfig(
-                    defaultRootPath,
-                    defaultCompression,
-                    defaultDigitsPerZipFileContents);
+            new FilesHistoricConfig(defaultRootPath, defaultCompression, powersOfTenPerZipFileContents);
             assertThat(defaultRootPath).doesNotExist();
         }
     }
@@ -173,7 +156,7 @@ class FilesHistoricConfigTest {
     /**
      * Stream of valid powersOfTenPerZipFileContents values.
      */
-    private static Stream<Arguments> invalidDigitsPerZipFileContents() {
+    private static Stream<Arguments> powersOfTenPerZipFileContents() {
         return Stream.of(
                 Arguments.of(Integer.MAX_VALUE),
                 Arguments.of(11),
@@ -186,6 +169,6 @@ class FilesHistoricConfigTest {
      * Stream of valid powersOfTenPerZipFileContents values.
      */
     private static Stream<Arguments> validDigitsPerZipFileContents() {
-        return IntStream.range(1,6).mapToObj(Arguments::of);
+        return IntStream.range(1, 6).mapToObj(Arguments::of);
     }
 }

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
@@ -184,9 +184,7 @@ class ZipBlockAccessorTest {
         return new FilesHistoricConfig(
                 basePath,
                 compressionType,
-                localDefaultConfig.digitsPerDir(),
-                localDefaultConfig.digitsPerZipFileName(),
-                localDefaultConfig.digitsPerZipFileContents());
+                localDefaultConfig.powersOfTenPerZipFileContents());
     }
 
     private FilesHistoricConfig getDefaultConfiguration() {

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
-import com.github.luben.zstd.Zstd;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.hedera.hapi.block.stream.Block;
@@ -97,6 +96,7 @@ class ZipBlockAccessorTest {
             assertThatNullPointerException().isThrownBy(() -> new ZipBlockAccessor(null));
         }
     }
+
     /**
      * Tests for the {@link ZipBlockAccessor} functionality.
      */
@@ -152,7 +152,7 @@ class ZipBlockAccessorTest {
             case NONE -> bytesToWrite = protoBytes.toByteArray();
             case ZSTD -> {
                 final byte[] compressedBytes = protoBytes.toByteArray();
-                bytesToWrite = Zstd.compress(compressedBytes);
+                bytesToWrite = CompressionType.ZSTD.compress(compressedBytes);
             }
             default -> throw new IllegalStateException("Unhandled compression type: " + testConfig.compression());
         }

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
@@ -1,20 +1,36 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.blocks.files.historic;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
+import com.github.luben.zstd.Zstd;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.ConfigurationBuilder;
 import java.io.IOException;
 import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+import org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder;
+import org.hiero.block.node.base.CompressionType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 /**
  * Test class for {@link ZipBlockAccessor}.
@@ -26,22 +42,17 @@ class ZipBlockAccessorTest {
     /** The configuration for the test. */
     private FilesHistoricConfig defaultConfig;
 
+    @TempDir
+    private Path tempDir;
+
     /** Set up the test environment before each test. */
     @BeforeEach
     void setup() {
         // Initialize the in-memory file system
-        jimfs = Jimfs.newFileSystem(Configuration.unix());
-        final FilesHistoricConfig localDefaultConfig = ConfigurationBuilder.create()
-                .withConfigDataType(FilesHistoricConfig.class)
-                .build()
-                .getConfigData(FilesHistoricConfig.class);
-        // Set the default configuration for the test, use jimfs for paths
-        defaultConfig = new FilesHistoricConfig(
-                jimfs.getPath("/opt/hashgraph/blocknode/data/historic"),
-                localDefaultConfig.compression(),
-                localDefaultConfig.digitsPerDir(),
-                localDefaultConfig.digitsPerZipFileName(),
-                localDefaultConfig.digitsPerZipFileContents());
+        jimfs = Jimfs.newFileSystem(
+                Configuration.unix()); // Set the default configuration for the test, use jimfs for paths
+        defaultConfig =
+                createTestConfiguration(tempDir, getDefaultConfiguration().compression());
     }
 
     /**
@@ -61,6 +72,7 @@ class ZipBlockAccessorTest {
     @Nested
     @DisplayName("Constructor Tests")
     final class ConstructorTests {
+
         /**
          * This test aims to assert that the constructor of
          * {@link ZipBlockAccessor} does not throw any exceptions when the input
@@ -85,7 +97,6 @@ class ZipBlockAccessorTest {
             assertThatNullPointerException().isThrownBy(() -> new ZipBlockAccessor(null));
         }
     }
-
     /**
      * Tests for the {@link ZipBlockAccessor} functionality.
      */
@@ -105,5 +116,83 @@ class ZipBlockAccessorTest {
             final ZipBlockAccessor actual = new ZipBlockAccessor(blockPath);
             assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(actual::delete);
         }
+
+        /**
+         * This test aims to verify that the {@link ZipBlockAccessor#block()}
+         * will correctly return a zipped block.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test block method returns correctly a persisted block")
+        @SuppressWarnings("DataFlowIssue")
+        void testBlock(final CompressionType compressionType) throws IOException {
+            // build a test block
+            final BlockItem[] blockItems = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocks(1);
+            final FilesHistoricConfig testConfig = createTestConfiguration(tempDir, compressionType);
+            final BlockPath blockPath = BlockPath.computeBlockPath(
+                    testConfig, blockItems[0].blockHeader().number());
+            final Block expected = new Block(List.of(blockItems));
+            final Bytes protoBytes = Block.PROTOBUF.toBytes(expected);
+            // test zipBlockAccessor.block()
+            final ZipBlockAccessor toTest = createBlockAndGetAssociatedAccessor(testConfig, blockPath, protoBytes);
+            final Block actual = toTest.block();
+            assertThat(actual).isEqualTo(expected);
+            // todo for now will not work with no compression as the production logic needs to support that
+        }
+    }
+
+    private ZipBlockAccessor createBlockAndGetAssociatedAccessor(
+            final FilesHistoricConfig testConfig, final BlockPath blockPath, Bytes protoBytes) throws IOException {
+        // create & assert existing block file path before call
+        Files.createDirectories(blockPath.dirPath());
+        // it is important the output stream is closed as the compression writes a footer on close
+        Files.createFile(blockPath.zipFilePath());
+        final byte[] bytesToWrite;
+        switch (testConfig.compression()) {
+            case NONE -> bytesToWrite = protoBytes.toByteArray();
+            case ZSTD -> {
+                final byte[] compressedBytes = protoBytes.toByteArray();
+                bytesToWrite = Zstd.compress(compressedBytes);
+            }
+            default -> throw new IllegalStateException("Unhandled compression type: " + testConfig.compression());
+        }
+        try (final ZipOutputStream zipOut = new ZipOutputStream(Files.newOutputStream(blockPath.zipFilePath()))) {
+            // create a new zip entry
+            final ZipEntry zipEntry = new ZipEntry(blockPath.blockFileName());
+            zipOut.putNextEntry(zipEntry);
+            zipOut.write(bytesToWrite);
+            zipOut.closeEntry();
+        }
+        assertThat(blockPath.zipFilePath())
+                .exists()
+                .isReadable()
+                .isWritable()
+                .isNotEmptyFile()
+                .hasExtension("zip");
+        try (final ZipFile zipFile = new ZipFile(blockPath.zipFilePath().toFile())) {
+            assertThat(zipFile.size()).isEqualTo(1);
+            final ZipEntry entry = zipFile.getEntry(blockPath.blockFileName());
+            assertThat(entry).isNotNull();
+            final byte[] fromZipEntry = zipFile.getInputStream(entry).readAllBytes();
+            assertThat(fromZipEntry).isEqualTo(bytesToWrite);
+        }
+        return new ZipBlockAccessor(blockPath);
+    }
+
+    private FilesHistoricConfig createTestConfiguration(final Path basePath, final CompressionType compressionType) {
+        final FilesHistoricConfig localDefaultConfig = getDefaultConfiguration();
+        return new FilesHistoricConfig(
+                basePath,
+                compressionType,
+                localDefaultConfig.digitsPerDir(),
+                localDefaultConfig.digitsPerZipFileName(),
+                localDefaultConfig.digitsPerZipFileContents());
+    }
+
+    private FilesHistoricConfig getDefaultConfiguration() {
+        return ConfigurationBuilder.create()
+                .withConfigDataType(FilesHistoricConfig.class)
+                .build()
+                .getConfigData(FilesHistoricConfig.class);
     }
 }

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
@@ -181,10 +181,7 @@ class ZipBlockAccessorTest {
 
     private FilesHistoricConfig createTestConfiguration(final Path basePath, final CompressionType compressionType) {
         final FilesHistoricConfig localDefaultConfig = getDefaultConfiguration();
-        return new FilesHistoricConfig(
-                basePath,
-                compressionType,
-                localDefaultConfig.powersOfTenPerZipFileContents());
+        return new FilesHistoricConfig(basePath, compressionType, localDefaultConfig.powersOfTenPerZipFileContents());
     }
 
     private FilesHistoricConfig getDefaultConfiguration() {


### PR DESCRIPTION
## Reviewer Notes

- this pr is semi-finished but has to merge in order to not stall further developments
- some more tests for the files historic plugin
- updated the BlockPath to be able to compute an existing path, adding the actual compression used on it (currently only naively checking for the extension)
- changes to the zip accessor were made to facilitate the block path updates, mainly to be able to correctly read (needs further testing, not asserting currently that it is 100% done, upcoming PRs will assert that)

## Related Issue(s)

Closes #990 
