### PR TITLE
fix: Add gpg logic for protobuf jar publish job

### DIFF
--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -188,8 +188,8 @@ jobs:
         id: gpg_key
         uses: step-security/ghaction-import-gpg@6c8fe4d0126a59d57c21f87c9ae5dd3451fa3cca # v6.1.0
         with:
-          gpg_private_key: ${{ secrets.GRADLE_PUBLISH_KEY }}
-          passphrase: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+          gpg_private_key: ${{ secrets.GPG_KEY_CONTENTS }}
+          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
           git_config_global: true
           git_user_signingkey: true
           git_commit_gpgsign: true


### PR DESCRIPTION
## Reviewer Notes
The protobuf publish step was failing as it expects gpg keys present

- Add gpg key setup to be available for publish step

## Related Issue(s)
Fixes: #1197 