### PR TITLE
chore: Disabled an incomplete test.

### DIFF
--- a/block-node/subscriber/src/test/java/org/hiero/block/node/subscriber/SubscriberTest.java
+++ b/block-node/subscriber/src/test/java/org/hiero/block/node/subscriber/SubscriberTest.java
@@ -29,6 +29,7 @@ import org.hiero.hapi.block.node.SubscribeStreamResponse.ResponseOneOfType;
 import org.hiero.hapi.block.node.SubscribeStreamResponseCode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -229,6 +230,7 @@ public class SubscriberTest extends GrpcPluginTestBase<SubscriberServicePlugin> 
         sendBatchesAndCheckTheyAreReceived(createNumberOfSimpleBlockBatches(15, 25));
     }
 
+    @Disabled
     @Test
     void testSubscribeFromZeroSlowClient() throws ParseException {
         // first we need to create and send a SubscribeStreamRequest


### PR DESCRIPTION
## Reviewer Notes

The test that is disabled needs more work to be correct.  It's passing _sometimes_ because it does not always reach a point to switch back to live blocks, and it's only succeeding when that happens.
We need to add a mechanism to the test historic block provider to better control how it behaves in the test so we can ensure the subscriber must switch to history (which already works) and _also_ reaches a point where it can switch back to live (which isn't there currently).
