### PR TITLE
build: change publishing to use maven central publishing portal

### DIFF
--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -215,7 +215,7 @@ jobs:
         env:
           NEXUS_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        run: ${GRADLE_EXEC} :block-node-protobuf-sources:releaseMavenCentral -PpublishingPackageGroup=org.hiero.block -PpublishSigningEnabled=true --scan --no-configuration-cache
+        run: ./gradlew publishAggregationToCentralPortal -PpublishSigningEnabled=true
 
   publish-simulator:
     timeout-minutes: 30

--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins {
+    id("org.hiero.gradle.feature.publish-maven-central-aggregation")
     id("org.hiero.gradle.report.code-coverage")
     id("org.hiero.gradle.check.spotless")
     id("org.hiero.gradle.check.spotless-kotlin")
 }
 
 dependencies {
+    published(project(":block-node-protobuf-sources"))
+
     implementation(project(":block-node-app"))
     implementation(project(":simulator"))
     implementation(project(":suites"))


### PR DESCRIPTION
## Reviewer Notes

This will fix the currently broken _protobuf-sources_ publishing in the pipeline.

In contrast to other repositories (still using the `com.hedera` group) this change can be done now as the `org.hiero` group (used here) is already switched to the new publishing mechanism.

## Related Issue(s)

https://github.com/hiero-ledger/hiero-consensus-node/pull/19567