### PR TITLE
fix: Fixing Publish Workflow

### DIFF
--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -41,8 +41,8 @@ jobs:
       java-distribution: ${{ inputs.java-distribution || 'temurin' }}
       java-version: ${{ inputs.java-version || '21.0.6' }}
 
-  publish:
-    timeout-minutes: 30
+  publish-block-node-app:
+    timeout-minutes: 60
     needs: [check-gradle]
     runs-on: hiero-block-node-linux-medium
 
@@ -64,7 +64,7 @@ jobs:
           java-version: "21.0.6"
 
       - name: Build
-        run: ${GRADLE_EXEC} clean build
+        run: ${GRADLE_EXEC} clean assemble
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -83,6 +83,7 @@ jobs:
           buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
+          version: v0.22.0
 
       - name: Extract version
         id: extract_version
@@ -112,8 +113,57 @@ jobs:
           build-contexts: |
             distributions=./block-node/server/build/distributions
 
-      # Build and push SIMULATOR image
+  publish-simulator:
+    timeout-minutes: 60
+    needs: [check-gradle]
+    runs-on: hiero-block-node-linux-medium
 
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Install JDK
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: "temurin"
+          java-version: "21.0.6"
+
+      - name: Build
+        run: ${GRADLE_EXEC} clean assemble
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Qemu
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        with:
+          driver-opts: network=host
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
+          version: v0.22.0
+
+      - name: Extract version
+        id: extract_version
+        run: |
+          VERSION=$(cat version.txt)
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      # Build and push SIMULATOR image
       - name: Simulator - Prepare docker directory
         run: |
           ${GRADLE_EXEC} :simulator:copyDependenciesFolders
@@ -122,7 +172,7 @@ jobs:
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: ./simulator/build/docker
-          file: ./simulator/docker/Dockerfile
+          file: ./simulator/build/docker/Dockerfile
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64, linux/arm64
@@ -131,9 +181,9 @@ jobs:
           build-args: |
             VERSION=${{ env.VERSION }}
 
-  helm-chart-release:
+  helm-chart-release-block-node-app:
     timeout-minutes: 15
-    needs: publish
+    needs: publish-block-node-app
     runs-on: hiero-block-node-linux-medium
 
     steps:
@@ -169,6 +219,36 @@ jobs:
       - name: Push helm chart
         run: |
           helm push block-node-helm-chart-${{ env.VERSION }}.tgz oci://ghcr.io/hiero-ledger/hiero-block-node
+
+  helm-chart-release-simulator:
+    timeout-minutes: 15
+    needs: publish-simulator
+    runs-on: hiero-block-node-linux-medium
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version
+        id: extract_version
+        run: |
+          VERSION=$(cat version.txt)
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
       - name: Simulator Chart - Package helm chart
         run: |

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -104,8 +104,8 @@ jobs:
       - name: Server - Build and push image
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
-          context: ./block-node/server/docker
-          file: ./block-node/server/docker/Dockerfile
+          context: ./block-node/app/docker
+          file: ./block-node/app/docker/Dockerfile
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64, linux/arm64
@@ -115,7 +115,7 @@ jobs:
             VERSION=${{ env.VERSION }}
             SOURCE_DATE_EPOCH=${{ env.SOURCE_DATE_EPOCH }}
           build-contexts: |
-            distributions=./block-node/server/build/distributions
+            distributions=./block-node/app/build/distributions
 
   publish-simulator:
     timeout-minutes: 30

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -31,6 +31,10 @@ env:
   PACKAGE_NAME: hedera-block-node
   REGISTRY: ghcr.io
   GRADLE_EXEC: "ionice -c 2 -n 2 nice -n 19 ./gradlew "
+  JAVA_DISTRIBUTION: "temurin"
+  JAVA_VERSION: "21.0.6"
+  DOCKER_MIRROR: "https://hub.mirror.docker.lat.ope.eng.hashgraph.io"
+  BUILDKIT_VERSION: "v0.22.0"
 
 jobs:
   check-gradle:
@@ -42,7 +46,7 @@ jobs:
       java-version: ${{ inputs.java-version || '21.0.6' }}
 
   publish-block-node-app:
-    timeout-minutes: 60
+    timeout-minutes: 30
     needs: [check-gradle]
     runs-on: hiero-block-node-linux-medium
 
@@ -60,8 +64,8 @@ jobs:
       - name: Install JDK
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          distribution: "temurin"
-          java-version: "21.0.6"
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
 
       - name: Build
         run: ${GRADLE_EXEC} clean assemble
@@ -82,8 +86,8 @@ jobs:
           driver-opts: network=host
           buildkitd-config-inline: |
             [registry."docker.io"]
-              mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
-          version: v0.22.0
+              mirrors = ["${{ env.DOCKER_MIRROR }}"]
+          version: ${{ env.BUILDKIT_VERSION }}
 
       - name: Extract version
         id: extract_version
@@ -114,7 +118,7 @@ jobs:
             distributions=./block-node/server/build/distributions
 
   publish-simulator:
-    timeout-minutes: 60
+    timeout-minutes: 30
     needs: [check-gradle]
     runs-on: hiero-block-node-linux-medium
 
@@ -132,8 +136,8 @@ jobs:
       - name: Install JDK
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          distribution: "temurin"
-          java-version: "21.0.6"
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
 
       - name: Build
         run: ${GRADLE_EXEC} clean assemble
@@ -154,8 +158,8 @@ jobs:
           driver-opts: network=host
           buildkitd-config-inline: |
             [registry."docker.io"]
-              mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
-          version: v0.22.0
+              mirrors = ["${{ env.DOCKER_MIRROR }}"]
+          version: ${{ env.BUILDKIT_VERSION }}
 
       - name: Extract version
         id: extract_version


### PR DESCRIPTION
## Reviewer Notes

- Updated internal version of docker/setup-buildx-action to fix cache deprecation issue by GitHub.

- replaced `build` for `assemble` to speed up the process, we only need assemble for this jobs and build was already done on previous job (deterministic check)
- Separated Publish of Block-Node-App and Simulator into its own Jobs, this was needed do to caching issues being reuseed from the first build failing with the 2nd build (simulator)
- Note: future work will complete decouple the simulator and block-node-app releases


Fixes issue: 
```
ERROR: failed to solve: This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset
```

Fixes #1041

take a look at this reference on how other teams fix it: 

Relay: https://github.com/hiero-ledger/hiero-json-rpc-relay/pull/3657
MN: https://github.com/hiero-ledger/hiero-mirror-node/pull/10869


![image](https://github.com/user-attachments/assets/0606b109-ea19-40af-b331-e63ed5e3e913)


