### PR TITLE
build: turn :block-node-protobuf-pbj into an alternative to :hapi

### DIFF
--- a/block-node/app/src/testFixtures/java/module-info.java
+++ b/block-node/app/src/testFixtures/java/module-info.java
@@ -5,12 +5,12 @@ module org.hiero.block.node.app.test.fixtures {
     exports org.hiero.block.node.app.fixtures.blocks;
     exports org.hiero.block.node.app.fixtures.plugintest;
 
+    requires com.hedera.node.hapi;
     requires com.hedera.pbj.runtime;
     requires com.swirlds.common;
     requires com.swirlds.config.api;
     requires com.swirlds.metrics.api;
     requires org.hiero.block.node.spi;
-    requires org.hiero.block.protobuf.pbj;
     requires io.helidon.webserver;
     requires java.logging;
     requires org.junit.jupiter.api;

--- a/block-node/base/build.gradle.kts
+++ b/block-node/base/build.gradle.kts
@@ -22,5 +22,5 @@ testModuleInfo {
     requires("org.testcontainers")
     requires("io.minio")
     requires("junit")
-    requires("org.hiero.block.protobuf.pbj")
+    requires("com.hedera.node.hapi")
 }

--- a/block-node/block-access/src/main/java/module-info.java
+++ b/block-node/block-access/src/main/java/module-info.java
@@ -4,8 +4,8 @@ import org.hiero.block.node.access.service.BlockAccessServicePlugin;
 module org.hiero.block.node.access.service {
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    requires transitive com.hedera.node.hapi;
     requires transitive org.hiero.block.node.spi;
-    requires transitive org.hiero.block.protobuf.pbj;
     requires com.hedera.pbj.runtime;
     requires com.swirlds.metrics.api;
 

--- a/block-node/block-providers/files.historic/src/main/java/module-info.java
+++ b/block-node/block-providers/files.historic/src/main/java/module-info.java
@@ -14,10 +14,10 @@ module org.hiero.block.node.blocks.files.historic {
     requires transitive com.swirlds.config.api;
     requires transitive org.hiero.block.node.base;
     requires transitive org.hiero.block.node.spi;
+    requires com.hedera.node.hapi;
     requires com.hedera.pbj.runtime;
     requires com.swirlds.metrics.api;
     requires org.hiero.block.common;
-    requires org.hiero.block.protobuf.pbj;
     requires com.github.spotbugs.annotations;
 
     provides org.hiero.block.node.spi.historicalblocks.BlockProviderPlugin with

--- a/block-node/block-providers/files.recent/src/main/java/module-info.java
+++ b/block-node/block-providers/files.recent/src/main/java/module-info.java
@@ -14,10 +14,10 @@ module org.hiero.block.node.blocks.files.recent {
     requires transitive com.swirlds.config.api;
     requires transitive org.hiero.block.node.base;
     requires transitive org.hiero.block.node.spi;
+    requires com.hedera.node.hapi;
     requires com.hedera.pbj.runtime;
     requires com.swirlds.metrics.api;
     requires org.hiero.block.common;
-    requires org.hiero.block.protobuf.pbj;
     requires com.github.luben.zstd_jni;
     requires com.github.spotbugs.annotations;
 

--- a/block-node/messaging/build.gradle.kts
+++ b/block-node/messaging/build.gradle.kts
@@ -15,7 +15,7 @@ mainModuleInfo {
 
 testModuleInfo {
     requires("com.hedera.pbj.runtime")
-    requires("org.hiero.block.protobuf.pbj")
+    requires("com.hedera.node.hapi")
     requires("java.logging")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")

--- a/block-node/protobuf-pbj/build.gradle.kts
+++ b/block-node/protobuf-pbj/build.gradle.kts
@@ -22,6 +22,17 @@ tasks.javadoc {
     }
 }
 
+// Let Gradle know that this is an 'alternative implementation' of com.hedera.node.hapi
+configurations.apiElements {
+    outgoing.capability("${project.group}:${project.name}:$version") // preserve default capability
+    outgoing.capability("com.hedera.hashgraph:hapi:$version") // original hapi capability
+}
+
+configurations.runtimeElements {
+    outgoing.capability("${project.group}:${project.name}:$version") // preserve default capability
+    outgoing.capability("com.hedera.hashgraph:hapi:$version") // original hapi capability
+}
+
 pbj { generateTestClasses = false }
 
 sourceSets {

--- a/block-node/protobuf-pbj/src/main/java/module-info.java
+++ b/block-node/protobuf-pbj/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-module org.hiero.block.protobuf.pbj {
+module com.hedera.node.hapi {
     exports com.hedera.hapi.block.stream;
     exports com.hedera.hapi.block.stream.input;
     exports com.hedera.hapi.block.stream.output;

--- a/block-node/s3-archive/src/main/java/module-info.java
+++ b/block-node/s3-archive/src/main/java/module-info.java
@@ -13,10 +13,10 @@ module org.hiero.block.node.archive.s3cloud {
 
     requires transitive com.swirlds.config.api;
     requires transitive org.hiero.block.node.spi;
+    requires com.hedera.node.hapi;
     requires com.hedera.pbj.runtime;
     requires org.hiero.block.common;
     requires org.hiero.block.node.base;
-    requires org.hiero.block.protobuf.pbj;
     requires com.github.spotbugs.annotations;
     requires java.management;
     requires java.net.http;

--- a/block-node/server-status/src/main/java/module-info.java
+++ b/block-node/server-status/src/main/java/module-info.java
@@ -4,8 +4,8 @@ import org.hiero.block.node.server.status.ServerStatusServicePlugin;
 module org.hiero.block.node.server.status {
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    requires transitive com.hedera.node.hapi;
     requires transitive org.hiero.block.node.spi;
-    requires transitive org.hiero.block.protobuf.pbj;
     requires com.hedera.pbj.runtime;
     requires com.swirlds.metrics.api;
     requires com.github.spotbugs.annotations;

--- a/block-node/spi/src/main/java/module-info.java
+++ b/block-node/spi/src/main/java/module-info.java
@@ -10,10 +10,10 @@ module org.hiero.block.node.spi {
     uses org.hiero.block.node.spi.historicalblocks.BlockProviderPlugin;
     uses org.hiero.block.node.spi.BlockNodePlugin;
 
+    requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.metrics.api;
-    requires transitive org.hiero.block.protobuf.pbj;
     requires transitive io.helidon.webserver;
     requires com.github.luben.zstd_jni;
     requires static transitive com.github.spotbugs.annotations;

--- a/block-node/stream-publisher/src/main/java/module-info.java
+++ b/block-node/stream-publisher/src/main/java/module-info.java
@@ -11,11 +11,11 @@ module org.hiero.block.node.stream.publisher {
             com.swirlds.config.extensions,
             org.hiero.block.node.app;
 
+    requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.metrics.api;
     requires transitive org.hiero.block.node.spi;
-    requires transitive org.hiero.block.protobuf.pbj;
     requires org.hiero.block.common;
     requires org.hiero.block.node.base;
     requires com.github.spotbugs.annotations;

--- a/block-node/stream-subscriber/src/main/java/module-info.java
+++ b/block-node/stream-subscriber/src/main/java/module-info.java
@@ -11,10 +11,10 @@ module org.hiero.block.node.stream.subscriber {
             com.swirlds.config.extensions,
             org.hiero.block.node.app;
 
+    requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.config.api;
     requires transitive org.hiero.block.node.spi;
-    requires transitive org.hiero.block.protobuf.pbj;
     requires com.swirlds.metrics.api;
     requires org.hiero.block.node.base;
     requires com.github.spotbugs.annotations;

--- a/block-node/verification/src/main/java/module-info.java
+++ b/block-node/verification/src/main/java/module-info.java
@@ -11,11 +11,11 @@ module org.hiero.block.node.verification {
             com.swirlds.config.extensions,
             org.hiero.block.node.app;
 
+    requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.config.api;
     requires transitive org.hiero.block.common;
     requires transitive org.hiero.block.node.spi;
-    requires transitive org.hiero.block.protobuf.pbj;
     requires com.swirlds.metrics.api;
     requires org.hiero.block.node.base;
     requires com.github.spotbugs.annotations;

--- a/common/src/main/java/module-info.java
+++ b/common/src/main/java/module-info.java
@@ -4,8 +4,8 @@ module org.hiero.block.common {
     exports org.hiero.block.common.utils;
     exports org.hiero.block.common.hasher;
 
+    requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;
-    requires transitive org.hiero.block.protobuf.pbj;
     requires com.swirlds.common;
     requires static com.github.spotbugs.annotations;
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,6 +39,16 @@ javaModules {
     }
 }
 
+@Suppress("UnstableApiUsage")
+gradle.lifecycle.beforeProject {
+    // Register resolution strategy for all modules that prefers :block-node-protobuf-pbj over :hapi
+    configurations.configureEach {
+        resolutionStrategy.capabilitiesResolution.withCapability("com.hedera.hashgraph", "hapi") {
+            select(candidates.single { it.id.toString().contains(":block-node-protobuf-pbj") })
+        }
+    }
+}
+
 // @jjohannes: remove once 'swirldsVersion' is updated to '0.63.x' in
 // hiero-dependency-versions/build.gradle.kts
 @Suppress("UnstableApiUsage")

--- a/tools-and-tests/simulator/src/main/java/module-info.java
+++ b/tools-and-tests/simulator/src/main/java/module-info.java
@@ -16,13 +16,13 @@ module org.hiero.block.simulator {
     exports org.hiero.block.simulator.config.logging to
             com.swirlds.config.impl;
 
+    requires com.hedera.node.hapi;
     requires com.hedera.pbj.runtime;
     requires com.swirlds.common;
     requires com.swirlds.config.api;
     requires com.swirlds.config.extensions;
     requires com.swirlds.metrics.api;
     requires org.hiero.block.common;
-    requires org.hiero.block.protobuf.pbj;
     requires org.hiero.block.protobuf.protoc;
     requires com.google.protobuf;
     requires dagger;

--- a/tools-and-tests/tools/build.gradle.kts
+++ b/tools-and-tests/tools/build.gradle.kts
@@ -11,7 +11,7 @@ description = "Hiero Block Stream Tools"
 application { mainClass = "org.hiero.block.tools.BlockStreamTool" }
 
 mainModuleInfo {
-    requires("org.hiero.block.protobuf.pbj")
+    requires("com.hedera.node.hapi")
     requires("com.hedera.pbj.runtime")
     requires("com.github.luben.zstd_jni")
     requires("com.google.api.gax")


### PR DESCRIPTION
Using the same Module Name and Gradle Capabilities, the Modules become interchangeable. If both are on the Module Path, because `:hapi` is referenced transitively, Gradle will resolve the conflict by picking `:block-node-protobuf-pbj` only.

## Reviewer Notes

Resolves #1279 inthe current setup, where Protobuf java files are (re-)generated in multiple modules. 

## Related Issue(s)

Resolves #1279
