### PR TITLE
chore: Files Historic Plugin Uses ZipFS When Reading

### DIFF
--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
@@ -10,6 +10,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -18,9 +20,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 import org.hiero.block.node.base.BlockFile;
 import org.hiero.block.node.spi.BlockNodeContext;
@@ -165,9 +167,9 @@ class ZipBlockArchive {
                                 return Long.parseLong(fileName.substring(0, fileName.indexOf('s')));
                             }));
                     if (zipFilePath.isPresent()) {
-                        try (var zipFile = new ZipFile(zipFilePath.get().toFile())) {
-                            return zipFile.stream()
-                                    .mapToLong(entry -> blockNumberFromFile(entry.getName()))
+                        try (final FileSystem zipFs = FileSystems.newFileSystem(zipFilePath.get());
+                                final Stream<Path> entries = Files.list(zipFs.getPath("/"))) {
+                            return entries.mapToLong(entry -> blockNumberFromFile(entry.getFileName()))
                                     .min()
                                     .orElse(-1);
                         }
@@ -217,9 +219,9 @@ class ZipBlockArchive {
                                 return Long.parseLong(fileName.substring(0, fileName.indexOf('s')));
                             }));
                     if (zipFilePath.isPresent()) {
-                        try (var zipFile = new ZipFile(zipFilePath.get().toFile())) {
-                            return zipFile.stream()
-                                    .mapToLong(entry -> blockNumberFromFile(entry.getName()))
+                        try (final FileSystem zipFs = FileSystems.newFileSystem(zipFilePath.get());
+                                final Stream<Path> entries = Files.list(zipFs.getPath("/"))) {
+                            return entries.mapToLong(entry -> blockNumberFromFile(entry.getFileName()))
                                     .max()
                                     .orElse(-1);
                         }

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 import org.junit.jupiter.params.provider.Arguments;
@@ -35,18 +34,18 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Test for {@link BlockPath}.
  */
 class BlockPathTest {
-    private static final String ROOT_PATH = "/foo/bar";
     /** The testing in-memory file system. */
     private FileSystem jimfs;
     /** The temporary directory for the test. */
-    @TempDir
     private Path tempDir;
 
     /** Set up the test environment before each test. */
     @BeforeEach
-    void setup() {
+    void setup() throws IOException {
         // Initialize the in-memory file system
         jimfs = Jimfs.newFileSystem(Configuration.unix());
+        tempDir = jimfs.getPath("/blocks");
+        Files.createDirectories(tempDir);
     }
 
     /** Tear down the test environment after each test. */
@@ -228,11 +227,11 @@ class BlockPathTest {
                 final long blockNumber,
                 final CompressionType expectedCompressionType,
                 final int digitsPerZipFileContents) {
-            final Path expectedZipFilePath = jimfs.getPath(ROOT_PATH + expectedRelativeZipFilePathStr);
+            final Path expectedZipFilePath = jimfs.getPath(tempDir + expectedRelativeZipFilePathStr);
             final Path expectedDirPath = expectedZipFilePath.getParent();
             // create the config to use for the test, resolve paths with jimfs
-            final FilesHistoricConfig testConfig = new FilesHistoricConfig(
-                    jimfs.getPath(ROOT_PATH), expectedCompressionType, digitsPerZipFileContents);
+            final FilesHistoricConfig testConfig =
+                    new FilesHistoricConfig(tempDir, expectedCompressionType, digitsPerZipFileContents);
             final BlockPath actual = BlockPath.computeBlockPath(testConfig, blockNumber);
             assertThat(actual)
                     .isNotNull()


### PR DESCRIPTION
## Reviewer Notes

- migrating from `ZipFile` to using the zip filesystem
- migrating tests to support the switch

## Related Issue(s)

Closes #741
