### PR TITLE
fix: BlockStream Image Container broken

### DIFF
--- a/protobuf/src/main/java/module-info.java
+++ b/protobuf/src/main/java/module-info.java
@@ -97,4 +97,7 @@ module org.hiero.block.protobuf {
     requires org.antlr.antlr4.runtime;
     requires static com.github.spotbugs.annotations;
     requires static java.annotation;
+
+    opens org.hiero.block.api.protoc to
+            com.google.protobuf;
 }

--- a/simulator/docker/Dockerfile
+++ b/simulator/docker/Dockerfile
@@ -5,6 +5,7 @@ ARG UNAME=hedera
 ARG UID=2000
 ARG GID=2000
 ARG BN_WORKDIR="/opt/hiero/block-node"
+ENV BN_WORKDIR=${BN_WORKDIR}
 RUN groupadd --gid $GID $UNAME
 RUN useradd --no-user-group --create-home --uid $UID --gid $GID --shell /bin/bash hedera
 WORKDIR ${BN_WORKDIR}
@@ -29,4 +30,4 @@ RUN SIMULATOR_DIR=$(ls -d simulator-*/) && \
     echo "#!/bin/bash\n${BN_WORKDIR}/${SIMULATOR_DIR}bin/simulator" > ${BN_WORKDIR}/start.sh && \
     chmod +x ${BN_WORKDIR}/start.sh
 
-ENTRYPOINT ["${BN_WORKDIR}/start.sh"]
+ENTRYPOINT ["sh","-c","${BN_WORKDIR}/start.sh"]


### PR DESCRIPTION
- Fixed simulator container entry-point when executing start script.

- Fixed ability to Java usage of reflection from org.hiero.block.api.protoc to module com.google.protobuf. (this was only happening in docker and k8, due to IDE running everything using a single classpath)

Fixes #1173 
