### PR TITLE
test: Files Historic Plugin Unit Tests Pt. 3

### DIFF
--- a/block-node/base/src/test/java/org/hiero/block/node/base/CompressionTypeTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/CompressionTypeTest.java
@@ -135,4 +135,43 @@ class CompressionTypeTest {
         final byte[] actual = compressionType.decompress(compressed);
         assertThat(actual).isEqualTo(expected).containsExactly(expected);
     }
+
+    /**
+     * This test aims to verify that the compress static method and wrapping
+     * a stream will produce the same result.
+     */
+    @ParameterizedTest
+    @EnumSource(CompressionType.class)
+    @DisplayName("Test compress() and wrapStream() methods produce same result")
+    void testCompressAndWrap(final CompressionType compressionType) throws IOException {
+        final byte[] testData = "test expected data".getBytes();
+        final ByteArrayOutputStream baosTarget;
+        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                final OutputStream wrappedBaos = compressionType.wrapStream(baos)) {
+            wrappedBaos.write(testData);
+            baosTarget = baos;
+        }
+        final byte[] bytesFromBaos = baosTarget.toByteArray();
+        final byte[] bytesFromCompress = compressionType.compress(testData);
+        assertThat(bytesFromBaos).isEqualTo(bytesFromCompress).containsExactly(bytesFromCompress);
+    }
+
+    /**
+     * This test aims to verify that the decompress static method and wrapping
+     * a stream will produce the same result.
+     */
+    @ParameterizedTest
+    @EnumSource(CompressionType.class)
+    @DisplayName("Test decompress() and wrapStream() methods produce same result")
+    void testDecompressAndWrap(final CompressionType compressionType) throws IOException {
+        final byte[] testData = "test expected data".getBytes();
+        final byte[] compressedData = compressionType.compress(testData);
+        final byte[] bytesFromInputStream;
+        try (final ByteArrayInputStream bais = new ByteArrayInputStream(compressedData);
+                final InputStream wrappedBais = compressionType.wrapStream(bais)) {
+            bytesFromInputStream = wrappedBais.readAllBytes();
+        }
+        final byte[] bytesFromDecompress = compressionType.decompress(compressedData);
+        assertThat(bytesFromInputStream).isEqualTo(bytesFromDecompress).containsExactly(bytesFromDecompress);
+    }
 }

--- a/block-node/block-providers/files.historic/build.gradle.kts
+++ b/block-node/block-providers/files.historic/build.gradle.kts
@@ -20,4 +20,5 @@ testModuleInfo {
     requires("org.junit.jupiter.params")
     requires("org.assertj.core")
     requires("org.hiero.block.node.app.test.fixtures")
+    requires("com.swirlds.metrics.api")
 }

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockPath.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockPath.java
@@ -101,6 +101,7 @@ record BlockPath(
                     // compression extension.
                     final CompressionType[] compressionOpts =
                             config.compression().getDeclaringClass().getEnumConstants();
+                    // noinspection ForLoopReplaceableByForEach
                     for (int i = 0; i < compressionOpts.length; i++) {
                         final CompressionType currentOpt = compressionOpts[i];
                         // we are only

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
@@ -67,7 +67,7 @@ public class BlocksFilesHistoricPlugin implements BlockProviderPlugin, BlockNoti
         // register to listen to block notifications
         context.blockMessaging().registerBlockNotificationHandler(this, false, "Blocks Files Historic");
         numberOfBlocksPerZipFile = (int) Math.pow(10, config.powersOfTenPerZipFileContents());
-        zipBlockArchive = new ZipBlockArchive(context, config);
+        zipBlockArchive = new ZipBlockArchive(context);
         // get the first and last block numbers from the zipBlockArchive
         availableBlocks.add(zipBlockArchive.minStoredBlockNumber(), zipBlockArchive.maxStoredBlockNumber());
     }

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
@@ -67,7 +67,7 @@ public class BlocksFilesHistoricPlugin implements BlockProviderPlugin, BlockNoti
         // register to listen to block notifications
         context.blockMessaging().registerBlockNotificationHandler(this, false, "Blocks Files Historic");
         numberOfBlocksPerZipFile = (int) Math.pow(10, config.powersOfTenPerZipFileContents());
-        zipBlockArchive = new ZipBlockArchive(context);
+        zipBlockArchive = new ZipBlockArchive(context, config);
         // get the first and last block numbers from the zipBlockArchive
         availableBlocks.add(zipBlockArchive.minStoredBlockNumber(), zipBlockArchive.maxStoredBlockNumber());
     }

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
@@ -6,6 +6,7 @@ import static org.hiero.block.node.blocks.files.historic.BlockPath.computeBlockP
 import static org.hiero.block.node.blocks.files.historic.BlockPath.computeExistingBlockPath;
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -14,6 +15,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.zip.CRC32;
@@ -31,28 +33,31 @@ import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
  * The ZipBlockArchive class provides methods for creating and managing zip files containing blocks.
  * It allows for writing new zip files and accessing individual blocks within the zip files.
  */
-public class ZipBlockArchive {
+class ZipBlockArchive {
     /** The logger for this class. */
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
-
+    /** The block node context. */
     private final BlockNodeContext context;
+    /** The configuration for the historic files. */
     private final FilesHistoricConfig config;
+    /** The historical block facility. */
     private final HistoricalBlockFacility historicalBlockFacility;
+    /** The number of blocks per zip file. */
     private final int numberOfBlocksPerZipFile;
+    /** The format for the blocks. */
     private final Format format;
 
     /**
      * Constructor for ZipBlockArchive.
      *
      * @param context The block node context
-     * @param historicConfig The configuration for the historic files
      */
-    public ZipBlockArchive(BlockNodeContext context, FilesHistoricConfig historicConfig) {
-        this.context = context;
-        this.historicalBlockFacility = context.historicalBlockProvider();
-        this.config = historicConfig;
-        numberOfBlocksPerZipFile = (int) Math.pow(10, historicConfig.powersOfTenPerZipFileContents());
-        format = switch (historicConfig.compression()) {
+    ZipBlockArchive(@NonNull final BlockNodeContext context) {
+        this.context = Objects.requireNonNull(context);
+        this.config = context.configuration().getConfigData(FilesHistoricConfig.class);
+        this.historicalBlockFacility = Objects.requireNonNull(context.historicalBlockProvider());
+        numberOfBlocksPerZipFile = (int) Math.pow(10, this.config.powersOfTenPerZipFileContents());
+        format = switch (this.config.compression()) {
             case ZSTD -> Format.ZSTD_PROTOBUF;
             case NONE -> Format.PROTOBUF;};
     }
@@ -64,7 +69,7 @@ public class ZipBlockArchive {
      * @throws IOException If an error occurs writing the block
      * @return A list of block accessors for the blocks written to the zip file, can be used to delete the blocks
      */
-    public List<BlockAccessor> writeNewZipFile(long firstBlockNumber) throws IOException {
+    List<BlockAccessor> writeNewZipFile(long firstBlockNumber) throws IOException {
         final long lastBlockNumber = firstBlockNumber + numberOfBlocksPerZipFile - 1;
         // compute block path
         final BlockPath firstBlockPath = computeBlockPath(config, firstBlockNumber);
@@ -118,7 +123,7 @@ public class ZipBlockArchive {
      * @param blockNumber The block number
      * @return The block accessor for the block number
      */
-    public BlockAccessor blockAccessor(long blockNumber) {
+    BlockAccessor blockAccessor(long blockNumber) {
         try {
             // get existing block path or null if we cannot find it
             final BlockPath blockPath = computeExistingBlockPath(config, blockNumber);
@@ -133,7 +138,7 @@ public class ZipBlockArchive {
      *
      * @return the minimum block number, or -1 if no block files are found
      */
-    public long minStoredBlockNumber() {
+    long minStoredBlockNumber() {
         // find the lowest block number first
         Path lowestPath = config.rootPath();
         while (lowestPath != null) {
@@ -190,7 +195,7 @@ public class ZipBlockArchive {
      *
      * @return the maximum block number, or -1 if no block files are found
      */
-    public long maxStoredBlockNumber() {
+    long maxStoredBlockNumber() {
         // find the highest block number
         Path highestPath = config.rootPath();
         while (highestPath != null) {

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
@@ -51,10 +51,11 @@ class ZipBlockArchive {
      * Constructor for ZipBlockArchive.
      *
      * @param context The block node context
+     * @param filesHistoricConfig Configuration to be used internally
      */
-    ZipBlockArchive(@NonNull final BlockNodeContext context) {
+    ZipBlockArchive(@NonNull final BlockNodeContext context, @NonNull final FilesHistoricConfig filesHistoricConfig) {
         this.context = Objects.requireNonNull(context);
-        this.config = context.configuration().getConfigData(FilesHistoricConfig.class);
+        this.config = Objects.requireNonNull(filesHistoricConfig);
         this.historicalBlockFacility = Objects.requireNonNull(context.historicalBlockProvider());
         numberOfBlocksPerZipFile = (int) Math.pow(10, this.config.powersOfTenPerZipFileContents());
         format = switch (this.config.compression()) {

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
@@ -23,6 +23,7 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 import org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder;
 import org.hiero.block.node.base.CompressionType;
+import org.hiero.block.node.spi.historicalblocks.BlockAccessor.Format;
 import org.hiero.hapi.block.node.BlockItemUnparsed;
 import org.hiero.hapi.block.node.BlockUnparsed;
 import org.junit.jupiter.api.AfterEach;
@@ -108,12 +109,105 @@ class ZipBlockAccessorTest {
     final class FunctionalityTests {
 
         /**
+         * This test aims to verify that the {@link ZipBlockAccessor#blockBytes(Format)}
+         * will correctly return a zipped block as bytes. This is the happy path test
+         * where the compression type is the same as the compression type used to create
+         * the block (zip entry inside the zip file we are trying to read).
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test blockBytes() returns correctly a persisted block as bytes happy path format")
+        @SuppressWarnings("DataFlowIssue")
+        void testBlockBytesHappyPathFormat(final CompressionType compressionType) throws IOException {
+            // build a test block
+            final BlockItem[] blockItems = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocks(1);
+            final FilesHistoricConfig testConfig = createTestConfiguration(tempDir, compressionType);
+            final BlockPath blockPath = BlockPath.computeBlockPath(
+                    testConfig, blockItems[0].blockHeader().number());
+            final Block block = new Block(List.of(blockItems));
+            final Bytes expected = Block.PROTOBUF.toBytes(block);
+            // test zipBlockAccessor.block()
+            final ZipBlockAccessor toTest = createBlockAndGetAssociatedAccessor(testConfig, blockPath, expected);
+            final Format format;
+            switch (compressionType) {
+                case ZSTD -> format = Format.ZSTD_PROTOBUF;
+                case NONE -> format = Format.PROTOBUF;
+                default -> throw new IllegalStateException("Unhandled compression type: " + compressionType);
+            }
+            // The blockBytes method should return the bytes of the block with the
+            // specified format. In order to assert the same bytes, we need to decompress
+            // the bytes returned by the blockBytes method and compare them to the expected.
+            final Bytes testResult = toTest.blockBytes(format);
+            final Bytes actual = Bytes.wrap(compressionType.decompress(testResult.toByteArray()));
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        /**
+         * This test aims to verify that the {@link ZipBlockAccessor#blockBytes(Format)}
+         * will correctly return a zipped block as bytes. This test will always use the
+         * {@link Format#ZSTD_PROTOBUF} format to read the block bytes.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test blockBytes() returns correctly a persisted block as bytes using ZSTD_PROTOBUF format")
+        @SuppressWarnings("DataFlowIssue")
+        void testBlockBytesZSTDPROTOBUFFormat(final CompressionType compressionType) throws IOException {
+            // build a test block
+            final BlockItem[] blockItems = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocks(1);
+            final FilesHistoricConfig testConfig = createTestConfiguration(tempDir, compressionType);
+            final BlockPath blockPath = BlockPath.computeBlockPath(
+                    testConfig, blockItems[0].blockHeader().number());
+            final Block block = new Block(List.of(blockItems));
+            final Bytes expected = Block.PROTOBUF.toBytes(block);
+            // test zipBlockAccessor.block()
+            final ZipBlockAccessor toTest = createBlockAndGetAssociatedAccessor(testConfig, blockPath, expected);
+            // The blockBytes method should return the bytes of the block with the
+            // specified format. In order to assert the same bytes, we need to decompress
+            // the bytes returned by the blockBytes method and compare them to the expected.
+            // For this test, we always use the ZSTD_PROTOBUF format to read the block bytes,
+            // no matter the actual compression type used to persist the block. With this format
+            // we always expect to be returned the bytes compressed using the ZStandard compression
+            // algorithm.
+            final Bytes testResult = toTest.blockBytes(Format.ZSTD_PROTOBUF);
+            final Bytes actual = Bytes.wrap(CompressionType.ZSTD.decompress(testResult.toByteArray()));
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        /**
+         * This test aims to verify that the {@link ZipBlockAccessor#blockBytes(Format)}
+         * will correctly return a zipped block as bytes. This test will always use the
+         * {@link Format#PROTOBUF} format to read the block bytes.
+         */
+        @ParameterizedTest
+        @EnumSource(CompressionType.class)
+        @DisplayName("Test blockBytes() returns correctly a persisted block as bytes using PROTOBUF format")
+        @SuppressWarnings("DataFlowIssue")
+        void testBlockBytesProtobufFormat(final CompressionType compressionType) throws IOException {
+            // build a test block
+            final BlockItem[] blockItems = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocks(1);
+            final FilesHistoricConfig testConfig = createTestConfiguration(tempDir, compressionType);
+            final BlockPath blockPath = BlockPath.computeBlockPath(
+                    testConfig, blockItems[0].blockHeader().number());
+            final Block block = new Block(List.of(blockItems));
+            final Bytes expected = Block.PROTOBUF.toBytes(block);
+            // test zipBlockAccessor.block()
+            final ZipBlockAccessor toTest = createBlockAndGetAssociatedAccessor(testConfig, blockPath, expected);
+            // The blockBytes method should return the bytes of the block with the
+            // specified format.
+            // For this test, we always use the PROTOBUF format to read the block bytes,
+            // no matter the actual compression type used to persist the block. With this format
+            // we always expect to be returned the bytes to not be compressed.
+            final Bytes testResult = toTest.blockBytes(Format.PROTOBUF);
+            assertThat(testResult).isEqualTo(expected);
+        }
+
+        /**
          * This test aims to verify that the {@link ZipBlockAccessor#block()}
          * will correctly return a zipped block.
          */
         @ParameterizedTest
         @EnumSource(CompressionType.class)
-        @DisplayName("Test block method returns correctly a persisted block")
+        @DisplayName("Test block() returns correctly a persisted block")
         @SuppressWarnings("DataFlowIssue")
         void testBlock(final CompressionType compressionType) throws IOException {
             // build a test block
@@ -135,7 +229,7 @@ class ZipBlockAccessorTest {
          */
         @ParameterizedTest
         @EnumSource(CompressionType.class)
-        @DisplayName("Test block method returns correctly a persisted block")
+        @DisplayName("Test blockUnparsed() returns correctly a persisted block unparsed")
         @SuppressWarnings("DataFlowIssue")
         void testBlockUnparsed(final CompressionType compressionType) throws IOException, ParseException {
             // build a test block

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
@@ -261,8 +261,8 @@ class ZipBlockAccessorTest {
             final FilesHistoricConfig testConfig = createTestConfiguration(tempDir, compressionType);
             final BlockPath blockPath = BlockPath.computeBlockPath(
                     testConfig, blockItems[0].blockHeader().number());
-            final Block expected = new Block(List.of(blockItems));
-            final Bytes protoBytes = Block.PROTOBUF.toBytes(expected);
+            final Block block = new Block(List.of(blockItems));
+            final Bytes protoBytes = Block.PROTOBUF.toBytes(block);
             // test zipBlockAccessor.writeBytesTo()
             final ZipBlockAccessor toTest = createBlockAndGetAssociatedAccessor(testConfig, blockPath, protoBytes);
             final Format format = getHappyPathFormat(compressionType);
@@ -272,7 +272,8 @@ class ZipBlockAccessorTest {
             final byte[] actual = baos.toByteArray();
             // we must always compress the bytes to compare them with whatever compression type
             // was used to persist the block
-            assertThat(actual).isEqualTo(compressionType.compress(protoBytes.toByteArray()));
+            final byte[] expected = compressionType.compress(protoBytes.toByteArray());
+            assertThat(actual).isEqualTo(expected).containsExactly(expected);
         }
 
         /**
@@ -294,8 +295,8 @@ class ZipBlockAccessorTest {
             final FilesHistoricConfig testConfig = createTestConfiguration(tempDir, compressionType);
             final BlockPath blockPath = BlockPath.computeBlockPath(
                     testConfig, blockItems[0].blockHeader().number());
-            final Block expected = new Block(List.of(blockItems));
-            final Bytes protoBytes = Block.PROTOBUF.toBytes(expected);
+            final Block block = new Block(List.of(blockItems));
+            final Bytes protoBytes = Block.PROTOBUF.toBytes(block);
             // test zipBlockAccessor.writeBytesTo()
             final ZipBlockAccessor toTest = createBlockAndGetAssociatedAccessor(testConfig, blockPath, protoBytes);
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -303,7 +304,8 @@ class ZipBlockAccessorTest {
             baos.close();
             final byte[] actual = baos.toByteArray();
             // we must always compress the bytes to compare them with the zstd compression type
-            assertThat(actual).isEqualTo(CompressionType.ZSTD.compress(protoBytes.toByteArray()));
+            final byte[] expected = CompressionType.ZSTD.compress(protoBytes.toByteArray());
+            assertThat(actual).isEqualTo(expected).containsExactly(expected);
         }
 
         /**
@@ -325,8 +327,8 @@ class ZipBlockAccessorTest {
             final FilesHistoricConfig testConfig = createTestConfiguration(tempDir, compressionType);
             final BlockPath blockPath = BlockPath.computeBlockPath(
                     testConfig, blockItems[0].blockHeader().number());
-            final Block expected = new Block(List.of(blockItems));
-            final Bytes protoBytes = Block.PROTOBUF.toBytes(expected);
+            final Block block = new Block(List.of(blockItems));
+            final Bytes protoBytes = Block.PROTOBUF.toBytes(block);
             // test zipBlockAccessor.writeBytesTo()
             final ZipBlockAccessor toTest = createBlockAndGetAssociatedAccessor(testConfig, blockPath, protoBytes);
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -334,7 +336,8 @@ class ZipBlockAccessorTest {
             baos.close();
             final byte[] actual = baos.toByteArray();
             // we must always compress the bytes to compare them with the zstd compression type
-            assertThat(actual).isEqualTo(protoBytes.toByteArray());
+            final byte[] expected = protoBytes.toByteArray();
+            assertThat(actual).isEqualTo(expected).containsExactly(expected);
         }
 
         private Format getHappyPathFormat(final CompressionType compressionType) {

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
@@ -16,6 +16,7 @@ import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBloc
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -112,6 +113,30 @@ class ZipBlockArchiveTest {
             final Path testRootPath = tempDir.resolve("testRootPath");
             Files.createDirectories(testRootPath);
             final ZipBlockArchive toTest = new ZipBlockArchive(testContext, createTestConfiguration(testRootPath, 1));
+            final long actual = toTest.minStoredBlockNumber();
+            assertThat(actual).isEqualTo(-1L);
+        }
+
+        /**
+         * This test aims to assert that the
+         * {@link ZipBlockArchive#minStoredBlockNumber()} returns -1L if the
+         * archive is empty.
+         */
+        @Test
+        @DisplayName("Test minStoredBlockNumber() returns -1L when zip file has no entries")
+        @Disabled(
+                "todo determine if the zips should have 's' at the end cause if so, then the logic in the min method must change")
+        void testMinStoredEmptyZipFile() throws IOException {
+            final Path testRootPath = tempDir.resolve("testRootPath");
+            Files.createDirectories(testRootPath);
+            final FilesHistoricConfig testConfiguration = createTestConfiguration(testRootPath, 1);
+            final BlockPath computedBlockPath00s = BlockPath.computeBlockPath(testConfiguration, 0L);
+            final BlockPath computedBlockPath10s = BlockPath.computeBlockPath(testConfiguration, 10L);
+            Files.createDirectories(computedBlockPath00s.dirPath());
+            Files.createFile(computedBlockPath00s.zipFilePath());
+            Files.createDirectories(computedBlockPath10s.dirPath());
+            Files.createFile(computedBlockPath10s.zipFilePath());
+            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, testConfiguration);
             final long actual = toTest.minStoredBlockNumber();
             assertThat(actual).isEqualTo(-1L);
         }

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
@@ -1,39 +1,68 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.blocks.files.historic;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
+import com.google.common.jimfs.Jimfs;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test class for {@link ZipBlockArchive}.
  */
 @DisplayName("ZipBlockArchive Tests")
 class ZipBlockArchiveTest {
+    /** The in-memory {@link FileSystem} used for testing. */
+    private FileSystem jimfs;
     /** The {@link SimpleInMemoryHistoricalBlockFacility} used for testing. */
     private SimpleInMemoryHistoricalBlockFacility historicalBlockProvider;
     /** The {@link BlockNodeContext} used for testing. */
     private BlockNodeContext testContext;
+    /** The default test {@link FilesHistoricConfig} used for testing. */
+    private FilesHistoricConfig defaultTestConfig;
+    /** Temp dir used for testing as the File abstraction is not supported by jimfs */
+    @TempDir
+    private Path tempDir;
 
     /**
      * Environment setup before each test.
      */
     @BeforeEach
     void setup() {
+        jimfs = Jimfs.newFileSystem(com.google.common.jimfs.Configuration.unix());
         final Configuration configuration = ConfigurationBuilder.create()
                 .withConfigDataType(FilesHistoricConfig.class)
-                .withValue("files.historic.powersOfTenPerZipFileContents", "1")
                 .build();
+        // we need a custom test config, because if we resolve it using the
+        // config dependency, we cannot resolve the path using the jimfs
+        // once we are able to override existing config converters, we will no
+        // longer need this createTestConfiguration and the production logic
+        // can also be simplified and to always get the configuration via the
+        // block context
+        defaultTestConfig = createTestConfiguration(jimfs.getPath("/opt/hashgraph/blocknode/data/historic"), 1);
         historicalBlockProvider = new SimpleInMemoryHistoricalBlockFacility();
         testContext = new BlockNodeContext(configuration, null, null, null, historicalBlockProvider, null);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (jimfs != null) {
+            jimfs.close();
+        }
     }
 
     /**
@@ -50,7 +79,7 @@ class ZipBlockArchiveTest {
         @Test
         @DisplayName("Test constructor with valid input")
         void testConstructorValidInput() {
-            assertThatNoException().isThrownBy(() -> new ZipBlockArchive(testContext));
+            assertThatNoException().isThrownBy(() -> new ZipBlockArchive(testContext, defaultTestConfig));
         }
 
         /**
@@ -62,7 +91,56 @@ class ZipBlockArchiveTest {
         @DisplayName("Test constructor with null input")
         @SuppressWarnings("all")
         void testConstructorNullInput() {
-            assertThatNullPointerException().isThrownBy(() -> new ZipBlockArchive(null));
+            assertThatNullPointerException().isThrownBy(() -> new ZipBlockArchive(null, defaultTestConfig));
         }
+    }
+
+    /**
+     * Functional tests for {@link ZipBlockArchive}.
+     */
+    @Nested
+    @DisplayName("Functional Tests")
+    final class FunctionalTests {
+        /**
+         * This test aims to assert that the
+         * {@link ZipBlockArchive#minStoredBlockNumber()} returns -1L if the
+         * archive is empty.
+         */
+        @Test
+        @DisplayName("Test minStoredBlockNumber() returns -1L when zip file is not present")
+        void testMinStoredNoZipFile() throws IOException {
+            final Path testRootPath = tempDir.resolve("testRootPath");
+            Files.createDirectories(testRootPath);
+            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, createTestConfiguration(testRootPath, 1));
+            final long actual = toTest.minStoredBlockNumber();
+            assertThat(actual).isEqualTo(-1L);
+        }
+
+        /**
+         * This test aims to assert that the
+         * {@link ZipBlockArchive#maxStoredBlockNumber()} returns -1L if the
+         * archive is empty.
+         */
+        @Test
+        @DisplayName("Test maxStoredBlockNumber() returns -1L when zip file is not present")
+        void testMaxStoredNoZipFile() throws IOException {
+            final Path testRootPath = tempDir.resolve("testRootPath");
+            Files.createDirectories(testRootPath);
+            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, createTestConfiguration(testRootPath, 1));
+            final long actual = toTest.maxStoredBlockNumber();
+            assertThat(actual).isEqualTo(-1L);
+        }
+    }
+
+    private FilesHistoricConfig createTestConfiguration(final Path basePath, final int powersOfTenPerZipFileContents) {
+        final FilesHistoricConfig localDefaultConfig = getDefaultConfiguration();
+        return new FilesHistoricConfig(basePath, localDefaultConfig.compression(), powersOfTenPerZipFileContents);
+    }
+
+    private FilesHistoricConfig getDefaultConfiguration() {
+        return ConfigurationBuilder.create()
+                .withConfigDataType(FilesHistoricConfig.class)
+                .build()
+                .getConfigData(FilesHistoricConfig.class);
     }
 }

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.blocks.files.historic;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
+import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
+import org.hiero.block.node.spi.BlockNodeContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for {@link ZipBlockArchive}.
+ */
+@DisplayName("ZipBlockArchive Tests")
+class ZipBlockArchiveTest {
+    /** The {@link SimpleInMemoryHistoricalBlockFacility} used for testing. */
+    private SimpleInMemoryHistoricalBlockFacility historicalBlockProvider;
+    /** The {@link BlockNodeContext} used for testing. */
+    private BlockNodeContext testContext;
+
+    /**
+     * Environment setup before each test.
+     */
+    @BeforeEach
+    void setup() {
+        final Configuration configuration = ConfigurationBuilder.create()
+                .withConfigDataType(FilesHistoricConfig.class)
+                .withValue("files.historic.powersOfTenPerZipFileContents", "1")
+                .build();
+        historicalBlockProvider = new SimpleInMemoryHistoricalBlockFacility();
+        testContext = new BlockNodeContext(configuration, null, null, null, historicalBlockProvider, null);
+    }
+
+    /**
+     * Constructor tests for {@link ZipBlockArchive}.
+     */
+    @Nested
+    @DisplayName("Constructor Tests")
+    final class ConstructorTests {
+        /**
+         * This test aims to assert that the constructor of
+         * {@link ZipBlockArchive} does not throw an exception when the input
+         * argument is valid.
+         */
+        @Test
+        @DisplayName("Test constructor with valid input")
+        void testConstructorValidInput() {
+            assertThatNoException().isThrownBy(() -> new ZipBlockArchive(testContext));
+        }
+
+        /**
+         * This test aims to assert that the constructor of
+         * {@link ZipBlockArchive} throws a {@link NullPointerException} when
+         * the input argument is null.
+         */
+        @Test
+        @DisplayName("Test constructor with null input")
+        @SuppressWarnings("all")
+        void testConstructorNullInput() {
+            assertThatNullPointerException().isThrownBy(() -> new ZipBlockArchive(null));
+        }
+    }
+}


### PR DESCRIPTION
## Reviewer Notes

- part 3 of unit tests for the files historic plugin
- some changes to the compress method for the ZSTD compression type for consistency with the wrapped stream method
- additional tests for the change in the compress method

## Related Issue(s)

Closes #1009
