### PR TITLE
refactor: Suites Must Not Use Services Build Files Directly

### DIFF
--- a/block-node/app/build.gradle.kts
+++ b/block-node/app/build.gradle.kts
@@ -86,19 +86,6 @@ val copyDockerFolder: TaskProvider<Copy> =
         into(dockerBuildRootDirectory)
     }
 
-// @todo(#343) - createProductionDotEnv is temporary and used by the suites,
-//  once the suites no longer rely on the .env file from the build root we
-//  should remove this task
-val createProductionDotEnv: TaskProvider<Exec> =
-    tasks.register<Exec>("createProductionDotEnv") {
-        description = "Creates the default dotenv file for the Block Node Server"
-        group = "docker"
-
-        dependsOn(copyDockerFolder)
-        workingDir(dockerBuildRootDirectory)
-        commandLine("sh", "-c", "./update-env.sh ${project.version} false false")
-    }
-
 val createDockerImage: TaskProvider<Exec> =
     tasks.register<Exec>("createDockerImage") {
         description =

--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -68,7 +68,6 @@ dependencies.constraints {
 
     // Testing only versions
     api("com.github.docker-java:docker-java-api:3.5.1") { because("com.github.dockerjava.api") }
-    api("io.github.cdimascio:dotenv-java:3.2.0") { because("io.github.cdimascio.dotenv.java") }
     api("org.assertj:assertj-core:3.27.3") { because("org.assertj.core") }
     api("org.junit.jupiter:junit-jupiter-api:5.12.2") { because("org.junit.jupiter.api") }
     api("org.mockito:mockito-core:${mockitoVersion}") { because("org.mockito") }

--- a/suites/build.gradle.kts
+++ b/suites/build.gradle.kts
@@ -24,10 +24,9 @@ tasks.register<Test>("runSuites") {
     group = "suites"
     modularity.inferModulePath = false
 
-    // @todo(#343) - :server:createProductionDotEnv should disappear
     // @todo(#813) All of the docker processing belongs here, not in block-node-app.
     //    This might mean duplication, which is perfectly fine.
-    dependsOn(":block-node-app:createDockerImage", ":block-node-app:createProductionDotEnv")
+    dependsOn(":block-node-app:createDockerImage")
 
     useJUnitPlatform()
     testLogging { events("passed", "skipped", "failed") }


### PR DESCRIPTION
## Reviewer Notes

- this was made redundant during our refactor we did recently
- minor cleanup is due

## Related Issue(s)

Closes #343 
