### PR TITLE
feat: create server status plugin

### DIFF
--- a/block-node/app/build.gradle.kts
+++ b/block-node/app/build.gradle.kts
@@ -63,6 +63,7 @@ mainModuleInfo {
     runtimeOnly("org.hiero.block.node.blocks.files.historic")
     runtimeOnly("org.hiero.block.node.blocks.files.recent")
     runtimeOnly("org.hiero.block.node.access.service")
+    runtimeOnly("org.hiero.block.node.server.status")
 }
 
 testModuleInfo {

--- a/block-node/server-status/build.gradle.kts
+++ b/block-node/server-status/build.gradle.kts
@@ -11,8 +11,9 @@ mainModuleInfo {
     runtimeOnly("com.swirlds.config.impl")
     runtimeOnly("io.helidon.logging.jul")
     runtimeOnly("com.hedera.pbj.grpc.helidon.config")
-} //
-// testModuleInfo {
-//    requires("org.junit.jupiter.api")
-//    requires("org.hiero.block.node.app.test.fixtures")
-// }
+}
+
+testModuleInfo {
+    requires("org.junit.jupiter.api")
+    requires("org.hiero.block.node.app.test.fixtures")
+}

--- a/block-node/server-status/build.gradle.kts
+++ b/block-node/server-status/build.gradle.kts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+plugins { id("org.hiero.gradle.module.library") }
+
+description = "Hiero Block Node - Block Node Server Status API Module"
+
+// Remove the following line to enable all 'javac' lint checks that we have turned on by default
+// and then fix the reported issues.
+tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
+
+mainModuleInfo {
+    runtimeOnly("com.swirlds.config.impl")
+    runtimeOnly("io.helidon.logging.jul")
+    runtimeOnly("com.hedera.pbj.grpc.helidon.config")
+} //
+// testModuleInfo {
+//    requires("org.junit.jupiter.api")
+//    requires("org.hiero.block.node.app.test.fixtures")
+// }

--- a/block-node/server-status/src/main/java/module-info.java
+++ b/block-node/server-status/src/main/java/module-info.java
@@ -4,10 +4,10 @@ import org.hiero.block.node.server.status.ServerStatusServicePlugin;
 module org.hiero.block.node.server.status {
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
-    requires transitive com.hedera.pbj.runtime;
     requires transitive org.hiero.block.node.spi;
+    requires transitive org.hiero.block.protobuf;
+    requires com.hedera.pbj.runtime;
     requires com.swirlds.metrics.api;
-    requires org.hiero.block.protobuf;
     requires com.github.spotbugs.annotations;
 
     provides org.hiero.block.node.spi.BlockNodePlugin with

--- a/block-node/server-status/src/main/java/module-info.java
+++ b/block-node/server-status/src/main/java/module-info.java
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.server.status.ServerStatusServicePlugin;
+
+module hiero.block.node.block.node.server.status.main {
+    uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
+
+    requires transitive com.hedera.pbj.runtime;
+    requires transitive org.hiero.block.node.spi;
+    requires com.swirlds.metrics.api;
+    requires org.hiero.block.protobuf;
+    requires com.github.spotbugs.annotations;
+
+    provides org.hiero.block.node.spi.BlockNodePlugin with
+            ServerStatusServicePlugin;
+}

--- a/block-node/server-status/src/main/java/module-info.java
+++ b/block-node/server-status/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import org.hiero.block.node.server.status.ServerStatusServicePlugin;
 
-module hiero.block.node.block.node.server.status.main {
+module org.hiero.block.node.server.status {
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
     requires transitive com.hedera.pbj.runtime;

--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.server.status;
+
+import static java.lang.System.Logger.Level.DEBUG;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.pbj.runtime.grpc.GrpcException;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.grpc.Pipelines;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.metrics.api.Counter;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
+import java.util.List;
+import org.hiero.block.api.ServerStatusRequest;
+import org.hiero.block.api.ServerStatusResponse;
+import org.hiero.block.api.protoc.BlockNodeServiceGrpc;
+import org.hiero.block.node.spi.BlockNodeContext;
+import org.hiero.block.node.spi.BlockNodePlugin;
+import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
+
+/**
+ * Plugin that implements the BlockNodeService and provides the 'serverStatus' RPC.
+ */
+public class ServerStatusServicePlugin implements BlockNodePlugin, ServiceInterface {
+    /** The logger for this class. */
+    private final System.Logger LOGGER = System.getLogger(getClass().getName());
+    /** The block provider */
+    private HistoricalBlockFacility blockProvider;
+    /** Counter for the number of requests */
+    private Counter requestCounter;
+    /** Counter for the number of responses Success */
+    private Counter responseCounterSuccess;
+    /** Counter for the number of responses Failed */
+    private Counter responseCounterFailed;
+
+    private ServerStatusResponse handleServiceStatusRequest(@NonNull final ServerStatusRequest request) {
+        LOGGER.log(DEBUG, "Received ServerStatusRequest: {0}", request);
+        requestCounter.increment();
+
+        return new ServerStatusResponse(UNKNOWN_BLOCK_NUMBER, UNKNOWN_BLOCK_NUMBER, false, null);
+    }
+
+    // ==== BlockNodePlugin Methods ====================================================================================
+    @Override
+    public String name() {
+        return "ServerStatusServicePlugin";
+    }
+
+    @Override
+    public void init(@NonNull final BlockNodeContext context, @NonNull final ServiceBuilder serviceBuilder) {
+        requireNonNull(serviceBuilder);
+        this.blockProvider = requireNonNull(context.historicalBlockProvider());
+
+        // Create the metrics
+        requestCounter = context.metrics()
+                .getOrCreate(new Counter.Config(METRICS_CATEGORY, "server-status-requests")
+                        .withDescription("Number of server status requests"));
+
+        // Register this service
+        serviceBuilder.registerGrpcService(this);
+    }
+    // ==== ServiceInterface Methods ===================================================================================
+    /**
+     * BlockNodeService methods define the gRPC methods available on the BlockNodeService.
+     */
+    enum BlockNodeServiceMethod implements Method {
+        /**
+         * The serverStatus method retrieves the status of this Block Node.
+         */
+        serverStatus
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public String serviceName() {
+        String[] parts = fullName().split("\\.");
+        return parts[parts.length - 1];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public String fullName() {
+        return BlockNodeServiceGrpc.SERVICE_NAME;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public List<Method> methods() {
+        return Arrays.asList(BlockNodeServiceMethod.values());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * This is called each time a new request is received.
+     */
+    @NonNull
+    @Override
+    public Pipeline<? super Bytes> open(
+            @NonNull Method method, @NonNull RequestOptions requestOptions, @NonNull Pipeline<? super Bytes> pipeline)
+            throws GrpcException {
+        final BlockNodeServiceMethod blockNodeServiceMethod = (BlockNodeServiceMethod) method;
+        return switch (blockNodeServiceMethod) {
+            case serverStatus:
+                yield Pipelines.<ServerStatusRequest, ServerStatusResponse>unary()
+                        .mapRequest(ServerStatusRequest.PROTOBUF::parse)
+                        .method(this::handleServiceStatusRequest)
+                        .mapResponse(ServerStatusResponse.PROTOBUF::toBytes)
+                        .respondTo(pipeline)
+                        .build();
+        };
+    }
+}

--- a/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java
+++ b/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.server.status;
+
+import static org.hiero.block.node.app.fixtures.TestUtils.enableDebugLogging;
+import static org.hiero.block.node.app.fixtures.blocks.BlockItemUtils.toBlockItemsUnparsed;
+import static org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocks;
+import static org.hiero.block.node.server.status.ServerStatusServicePlugin.BlockNodeServiceMethod.serverStatus;
+import static org.hiero.block.node.spi.BlockNodePlugin.UNKNOWN_BLOCK_NUMBER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import java.util.List;
+import org.hiero.block.api.ServerStatusRequest;
+import org.hiero.block.api.ServerStatusResponse;
+import org.hiero.block.node.app.fixtures.plugintest.GrpcPluginTestBase;
+import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
+import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the ServerStatusServicePlugin class.
+ * Validates the functionality of the server status service and its responses
+ * under different conditions.
+ */
+public class ServerStatusServicePluginTest extends GrpcPluginTestBase<ServerStatusServicePlugin> {
+
+    public ServerStatusServicePluginTest() {
+        super();
+        start(new ServerStatusServicePlugin(), serverStatus, new SimpleInMemoryHistoricalBlockFacility());
+    }
+
+    /**
+     * Enable debug logging for each test.
+     */
+    @BeforeEach
+    void setup() {
+        enableDebugLogging();
+    }
+
+    /**
+     * Verifies that the service interface correctly registers and exposes
+     * the server status method.
+     */
+    @Test
+    @DisplayName("Should return correct method for ServerStatusServicePlugin")
+    void shouldReturnCorrectMethod() {
+        assertNotNull(serviceInterface);
+        List<ServiceInterface.Method> methods = serviceInterface.methods();
+        assertNotNull(methods);
+        assertEquals(1, methods.size());
+        assertEquals(serverStatus, methods.getFirst());
+    }
+
+    /**
+     * Tests that the server status response is valid when no blocks are available.
+     * Verifies the first and last available block numbers and other response properties.
+     *
+     * @throws ParseException if there is an error parsing the response
+     */
+    @Test
+    @DisplayName("Should return valid Server Status when no blocks available")
+    void shouldReturnValidServerStatus() throws ParseException {
+        //        sendBlocks(5);
+        final ServerStatusRequest request = ServerStatusRequest.newBuilder().build();
+        toPluginPipe.onNext(ServerStatusRequest.PROTOBUF.toBytes(request));
+        assertEquals(1, fromPluginBytes.size());
+
+        final ServerStatusResponse response = ServerStatusResponse.PROTOBUF.parse(fromPluginBytes.getFirst());
+
+        assertNotNull(response);
+        assertEquals(0, response.firstAvailableBlock());
+        assertEquals(0, response.lastAvailableBlock());
+        assertFalse(response.onlyLatestState());
+
+        // TODO() Remove when block node version information is implemented.
+        assertFalse(response.hasVersionInformation());
+    }
+
+    /**
+     * Tests the server status response after adding a new batch of blocks.
+     * Verifies that the first and last available block numbers are correctly updated.
+     *
+     * @throws ParseException if there is an error parsing the response
+     */
+    @Test
+    @DisplayName("Should return valid Server Status, after new batch of blocks")
+    void shouldReturnValidServerStatusForNewBlockBatch() throws ParseException {
+        final int blocks = 5;
+        sendBlocks(blocks);
+        final ServerStatusRequest request = ServerStatusRequest.newBuilder().build();
+        toPluginPipe.onNext(ServerStatusRequest.PROTOBUF.toBytes(request));
+        assertEquals(1, fromPluginBytes.size());
+
+        final ServerStatusResponse response = ServerStatusResponse.PROTOBUF.parse(fromPluginBytes.getLast());
+
+        assertNotNull(response);
+        assertEquals(0, response.firstAvailableBlock());
+        assertEquals(blocks - 1, response.lastAvailableBlock());
+        assertFalse(response.onlyLatestState());
+
+        // TODO() Remove when block node version information is implemented.
+        assertFalse(response.hasVersionInformation());
+    }
+
+    /**
+     * Helper method to send a specified number of test blocks to the block messaging system.
+     *
+     * @param numberOfBlocks the number of test blocks to create and send
+     */
+    private void sendBlocks(int numberOfBlocks) {
+        BlockItem[] blockItems = createNumberOfVerySimpleBlocks(numberOfBlocks);
+        // Send some blocks
+        for (BlockItem blockItem : blockItems) {
+            long blockNumber =
+                    blockItem.hasBlockHeader() ? blockItem.blockHeader().number() : UNKNOWN_BLOCK_NUMBER;
+            blockMessaging.sendBlockItems(new BlockItems(toBlockItemsUnparsed(blockItem), blockNumber));
+        }
+    }
+}

--- a/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java
+++ b/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java
@@ -4,7 +4,6 @@ package org.hiero.block.node.server.status;
 import static org.hiero.block.node.app.fixtures.TestUtils.enableDebugLogging;
 import static org.hiero.block.node.app.fixtures.blocks.BlockItemUtils.toBlockItemsUnparsed;
 import static org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocks;
-import static org.hiero.block.node.server.status.ServerStatusServicePlugin.BlockNodeServiceMethod.serverStatus;
 import static org.hiero.block.node.spi.BlockNodePlugin.UNKNOWN_BLOCK_NUMBER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -29,10 +28,11 @@ import org.junit.jupiter.api.Test;
  * under different conditions.
  */
 public class ServerStatusServicePluginTest extends GrpcPluginTestBase<ServerStatusServicePlugin> {
+    private final ServerStatusServicePlugin plugin = new ServerStatusServicePlugin();
 
     public ServerStatusServicePluginTest() {
         super();
-        start(new ServerStatusServicePlugin(), serverStatus, new SimpleInMemoryHistoricalBlockFacility());
+        start(plugin, plugin.methods().getFirst(), new SimpleInMemoryHistoricalBlockFacility());
     }
 
     /**
@@ -54,7 +54,7 @@ public class ServerStatusServicePluginTest extends GrpcPluginTestBase<ServerStat
         List<ServiceInterface.Method> methods = serviceInterface.methods();
         assertNotNull(methods);
         assertEquals(1, methods.size());
-        assertEquals(serverStatus, methods.getFirst());
+        assertEquals(plugin.methods().getFirst(), methods.getFirst());
     }
 
     /**
@@ -66,7 +66,6 @@ public class ServerStatusServicePluginTest extends GrpcPluginTestBase<ServerStat
     @Test
     @DisplayName("Should return valid Server Status when no blocks available")
     void shouldReturnValidServerStatus() throws ParseException {
-        //        sendBlocks(5);
         final ServerStatusRequest request = ServerStatusRequest.newBuilder().build();
         toPluginPipe.onNext(ServerStatusRequest.PROTOBUF.toBytes(request));
         assertEquals(1, fromPluginBytes.size());
@@ -78,7 +77,7 @@ public class ServerStatusServicePluginTest extends GrpcPluginTestBase<ServerStat
         assertEquals(0, response.lastAvailableBlock());
         assertFalse(response.onlyLatestState());
 
-        // TODO() Remove when block node version information is implemented.
+        // TODO(#579) Remove when block node version information is implemented.
         assertFalse(response.hasVersionInformation());
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ javaModules {
         module("messaging") { artifact = "facility-messaging" }
         module("publisher") { artifact = "block-node-publisher" }
         module("s3-archive") { artifact = "block-node-s3-archive" }
+        module("server-status") { artifact = "block-node-server-status" }
         module("spi") { artifact = "block-node-spi-plugins" }
         module("stream-subscriber") { artifact = "block-node-stream-subscriber" }
         module("verification") { artifact = "block-node-verification" }

--- a/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
+++ b/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.hiero.block.api.protoc.BlockAccessServiceGrpc;
+import org.hiero.block.api.protoc.BlockNodeServiceGrpc;
 import org.hiero.block.simulator.BlockStreamSimulatorApp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +48,9 @@ public abstract class BaseSuite {
     /** gRPC client stub for BlockAccessService */
     protected static BlockAccessServiceGrpc.BlockAccessServiceBlockingStub blockAccessStub;
 
+    /** gRPC client stub for BlockNodeService */
+    protected static BlockNodeServiceGrpc.BlockNodeServiceBlockingStub blockServiceStub;
+
     /**
      * Default constructor for the BaseSuite class.
      *
@@ -68,6 +72,7 @@ public abstract class BaseSuite {
         blockNodeContainer.start();
         executorService = new ErrorLoggingExecutor();
         blockAccessStub = initializeBlockAccessGrpcClient();
+        blockServiceStub = initializeBlockNodeServiceGrpcClient();
     }
 
     /**
@@ -134,6 +139,13 @@ public abstract class BaseSuite {
                 .build();
 
         return BlockAccessServiceGrpc.newBlockingStub(channel);
+    }
+
+    protected static BlockNodeServiceGrpc.BlockNodeServiceBlockingStub initializeBlockNodeServiceGrpcClient() {
+        final String host = blockNodeContainer.getHost();
+        final int port = blockNodePort;
+        channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
+        return BlockNodeServiceGrpc.newBlockingStub(channel);
     }
 
     /**

--- a/suites/src/main/java/org/hiero/block/suites/server/status/ServerStatusTestSuites.java
+++ b/suites/src/main/java/org/hiero/block/suites/server/status/ServerStatusTestSuites.java
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.suites.server.status;
+
+import org.hiero.block.suites.server.status.positive.PositiveServerStatusTests;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({PositiveServerStatusTests.class})
+public class ServerStatusTestSuites {
+    /**
+     * Default constructor for the {@link ServerStatusTestSuites} class.This constructor is
+     * empty as it does not need to perform any initialization.
+     */
+    public ServerStatusTestSuites() {}
+}

--- a/suites/src/main/java/org/hiero/block/suites/server/status/positive/PositiveServerStatusTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/server/status/positive/PositiveServerStatusTests.java
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.suites.server.status.positive;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+import org.hiero.block.simulator.BlockStreamSimulatorApp;
+import org.hiero.block.suites.BaseSuite;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class PositiveServerStatusTests extends BaseSuite {
+    private final List<Future<?>> simulators = new ArrayList<>();
+    private final List<BlockStreamSimulatorApp> simulatorAppsRef = new ArrayList<>();
+
+    /** Default constructor for the {@link PositiveServerStatusTests} class. */
+    public PositiveServerStatusTests() {}
+
+    @AfterEach
+    void teardownEnvironment() {
+        simulatorAppsRef.forEach(simulator -> {
+            try {
+                simulator.stop();
+                while (simulator.isRunning()) {
+                    Thread.sleep(100);
+                }
+            } catch (InterruptedException e) {
+                // Do nothing, this is not mandatory, we try to shut down cleaner and graceful
+            }
+        });
+        simulators.forEach(simulator -> simulator.cancel(true));
+        simulators.clear();
+    }
+
+    @Test
+    @DisplayName("Should be able to request and receive server status")
+    public void shouldSuccessfullyRequestServerStatus() {
+        // request server status
+        // start publisher
+        // request server status and compare
+    }
+}

--- a/suites/src/main/java/org/hiero/block/suites/server/status/positive/PositiveServerStatusTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/server/status/positive/PositiveServerStatusTests.java
@@ -36,7 +36,7 @@ public class PositiveServerStatusTests extends BaseSuite {
                     Thread.sleep(100);
                 }
             } catch (InterruptedException e) {
-                // Do nothing, this is not mandatory, we try to shut down cleaner and graceful
+                Thread.currentThread().interrupt();
             }
         });
         simulators.forEach(simulator -> simulator.cancel(true));
@@ -50,8 +50,8 @@ public class PositiveServerStatusTests extends BaseSuite {
         final ServerStatusResponse serverStatusBefore = requestServerStatus(blockServiceStub);
 
         assertNotNull(serverStatusBefore);
-        assertEquals(0L, serverStatusBefore.getFirstAvailableBlock());
-        assertEquals(0L, serverStatusBefore.getLastAvailableBlock());
+        assertEquals(-1L, serverStatusBefore.getFirstAvailableBlock());
+        assertEquals(-1L, serverStatusBefore.getLastAvailableBlock());
 
         final BlockStreamSimulatorApp publisherSimulator = createBlockSimulator();
         simulatorAppsRef.add(publisherSimulator);

--- a/suites/src/main/java/org/hiero/block/suites/server/status/positive/PositiveServerStatusTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/server/status/positive/PositiveServerStatusTests.java
@@ -1,9 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.suites.server.status.positive;
 
+import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
+import static org.hiero.block.suites.utils.ServerStatusUtils.requestServerStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Future;
+import org.hiero.block.api.protoc.ServerStatusResponse;
 import org.hiero.block.simulator.BlockStreamSimulatorApp;
 import org.hiero.block.suites.BaseSuite;
 import org.junit.jupiter.api.AfterEach;
@@ -35,9 +45,51 @@ public class PositiveServerStatusTests extends BaseSuite {
 
     @Test
     @DisplayName("Should be able to request and receive server status")
-    public void shouldSuccessfullyRequestServerStatus() {
-        // request server status
-        // start publisher
-        // request server status and compare
+    public void shouldSuccessfullyRequestServerStatus() throws IOException {
+        // ===== Get Server Status before starting publisher ========================================
+        final ServerStatusResponse serverStatusBefore = requestServerStatus(blockServiceStub);
+
+        assertNotNull(serverStatusBefore);
+        assertEquals(0L, serverStatusBefore.getFirstAvailableBlock());
+        assertEquals(0L, serverStatusBefore.getLastAvailableBlock());
+
+        final BlockStreamSimulatorApp publisherSimulator = createBlockSimulator();
+        simulatorAppsRef.add(publisherSimulator);
+
+        // ===== Start publisher and make sure it's streaming =======================================
+        final Future<?> publisherSimulatorThread = startSimulatorInstance(publisherSimulator);
+        simulators.add(publisherSimulatorThread);
+
+        // ===== Get Server Status after and assert =================================================
+        final ServerStatusResponse serverStatusAfter = requestServerStatus(blockServiceStub);
+
+        assertNotNull(serverStatusAfter);
+        assertTrue(serverStatusAfter.getLastAvailableBlock() > serverStatusBefore.getLastAvailableBlock());
+    }
+
+    /**
+     * Starts a simulator in a thread and make sure that it's running and trying to publish blocks
+     *
+     * @param simulator instance with configuration depending on the test
+     * @return a {@link Future} representing the asynchronous execution of the block stream simulator
+     */
+    private Future<?> startSimulatorInstance(@NonNull final BlockStreamSimulatorApp simulator) {
+        Objects.requireNonNull(simulator);
+        final int statusesRequired = 5; // we wait for at least 5 statuses, to avoid flakiness
+
+        final Future<?> simulatorThread = startSimulatorInThread(simulator);
+        simulators.add(simulatorThread);
+        String simulatorStatus = null;
+        while (simulator.getStreamStatus().lastKnownPublisherClientStatuses().size() < statusesRequired) {
+            if (!simulator.getStreamStatus().lastKnownPublisherClientStatuses().isEmpty()) {
+                simulatorStatus = simulator
+                        .getStreamStatus()
+                        .lastKnownPublisherClientStatuses()
+                        .getLast();
+            }
+        }
+        assertNotNull(simulatorStatus);
+        assertTrue(simulator.isRunning());
+        return simulatorThread;
     }
 }

--- a/suites/src/main/java/org/hiero/block/suites/utils/ServerStatusUtils.java
+++ b/suites/src/main/java/org/hiero/block/suites/utils/ServerStatusUtils.java
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.suites.utils;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.hiero.block.api.protoc.BlockNodeServiceGrpc;
+import org.hiero.block.api.protoc.ServerStatusRequest;
+import org.hiero.block.api.protoc.ServerStatusResponse;
+
+public final class ServerStatusUtils {
+    private ServerStatusUtils() {
+        // Prevent instantiation
+    }
+
+    public static ServerStatusResponse requestServerStatus(
+            @NonNull final BlockNodeServiceGrpc.BlockNodeServiceBlockingStub blockNodeServiceStub) {
+        return blockNodeServiceStub.serverStatus(
+                ServerStatusRequest.newBuilder().build());
+    }
+}


### PR DESCRIPTION
## Reviewer Notes
This PR aims to:
- Create new plugin responsible for opening a unary endpoint for serving `ServerStatusRequest`.
- Handling of this requests is responsibility of the plugin, which returns:
```
message ServerStatusResponse {
    uint64 first_available_block = 1;
    uint64 last_available_block = 2;
    bool only_latest_state = 3;
    BlockNodeVersions version_information = 4;
}
```
- Add unit tests validating the correct behavior, using already existing test fixtures.
- Add E2E tests validating the behaviour of the endpoint.

Left out for next PRs:
- Handling of `only_latest_state` information, for now we just set it to false.
- Handling the construction of BlockNodeVersions object. We currently does not have this information at hand. Will require some change in order to be availble across the project. 

## Related Issue(s)
Fixes #1111
Fixes #781 
