### PR TITLE
fix: Adjust block access service to be correct without workarounds

### DIFF
--- a/block-node/block-access/src/test/java/org/hiero/block/node/access/service/BlockAccessServicePluginTest.java
+++ b/block-node/block-access/src/test/java/org/hiero/block/node/access/service/BlockAccessServicePluginTest.java
@@ -61,18 +61,15 @@ public class BlockAccessServicePluginTest extends GrpcPluginTestBase<BlockAccess
     @DisplayName("Happy Path Test, BlockAccessServicePlugin for an existing Block Number")
     void happyTestGetBlock() throws ParseException {
         final long blockNumber = 1;
-        final BlockRequest request = BlockRequest.newBuilder()
-                .blockNumber(blockNumber)
-                .allowUnverified(true)
-                .retrieveLatest(false)
-                .build();
+        final BlockRequest request =
+                BlockRequest.newBuilder().blockNumber(blockNumber).build();
         toPluginPipe.onNext(BlockRequest.PROTOBUF.toBytes(request));
         // Check we get a response
         assertEquals(1, fromPluginBytes.size());
         // parse the response
         BlockResponse response = BlockResponse.PROTOBUF.parse(fromPluginBytes.get(0));
         // check that the status is success
-        assertEquals(Code.READ_BLOCK_SUCCESS, response.status());
+        assertEquals(Code.SUCCESS, response.status());
         // check that the block number is correct
         assertEquals(1, response.block().items().getFirst().blockHeader().number());
     }
@@ -81,18 +78,15 @@ public class BlockAccessServicePluginTest extends GrpcPluginTestBase<BlockAccess
     @DisplayName("Negative Test, GetBlock for a non-existing Block Number")
     void negativeTestNonExistingBlock() throws ParseException {
         final long blockNumber = 1000;
-        final BlockRequest request = BlockRequest.newBuilder()
-                .blockNumber(blockNumber)
-                .allowUnverified(true)
-                .retrieveLatest(false)
-                .build();
+        final BlockRequest request =
+                BlockRequest.newBuilder().blockNumber(blockNumber).build();
         toPluginPipe.onNext(BlockRequest.PROTOBUF.toBytes(request));
         // Check we get a response
         assertEquals(1, fromPluginBytes.size());
         // parse the response
         BlockResponse response = BlockResponse.PROTOBUF.parse(fromPluginBytes.get(0));
-        // check that the status is NOT FOUND
-        assertEquals(Code.READ_BLOCK_NOT_AVAILABLE, response.status());
+        // check that the status is NOT AVAILABLE
+        assertEquals(Code.NOT_AVAILABLE, response.status());
         // check block is null
         assertNull(response.block());
     }
@@ -100,55 +94,32 @@ public class BlockAccessServicePluginTest extends GrpcPluginTestBase<BlockAccess
     @Test
     @DisplayName("Request Latest Block")
     void testRequestLatestBlock() throws ParseException {
-        final BlockRequest request = BlockRequest.newBuilder()
-                .blockNumber(-1)
-                .allowUnverified(true)
-                .retrieveLatest(true)
-                .build();
+        final BlockRequest request =
+                BlockRequest.newBuilder().retrieveLatest(true).build();
         toPluginPipe.onNext(BlockRequest.PROTOBUF.toBytes(request));
         // Check we get a response
         assertEquals(1, fromPluginBytes.size());
         // parse the response
         BlockResponse response = BlockResponse.PROTOBUF.parse(fromPluginBytes.get(0));
         // check that the status is success
-        assertEquals(Code.READ_BLOCK_SUCCESS, response.status());
+        assertEquals(Code.SUCCESS, response.status());
         // check that the block number is correct
         assertEquals(24, response.block().items().getFirst().blockHeader().number());
     }
 
     @Test
-    @DisplayName("Request Latest and a specific Block different from latest, should fail with READ_BLOCK_NOT_FOUND")
-    void testRequestLatestBlockDifferent() throws ParseException {
-        final long blockNumber = 1;
-        final BlockRequest request = BlockRequest.newBuilder()
-                .blockNumber(blockNumber)
-                .allowUnverified(true)
-                .retrieveLatest(true)
-                .build();
+    @DisplayName("block_number is -1 - should return latest block")
+    void testBlockNumberIsMinusOne() throws ParseException {
+        final BlockRequest request = BlockRequest.newBuilder().blockNumber(-1).build();
         toPluginPipe.onNext(BlockRequest.PROTOBUF.toBytes(request));
         // Check we get a response
         assertEquals(1, fromPluginBytes.size());
         // parse the response
         BlockResponse response = BlockResponse.PROTOBUF.parse(fromPluginBytes.get(0));
         // check that the status is success
-        assertEquals(Code.READ_BLOCK_NOT_FOUND, response.status());
-    }
-
-    @Test
-    @DisplayName("block_number is -1 and retrieve_latest is false - should return READ_BLOCK_NOT_FOUND")
-    void testBlockNumberIsMinusOneAndRetrieveLatestIsFalse() throws ParseException {
-        final BlockRequest request = BlockRequest.newBuilder()
-                .blockNumber(-1)
-                .allowUnverified(true)
-                .retrieveLatest(false)
-                .build();
-        toPluginPipe.onNext(BlockRequest.PROTOBUF.toBytes(request));
-        // Check we get a response
-        assertEquals(1, fromPluginBytes.size());
-        // parse the response
-        BlockResponse response = BlockResponse.PROTOBUF.parse(fromPluginBytes.get(0));
-        // check that the status is READ_BLOCK_NOT_FOUND
-        assertEquals(Code.READ_BLOCK_NOT_FOUND, response.status());
+        assertEquals(Code.SUCCESS, response.status());
+        // check that the block number is correct
+        assertEquals(24, response.block().items().getFirst().blockHeader().number());
     }
 
     private void sendBlocks(int numberOfBlocks) {

--- a/protobuf/src/main/proto/org/hiero/block/api/block_access_service.proto
+++ b/protobuf/src/main/proto/org/hiero/block/api/block_access_service.proto
@@ -13,50 +13,29 @@ import "stream/block.proto";
  * A request to read a single block.
  *
  * A client system SHALL send this message to request a single block,
- * including the block state proof.<br/>
- * A client MAY request that the block be sent without verification.
- * A compliant Block Node MAY respond to requests that allow unverified
- * responses by returning the full requested block before verifying
- * the included block proof.<br/>
- * A compliant Block Node MAY support _only_ requests that allow unverified
- * blocks, but MUST clearly document that limitation, and MUST respond to
- * a request that does not allow unverified blocks with the
- * `ALLOW_UNVERIFIED_REQUIRED` response code.
+ * including the block state proof.
  */
 message BlockRequest {
-    /**
-     * The block number of a block to retrieve.
-     * <p>
-     * The requested block MUST exist on the block node.<br/>
-     * This value MUST NOT be set if `retrieve_latest` is set `true`.<br/>
-     * This value MUST be set to a valid block number if `retrieve_latest` is
-     * unset or is set `false`.
-     */
-    uint64 block_number = 1;
+    oneof block_specifier {
+        /**
+         * The block number of a block to retrieve.
+         * <p>
+         * The requested block MUST exist on the block node.<br/>
+         * A request MAY specify `uint64_max` to signal that the last possible
+         * block should be returned (which is subtly different from setting
+         * `retrieve_latest` instead of setting a `block_number`, though the
+         * result will always be the same, in most implementations).
+         */
+        uint64 block_number = 1;
 
-    /**
-     * A flag to indicate that the requested block may be sent without
-     * verifying its `BlockProof`.<br/>
-     * This might be set by a client that expects to perform its own
-     * verification and wishes lower latency or, potentially, lower cost.
-     * <p>
-     * If this value is set, then the responding Block Node MAY respond with a
-     * block that has not completed verification of its `BlockProof`.<br/>
-     * If this is _not_ set then the Block Node MUST respond with either a
-     * fully verified and validated block, or `VERIFIED_BLOCK_UNAVAILABLE` if
-     * the requested block is not yet verified.<br/>
-     * The default value is _not set_.
-     */
-    bool allow_unverified = 2;
-
-    /**
-     * A flag to request the latest available block.
-     * <p>
-     * This value MAY be set `true` to request the last block available.<br/>
-     * If this value is set to `true` then `block_number` MUST NOT be set and
-     * SHALL be ignored.
-     */
-    bool retrieve_latest = 3;
+        /**
+         * A flag to request the latest available block.
+         * <p>
+         * This value SHOULD be set `true`, instead of setting `block_number`
+         * if the intent is to request the latest block available.
+         */
+        bool retrieve_latest = 2;
+    }
 }
 
 /**
@@ -81,21 +60,22 @@ message BlockResponse {
          * This status indicates the server software failed to set a status,
          * and SHALL be considered a software defect.
          */
-        READ_BLOCK_UNKNOWN = 0;
-
-        /**
-         * The requesting client account lacks sufficient HBAR to pay the
-         * service fee for this request.<br/>
-         * The client MAY retry the request, but MUST increase the client
-         * account balance with this block node server before doing so.
-         */
-        READ_BLOCK_INSUFFICIENT_BALANCE = 1;
+        UNKNOWN = 0;
 
         /**
          * The request succeeded.<br/>
          * The requested block SHALL be returned in the `block` field.
          */
-        READ_BLOCK_SUCCESS = 2;
+        SUCCESS = 1;
+
+        /**
+         * The request cannot be fulfilled.<br/>
+         * The client sent a malformed or structurally incorrect request.
+         * <p>
+         * The client MAY retry the request after correcting the form and
+         * structure.
+         */
+        INVALID_REQUEST = 2;
 
         /**
          * The requested block was not found.<br/>
@@ -104,33 +84,14 @@ message BlockResponse {
          * The client MAY retry the request; if this result is repeated the
          * request SHOULD be directed to a different block node server.
          */
-        READ_BLOCK_NOT_FOUND = 3;
+        NOT_FOUND = 3;
 
         /**
          * The requested block is not available on this block node server.<br/>
          * The client SHOULD send a `serverStatus` request to determine the
          * lowest and highest block numbers available at this block node server.
          */
-        READ_BLOCK_NOT_AVAILABLE = 4;
-
-        /**
-         * The request for a verified block cannot be fulfilled.<br/>
-         * The client requested a verified block from a block node that does not
-         * offer verified blocks.
-         * <p>
-         * The client MAY retry the request with the `allow_unverified` flag set.
-         */
-        ALLOW_UNVERIFIED_REQUIRED = 5;
-
-        /**
-         * The request for a verified block cannot be fulfilled.<br/>
-         * The client requested a verified block from a block node but the
-         * requested block is not yet verified.
-         * <p>
-         * The client MAY retry the request after a short delay
-         * (typically 2 seconds or more).
-         */
-        VERIFIED_BLOCK_UNAVAILABLE = 6;
+        NOT_AVAILABLE = 4;
     }
 
     /**

--- a/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.suites.block.access;
 
-import static org.hiero.block.suites.utils.BlockAccessUtils.createGetBlockRequest;
 import static org.hiero.block.suites.utils.BlockAccessUtils.getBlock;
 import static org.hiero.block.suites.utils.BlockAccessUtils.getLatestBlock;
 import static org.hiero.block.suites.utils.BlockSimulatorUtils.createBlockSimulator;
@@ -12,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.concurrent.Future;
-import org.hiero.block.api.protoc.BlockRequest;
 import org.hiero.block.api.protoc.BlockResponse;
 import org.hiero.block.api.protoc.BlockResponse.Code;
 import org.hiero.block.simulator.BlockStreamSimulatorApp;
@@ -66,11 +64,11 @@ public class GetBlockApiTests extends BaseSuite {
     void requestExistingBlockUsingBlockAPI() {
         // Request block number 1 (which should have been published by the simulator)
         final long blockNumber = 1;
-        final BlockResponse response = getBlock(blockAccessStub, blockNumber, false);
+        final BlockResponse response = getBlock(blockAccessStub, blockNumber);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
-        assertEquals(Code.READ_BLOCK_SUCCESS, response.getStatus(), "Block retrieval should be successful");
+        assertEquals(Code.SUCCESS, response.getStatus(), "Block retrieval should be successful");
 
         // Verify the block content
         assertTrue(response.hasBlock(), "Response should contain a block");
@@ -85,14 +83,11 @@ public class GetBlockApiTests extends BaseSuite {
     void requestNonExistingBlockUsingBlockAPI() {
         // Request a non-existing block number
         final long blockNumber = 1000;
-        final BlockResponse response = getBlock(blockAccessStub, blockNumber, false);
+        final BlockResponse response = getBlock(blockAccessStub, blockNumber);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
-        assertEquals(
-                Code.READ_BLOCK_NOT_AVAILABLE,
-                response.getStatus(),
-                "Block retrieval should fail for non-existing block");
+        assertEquals(Code.NOT_AVAILABLE, response.getStatus(), "Block retrieval should fail for non-existing block");
 
         // Verify that the block is null
         assertFalse(response.hasBlock(), "Response should not contain a block");
@@ -102,11 +97,11 @@ public class GetBlockApiTests extends BaseSuite {
     @DisplayName("Get a Single Block using API - Request Latest Block")
     void requestLatestBlockUsingBlockAPI() {
         // Request the latest block
-        final BlockResponse response = getLatestBlock(blockAccessStub, false);
+        final BlockResponse response = getLatestBlock(blockAccessStub);
 
         // Verify the response
         assertNotNull(response, "Response should not be null");
-        assertEquals(Code.READ_BLOCK_SUCCESS, response.getStatus(), "Block retrieval should be successful");
+        assertEquals(Code.SUCCESS, response.getStatus(), "Block retrieval should be successful");
 
         // Verify the block content
         final long latestPublishedBlock =
@@ -116,39 +111,5 @@ public class GetBlockApiTests extends BaseSuite {
                 latestPublishedBlock,
                 response.getBlock().getItemsList().getFirst().getBlockHeader().getNumber(),
                 "Block number should match the latest block number");
-    }
-
-    @Test
-    @DisplayName("Get a Single Block using API - Request Latest and Specific Block - should fail with NOT_FOUND")
-    void requestLatestBlockAndSpecificBlockUsingBlockAPI() {
-        // Request the latest block and a specific block number
-        final long blockNumber = 1;
-        final BlockRequest request = createGetBlockRequest(blockNumber, true);
-        final BlockResponse response = blockAccessStub.getBlock(request);
-
-        // Verify the response
-        assertNotNull(response, "Response should not be null");
-        assertEquals(
-                Code.READ_BLOCK_NOT_FOUND, response.getStatus(), "Block retrieval should fail for non-existing block");
-
-        // Verify that the block is null
-        assertFalse(response.hasBlock(), "Response should not contain a block");
-    }
-
-    @Test
-    @DisplayName(
-            "Get a Single Block using API - block_number to -1 and retrieve_latest to false - should return NOT_FOUND")
-    void requestWithoutBlockNumberAndRetrieveLatestFalse() {
-        // Request the latest block and a specific block number
-        final BlockRequest request = createGetBlockRequest(-1, false);
-        final BlockResponse response = blockAccessStub.getBlock(request);
-
-        // Verify the response
-        assertNotNull(response, "Response should not be null");
-        assertEquals(
-                Code.READ_BLOCK_NOT_FOUND, response.getStatus(), "Block retrieval should fail for non-existing block");
-
-        // Verify that the block is null
-        assertFalse(response.hasBlock(), "Response should not contain a block");
     }
 }

--- a/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
+++ b/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
@@ -156,13 +156,13 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
         simulators.add(futureSimulatorThread);
 
         // ===== Assert that we are persisting only the current blocks =================================
-        final BlockResponse currentBlockResponse = getLatestBlock(blockAccessStub, false);
-        final BlockResponse futureBlockResponse = getBlock(blockAccessStub, 1000, false);
+        final BlockResponse currentBlockResponse = getLatestBlock(blockAccessStub);
+        final BlockResponse futureBlockResponse = getBlock(blockAccessStub, 1000);
 
         assertNotNull(currentBlockResponse);
         assertNotNull(futureBlockResponse);
-        assertEquals(Code.READ_BLOCK_SUCCESS, currentBlockResponse.getStatus());
-        assertEquals(Code.READ_BLOCK_NOT_AVAILABLE, futureBlockResponse.getStatus());
+        assertEquals(Code.SUCCESS, currentBlockResponse.getStatus());
+        assertEquals(Code.NOT_AVAILABLE, futureBlockResponse.getStatus());
         assertTrue(currentBlockResponse.getBlock().getItemsList().getFirst().hasBlockHeader());
     }
 
@@ -190,9 +190,9 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
         firstSimulatorThread.cancel(true);
 
         final BlockResponse latestPublishedBlockBefore =
-                getBlock(blockAccessStub, firstSimulatorLatestPublishedBlockNumber, false);
+                getBlock(blockAccessStub, firstSimulatorLatestPublishedBlockNumber);
         final BlockResponse nextPublishedBlockBefore =
-                getBlock(blockAccessStub, firstSimulatorLatestPublishedBlockNumber + 1, false);
+                getBlock(blockAccessStub, firstSimulatorLatestPublishedBlockNumber + 1);
 
         assertNotNull(firstSimulatorLatestStatus);
         assertTrue(firstSimulatorLatestStatus.contains(Long.toString(firstSimulatorLatestPublishedBlockNumber)));
@@ -204,7 +204,7 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
                         .getFirst()
                         .getBlockHeader()
                         .getNumber());
-        assertEquals(Code.READ_BLOCK_NOT_AVAILABLE, nextPublishedBlockBefore.getStatus());
+        assertEquals(Code.NOT_AVAILABLE, nextPublishedBlockBefore.getStatus());
 
         // ===== Prepare and Start second simulator and make sure it's streaming =====================
         final Map<String, String> secondSimulatorConfiguration =
@@ -219,7 +219,7 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
                 .getLast();
         secondSimulatorThread.cancel(true);
 
-        final BlockResponse latestPublishedBlockAfter = getLatestBlock(blockAccessStub, false);
+        final BlockResponse latestPublishedBlockAfter = getLatestBlock(blockAccessStub);
 
         assertNotNull(secondSimulatorLatestStatus);
         assertNotNull(latestPublishedBlockAfter);

--- a/suites/src/main/java/org/hiero/block/suites/utils/BlockAccessUtils.java
+++ b/suites/src/main/java/org/hiero/block/suites/utils/BlockAccessUtils.java
@@ -6,6 +6,7 @@ import static java.util.Objects.requireNonNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.hiero.block.api.protoc.BlockAccessServiceGrpc;
 import org.hiero.block.api.protoc.BlockRequest;
+import org.hiero.block.api.protoc.BlockRequest.Builder;
 import org.hiero.block.api.protoc.BlockResponse;
 
 /**
@@ -26,51 +27,39 @@ public final class BlockAccessUtils {
      * @return A SingleBlockRequest object
      */
     public static BlockRequest createGetBlockRequest(long blockNumber, boolean latest) {
-        return BlockRequest.newBuilder()
-                .setBlockNumber(blockNumber)
-                .setRetrieveLatest(latest)
-                .setAllowUnverified(true)
-                .build();
+        final Builder builder = BlockRequest.newBuilder().setBlockNumber(blockNumber);
+        if (latest) {
+            builder.setRetrieveLatest(true);
+        }
+        return builder.build();
     }
 
     /**
      * Retrieves a single block using the Block Node API.
      *
      * @param blockNumber The block number to retrieve
-     * @param allowUnverified A flag to indicate that the requested block may be sent without
-     *   verifying its `BlockProof`
      * @return The SingleBlockResponse from the API
      */
     public static BlockResponse getBlock(
             @NonNull final BlockAccessServiceGrpc.BlockAccessServiceBlockingStub blockAccessStub,
-            final long blockNumber,
-            final boolean allowUnverified) {
+            final long blockNumber) {
         requireNonNull(blockAccessStub);
 
-        BlockRequest request = BlockRequest.newBuilder()
-                .setBlockNumber(blockNumber)
-                .setAllowUnverified(allowUnverified)
-                .build();
+        BlockRequest request =
+                BlockRequest.newBuilder().setBlockNumber(blockNumber).build();
         return blockAccessStub.getBlock(request);
     }
 
     /**
      * Retrieves a single block using the Block Node API.
      *
-     * @param allowUnverified A flag to indicate that the requested block may be sent without
-     * verifying its `BlockProof`
      * @return The SingleBlockResponse from the API
      */
     public static BlockResponse getLatestBlock(
-            @NonNull final BlockAccessServiceGrpc.BlockAccessServiceBlockingStub blockAccessStub,
-            final boolean allowUnverified) {
+            @NonNull final BlockAccessServiceGrpc.BlockAccessServiceBlockingStub blockAccessStub) {
         requireNonNull(blockAccessStub);
 
-        BlockRequest request = BlockRequest.newBuilder()
-                .setBlockNumber(-1)
-                .setRetrieveLatest(true)
-                .setAllowUnverified(allowUnverified)
-                .build();
+        BlockRequest request = BlockRequest.newBuilder().setRetrieveLatest(true).build();
         return blockAccessStub.getBlock(request);
     }
 }


### PR DESCRIPTION
## Reviewer Notes

* Modified the proto definition to remove unverified and prevent calling with both latest and a block number.
* Added an "invalid" response and removed the verified/unverified responses
* Removed unnecessary prefixes in the response enum names
* Removed check for both fields set in Java (it's no longer possible).
* Fixed up all references
* Removed tests that set both fields as it's no longer possible (the last one set is the only one set).

## Related Issue(s)
 Fixes #1148
