### PR TITLE
Improve Default metrics retention period from 10d to 90d for BN Deployment using included Chart

### DIFF
--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -158,6 +158,7 @@ kubepromstack:
   enabled: true
   prometheus:
     prometheusSpec:
+      retention: 90d
       storageSpec:
         volumeClaimTemplate:
           spec:


### PR DESCRIPTION
Setting default retention period for metrics for 90d
Loki does not have a period, but rather when the available space is filled starts to remove older logs, I believe this is desired.

Fixes #1059 