### PR TITLE
chore: Clean up ThreadPoolManager API

### DIFF
--- a/block-node/app/src/main/java/org/hiero/block/node/app/DefaultThreadPoolManager.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/DefaultThreadPoolManager.java
@@ -26,35 +26,21 @@ final class DefaultThreadPoolManager implements ThreadPoolManager {
 
     /**
      * {@inheritDoc}
-     *
-     * This implementation tries to returns the same static thread-per-task executor specialized to
-     * use virtual threads for every call. If threadName is not null, however,
-     * a unique executor is returned instead.
-     *
-     * The threadName parameter is ignored.
-     */
-    @NonNull
-    @Override
-    public ExecutorService getVirtualThreadExecutor(@Nullable final String threadName) {
-        return getVirtualThreadExecutor(threadName, null);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
+     * <p>
      * This implementation caches executors based on the exception handler, and
      * tries to return the same thread-per-task executor specialized to use virtual
      * threads for each exception handler instance. If threadName is not null,
      * however, a unique executor service is returned.
      *
-     * If no exception handler is provided, this returns the same static executor as
-     * {@link #getVirtualThreadExecutor(String)}.
+     * If no exception handler or name is provided, this returns the same static
+     * executor as {@link #getVirtualThreadExecutor()}.
      */
     @NonNull
     @Override
     public ExecutorService getVirtualThreadExecutor(
             @Nullable final String threadName, @Nullable final UncaughtExceptionHandler uncaughtExceptionHandler) {
         if (threadName != null) {
+            Preconditions.requireNotBlank(threadName);
             return createVirtualThreadExecutor(threadName, uncaughtExceptionHandler);
         } else if (uncaughtExceptionHandler != null) {
             if (!VIRTUAL_THREAD_MAP.containsKey(uncaughtExceptionHandler)) {
@@ -95,20 +81,14 @@ final class DefaultThreadPoolManager implements ThreadPoolManager {
      */
     @NonNull
     @Override
-    public ExecutorService createSingleThreadExecutor(@NonNull final String threadName) {
-        return createSingleThreadExecutor(threadName, null);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @NonNull
-    @Override
     public ExecutorService createSingleThreadExecutor(
-            @NonNull final String threadName,
+            @Nullable final String threadName,
             @Nullable final Thread.UncaughtExceptionHandler uncaughtExceptionHandler) {
-        Preconditions.requireNotBlank(threadName);
-        final OfPlatform factoryBuilder = Thread.ofPlatform().name(threadName);
+        final OfPlatform factoryBuilder = Thread.ofPlatform();
+        if (threadName != null) {
+            Preconditions.requireNotBlank(threadName);
+            factoryBuilder.name(threadName);
+        }
         if (uncaughtExceptionHandler != null) {
             factoryBuilder.uncaughtExceptionHandler(uncaughtExceptionHandler);
         }

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/async/TestThreadPoolManager.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/async/TestThreadPoolManager.java
@@ -23,20 +23,9 @@ public class TestThreadPoolManager<T extends ExecutorService> implements ThreadP
         this.executor = Objects.requireNonNull(executor);
     }
 
-    @NonNull
-    @Override
-    public T getVirtualThreadExecutor(@NonNull final String threadName) {
-        return executor;
-    }
-
-    @NonNull
-    @Override
-    public T getVirtualThreadExecutor(
-            @NonNull final String threadName, @Nullable final UncaughtExceptionHandler uncaughtExceptionHandler) {
-        return executor;
-    }
-
     /**
+     * {@inheritDoc}
+     * <p>
      * Test implementation, always returns the same executor service that was
      * passed to the constructor of this class.
      *
@@ -44,11 +33,14 @@ public class TestThreadPoolManager<T extends ExecutorService> implements ThreadP
      */
     @NonNull
     @Override
-    public T createSingleThreadExecutor(@NonNull final String threadName) {
+    public T getVirtualThreadExecutor(
+            @Nullable final String threadName, @Nullable final UncaughtExceptionHandler uncaughtExceptionHandler) {
         return executor;
     }
 
     /**
+     * {@inheritDoc}
+     * <p>
      * Test implementation, always returns the same executor service that was
      * passed to the constructor of this class.
      *
@@ -57,7 +49,7 @@ public class TestThreadPoolManager<T extends ExecutorService> implements ThreadP
     @NonNull
     @Override
     public T createSingleThreadExecutor(
-            @NonNull final String threadName,
+            @Nullable final String threadName,
             @Nullable final Thread.UncaughtExceptionHandler uncaughtExceptionHandler) {
         return executor;
     }

--- a/block-node/spi/src/main/java/org/hiero/block/node/spi/threading/ThreadPoolManager.java
+++ b/block-node/spi/src/main/java/org/hiero/block/node/spi/threading/ThreadPoolManager.java
@@ -3,6 +3,7 @@ package org.hiero.block.node.spi.threading;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -11,22 +12,46 @@ import java.util.concurrent.ExecutorService;
  * for any given plugin. This allows for the block node to control the threading
  * across the entire system. It also allows for easy testing of the system where
  * thread pools are utilized, because the manager can be mocked or stubbed. In
- * this way, the system can be tested without facilitating any special
- * "test-only" logic in the plugins themselves.
+ * this way, the system can be tested with less special "test-only" logic in
+ * the plugins themselves.
  */
 public interface ThreadPoolManager {
     /**
      * Factory method. Creates a new virtual thread-per-task {@link ExecutorService}.
      *
+     * @return a new virtual thread-per-task executor service
+     */
+    @NonNull
+    default ExecutorService getVirtualThreadExecutor() {
+        return getVirtualThreadExecutor(null, null);
+    }
+
+    /**
+     * Factory method. Creates a new virtual thread-per-task {@link ExecutorService}.
+     *
+     * Note, the thread name is a debugging aid. Naming threads may prevent
+     * caching or reusing executor services, and may result in more overhead.
+     *
      * @param threadName the thread name prefix, must not be blank
      * @return a new virtual thread-per-task executor service
      */
     @NonNull
-    ExecutorService getVirtualThreadExecutor(@NonNull final String threadName);
+    default ExecutorService getVirtualThreadExecutor(@NonNull final String threadName) {
+        return getVirtualThreadExecutor(Objects.requireNonNull(threadName), null);
+    }
 
     /**
      * Factory method. Creates a new virtual thread-per-task {@link ExecutorService} using
      * the specified (nullable) {@link Thread.UncaughtExceptionHandler}.
+     *
+     * Note, the thread name is a debugging aid, and optional. Naming threads
+     * may prevent caching or reusing executor services, and may result in more
+     * overhead.<br/>
+     * Some implementations may reuse the same executor service for each
+     * uncaught exception handler, but this is not guaranteed.<br/>
+     * If both the thread name and the uncaught exception handler are null,
+     * the executor service returned will be generic, and <strong>may</strong>
+     * be shared among multiple callers.
      *
      * @param threadName the thread name prefix, must not be blank
      * @param uncaughtExceptionHandler the uncaught exception handler, nullable
@@ -34,26 +59,56 @@ public interface ThreadPoolManager {
      */
     @NonNull
     ExecutorService getVirtualThreadExecutor(
-            @NonNull final String threadName, @Nullable final Thread.UncaughtExceptionHandler uncaughtExceptionHandler);
+            @Nullable final String threadName,
+            @Nullable final Thread.UncaughtExceptionHandler uncaughtExceptionHandler);
 
     /**
-     * Factory method. Creates a new single thread {@link ExecutorService}.
+     * Factory method for a single thread executor.
+     * Creates a new, unnamed, single thread {@link ExecutorService}.
+     *
+     * @return a new single thread executor service
+     */
+    @NonNull
+    default ExecutorService createSingleThreadExecutor() {
+        return createSingleThreadExecutor(null, null);
+    }
+
+    /**
+     * Factory method for a single thread executor.
+     * Creates a new, named, single thread {@link ExecutorService}.
+     *
+     * Note, the thread name is a debugging aid. Naming threads may prevent
+     * caching or reusing executor services, and may result in more overhead.
      *
      * @param threadName the thread's name, must not be blank
      * @return a new single thread executor service
      */
     @NonNull
-    ExecutorService createSingleThreadExecutor(@NonNull final String threadName);
+    default ExecutorService createSingleThreadExecutor(@NonNull final String threadName) {
+        return createSingleThreadExecutor(Objects.requireNonNull(threadName), null);
+    }
 
     /**
-     * Factory method. Creates a new single thread {@link ExecutorService} using
-     * the specified (nullable) {@link Thread.UncaughtExceptionHandler}.
+     * Factory method for a single thread executor.
+     * Creates a new single thread {@link ExecutorService} using the name
+     * provided, if not null, and the specified
+     * {@link Thread.UncaughtExceptionHandler}, if not null.
      *
-     * @param threadName the thread's name, must not be blank
+     * Note, the thread name is a debugging aid, and optional. Naming threads
+     * may prevent caching or reusing executor services, and may result in more
+     * overhead.<br/>
+     * Some implementations may reuse the same executor service for each
+     * uncaught exception handler, but this is not guaranteed.<br/>
+     * If both the thread name and the uncaught exception handler are null,
+     * the executor service returned will be generic, and <strong>may</strong>
+     * be shared among multiple callers.
+     *
+     * @param threadName the thread's name, must not be blank if filled in.
      * @param uncaughtExceptionHandler the uncaught exception handler, nullable
      * @return a new single thread executor service
      */
     @NonNull
     ExecutorService createSingleThreadExecutor(
-            @NonNull final String threadName, @Nullable final Thread.UncaughtExceptionHandler uncaughtExceptionHandler);
+            @Nullable final String threadName,
+            @Nullable final Thread.UncaughtExceptionHandler uncaughtExceptionHandler);
 }

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
@@ -140,7 +140,7 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
         private SubscribeBlockStreamHandler(@NonNull final BlockNodeContext context) {
             this.context = requireNonNull(context);
             this.openSessions = new ConcurrentSkipListMap<>();
-            virtualThreadExecutor = context.threadPoolManager().getVirtualThreadExecutor(null);
+            virtualThreadExecutor = context.threadPoolManager().getVirtualThreadExecutor();
             streamSessions = new ExecutorCompletionService<>(virtualThreadExecutor);
             // create the metrics
             numberOfSubscribers = context.metrics()


### PR DESCRIPTION
## Reviewer Notes
* Added default implementations for reduced-call overloads.
* Adjusted both default and test implementations to clean up overloads
* Adjusted default implementation to handle null thread names
* Cleaned up JavaDoc and explained potential caching impacts.
