### PR TITLE
fix: Add protobuf path to artificat upload and fail on error

### DIFF
--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -81,7 +81,8 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: block-node-protobuf-${{ env.VERSION }}.tgz
-          path: ./block-node-protobuf-${{ env.VERSION }}.tgz
+          path: ./protobuf/block-node-protobuf-${{ env.VERSION }}.tgz
+          if-no-files-found: error
 
   publish-block-node-app:
     timeout-minutes: 30


### PR DESCRIPTION
## Reviewer Notes
The package-block-node-protobuf jobs upload step succeeded but doesn't upload anything

Update path of upload to use `/protobuf`
Set if-no-files-found to error so we don't have silent failures

## Related Issue(s)
Fixes #1189