### PR TITLE
chore: #1159 Fix incorrect timeout for publisher

### DIFF
--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfig.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfig.java
@@ -17,7 +17,7 @@ import org.hiero.block.node.base.Loggable;
 @ConfigData("producer")
 public record PublisherConfig(
         @Loggable @ConfigProperty(defaultValue = "PRODUCTION") PublisherType type,
-        @Loggable @ConfigProperty(defaultValue = "1500") @Min(1) int timeoutThresholdMillis) {
+        @Loggable @ConfigProperty(defaultValue = "8000") @Min(2000) int timeoutThresholdMillis) {
     /**
      * The type of the publisher service to use - PRODUCTION or NO_OP.
      */


### PR DESCRIPTION
## Reviewer Notes
* Increased the default timeout to account for block proof delays and block interleave in a multi-publisher scenario.

## Related Issue(s)
 Resolves #1159.
