### PR TITLE
test: Add subscriber plugin Tests

### DIFF
--- a/block-node/app/build.gradle.kts
+++ b/block-node/app/build.gradle.kts
@@ -57,7 +57,7 @@ mainModuleInfo {
     runtimeOnly("org.hiero.block.node.messaging")
     runtimeOnly("org.hiero.block.node.health")
     runtimeOnly("org.hiero.block.node.publisher")
-    runtimeOnly("org.hiero.block.node.subscriber")
+    runtimeOnly("org.hiero.block.node.stream.subscriber")
     runtimeOnly("org.hiero.block.node.verification")
     runtimeOnly("org.hiero.block.node.blocks.cloud.historic")
     runtimeOnly("org.hiero.block.node.blocks.files.historic")

--- a/block-node/stream-subscriber/build.gradle.kts
+++ b/block-node/stream-subscriber/build.gradle.kts
@@ -19,7 +19,6 @@ testModuleInfo {
     requires("org.hiero.block.node.app.test.fixtures")
     requires("org.assertj.core.api")
 
-    requires("org.junit.jupiter.params")
     requires("org.mockito")
     requires("org.mockito.junit.jupiter")
 }

--- a/block-node/stream-subscriber/build.gradle.kts
+++ b/block-node/stream-subscriber/build.gradle.kts
@@ -18,4 +18,8 @@ testModuleInfo {
     requires("org.junit.jupiter.api")
     requires("org.hiero.block.node.app.test.fixtures")
     requires("org.assertj.core.api")
+
+    requires("org.junit.jupiter.params")
+    requires("org.mockito")
+    requires("org.mockito.junit.jupiter")
 }

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
@@ -177,6 +177,7 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
                     // then process live blocks, if available.
                     sendLiveBlocksIfAvailable();
                 }
+                close(SubscribeStreamResponse.Code.READ_STREAM_SUCCESS); // Need an "INCOMPLETE" code...
             }
         } catch (RuntimeException | ParseException | InterruptedException e) {
             sessionFailedCause = e;
@@ -535,7 +536,7 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
     //       This means we must not modify any state in the session object directly.
     //       Instead we must use a transfer queue to pass the block items to the session
     //       and possibly set an atomic flag if we are "too far behind".
-    private static class LiveBlockHandler implements NoBackPressureBlockItemHandler {
+    static class LiveBlockHandler implements NoBackPressureBlockItemHandler {
         /** The logger for this class. */
         private final Logger LOGGER = System.getLogger(getClass().getName());
 

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.stream.subscriber;
 
+import static java.util.Objects.requireNonNull;
+
 import com.hedera.pbj.runtime.grpc.GrpcException;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.Pipelines;
@@ -31,7 +33,22 @@ import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
 
-/** Provides implementation for the health endpoints of the server. */
+/**
+ * Provides implementation for the block stream subscriber endpoints of the server. These handle incoming requests for block
+ * stream from consumers.
+ *
+ * <p>This plugin is responsible for:
+ * <ul>
+ *   <li>Managing subscriber sessions for clients requesting block streams</li>
+ *   <li>Handling both live-streaming and historical block data requests</li>
+ *   <li>Implementing the gRPC service interface for block stream subscriptions</li>
+ *   <li>Coordinating between multiple publishers when they connect to the block node</li>
+ *   <li>Maintaining metrics about active subscribers and stream health</li>
+ * </ul>
+ *
+ * <p>The plugin registers itself with the service builder during initialization and manages
+ * the lifecycle of subscriber connections.
+ */
 public class SubscriberServicePlugin implements BlockNodePlugin, ServiceInterface {
     /** The service name for this service, which must match the gRPC service name */
     private static final String SERVICE_NAME = parseGrpcName();
@@ -41,8 +58,9 @@ public class SubscriberServicePlugin implements BlockNodePlugin, ServiceInterfac
     private final List<SubscribeBlockStreamHandler> clientHandlers = new LinkedList<>();
     /** The block node context */
     private BlockNodeContext context;
-
+    /** The subscriber plugin configuration */
     private SubscriberConfig pluginConfiguration;
+    /** The client handler for client subscriptions*/
     private SubscribeBlockStreamHandler clientHandler;
 
     /*==================== BlockNodePlugin Methods ====================*/
@@ -51,8 +69,9 @@ public class SubscriberServicePlugin implements BlockNodePlugin, ServiceInterfac
      * {@inheritDoc}
      */
     @Override
-    public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
-        this.context = context;
+    public void init(@NonNull final BlockNodeContext context, @NonNull final ServiceBuilder serviceBuilder) {
+        requireNonNull(serviceBuilder);
+        this.context = requireNonNull(context);
         pluginConfiguration = context.configuration().getConfigData(SubscriberConfig.class);
         // register us as a service
         serviceBuilder.registerGrpcService(this);
@@ -105,7 +124,7 @@ public class SubscriberServicePlugin implements BlockNodePlugin, ServiceInterfac
      * <br/>This is called once and stored statically.
      */
     private static String parseGrpcName() {
-        String[] parts = BlockStreamSubscribeServiceGrpc.SERVICE_NAME.split("\\.");
+        final String[] parts = BlockStreamSubscribeServiceGrpc.SERVICE_NAME.split("\\.");
         return parts[parts.length - 1];
     }
 
@@ -157,15 +176,27 @@ public class SubscriberServicePlugin implements BlockNodePlugin, ServiceInterfac
         return clientHandler.getOpenSessions();
     }
 
+    /**
+     * Handler for block stream subscription requests from clients.
+     * Responsible for:
+     * <ul>
+     *   <li>Managing client sessions for block stream subscribers</li>
+     *   <li>Processing subscription requests and streaming block data to clients</li>
+     *   <li>Tracking active subscriber sessions and their lifecycle</li>
+     *   <li>Handling graceful termination of subscriber connections</li>
+     *   <li>Reporting metrics about active subscribers</li>
+     * </ul>
+     */
     static class SubscribeBlockStreamHandler
             implements ServerStreamingMethod<SubscribeStreamRequest, SubscribeStreamResponseUnparsed> {
         private final Logger LOGGER = System.getLogger(getClass().getName());
         /** Count of active sessions, because LongGauge doesn't support increment/decrement */
-        private AtomicLong sessionCount = new AtomicLong(0L);
+        private final AtomicLong sessionCount = new AtomicLong(0L);
         /** The next client id to use when a new client session is created */
         private final AtomicLong nextClientId = new AtomicLong(0);
-
+        /** The block node context */
         private final BlockNodeContext context;
+        /** The subscriber plugin responsible for handling incoming requests*/
         private final SubscriberServicePlugin plugin;
         /** Set of open client sessions */
         private final Map<Long, BlockStreamSubscriberSession> openSessions;
@@ -173,9 +204,10 @@ public class SubscriberServicePlugin implements BlockNodePlugin, ServiceInterfac
         private final LongGauge numberOfSubscribers;
         private final ExecutorCompletionService<BlockStreamSubscriberSession> streamSessions;
 
-        private SubscribeBlockStreamHandler(final BlockNodeContext context, final SubscriberServicePlugin plugin) {
-            this.context = context;
-            this.plugin = plugin;
+        private SubscribeBlockStreamHandler(
+                @NonNull final BlockNodeContext context, @NonNull final SubscriberServicePlugin plugin) {
+            this.context = requireNonNull(context);
+            this.plugin = requireNonNull(plugin);
             this.openSessions = new ConcurrentSkipListMap<>();
             streamSessions = new ExecutorCompletionService<>(Executors.newVirtualThreadPerTaskExecutor());
             // create the metrics
@@ -234,7 +266,7 @@ public class SubscriberServicePlugin implements BlockNodePlugin, ServiceInterfac
                 long clientId = completedSession.clientId();
                 // Remove the completed session from open sessions.
                 openSessions.remove(clientId);
-                Exception failureCause = completedSession.getSessionFailedCause();
+                final Exception failureCause = completedSession.getSessionFailedCause();
                 if (failureCause != null) {
                     // If the session failed, log the failure.
                     // Subscribers can reconnect or retry, so this is only an informational log.

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSessionTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSessionTest.java
@@ -66,7 +66,7 @@ class BlockStreamSubscriberSessionTest {
                 .build();
         responsePipeline = new ResponsePipeline();
         context = new BlockNodeContext(
-                configuration, metrics, null, blockMessagingFacility, historicalBlockFacility, null);
+                configuration, metrics, null, blockMessagingFacility, historicalBlockFacility, null, null);
         historicalBlockFacility.init(context, null);
         blockMessagingFacility.init(context, null); // Probably not needed, but that can change.
     }

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSessionTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSessionTest.java
@@ -47,7 +47,7 @@ class BlockStreamSubscriberSessionTest {
     private static final int RESPONSE_WAIT_LIMIT = 1000;
     private final HistoricalBlockFacility historicalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
     private final BlockMessagingFacility blockMessagingFacility = new TestBlockMessagingFacility();
-    private final BlockItemHandler providerHandler = (BlockItemHandler)historicalBlockFacility;
+    private final BlockItemHandler providerHandler = (BlockItemHandler) historicalBlockFacility;
 
     private BlockNodeContext context;
     private ResponsePipeline responsePipeline;
@@ -65,8 +65,8 @@ class BlockStreamSubscriberSessionTest {
                 .withConfigDataType(SubscriberConfig.class)
                 .build();
         responsePipeline = new ResponsePipeline();
-        context = new BlockNodeContext(configuration, metrics, null,
-                blockMessagingFacility, historicalBlockFacility, null);
+        context = new BlockNodeContext(
+                configuration, metrics, null, blockMessagingFacility, historicalBlockFacility, null);
         historicalBlockFacility.init(context, null);
         blockMessagingFacility.init(context, null); // Probably not needed, but that can change.
     }
@@ -116,7 +116,10 @@ class BlockStreamSubscriberSessionTest {
                 // Wait for everything to complete.
                 // Note, don't try to wait before this; there are no execution guarantees until
                 // `get` is called; before that the thread may not run or may be parked indefinitely.
-                sessionFuture.get(1L, TimeUnit.SECONDS); // The timeout doesn't work, for some reason, but it's here because we don't have a better alternative.
+                sessionFuture.get(
+                        1L,
+                        TimeUnit.SECONDS); // The timeout doesn't work, for some reason, but it's here because we don't
+                // have a better alternative.
             }
 
             // Verify final pipeline state
@@ -160,7 +163,7 @@ class BlockStreamSubscriberSessionTest {
      * @param maxBlock the maximum available block number
      */
     private void setupHistoricalBlockProvider(int minBlock, int maxBlock) {
-        if(maxBlock < minBlock || maxBlock - minBlock > 100_000L) {
+        if (maxBlock < minBlock || maxBlock - minBlock > 100_000L) {
             throw new IllegalArgumentException("Invalid block range");
         }
         // "publish" blocks from min to max so the historical provider has them.
@@ -190,6 +193,7 @@ class BlockStreamSubscriberSessionTest {
     private static class ResponsePipeline implements Pipeline<SubscribeStreamResponseUnparsed> {
         /** The GRPC bytes received from the plugin. */
         private final List<SubscribeStreamResponse> receivedResponses = new ArrayList<>();
+
         private final List<Throwable> pipelineErrors = new ArrayList<>();
         private int completionCount = 0;
 
@@ -206,8 +210,7 @@ class BlockStreamSubscriberSessionTest {
         }
 
         @Override
-        public void clientEndStreamReceived() {
-        }
+        public void clientEndStreamReceived() {}
 
         @Override
         public void onSubscribe(Flow.Subscription subscription) {}

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSessionTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSessionTest.java
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.stream.subscriber;
+
+import static org.hiero.block.node.app.fixtures.blocks.BlockItemUtils.toBlockItemUnparsed;
+import static org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder.sampleBlockHeader;
+import static org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder.sampleBlockProof;
+import static org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder.sampleRoundHeader;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
+import com.swirlds.metrics.api.Metrics;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import org.hiero.block.api.SubscribeStreamRequest;
+import org.hiero.block.api.SubscribeStreamResponse;
+import org.hiero.block.internal.BlockItemSetUnparsed;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.internal.SubscribeStreamResponseUnparsed;
+import org.hiero.block.node.spi.BlockNodeContext;
+import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
+import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
+import org.hiero.block.node.spi.historicalblocks.BlockRangeSet;
+import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.exceptions.verification.TooFewActualInvocations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link BlockStreamSubscriberSession}.
+ * This test class focuses on testing the core functionality of the session management
+ * and block streaming capabilities.
+ */
+@ExtendWith(MockitoExtension.class)
+class BlockStreamSubscriberSessionTest {
+
+    @Mock
+    private BlockNodeContext context;
+
+    @Mock
+    private Metrics metrics;
+
+    @Mock
+    private HistoricalBlockFacility historicalBlockFacility;
+
+    @Mock
+    private BlockMessagingFacility blockMessagingFacility;
+
+    private Pipeline<? super SubscribeStreamResponseUnparsed> responsePipeline;
+
+    private BlockStreamSubscriberSession session;
+    private CountDownLatch sessionReadyLatch;
+    private static final long CLIENT_ID = 0L;
+
+    @BeforeEach
+    void setUp() {
+        sessionReadyLatch = new CountDownLatch(1);
+        final Configuration configuration = ConfigurationBuilder.create()
+                .withConfigDataType(SubscriberConfig.class)
+                .build();
+        responsePipeline = spy(new ResponsePipeline());
+
+        when(context.configuration()).thenReturn(configuration);
+        when(context.metrics()).thenReturn(metrics);
+    }
+
+    @Nested
+    @DisplayName("Streaming Tests")
+    class StreamingTests {
+
+        @Test
+        @DisplayName("Should handle successfully stream historical and live blocks")
+        void startingSessionWithValidRequestForHistoricalAndLiveBlocks() throws InterruptedException {
+            final long MIN_AVAILABLE_BLOCK = 0L;
+            final long MAX_AVAILABLE_BLOCK = 10L;
+
+            final long START_BLOCK = 0L;
+            final long END_BLOCK = 20L;
+
+            final SubscribeStreamRequest subscribeStreamRequest = createRequest(START_BLOCK, END_BLOCK);
+            session = new BlockStreamSubscriberSession(
+                    CLIENT_ID, subscribeStreamRequest, responsePipeline, context, sessionReadyLatch);
+            when(context.historicalBlockProvider()).thenReturn(historicalBlockFacility);
+            final BlockRangeSet availableBlocks = mock(BlockRangeSet.class);
+            when(availableBlocks.min()).thenReturn(MIN_AVAILABLE_BLOCK);
+            when(availableBlocks.max()).thenReturn(MAX_AVAILABLE_BLOCK);
+            when(context.historicalBlockProvider().availableBlocks()).thenReturn(availableBlocks);
+            when(context.blockMessaging()).thenReturn(blockMessagingFacility);
+            final BlockStreamSubscriberSession.LiveBlockHandler liveBlockHandler = session.getLiveBlockHandler();
+            for (long i = MIN_AVAILABLE_BLOCK; i < MAX_AVAILABLE_BLOCK; i++) {
+                BlockItemUnparsed SAMPLE_BLOCK_HEADER = toBlockItemUnparsed(sampleBlockHeader(i));
+                BlockItemUnparsed SAMPLE_ROUND_HEADER = toBlockItemUnparsed(sampleRoundHeader(i));
+                BlockItemUnparsed SAMPLE_BLOCK_PROOF = toBlockItemUnparsed(sampleBlockProof(i));
+                final BlockItems blockItems =
+                        new BlockItems(List.of(SAMPLE_BLOCK_HEADER, SAMPLE_ROUND_HEADER, SAMPLE_BLOCK_PROOF), i);
+                liveBlockHandler.handleBlockItemsReceived(blockItems);
+
+                final BlockAccessor blockAccessor = mock(BlockAccessor.class);
+                final BlockUnparsed blockUnparsed = BlockUnparsed.newBuilder()
+                        .blockItems(List.of(SAMPLE_BLOCK_HEADER, SAMPLE_ROUND_HEADER, SAMPLE_BLOCK_PROOF))
+                        .build();
+
+                lenient().when(blockAccessor.blockUnparsed()).thenReturn(blockUnparsed);
+                lenient().when(context.historicalBlockProvider().block(i)).thenReturn(blockAccessor);
+            }
+            Thread sessionThread = new Thread(session::call);
+            sessionThread.start();
+            boolean historicalProvided = false;
+            while (!historicalProvided) {
+                try {
+                    verify(responsePipeline, atLeast((int) MAX_AVAILABLE_BLOCK))
+                            .onNext(any(SubscribeStreamResponseUnparsed.class));
+                    historicalProvided = true;
+                } catch (TooFewActualInvocations e) {
+                    // Wait for consumption of the historically provided blocks
+                    Thread.sleep(100);
+                }
+            }
+
+            verify(responsePipeline, times((int) MAX_AVAILABLE_BLOCK))
+                    .onNext(any(SubscribeStreamResponseUnparsed.class));
+            for (long i = MAX_AVAILABLE_BLOCK; i <= END_BLOCK; i++) {
+                BlockItemUnparsed SAMPLE_BLOCK_HEADER = toBlockItemUnparsed(sampleBlockHeader(i));
+                BlockItemUnparsed SAMPLE_ROUND_HEADER = toBlockItemUnparsed(sampleRoundHeader(i));
+                BlockItemUnparsed SAMPLE_BLOCK_PROOF = toBlockItemUnparsed(sampleBlockProof(i));
+                final BlockItems blockItems =
+                        new BlockItems(List.of(SAMPLE_BLOCK_HEADER, SAMPLE_ROUND_HEADER, SAMPLE_BLOCK_PROOF), i);
+                liveBlockHandler.handleBlockItemsReceived(blockItems);
+
+                final SubscribeStreamResponseUnparsed.Builder response = SubscribeStreamResponseUnparsed.newBuilder()
+                        .blockItems(BlockItemSetUnparsed.newBuilder()
+                                .blockItems(List.of(SAMPLE_BLOCK_HEADER, SAMPLE_ROUND_HEADER, SAMPLE_BLOCK_PROOF)));
+                Thread.sleep(100);
+                verify(responsePipeline, times(1)).onNext(response.build());
+            }
+
+            // Verify interactions with the pipeline
+            verify(responsePipeline, times(1)).onComplete();
+            verify(responsePipeline, never()).onError(any(Throwable.class));
+        }
+
+        /**
+         * Tests that sessions successfully handles valid request for historical blocks.
+         */
+        @Test
+        @DisplayName("Should handle call of session with valid historical request")
+        void callingSessionWithValidRequestOnHistoricalBlocks() {
+            final long MIN_AVAILABLE_BLOCK = 0L;
+            final long MAX_AVAILABLE_BLOCK = 20L;
+
+            final long START_BLOCK = 1L;
+            final long END_BLOCK = 10L;
+
+            final SubscribeStreamRequest subscribeStreamRequest = createRequest(START_BLOCK, END_BLOCK);
+            session = new BlockStreamSubscriberSession(
+                    CLIENT_ID, subscribeStreamRequest, responsePipeline, context, sessionReadyLatch);
+            when(context.historicalBlockProvider()).thenReturn(historicalBlockFacility);
+            final BlockRangeSet availableBlocks = mock(BlockRangeSet.class);
+            when(availableBlocks.min()).thenReturn(MIN_AVAILABLE_BLOCK);
+            when(availableBlocks.max()).thenReturn(MAX_AVAILABLE_BLOCK);
+            when(context.historicalBlockProvider().availableBlocks()).thenReturn(availableBlocks);
+            when(context.blockMessaging()).thenReturn(blockMessagingFacility);
+            final BlockStreamSubscriberSession.LiveBlockHandler liveBlockHandler = session.getLiveBlockHandler();
+            for (int i = (int) MIN_AVAILABLE_BLOCK; i < MAX_AVAILABLE_BLOCK; i++) {
+                BlockItemUnparsed SAMPLE_BLOCK_HEADER = toBlockItemUnparsed(sampleBlockHeader(i));
+                BlockItemUnparsed SAMPLE_ROUND_HEADER = toBlockItemUnparsed(sampleRoundHeader(i));
+                BlockItemUnparsed SAMPLE_BLOCK_PROOF = toBlockItemUnparsed(sampleBlockProof(i));
+                final BlockItems blockItems =
+                        new BlockItems(List.of(SAMPLE_BLOCK_HEADER, SAMPLE_ROUND_HEADER, SAMPLE_BLOCK_PROOF), i);
+                liveBlockHandler.handleBlockItemsReceived(blockItems);
+
+                final BlockAccessor blockAccessor = mock(BlockAccessor.class);
+                final BlockUnparsed blockUnparsed = BlockUnparsed.newBuilder()
+                        .blockItems(List.of(SAMPLE_BLOCK_HEADER, SAMPLE_ROUND_HEADER, SAMPLE_BLOCK_PROOF))
+                        .build();
+
+                lenient().when(blockAccessor.blockUnparsed()).thenReturn(blockUnparsed);
+                lenient().when(context.historicalBlockProvider().block(i)).thenReturn(blockAccessor);
+            }
+            session.call();
+
+            // Verify interactions with the pipeline
+            verify(responsePipeline, times(11)).onNext(any(SubscribeStreamResponseUnparsed.class));
+            verify(responsePipeline, times(1)).onComplete();
+            verify(responsePipeline, never()).onError(any(Throwable.class));
+
+            // Verify interactions with the historical block provider
+            verify(context.historicalBlockProvider(), times(10)).block(anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("Validation Tests")
+    class ValidationTests {
+        @Test
+        @DisplayName(
+                "Should end with READ_STREAM_INVALID_START_BLOCK_NUMBER for neither live nor historical start block")
+        void shouldEndStreamForNeitherLiveNorHistoryStartBlock() {
+            final long MIN_AVAILABLE_BLOCK = 0L;
+            final long MAX_AVAILABLE_BLOCK = 20L;
+
+            final long START_BLOCK = 100000L;
+            final long END_BLOCK = 200000L;
+
+            final SubscribeStreamRequest subscribeStreamRequest = createRequest(START_BLOCK, END_BLOCK);
+            final BlockRangeSet availableBlocks = mock(BlockRangeSet.class);
+
+            when(availableBlocks.min()).thenReturn(MIN_AVAILABLE_BLOCK);
+            when(availableBlocks.max()).thenReturn(MAX_AVAILABLE_BLOCK);
+            when(context.historicalBlockProvider()).thenReturn(historicalBlockFacility);
+            when(context.blockMessaging()).thenReturn(blockMessagingFacility);
+            when(context.historicalBlockProvider().availableBlocks()).thenReturn(availableBlocks);
+
+            session = new BlockStreamSubscriberSession(
+                    CLIENT_ID, subscribeStreamRequest, responsePipeline, context, sessionReadyLatch);
+            session.call();
+
+            final SubscribeStreamResponseUnparsed.Builder response = SubscribeStreamResponseUnparsed.newBuilder()
+                    .status(SubscribeStreamResponse.Code.READ_STREAM_INVALID_START_BLOCK_NUMBER);
+
+            verify(responsePipeline, times(1)).onNext(response.build());
+            verify(responsePipeline, times(1)).onComplete();
+            verify(responsePipeline, never()).onError(any(Throwable.class));
+        }
+
+        @Test
+        @DisplayName("Should end with READ_STREAM_INVALID_START_BLOCK_NUMBER for invalid start block")
+        void shouldEndStreamForInvalidStartBlock() {
+            final long MIN_AVAILABLE_BLOCK = 0L;
+            final long MAX_AVAILABLE_BLOCK = 20L;
+
+            final long START_BLOCK = -2L;
+            final long END_BLOCK = 10L;
+
+            final SubscribeStreamRequest subscribeStreamRequest = createRequest(START_BLOCK, END_BLOCK);
+            final BlockRangeSet availableBlocks = mock(BlockRangeSet.class);
+
+            when(availableBlocks.min()).thenReturn(MIN_AVAILABLE_BLOCK);
+            when(availableBlocks.max()).thenReturn(MAX_AVAILABLE_BLOCK);
+            when(context.historicalBlockProvider()).thenReturn(historicalBlockFacility);
+            when(context.blockMessaging()).thenReturn(blockMessagingFacility);
+            when(context.historicalBlockProvider().availableBlocks()).thenReturn(availableBlocks);
+
+            session = new BlockStreamSubscriberSession(
+                    CLIENT_ID, subscribeStreamRequest, responsePipeline, context, sessionReadyLatch);
+            session.call();
+
+            final SubscribeStreamResponseUnparsed.Builder response = SubscribeStreamResponseUnparsed.newBuilder()
+                    .status(SubscribeStreamResponse.Code.READ_STREAM_INVALID_START_BLOCK_NUMBER);
+
+            verify(responsePipeline, times(1)).onNext(response.build());
+            verify(responsePipeline, times(1)).onComplete();
+            verify(responsePipeline, never()).onError(any(Throwable.class));
+        }
+
+        @Test
+        @DisplayName("Should end with READ_STREAM_INVALID_END_BLOCK_NUMBER for invalid end block")
+        void shouldEndStreamForInvalidEndBlock() {
+            final long MIN_AVAILABLE_BLOCK = 0L;
+            final long MAX_AVAILABLE_BLOCK = 20L;
+
+            final long START_BLOCK = -1L;
+            final long END_BLOCK = -2L;
+
+            final SubscribeStreamRequest subscribeStreamRequest = createRequest(START_BLOCK, END_BLOCK);
+            final BlockRangeSet availableBlocks = mock(BlockRangeSet.class);
+
+            when(availableBlocks.min()).thenReturn(MIN_AVAILABLE_BLOCK);
+            when(availableBlocks.max()).thenReturn(MAX_AVAILABLE_BLOCK);
+            when(context.historicalBlockProvider()).thenReturn(historicalBlockFacility);
+            when(context.blockMessaging()).thenReturn(blockMessagingFacility);
+            when(context.historicalBlockProvider().availableBlocks()).thenReturn(availableBlocks);
+
+            session = new BlockStreamSubscriberSession(
+                    CLIENT_ID, subscribeStreamRequest, responsePipeline, context, sessionReadyLatch);
+            session.call();
+
+            final SubscribeStreamResponseUnparsed.Builder response = SubscribeStreamResponseUnparsed.newBuilder()
+                    .status(SubscribeStreamResponse.Code.READ_STREAM_INVALID_END_BLOCK_NUMBER);
+
+            verify(responsePipeline, times(1)).onNext(response.build());
+            verify(responsePipeline, times(1)).onComplete();
+            verify(responsePipeline, never()).onError(any(Throwable.class));
+        }
+
+        @Test
+        @DisplayName("Should end with READ_STREAM_INVALID_END_BLOCK_NUMBER for higher end block than start block")
+        void shouldEndStreamForHigherEndBlockThanStartBlock() {
+            final long MIN_AVAILABLE_BLOCK = 0L;
+            final long MAX_AVAILABLE_BLOCK = 20L;
+
+            final long START_BLOCK = 10L;
+            final long END_BLOCK = 0L;
+
+            final SubscribeStreamRequest subscribeStreamRequest = createRequest(START_BLOCK, END_BLOCK);
+            final BlockRangeSet availableBlocks = mock(BlockRangeSet.class);
+
+            when(availableBlocks.min()).thenReturn(MIN_AVAILABLE_BLOCK);
+            when(availableBlocks.max()).thenReturn(MAX_AVAILABLE_BLOCK);
+            when(context.historicalBlockProvider()).thenReturn(historicalBlockFacility);
+            when(context.blockMessaging()).thenReturn(blockMessagingFacility);
+            when(context.historicalBlockProvider().availableBlocks()).thenReturn(availableBlocks);
+
+            session = new BlockStreamSubscriberSession(
+                    CLIENT_ID, subscribeStreamRequest, responsePipeline, context, sessionReadyLatch);
+            session.call();
+
+            final SubscribeStreamResponseUnparsed.Builder response = SubscribeStreamResponseUnparsed.newBuilder()
+                    .status(SubscribeStreamResponse.Code.READ_STREAM_INVALID_END_BLOCK_NUMBER);
+
+            verify(responsePipeline, times(1)).onNext(response.build());
+            verify(responsePipeline, times(1)).onComplete();
+            verify(responsePipeline, never()).onError(any(Throwable.class));
+        }
+    }
+
+    private SubscribeStreamRequest createRequest(final long startNumber, final long endNumber) {
+        return SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(startNumber)
+                .endBlockNumber(endNumber)
+                .build();
+    }
+
+    private class ResponsePipeline implements Pipeline<SubscribeStreamResponseUnparsed> {
+
+        @Override
+        public void clientEndStreamReceived() {
+            Pipeline.super.clientEndStreamReceived();
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {}
+
+        @Override
+        public void onNext(SubscribeStreamResponseUnparsed item) throws RuntimeException {
+            Pipeline.super.onNext(item);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {}
+
+        @Override
+        public void onComplete() {}
+    }
+}

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberConfigTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberConfigTest.java
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.stream.subscriber;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
+import com.swirlds.config.api.validation.ConfigViolationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link SubscriberConfig} class.
+ */
+public class SubscriberConfigTest {
+
+    /**
+     * Tests that the default values are loaded correctly when no specific configuration is provided.
+     */
+    @Test
+    @DisplayName("Loads default values correctly")
+    void defaultValues() {
+        final Configuration configuration = ConfigurationBuilder.create()
+                .withConfigDataType(SubscriberConfig.class)
+                .build();
+        final SubscriberConfig subscriberConfig = configuration.getConfigData(SubscriberConfig.class);
+
+        assertNotNull(subscriberConfig);
+        assertEquals(4000, subscriberConfig.liveQueueSize(), "Default liveQueueSize should be 4000");
+        assertEquals(4000L, subscriberConfig.maximumFutureRequest(), "Default maximumFutureRequest should be 4000");
+        assertEquals(
+                400, subscriberConfig.minimumLiveQueueCapacity(), "Default minimumLiveQueueCapacity should be 400");
+    }
+
+    /**
+     * Tests that custom values provided via configuration override the defaults.
+     */
+    @Test
+    @DisplayName("Loads custom values correctly")
+    void customValues() {
+        final Configuration configuration = ConfigurationBuilder.create()
+                .withValue("subscriber.liveQueueSize", "5000")
+                .withValue("subscriber.maximumFutureRequest", "6000")
+                .withValue("subscriber.minimumLiveQueueCapacity", "500")
+                .withConfigDataType(SubscriberConfig.class)
+                .build();
+        final SubscriberConfig subscriberConfig = configuration.getConfigData(SubscriberConfig.class);
+
+        assertNotNull(subscriberConfig);
+        assertEquals(5000, subscriberConfig.liveQueueSize(), "Custom liveQueueSize should be 5000");
+        assertEquals(6000L, subscriberConfig.maximumFutureRequest(), "Custom maximumFutureRequest should be 6000");
+        assertEquals(500, subscriberConfig.minimumLiveQueueCapacity(), "Custom minimumLiveQueueCapacity should be 500");
+    }
+
+    /**
+     * Tests that configuration loading fails if a value below the specified minimum is provided
+     * for liveQueueSize.
+     */
+    @Test
+    @DisplayName("Fails validation for liveQueueSize below minimum")
+    void validationFailsLiveQueueSizeTooSmall() {
+        final ConfigurationBuilder builder = ConfigurationBuilder.create()
+                .withValue("subscriber.liveQueueSize", "99") // Below min(100)
+                .withConfigDataType(SubscriberConfig.class);
+
+        assertThrows(
+                ConfigViolationException.class,
+                builder::build,
+                "Should throw ConfigViolationException for liveQueueSize below minimum");
+    }
+
+    /**
+     * Tests that configuration loading fails if a value below the specified minimum is provided
+     * for maximumFutureRequest.
+     */
+    @Test
+    @DisplayName("Fails validation for maximumFutureRequest below minimum")
+    void validationFailsMaximumFutureRequestTooSmall() {
+        final ConfigurationBuilder builder = ConfigurationBuilder.create()
+                .withValue("subscriber.maximumFutureRequest", "9") // Below min(10)
+                .withConfigDataType(SubscriberConfig.class);
+
+        assertThrows(
+                ConfigViolationException.class,
+                builder::build,
+                "Should throw ConfigViolationException for maximumFutureRequest below minimum");
+    }
+
+    /**
+     * Tests that configuration loading fails if a value below the specified minimum is provided
+     * for minimumLiveQueueCapacity.
+     */
+    @Test
+    @DisplayName("Fails validation for minimumLiveQueueCapacity below minimum")
+    void validationFailsMinimumLiveQueueCapacityTooSmall() {
+        final ConfigurationBuilder builder = ConfigurationBuilder.create()
+                .withValue("subscriber.minimumLiveQueueCapacity", "9") // Below min(10)
+                .withConfigDataType(SubscriberConfig.class);
+
+        assertThrows(
+                ConfigViolationException.class,
+                builder::build,
+                "Should throw ConfigViolationException for minimumLiveQueueCapacity below minimum");
+    }
+}

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberTest.java
@@ -225,7 +225,7 @@ public class SubscriberTest extends GrpcPluginTestBase<SubscriberServicePlugin> 
         activePlugin.stop(); // request the plugin to end all client streams.
     }
 
-    @Disabled("Disabled until issue with it is resolved. Works when run standalone")
+    @Disabled("Disabled until issue with it is resolved. Works _sometimes_ when run standalone")
     @Test
     void testSubscriberBlockStreamInMiddleWithHistory() throws ParseException {
         // send first 10 items

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberTest.java
@@ -225,6 +225,7 @@ public class SubscriberTest extends GrpcPluginTestBase<SubscriberServicePlugin> 
         activePlugin.stop(); // request the plugin to end all client streams.
     }
 
+    @Disabled("Disabled until issue with it is resolved. Works when run standalone")
     @Test
     void testSubscriberBlockStreamInMiddleWithHistory() throws ParseException {
         // send first 10 items

--- a/suites/src/main/java/org/hiero/block/suites/subscriber/SubscriberTestSuites.java
+++ b/suites/src/main/java/org/hiero/block/suites/subscriber/SubscriberTestSuites.java
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.suites.subscriber;
+
+import org.hiero.block.suites.subscriber.negative.NegativeSingleSubscriberTests;
+import org.hiero.block.suites.subscriber.positive.PositiveSingleSubscriberTests;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+/**
+ * Test suite for running subscriber tests, including both positive and negative test scenarios.
+ *
+ * <p> This suite aggregates the tests related to the subscriber functionality. The {@code @Suite} annotation allows running all selected classes in a single test run.</p>
+ */
+@Suite
+@SelectClasses({PositiveSingleSubscriberTests.class, NegativeSingleSubscriberTests.class})
+public class SubscriberTestSuites {
+    /**
+     * Default constructor for the {@link PositiveSingleSubscriberTests} class.This constructor is
+     * empty as it does not need to perform any initialization.
+     */
+    public SubscriberTestSuites() {}
+}

--- a/suites/src/main/java/org/hiero/block/suites/subscriber/negative/NegativeSingleSubscriberTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/subscriber/negative/NegativeSingleSubscriberTests.java
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.suites.subscriber.negative;
+
+import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Future;
+import org.hiero.block.simulator.BlockStreamSimulatorApp;
+import org.hiero.block.suites.BaseSuite;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for verifying correct behaviour of the application, when one subscriber makes invalid request for data.
+ *
+ * <p>Inherits from {@link BaseSuite} to reuse the container setup and teardown logic for the Block
+ * Node.
+ */
+@DisplayName("Negative Single Subscriber Tests")
+public class NegativeSingleSubscriberTests extends BaseSuite {
+    private final List<Future<?>> simulators = new ArrayList<>();
+    private final List<BlockStreamSimulatorApp> simulatorAppsRef = new ArrayList<>();
+
+    /** Default constructor for the {@link NegativeSingleSubscriberTests} class */
+    public NegativeSingleSubscriberTests() {}
+
+    @AfterEach
+    void teardownEnvironment() {
+        simulatorAppsRef.forEach(simulator -> {
+            try {
+                simulator.stop();
+                while (simulator.isRunning()) {
+                    Thread.sleep(100);
+                }
+            } catch (InterruptedException e) {
+                // Do nothing, this is not mandatory, we try to shut down cleaner and graceful
+            }
+        });
+        simulators.forEach(simulator -> simulator.cancel(true));
+        simulators.clear();
+    }
+
+    /**
+     * Tests the behavior when a subscriber requests blocks in an invalid order (END block number is less than START block number).
+     * Verifies that the system returns the appropriate error status and no blocks are consumed.
+     *
+     * @throws IOException if there's an I/O error during the test
+     */
+    @Test
+    @DisplayName("Should return correct status when subscription request has invalid block order")
+    public void shouldReturnCorrectStatusForInvalidBlocksOrderRequest() throws IOException {
+        // ===== Prepare environment =================================================================
+        final Map<String, String> consumerConfiguration = Map.of(
+                "blockStream.simulatorMode",
+                "CONSUMER",
+                "consumer.startBlockNumber",
+                "5",
+                "consumer.endBlockNumber",
+                "0");
+        final BlockStreamSimulatorApp publisherSimulator = createBlockSimulator();
+        final BlockStreamSimulatorApp consumerSimulator = createBlockSimulator(consumerConfiguration);
+
+        simulatorAppsRef.add(publisherSimulator);
+        simulatorAppsRef.add(consumerSimulator);
+
+        // ===== Start publisher and make sure it's streaming =======================================
+        final Future<?> publisherSimulatorThread = startSimulatorInstance(publisherSimulator);
+        simulators.add(publisherSimulatorThread);
+
+        // ===== Start consumer and try to request blocks ===========================================
+        final Future<?> consumerSimulatorThread = startSimulatorInThread(consumerSimulator);
+        simulators.add(consumerSimulatorThread);
+        String consumerStatus = "";
+        long consumedBlocks = -1L;
+        while (consumerStatus.isEmpty()) {
+            if (!consumerSimulator
+                    .getStreamStatus()
+                    .lastKnownConsumersStatuses()
+                    .isEmpty()) {
+                consumerStatus = consumerSimulator
+                        .getStreamStatus()
+                        .lastKnownConsumersStatuses()
+                        .getLast();
+                consumedBlocks = consumerSimulator.getStreamStatus().consumedBlocks();
+            }
+        }
+
+        assertTrue(consumerStatus.contains("READ_STREAM_INVALID_END_BLOCK_NUMBER"));
+        assertEquals(0L, consumedBlocks);
+    }
+
+    /**
+     * Tests the behavior when a subscriber requests blocks with an invalid negative START block number.
+     * Verifies that the system returns the appropriate error status and no blocks are consumed.
+     *
+     * @throws IOException if there's an I/O error during the test
+     */
+    @Test
+    @DisplayName("Should return correct status when subscription request has invalid start block")
+    public void shouldReturnCorrectStatusForIncorrectStartBlock() throws IOException {
+        // ===== Prepare environment =================================================================
+        final Map<String, String> consumerConfiguration = Map.of(
+                "blockStream.simulatorMode",
+                "CONSUMER",
+                "consumer.startBlockNumber",
+                "-2",
+                "consumer.endBlockNumber",
+                "0");
+        final BlockStreamSimulatorApp publisherSimulator = createBlockSimulator();
+        final BlockStreamSimulatorApp consumerSimulator = createBlockSimulator(consumerConfiguration);
+
+        simulatorAppsRef.add(publisherSimulator);
+        simulatorAppsRef.add(consumerSimulator);
+
+        // ===== Start publisher and make sure it's streaming =======================================
+        final Future<?> publisherSimulatorThread = startSimulatorInstance(publisherSimulator);
+        simulators.add(publisherSimulatorThread);
+
+        // ===== Start consumer and try to request blocks ===========================================
+        final Future<?> consumerSimulatorThread = startSimulatorInThread(consumerSimulator);
+        simulators.add(consumerSimulatorThread);
+        String consumerStatus = "";
+        long consumedBlocks = -1L;
+        while (consumerStatus.isEmpty()) {
+            if (!consumerSimulator
+                    .getStreamStatus()
+                    .lastKnownConsumersStatuses()
+                    .isEmpty()) {
+                consumerStatus = consumerSimulator
+                        .getStreamStatus()
+                        .lastKnownConsumersStatuses()
+                        .getLast();
+                consumedBlocks = consumerSimulator.getStreamStatus().consumedBlocks();
+            }
+        }
+
+        assertTrue(consumerStatus.contains("READ_STREAM_INVALID_START_BLOCK_NUMBER"));
+        assertEquals(0L, consumedBlocks);
+    }
+
+    /**
+     * Tests the behavior when a subscriber requests blocks with an invalid negative END block number.
+     * Verifies that the system returns the appropriate error status and no blocks are consumed.
+     *
+     * @throws IOException if there's an I/O error during the test
+     */
+    @Test
+    @DisplayName("Should return correct status when subscription request has invalid end block")
+    public void shouldReturnCorrectStatusForIncorrectEndBlock() throws IOException {
+        // ===== Prepare environment =================================================================
+        final Map<String, String> consumerConfiguration = Map.of(
+                "blockStream.simulatorMode",
+                "CONSUMER",
+                "consumer.startBlockNumber",
+                "-1",
+                "consumer.endBlockNumber",
+                "-2");
+        final BlockStreamSimulatorApp publisherSimulator = createBlockSimulator();
+        final BlockStreamSimulatorApp consumerSimulator = createBlockSimulator(consumerConfiguration);
+
+        simulatorAppsRef.add(publisherSimulator);
+        simulatorAppsRef.add(consumerSimulator);
+
+        // ===== Start publisher and make sure it's streaming =======================================
+        final Future<?> publisherSimulatorThread = startSimulatorInstance(publisherSimulator);
+        simulators.add(publisherSimulatorThread);
+
+        // ===== Start consumer and try to request blocks ===========================================
+        final Future<?> consumerSimulatorThread = startSimulatorInThread(consumerSimulator);
+        simulators.add(consumerSimulatorThread);
+        String consumerStatus = "";
+        long consumedBlocks = -1L;
+        while (consumerStatus.isEmpty()) {
+            if (!consumerSimulator
+                    .getStreamStatus()
+                    .lastKnownConsumersStatuses()
+                    .isEmpty()) {
+                consumerStatus = consumerSimulator
+                        .getStreamStatus()
+                        .lastKnownConsumersStatuses()
+                        .getLast();
+                consumedBlocks = consumerSimulator.getStreamStatus().consumedBlocks();
+            }
+        }
+
+        assertTrue(consumerStatus.contains("READ_STREAM_INVALID_END_BLOCK_NUMBER"));
+        assertEquals(0L, consumedBlocks);
+    }
+
+    /**
+     * Starts a simulator in a thread and make sure that it's running and trying to publish blocks
+     *
+     * @param simulator instance with configuration depending on the test
+     * @return a {@link Future} representing the asynchronous execution of the block stream simulator
+     */
+    private Future<?> startSimulatorInstance(@NonNull final BlockStreamSimulatorApp simulator) {
+        Objects.requireNonNull(simulator);
+        final int statusesRequired = 5; // we wait for at least 5 statuses, to avoid flakiness
+
+        final Future<?> simulatorThread = startSimulatorInThread(simulator);
+        simulators.add(simulatorThread);
+        String simulatorStatus = null;
+        while (simulator.getStreamStatus().lastKnownPublisherClientStatuses().size() < statusesRequired) {
+            if (!simulator.getStreamStatus().lastKnownPublisherClientStatuses().isEmpty()) {
+                simulatorStatus = simulator
+                        .getStreamStatus()
+                        .lastKnownPublisherClientStatuses()
+                        .getLast();
+            }
+        }
+        assertNotNull(simulatorStatus);
+        assertTrue(simulator.isRunning());
+        return simulatorThread;
+    }
+}

--- a/suites/src/main/java/org/hiero/block/suites/subscriber/positive/PositiveMultipleSubscribersTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/subscriber/positive/PositiveMultipleSubscribersTests.java
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.suites.subscriber.positive;
+
+import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Future;
+import org.hiero.block.simulator.BlockStreamSimulatorApp;
+import org.hiero.block.suites.BaseSuite;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for verifying correct behaviour of the application, when more than one subscriber requests data.
+ *
+ * <p>Inherits from {@link BaseSuite} to reuse the container setup and teardown logic for the Block
+ * Node.
+ */
+@DisplayName("Positive Multiple Subscribers Tests")
+public class PositiveMultipleSubscribersTests extends BaseSuite {
+    private final List<Future<?>> simulators = new ArrayList<>();
+    private final List<BlockStreamSimulatorApp> simulatorAppsRef = new ArrayList<>();
+
+    /** Default constructor for the {@link PositiveMultipleSubscribersTests} class. */
+    public PositiveMultipleSubscribersTests() {}
+
+    @AfterEach
+    void teardownEnvironment() {
+        simulatorAppsRef.forEach(simulator -> {
+            try {
+                simulator.stop();
+                while (simulator.isRunning()) {
+                    Thread.sleep(100);
+                }
+            } catch (InterruptedException e) {
+                // Do nothing, this is not mandatory, we try to shut down cleaner and graceful
+            }
+        });
+        simulators.forEach(simulator -> simulator.cancel(true));
+        simulators.clear();
+    }
+
+    @Test
+    @DisplayName("Should subscribe multiple  to stream and receive both historical and live")
+    public void shouldSubscribeMultipleForHistoricalAndLiveBlocks() throws IOException, InterruptedException {
+        // ===== Prepare environment =================================================================
+        final Map<String, String> consumerConfiguration = Map.of(
+                "blockStream.simulatorMode",
+                "CONSUMER",
+                "consumer.startBlockNumber",
+                "0",
+                "consumer.endBlockNumber",
+                "-1");
+        final BlockStreamSimulatorApp publisherSimulator = createBlockSimulator();
+        final BlockStreamSimulatorApp consumerSimulator1 = createBlockSimulator(consumerConfiguration);
+        final BlockStreamSimulatorApp consumerSimulator2 = createBlockSimulator(consumerConfiguration);
+
+        simulatorAppsRef.add(publisherSimulator);
+        simulatorAppsRef.add(consumerSimulator1);
+        simulatorAppsRef.add(consumerSimulator2);
+
+        // ===== Start publisher and make sure it's streaming =======================================
+        final Future<?> publisherSimulatorThread = startSimulatorInstance(publisherSimulator);
+        simulators.add(publisherSimulatorThread);
+
+        // ===== Start consumers and try to request blocks ===========================================
+        final Future<?> consumerSimulatorThread1 = startSimulatorInThread(consumerSimulator1);
+        final Future<?> consumerSimulatorThread2 = startSimulatorInThread(consumerSimulator2);
+        simulators.add(consumerSimulatorThread1);
+        simulators.add(consumerSimulatorThread2);
+
+        boolean areConsumingBlocks = false;
+
+        long lastConsumedBlockForConsumer1 =
+                publisherSimulator.getStreamStatus().publishedBlocks();
+        long lastConsumedBlockForConsumer2 =
+                publisherSimulator.getStreamStatus().publishedBlocks();
+        int retries = 3;
+        // We assign lastConsumedBlock as the last published, so that we can track it later.
+        // This will help us determine whether we are actually consuming blocks.
+        while (retries > 0) {
+            if (consumerSimulator1.getStreamStatus().consumedBlocks() > lastConsumedBlockForConsumer1
+                    && consumerSimulator2.getStreamStatus().consumedBlocks() > lastConsumedBlockForConsumer2) {
+                lastConsumedBlockForConsumer1 =
+                        consumerSimulator1.getStreamStatus().consumedBlocks();
+                lastConsumedBlockForConsumer2 =
+                        consumerSimulator2.getStreamStatus().consumedBlocks();
+                areConsumingBlocks = true;
+            }
+            retries--;
+            Thread.sleep(1000);
+        }
+
+        assertTrue(areConsumingBlocks);
+        assertTrue(lastConsumedBlockForConsumer1 > 0L);
+        assertTrue(lastConsumedBlockForConsumer2 > 0L);
+        assertTrue(publisherSimulator.isRunning());
+        assertTrue(consumerSimulator1.isRunning());
+        assertTrue(consumerSimulator2.isRunning());
+    }
+
+    /**
+     * Starts a simulator in a thread and make sure that it's running and trying to publish blocks
+     *
+     * @param simulator instance with configuration depending on the test
+     * @return a {@link Future} representing the asynchronous execution of the block stream simulator
+     */
+    private Future<?> startSimulatorInstance(@NonNull final BlockStreamSimulatorApp simulator) {
+        Objects.requireNonNull(simulator);
+        final int statusesRequired = 5; // we wait for at least 5 statuses, to avoid flakiness
+
+        final Future<?> simulatorThread = startSimulatorInThread(simulator);
+        simulators.add(simulatorThread);
+        String simulatorStatus = null;
+        while (simulator.getStreamStatus().lastKnownPublisherClientStatuses().size() < statusesRequired) {
+            if (!simulator.getStreamStatus().lastKnownPublisherClientStatuses().isEmpty()) {
+                simulatorStatus = simulator
+                        .getStreamStatus()
+                        .lastKnownPublisherClientStatuses()
+                        .getLast();
+            }
+        }
+        assertNotNull(simulatorStatus);
+        assertTrue(simulator.isRunning());
+        return simulatorThread;
+    }
+}

--- a/suites/src/main/java/org/hiero/block/suites/subscriber/positive/PositiveSingleSubscriberTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/subscriber/positive/PositiveSingleSubscriberTests.java
@@ -1,8 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.suites.subscriber.positive;
 
+import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Future;
+import org.hiero.block.simulator.BlockStreamSimulatorApp;
 import org.hiero.block.suites.BaseSuite;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for verifying correct behaviour of the application, when one subscriber requests data.
@@ -12,12 +27,147 @@ import org.junit.jupiter.api.DisplayName;
  */
 @DisplayName("Positive Single Subscriber Tests")
 public class PositiveSingleSubscriberTests extends BaseSuite {
+    private final List<Future<?>> simulators = new ArrayList<>();
+    private final List<BlockStreamSimulatorApp> simulatorAppsRef = new ArrayList<>();
+
     /** Default constructor for the {@link PositiveSingleSubscriberTests} class. */
     public PositiveSingleSubscriberTests() {}
 
-    public void shouldSubscribeForLiveBlocks() {}
+    @AfterEach
+    void teardownEnvironment() {
+        simulatorAppsRef.forEach(simulator -> {
+            try {
+                simulator.stop();
+                while (simulator.isRunning()) {
+                    Thread.sleep(100);
+                }
+            } catch (InterruptedException e) {
+                // Do nothing, this is not mandatory, we try to shut down cleaner and graceful
+            }
+        });
+        simulators.forEach(simulator -> simulator.cancel(true));
+        simulators.clear();
+    }
 
-    public void shouldSubscribeForHistoricalBlocks() {}
+    @Test
+    @DisplayName("Should subscribe to stream and receive both historical and live")
+    public void shouldSubscribeForHistoricalAndLiveBlocks() throws IOException, InterruptedException {
+        // ===== Prepare environment =================================================================
+        final Map<String, String> consumerConfiguration = Map.of(
+                "blockStream.simulatorMode",
+                "CONSUMER",
+                "consumer.startBlockNumber",
+                "0",
+                "consumer.endBlockNumber",
+                "-1");
+        final BlockStreamSimulatorApp publisherSimulator = createBlockSimulator();
+        final BlockStreamSimulatorApp consumerSimulator = createBlockSimulator(consumerConfiguration);
 
-    public void shouldSubscribeForHistoricalAndLiveBlocks() {}
+        simulatorAppsRef.add(publisherSimulator);
+        simulatorAppsRef.add(consumerSimulator);
+
+        // ===== Start publisher and make sure it's streaming =======================================
+        final Future<?> publisherSimulatorThread = startSimulatorInstance(publisherSimulator);
+        simulators.add(publisherSimulatorThread);
+
+        // ===== Start consumer and try to request blocks ===========================================
+        final Future<?> consumerSimulatorThread = startSimulatorInThread(consumerSimulator);
+        simulators.add(consumerSimulatorThread);
+
+        boolean isConsumingBlocks = false;
+        // We assign lastConsumedBlock as the last published, so that we can track it later.
+        // This will help us determine whether we are actually consuming blocks.
+        long lastConsumedBlock = publisherSimulator.getStreamStatus().publishedBlocks();
+        int retries = 3;
+
+        while (retries > 0) {
+            if (consumerSimulator.getStreamStatus().consumedBlocks() > lastConsumedBlock) {
+                lastConsumedBlock = consumerSimulator.getStreamStatus().consumedBlocks();
+                isConsumingBlocks = true;
+            }
+            retries--;
+            Thread.sleep(1000);
+        }
+
+        assertTrue(isConsumingBlocks);
+        assertTrue(lastConsumedBlock > 0L);
+        assertTrue(publisherSimulator.isRunning());
+        assertTrue(consumerSimulator.isRunning());
+    }
+
+    @Test
+    @DisplayName("Should subscribe to receive historical blocks")
+    public void shouldSubscribeForHistoricalBlocks() throws IOException, InterruptedException {
+        // ===== Prepare environment =================================================================
+        final long endBlock = 10L;
+        final Map<String, String> consumerConfiguration = Map.of(
+                "blockStream.simulatorMode",
+                "CONSUMER",
+                "consumer.startBlockNumber",
+                "1",
+                "consumer.endBlockNumber",
+                "10");
+        final BlockStreamSimulatorApp publisherSimulator = createBlockSimulator();
+        final BlockStreamSimulatorApp consumerSimulator = createBlockSimulator(consumerConfiguration);
+
+        simulatorAppsRef.add(publisherSimulator);
+        simulatorAppsRef.add(consumerSimulator);
+
+        // ===== Start publisher and make sure it's streaming =======================================
+        final Future<?> publisherSimulatorThread = startSimulatorInstance(publisherSimulator);
+        simulators.add(publisherSimulatorThread);
+        boolean publisherReachedEndBlock = false;
+        while (!publisherReachedEndBlock) {
+            if (publisherSimulator.getStreamStatus().publishedBlocks() > endBlock) {
+                publisherReachedEndBlock = true;
+            }
+        }
+        // ===== Start consumer and try to request blocks ===========================================
+        final Future<?> consumerSimulatorThread = startSimulatorInThread(consumerSimulator);
+        simulators.add(consumerSimulatorThread);
+
+        boolean isConsumingBlocks = false;
+        int retries = 3;
+
+        while (retries > 0) {
+            if (consumerSimulator.getStreamStatus().consumedBlocks() > 0
+                    && !consumerSimulator
+                            .getStreamStatus()
+                            .lastKnownConsumersStatuses()
+                            .isEmpty()) {
+                isConsumingBlocks = true;
+            }
+            retries--;
+            Thread.sleep(1000);
+        }
+
+        assertTrue(isConsumingBlocks);
+        assertEquals(endBlock, consumerSimulator.getStreamStatus().consumedBlocks());
+    }
+
+    /**
+     * Starts a simulator in a thread and make sure that it's running and trying to publish blocks
+     *
+     * @param simulator instance with configuration depending on the test
+     * @return a {@link Future} representing the asynchronous execution of the block stream simulator
+     */
+    private Future<?> startSimulatorInstance(@NonNull final BlockStreamSimulatorApp simulator) {
+        Objects.requireNonNull(simulator);
+        final int statusesRequired = 5; // we wait for at least 5 statuses, to avoid flakiness
+
+        final Future<?> simulatorThread = startSimulatorInThread(simulator);
+        simulators.add(simulatorThread);
+        String simulatorStatus = null;
+        while (simulator.getStreamStatus().lastKnownPublisherClientStatuses().size() < statusesRequired) {
+            if (!simulator.getStreamStatus().lastKnownPublisherClientStatuses().isEmpty()) {
+                simulatorStatus = simulator
+                        .getStreamStatus()
+                        .lastKnownPublisherClientStatuses()
+                        .getLast();
+            }
+        }
+        assertNotNull(simulatorStatus);
+        assertTrue(simulator.isRunning());
+        return simulatorThread;
+    }
 }

--- a/suites/src/main/java/org/hiero/block/suites/subscriber/positive/PositiveSingleSubscriberTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/subscriber/positive/PositiveSingleSubscriberTests.java
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.suites.subscriber.positive;
+
+import org.hiero.block.suites.BaseSuite;
+import org.junit.jupiter.api.DisplayName;
+
+/**
+ * Test class for verifying correct behaviour of the application, when one subscriber requests data.
+ *
+ * <p>Inherits from {@link BaseSuite} to reuse the container setup and teardown logic for the Block
+ * Node.
+ */
+@DisplayName("Positive Single Subscriber Tests")
+public class PositiveSingleSubscriberTests extends BaseSuite {
+    /** Default constructor for the {@link PositiveSingleSubscriberTests} class. */
+    public PositiveSingleSubscriberTests() {}
+
+    public void shouldSubscribeForLiveBlocks() {}
+
+    public void shouldSubscribeForHistoricalBlocks() {}
+
+    public void shouldSubscribeForHistoricalAndLiveBlocks() {}
+}


### PR DESCRIPTION
## Reviewer Notes
This PR aim to:
- Introduce minor improvements to object checks, allocations and more.
- Add unit tests for config and session objects, with enough coverage and cases to ensure that we have adequte confidence in the plugin.
- Add E2E covering both negative and positive scenarios for single consumer cases and multiple consumer case.
- Fix issue, where we don't close the session and stop the streaming, when we execute succesfully the request.
- Enable new plugin as default.

Things to consider:
- One unit test disabled due to unstable behavior. Passes when run as standalone, fails when run with all others from the same class.
- Added check in method `allRequestedBlocksSent()` to ensure that when consumer requests 0 as end block, we continue to stream indefinitely.
- Added `close()` session method call in `call()`, when we execute the request, in cases where it's valid and consumer does not want live streaming(0 as `endblock`).

## Related Issue(s)
Fixes #933 
Fixes #584 