### PR TITLE
build(deps): upgrading Java to 21.0.7+6 due to an issue with M4 Apple Silicon.

### DIFF
--- a/block-node/app/docker/Dockerfile
+++ b/block-node/app/docker/Dockerfile
@@ -40,12 +40,12 @@ RUN set -eux; \
         ARCH="$(dpkg --print-architecture)"; \
         case "${ARCH}" in \
            aarch64|arm64) \
-            ESUM='04fe1273f624187d927f1b466e8cdb630d70786db07bee7599bfa5153060afd3'; \
-            BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.6_7.tar.gz' \
+            ESUM='31dba70ba928c78c20d62049ac000f79f7a7ab11f9d9c11e703f52d60aa64f93'; \
+            BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.7_6.tar.gz' \
             ;; \
           amd64|i386:x86-64) \
-            ESUM='a2650fba422283fbed20d936ce5d2a52906a5414ec17b2f7676dddb87201dbae'; \
-            BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_x64_linux_hotspot_21.0.6_7.tar.gz' \
+            ESUM='974d3acef0b7193f541acb61b76e81670890551366625d4f6ca01b91ac152ce0'; \
+            BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_linux_hotspot_21.0.7_6.tar.gz' \
             ;; \
            *) \
             echo "Unsupported arch: ${ARCH}"; \
@@ -127,7 +127,7 @@ ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
-ENV JAVA_VERSION="jdk-21.0.6+7"
+ENV JAVA_VERSION="jdk-21.0.7+6"
 ENV JAVA_HOME=/usr/local/java
 ENV PATH=${JAVA_HOME}/bin:${PATH}
 


### PR DESCRIPTION
## Reviewer Notes

upgrading Java to 21.0.7+6 due to an issue with M4 Apple Silicon.

Related this this: https://github.com/hiero-ledger/solo/issues/1895

Using release from here:
https://github.com/adoptium/temurin21-binaries/releases


Fixes #1097 
