### PR TITLE
fix: hard shutdown of the producer causes exception when another is connected

### DIFF
--- a/block-node/publisher/src/main/java/org/hiero/block/node/publisher/BlockStreamProducerSession.java
+++ b/block-node/publisher/src/main/java/org/hiero/block/node/publisher/BlockStreamProducerSession.java
@@ -12,7 +12,6 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.swirlds.metrics.api.Counter;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
@@ -309,7 +308,7 @@ public final class BlockStreamProducerSession implements Pipeline<List<BlockItem
 
         try {
             responsePipeline.onNext(response);
-        } catch (UncheckedIOException e) {
+        } catch (RuntimeException e) {
             LOGGER.log(
                     WARNING,
                     "Failed to send response to {0}. Disconnecting this session. Error: {1}",

--- a/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
+++ b/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.suites;
 
-import com.hedera.hapi.block.protoc.BlockAccessServiceGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import java.util.ArrayList;
@@ -9,8 +8,6 @@ import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.hiero.block.api.protoc.BlockAccessServiceGrpc;
-import org.hiero.block.api.protoc.BlockRequest;
-import org.hiero.block.api.protoc.BlockResponse;
 import org.hiero.block.simulator.BlockStreamSimulatorApp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
+++ b/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
@@ -2,29 +2,16 @@
 package org.hiero.block.suites;
 
 import com.hedera.hapi.block.protoc.BlockAccessServiceGrpc;
-import com.swirlds.config.api.Configuration;
-import com.swirlds.config.api.ConfigurationBuilder;
-import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
-import com.swirlds.config.extensions.sources.SimpleConfigSource;
-import com.swirlds.config.extensions.sources.SystemEnvironmentConfigSource;
-import com.swirlds.config.extensions.sources.SystemPropertiesConfigSource;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.hiero.block.api.protoc.BlockAccessServiceGrpc;
 import org.hiero.block.api.protoc.BlockRequest;
 import org.hiero.block.api.protoc.BlockResponse;
 import org.hiero.block.simulator.BlockStreamSimulatorApp;
-import org.hiero.block.simulator.BlockStreamSimulatorInjectionComponent;
-import org.hiero.block.simulator.DaggerBlockStreamSimulatorInjectionComponent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.containers.GenericContainer;
@@ -166,55 +153,6 @@ public abstract class BaseSuite {
                 throw new RuntimeException(e);
             }
         });
-    }
-
-    /**
-     * Creates a new instance of the block stream simulator with custom configuration.
-     *
-     * @param customConfiguration the custom configuration which will be applied to simulator upon startup
-     * @return a new instance of the block stream simulator
-     * @throws IOException if an I/O error occurs
-     */
-    protected BlockStreamSimulatorApp createBlockSimulator(@NonNull final Map<String, String> customConfiguration)
-            throws IOException {
-        BlockStreamSimulatorInjectionComponent DIComponent = DaggerBlockStreamSimulatorInjectionComponent.factory()
-                .create(loadSimulatorConfiguration(customConfiguration));
-        return DIComponent.getBlockStreamSimulatorApp();
-    }
-
-    /**
-     * Creates a new instance of the block stream simulator with default configuration.
-     *
-     * @return a new instance of the block stream simulator
-     * @throws IOException if an I/O error occurs
-     */
-    protected BlockStreamSimulatorApp createBlockSimulator() throws IOException {
-        BlockStreamSimulatorInjectionComponent DIComponent = DaggerBlockStreamSimulatorInjectionComponent.factory()
-                .create(loadSimulatorConfiguration(Collections.emptyMap()));
-        return DIComponent.getBlockStreamSimulatorApp();
-    }
-
-    /**
-     * Builds the desired block simulator configuration
-     *
-     * @return block simulator configuration
-     * @throws IOException if an I/O error occurs
-     */
-    protected static Configuration loadSimulatorConfiguration(@NonNull final Map<String, String> customProperties)
-            throws IOException {
-        final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
-                .withSource(SystemEnvironmentConfigSource.getInstance())
-                .withSource(SystemPropertiesConfigSource.getInstance())
-                .withSource(new ClasspathFileConfigSource(Path.of("app.properties")))
-                .autoDiscoverExtensions();
-
-        for (Map.Entry<String, String> entry : customProperties.entrySet()) {
-            final String key = entry.getKey();
-            final String value = entry.getValue();
-            configurationBuilder.withSource(new SimpleConfigSource(key, value).withOrdinal(500));
-        }
-
-        return configurationBuilder.build();
     }
 
     /**

--- a/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
+++ b/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.suites;
 
+import com.hedera.hapi.block.protoc.BlockAccessServiceGrpc;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
@@ -149,53 +150,6 @@ public abstract class BaseSuite {
                 .build();
 
         return BlockAccessServiceGrpc.newBlockingStub(channel);
-    }
-
-    /**
-     * Creates a BlockRequest to retrieve a specific block.
-     *
-     * @param blockNumber The block number to retrieve
-     * @param latest Whether to retrieve the latest block
-     * @return A BlockRequest object
-     */
-    protected BlockRequest createBlockRequest(long blockNumber, boolean latest) {
-        return BlockRequest.newBuilder()
-                .setBlockNumber(blockNumber)
-                .setRetrieveLatest(latest)
-                .setAllowUnverified(true)
-                .build();
-    }
-
-    /**
-     * Retrieves a single block using the Block Node API.
-     *
-     * @param blockNumber The block number to retrieve
-     * @param allowUnverified A flag to indicate that the requested block may be sent without
-     *   verifying its `BlockProof`
-     * @return The BlockResponse from the API
-     */
-    protected BlockResponse getBlock(final long blockNumber, final boolean allowUnverified) {
-        BlockRequest request = BlockRequest.newBuilder()
-                .setBlockNumber(blockNumber)
-                .setAllowUnverified(allowUnverified)
-                .build();
-        return blockAccessStub.getBlock(request);
-    }
-
-    /**
-     * Retrieves a single block using the Block Node API.
-     *
-     * @param allowUnverified A flag to indicate that the requested block may be sent without
-     * verifying its `BlockProof`
-     * @return The BlockResponse from the API
-     */
-    protected BlockResponse getLatestBlock(final boolean allowUnverified) {
-        BlockRequest request = BlockRequest.newBuilder()
-                .setBlockNumber(-1)
-                .setRetrieveLatest(true)
-                .setAllowUnverified(allowUnverified)
-                .build();
-        return blockAccessStub.getBlock(request);
     }
 
     /**

--- a/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
@@ -66,7 +66,7 @@ public class GetBlockApiTests extends BaseSuite {
     void requestExistingBlockUsingBlockAPI() {
         // Request block number 1 (which should have been published by the simulator)
         final long blockNumber = 1;
-        final SingleBlockResponse response = getSingleBlock(blockAccessStub, blockNumber, false);
+        final BlockResponse response = getSingleBlock(blockAccessStub, blockNumber, false);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
@@ -85,7 +85,7 @@ public class GetBlockApiTests extends BaseSuite {
     void requestNonExistingBlockUsingBlockAPI() {
         // Request a non-existing block number
         final long blockNumber = 1000;
-        final SingleBlockResponse response = getSingleBlock(blockAccessStub, blockNumber, false);
+        final BlockResponse response = getSingleBlock(blockAccessStub, blockNumber, false);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
@@ -102,7 +102,7 @@ public class GetBlockApiTests extends BaseSuite {
     @DisplayName("Get a Single Block using API - Request Latest Block")
     void requestLatestBlockUsingBlockAPI() {
         // Request the latest block
-        final SingleBlockResponse response = getLatestBlock(blockAccessStub, false);
+        final BlockResponse response = getLatestBlock(blockAccessStub, false);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
@@ -123,8 +123,8 @@ public class GetBlockApiTests extends BaseSuite {
     void requestLatestBlockAndSpecificBlockUsingBlockAPI() {
         // Request the latest block and a specific block number
         final long blockNumber = 1;
-        final SingleBlockRequest request = createSingleBlockRequest(blockNumber, true);
-        final SingleBlockResponse response = blockAccessStub.singleBlock(request);
+        final BlockRequest request = createSingleBlockRequest(blockNumber, true);
+        final BlockResponse response = blockAccessStub.getBlock(request);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
@@ -140,8 +140,8 @@ public class GetBlockApiTests extends BaseSuite {
             "Get a Single Block using API - block_number to -1 and retrieve_latest to false - should return NOT_FOUND")
     void requestWithoutBlockNumberAndRetrieveLatestFalse() {
         // Request the latest block and a specific block number
-        final SingleBlockRequest request = createSingleBlockRequest(-1, false);
-        final SingleBlockResponse response = blockAccessStub.singleBlock(request);
+        final BlockRequest request = createSingleBlockRequest(-1, false);
+        final BlockResponse response = blockAccessStub.getBlock(request);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");

--- a/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.suites.block.access;
 
-import static org.hiero.block.suites.utils.BlockAccessUtils.createSingleBlockRequest;
+import static org.hiero.block.suites.utils.BlockAccessUtils.createGetBlockRequest;
 import static org.hiero.block.suites.utils.BlockAccessUtils.getLatestBlock;
-import static org.hiero.block.suites.utils.BlockAccessUtils.getSingleBlock;
+import static org.hiero.block.suites.utils.BlockAccessUtils.getBlock;
 import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -66,7 +66,7 @@ public class GetBlockApiTests extends BaseSuite {
     void requestExistingBlockUsingBlockAPI() {
         // Request block number 1 (which should have been published by the simulator)
         final long blockNumber = 1;
-        final BlockResponse response = getSingleBlock(blockAccessStub, blockNumber, false);
+        final BlockResponse response = getBlock(blockAccessStub, blockNumber, false);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
@@ -85,7 +85,7 @@ public class GetBlockApiTests extends BaseSuite {
     void requestNonExistingBlockUsingBlockAPI() {
         // Request a non-existing block number
         final long blockNumber = 1000;
-        final BlockResponse response = getSingleBlock(blockAccessStub, blockNumber, false);
+        final BlockResponse response = getBlock(blockAccessStub, blockNumber, false);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
@@ -123,7 +123,7 @@ public class GetBlockApiTests extends BaseSuite {
     void requestLatestBlockAndSpecificBlockUsingBlockAPI() {
         // Request the latest block and a specific block number
         final long blockNumber = 1;
-        final BlockRequest request = createSingleBlockRequest(blockNumber, true);
+        final BlockRequest request = createGetBlockRequest(blockNumber, true);
         final BlockResponse response = blockAccessStub.getBlock(request);
 
         // Verify the response
@@ -140,7 +140,7 @@ public class GetBlockApiTests extends BaseSuite {
             "Get a Single Block using API - block_number to -1 and retrieve_latest to false - should return NOT_FOUND")
     void requestWithoutBlockNumberAndRetrieveLatestFalse() {
         // Request the latest block and a specific block number
-        final BlockRequest request = createSingleBlockRequest(-1, false);
+        final BlockRequest request = createGetBlockRequest(-1, false);
         final BlockResponse response = blockAccessStub.getBlock(request);
 
         // Verify the response

--- a/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.suites.block.access;
 
+import static org.hiero.block.suites.utils.BlockAccessUtils.createSingleBlockRequest;
+import static org.hiero.block.suites.utils.BlockAccessUtils.getLatestBlock;
+import static org.hiero.block.suites.utils.BlockAccessUtils.getSingleBlock;
+import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -13,7 +17,6 @@ import org.hiero.block.api.protoc.BlockResponse;
 import org.hiero.block.api.protoc.BlockResponse.Code;
 import org.hiero.block.simulator.BlockStreamSimulatorApp;
 import org.hiero.block.suites.BaseSuite;
-import org.hiero.block.suites.utils.BlockAccessUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -63,7 +66,7 @@ public class GetBlockApiTests extends BaseSuite {
     void requestExistingBlockUsingBlockAPI() {
         // Request block number 1 (which should have been published by the simulator)
         final long blockNumber = 1;
-        final SingleBlockResponse response = BlockAccessUtils.getSingleBlock(blockAccessStub, blockNumber, false);
+        final SingleBlockResponse response = getSingleBlock(blockAccessStub, blockNumber, false);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
@@ -82,7 +85,7 @@ public class GetBlockApiTests extends BaseSuite {
     void requestNonExistingBlockUsingBlockAPI() {
         // Request a non-existing block number
         final long blockNumber = 1000;
-        final SingleBlockResponse response = BlockAccessUtils.getSingleBlock(blockAccessStub, blockNumber, false);
+        final SingleBlockResponse response = getSingleBlock(blockAccessStub, blockNumber, false);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
@@ -99,7 +102,7 @@ public class GetBlockApiTests extends BaseSuite {
     @DisplayName("Get a Single Block using API - Request Latest Block")
     void requestLatestBlockUsingBlockAPI() {
         // Request the latest block
-        final SingleBlockResponse response = BlockAccessUtils.getLatestBlock(blockAccessStub, false);
+        final SingleBlockResponse response = getLatestBlock(blockAccessStub, false);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
@@ -120,7 +123,7 @@ public class GetBlockApiTests extends BaseSuite {
     void requestLatestBlockAndSpecificBlockUsingBlockAPI() {
         // Request the latest block and a specific block number
         final long blockNumber = 1;
-        final SingleBlockRequest request = BlockAccessUtils.createSingleBlockRequest(blockNumber, true);
+        final SingleBlockRequest request = createSingleBlockRequest(blockNumber, true);
         final SingleBlockResponse response = blockAccessStub.singleBlock(request);
 
         // Verify the response
@@ -137,7 +140,7 @@ public class GetBlockApiTests extends BaseSuite {
             "Get a Single Block using API - block_number to -1 and retrieve_latest to false - should return NOT_FOUND")
     void requestWithoutBlockNumberAndRetrieveLatestFalse() {
         // Request the latest block and a specific block number
-        final SingleBlockRequest request = BlockAccessUtils.createSingleBlockRequest(-1, false);
+        final SingleBlockRequest request = createSingleBlockRequest(-1, false);
         final SingleBlockResponse response = blockAccessStub.singleBlock(request);
 
         // Verify the response

--- a/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
@@ -2,8 +2,8 @@
 package org.hiero.block.suites.block.access;
 
 import static org.hiero.block.suites.utils.BlockAccessUtils.createGetBlockRequest;
-import static org.hiero.block.suites.utils.BlockAccessUtils.getLatestBlock;
 import static org.hiero.block.suites.utils.BlockAccessUtils.getBlock;
+import static org.hiero.block.suites.utils.BlockAccessUtils.getLatestBlock;
 import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
@@ -13,6 +13,7 @@ import org.hiero.block.api.protoc.BlockResponse;
 import org.hiero.block.api.protoc.BlockResponse.Code;
 import org.hiero.block.simulator.BlockStreamSimulatorApp;
 import org.hiero.block.suites.BaseSuite;
+import org.hiero.block.suites.utils.BlockAccessUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -62,7 +63,7 @@ public class GetBlockApiTests extends BaseSuite {
     void requestExistingBlockUsingBlockAPI() {
         // Request block number 1 (which should have been published by the simulator)
         final long blockNumber = 1;
-        final BlockResponse response = getBlock(blockNumber, false);
+        final SingleBlockResponse response = BlockAccessUtils.getSingleBlock(blockAccessStub, blockNumber, false);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
@@ -81,7 +82,7 @@ public class GetBlockApiTests extends BaseSuite {
     void requestNonExistingBlockUsingBlockAPI() {
         // Request a non-existing block number
         final long blockNumber = 1000;
-        final BlockResponse response = getBlock(blockNumber, false);
+        final SingleBlockResponse response = BlockAccessUtils.getSingleBlock(blockAccessStub, blockNumber, false);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
@@ -98,7 +99,7 @@ public class GetBlockApiTests extends BaseSuite {
     @DisplayName("Get a Single Block using API - Request Latest Block")
     void requestLatestBlockUsingBlockAPI() {
         // Request the latest block
-        final BlockResponse response = getLatestBlock(false);
+        final SingleBlockResponse response = BlockAccessUtils.getLatestBlock(blockAccessStub, false);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
@@ -119,8 +120,8 @@ public class GetBlockApiTests extends BaseSuite {
     void requestLatestBlockAndSpecificBlockUsingBlockAPI() {
         // Request the latest block and a specific block number
         final long blockNumber = 1;
-        final BlockRequest request = createBlockRequest(blockNumber, true);
-        final BlockResponse response = blockAccessStub.getBlock(request);
+        final SingleBlockRequest request = BlockAccessUtils.createSingleBlockRequest(blockNumber, true);
+        final SingleBlockResponse response = blockAccessStub.singleBlock(request);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
@@ -136,8 +137,8 @@ public class GetBlockApiTests extends BaseSuite {
             "Get a Single Block using API - block_number to -1 and retrieve_latest to false - should return NOT_FOUND")
     void requestWithoutBlockNumberAndRetrieveLatestFalse() {
         // Request the latest block and a specific block number
-        final BlockRequest request = createBlockRequest(-1, false);
-        final BlockResponse response = blockAccessStub.getBlock(request);
+        final SingleBlockRequest request = BlockAccessUtils.createSingleBlockRequest(-1, false);
+        final SingleBlockResponse response = blockAccessStub.singleBlock(request);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");

--- a/suites/src/main/java/org/hiero/block/suites/grpc/positive/PositiveEndpointBehaviourTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/grpc/positive/PositiveEndpointBehaviourTests.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.suites.grpc.positive;
 
+import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;

--- a/suites/src/main/java/org/hiero/block/suites/persistence/positive/PositiveDataPersistenceTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/persistence/positive/PositiveDataPersistenceTests.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.suites.persistence.positive;
 
+import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
@@ -17,6 +17,7 @@ import org.hiero.block.api.protoc.BlockResponse;
 import org.hiero.block.api.protoc.BlockResponse.Code;
 import org.hiero.block.simulator.BlockStreamSimulatorApp;
 import org.hiero.block.suites.BaseSuite;
+import org.hiero.block.suites.utils.BlockAccessUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -153,8 +154,8 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
         simulators.add(futureSimulatorThread);
 
         // ===== Assert that we are persisting only the current blocks =================================
-        final BlockResponse currentBlockResponse = getLatestBlock(false);
-        final BlockResponse futureBlockResponse = getBlock(1000, false);
+        final SingleBlockResponse currentBlockResponse = BlockAccessUtils.getLatestBlock(blockAccessStub, false);
+        final SingleBlockResponse futureBlockResponse = BlockAccessUtils.getSingleBlock(blockAccessStub, 1000, false);
 
         assertNotNull(currentBlockResponse);
         assertNotNull(futureBlockResponse);
@@ -186,8 +187,10 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
                 firstSimulator.getStreamStatus().publishedBlocks() - 1; // we subtract one since we started on 0
         firstSimulatorThread.cancel(true);
 
-        final BlockResponse latestPublishedBlockBefore = getBlock(firstSimulatorLatestPublishedBlockNumber, false);
-        final BlockResponse nextPublishedBlockBefore = getBlock(firstSimulatorLatestPublishedBlockNumber + 1, false);
+        final SingleBlockResponse latestPublishedBlockBefore =
+                BlockAccessUtils.getSingleBlock(blockAccessStub, firstSimulatorLatestPublishedBlockNumber, false);
+        final SingleBlockResponse nextPublishedBlockBefore =
+                BlockAccessUtils.getSingleBlock(blockAccessStub, firstSimulatorLatestPublishedBlockNumber + 1, false);
 
         assertNotNull(firstSimulatorLatestStatus);
         assertTrue(firstSimulatorLatestStatus.contains(Long.toString(firstSimulatorLatestPublishedBlockNumber)));
@@ -214,7 +217,7 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
                 .getLast();
         secondSimulatorThread.cancel(true);
 
-        final BlockResponse latestPublishedBlockAfter = getLatestBlock(false);
+        final SingleBlockResponse latestPublishedBlockAfter = BlockAccessUtils.getLatestBlock(blockAccessStub, false);
 
         assertNotNull(secondSimulatorLatestStatus);
         assertNotNull(latestPublishedBlockAfter);

--- a/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.suites.publisher.positive;
 
-import static org.hiero.block.suites.utils.BlockAccessUtils.getLatestBlock;
 import static org.hiero.block.suites.utils.BlockAccessUtils.getBlock;
+import static org.hiero.block.suites.utils.BlockAccessUtils.getLatestBlock;
 import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
@@ -2,7 +2,7 @@
 package org.hiero.block.suites.publisher.positive;
 
 import static org.hiero.block.suites.utils.BlockAccessUtils.getLatestBlock;
-import static org.hiero.block.suites.utils.BlockAccessUtils.getSingleBlock;
+import static org.hiero.block.suites.utils.BlockAccessUtils.getBlock;
 import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -157,7 +157,7 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
 
         // ===== Assert that we are persisting only the current blocks =================================
         final BlockResponse currentBlockResponse = getLatestBlock(blockAccessStub, false);
-        final BlockResponse futureBlockResponse = getSingleBlock(blockAccessStub, 1000, false);
+        final BlockResponse futureBlockResponse = getBlock(blockAccessStub, 1000, false);
 
         assertNotNull(currentBlockResponse);
         assertNotNull(futureBlockResponse);
@@ -190,9 +190,9 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
         firstSimulatorThread.cancel(true);
 
         final BlockResponse latestPublishedBlockBefore =
-                getSingleBlock(blockAccessStub, firstSimulatorLatestPublishedBlockNumber, false);
+                getBlock(blockAccessStub, firstSimulatorLatestPublishedBlockNumber, false);
         final BlockResponse nextPublishedBlockBefore =
-                getSingleBlock(blockAccessStub, firstSimulatorLatestPublishedBlockNumber + 1, false);
+                getBlock(blockAccessStub, firstSimulatorLatestPublishedBlockNumber + 1, false);
 
         assertNotNull(firstSimulatorLatestStatus);
         assertTrue(firstSimulatorLatestStatus.contains(Long.toString(firstSimulatorLatestPublishedBlockNumber)));

--- a/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.suites.publisher.positive;
 
+import static org.hiero.block.suites.utils.BlockAccessUtils.getLatestBlock;
+import static org.hiero.block.suites.utils.BlockAccessUtils.getSingleBlock;
 import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -18,7 +20,6 @@ import org.hiero.block.api.protoc.BlockResponse;
 import org.hiero.block.api.protoc.BlockResponse.Code;
 import org.hiero.block.simulator.BlockStreamSimulatorApp;
 import org.hiero.block.suites.BaseSuite;
-import org.hiero.block.suites.utils.BlockAccessUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -155,8 +156,8 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
         simulators.add(futureSimulatorThread);
 
         // ===== Assert that we are persisting only the current blocks =================================
-        final SingleBlockResponse currentBlockResponse = BlockAccessUtils.getLatestBlock(blockAccessStub, false);
-        final SingleBlockResponse futureBlockResponse = BlockAccessUtils.getSingleBlock(blockAccessStub, 1000, false);
+        final BlockResponse currentBlockResponse = getLatestBlock(blockAccessStub, false);
+        final BlockResponse futureBlockResponse = getSingleBlock(blockAccessStub, 1000, false);
 
         assertNotNull(currentBlockResponse);
         assertNotNull(futureBlockResponse);
@@ -188,10 +189,10 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
                 firstSimulator.getStreamStatus().publishedBlocks() - 1; // we subtract one since we started on 0
         firstSimulatorThread.cancel(true);
 
-        final SingleBlockResponse latestPublishedBlockBefore =
-                BlockAccessUtils.getSingleBlock(blockAccessStub, firstSimulatorLatestPublishedBlockNumber, false);
-        final SingleBlockResponse nextPublishedBlockBefore =
-                BlockAccessUtils.getSingleBlock(blockAccessStub, firstSimulatorLatestPublishedBlockNumber + 1, false);
+        final BlockResponse latestPublishedBlockBefore =
+                getSingleBlock(blockAccessStub, firstSimulatorLatestPublishedBlockNumber, false);
+        final BlockResponse nextPublishedBlockBefore =
+                getSingleBlock(blockAccessStub, firstSimulatorLatestPublishedBlockNumber + 1, false);
 
         assertNotNull(firstSimulatorLatestStatus);
         assertTrue(firstSimulatorLatestStatus.contains(Long.toString(firstSimulatorLatestPublishedBlockNumber)));
@@ -218,7 +219,7 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
                 .getLast();
         secondSimulatorThread.cancel(true);
 
-        final SingleBlockResponse latestPublishedBlockAfter = BlockAccessUtils.getLatestBlock(blockAccessStub, false);
+        final BlockResponse latestPublishedBlockAfter = getLatestBlock(blockAccessStub, false);
 
         assertNotNull(secondSimulatorLatestStatus);
         assertNotNull(latestPublishedBlockAfter);

--- a/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.suites.publisher.positive;
 
+import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/suites/src/main/java/org/hiero/block/suites/utils/BlockAccessUtils.java
+++ b/suites/src/main/java/org/hiero/block/suites/utils/BlockAccessUtils.java
@@ -25,7 +25,7 @@ public final class BlockAccessUtils {
      * @param latest Whether to retrieve the latest block
      * @return A SingleBlockRequest object
      */
-    public static BlockRequest createSingleBlockRequest(long blockNumber, boolean latest) {
+    public static BlockRequest createGetBlockRequest(long blockNumber, boolean latest) {
         return BlockRequest.newBuilder()
                 .setBlockNumber(blockNumber)
                 .setRetrieveLatest(latest)
@@ -41,7 +41,7 @@ public final class BlockAccessUtils {
      *   verifying its `BlockProof`
      * @return The SingleBlockResponse from the API
      */
-    public static BlockResponse getSingleBlock(
+    public static BlockResponse getBlock(
             @NonNull final BlockAccessServiceGrpc.BlockAccessServiceBlockingStub blockAccessStub,
             final long blockNumber,
             final boolean allowUnverified) {

--- a/suites/src/main/java/org/hiero/block/suites/utils/BlockAccessUtils.java
+++ b/suites/src/main/java/org/hiero/block/suites/utils/BlockAccessUtils.java
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.suites.utils;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.block.protoc.BlockAccessServiceGrpc;
+import com.hedera.hapi.block.protoc.SingleBlockRequest;
+import com.hedera.hapi.block.protoc.SingleBlockResponse;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Utility class for block access operations.
+ * Contains methods for creating block requests and interacting with the Block Node gRPC service.
+ */
+public final class BlockAccessUtils {
+
+    private BlockAccessUtils() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Creates a SingleBlockRequest to retrieve a specific block.
+     *
+     * @param blockNumber The block number to retrieve
+     * @param latest Whether to retrieve the latest block
+     * @return A SingleBlockRequest object
+     */
+    public static SingleBlockRequest createSingleBlockRequest(long blockNumber, boolean latest) {
+        return SingleBlockRequest.newBuilder()
+                .setBlockNumber(blockNumber)
+                .setRetrieveLatest(latest)
+                .setAllowUnverified(true)
+                .build();
+    }
+
+    /**
+     * Retrieves a single block using the Block Node API.
+     *
+     * @param blockNumber The block number to retrieve
+     * @param allowUnverified A flag to indicate that the requested block may be sent without
+     *   verifying its `BlockProof`
+     * @return The SingleBlockResponse from the API
+     */
+    public static SingleBlockResponse getSingleBlock(
+            @NonNull final BlockAccessServiceGrpc.BlockAccessServiceBlockingStub blockAccessStub,
+            final long blockNumber,
+            final boolean allowUnverified) {
+        requireNonNull(blockAccessStub);
+
+        SingleBlockRequest request = SingleBlockRequest.newBuilder()
+                .setBlockNumber(blockNumber)
+                .setAllowUnverified(allowUnverified)
+                .build();
+        return blockAccessStub.singleBlock(request);
+    }
+
+    /**
+     * Retrieves a single block using the Block Node API.
+     *
+     * @param allowUnverified A flag to indicate that the requested block may be sent without
+     * verifying its `BlockProof`
+     * @return The SingleBlockResponse from the API
+     */
+    public static SingleBlockResponse getLatestBlock(
+            @NonNull final BlockAccessServiceGrpc.BlockAccessServiceBlockingStub blockAccessStub,
+            final boolean allowUnverified) {
+        requireNonNull(blockAccessStub);
+
+        SingleBlockRequest request = SingleBlockRequest.newBuilder()
+                .setBlockNumber(-1)
+                .setRetrieveLatest(true)
+                .setAllowUnverified(allowUnverified)
+                .build();
+        return blockAccessStub.singleBlock(request);
+    }
+}

--- a/suites/src/main/java/org/hiero/block/suites/utils/BlockAccessUtils.java
+++ b/suites/src/main/java/org/hiero/block/suites/utils/BlockAccessUtils.java
@@ -3,10 +3,10 @@ package org.hiero.block.suites.utils;
 
 import static java.util.Objects.requireNonNull;
 
-import com.hedera.hapi.block.protoc.BlockAccessServiceGrpc;
-import com.hedera.hapi.block.protoc.SingleBlockRequest;
-import com.hedera.hapi.block.protoc.SingleBlockResponse;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.hiero.block.api.protoc.BlockAccessServiceGrpc;
+import org.hiero.block.api.protoc.BlockRequest;
+import org.hiero.block.api.protoc.BlockResponse;
 
 /**
  * Utility class for block access operations.
@@ -25,8 +25,8 @@ public final class BlockAccessUtils {
      * @param latest Whether to retrieve the latest block
      * @return A SingleBlockRequest object
      */
-    public static SingleBlockRequest createSingleBlockRequest(long blockNumber, boolean latest) {
-        return SingleBlockRequest.newBuilder()
+    public static BlockRequest createSingleBlockRequest(long blockNumber, boolean latest) {
+        return BlockRequest.newBuilder()
                 .setBlockNumber(blockNumber)
                 .setRetrieveLatest(latest)
                 .setAllowUnverified(true)
@@ -41,17 +41,17 @@ public final class BlockAccessUtils {
      *   verifying its `BlockProof`
      * @return The SingleBlockResponse from the API
      */
-    public static SingleBlockResponse getSingleBlock(
+    public static BlockResponse getSingleBlock(
             @NonNull final BlockAccessServiceGrpc.BlockAccessServiceBlockingStub blockAccessStub,
             final long blockNumber,
             final boolean allowUnverified) {
         requireNonNull(blockAccessStub);
 
-        SingleBlockRequest request = SingleBlockRequest.newBuilder()
+        BlockRequest request = BlockRequest.newBuilder()
                 .setBlockNumber(blockNumber)
                 .setAllowUnverified(allowUnverified)
                 .build();
-        return blockAccessStub.singleBlock(request);
+        return blockAccessStub.getBlock(request);
     }
 
     /**
@@ -61,16 +61,16 @@ public final class BlockAccessUtils {
      * verifying its `BlockProof`
      * @return The SingleBlockResponse from the API
      */
-    public static SingleBlockResponse getLatestBlock(
+    public static BlockResponse getLatestBlock(
             @NonNull final BlockAccessServiceGrpc.BlockAccessServiceBlockingStub blockAccessStub,
             final boolean allowUnverified) {
         requireNonNull(blockAccessStub);
 
-        SingleBlockRequest request = SingleBlockRequest.newBuilder()
+        BlockRequest request = BlockRequest.newBuilder()
                 .setBlockNumber(-1)
                 .setRetrieveLatest(true)
                 .setAllowUnverified(allowUnverified)
                 .build();
-        return blockAccessStub.singleBlock(request);
+        return blockAccessStub.getBlock(request);
     }
 }

--- a/suites/src/main/java/org/hiero/block/suites/utils/BlockSimulatorUtils.java
+++ b/suites/src/main/java/org/hiero/block/suites/utils/BlockSimulatorUtils.java
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.suites.utils;
+
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
+import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
+import com.swirlds.config.extensions.sources.SimpleConfigSource;
+import com.swirlds.config.extensions.sources.SystemEnvironmentConfigSource;
+import com.swirlds.config.extensions.sources.SystemPropertiesConfigSource;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import org.hiero.block.simulator.BlockStreamSimulatorApp;
+import org.hiero.block.simulator.BlockStreamSimulatorInjectionComponent;
+import org.hiero.block.simulator.DaggerBlockStreamSimulatorInjectionComponent;
+
+/**
+ * Utility class for block simulator operations.
+ * Contains methods for creating and operating with block simulators.
+ */
+public final class BlockSimulatorUtils {
+    private BlockSimulatorUtils() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Creates a new instance of the block stream simulator with custom configuration.
+     *
+     * @param customConfiguration the custom configuration which will be applied to simulator upon startup
+     * @return a new instance of the block stream simulator
+     * @throws IOException if an I/O error occurs
+     */
+    public static BlockStreamSimulatorApp createBlockSimulator(@NonNull final Map<String, String> customConfiguration)
+            throws IOException {
+        BlockStreamSimulatorInjectionComponent DIComponent = DaggerBlockStreamSimulatorInjectionComponent.factory()
+                .create(loadSimulatorConfiguration(customConfiguration));
+        return DIComponent.getBlockStreamSimulatorApp();
+    }
+
+    /**
+     * Creates a new instance of the block stream simulator with default configuration.
+     *
+     * @return a new instance of the block stream simulator
+     * @throws IOException if an I/O error occurs
+     */
+    public static BlockStreamSimulatorApp createBlockSimulator() throws IOException {
+        BlockStreamSimulatorInjectionComponent DIComponent = DaggerBlockStreamSimulatorInjectionComponent.factory()
+                .create(loadSimulatorConfiguration(Collections.emptyMap()));
+        return DIComponent.getBlockStreamSimulatorApp();
+    }
+
+    /**
+     * Builds the desired block simulator configuration
+     *
+     * @return block simulator configuration
+     * @throws IOException if an I/O error occurs
+     */
+    public static Configuration loadSimulatorConfiguration(@NonNull final Map<String, String> customProperties)
+            throws IOException {
+        final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
+                .withSource(SystemEnvironmentConfigSource.getInstance())
+                .withSource(SystemPropertiesConfigSource.getInstance())
+                .withSource(new ClasspathFileConfigSource(Path.of("app.properties")))
+                .autoDiscoverExtensions();
+
+        for (Map.Entry<String, String> entry : customProperties.entrySet()) {
+            final String key = entry.getKey();
+            final String value = entry.getValue();
+            configurationBuilder.withSource(new SimpleConfigSource(key, value).withOrdinal(500));
+        }
+
+        return configurationBuilder.build();
+    }
+}

--- a/suites/src/main/java/org/hiero/block/suites/verification/VerificationCommonTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/verification/VerificationCommonTests.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.suites.verification;
 
+import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 


### PR DESCRIPTION
## Reviewer Notes
This PR resolves a case where, after hard shutdown of a producer the publisher stops accepting new producers.
Also moves around and cleans up the `suites`, by separating utils that can be used everywhere.

## Related Issue(s)
Fixes #1053 
Fixes #932 
