### PR TITLE
chore: Improving secret handling for BN chart deployments

### DIFF
--- a/charts/block-node-server/templates/deployment.yaml
+++ b/charts/block-node-server/templates/deployment.yaml
@@ -83,8 +83,13 @@ spec:
         envFrom:
           - configMapRef:
               name: {{ include "hiero-block-node.fullname" . }}-config
+          {{ if .Values.blockNode.secret }}
           - secretRef:
-              name: {{ include "hiero-block-node.fullname" . }}-secret
+             name: {{ include "hiero-block-node.fullname" . }}-secret
+          {{ else if .Values.blockNode.secretRef }}
+          - secretRef:
+              name: {{ .Values.blockNode.secretRef }}
+          {{ end }}
         volumeMounts:
           - name: logging-config
             mountPath: {{ .Values.blockNode.logs.configMountPath }}

--- a/charts/block-node-server/templates/secret.yaml
+++ b/charts/block-node-server/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.blockNode.secret }}
 {{- /*
 SPDX-License-Identifier: Apache-2.0
 */}}
@@ -11,3 +12,4 @@ data:
 {{- range $key, $value := .Values.blockNode.secret }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- end}}

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -124,8 +124,11 @@ blockNode:
       # this does not create a PVC.
       # should match PERSISTENCE_STORAGE_UNVERIFIED_ROOT_PATH, leave as is for default.
       mountPath: "/opt/hiero/block-node/data/unverified"
-  secret:
-    PRIVATE_KEY: "fake_private_key"
+  # For secrets, is recommended to use a secretRef to an existing secret on the cluster.
+  # secretRef: secret-name-reference
+  # not recommended to use this, but for testing purposes you can use the following collection for secrets auto-creation
+  # secret:
+  #   EXAMPLE_SECRET: "FAKE EXAMPLE VALUE SECRET"
   health:
     readiness:
       endpoint: "/healthz/readyz"


### PR DESCRIPTION
## Reviewer Notes

Due to how much Operators plan to deploy their BNs the best practice is to pre-create a secret source and then just specify it to the blockNode using a .Values override.

If for testing purposes still desires to create a secret object with entries provided in the collection of values, is still possible but discouraged other than for testing purposes

Fixes #1005