### PR TITLE
fix: Fix BlockAccessService - getBlock - when using only `retrieve_latest=true`

### DIFF
--- a/block-node/block-access/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
+++ b/block-node/block-access/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
@@ -54,8 +54,9 @@ public class BlockAccessServicePlugin implements BlockNodePlugin, ServiceInterfa
         requestCounter.increment();
 
         try {
-            // Log in case both block_number and retrieve_latest are set, this should not happen
-            if (request.retrieveLatest() && request.blockNumber() != -1) {
+            // Log and return an error if both block_number and retrieve_latest are set.
+            // blockNumber is considered set if it is different from 0 (default)
+            if (request.retrieveLatest() && request.blockNumber() != 0) {
                 LOGGER.log(
                         INFO,
                         "Both block_number and retrieve_latest set. Using retrieve_latest instead of block_number: {0}",
@@ -63,15 +64,7 @@ public class BlockAccessServicePlugin implements BlockNodePlugin, ServiceInterfa
                 responseCounterNotFound.increment();
                 return new BlockResponse(Code.READ_BLOCK_NOT_FOUND, null);
             }
-            // when block_number is -1 and retrieve_latest is false, return an NOT_FOUND error
-            if (request.blockNumber() == -1 && !request.retrieveLatest()) {
-                LOGGER.log(INFO, "Block number is -1 and retrieve_latest is false");
-                responseCounterNotFound.increment();
-                return new BlockResponse(Code.READ_BLOCK_NOT_FOUND, null);
-            }
-
             long blockNumberToRetrieve;
-
             // if retrieveLatest is set, get the latest block number
             if (request.retrieveLatest()) {
                 blockNumberToRetrieve = blockProvider.availableBlocks().max();

--- a/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
@@ -137,18 +137,21 @@ public class GetBlockApiTests extends BaseSuite {
 
     @Test
     @DisplayName(
-            "Get a Single Block using API - block_number to -1 and retrieve_latest to false - should return NOT_FOUND")
+            "Get a Single Block using API - block_number to 0 and retrieve_latest to false - should return Block 0")
     void requestWithoutBlockNumberAndRetrieveLatestFalse() {
         // Request the latest block and a specific block number
-        final BlockRequest request = createGetBlockRequest(-1, false);
+        final BlockRequest request = createGetBlockRequest(0, false);
         final BlockResponse response = blockAccessStub.getBlock(request);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
-        assertEquals(
-                Code.READ_BLOCK_NOT_FOUND, response.getStatus(), "Block retrieval should fail for non-existing block");
+        assertEquals(Code.READ_BLOCK_SUCCESS, response.getStatus(), "Block retrieval should be successful");
 
-        // Verify that the block is null
-        assertFalse(response.hasBlock(), "Response should not contain a block");
+        // Verify the block content
+        assertTrue(response.hasBlock(), "Response should contain a block");
+        assertEquals(
+                0,
+                response.getBlock().getItemsList().getFirst().getBlockHeader().getNumber(),
+                "Block number should match the requested block number");
     }
 }

--- a/suites/src/main/java/org/hiero/block/suites/utils/BlockAccessUtils.java
+++ b/suites/src/main/java/org/hiero/block/suites/utils/BlockAccessUtils.java
@@ -67,7 +67,7 @@ public final class BlockAccessUtils {
         requireNonNull(blockAccessStub);
 
         BlockRequest request = BlockRequest.newBuilder()
-                .setBlockNumber(-1)
+                .setBlockNumber(0)
                 .setRetrieveLatest(true)
                 .setAllowUnverified(allowUnverified)
                 .build();


### PR DESCRIPTION
## Reviewer Notes

current request does not work:
```

grpcurl -plaintext -import-path  <insertDir> -proto block_access_service.proto -d '{"retrieve_latest":"true"}' 127.0.0.1:8080 org.hiero.block.api.BlockAccessService.getBlock

```

with this temporary fix, we make it work.

but it could also work when:

```
grpcurl -plaintext -import-path  <insertDir> -proto block_access_service.proto -d '{"block_number": "18446744073709551615", "retrieve_latest":"true"}' 127.0.0.1:8080 org.hiero.block.api.BlockAccessService.getBlock
```
