### PR TITLE
fix: Opening for reflection, so Simulator can run in Consumer mode

### DIFF
--- a/protobuf/src/main/java/module-info.java
+++ b/protobuf/src/main/java/module-info.java
@@ -98,6 +98,25 @@ module org.hiero.block.protobuf {
     requires static com.github.spotbugs.annotations;
     requires static java.annotation;
 
+    // only open protoc to com.google.protobuf
+    opens com.hedera.hapi.platform.state.legacy to
+            com.google.protobuf;
     opens org.hiero.block.api.protoc to
+            com.google.protobuf;
+    opens org.hiero.block.internal.protoc to
+            com.google.protobuf;
+    opens com.hedera.services.stream.proto to
+            com.google.protobuf;
+    opens com.hederahashgraph.api.proto.java to
+            com.google.protobuf;
+    opens com.hederahashgraph.service.proto.java to
+            com.google.protobuf;
+    opens com.hedera.hapi.block.stream.protoc to
+            com.google.protobuf;
+    opens com.hedera.hapi.block.stream.input.protoc to
+            com.google.protobuf;
+    opens com.hedera.hapi.block.stream.output.protoc to
+            com.google.protobuf;
+    opens com.hedera.hapi.platform.event.legacy to
             com.google.protobuf;
 }


### PR DESCRIPTION
Cherry-pick of (#1191) into `release/0.11` so we can unblock complete testing workflows

Fixes #1190 