### PR TITLE
feat: Create new stream subscriber plugin

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/GrpcPluginTestBase.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/GrpcPluginTestBase.java
@@ -60,7 +60,6 @@ public abstract class GrpcPluginTestBase<P extends BlockNodePlugin> extends Plug
             @Override
             public void onNext(Bytes item) throws RuntimeException {
                 fromPluginBytes.add(item);
-                LOGGER.log(TRACE, "onNext: %d".formatted(fromPluginBytes.size()));
             }
 
             @Override

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
@@ -134,8 +134,8 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
         final int handlerCount = blockItemHandlers.size() + nonBackpressureBlockItemHandlers.size();
         LOGGER.log(
                 Level.TRACE,
-                "Sending next %d block items to %d handlers."
-                        .formatted(blockItems.blockItems().size(), handlerCount));
+                "Sending next %d block items for block %d to %d handlers."
+                        .formatted(blockItems.blockItems().size(), blockItems.newBlockNumber(), handlerCount));
         sentBlockBlockItems.add(blockItems);
         boolean handlerHasBackpressure = false;
         for (BlockItemHandler handler : blockItemHandlers) {

--- a/block-node/block-access/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
+++ b/block-node/block-access/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.hiero.block.api.BlockRequest;
 import org.hiero.block.api.BlockResponse;
 import org.hiero.block.api.BlockResponse.Code;
+// PBJ doesn't generate GRPC stubs for some reason, also the proto file is broken when PBJ compiles it...
 import org.hiero.block.api.protoc.BlockAccessServiceGrpc;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;

--- a/block-node/stream-subscriber/build.gradle.kts
+++ b/block-node/stream-subscriber/build.gradle.kts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+plugins { id("org.hiero.gradle.module.library") }
+
+description = "Hiero Block Node Subscriber Service"
+
+// Remove the following line to enable all 'javac' lint checks that we have turned on by default
+// and then fix the reported issues.
+tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
+
+mainModuleInfo {
+    runtimeOnly("com.swirlds.config.impl")
+    runtimeOnly("org.apache.logging.log4j.slf4j2.impl")
+    runtimeOnly("io.helidon.logging.jul")
+    runtimeOnly("com.hedera.pbj.grpc.helidon.config")
+}
+
+testModuleInfo {
+    requires("org.junit.jupiter.api")
+    requires("org.hiero.block.node.app.test.fixtures")
+    requires("org.assertj.core.api")
+}

--- a/block-node/stream-subscriber/src/main/java/module-info.java
+++ b/block-node/stream-subscriber/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.stream.subscriber.SubscriberServicePlugin;
+
+// SPDX-License-Identifier: Apache-2.0
+module org.hiero.block.node.stream.subscriber {
+    uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
+
+    // export configuration classes to the config module and app
+    exports org.hiero.block.node.stream.subscriber to
+            com.swirlds.config.impl,
+            com.swirlds.config.extensions,
+            org.hiero.block.node.app;
+
+    requires transitive com.hedera.pbj.runtime;
+    requires transitive com.swirlds.config.api;
+    requires transitive org.hiero.block.node.spi;
+    requires transitive org.hiero.block.protobuf;
+    requires com.swirlds.metrics.api;
+    requires org.hiero.block.node.base;
+    requires com.github.spotbugs.annotations;
+
+    provides org.hiero.block.node.spi.BlockNodePlugin with
+            SubscriberServicePlugin;
+}

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
@@ -1,0 +1,574 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.stream.subscriber;
+
+import static java.util.concurrent.locks.LockSupport.parkNanos;
+import static org.hiero.block.node.spi.BlockNodePlugin.METRICS_CATEGORY;
+import static org.hiero.block.node.spi.BlockNodePlugin.UNKNOWN_BLOCK_NUMBER;
+
+import com.hedera.hapi.block.stream.output.BlockHeader;
+import com.hedera.pbj.runtime.OneOf;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.swirlds.metrics.api.Counter;
+import com.swirlds.metrics.api.Counter.Config;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.hiero.block.api.SubscribeStreamRequest;
+import org.hiero.block.api.SubscribeStreamResponse;
+import org.hiero.block.internal.BlockItemSetUnparsed;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.internal.SubscribeStreamResponseUnparsed;
+import org.hiero.block.internal.SubscribeStreamResponseUnparsed.Builder;
+import org.hiero.block.internal.SubscribeStreamResponseUnparsed.ResponseOneOfType;
+import org.hiero.block.node.spi.BlockNodeContext;
+import org.hiero.block.node.spi.BlockNodePlugin;
+import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.blockmessaging.NoBackPressureBlockItemHandler;
+import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
+
+/**
+ * This class is used to represent a session for a single BlockStream subscriber that has connected to the block node.
+ * At least to start with we will only support receiving a single SubscribeStreamRequest per session.
+ * <p>
+ * This session supports two primary modes of operation: live-streaming and historical streaming. Also switching between
+ * on demand as needed.<p>
+ * #### Threading<br/>
+ * This class is called from many threads from web server, the block messaging system and its own background historical
+ * fetching thread. To make its state thread safe it uses synchronized methods around all entry points from other
+ * threads (which are minimized to avoid potential for deadlock or contention). Currently only the close method is
+ * synchronized.
+ */
+public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscriberSession> {
+    /** The logger for this class. */
+    private final Logger LOGGER = System.getLogger(getClass().getName());
+
+    /** The maximum time units to wait for a live block to be available */
+    private static final long MAX_LIVE_POLL_DELAY = 500;
+    /** The time unit for the maximum live poll delay */
+    private static final TimeUnit LIVE_POLL_UNITS = TimeUnit.MILLISECONDS;
+    /** The "resolution", in ns, to use for a polling delays. */
+    private static final long PARK_DELAY_TIME = 100_000;
+
+    /** The client id for this session */
+    private final long clientId;
+    /** The first block number to stream */
+    private final long startBlockNumber;
+    /** The last block number to stream, can be {@value BlockNodePlugin#UNKNOWN_BLOCK_NUMBER } to mean infinite */
+    private final long endBlockNumber;
+    /** The pipeline to send responses to the client */
+    private final Pipeline<? super SubscribeStreamResponseUnparsed> responsePipeline;
+    /** The context for the block node */
+    private final BlockNodeContext context;
+    /** The configuration for the "owning" plugin */
+    private final SubscriberConfig pluginConfiguration;
+    /** The number of historic to live stream transitions metric */
+    private final Counter historicToLiveStreamTransitions;
+    /** The number of live to historic stream transitions metric */
+    private final Counter liveToHistoricStreamTransitions;
+    /** The name of this handler, used in toString and for testing */
+    private final String handlerName;
+    /** A blocking queue to send blocks from the live handler to the session. */
+    private final BlockingQueue<BlockItems> liveBlockQueue;
+    /** A lock to hold the pipeline thread until this session is ready */
+    private final CountDownLatch sessionReadyLatch;
+    /** A flag indicating if the session should be interrupted */
+    private final AtomicBoolean interruptedStream = new AtomicBoolean(false);
+    /** The subscription for the GRPC connection with client */
+    private Subscription subscription;
+    /** The current block being sent to the client */
+    private long nextBlockToSend;
+    /** The latest block received from the live stream. */
+    private final AtomicLong latestLiveStreamBlock;
+    /**
+     * A thread that receives live blocks from the messaging facility.
+     * Each received block is offered to the session via a blocking queue.
+     */
+    private final LiveBlockHandler liveBlockHandler;
+    /**
+     * Exception that caused this session to fail during operation.
+     * This is only set if an unexpected exception is thrown in the call method
+     * and enables the plugin to remove failed sessions from the open sessions
+     * list it maintains, and log the cause of that failure.
+     */
+    private Exception sessionFailedCause;
+
+    /**
+     * Constructor for the BlockStreamSubscriberSession class.
+     *
+     * @param clientId The client id for this session
+     * @param responsePipeline The pipeline to send responses to the client
+     * @param context The context for the block node
+     */
+    public BlockStreamSubscriberSession(
+            long clientId,
+            SubscribeStreamRequest request,
+            Pipeline<? super SubscribeStreamResponseUnparsed> responsePipeline,
+            BlockNodeContext context,
+            final CountDownLatch sessionReadyLatch) {
+        LOGGER.log(Level.TRACE, request.toString());
+        this.clientId = clientId;
+        this.startBlockNumber = request.startBlockNumber();
+        this.endBlockNumber = request.endBlockNumber();
+        this.responsePipeline = Objects.requireNonNull(responsePipeline);
+        this.context = Objects.requireNonNull(context);
+        this.sessionReadyLatch = Objects.requireNonNull(sessionReadyLatch);
+        latestLiveStreamBlock = new AtomicLong(UNKNOWN_BLOCK_NUMBER - 1);
+        pluginConfiguration = context.configuration().getConfigData(SubscriberConfig.class);
+        // Next block to send depends on what was requested and what is available.
+        nextBlockToSend = startBlockNumber < 0 ? getLatestKnownBlock() : startBlockNumber;
+        handlerName = "Live stream client " + clientId;
+        // create metrics
+        // Note: These two may, or may not, be useful...
+        historicToLiveStreamTransitions = context.metrics()
+                .getOrCreate(new Config(METRICS_CATEGORY, "historicToLiveStreamTransitions")
+                        .withDescription("Historic to Live Stream Transitions"));
+        liveToHistoricStreamTransitions = context.metrics()
+                .getOrCreate(new Config(METRICS_CATEGORY, "liveToHistoricStreamTransitions")
+                        .withDescription("Live to Historic Stream Transitions"));
+        liveBlockQueue = new ArrayBlockingQueue<>(pluginConfiguration.liveQueueSize());
+        liveBlockHandler = new LiveBlockHandler(liveBlockQueue, latestLiveStreamBlock, handlerName);
+    }
+
+    private long getEarliestHistoricalBlock() {
+        return context.historicalBlockProvider().availableBlocks().min();
+    }
+
+    private long getLatestKnownBlock() {
+        return Math.max(getLatestHistoricalBlock(), latestLiveStreamBlock.get());
+    }
+
+    private long getLatestHistoricalBlock() {
+        return context.historicalBlockProvider().availableBlocks().max();
+    }
+
+    @Override
+    public BlockStreamSubscriberSession call() {
+        try {
+            // get latest available blocks
+            final long oldestBlockNumber = getEarliestHistoricalBlock();
+            final long latestBlockNumber = getLatestKnownBlock();
+            // we have just started with a new subscribe request, now we need to work out if we can complete it
+            if (validateRequest(
+                    oldestBlockNumber, latestBlockNumber, startBlockNumber, endBlockNumber, clientId, LOGGER)) {
+                // register us to listen to block items from the block messaging system
+                LOGGER.log(Level.TRACE, "Registering a block subscriber handler for " + handlerName);
+                context.blockMessaging().registerNoBackpressureBlockItemHandler(liveBlockHandler, false, handlerName);
+                sessionReadyLatch.countDown();
+                // Send blocks forever if requested, otherwise send until we reach the requested end block
+                // or the stream is interrupted.
+                while (!(interruptedStream.get() || allRequestedBlocksSent())) {
+                    // Note, nextBlockToSend is always the next block we need to send.
+                    // start by sending from history if we can.
+                    sendHistoricalBlocks();
+                    // then process live blocks, if available.
+                    sendLiveBlocksIfAvailable();
+                }
+            }
+        } catch (RuntimeException | ParseException | InterruptedException e) {
+            sessionFailedCause = e;
+            interruptedStream.set(true);
+            close(SubscribeStreamResponse.Code.READ_STREAM_SUCCESS); // Need an "INCOMPLETE" code...
+        }
+        // Need to record a metric here with client ID tag, so we can record
+        // requested vs sent metrics.
+        return this;
+    }
+
+    private void sendHistoricalBlocks() throws ParseException {
+        // Don't send anything from history if this stream is interrupted, has sent
+        // every requested block, or we can send the next block from "live".
+        while (isHistoryPermitted()) {
+            LOGGER.log(Level.TRACE, "Sending historical block {0} to {1}", nextBlockToSend, handlerName);
+            // We need to send historical blocks.
+            // We will only send one block at a time to keep things "smooth".
+            // Start by getting a block accessor for the next block to send from the historical provider.
+            BlockAccessor nextBlockAccessor = context.historicalBlockProvider().block(nextBlockToSend);
+            if (nextBlockAccessor != null) {
+                // We have a block to send, so send it.
+                sendOneBlockItemSet(nextBlockAccessor.blockUnparsed());
+                // Trim the queue if necessary, also increment the next block to send.
+                trimBlockItemQueue(++nextBlockToSend);
+            } else {
+                // Only give up if this is an historical block, otherwise just
+                // go back up and see if live has the block.
+                if (!(nextBlockToSend < 0 || nextBlockToSend >= getLatestKnownBlock())) {
+                    // We cannot get the block needed, something has failed.
+                    // close the stream with an "unavailable" response.
+                    final String message = "Unable to read historical block {0}.";
+                    LOGGER.log(Level.INFO, message, nextBlockToSend);
+                    close(SubscribeStreamResponse.Code.READ_STREAM_NOT_AVAILABLE);
+                } else {
+                    awaitNewLiveEntries();
+                }
+                break;
+            }
+            LOGGER.log(Level.TRACE, "Done sending historical block to {1}, {0} up next.", nextBlockToSend, handlerName);
+        }
+    }
+
+    /**
+     * Is sending a block from history permitted?
+     * <p>
+     * This is true if all of the following are true:
+     *     1. The stream is not interrupted
+     *     2. We have not run past the latest live block
+     *     3. All requested blocks have not been sent
+     *     4. The next block to send is not available from the live stream.
+     */
+    private boolean isHistoryPermitted() {
+        return !(interruptedStream.get()
+                || latestLiveStreamBlock.get() < nextBlockToSend
+                || allRequestedBlocksSent()
+                || nextBatchIsLive());
+    }
+
+    private boolean nextBatchIsLive() {
+        BlockItems queueHead = liveBlockQueue.peek();
+        if (queueHead != null && latestLiveStreamBlock.get() >= nextBlockToSend) {
+            return queueHead.newBlockNumber() == nextBlockToSend || !queueHead.isStartOfNewBlock();
+        } else {
+            return false;
+        }
+    }
+
+    private void awaitNewLiveEntries() {
+        final long maximumDelay = (LIVE_POLL_UNITS.toNanos(MAX_LIVE_POLL_DELAY) / PARK_DELAY_TIME);
+        for (long i = 0; i < maximumDelay && liveBlockQueue.isEmpty(); i++) {
+            // Sleep for a bit to avoid excessive spin overhead.
+            parkNanos(PARK_DELAY_TIME);
+        }
+    }
+
+    private boolean allRequestedBlocksSent() {
+        return endBlockNumber != UNKNOWN_BLOCK_NUMBER && nextBlockToSend > endBlockNumber;
+    }
+
+    /**
+     * Process live blocks to send to the client.
+     *
+     * @throws InterruptedException if the thread is interrupted while waiting for a "live" batch.
+     */
+    private void sendLiveBlocksIfAvailable() throws InterruptedException {
+        // Need to park here waiting for at least one entry on the queue, otherwise
+        // we'll spin in the caller thread in an extreme form of spin wait.
+        if (liveBlockQueue.isEmpty()) {
+            // Wait briefly for a live block to be available.
+            awaitNewLiveEntries();
+        }
+        // Send as much as we can from live. If we have no live blocks, or have sent everything
+        // currently available, then we'll go back to the caller's loop.
+        // If we run out, get ahead of live, or have to send historical blocks,
+        // then we'll also break out of the loop and return to the caller.
+        while (!liveBlockQueue.isEmpty()) {
+            // take the block item from the queue and process it
+            final BlockItems blockItems = liveBlockQueue.poll();
+            // Live _might_ be behind the next expected block (particularly if
+            // the requested start block is in the future), skip this block, in that case.
+            if (blockItems.isStartOfNewBlock() && blockItems.newBlockNumber() != nextBlockToSend) {
+                LOGGER.log(Level.TRACE, "Skipping block {0} for client {1}", blockItems.newBlockNumber(), clientId);
+                skipCurrentBlockInQueue(blockItems);
+            } else {
+                if (blockItems != null) {
+                    sendOneBlockItemSet(blockItems);
+                }
+                if (blockItems.isEndOfBlock()) {
+                    nextBlockToSend++;
+                    trimBlockItemQueue(nextBlockToSend);
+                }
+            }
+            // Note: We depend here on the rule that there are no gaps between blocks.
+            //       The header for block N immediately follows the proof for block N-1.
+            final BlockItems nextBatch = liveBlockQueue.peek();
+            if (nextBatch != null && nextBatch.isStartOfNewBlock()) {
+                if (nextBatch.newBlockNumber() != nextBlockToSend) {
+                    // Exit this method if we fall behind, the next call will
+                    // start by catching up from the historical provider.
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Trim the head of the block item queue if needed.
+     * <p>
+     * This is called after each block sent (whether live or historical).
+     * The goal is to ensure that the queue doesn't become full, so after
+     * each block sent, we try to ensure at least a minimum amount of
+     * open capacity (controlled by {@link SubscriberConfig#minimumLiveQueueCapacity()})
+     * is available for new live batches.
+     * This may delay the point at which we "catch up" and return to streaming
+     * live batches, but it also prevents most cases that would stall the
+     * messaging threads.
+     */
+    private void trimBlockItemQueue(final long nextBlockNumber) {
+        if (nextBlockNumber > UNKNOWN_BLOCK_NUMBER) {
+            // peek at the head of the queue, if it's a header, and the number is later
+            // than what we need to send next, and the queue is nearly full (less than
+            // the minimum desired capacity is available), then we will remove
+            // one or more _whole blocks_ from the queue (we must _never_ remove
+            // a partial block).
+            BlockItems queueHead = liveBlockQueue.peek();
+            if (queueHead != null && queueHead.isStartOfNewBlock()) {
+                // After this loop, the head of the queue must be the start of a
+                // new block or empty (and it really _should_ never be empty).
+                while (queueHead.newBlockNumber() > nextBlockNumber && queueFull()) {
+                    removeHeadBlockFromQueue();
+                    queueHead = liveBlockQueue.peek();
+                }
+            }
+        }
+    }
+
+    private boolean queueFull() {
+        return liveBlockQueue.remainingCapacity() <= pluginConfiguration.minimumLiveQueueCapacity();
+    }
+
+    /**
+     * Remove the remainder of a block from the queue.
+     * <p>
+     * This method assumes that a possible header batch has already been removed
+     * from the queue (and is provided). The provided item is checked, and if it
+     * is a header block, the remainder of that block, up to the next header
+     * batch (which might be the next item) is removed from the queue.<br/>
+     * Note, the item provided and the next item are not removed from the queue,
+     * so it is important to only call this method after polling and item, and
+     * when this method returns, the next item in the queue will be the start of
+     * a new block (or else the queue will be empty).
+     */
+    private void skipCurrentBlockInQueue(BlockItems queueHead) {
+        // The "head" entry is already removed, remove the rest of its block if it's a block header.
+        if (queueHead != null && queueHead.isStartOfNewBlock()) {
+            queueHead = liveBlockQueue.peek();
+            // Now remove "head" entries until the _next_ item is a block header
+            while (queueHead != null && !(queueHead.isStartOfNewBlock())) {
+                liveBlockQueue.poll();
+                queueHead = liveBlockQueue.peek();
+            }
+        }
+    }
+
+    /**
+     * Remove the head of the queue if, and only if, it's a full block.
+     * <p>
+     * This does much the same thing skipCurrentBlockInQueue does, but
+     * we don't remove the head until we check whether it's a block header.<br/>
+     * This method is called when _checking_ before removing a block, while
+     * the skip method is used _after_ polling the head to _finish_ a block
+     * that should be skipped.<br/>
+     * Note, this method calls the skip after removing the head in order to
+     * keep the skip logic consistent.
+     */
+    private void removeHeadBlockFromQueue() {
+        BlockItems queueHead = liveBlockQueue.peek();
+        // Remove the "head" entry if it's a block header.
+        // Otherwise skip this, because we don't want to remove a partial block.
+        if (queueHead != null && queueHead.isStartOfNewBlock()) {
+            queueHead = liveBlockQueue.poll();
+            skipCurrentBlockInQueue(queueHead);
+        }
+    }
+
+    /**
+     * Get the exception that caused this session to fail.
+     *
+     * This is package scope so that the plugin can read it.
+     *
+     * @return The exception that caused this session to fail
+     */
+    Exception getSessionFailedCause() {
+        return sessionFailedCause;
+    }
+
+    /**
+     * Validate the client subscribe request.
+     * This will check the following:
+     * 1. The start block number is greater than or equal to the "unknown" block number sentinel.
+     * 2. The end block number is greater than or equal to the "unknown" block number sentinel.
+     * 3. The end block number is _either_ the "unknown" sentinal, _or_  greater than or equal to
+     *    the start block number.
+     * 4. The start block number is _either_ the "unknown" sentinal, _or_ greater than or equal to
+     *    the oldest block number.
+     */
+    private boolean validateRequest(
+            final long oldestBlock,
+            final long latestBlock,
+            final long startBlock,
+            final long endBlock,
+            final long clientId,
+            final Logger logger) {
+        boolean isValid = false;
+        if (startBlock < UNKNOWN_BLOCK_NUMBER) {
+            logger.log(Level.DEBUG, "Client {0} requested negative block {1}", clientId, startBlock);
+            close(SubscribeStreamResponse.Code.READ_STREAM_INVALID_START_BLOCK_NUMBER);
+        } else if (endBlock < UNKNOWN_BLOCK_NUMBER) {
+            logger.log(Level.DEBUG, "Client {0} requested negative end block {1}", clientId, endBlock);
+            // send invalid end block number response
+            close(SubscribeStreamResponse.Code.READ_STREAM_INVALID_END_BLOCK_NUMBER);
+        } else if (endBlock >= 0 && startBlock > endBlock) {
+            final String message = "Client {0} requested end block {1} before start {2}";
+            logger.log(Level.DEBUG, message, clientId, endBlock, startBlock);
+            // send invalid end block number response
+            close(SubscribeStreamResponse.Code.READ_STREAM_INVALID_END_BLOCK_NUMBER);
+        } else {
+            final long lastPermittedStart = latestBlock + pluginConfiguration.maximumFutureRequest();
+            if (startBlock != UNKNOWN_BLOCK_NUMBER && (startBlock < oldestBlock || startBlock > lastPermittedStart)) {
+                // client has requested a block that is neither live nor available in history
+                // _and_ will not be available within a reasonable number of future blocks.
+                final String message =
+                        "Client {0} requested start block {1} that is neither live nor historical. Newest historical block is {2}";
+                logger.log(Level.DEBUG, message, clientId, startBlock, latestBlock);
+                // send invalid start block number response
+                close(SubscribeStreamResponse.Code.READ_STREAM_INVALID_START_BLOCK_NUMBER);
+            } else {
+                if (startBlock == UNKNOWN_BLOCK_NUMBER || startBlock >= latestBlock) {
+                    // Start at next live block or a future block within the "max live" range.
+                    logger.log(Level.TRACE, "Client {0} has started streaming live blocks", clientId);
+                } else {
+                    // we are starting at a block that is in the historical stream
+                    final String message = "Client {0} has started streaming historical blocks from {1}";
+                    logger.log(Level.TRACE, message, clientId, startBlock);
+                }
+                isValid = true;
+            }
+        }
+        return isValid;
+    }
+
+    /**
+     * Get the client id for this session
+     *
+     * @return The client id for this session
+     */
+    public long clientId() {
+        return clientId;
+    }
+
+    @Override
+    public String toString() {
+        return handlerName;
+    }
+
+    // Visible for testing.
+    long getNextBlockToSend() {
+        return nextBlockToSend;
+    }
+
+    // Visible for testing.
+    LiveBlockHandler getLiveBlockHandler() {
+        return liveBlockHandler;
+    }
+
+    /**
+     * Close this session. This will unregister us from the block messaging system and cancel the subscription.
+     */
+    synchronized void close(final SubscribeStreamResponse.Code endStreamResponseCode) {
+        LOGGER.log(Level.TRACE, "Closing BlockStreamSubscriberSession for client {0}", clientId);
+        // Might get here before the session is ready, so check the countdown latch
+        if (sessionReadyLatch.getCount() > 0) {
+            sessionReadyLatch.countDown();
+            LOGGER.log(Level.DEBUG, "Session ready latch was not counted down on close, releasing now");
+        }
+        // unregister us from the block messaging system, if we are not registered then this is noop
+        context.blockMessaging().unregisterBlockItemHandler(liveBlockHandler);
+        final Builder response = SubscribeStreamResponseUnparsed.newBuilder().status(endStreamResponseCode);
+        responsePipeline.onNext(response.build());
+        responsePipeline.onComplete();
+        if (subscription != null) {
+            subscription.cancel();
+            subscription = null;
+        }
+        // Break out of the loop that sends blocks to the client, so the thread completes.
+        interruptedStream.set(true);
+    }
+
+    private void sendOneBlockItemSet(final BlockUnparsed nextBlock) throws ParseException {
+        LOGGER.log(Level.TRACE, "Sending full block {0} to {1}", nextBlockToSend, handlerName);
+        BlockHeader header =
+                BlockHeader.PROTOBUF.parse(nextBlock.blockItems().getFirst().blockHeader());
+        BlockItems blockBatch = new BlockItems(nextBlock.blockItems(), header.number());
+        if (header.number() == nextBlockToSend) {
+            sendOneBlockItemSet(nextBlock.blockItems());
+        } else {
+            LOGGER.log(
+                    Level.ERROR,
+                    "Block {0} should be sent, but we are trying to send block {1}.",
+                    nextBlockToSend,
+                    header.number());
+        }
+    }
+
+    private void sendOneBlockItemSet(final BlockItems nextBatch) {
+        LOGGER.log(
+                Level.TRACE,
+                "Sending next batch of {0} items for block {1} to client {2}",
+                nextBatch.blockItems().size(),
+                nextBatch.newBlockNumber(),
+                handlerName);
+        sendOneBlockItemSet(nextBatch.blockItems());
+    }
+
+    private void sendOneBlockItemSet(final List<BlockItemUnparsed> blockItems) {
+        final BlockItemSetUnparsed dataToSend = new BlockItemSetUnparsed(blockItems);
+        final OneOf<ResponseOneOfType> responseOneOf = new OneOf<>(ResponseOneOfType.BLOCK_ITEMS, dataToSend);
+        responsePipeline.onNext(new SubscribeStreamResponseUnparsed(responseOneOf));
+        LOGGER.log(Level.TRACE, "Sent block items for block {0} to {1}.", nextBlockToSend, handlerName);
+    }
+
+    // ==== Block Item Handler Class ===========================================
+
+    // NOTE: The methods of this class are called from the messaging threads.
+    //       This means we must not modify any state in the session object directly.
+    //       Instead we must use a transfer queue to pass the block items to the session
+    //       and possibly set an atomic flag if we are "too far behind".
+    private static class LiveBlockHandler implements NoBackPressureBlockItemHandler {
+        /** The logger for this class. */
+        private final Logger LOGGER = System.getLogger(getClass().getName());
+
+        private final BlockingQueue<BlockItems> liveBlockQueue;
+        private final AtomicLong latestLiveStreamBlock;
+        private final String clientId;
+
+        private LiveBlockHandler(
+                final BlockingQueue<BlockItems> liveBlockQueue,
+                final AtomicLong latestLiveStreamBlock,
+                final String clientId) {
+            this.liveBlockQueue = liveBlockQueue;
+            this.latestLiveStreamBlock = latestLiveStreamBlock;
+            this.clientId = clientId;
+        }
+
+        @Override
+        public void onTooFarBehindError() {
+            // Insert a signal to the session that it is "too far behind" live.
+            // Should not ever happen with this design.
+            LOGGER.log(Level.INFO, "Handler for {0} has fallen behind.", clientId);
+        }
+
+        @Override
+        public void handleBlockItemsReceived(final BlockItems blockItems) {
+            if (blockItems.newBlockNumber() > latestLiveStreamBlock.get()) {
+                latestLiveStreamBlock.set(blockItems.newBlockNumber());
+                LOGGER.log(Level.TRACE, "Updated latest block to {0}.", latestLiveStreamBlock);
+            }
+            // Blocking so that the client thread has a chance to pull items
+            // off the head when it's full.
+            try {
+                liveBlockQueue.put(blockItems);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberConfig.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberConfig.java
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.stream.subscriber;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import com.swirlds.config.api.validation.annotation.Min;
+import org.hiero.block.node.base.Loggable;
+
+/**
+ * Use this configuration across the stream subscriber plugin.
+ *
+ * @param liveQueueSize The size of the queue used to transfer live batches
+ *     between the messaging and the client thread.<br/>
+ *     This value is a number of _batches_, not blocks, so generally this should
+ *     be around 100 times the number of blocks that should be pending at any
+ *     moment (i.e. a typical block is 100 batches, so to support 50 blocks this
+ *     value would be 5000).
+ * @param maximumFutureRequest The furthest in the future a request can set the
+ *     start block for a stream.  If a request specifies a start block further
+ *     than this many blocks above the latest known "live" block, the request will
+ *     be rejected.
+ * @param minimumLiveQueueCapacity The minimum available capacity in the live queue
+ *     that the session will try to maintain.  If there is less than this much
+ *     capacity available, the session will drop the oldest full blocks (at the queue head)
+ *     in the queue until at least this many batches can be added without blocking.<br/>
+ *     This value should typically be around 10% of the live queue size.
+ */
+@ConfigData("subscriber")
+public record SubscriberConfig(
+        @Loggable @ConfigProperty(defaultValue = "4000") @Min(100) int liveQueueSize,
+        @Loggable @ConfigProperty(defaultValue = "4000") @Min(10) long maximumFutureRequest,
+        @Loggable @ConfigProperty(defaultValue = "400") @Min(10) int minimumLiveQueueCapacity) {}

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.stream.subscriber;
+
+import com.hedera.pbj.runtime.grpc.GrpcException;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.grpc.Pipelines;
+import com.hedera.pbj.runtime.grpc.Pipelines.ServerStreamingMethod;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.metrics.api.LongGauge;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
+import org.hiero.block.api.SubscribeStreamRequest;
+import org.hiero.block.api.SubscribeStreamResponse;
+import org.hiero.block.api.protoc.BlockStreamSubscribeServiceGrpc;
+import org.hiero.block.internal.SubscribeStreamResponseUnparsed;
+import org.hiero.block.node.spi.BlockNodeContext;
+import org.hiero.block.node.spi.BlockNodePlugin;
+import org.hiero.block.node.spi.ServiceBuilder;
+
+/** Provides implementation for the health endpoints of the server. */
+public class SubscriberServicePlugin implements BlockNodePlugin, ServiceInterface {
+    /** The service name for this service, which must match the gRPC service name */
+    private static final String SERVICE_NAME = parseGrpcName();
+    /** The logger for this class. */
+    private final Logger LOGGER = System.getLogger(getClass().getName());
+    /** Metric for the number of subscribers receiving block items. */
+    private final List<SubscribeBlockStreamHandler> clientHandlers = new LinkedList<>();
+    /** The block node context */
+    private BlockNodeContext context;
+
+    private SubscriberConfig pluginConfiguration;
+    private SubscribeBlockStreamHandler clientHandler;
+
+    /*==================== BlockNodePlugin Methods ====================*/
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
+        this.context = context;
+        pluginConfiguration = context.configuration().getConfigData(SubscriberConfig.class);
+        // register us as a service
+        serviceBuilder.registerGrpcService(this);
+    }
+
+    /*==================== ServiceInterface Methods ====================*/
+
+    /**
+     * BlockStreamSubscriberService types define the gRPC methods available on the BlockStreamSubscriberService.
+     */
+    enum SubscriberServiceMethod implements Method {
+        /**
+         * The subscribeBlockStream method represents the server-streaming gRPC method
+         * consumers should use to subscribe to the BlockStream from the Block Node.
+         */
+        subscribeBlockStream
+    }
+
+    @Override
+    public void start() {
+        // Create the client handler and wait for it to start and reach a ready state.
+        clientHandler = new SubscribeBlockStreamHandler(context, this);
+    }
+
+    @Override
+    public void stop() {
+        clientHandler.stop();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public String serviceName() {
+        return SERVICE_NAME;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public String fullName() {
+        return BlockStreamSubscribeServiceGrpc.SERVICE_NAME;
+    }
+
+    /**
+     * Minimal method to parse the gRPC service name from the full name.
+     * <br/>This is called once and stored statically.
+     */
+    private static String parseGrpcName() {
+        String[] parts = BlockStreamSubscribeServiceGrpc.SERVICE_NAME.split("\\.");
+        return parts[parts.length - 1];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public List<Method> methods() {
+        return Arrays.asList(SubscriberServiceMethod.values());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Class<? extends Record>> configDataTypes() {
+        return List.of(SubscriberConfig.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * This is called each time a new stream consumer connects to the server.
+     */
+    @Override
+    @NonNull
+    public Pipeline<? super Bytes> open(
+            @NonNull Method method, @NonNull RequestOptions opts, @NonNull Pipeline<? super Bytes> responses)
+            throws GrpcException {
+        LOGGER.log(Level.DEBUG, "Real Plugin Open called");
+        final SubscriberServiceMethod subscriberServiceMethod = (SubscriberServiceMethod) method;
+        return switch (subscriberServiceMethod) {
+            case subscribeBlockStream:
+                clientHandlers.add(clientHandler);
+                // subscribeBlockStream is server streaming end point so the client sends a single request and the
+                // server sends many responses
+                yield Pipelines.<SubscribeStreamRequest, SubscribeStreamResponseUnparsed>serverStreaming()
+                        .mapRequest(SubscribeStreamRequest.PROTOBUF::parse)
+                        .method(clientHandler)
+                        .mapResponse(SubscribeStreamResponseUnparsed.PROTOBUF::toBytes)
+                        .respondTo(responses)
+                        .build();
+        };
+    }
+
+    // Visible for Testing
+    Map<Long, BlockStreamSubscriberSession> getOpenSessions() {
+        return clientHandler.getOpenSessions();
+    }
+
+    static class SubscribeBlockStreamHandler
+            implements ServerStreamingMethod<SubscribeStreamRequest, SubscribeStreamResponseUnparsed> {
+        private final Logger LOGGER = System.getLogger(getClass().getName());
+        /** Count of active sessions, because LongGauge doesn't support increment/decrement */
+        private AtomicLong sessionCount = new AtomicLong(0L);
+        /** The next client id to use when a new client session is created */
+        private final AtomicLong nextClientId = new AtomicLong(0);
+
+        private final BlockNodeContext context;
+        private final SubscriberServicePlugin plugin;
+        /** Set of open client sessions */
+        private final Map<Long, BlockStreamSubscriberSession> openSessions;
+
+        private final LongGauge numberOfSubscribers;
+        private final ExecutorCompletionService<BlockStreamSubscriberSession> streamSessions;
+
+        private SubscribeBlockStreamHandler(final BlockNodeContext context, final SubscriberServicePlugin plugin) {
+            this.context = context;
+            this.plugin = plugin;
+            this.openSessions = new ConcurrentSkipListMap<>();
+            streamSessions = new ExecutorCompletionService<>(Executors.newVirtualThreadPerTaskExecutor());
+            // create the metrics
+            numberOfSubscribers = context.metrics()
+                    .getOrCreate(new LongGauge.Config(METRICS_CATEGORY, "subscribers")
+                            .withDescription("Number of Connected Subscribers"));
+        }
+
+        private void stop() {
+            // Close all connections and notify the clients.
+            for (final BlockStreamSubscriberSession session : openSessions.values()) {
+                session.close(SubscribeStreamResponse.Code.READ_STREAM_SUCCESS);
+            }
+            // Make sure all the threads complete.
+            while (!openSessions.isEmpty()) {
+                try {
+                    // This blocks until the session thread ends, but the close
+                    // calls above _should have_ ended all the threads already.
+                    openSessions.remove(streamSessions.take().get().clientId());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } catch (ExecutionException e) {
+                    // This should never happen, but if it does, log the error.
+                    final String message = "Error ending subscriber session: {0}.";
+                    LOGGER.log(Level.ERROR, message, e);
+                }
+            }
+        }
+
+        @Override
+        public void apply(
+                @NonNull final SubscribeStreamRequest request,
+                @NonNull final Pipeline<? super SubscribeStreamResponseUnparsed> responsePipeline)
+                throws InterruptedException {
+            final long clientId = nextClientId.getAndIncrement();
+            final CountDownLatch sessionReadyLatch = new CountDownLatch(1);
+            final BlockStreamSubscriberSession blockStreamSession =
+                    new BlockStreamSubscriberSession(clientId, request, responsePipeline, context, sessionReadyLatch);
+            streamSessions.submit(blockStreamSession);
+            // add the session to the set of open sessions
+            sessionReadyLatch.await();
+            openSessions.put(clientId, blockStreamSession);
+            numberOfSubscribers.set(sessionCount.incrementAndGet());
+            Future<BlockStreamSubscriberSession> completedSessionFuture;
+            // Get any available completed sessions and log success/failure.
+            // noinspection NestedAssignment
+            while ((completedSessionFuture = streamSessions.poll()) != null) {
+                handleCompletedStream(completedSessionFuture);
+            }
+        }
+
+        private void handleCompletedStream(final Future<BlockStreamSubscriberSession> completedSessionFuture)
+                throws InterruptedException {
+            try {
+                BlockStreamSubscriberSession completedSession = completedSessionFuture.get();
+                long clientId = completedSession.clientId();
+                // Remove the completed session from open sessions.
+                openSessions.remove(clientId);
+                Exception failureCause = completedSession.getSessionFailedCause();
+                if (failureCause != null) {
+                    // If the session failed, log the failure.
+                    // Subscribers can reconnect or retry, so this is only an informational log.
+                    final String message = "Subscriber session %(,d failed due to {0}.".formatted(clientId);
+                    LOGGER.log(Level.INFO, message, failureCause);
+                } else {
+                    // Otherwise, log that the session completed successfully.
+                    LOGGER.log(Level.TRACE, "Subscriber session %(,d completed successfully.".formatted(clientId));
+                }
+            } catch (ExecutionException e) {
+                // Note, this only happens if something truly unexpected (i.e. an Error) caused
+                // the session to fail, so the error is significant.
+                final String message = "Subscriber session failed due to unhandled %s:%n{0}.".formatted(e.getCause());
+                LOGGER.log(Level.ERROR, message, e);
+            }
+            // Decrement the session count and update the metric.
+            numberOfSubscribers.set(sessionCount.decrementAndGet());
+        }
+
+        /*==================== Testing Access Methods ====================*/
+        /**
+         * Testing method to provide visibility into the open sessions (which are message handlers)
+         * so we can trigger messaging behaviors and see results.
+         */
+        Map<Long, BlockStreamSubscriberSession> getOpenSessions() {
+            return Collections.unmodifiableMap(openSessions);
+        }
+    }
+}

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberTest.java
@@ -1,0 +1,463 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.stream.subscriber;
+
+import static java.util.concurrent.locks.LockSupport.parkNanos;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hiero.block.node.app.fixtures.TestUtils.enableDebugLogging;
+import static org.hiero.block.node.app.fixtures.blocks.BlockItemUtils.toBlockItem;
+import static org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder.createNumberOfSimpleBlockBatches;
+import static org.hiero.block.node.spi.BlockNodePlugin.UNKNOWN_BLOCK_NUMBER;
+import static org.hiero.block.node.stream.subscriber.SubscriberServicePlugin.SubscriberServiceMethod.subscribeBlockStream;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.grpc.ServiceInterface.Method;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.hiero.block.api.SubscribeStreamRequest;
+import org.hiero.block.api.SubscribeStreamResponse;
+import org.hiero.block.api.SubscribeStreamResponse.ResponseOneOfType;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.node.app.fixtures.plugintest.GrpcPluginTestBase;
+import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
+import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the SubscriberServicePlugin. It mocks out the rest of the block node so we can simply test just this
+ * plugin.
+ */
+@SuppressWarnings("DataFlowIssue")
+public class SubscriberTest extends GrpcPluginTestBase<SubscriberServicePlugin> {
+    private static final int RESPONSE_WAIT_LIMIT = 1000;
+
+    private final SubscriberServicePlugin activePlugin;
+    private final SimpleInMemoryHistoricalBlockFacility historicalFacility;
+
+    /**
+     * Constructor that creates new subscriber plugin and in-memory block facility.
+     */
+    public SubscriberTest() {
+        historicalFacility = new SimpleInMemoryHistoricalBlockFacility();
+        activePlugin = new SubscriberServicePlugin();
+        start(activePlugin, subscribeBlockStream, historicalFacility);
+    }
+
+    /**
+     * Enable debug logging for each test.
+     */
+    @BeforeEach
+    void setup() {
+        // enable debug System.logger logging
+        enableDebugLogging();
+    }
+
+    /**
+     * Test the service methods are correctly defined.
+     */
+    @Test
+    void testServiceInterfaceBasics() {
+        // check we have a service interface
+        assertNotNull(serviceInterface);
+        // check the methods from service interface
+        List<Method> methods = serviceInterface.methods();
+        assertNotNull(methods);
+        assertEquals(1, methods.size());
+        assertEquals(subscribeBlockStream, methods.getFirst());
+    }
+
+    /**
+     * Test the subscriber service, create a single subscriber and send it some block items via the messaging services
+     * and makes sure they are delivered correctly. Tests block range:
+     * <ul>
+     *     <li>Starting at block UNKNOWN_BLOCK_NUMBER which means any block</li>
+     *     <li>Ending at block UNKNOWN_BLOCK_NUMBER which means stream forever</li>
+     * </ul>
+     *
+     * @throws ParseException should not happen
+     */
+    @Test
+    void testSubscribeAnyToMaxBlocksUnknown() throws ParseException {
+        // first we need to create and send a SubscribeStreamRequest
+        final SubscribeStreamRequest subscribeStreamRequest = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(UNKNOWN_BLOCK_NUMBER)
+                .endBlockNumber(UNKNOWN_BLOCK_NUMBER)
+                .build();
+        toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(subscribeStreamRequest));
+        // Need to wait for the handler to be registered...
+        awaitSession();
+        // should not have got a response
+        assertEquals(0, fromPluginBytes.size());
+        // check we can send some block items and they are received
+        sendBatchesAndCheckTheyAreReceived(createNumberOfSimpleBlockBatches(1), 0);
+        activePlugin.stop(); // request the plugin to end all client streams.
+    }
+
+    /**
+     * Test the subscriber service, create a single subscriber and send it some block items via the messaging services
+     * and makes sure they are delivered correctly. Tests block range:
+     * <ul>
+     *     <li>Starting at block UNKNOWN_BLOCK_NUMBER which means any block</li>
+     *     <li>Ending at block 0 which means stream forever</li>
+     * </ul>
+     *
+     * @throws ParseException should not happen
+     */
+    @Test
+    void testSubscribeAnyToMaxBlocksZero() throws ParseException {
+        // first we need to create and send a SubscribeStreamRequest
+        final SubscribeStreamRequest subscribeStreamRequest = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(UNKNOWN_BLOCK_NUMBER)
+                .endBlockNumber(0)
+                .build();
+        toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(subscribeStreamRequest));
+        // Need to wait for the handler to be registered...
+        awaitSession();
+        // should not have got a response
+        assertEquals(0, fromPluginBytes.size());
+        // check we can send some block items and they are received
+        sendBatchesAndCheckTheyAreReceived(createNumberOfSimpleBlockBatches(1), 0);
+        awaitResponse(fromPluginBytes, 1);
+        activePlugin.stop(); // request the plugin to end all client streams.
+        assertEquals(2, fromPluginBytes.size());
+    }
+
+    /**
+     * Test the subscriber service, create a single subscriber and send it some block items via the messaging services
+     * and makes sure they are delivered correctly. Tests block range:
+     * <ul>
+     *     <li>Starting at block UNKNOWN_BLOCK_NUMBER which means any block</li>
+     *     <li>Ending at block Long.MAX_VALUE which means stream forever</li>
+     * </ul>
+     *
+     * @throws ParseException should not happen
+     */
+    @Test
+    void testSubscribeAnyToMaxBlocksMax() throws ParseException {
+        // first we need to create and send a SubscribeStreamRequest
+        final SubscribeStreamRequest subscribeStreamRequest = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(UNKNOWN_BLOCK_NUMBER)
+                .endBlockNumber(Long.MAX_VALUE)
+                .build();
+        toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(subscribeStreamRequest));
+        // Need to wait for the handler to be registered...
+        awaitSession();
+        // should not have got a response yet
+        assertEquals(0, fromPluginBytes.size());
+        // check we can send some block items and they are received
+        sendBatchesAndCheckTheyAreReceived(createNumberOfSimpleBlockBatches(10), 0);
+        activePlugin.stop(); // request the plugin to end all client streams.
+    }
+
+    private void awaitSession() {
+        int retries = 0;
+        while (activePlugin.getOpenSessions().isEmpty() && retries < RESPONSE_WAIT_LIMIT) {
+            // wait for the session to be established
+            parkNanos(100_000L);
+            retries++;
+        }
+        if (retries >= RESPONSE_WAIT_LIMIT) {
+            System.out.println("Timed out waiting for session to be established");
+        } else {
+            System.out.printf(
+                    "Session %d established.%n", activePlugin.getOpenSessions().size());
+        }
+    }
+
+    @Test
+    void testSubscriberBlockZero() throws ParseException {
+        // Disable history so we really test live flow.
+        historicalFacility.setDisablePlugin();
+        // first we need to create and send a SubscribeStreamRequest
+        final SubscribeStreamRequest subscribeStreamRequest = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(0)
+                .endBlockNumber(UNKNOWN_BLOCK_NUMBER)
+                .build();
+        toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(subscribeStreamRequest));
+        // Need to wait for the handler to be registered...
+        awaitSession();
+        // check we can send some block items and they are received
+        sendBatchesAndCheckTheyAreReceived(createNumberOfSimpleBlockBatches(25), 0);
+        activePlugin.stop(); // request the plugin to end all client streams.
+    }
+
+    @Test
+    void testSubscriberBlockZeroTwoChunks() throws ParseException {
+        // Disable history so we really test live flow.
+        historicalFacility.setDisablePlugin();
+        // first we need to create and send a SubscribeStreamRequest
+        final SubscribeStreamRequest subscribeStreamRequest = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(0)
+                .endBlockNumber(UNKNOWN_BLOCK_NUMBER)
+                .build();
+        toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(subscribeStreamRequest));
+        // Need to wait for the handler to be registered...
+        awaitSession();
+        // check we can send some block items and they are received
+        sendBatchesAndCheckTheyAreReceived(createNumberOfSimpleBlockBatches(0, 10), 0);
+        sendBatchesAndCheckTheyAreReceived(createNumberOfSimpleBlockBatches(10, 20), 10);
+        activePlugin.stop(); // request the plugin to end all client streams.
+    }
+
+    @Test
+    void testSubscriberBlockStreamInMiddleNoHistory() throws ParseException {
+        // Disable history so we really test live flow.
+        historicalFacility.setDisablePlugin();
+        // send first 10 items
+        sendBatches(createNumberOfSimpleBlockBatches(0, 10), false, 0);
+        // first we need to create and send a SubscribeStreamRequest
+        final SubscribeStreamRequest subscribeStreamRequest = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(10)
+                .endBlockNumber(UNKNOWN_BLOCK_NUMBER)
+                .build();
+        toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(subscribeStreamRequest));
+        // Need to wait for the handler to be registered...
+        awaitSession();
+        // check we did not get a bad response
+        assertEquals(0, fromPluginBytes.size(), this::ErrorForSubscribeResponse);
+        // check we can send some block items and they are received
+        sendBatchesAndCheckTheyAreReceived(createNumberOfSimpleBlockBatches(10, 20), 0);
+        activePlugin.stop(); // request the plugin to end all client streams.
+    }
+
+    @Test
+    void testSubscriberBlockStreamInMiddleWithHistory() throws ParseException {
+        // send first 10 items
+        sendBatches(createNumberOfSimpleBlockBatches(0, 10), false, 0);
+        System.out.print("\n\n\n============================================================\n\n\n");
+        // first we need to create and send a SubscribeStreamRequest
+        final SubscribeStreamRequest subscribeStreamRequest = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(5)
+                .endBlockNumber(19)
+                .build();
+        toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(subscribeStreamRequest));
+        // Need to wait for the handler to be registered...
+        awaitSession();
+        System.out.print("\n\n\n============================================================\n\n\n");
+        sendBatchesWithoutChecks(createNumberOfSimpleBlockBatches(10, 11), 6);
+        // check we can send some block items and they are received
+        sendBatchesWithoutChecks(createNumberOfSimpleBlockBatches(11, 20), 8);
+        System.out.print("\n\n\n============================================================\n\n\n");
+        compareBatchesToResponses(createNumberOfSimpleBlockBatches(5, 20), 0, fromPluginBytes);
+        activePlugin.stop(); // request the plugin to end all client streams.
+    }
+
+    @Test
+    void testSubscriberBlockStreamAheadOfMiddle() throws ParseException {
+        // Disable history so we really test live flow.
+        historicalFacility.setDisablePlugin();
+        // send first 10 items
+        sendBatches(createNumberOfSimpleBlockBatches(0, 10), false, 0);
+        // first we need to create and send a SubscribeStreamRequest
+        final SubscribeStreamRequest subscribeStreamRequest = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(15)
+                .endBlockNumber(UNKNOWN_BLOCK_NUMBER)
+                .build();
+        toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(subscribeStreamRequest));
+        // Need to wait for the handler to be registered...
+        awaitSession();
+        // check we did not get a bad response
+        assertEquals(0, fromPluginBytes.size(), this::ErrorForSubscribeResponse);
+        // now send some blocks up to (but not including) the starting block
+        sendBatches(createNumberOfSimpleBlockBatches(10, 15), false, 0);
+        // check we can send some block items and they are received
+        sendBatchesAndCheckTheyAreReceived(createNumberOfSimpleBlockBatches(15, 25), 0);
+        activePlugin.stop(); // request the plugin to end all client streams.
+    }
+
+    @Disabled("Disabled until I rewrite this for the new approach.")
+    @Test
+    void testSubscribeFromZeroSlowClient() throws ParseException {
+        // first we need to create and send a SubscribeStreamRequest
+        final SubscribeStreamRequest subscribeStreamRequest = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(0)
+                .endBlockNumber(UNKNOWN_BLOCK_NUMBER)
+                .build();
+        toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(subscribeStreamRequest));
+        // Need to wait for the handler to be registered...
+        awaitSession();
+        // check we can send some block items and they are received
+        sendBatchesWithBackpressure(createNumberOfSimpleBlockBatches(0, 25), new int[] {5, 6, 7, 8, 9, 10}, 0);
+    }
+
+    // ==== Test bad response codes ====================================================================================
+
+    @Test
+    void testBadResponse() throws ParseException {
+        // send first 10 items
+        sendBatches(createNumberOfSimpleBlockBatches(0, 10), false, 0);
+        // first we need to create and send a SubscribeStreamRequest
+        final SubscribeStreamRequest subscribeStreamRequest = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(10000) // We allow a significant amount of future blocks, so make this larger.
+                .endBlockNumber(UNKNOWN_BLOCK_NUMBER)
+                .build();
+        toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(subscribeStreamRequest));
+        // Just wait for the "bad request" response.
+        awaitResponse(fromPluginBytes);
+        activePlugin.stop(); // request the plugin to end all client streams.
+        // check we did not get a bad response
+        SubscribeStreamResponse response = parseResponse(fromPluginBytes.getFirst());
+        assertEquals(ResponseOneOfType.STATUS, response.response().kind());
+        assertEquals(SubscribeStreamResponse.Code.READ_STREAM_INVALID_START_BLOCK_NUMBER, response.status());
+    }
+
+    @Test
+    void testBadResponseLargeNegativeStart() throws ParseException {
+        // send first 10 items
+        sendBatches(createNumberOfSimpleBlockBatches(0, 10), false, 0);
+        // first we need to create and send a SubscribeStreamRequest
+        final SubscribeStreamRequest subscribeStreamRequest = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(UNKNOWN_BLOCK_NUMBER)
+                .endBlockNumber(UNKNOWN_BLOCK_NUMBER - 1)
+                .build();
+        toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(subscribeStreamRequest));
+        // Just wait for the "bad request" response.
+        awaitResponse(fromPluginBytes);
+        toPluginPipe.clientEndStreamReceived();
+        // check we got a response, but did not get an incorrect response
+        assertThat(fromPluginBytes.size())
+                .as("Expected at least one response, but got 0.")
+                .isGreaterThan(0);
+        SubscribeStreamResponse response = parseResponse(fromPluginBytes.getFirst());
+        assertEquals(ResponseOneOfType.STATUS, response.response().kind());
+        assertEquals(SubscribeStreamResponse.Code.READ_STREAM_INVALID_END_BLOCK_NUMBER, response.status());
+    }
+
+    @Test
+    void testBadResponseEndBeforeStart() {
+        // send first 10 items
+        sendBatches(createNumberOfSimpleBlockBatches(0, 10), false, 0);
+        // first we need to create and send a SubscribeStreamRequest
+        final SubscribeStreamRequest subscribeStreamRequest = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(10)
+                .endBlockNumber(5)
+                .build();
+        toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(subscribeStreamRequest));
+        // Just wait for the "bad request" response.
+        awaitResponse(fromPluginBytes);
+        toPluginPipe.clientEndStreamReceived();
+        // check we did get a bad response
+        assertThat(fromPluginBytes.size()).isGreaterThan(0);
+        SubscribeStreamResponse response = parseResponse(fromPluginBytes.getFirst());
+        assertEquals(ResponseOneOfType.STATUS, response.response().kind());
+        assertEquals(SubscribeStreamResponse.Code.READ_STREAM_INVALID_END_BLOCK_NUMBER, response.status());
+    }
+
+    // ==== Testing Utility Methods ====================================================================================
+
+    private String ErrorForSubscribeResponse() {
+        try {
+            final SubscribeStreamResponse actualResponse = parseResponse(fromPluginBytes.getFirst());
+            return "Expected no response but got %s.".formatted(actualResponse);
+        } catch (final RuntimeException e) {
+            return "Expected no response and unable to parse actual response. %s.".formatted(e);
+        }
+    }
+
+    private void awaitResponse(List<Bytes> fromPluginBytes) {
+        awaitResponse(fromPluginBytes, 1);
+    }
+
+    private void awaitResponse(List<Bytes> fromPluginBytes, int requiredReplies) {
+        int retries = 0;
+        parkNanos(100_000L); // Always wait at least once.
+        while (fromPluginBytes.size() < requiredReplies && retries < RESPONSE_WAIT_LIMIT) {
+            // wait for a response
+            parkNanos(100_000L);
+            retries++;
+        }
+        if (retries >= RESPONSE_WAIT_LIMIT) {
+            System.out.printf("Timed out waiting for %d responses%n", requiredReplies);
+        }
+    }
+
+    /**
+     * Test the subscriber service, sending blocks to the messaging facility.
+     */
+    void sendBatchesWithoutChecks(final BlockItems[] batches, final int expectedResponses) {
+        final int offset = fromPluginBytes.size();
+        // send all the block items
+        sendBatches(batches, true, 0);
+        awaitResponse(fromPluginBytes, expectedResponses);
+    }
+
+    /**
+     * Test the subscriber service, sending 25 blocks to the messaging facility and checking they are received
+     * correctly.
+     */
+    void sendBatchesAndCheckTheyAreReceived(final BlockItems[] batches, int responsesAlreadyReceived) {
+        final int offset = responsesAlreadyReceived;
+        System.out.printf("Sending %d batches after receiving %d%n", batches.length, offset);
+        // send all the block items
+        sendBatches(batches, true, offset);
+        compareBatchesToResponses(batches, offset, fromPluginBytes);
+    }
+
+    /**
+     * Test the subscriber service, sending blocks to the messaging facility.
+     * At indicated blocks, apply backpressure (as though the client is slow)
+     */
+    void sendBatchesWithBackpressure(final BlockItems[] batches, final int[] blocksToSlow, final int sessionToSlow)
+            throws ParseException {
+        final int offset = fromPluginBytes.size();
+        // send all the block items
+        // sendBatches(batches, blocksToSlow, null, sessionToSlow);
+        // check we got all the items
+        final int responseCount = fromPluginBytes.size() - offset;
+        assertThat(responseCount)
+                .as("Expected %d responses, but got %d.".formatted(batches.length, responseCount))
+                .isEqualTo(batches.length);
+        compareBatchesToResponses(batches, offset, fromPluginBytes);
+    }
+
+    private void compareBatchesToResponses(
+            final BlockItems[] batches, final int offset, final List<Bytes> responseBytes) {
+        final int responseCount = responseBytes.size() - offset;
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(responseCount)
+                    .as("Expected %d responses, but got %d.".formatted(batches.length, responseCount))
+                    .isEqualTo(batches.length);
+            for (int i = 0; i < batches.length && i < responseCount; i++) {
+                SubscribeStreamResponse response = parseResponse(responseBytes.get(i + offset));
+                softly.assertThat(response.response().kind())
+                        .as("Expected BLOCK_ITEMS but got " + response.response())
+                        .isEqualTo(ResponseOneOfType.BLOCK_ITEMS);
+                BlockItems next = batches[i];
+                final List<BlockItem> returned = response.blockItems().blockItems();
+                final List<BlockItemUnparsed> sent = next.blockItems();
+                for (int u = 0; u < sent.size(); u++) {
+                    final BlockItem expectedItem = toBlockItem(sent.get(u));
+                    final BlockItem actualItem = returned.get(u);
+                    softly.assertThat(actualItem)
+                            .as("Failed to match batch %d, block %d, Item %d.".formatted(i, next.newBlockNumber(), u))
+                            .isEqualTo(expectedItem);
+                }
+            }
+        });
+    }
+
+    private SubscribeStreamResponse parseResponse(Bytes responseToParse) {
+        try {
+            return SubscribeStreamResponse.PROTOBUF.parse(responseToParse);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    void sendBatches(final BlockItems[] batches, final boolean waitForResponses, int previousResponses) {
+        for (int i = 0; i < batches.length; i++) {
+            final BlockItems batch = batches[i];
+            blockMessaging.sendBlockItems(batch);
+            // minimal delay (10 μs) so we don't stream too fast.
+            parkNanos(10_000L);
+        }
+        if (waitForResponses && batches.length >= 1) {
+            awaitResponse(fromPluginBytes, batches.length + previousResponses);
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,8 @@ javaModules {
         module("health") { artifact = "block-node-health" }
         module("messaging") { artifact = "facility-messaging" }
         module("publisher") { artifact = "block-node-publisher" }
-        module("subscriber") { artifact = "block-node-subscriber" }
+        // module("subscriber") { artifact = "block-node-subscriber" }
+        module("stream-subscriber") { artifact = "block-node-stream-subscriber" }
         module("verification") { artifact = "block-node-verification" }
         module("block-providers/cloud.historic") { artifact = "block-node-blocks-cloud-historic" }
         module("block-providers/files.historic") { artifact = "block-node-blocks-file-historic" }


### PR DESCRIPTION
## Reviewer Notes
Adding a new plugin
 * Instead of beating on the old implementation, implement a new subscriber plugin
   that uses a single client thread and feeds that alternately from messaging or history
   This avoids the countdown latch and state transition logic.
   Also avoids a state machine, just take the next block from one source or the other,
   always getting just the next block to send the client.
   Does require a secondary queue from the messaging, but it's small and simple.
* Adjust the subscriber "method" class to be reused, so we track sessions properly
* Added a latch so the pipeline thread holds until the session is registered with
  messaging before returning. This has minimal impact in production, and makes
  it possible to test reliably.
* Added live block push to queue, live blocks stream correctly.
* Added handling for request ahead of live condition
    * Session just skips over live blocks until live reaches the start block.
* Added proper shutdown of all sessions if the plugin is stopped.
* History and Live both work, and the test disables history to prove it
    * This is necessary because otherwise the test "history" plugin is too fast
      and we always serve history.

### TODO
* Add more unit tests
* Add testing that forces a client to fall behind and catch up
* Add some end-to-end test suites to exercise this plugin better
* Add more and better javadoc
* Clean up the (excessive) trace logging
* Add better metrics, the "transition" metrics aren't super helpful.
* Suggested metrics
    * Live batches sent to client (would be good if we can tag this with a client ID)
    * History blocks sent to client (would be good if we can tag this with a client ID)
    * Count of times the client thread must wait for live blocks, and time spent waiting
    * Count of times the client cannot read from history, but subsequently reads from live
    * Client connection and time from connect to session established

## Related Issue(s)
 Resolves: #1051
