### PR TITLE
fix: Fix e2e test after latest refactor

### DIFF
--- a/block-node/publisher/src/main/java/org/hiero/block/node/publisher/PublisherServicePlugin.java
+++ b/block-node/publisher/src/main/java/org/hiero/block/node/publisher/PublisherServicePlugin.java
@@ -530,7 +530,8 @@ public final class PublisherServicePlugin implements BlockNodePlugin, ServiceInt
                                         this::onSessionUpdate,
                                         liveBlockItemsReceived,
                                         stateLock,
-                                        this::sendBlockItemsToMessagingService);
+                                        this::sendBlockItemsToMessagingService,
+                                        latestAckedBlockNumber);
                                 // add the session to the set of open sessions
                                 openSessions.add(producerBlockItemObserver);
                                 numberOfProducers.set(openSessions.size());

--- a/block-node/publisher/src/test/java/org/hiero/block/node/publisher/BlockStreamProducerSessionTest.java
+++ b/block-node/publisher/src/test/java/org/hiero/block/node/publisher/BlockStreamProducerSessionTest.java
@@ -67,7 +67,8 @@ public class BlockStreamProducerSessionTest {
                 onUpdate,
                 liveBlockItemsReceived,
                 stateLock,
-                sendToBlockMessaging);
+                sendToBlockMessaging,
+                -1);
     }
 
     /**
@@ -392,7 +393,8 @@ public class BlockStreamProducerSessionTest {
                 onUpdate,
                 liveBlockItemsReceived,
                 new ReentrantLock(),
-                sendToBlockMessaging);
+                sendToBlockMessaging,
+                -1);
 
         // Try to send a response that should trigger the exception
         failingSession.handlePersisted(new PersistedNotification(0L, 0L, 1));

--- a/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
@@ -173,7 +173,7 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
     @Timeout(30)
     public void shouldResumeFromNewPublisherAfterPrimaryDisconnects() throws IOException, InterruptedException {
         // ===== Prepare and Start first simulator and make sure it's streaming ======================
-        final Map<String, String> firstSimulatorConfiguration = Map.of("generator.startBlockNumber", "1");
+        final Map<String, String> firstSimulatorConfiguration = Map.of("generator.startBlockNumber", "0");
         final BlockStreamSimulatorApp firstSimulator = createBlockSimulator(firstSimulatorConfiguration);
         final Future<?> firstSimulatorThread = startSimulatorInstance(firstSimulator);
         // ===== Stop simulator and assert ===========================================================]
@@ -183,7 +183,7 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
                 .lastKnownPublisherClientStatuses()
                 .getLast();
         final long firstSimulatorLatestPublishedBlockNumber =
-                firstSimulator.getStreamStatus().publishedBlocks();
+                firstSimulator.getStreamStatus().publishedBlocks() - 1; // we subtract one since we started on 0
         firstSimulatorThread.cancel(true);
 
         final SingleBlockResponse latestPublishedBlockBefore =


### PR DESCRIPTION
## Reviewer Notes
- Due to Refactor to the `handlePersisted` method on `BlockStreamProducerSession` newer and faster publishing was not receiving ACKs, even when the BN did correctly switched to that publisher and the original (slower) publisher was correctly getting the acks (as it should)
- Fixed Other UT, since cannot longer start from 1, needs to start at 0.

Fixes #1033 
