### PR TITLE
test: Files Historic Plugin Unit Tests Pt. 4

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/blocks/SimpleTestBlockItemBuilder.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/blocks/SimpleTestBlockItemBuilder.java
@@ -161,5 +161,13 @@ public final class SimpleTestBlockItemBuilder {
         return batches;
     }
 
+    public static BlockItem[] createSimpleBlockWithNumber(final long blockNumber) {
+        final BlockItem[] blockItems = new BlockItem[3];
+        blockItems[0] = sampleBlockHeader(blockNumber);
+        blockItems[1] = sampleRoundHeader(blockNumber * 10L);
+        blockItems[2] = sampleBlockProof(blockNumber);
+        return blockItems;
+    }
+
     private SimpleTestBlockItemBuilder() {}
 }

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/blocks/SimpleTestBlockItemBuilder.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/blocks/SimpleTestBlockItemBuilder.java
@@ -169,5 +169,13 @@ public final class SimpleTestBlockItemBuilder {
         return blockItems;
     }
 
+    public static BlockItemUnparsed[] createSimpleBlockUnparsedWithNumber(final long blockNumber) {
+        final BlockItemUnparsed[] blockItems = new BlockItemUnparsed[3];
+        blockItems[0] = sampleBlockHeaderUnparsed(blockNumber);
+        blockItems[1] = sampleRoundHeaderUnparsed(blockNumber * 10L);
+        blockItems[2] = sampleBlockProofUnparsed(blockNumber);
+        return blockItems;
+    }
+
     private SimpleTestBlockItemBuilder() {}
 }

--- a/block-node/base/src/main/java/org/hiero/block/node/base/CompressionType.java
+++ b/block-node/base/src/main/java/org/hiero/block/node/base/CompressionType.java
@@ -5,11 +5,9 @@ import com.github.luben.zstd.Zstd;
 import com.github.luben.zstd.ZstdInputStream;
 import com.github.luben.zstd.ZstdOutputStream;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UncheckedIOException;
 import java.util.Objects;
 
 /**
@@ -89,24 +87,7 @@ public enum CompressionType {
     public byte[] compress(@NonNull final byte[] data) {
         Objects.requireNonNull(data);
         return switch (this) {
-            case ZSTD -> {
-                // Seems that if we use Zstd.compress(data, DEFAULT_ZSTD_COMPRESSION_LEVEL);
-                // directly it will not produce the same result as wrapping
-                // a stream with the same compression level. For consistency,
-                // we need to use the same approach as the one used in the
-                // wrapStream method. This method is a convenience for
-                // compressing data in memory.
-                try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                        final OutputStream wrappedBaos = wrapStream(baos)) {
-                    wrappedBaos.write(data);
-                    wrappedBaos.close();
-                    // close before return so that we are absolutely sure that
-                    // all data is written including possible footer and others
-                    yield baos.toByteArray();
-                } catch (final IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            }
+            case ZSTD -> Zstd.compress(data, DEFAULT_ZSTD_COMPRESSION_LEVEL);
             case NONE -> data;
         };
     }

--- a/block-node/base/src/test/java/org/hiero/block/node/base/CompressionTypeTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/CompressionTypeTest.java
@@ -153,7 +153,12 @@ class CompressionTypeTest {
         }
         final byte[] bytesFromBaos = baosTarget.toByteArray();
         final byte[] bytesFromCompress = compressionType.compress(testData);
-        assertThat(bytesFromBaos).isEqualTo(bytesFromCompress).containsExactly(bytesFromCompress);
+        // we must always decompress as the binary content may be different, but
+        // a decompression after compression asserts that the results have been
+        // preserved after a compression has occurred
+        final byte[] actual = compressionType.decompress(bytesFromBaos);
+        final byte[] expected = compressionType.decompress(bytesFromCompress);
+        assertThat(actual).isEqualTo(expected).containsExactly(expected);
     }
 
     /**

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
@@ -160,7 +160,7 @@ class ZipBlockArchive {
                             .filter(path -> path.getFileName().toString().endsWith(".zip"))
                             .min(Comparator.comparingLong(filePath -> {
                                 String fileName = filePath.getFileName().toString();
-                                return Long.parseLong(fileName.substring(0, fileName.indexOf('.')));
+                                return Long.parseLong(fileName.substring(0, fileName.indexOf('s')));
                             }));
                     if (zipFilePath.isPresent()) {
                         try (var zipFile = new ZipFile(zipFilePath.get().toFile())) {
@@ -168,24 +168,19 @@ class ZipBlockArchive {
                                     .mapToLong(entry -> blockNumberFromFile(entry.getName()))
                                     .min()
                                     .orElse(-1);
-                        } catch (IOException e) {
-                            LOGGER.log(System.Logger.Level.ERROR, "Failed to read zip file", e);
-                            context.serverHealth()
-                                    .shutdown(
-                                            ZipBlockArchive.class.getName(),
-                                            "Error reading directory: " + lowestPath + " because " + e.getMessage());
                         }
                     } else {
                         // no zip files found in min directory
                         return -1;
                     }
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 LOGGER.log(System.Logger.Level.ERROR, "Error reading directory: " + lowestPath, e);
                 context.serverHealth()
                         .shutdown(
                                 ZipBlockArchive.class.getName(),
                                 "Error reading directory: " + lowestPath + " because " + e.getMessage());
+                lowestPath = null;
             }
         }
         return -1;
@@ -217,7 +212,7 @@ class ZipBlockArchive {
                             .filter(path -> path.getFileName().toString().endsWith(".zip"))
                             .max(Comparator.comparingLong(filePath -> {
                                 String fileName = filePath.getFileName().toString();
-                                return Long.parseLong(fileName.substring(0, fileName.indexOf('.')));
+                                return Long.parseLong(fileName.substring(0, fileName.indexOf('s')));
                             }));
                     if (zipFilePath.isPresent()) {
                         try (var zipFile = new ZipFile(zipFilePath.get().toFile())) {
@@ -225,24 +220,19 @@ class ZipBlockArchive {
                                     .mapToLong(entry -> blockNumberFromFile(entry.getName()))
                                     .max()
                                     .orElse(-1);
-                        } catch (IOException e) {
-                            LOGGER.log(System.Logger.Level.ERROR, "Failed to read zip file", e);
-                            context.serverHealth()
-                                    .shutdown(
-                                            ZipBlockArchive.class.getName(),
-                                            "Error reading directory: " + highestPath + " because " + e.getMessage());
                         }
                     } else {
                         // no zip files found in max directory
                         return -1;
                     }
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 LOGGER.log(System.Logger.Level.ERROR, "Error reading directory: " + highestPath, e);
                 context.serverHealth()
                         .shutdown(
                                 ZipBlockArchive.class.getName(),
                                 "Error reading directory: " + highestPath + " because " + e.getMessage());
+                highestPath = null;
             }
         }
         return -1;

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
@@ -94,8 +94,7 @@ class ZipBlockArchive {
                 //   what if the file is zstd compressed but the current runtime compression is none?
                 //   then the file name would be wrong? For now appending, maybe a slight cleanup is in order for this
                 //   logic.
-                final String blockFileName = BlockFile.blockFileName(blockNumber)
-                        .concat(config.compression().extension());
+                final String blockFileName = BlockFile.blockFileName(blockNumber, config.compression());
                 // get block accessor
                 final BlockAccessor blockAccessor = blockAccessors.get((int) (blockNumber - firstBlockNumber));
                 // get the bytes to write, we have to do this as we need to know the size

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
@@ -123,7 +123,6 @@ class ZipBlockArchiveTest {
         @Test
         @DisplayName("Test minStoredBlockNumber() returns -1L when zip file is not present")
         void testMinStoredNoZipFile() {
-            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, testConfig);
             // assert that server is running before we call actual
             assertThat(testContext.serverHealth().isRunning()).isTrue();
             final long actual = toTest.minStoredBlockNumber();
@@ -145,8 +144,6 @@ class ZipBlockArchiveTest {
             final BlockPath computedBlockPath00s = BlockPath.computeBlockPath(testConfig, 0L);
             Files.createDirectories(computedBlockPath00s.dirPath());
             Files.createFile(computedBlockPath00s.zipFilePath());
-            // create test instance
-            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, testConfig);
             // assert that server is running before we call actual
             assertThat(testContext.serverHealth().isRunning()).isTrue();
             // call
@@ -168,8 +165,6 @@ class ZipBlockArchiveTest {
             final long expected = 3L;
             createAndAddBlockEntry(expected);
             createAndAddBlockEntry(4L);
-            // create test instance
-            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, testConfig);
             // assert that server is running before we call actual
             assertThat(testContext.serverHealth().isRunning()).isTrue();
             // call
@@ -194,8 +189,6 @@ class ZipBlockArchiveTest {
             // zip size are 10 blocks, so the following 2 will be in another file
             createAndAddBlockEntry(13L);
             createAndAddBlockEntry(14L);
-            // create test instance
-            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, testConfig);
             // assert that server is running before we call actual
             assertThat(testContext.serverHealth().isRunning()).isTrue();
             // call
@@ -213,7 +206,6 @@ class ZipBlockArchiveTest {
         @Test
         @DisplayName("Test maxStoredBlockNumber() returns -1L when zip file is not present")
         void testMaxStoredNoZipFile() {
-            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, testConfig);
             // assert that server is running before we call actual
             assertThat(testContext.serverHealth().isRunning()).isTrue();
             final long actual = toTest.maxStoredBlockNumber();
@@ -235,8 +227,6 @@ class ZipBlockArchiveTest {
             final BlockPath computedBlockPath00s = BlockPath.computeBlockPath(testConfig, 0L);
             Files.createDirectories(computedBlockPath00s.dirPath());
             Files.createFile(computedBlockPath00s.zipFilePath());
-            // create test instance
-            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, testConfig);
             // assert that server is running before we call actual
             assertThat(testContext.serverHealth().isRunning()).isTrue();
             // call
@@ -258,8 +248,6 @@ class ZipBlockArchiveTest {
             final long expected = 4L;
             createAndAddBlockEntry(3L);
             createAndAddBlockEntry(expected);
-            // create test instance
-            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, testConfig);
             // assert that server is running before we call actual
             assertThat(testContext.serverHealth().isRunning()).isTrue();
             // call
@@ -284,8 +272,6 @@ class ZipBlockArchiveTest {
             // zip size are 10 blocks, so the following 2 will be in another file
             createAndAddBlockEntry(13L);
             createAndAddBlockEntry(expected);
-            // create test instance
-            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, testConfig);
             // assert that server is running before we call actual
             assertThat(testContext.serverHealth().isRunning()).isTrue();
             // call
@@ -303,7 +289,6 @@ class ZipBlockArchiveTest {
         @Test
         @DisplayName("Test blockAccessor() returns null when no block is present")
         void testBlockAccessorNoBlocksPresent() {
-            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, testConfig);
             // call
             final BlockAccessor actual = toTest.blockAccessor(1L);
             // assert
@@ -320,7 +305,6 @@ class ZipBlockArchiveTest {
         void testBlockAccessorBlockNotFound() throws IOException {
             // we create a block with number 0L so we have some block present,
             createAndAddBlockEntry(0L);
-            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, testConfig);
             // call
             final BlockAccessor actual = toTest.blockAccessor(1L);
             // assert
@@ -338,8 +322,6 @@ class ZipBlockArchiveTest {
             // create test environment, for this test we need one zip file with two zip entries inside
             final long targetBlockNumber = 1L;
             final ZipBlockAccessor expected = createAndAddBlockEntry(targetBlockNumber);
-            // create test instance
-            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, testConfig);
             // call
             final BlockAccessor actual = toTest.blockAccessor(targetBlockNumber);
             // assert
@@ -371,8 +353,6 @@ class ZipBlockArchiveTest {
             assertThat(historicalBlockProvider.availableBlocks())
                     .returns(0L, from(BlockRangeSet::min))
                     .returns(19L, from(BlockRangeSet::max));
-            // create the instance to test
-            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, testConfig);
             // assert no zip file is created yet, the zip file will be all the same
             // for all the 10 zips, so we can rely on asserting based on computed path for the first block
             // expected
@@ -419,7 +399,6 @@ class ZipBlockArchiveTest {
             assertThat(historicalBlockProvider.availableBlocks())
                     .returns(0L, from(BlockRangeSet::min))
                     .returns(19L, from(BlockRangeSet::max));
-            final ZipBlockArchive toTest = new ZipBlockArchive(testContext, testConfig);
             // assert no zip file is created yet, the zip file will be all the same
             // for all the 10 zips, so we can rely on asserting based on computed path for the first block
             // expected
@@ -439,6 +418,11 @@ class ZipBlockArchiveTest {
                         final byte[] rawContents = in.readAllBytes();
                         final BlockUnparsed actualValue = BlockUnparsed.PROTOBUF.parse(Bytes.wrap(rawContents));
                         assertThat(actualValue).isEqualTo(expectedValue);
+                        final String actualHex =
+                                BlockUnparsed.PROTOBUF.toBytes(actualValue).toHex();
+                        final String expectedHex =
+                                BlockUnparsed.PROTOBUF.toBytes(expectedValue).toHex();
+                        assertThat(actualHex).isEqualTo(expectedHex);
                     }
                 }
             }


### PR DESCRIPTION
## Reviewer Notes

- part 4 of tests for the zip file
- reverted to using the static zstd compression method instead of streaming approach in our convenience implementation
- modified some tests so they can be more resilient

## Related Issue(s)

Closes #1021 
