### PR TITLE
test: Files Historic Plugin Unit Tests Pt. 5

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/async/BlockingSerialExecutor.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/async/BlockingSerialExecutor.java
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.app.fixtures.async;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A very simple executor to be used only for testing! This executor will
+ * collect all submitted tasks to it and will hold them in order. After that
+ * when the {@link #executeSerially()} method is called, all tasks will be
+ * executed in order serially on the same thread that called the method. This
+ * will ensure that all tasks will complete before doing any asserts
+ */
+public class BlockingSerialExecutor extends ThreadPoolExecutor {
+    /** The work queue that will be used to hold the tasks */
+    private final BlockingQueue<Runnable> workQueue;
+
+    /**
+     * Constructor.
+     */
+    public BlockingSerialExecutor(@NonNull final BlockingQueue<Runnable> workQueue) {
+        // supply super with arbitrary values, they will not be used
+        super(
+                1,
+                1,
+                0L,
+                TimeUnit.MILLISECONDS,
+                Objects.requireNonNull(workQueue), // super will not use this queue
+                Executors.defaultThreadFactory(),
+                new AbortPolicy());
+        this.workQueue = workQueue; // actual work queue
+    }
+
+    /**
+     * Overriding this method in order to make sure this logic will be called
+     * every time we will submit a task to the pool.
+     */
+    @Override
+    @SuppressWarnings("all")
+    public void execute(@NonNull final Runnable command) {
+        workQueue.offer(command);
+    }
+
+    /**
+     * Invoke this method once you have submitted all the tasks that need to be
+     * run by this executor. This method will then proceed to poll each task
+     * (in the same order that they have been submitted) and will execute the
+     * tasks serially on the same thread that called this method. Once this
+     * method returns (or throws), we are certain that all tasks have run and
+     * can safely assert based on that. This method will throw an
+     * {@link IllegalStateException} to indicate a broken state, when the queue
+     * is empty.
+     */
+    public void executeSerially() {
+        if (workQueue.isEmpty()) {
+            throw new IllegalStateException("Queue is empty");
+        } else {
+            while (!workQueue.isEmpty()) {
+                workQueue.poll().run();
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        shutdownNow();
+    }
+
+    @Override
+    public void shutdown() {
+        shutdownNow();
+    }
+
+    @Override
+    public boolean awaitTermination(final long timeout, final TimeUnit unit) {
+        shutdownNow();
+        return true;
+    }
+
+    /**
+     * Operation currently not supported!
+     */
+    @Override
+    @NonNull
+    public <T> T invokeAny(@NonNull final Collection<? extends Callable<T>> tasks) {
+        throw new UnsupportedOperationException("Operation not supported, to be extended as needed");
+    }
+
+    /**
+     * Operation currently not supported!
+     */
+    @Override
+    @NonNull
+    public <T> T invokeAny(
+            @NonNull final Collection<? extends Callable<T>> tasks, final long timeout, @NonNull final TimeUnit unit) {
+        throw new UnsupportedOperationException("Operation not supported, to be extended as needed");
+    }
+
+    /**
+     * Operation currently not supported!
+     */
+    @Override
+    @NonNull
+    public <T> List<Future<T>> invokeAll(@NonNull final Collection<? extends Callable<T>> tasks) {
+        throw new UnsupportedOperationException("Operation not supported, to be extended as needed");
+    }
+
+    /**
+     * Operation currently not supported!
+     */
+    @Override
+    @NonNull
+    public <T> List<Future<T>> invokeAll(
+            @NonNull final Collection<? extends Callable<T>> tasks, final long timeout, @NonNull final TimeUnit unit) {
+        throw new UnsupportedOperationException("Operation not supported, to be extended as needed");
+    }
+}

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/async/BlockingSerialExecutor.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/async/BlockingSerialExecutor.java
@@ -20,8 +20,10 @@ import java.util.concurrent.TimeUnit;
  * will ensure that all tasks will complete before doing any asserts
  */
 public class BlockingSerialExecutor extends ThreadPoolExecutor {
-    /** The work queue that will be used to hold the tasks */
+    /** The work queue that will be used to hold the tasks. */
     private final BlockingQueue<Runnable> workQueue;
+    /** Counter to indicate total submitted tasks. */
+    private int tasksSubmitted;
 
     /**
      * Constructor.
@@ -47,6 +49,7 @@ public class BlockingSerialExecutor extends ThreadPoolExecutor {
     @SuppressWarnings("all")
     public void execute(@NonNull final Runnable command) {
         workQueue.offer(command);
+        tasksSubmitted++;
     }
 
     /**
@@ -67,6 +70,24 @@ public class BlockingSerialExecutor extends ThreadPoolExecutor {
                 workQueue.poll().run();
             }
         }
+    }
+
+    /**
+     * This method indicates if any task was ever submitted to this executor.
+     * This is useful during tests in order to assert that the pool was
+     * essentially not interacted with. An example would be if we have a test
+     * where we want to assert that some production logic will never submit a
+     * task to the executor given some condition, then we can use this method
+     * to assert that. This method does not reflect the current state of the
+     * queue, meaning the queue might be empty due to a call to the
+     * {@link #executeSerially()} method, but this method will still return
+     * true if any task was submitted before that.
+     *
+     * @return boolean value, true if any task was ever submitted, false
+     * otherwise
+     */
+    public boolean wasAnyTaskSubmitted() {
+        return tasksSubmitted > 0;
     }
 
     @Override

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/NoOpServiceBuilder.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/NoOpServiceBuilder.java
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.app.fixtures.plugintest;
+
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.helidon.webserver.http.HttpService;
+import org.hiero.block.node.spi.ServiceBuilder;
+
+/**
+ * A simple no-op implementation of {@link ServiceBuilder} that does nothing.
+ * To be used for testing purposes only where we need a non-null implementation
+ * that we do not want to act upon.
+ */
+public final class NoOpServiceBuilder implements ServiceBuilder {
+    /** No-op implementation, does nothing. */
+    @Override
+    public void registerHttpService(final String path, final HttpService... service) {}
+
+    /** No-op implementation, does nothing. */
+    @Override
+    public void registerGrpcService(@NonNull final ServiceInterface service) {}
+}

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/NoOpServiceBuilder.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/NoOpServiceBuilder.java
@@ -12,11 +12,19 @@ import org.hiero.block.node.spi.ServiceBuilder;
  * that we do not want to act upon.
  */
 public final class NoOpServiceBuilder implements ServiceBuilder {
-    /** No-op implementation, does nothing. */
+    /**
+     * No-op implementation, does nothing.
+     */
     @Override
-    public void registerHttpService(final String path, final HttpService... service) {}
+    public void registerHttpService(final String path, final HttpService... service) {
+        // No-op implementation, does nothing.
+    }
 
-    /** No-op implementation, does nothing. */
+    /**
+     * No-op implementation, does nothing.
+     */
     @Override
-    public void registerGrpcService(@NonNull final ServiceInterface service) {}
+    public void registerGrpcService(@NonNull final ServiceInterface service) {
+        // No-op implementation, does nothing.
+    }
 }

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/SimpleInMemoryHistoricalBlockFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/SimpleInMemoryHistoricalBlockFacility.java
@@ -43,11 +43,16 @@ public class SimpleInMemoryHistoricalBlockFacility implements HistoricalBlockFac
      */
     @Override
     public void handleBlockItemsReceived(BlockItems blockItems) {
+        handleBlockItemsReceived(blockItems, true);
+    }
+
+    public void handleBlockItemsReceived(BlockItems blockItems, final boolean sendNotification) {
         if (!disablePlugin.get()) {
             if (blockItems.isStartOfNewBlock()) {
                 if (!partialBlock.isEmpty()) {
                     throw new RuntimeException(
-                            "Something went wrong, partitionedBlock is not empty. So we never got a end block for current block");
+                            "Something went wrong, partitionedBlock is not empty. So we never got a end "
+                                    + "block for current block");
                 }
                 currentBlockNumber.set(blockItems.newBlockNumber());
             }
@@ -63,9 +68,11 @@ public class SimpleInMemoryHistoricalBlockFacility implements HistoricalBlockFac
                 availableBlocks.add(blockNumber);
                 partialBlock.clear();
                 // send block persisted message
-                blockNodeContext
-                        .blockMessaging()
-                        .sendBlockPersisted(new PersistedNotification(blockNumber, blockNumber, 2000));
+                if (sendNotification) {
+                    blockNodeContext
+                            .blockMessaging()
+                            .sendBlockPersisted(new PersistedNotification(blockNumber, blockNumber, 2000));
+                }
             }
         }
     }

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
@@ -71,8 +71,8 @@ public final class BlocksFilesHistoricPlugin implements BlockProviderPlugin, Blo
      * {@inheritDoc}
      */
     @Override
-    public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
-        this.context = context;
+    public void init(final BlockNodeContext context, final ServiceBuilder serviceBuilder) {
+        this.context = Objects.requireNonNull(context);
         final FilesHistoricConfig localConfig =
                 this.config == null ? context.configuration().getConfigData(FilesHistoricConfig.class) : this.config;
         // create plugin data root directory if it does not exist

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
@@ -220,26 +220,29 @@ public final class BlocksFilesHistoricPlugin implements BlockProviderPlugin, Blo
                     batchFirstBlockNumber,
                     batchLastBlockNumber);
             zipBlockArchive.writeNewZipFile(batchFirstBlockNumber);
-            // update the first and last block numbers
-            availableBlocks.add(batchFirstBlockNumber, batchLastBlockNumber);
-            // log done
-            LOGGER.log(
-                    System.Logger.Level.INFO,
-                    "Moved batch of blocks[%d -> %d] to zip file",
-                    batchFirstBlockNumber,
-                    batchLastBlockNumber);
-            // now all the blocks are in the zip file and accessible, send notification
-            context.blockMessaging()
-                    .sendBlockPersisted(
-                            new PersistedNotification(batchFirstBlockNumber, batchLastBlockNumber, defaultPriority()));
-            // remove the batch of blocks from in progress ranges
-            inProgressZipRanges.remove(batchRange);
-        } catch (final Exception e) {
+        } catch (final IOException e) {
             LOGGER.log(
                     System.Logger.Level.ERROR,
                     "Failed to move batch of blocks[" + batchFirstBlockNumber + " -> " + batchLastBlockNumber
                             + "] to zip file",
                     e);
+            return;
         }
+        // if we have reached here, then the batch of blocks has been zipped,
+        // now we need to make some updates
+        // update the first and last block numbers
+        availableBlocks.add(batchFirstBlockNumber, batchLastBlockNumber);
+        // log done
+        LOGGER.log(
+                System.Logger.Level.INFO,
+                "Moved batch of blocks[%d -> %d] to zip file",
+                batchFirstBlockNumber,
+                batchLastBlockNumber);
+        // now all the blocks are in the zip file and accessible, send notification
+        context.blockMessaging()
+                .sendBlockPersisted(
+                        new PersistedNotification(batchFirstBlockNumber, batchLastBlockNumber, defaultPriority()));
+        // remove the batch of blocks from in progress ranges
+        inProgressZipRanges.remove(batchRange);
     }
 }

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
@@ -150,7 +150,10 @@ public final class BlocksFilesHistoricPlugin implements BlockProviderPlugin, Blo
     public void handlePersisted(PersistedNotification notification) {
         if (notification.blockProviderPriority() > defaultPriority()) {
             attemptZipping();
-        }
+        } // todo this is not enough of an assertion that the blocks will be coming from the right place
+        //     as notifications are async and things can happen, when we get the accessors later, we should
+        //     be able to get accessors only from places that have higher priority than us. We should probably
+        //     have that as a feature in the block accessor api.
     }
 
     // ==== Private Methods ============================================================================================

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
@@ -153,7 +153,8 @@ public final class BlocksFilesHistoricPlugin implements BlockProviderPlugin, Blo
         } // todo this is not enough of an assertion that the blocks will be coming from the right place
         //     as notifications are async and things can happen, when we get the accessors later, we should
         //     be able to get accessors only from places that have higher priority than us. We should probably
-        //     have that as a feature in the block accessor api.
+        //     have that as a feature in the block accessor api. (meaning we should be able to query the
+        //     historical block facility for blocks that are coming from higher priority plugins)
     }
 
     // ==== Private Methods ============================================================================================

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
@@ -83,7 +83,7 @@ class BlocksFilesHistoricPluginTest {
          * Construct plugin base.
          */
         PluginTests() {
-            super(toTest, testHistoricalBlockFacility);
+            start(toTest, testHistoricalBlockFacility);
         }
 
         /**
@@ -102,7 +102,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 0; i < 10; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -136,7 +136,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 0; i < 20; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 20 blocks are zipped yet
             for (int i = 0; i < 20; i++) {
@@ -170,7 +170,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 0; i < 14; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 20 blocks are zipped yet
             for (int i = 0; i < 14; i++) {
@@ -209,7 +209,7 @@ class BlocksFilesHistoricPluginTest {
             final List<BlockUnparsed> expectedBlocks = new ArrayList<>();
             for (int i = 0; i < 10; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
                 expectedBlocks.add(new BlockUnparsed(List.of(block)));
             }
             // assert that none of the first 10 blocks are zipped yet
@@ -257,7 +257,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 0; i < 5; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 5 blocks are zipped yet
             for (int i = 0; i < 5; i++) {
@@ -277,7 +277,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 5; i < 10; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -307,7 +307,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 0; i < 10; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -338,7 +338,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 0; i < 10; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -366,7 +366,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 0; i < 10; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 10 blocks have accessors yet
             for (int i = 0; i < 10; i++) {
@@ -395,7 +395,7 @@ class BlocksFilesHistoricPluginTest {
             final List<BlockUnparsed> expectedBlocks = new ArrayList<>();
             for (int i = 0; i < 10; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
                 expectedBlocks.add(new BlockUnparsed(List.of(block)));
             }
             // assert that none of the first 10 blocks have accessors yet
@@ -426,7 +426,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 0; i < 10; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -461,7 +461,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 0; i < 10; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 10 blocks appear in the available range
             for (int i = 0; i < 10; i++) {
@@ -491,7 +491,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 0; i < 10; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -523,7 +523,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 0; i < 10; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -557,7 +557,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 0; i < 10; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -590,7 +590,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 0; i < 10; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -625,7 +625,7 @@ class BlocksFilesHistoricPluginTest {
             // test historical block facility
             for (int i = 0; i < 10; i++) {
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
@@ -120,6 +120,40 @@ class BlocksFilesHistoricPluginTest {
          * messaging facility. The block provider that has persisted the blocks
          * must have a higher priority than the plugin we are testing. We expect
          * that the plugin we test will create a zip file with all the blocks in
+         * the notification range (we set the range to 0-19 which fits the config
+         * of 10 blocks per zip), i.e. this is the happy path test for two full
+         * consecutive batches to be archived in a single notification. We expect
+         * all blocks to be archived.
+         */
+        @Test
+        @DisplayName("Test happy path zip range successful archival")
+        void testZipRangeHappyPathArchivalTwoFullBatches() throws IOException {
+            // generate first 20 blocks from numbers 0-9 and add them to the
+            // test historical block facility
+            for (int i = 0; i < 20; i++) {
+                final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+            }
+            // assert that none of the first 20 blocks are zipped yet
+            for (int i = 0; i < 20; i++) {
+                assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
+            }
+            // send a block persisted notification for the range we just created
+            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority() + 1));
+            // execute serially to ensure all tasks are completed
+            pluginExecutor.executeSerially();
+            // assert that the first 20 blocks are zipped now
+            for (int i = 0; i < 20; i++) {
+                assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNotNull();
+            }
+        }
+
+        /**
+         * This test aims to verify that the plugin can handle a simple range of
+         * blocks that have been persisted and a notification is sent to the
+         * messaging facility. The block provider that has persisted the blocks
+         * must have a higher priority than the plugin we are testing. We expect
+         * that the plugin we test will create a zip file with all the blocks in
          * the notification range (we set the range to 0-9 which fits the config
          * of 10 blocks per zip), i.e. this is the happy path test. We assert
          * here the contents of each entry produce the same blocks as before

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
@@ -13,6 +13,8 @@ import java.util.Objects;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.app.fixtures.async.BlockingSerialExecutor;
 import org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder;
 import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
@@ -20,8 +22,6 @@ import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBloc
 import org.hiero.block.node.base.CompressionType;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
-import org.hiero.hapi.block.node.BlockItemUnparsed;
-import org.hiero.hapi.block.node.BlockUnparsed;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
@@ -15,6 +15,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.zip.ZipEntry;
@@ -70,7 +72,7 @@ class BlocksFilesHistoricPluginTest {
         // also we will not use compression, and we will use the jUnit temp dir
         testConfig = new FilesHistoricConfig(tempDir, CompressionType.NONE, 1);
         // build the plugin using the test environment
-        toTest = new BlocksFilesHistoricPlugin(testConfig, pluginExecutor);
+        toTest = new BlocksFilesHistoricPlugin(pluginExecutor);
         // initialize an in memory historical block facility to use for testing
         testHistoricalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
     }
@@ -148,7 +150,21 @@ class BlocksFilesHistoricPluginTest {
          * Construct plugin base.
          */
         PluginTests() {
-            start(toTest, testHistoricalBlockFacility);
+            // match overrides to the test config
+            final Map<String, String> configOverrides = getConfigOverrides();
+            // initialize and start the test plugin using the config overrides
+            start(toTest, testHistoricalBlockFacility, configOverrides);
+        }
+
+        private Map<String, String> getConfigOverrides() {
+            final Entry<String, String> rootPath =
+                    Map.entry("files.historic.rootPath", testConfig.rootPath().toString());
+            final Entry<String, String> compression = Map.entry(
+                    "files.historic.compression", testConfig.compression().name());
+            final Entry<String, String> powersOfTenPerZipFileContents = Map.entry(
+                    "files.historic.powersOfTenPerZipFileContents",
+                    String.valueOf(testConfig.powersOfTenPerZipFileContents()));
+            return Map.ofEntries(rootPath, compression, powersOfTenPerZipFileContents);
         }
 
         /**

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.blocks.files.historic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.LinkedBlockingQueue;
+import org.hiero.block.node.app.fixtures.async.BlockingSerialExecutor;
+import org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder;
+import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
+import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
+import org.hiero.block.node.base.CompressionType;
+import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
+import org.hiero.hapi.block.node.BlockItemUnparsed;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link BlocksFilesHistoricPlugin}.
+ */
+@DisplayName("BlocksFilesHistoricPlugin Tests")
+class BlocksFilesHistoricPluginTest {
+    /** The test block messaging facility to use for testing. */
+    private final SimpleInMemoryHistoricalBlockFacility testHistoricalBlockFacility;
+    /** The test block serial executor service to use for the plugin. */
+    private final BlockingSerialExecutor pluginExecutor;
+    /** The test config to use for the plugin. */
+    private final FilesHistoricConfig testConfig;
+    /** The instance under test. */
+    private final BlocksFilesHistoricPlugin toTest;
+
+    /**
+     * Construct test environment.
+     */
+    BlocksFilesHistoricPluginTest(@TempDir final Path tempDir) {
+        Objects.requireNonNull(tempDir);
+        // create a blocking serial executor to run the plugin tasks that use
+        // an executor service internally
+        pluginExecutor = new BlockingSerialExecutor(new LinkedBlockingQueue<>());
+        // generate test config, for the purposes of this test, we will always
+        // use 10 blocks per zip, assuming that the first zip file will contain
+        // for example blocks 0-9, the second zip file will contain blocks 10-19
+        // also we will not use compression, and we will use the jUnit temp dir
+        testConfig = new FilesHistoricConfig(tempDir, CompressionType.NONE, 1);
+        // build the plugin using the test environment
+        toTest = new BlocksFilesHistoricPlugin(testConfig, pluginExecutor);
+        // initialize an in memory historical block facility to use for testing
+        testHistoricalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
+    }
+
+    /**
+     * Teardown logic to run after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        pluginExecutor.shutdownNow();
+    }
+
+    /**
+     * Plugin tests.
+     */
+    @Nested
+    @DisplayName("Plugin Tests")
+    final class PluginTests extends PluginTestBase<BlocksFilesHistoricPlugin> {
+        /**
+         * Construct plugin base.
+         */
+        PluginTests() {
+            super(toTest, testHistoricalBlockFacility);
+        }
+
+        /**
+         * This test aims to verify that the plugin can handle a simple range of
+         * blocks that have been persisted and a notification is sent to the
+         * messaging facility. The block provider that has persisted the blocks
+         * must have a higher priority than the plugin we are testing. We expect
+         * that the plugin we test will create a zip file with all the blocks in
+         * the notification range (we set the range to 0-9 which fits the config
+         * of 10 blocks per zip), i.e. this is the happy path test.
+         */
+        @Test
+        @DisplayName("Test happy path zip range successful archival")
+        void testZipRangeHappyPathArchival() throws IOException {
+            // generate first 10 blocks from numbers 0-9 and add them to the
+            // test historical block facility
+            for (int i = 0; i < 10; i++) {
+                final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
+                testHistoricalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i));
+            }
+            // assert that none of the first 10 blocks exist yet
+            for (int i = 0; i < 10; i++) {
+                assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
+            }
+            // send a block persisted notification for the range we just created
+            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority() + 1));
+            // execute serially to ensure all tasks are completed
+            pluginExecutor.executeSerially();
+            // assert that the first 10 blocks exist now
+            for (int i = 0; i < 10; i++) {
+                assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNotNull();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Reviewer Notes

- Part 5 of tests for the `Files Historic` Plugin.
- We test the actual plugin here.
- Introduced a new blocking serial executor service for testing purposes that will allow us to serially execute tasks in the order they have been submitted, all on the caller thread, this ensure that tests will always be in assertable state and debugging is a breeze.
- Found a bug when merging a range in a ranged set, we allow the `LongRange` record to have -1 for start and end, but the merging logic does not allow that, which produces a runtime exception when we initialize a ranged set with `-1 -> -1` and then we try to add anything to it, for example if we add `0 - 9` to it, the ranged set will attempt to produce the following values `-1 -> 9` which the constructor of the `LongRange` record does not allow. For now, I have handled the ranged set in the plugin, the available ranges to only insert anything if we have found some values initially when starting up the server. Otherwise the first insert will be after the first successful zip.
- Another bug was in the `start()` where the range was not correctly established
  - I have extracted and reused the zipping logic from the notification handling method
  - A concern here is again "where are the blocks coming from?"
  - I think we might need to extend the historical block facility method to provide us with accessors from a provider with some priority filter, but I am not sure as of yet if we really need that + if that will over complicate things, potentially hanging some places to wait for accessors that may never come but are available in other places. What are the tradeoffs?
- Am I missing some good cases that I can add as tests?

## Related Issue(s)

Closes #1039 
