### PR TITLE
feat: BlockAccessService E2E Tests Suite and other improvements to Plugin

### DIFF
--- a/suites/src/main/java/module-info.java
+++ b/suites/src/main/java/module-info.java
@@ -3,6 +3,8 @@ module org.hiero.block.node.suites {
     requires com.swirlds.config.api;
     requires com.swirlds.config.extensions;
     requires org.hiero.block.simulator;
+    requires org.hiero.block.stream;
+    requires io.grpc;
     requires org.junit.jupiter.api;
     requires org.junit.platform.suite.api;
     requires org.testcontainers;

--- a/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
+++ b/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
@@ -44,6 +44,9 @@ public abstract class BaseSuite {
     /** Port that is used by the Block Node Application */
     protected static int blockNodePort;
 
+    /** Port that is used by the Block Node Application for metrics */
+    protected static int blockNodeMetricsPort;
+
     /** Executor service for managing threads */
     protected static ErrorLoggingExecutor executorService;
 
@@ -105,8 +108,10 @@ public abstract class BaseSuite {
     protected static GenericContainer<?> createContainer() {
         String blockNodeVersion = BaseSuite.getBlockNodeVersion();
         blockNodePort = 8080;
+        blockNodeMetricsPort = 9999;
         List<String> portBindings = new ArrayList<>();
         portBindings.add(String.format("%d:%2d", blockNodePort, blockNodePort));
+        portBindings.add(String.format("%d:%2d", blockNodeMetricsPort, blockNodeMetricsPort));
         blockNodeContainer = new GenericContainer<>(DockerImageName.parse("block-node-server:" + blockNodeVersion))
                 .withExposedPorts(blockNodePort)
                 .withEnv("VERSION", blockNodeVersion)

--- a/suites/src/main/java/org/hiero/block/suites/block/access/BlockAccessTestSuites.java
+++ b/suites/src/main/java/org/hiero/block/suites/block/access/BlockAccessTestSuites.java
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.suites.block.access;
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+/**
+ * Test suite for running block access tests, including both positive and negative test
+ * scenarios.
+ *
+ * <p>This suite aggregates the tests from {@link GetSingleBlockApiTests}. The {@code @Suite}
+ * annotation allows running all selected classes in a single test run.
+ */
+@Suite
+@SelectClasses({GetSingleBlockApiTests.class})
+public class BlockAccessTestSuites {
+
+    /**
+     * Default constructor for the {@link BlockAccessTestSuites} class. This constructor is empty as
+     * it does not need to perform any initialization.
+     */
+    public BlockAccessTestSuites() {}
+}

--- a/suites/src/main/java/org/hiero/block/suites/block/access/BlockAccessTestSuites.java
+++ b/suites/src/main/java/org/hiero/block/suites/block/access/BlockAccessTestSuites.java
@@ -13,11 +13,4 @@ import org.junit.platform.suite.api.Suite;
  */
 @Suite
 @SelectClasses({GetSingleBlockApiTests.class})
-public class BlockAccessTestSuites {
-
-    /**
-     * Default constructor for the {@link BlockAccessTestSuites} class. This constructor is empty as
-     * it does not need to perform any initialization.
-     */
-    public BlockAccessTestSuites() {}
-}
+public class BlockAccessTestSuites {}

--- a/suites/src/main/java/org/hiero/block/suites/block/access/GetSingleBlockApiTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/block/access/GetSingleBlockApiTests.java
@@ -39,12 +39,6 @@ import org.junit.jupiter.api.TestInstance;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class GetSingleBlockApiTests extends BaseSuite {
 
-    /**
-     * Default constructor for the {@link GetSingleBlockApiTests} class. This constructor does not
-     * require any specific initialization.
-     */
-    public GetSingleBlockApiTests() {}
-
     // Simulator instance to be used for testing
     private BlockStreamSimulatorApp blockStreamSimulatorApp;
 

--- a/suites/src/main/java/org/hiero/block/suites/block/access/GetSingleBlockApiTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/block/access/GetSingleBlockApiTests.java
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.suites.block.access;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hapi.block.protoc.BlockAccessServiceGrpc;
+import com.hedera.hapi.block.protoc.SingleBlockRequest;
+import com.hedera.hapi.block.protoc.SingleBlockResponse;
+import com.hedera.hapi.block.protoc.SingleBlockResponseCode;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.io.IOException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.hiero.block.simulator.BlockStreamSimulatorApp;
+import org.hiero.block.suites.BaseSuite;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ *
+ * Test class for verifying the functionality of the GetSingleBlock API in the Block Node
+ * application.
+ *
+ * <p>This class is part of the Block Node suite and aims to test the behavior of the GetSingleBlock
+ * API under various conditions, including both positive and negative scenarios.
+ *
+ * <p>Inherits from {@link BaseSuite} to reuse the container setup and teardown logic for the Block
+ * Node.
+ *
+ */
+@DisplayName("GetSingleBlockApiTests")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class GetSingleBlockApiTests extends BaseSuite {
+
+    /**
+     * Default constructor for the {@link GetSingleBlockApiTests} class. This constructor does not
+     * require any specific initialization.
+     */
+    public GetSingleBlockApiTests() {}
+
+    // Simulator instance to be used for testing
+    private BlockStreamSimulatorApp blockStreamSimulatorApp;
+
+    // Thread to run the simulator
+    private Future<?> simulatorThread;
+
+    // gRPC channel for connecting to the Block Node
+    private ManagedChannel channel;
+
+    // gRPC client stub for BlockAccessService
+    private BlockAccessServiceGrpc.BlockAccessServiceBlockingStub blockAccessStub;
+
+    @AfterEach
+    void teardownEnvironment() {
+        if (simulatorThread != null && !simulatorThread.isCancelled()) {
+            simulatorThread.cancel(true);
+        }
+    }
+
+    @BeforeAll
+    void publishSomeBlocks() throws IOException, InterruptedException {
+        // Initialize the gRPC client
+        initializeGrpcClient();
+
+        // Use the simulator to publish some blocks
+        blockStreamSimulatorApp = createBlockSimulator();
+        simulatorThread = startSimulatorInThread(blockStreamSimulatorApp);
+        Thread.sleep(5000);
+        blockStreamSimulatorApp.stop();
+    }
+
+    @AfterAll
+    void shutdown() throws InterruptedException {
+        // Shutdown the gRPC channel
+        if (channel != null) {
+            channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Initializes the gRPC client for connecting to the Block Node.
+     */
+    private void initializeGrpcClient() {
+        String host = blockNodeContainer.getHost();
+        int port = blockNodePort;
+
+        channel = ManagedChannelBuilder.forAddress(host, port)
+                .usePlaintext() // For testing only
+                .build();
+
+        blockAccessStub = BlockAccessServiceGrpc.newBlockingStub(channel);
+    }
+
+    /**
+     * Creates a SingleBlockRequest to retrieve a specific block.
+     *
+     * @param blockNumber The block number to retrieve
+     * @param latest Whether to retrieve the latest block
+     * @return A SingleBlockRequest object
+     */
+    private SingleBlockRequest createSingleBlockRequest(long blockNumber, boolean latest) {
+        return SingleBlockRequest.newBuilder()
+                .setBlockNumber(blockNumber)
+                .setRetrieveLatest(latest)
+                .setAllowUnverified(true)
+                .build();
+    }
+
+    /**
+     * Retrieves a single block using the Block Node API.
+     *
+     * @param blockNumber The block number to retrieve
+     * @param latest Whether to retrieve the latest block
+     * @return The SingleBlockResponse from the API
+     */
+    private SingleBlockResponse getSingleBlock(long blockNumber, boolean latest) {
+        SingleBlockRequest request = createSingleBlockRequest(blockNumber, latest);
+        return blockAccessStub.singleBlock(request);
+    }
+
+    @Test
+    @DisplayName("Get a Single Block using API - Happy Path")
+    void requestExistingBlockUsingSingleBlockAPI() {
+        // Request block number 1 (which should have been published by the simulator)
+        long blockNumber = 1;
+        SingleBlockResponse response = getSingleBlock(blockNumber, false);
+
+        // Verify the response
+        assertNotNull(response, "Response should not be null");
+        assertEquals(
+                SingleBlockResponseCode.READ_BLOCK_SUCCESS,
+                response.getStatus(),
+                "Block retrieval should be successful");
+
+        // Verify the block content
+        assertTrue(response.hasBlock(), "Response should contain a block");
+        assertEquals(
+                blockNumber,
+                response.getBlock().getItemsList().getFirst().getBlockHeader().getNumber(),
+                "Block number should match the requested block number");
+    }
+
+    @Test
+    @DisplayName("Get a Single Block using API - Negative Test - Non-existing Block")
+    void requestNonExistingBlockUsingSingleBlockAPI() {
+        // Request a non-existing block number
+        long blockNumber = 1000;
+        SingleBlockResponse response = getSingleBlock(blockNumber, false);
+
+        // Verify the response
+        assertNotNull(response, "Response should not be null");
+        assertEquals(
+                SingleBlockResponseCode.READ_BLOCK_NOT_AVAILABLE,
+                response.getStatus(),
+                "Block retrieval should fail for non-existing block");
+
+        // Verify that the block is null
+        assertTrue(!response.hasBlock(), "Response should not contain a block");
+    }
+
+    @Test
+    @DisplayName("Get a Single Block using API - Request Latest Block")
+    void requestLatestBlockUsingSingleBlockAPI() {
+        // Request the latest block
+        SingleBlockResponse response = getSingleBlock(-1, true);
+
+        // Verify the response
+        assertNotNull(response, "Response should not be null");
+        assertEquals(
+                SingleBlockResponseCode.READ_BLOCK_SUCCESS,
+                response.getStatus(),
+                "Block retrieval should be successful");
+
+        // Verify the block content
+        long latestPublishedBlock = blockStreamSimulatorApp.getStreamStatus().publishedBlocks() - 1;
+        assertTrue(response.hasBlock(), "Response should contain a block");
+        assertEquals(
+                latestPublishedBlock,
+                response.getBlock().getItemsList().getFirst().getBlockHeader().getNumber(),
+                "Block number should match the latest block number");
+    }
+
+    @Test
+    @DisplayName("Get a Single Block using API - Request Latest and Specific Block - should fail with NOT_FOUND")
+    void requestLatestBlockAndSpecificBlockUsingSingleBlockAPI() {
+        // Request the latest block and a specific block number
+        long blockNumber = 1;
+        SingleBlockRequest request = createSingleBlockRequest(blockNumber, true);
+        SingleBlockResponse response = blockAccessStub.singleBlock(request);
+
+        // Verify the response
+        assertNotNull(response, "Response should not be null");
+        assertEquals(
+                SingleBlockResponseCode.READ_BLOCK_NOT_FOUND,
+                response.getStatus(),
+                "Block retrieval should fail for non-existing block");
+
+        // Verify that the block is null
+        assertTrue(!response.hasBlock(), "Response should not contain a block");
+    }
+
+    @Test
+    @DisplayName(
+            "Get a Single Block using API - block_number to -1 and retrieve_latest to false - should return NOT_FOUND")
+    void requestWithoutBlockNumberAndRetrieveLatestFalse() {
+        // Request the latest block and a specific block number
+        SingleBlockRequest request = createSingleBlockRequest(-1, false);
+        SingleBlockResponse response = blockAccessStub.singleBlock(request);
+
+        // Verify the response
+        assertNotNull(response, "Response should not be null");
+        assertEquals(
+                SingleBlockResponseCode.READ_BLOCK_NOT_FOUND,
+                response.getStatus(),
+                "Block retrieval should fail for non-existing block");
+
+        // Verify that the block is null
+        assertTrue(!response.hasBlock(), "Response should not contain a block");
+    }
+}

--- a/suites/src/main/java/org/hiero/block/suites/grpc/positive/PositiveServerAvailabilityTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/grpc/positive/PositiveServerAvailabilityTests.java
@@ -69,14 +69,14 @@ public class PositiveServerAvailabilityTests extends BaseSuite {
 
         // Test /healthz/readyz endpoint
         final HttpURLConnection readyzConnection =
-                (java.net.HttpURLConnection) new java.net.URL(baseUrl + "/healthz/readyz").openConnection();
+                (HttpURLConnection) new java.net.URL(baseUrl + "/healthz/readyz").openConnection();
         readyzConnection.setRequestMethod("GET");
         final int readyzResponseCode = readyzConnection.getResponseCode();
         assertEquals(200, readyzResponseCode, "Expected HTTP 200 for /healthz/readyz endpoint.");
 
         // Test /healthz/livez endpoint
         final HttpURLConnection livezConnection =
-                (java.net.HttpURLConnection) new java.net.URL(baseUrl + "/healthz/livez").openConnection();
+                (HttpURLConnection) new java.net.URL(baseUrl + "/healthz/livez").openConnection();
         livezConnection.setRequestMethod("GET");
         final int livezResponseCode = livezConnection.getResponseCode();
         assertEquals(200, livezResponseCode, "Expected HTTP 200 for /healthz/livez endpoint.");
@@ -96,7 +96,7 @@ public class PositiveServerAvailabilityTests extends BaseSuite {
 
         // Test /metrics endpoint
         final HttpURLConnection metricsConnection =
-                (java.net.HttpURLConnection) new java.net.URL(baseUrl + "/metrics").openConnection();
+                (HttpURLConnection) new java.net.URL(baseUrl + "/metrics").openConnection();
         metricsConnection.setRequestMethod("GET");
         final int metricsResponseCode = metricsConnection.getResponseCode();
         assertEquals(200, metricsResponseCode, "Expected HTTP 200 for /metrics endpoint.");

--- a/suites/src/main/java/org/hiero/block/suites/grpc/positive/PositiveServerAvailabilityTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/grpc/positive/PositiveServerAvailabilityTests.java
@@ -4,6 +4,7 @@ package org.hiero.block.suites.grpc.positive;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.HttpURLConnection;
 import org.hiero.block.suites.BaseSuite;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,5 +50,55 @@ public class PositiveServerAvailabilityTests extends BaseSuite {
                 blockNodePort,
                 blockNodeContainer.getExposedPorts().getFirst(),
                 "The exposed port should match the expected gRPC server port.");
+    }
+
+    /**
+     * Test should verify the healthz endpoints of the REST API.
+     *
+     * <p>The test asserts that /healthz/readyz REST endpoint returns HTTP 200 Status</p>
+     * <p>The test asserts that /healthz/livez REST endpoint returns HTTP 200 Status</p>
+     *
+     * @throws Exception catch all exceptions
+     */
+    @Test
+    @DisplayName("Verify /healthz endpoints")
+    public void verifyHealthzEndpoints() throws Exception {
+        final String host = "localhost";
+        final int port = blockNodeContainer.getExposedPorts().getFirst();
+        final String baseUrl = String.format("http://%s:%d", host, port);
+
+        // Test /healthz/readyz endpoint
+        final HttpURLConnection readyzConnection =
+                (java.net.HttpURLConnection) new java.net.URL(baseUrl + "/healthz/readyz").openConnection();
+        readyzConnection.setRequestMethod("GET");
+        final int readyzResponseCode = readyzConnection.getResponseCode();
+        assertEquals(200, readyzResponseCode, "Expected HTTP 200 for /healthz/readyz endpoint.");
+
+        // Test /healthz/livez endpoint
+        final HttpURLConnection livezConnection =
+                (java.net.HttpURLConnection) new java.net.URL(baseUrl + "/healthz/livez").openConnection();
+        livezConnection.setRequestMethod("GET");
+        final int livezResponseCode = livezConnection.getResponseCode();
+        assertEquals(200, livezResponseCode, "Expected HTTP 200 for /healthz/livez endpoint.");
+    }
+
+    /**
+     * Test should verify the metrics endpoints of the REST API.
+     *
+     * @throws Exception catch all exceptions
+     */
+    @Test
+    @DisplayName("Verify /metrics endpoint")
+    public void verifyMetricsEndpoint() throws Exception {
+        final String host = "localhost";
+        final int port = 9999;
+        final String baseUrl = String.format("http://%s:%d", host, port);
+
+        // Test /metrics endpoint
+        final HttpURLConnection metricsConnection =
+                (java.net.HttpURLConnection) new java.net.URL(baseUrl + "/metrics").openConnection();
+        metricsConnection.setRequestMethod("GET");
+        final int metricsResponseCode = metricsConnection.getResponseCode();
+        assertEquals(200, metricsResponseCode, "Expected HTTP 200 for /metrics endpoint.");
     }
 }


### PR DESCRIPTION
- Added metrics port binding to BaseSuite
- Improvement on check for avaiable block at BlockAccessServicePlugin
- Fail fast when receiving both `retrieve_latest` and `block_number` on getSingleBlock Request to avoid bad DevEx and confusion
- since 0 is a valid block, we expect -1 when latest is set to true.
- Fixed UTs
- Added E2E Test Suite for Healthz and Metrics endpoints
- Added E2E Test Suite for GetSingleBlockAPI scenarios


