### PR TITLE
fix: BN is Unable to Restart due to `BlocksFilesHistoric` Plugin

### DIFF
--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
@@ -73,11 +73,13 @@ public final class BlocksFilesHistoricPlugin implements BlockProviderPlugin, Blo
         // get the first and last block numbers from the zipBlockArchive
         final long firstZippedBlock = zipBlockArchive.minStoredBlockNumber();
         final long latestZippedBlock = zipBlockArchive.maxStoredBlockNumber();
-        if (latestZippedBlock > firstZippedBlock) {
+        if (firstZippedBlock > latestZippedBlock) {
             // we never expect to enter here, if we do, we have an issue that
             // needs to be investigated
+            // the first zipped block number must always be less than or equal
+            // to the latest zipped block number
             throw new IllegalStateException(
-                    "Latest zipped block number [%d] cannot be greater than the first zipped block number [%d]"
+                    "First zipped block number [%d] cannot be greater than the latest zipped block number [%d]"
                             .formatted(latestZippedBlock, firstZippedBlock));
         }
         if (firstZippedBlock >= 0) {

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
@@ -73,6 +73,10 @@ public final class BlocksFilesHistoricPlugin implements BlockProviderPlugin, Blo
         // get the first and last block numbers from the zipBlockArchive
         final long firstZippedBlock = zipBlockArchive.minStoredBlockNumber();
         final long latestZippedBlock = zipBlockArchive.maxStoredBlockNumber();
+        // todo(1138) let's make sure that we have this case covered by an E2E
+        //   test where we will assert the correct behavior of the plugin after
+        //   a restart has happened. We will be able to correctly assert this
+        //   logic as we will be seeing a failing CI otherwise.
         if (firstZippedBlock > latestZippedBlock) {
             // we never expect to enter here, if we do, we have an issue that
             // needs to be investigated
@@ -80,7 +84,7 @@ public final class BlocksFilesHistoricPlugin implements BlockProviderPlugin, Blo
             // to the latest zipped block number
             throw new IllegalStateException(
                     "First zipped block number [%d] cannot be greater than the latest zipped block number [%d]"
-                            .formatted(latestZippedBlock, firstZippedBlock));
+                            .formatted(firstZippedBlock, latestZippedBlock));
         }
         if (firstZippedBlock >= 0) {
             // add the blocks to the available blocks only if the range is a valid one (positive)


### PR DESCRIPTION
## Reviewer Notes

- a wrongful precondition is causing the server to not be able to start
- the precondition must simply be flipped (it is a numeric comparison)

## Related Issue(s)

Fixes #1134
