### PR TITLE
fix: typo in quickstart

### DIFF
--- a/docs/block-node/quickstart.md
+++ b/docs/block-node/quickstart.md
@@ -46,7 +46,7 @@ Refer to the [Configuration](../configuration.md) for configuration options.
 3. To build the Server docker image, do the following:
 
    ```bash
-   ./gradlew :block-node:app:createDockerImage
+   ./gradlew :block-node-app:createDockerImage
    ```
 
 ### Run the Server
@@ -54,7 +54,7 @@ Refer to the [Configuration](../configuration.md) for configuration options.
 1. To start the Server, do the following:
 
    ```bash
-   ./gradlew :block-node:app:startDockerContainer
+   ./gradlew :block-node-app:startDockerContainer
    ```
 
 ### Run the Server with Debug
@@ -62,7 +62,7 @@ Refer to the [Configuration](../configuration.md) for configuration options.
 1. To start the Server with debug enabled, do the following:
 
    ```bash
-   ./gradlew :block-node:app:startDockerDebugContainer
+   ./gradlew :block-node-app:startDockerDebugContainer
    ```
 2. Attach your remote jvm debugger to port 5005.
 
@@ -71,5 +71,5 @@ Refer to the [Configuration](../configuration.md) for configuration options.
 1. To stop the Server do the following:
 
    ```bash
-   ./gradlew :block-node:app:stopDockerContainer
+   ./gradlew :block-node-app:stopDockerContainer
    ```


### PR DESCRIPTION
Fix typos in quickstart markdown file

Original command "./gradlew :block-node:app:createDockerImage" lead to error

```

FAILURE: Build failed with an exception.

* What went wrong:
Cannot locate tasks that match ':block-node:app:createDockerImage' as project 'block-node' is ambiguous in root project 'hiero-block-node'. Candidates are: 'block-node-app', 'block-node-base', 'block-node-blocks-file-historic', 'block-node-blocks-file-recent', 'block-node-health', 'block-node-protobuf-pbj', 'block-node-protobuf-sources', 'block-node-s3-archive', 'block-node-server-status', 'block-node-spi-plugins', 'block-node-stream-publisher', 'block-node-stream-subscriber', 'block-node-verification'.

* Try:
> Run gradlew projects to get a list of available projects.
> For more on name expansion, please refer to https://docs.gradle.org/8.14.1/userguide/command_line_interface.html#sec:name_abbreviation in the Gradle documentation.
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.

BUILD FAILED in 908ms
Configuration cache entry stored.
```