### PR TITLE
fix: Publisher API is missing some request forms

### DIFF
--- a/block-node/publisher/src/main/java/org/hiero/block/node/publisher/PublisherServicePlugin.java
+++ b/block-node/publisher/src/main/java/org/hiero/block/node/publisher/PublisherServicePlugin.java
@@ -96,7 +96,7 @@ public final class PublisherServicePlugin implements BlockNodePlugin, ServiceInt
     /** The current ACKED block number */
     private long latestAckedBlockNumber = UNKNOWN_BLOCK_NUMBER;
     /** The current chosen primary consensus node session, or null if there is no primary */
-    private BlockStreamProducerSession currentPrimarySession = null;
+    private BlockStreamProducerSession currentPrimarySession;
     /** The next session id to use when a new session is created */
     private long nextSessionId = 0;
 

--- a/protobuf/src/main/proto/org/hiero/block/api/block_stream_publish_service.proto
+++ b/protobuf/src/main/proto/org/hiero/block/api/block_stream_publish_service.proto
@@ -38,66 +38,132 @@ message PublishStreamRequest {
          * followed by a single `status` message.
          */
         BlockItemSet block_items = 1;
+
+        /**
+         * A message when the Publisher is deliberately ending the stream.<br/>
+         * <p>
+         * This message SHALL be sent exactly once for each `publishBlockStream`
+         * call.<br/>
+         * The Publisher SHALL cease sending block items and close the gRPC
+         * connection after sending this message.<br/>
+         * The Publisher MUST fill in the earliest and latest block numbers
+         * when sending this message for any non-error condition.
+         */
+        EndStream end_stream = 2;
     }
-}
-
-/**
- * An enumeration indicating why a Publisher ended a stream.
- *
- * This enumeration describes the reason a block stream
- * (sent via `publishBlockStream`) was ended by the Publisher.
- */
-enum PublishStreamEndCode {
-    /**
-     * An "unset value" flag, this value SHALL NOT be used.<br/>
-     * This status indicates the server software failed to set a
-     * status, and SHALL be considered a software defect.
-     */
-    STREAM_END_UNKNOWN = 0;
 
     /**
-     * The Publisher reached a reset point.<br/>
-     * No errors occurred and the source Block-Node orderly ended the stream.
+     * A message sent to end a stream.
      *
-     * Publishers SHOULD use this code to end a stream and restart
-     * occasionally. Occasionally resetting the stream increases stability and
-     * allows for routine network configuration changes.
+     * This request message SHALL be sent from a Publisher to a Block-Node
+     * when a `publishBlockStream` stream ends in an orderly manner.<br/>
+     * This message SHALL be sent exactly once for each `publishBlockStream`
+     * call.<br/>
+     * The Publisher SHALL cease sending block items after sending
+     * this request, and SHALL express the ending state of the stream with
+     * the `status` enumeration.<br/>
+     * A Publisher SHALL include the `earliest_block_number` and
+     * `latest_block_number` values when sending this message for any
+     * non-error condition.
      */
-    STREAM_END_RESET = 1;
+    message EndStream {
+        // Note: MUST NOT name this `EndOfStream`, a PBJ bug in automatic unit
+        //       test generation will attempt to convert this inner enum to the
+        //       inner enum of the `Response` `EndOfStream` message, resulting
+        //       in compilation errors. This bug will even attempt to convert
+        //       the enums if the enums are not named the same.
 
-    /**
-     * The delay between items was too long.<br/>
-     * The destination system did not timely acknowledge a block.
-     * <p>
-     * The source SHALL start a new stream before the failed block.
-     */
-    STREAM_END_TIMEOUT = 2;
+        /**
+         * A stream end code.
+         * This code indicates the reason the stream ended.<br/>
+         * <p>
+         * This value MUST be set to a non-default value.
+         */
+        Code end_code = 1;
 
-    /**
-     * The Publisher encountered an error.<br/>
-     * The Publisher encountered an internal error and must try again later.
-     * <p>
-     * Publishers that encounter internal logic errors, find themselves
-     * "behind" the network, or otherwise detect an unexpected situation MUST
-     * send this code and restart the stream before the failed block.
-     */
-    STREAM_END_ERROR = 3;
+        /**
+         * The number of the _earliest_ block available from the Publisher.
+         * <p>
+         * This value SHALL be set to the earliest block number available from
+         * this Publisher.<br/>
+         * This value MUST be set unless the stream `end_code`
+         * is `ERROR`.
+         */
+        uint64 earliest_block_number = 2;
 
-    /**
-     * The Block-Node is too far behind to catch up directly.<br/>
-     * The Block-Node responded to a block header with "BEHIND" and is
-     * too far behind the Publisher.
-     * <p>
-     * The Block-Node MUST recover and "catch up" from another trustworthy
-     * Block-Node.<br/>
-     * The Publisher MAY stream items to a different Block-Node.<br/>
-     * The Publisher MAY resume streaming to this Block-Node later.<br/>
-     * The `EndOfStream` message MUST include the earliest and latest blocks
-     * currently available from the Publisher.<br/>
-     * The Block-Node SHOULD attempt to "catch up" to the _latest_ block
-     * available from the Publisher.
-     */
-    STREAM_END_TOO_FAR_BEHIND = 4;
+        /**
+         * The number of the _latest_ block available from the Publisher.<br/>
+         * This is the last _acknowledged_ block, not the last block produced.
+         * <p>
+         * This value SHALL be set to the latest block number available from
+         * this Publisher.<br/>
+         * This value MUST be set unless the stream `end_code`
+         * is `ERROR`.
+         */
+        uint64 latest_block_number = 3;
+
+        /**
+         * An enumeration indicating why a Publisher ended a stream.
+         *
+         * This enumeration describes the reason a block stream
+         * (sent via `publishBlockStream`) was ended by the Publisher.
+         */
+        enum Code {
+            /**
+             * An "unset value" flag, this value SHALL NOT be used.<br/>
+             * This status indicates the server software failed to set a
+             * status, and SHALL be considered a software defect.
+             */
+            UNKNOWN = 0;
+
+            /**
+             * The Publisher reached a reset point.<br/>
+             * No errors occurred and the source Publisher orderly ended
+             * the stream.
+             * <p>
+             * Publishers SHOULD use this code to end a stream and restart
+             * occasionally. Occasionally resetting the stream increases
+             * stability and allows for routine network configuration changes.
+             */
+            RESET = 1;
+
+            /**
+             * The delay between items was too long.<br/>
+             * The destination system did not timely acknowledge a block.
+             * <p>
+             * The source SHALL start a new stream before the failed block.
+             */
+            TIMEOUT = 2;
+
+            /**
+             * The Publisher encountered an error.<br/>
+             * The Publisher encountered an internal error and must try
+             * again later.
+             * <p>
+             * Publishers that encounter internal logic errors, find themselves
+             * "behind" the network, or otherwise detect an unexpected
+             * situation MUST send this code and restart the stream before
+             * the failed block.
+             */
+            ERROR = 3;
+
+            /**
+             * The Block-Node is too far behind to catch up directly.<br/>
+             * The Block-Node responded to a block header with "BEHIND" and is
+             * too far behind the Publisher.
+             * <p>
+             * The Block-Node MUST recover and "catch up" from another
+             * trustworthy Block-Node.<br/>
+             * The Publisher MAY stream items to a different Block-Node.<br/>
+             * The Publisher MAY resume streaming to this Block-Node later.<br/>
+             * The `EndOfStream` message MUST include the earliest and latest
+             * blocks currently available from the Publisher.<br/>
+             * The Block-Node SHOULD attempt to "catch up" to the _latest_ block
+             * available from the Publisher.
+             */
+            TOO_FAR_BEHIND = 4;
+        }
+    }
 }
 
 /**
@@ -127,7 +193,7 @@ message PublishStreamResponse {
         /**
          * A response sent to acknowledge successful receipt of a block.
          */
-        Acknowledgement acknowledgement = 1;
+        BlockAcknowledgement acknowledgement = 1;
 
         /**
          * A response sent to request the Publisher end the current stream.
@@ -146,23 +212,11 @@ message PublishStreamResponse {
     }
 
     /**
-     * A response to acknowledge receipt and verification of a full block.
-     */
-    message Acknowledgement {
-        /**
-         * A response type to acknowledge a full and complete block.
-         * <p>
-         * All Block-Nodes SHOULD acknowledge each block.
-         */
-        BlockAcknowledgement block_ack = 1;
-    }
-
-    /**
      * Acknowledgement of a full block.<br/>
      * This message is a necessary part of the block streaming protocol.
      *
      * This response SHALL be sent after a block state proof item is
-     * received and verified.<br/>
+     * received and verified, and that block is persisted.<br/>
      * The Block-Node SHALL send exactly one `BlockAcknowledgement` for
      * each successful block.
      */
@@ -275,10 +329,10 @@ message PublishStreamResponse {
          * This code indicates the reason the stream ended.<br/>
          * This value MUST be set to a non-default value.
          */
-        PublishStreamResponseCode status = 1;
+        Code status = 1;
 
         /**
-         * The number of the last completed and _verified_ block.
+         * The number of the last completed, _persisted_, and _verified_ block.
          * <p>
          * Block-Nodes SHOULD only end a stream after a block state proof to avoid
          * the need to resend items.<br/>
@@ -288,80 +342,82 @@ message PublishStreamResponse {
          * the _header_ for block 91827362984).
          */
         uint64 block_number = 2;
+
+        /**
+         * An enumeration indicating the status of this request.
+         *
+         * This enumeration SHALL describe the reason a block stream
+         * (sent via `publishBlockStream`) was ended by the receiving
+         * Block-Node.
+         */
+        enum Code {
+            /**
+             * An "unset value" flag, this value SHALL NOT be used.<br/>
+             * This status indicates the server software failed to set a
+             * status, and SHALL be considered a software defect.
+             */
+            UNKNOWN = 0;
+
+            /**
+             * The request succeeded.<br/>
+             * No errors occurred and the receiving Block-Node orderly ended the stream.
+             * <p>
+             * The Publisher MAY start a new stream beginning with the next block.
+             */
+            SUCCESS = 1;
+
+            /**
+             * The delay between items was too long.
+             * <p>
+             * The source MUST start a new stream before the failed block.
+             */
+            TIMEOUT = 2;
+
+            /**
+             * An item was received out-of-order.<br/>
+             * This might be two headers without a proof between them, or similar.
+             * <p>
+             * The source MUST start a new stream before the failed block.
+             */
+            OUT_OF_ORDER = 3;
+
+            /**
+             * A block state proof item could not be validated.<br/>
+             * The source MUST start a new stream before the failed block.
+             */
+            BAD_STATE_PROOF = 4;
+
+            /**
+             * The Block-Node is "behind" the Publisher.<br/>
+             * Ths Publisher has sent a block later than this Block-Node
+             * can process. The Publisher may retry by sending blocks immediately
+             * following the `block_number` returned, or may connect
+             * to another Block-Node.
+             * <p>
+             * Block-Nodes that are "behind" SHOULD attempt to "catch up" by requesting
+             * blocks from another Block-Node or other source of recent historical
+             * block stream data.
+             */
+            BEHIND = 5;
+
+            /**
+             * The Block-Node had an internal error and cannot continue processing.<br/>
+             * The Publisher may retry again later.
+             */
+            INTERNAL_ERROR = 6;
+
+            /**
+             * The Block-Node failed to store the block persistently.
+             * <p>
+             * The Publisher SHOULD start a new stream to send the block to
+             * this Block-Node, or any other reliable Block-Node.
+             * The Publisher MUST NOT discard the block until it is successfully
+             * persisted and verified (and acknowledged) by at least one Block-Node.
+             */
+            PERSISTENCE_FAILED = 7;
+        }
+
     }
-}
-
-/**
- * An enumeration indicating the status of this request.
- *
- * This enumeration SHALL describe the reason a block stream
- * (sent via `publishBlockStream`) ended.
- */
-enum PublishStreamResponseCode {
-    /**
-     * An "unset value" flag, this value SHALL NOT be used.<br/>
-     * This status indicates the server software failed to set a
-     * status, and SHALL be considered a software defect.
-     */
-    STREAM_ITEMS_UNKNOWN = 0;
-
-    /**
-     * The request succeeded.<br/>
-     * No errors occurred and the receiving Block-Node orderly ended the stream.
-     * <p>
-     * The Publisher MAY start a new stream beginning with the next block.
-     */
-    STREAM_ITEMS_SUCCESS = 1;
-
-    /**
-     * The delay between items was too long.
-     * <p>
-     * The source MUST start a new stream before the failed block.
-     */
-    STREAM_ITEMS_TIMEOUT = 2;
-
-    /**
-     * An item was received out-of-order.<br/>
-     * This might be two headers without a proof between them, or similar.
-     * <p>
-     * The source MUST start a new stream before the failed block.
-     */
-    STREAM_ITEMS_OUT_OF_ORDER = 3;
-
-    /**
-     * A block state proof item could not be validated.<br/>
-     * The source MUST start a new stream before the failed block.
-     */
-    STREAM_ITEMS_BAD_STATE_PROOF = 4;
-
-    /**
-     * The Block-Node is "behind" the Publisher.<br/>
-     * Ths Publisher has sent a block later than this Block-Node
-     * can process. The Publisher may retry by sending blocks immediately
-     * following the `block_number` returned, or may connect
-     * to another Block-Node.
-     * <p>
-     * Block-Nodes that are "behind" SHOULD attempt to "catch up" by requesting
-     * blocks from another Block-Node or other source of recent historical
-     * block stream data.
-     */
-    STREAM_ITEMS_BEHIND = 5;
-
-    /**
-     * The Block-Node had an internal error and cannot continue processing.<br/>
-     * The Publisher may retry again later.
-     */
-    STREAM_ITEMS_INTERNAL_ERROR = 6;
-
-    /**
-     * The Block-Node failed to store the block persistently.
-     * <p>
-     * The Publisher SHOULD start a new stream to send the block to
-     * this Block-Node, or any other reliable Block-Node.
-     * The Publisher MUST NOT discard the block until it is successfully
-     * persisted and verified (and acknowledged) by at least one Block-Node.
-     */
-    STREAM_ITEMS_PERSISTENCE_FAILED = 7;
 }
 
 /**

--- a/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamObserver.java
+++ b/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamObserver.java
@@ -61,8 +61,7 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
         }
 
         if (publishStreamResponse.hasAcknowledgement()) {
-            final BlockAcknowledgement ack =
-                    publishStreamResponse.getAcknowledgement().getBlockAck();
+            final BlockAcknowledgement ack = publishStreamResponse.getAcknowledgement();
             try {
                 startupData.updateLatestAckBlockStartupData(
                         ack.getBlockNumber(), ack.getBlockRootHash().toByteArray(), ack.getBlockAlreadyExists());

--- a/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamServerObserver.java
+++ b/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamServerObserver.java
@@ -15,7 +15,6 @@ import java.util.Deque;
 import java.util.List;
 import org.hiero.block.api.protoc.PublishStreamRequest;
 import org.hiero.block.api.protoc.PublishStreamResponse;
-import org.hiero.block.api.protoc.PublishStreamResponse.Acknowledgement;
 import org.hiero.block.api.protoc.PublishStreamResponse.BlockAcknowledgement;
 import org.hiero.block.simulator.metrics.MetricsService;
 
@@ -112,10 +111,10 @@ public class PublishStreamServerObserver implements StreamObserver<PublishStream
         final long blockNumber = blockProof.getBlock();
         final BlockAcknowledgement blockAcknowledgement =
                 BlockAcknowledgement.newBuilder().setBlockNumber(blockNumber).build();
-        final Acknowledgement ack =
-                Acknowledgement.newBuilder().setBlockAck(blockAcknowledgement).build();
         LOGGER.log(INFO, "Returning block acknowledgement for block number: %s".formatted(blockNumber));
 
-        return PublishStreamResponse.newBuilder().setAcknowledgement(ack).build();
+        return PublishStreamResponse.newBuilder()
+                .setAcknowledgement(blockAcknowledgement)
+                .build();
     }
 }

--- a/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
@@ -25,7 +25,7 @@ import org.hiero.block.api.protoc.BlockItemSet;
 import org.hiero.block.api.protoc.BlockStreamPublishServiceGrpc;
 import org.hiero.block.api.protoc.PublishStreamRequest;
 import org.hiero.block.api.protoc.PublishStreamResponse;
-import org.hiero.block.api.protoc.PublishStreamResponseCode;
+import org.hiero.block.api.protoc.PublishStreamResponse.EndOfStream.Code;
 import org.hiero.block.simulator.TestUtils;
 import org.hiero.block.simulator.config.data.BlockStreamConfig;
 import org.hiero.block.simulator.config.data.GrpcConfig;
@@ -83,12 +83,9 @@ class PublishStreamGrpcClientImplTest {
                                     // Assume that the last BlockItem is a BlockProof
                                     if (item.hasBlockProof()) {
                                         // Send BlockAcknowledgement
-                                        PublishStreamResponse.Acknowledgement acknowledgement =
-                                                PublishStreamResponse.Acknowledgement.newBuilder()
-                                                        .setBlockAck(
-                                                                PublishStreamResponse.BlockAcknowledgement.newBuilder()
-                                                                        .setBlockNumber(lastBlockNumber)
-                                                                        .build())
+                                        PublishStreamResponse.BlockAcknowledgement acknowledgement =
+                                                PublishStreamResponse.BlockAcknowledgement.newBuilder()
+                                                        .setBlockNumber(lastBlockNumber)
                                                         .build();
                                         responseObserver.onNext(PublishStreamResponse.newBuilder()
                                                 .setAcknowledgement(acknowledgement)
@@ -106,7 +103,7 @@ class PublishStreamGrpcClientImplTest {
                             public void onCompleted() {
                                 PublishStreamResponse.EndOfStream endOfStream =
                                         PublishStreamResponse.EndOfStream.newBuilder()
-                                                .setStatus(PublishStreamResponseCode.STREAM_ITEMS_SUCCESS)
+                                                .setStatus(Code.SUCCESS)
                                                 .setBlockNumber(lastBlockNumber)
                                                 .build();
                                 responseObserver.onNext(PublishStreamResponse.newBuilder()

--- a/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamServerObserverTest.java
+++ b/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamServerObserverTest.java
@@ -74,7 +74,7 @@ class PublishStreamServerObserverTest {
 
         // Verify the response contains correct block number
         PublishStreamResponse capturedResponse = responseCaptor.getValue();
-        assertEquals(123L, capturedResponse.getAcknowledgement().getBlockAck().getBlockNumber());
+        assertEquals(123L, capturedResponse.getAcknowledgement().getBlockNumber());
 
         // Verify status was stored
         assertEquals(1, lastKnownStatuses.size());


### PR DESCRIPTION
## Reviewer Notes
* Added the missing `EndStream` item for publish request
   * Note, this does _not_ implement handling for this new message; it only adds the API definitions.
* Moved publish end stream code and response end stream code into their respective messages
* Removed `Acknowledgement` wrapper around `BlockAcknowledgement`.
* Removed unnecessary enum name prefixes
* Discovered another PBJ bug (unit tests generation) related to message name conflicts
* Fixed all references in code and tests

## Related Issue(s)
 Fixes #1151
