### PR TITLE
feat: Simulator Add Publisher Support for EndOfStream Message

### DIFF
--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileBlockStreamManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileBlockStreamManager.java
@@ -92,6 +92,7 @@ public class BlockAsFileBlockStreamManager implements BlockStreamManager {
         return nextBlock;
     }
 
+    // TODO: Implement resetToBlock to reset the actual block not the index
     @Override
     public void resetToBlock(final long block) {
         currentBlockIndex = (int) block;

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileBlockStreamManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileBlockStreamManager.java
@@ -93,8 +93,8 @@ public class BlockAsFileBlockStreamManager implements BlockStreamManager {
     }
 
     @Override
-    public void resetToBlock(Block block) {
-        currentBlockIndex = (int) block.getItems(0).getBlockHeader().getNumber();
+    public void resetToBlock(long block) {
+        currentBlockIndex = (int) block;
     }
 
     private void loadBlocks() throws IOException, ParseException {

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileBlockStreamManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileBlockStreamManager.java
@@ -93,7 +93,7 @@ public class BlockAsFileBlockStreamManager implements BlockStreamManager {
     }
 
     @Override
-    public void resetToBlock(long block) {
+    public void resetToBlock(final long block) {
         currentBlockIndex = (int) block;
     }
 

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileBlockStreamManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileBlockStreamManager.java
@@ -92,6 +92,11 @@ public class BlockAsFileBlockStreamManager implements BlockStreamManager {
         return nextBlock;
     }
 
+    @Override
+    public void resetToBlock(Block block) {
+        currentBlockIndex = (int) block.getItems(0).getBlockHeader().getNumber();
+    }
+
     private void loadBlocks() throws IOException, ParseException {
 
         final Path rootPath = Path.of(rootFolder);

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileBlockStreamManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileBlockStreamManager.java
@@ -92,10 +92,11 @@ public class BlockAsFileBlockStreamManager implements BlockStreamManager {
         return nextBlock;
     }
 
-    // TODO: Implement resetToBlock to reset the actual block not the index
+    // This class will be removed so leaving it like that for now.
     @Override
     public void resetToBlock(final long block) {
         currentBlockIndex = (int) block;
+        lastGivenBlockNumber = (int) block;
     }
 
     private void loadBlocks() throws IOException, ParseException {

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileLargeDataSets.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileLargeDataSets.java
@@ -102,4 +102,9 @@ public class BlockAsFileLargeDataSets implements BlockStreamManager {
 
         return block;
     }
+
+    @Override
+    public void resetToBlock(Block block) {
+        currentBlockIndex = (int) block.getItems(0).getBlockHeader().getNumber();
+    }
 }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileLargeDataSets.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileLargeDataSets.java
@@ -104,7 +104,7 @@ public class BlockAsFileLargeDataSets implements BlockStreamManager {
     }
 
     @Override
-    public void resetToBlock(long block) {
+    public void resetToBlock(final long block) {
         currentBlockIndex = (int) block;
     }
 }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileLargeDataSets.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileLargeDataSets.java
@@ -25,7 +25,7 @@ public class BlockAsFileLargeDataSets implements BlockStreamManager {
 
     // State for getNextBlock()
     private final String blockStreamPath;
-    private int currentBlockIndex;
+    private long currentBlockIndex;
     private final int endBlockNumber;
 
     // State for getNextBlockItem()
@@ -103,9 +103,8 @@ public class BlockAsFileLargeDataSets implements BlockStreamManager {
         return block;
     }
 
-    // TODO: Implement resetToBlock to reset the actual block not the index
     @Override
     public void resetToBlock(final long block) {
-        currentBlockIndex = (int) block;
+        currentBlockIndex = block;
     }
 }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileLargeDataSets.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileLargeDataSets.java
@@ -104,7 +104,7 @@ public class BlockAsFileLargeDataSets implements BlockStreamManager {
     }
 
     @Override
-    public void resetToBlock(Block block) {
-        currentBlockIndex = (int) block.getItems(0).getBlockHeader().getNumber();
+    public void resetToBlock(long block) {
+        currentBlockIndex = (int) block;
     }
 }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileLargeDataSets.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockAsFileLargeDataSets.java
@@ -103,6 +103,7 @@ public class BlockAsFileLargeDataSets implements BlockStreamManager {
         return block;
     }
 
+    // TODO: Implement resetToBlock to reset the actual block not the index
     @Override
     public void resetToBlock(final long block) {
         currentBlockIndex = (int) block;

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockStreamManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockStreamManager.java
@@ -40,5 +40,5 @@ public interface BlockStreamManager {
      */
     Block getNextBlock() throws IOException, BlockSimulatorParsingException;
 
-    void resetToBlock(Block block);
+    void resetToBlock(long block);
 }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockStreamManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockStreamManager.java
@@ -39,4 +39,6 @@ public interface BlockStreamManager {
      * @throws BlockSimulatorParsingException if a parse error occurs
      */
     Block getNextBlock() throws IOException, BlockSimulatorParsingException;
+
+    void resetToBlock(Block block);
 }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockStreamManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/BlockStreamManager.java
@@ -40,5 +40,10 @@ public interface BlockStreamManager {
      */
     Block getNextBlock() throws IOException, BlockSimulatorParsingException;
 
-    void resetToBlock(long block);
+    /**
+     * Reset the block stream manager to a specific block.
+     *
+     * @param block the block number to reset to
+     */
+    void resetToBlock(final long block);
 }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/CraftBlockStreamManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/CraftBlockStreamManager.java
@@ -175,8 +175,8 @@ public class CraftBlockStreamManager implements BlockStreamManager {
     }
 
     @Override
-    public void resetToBlock(Block block) {
-        currentBlockNumber = block.getItems(0).getBlockHeader().getNumber();
+    public void resetToBlock(long block) {
+        currentBlockNumber = block + 1;
     }
 
     private Block createNextBlock() throws BlockSimulatorParsingException {

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/CraftBlockStreamManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/CraftBlockStreamManager.java
@@ -175,7 +175,7 @@ public class CraftBlockStreamManager implements BlockStreamManager {
     }
 
     @Override
-    public void resetToBlock(long block) {
+    public void resetToBlock(final long block) {
         currentBlockNumber = block;
     }
 

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/CraftBlockStreamManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/CraftBlockStreamManager.java
@@ -174,6 +174,11 @@ public class CraftBlockStreamManager implements BlockStreamManager {
         }
     }
 
+    @Override
+    public void resetToBlock(Block block) {
+        currentBlockNumber = block.getItems(0).getBlockHeader().getNumber();
+    }
+
     private Block createNextBlock() throws BlockSimulatorParsingException {
         LOGGER.log(DEBUG, "Started creation of block number %s.".formatted(currentBlockNumber));
         // todo(683) Refactor common hasher to accept protoc types, in order to avoid the additional overhead of keeping

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/CraftBlockStreamManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/CraftBlockStreamManager.java
@@ -176,7 +176,7 @@ public class CraftBlockStreamManager implements BlockStreamManager {
 
     @Override
     public void resetToBlock(long block) {
-        currentBlockNumber = block + 1;
+        currentBlockNumber = block;
     }
 
     private Block createNextBlock() throws BlockSimulatorParsingException {

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/PublishStreamGrpcClient.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/PublishStreamGrpcClient.java
@@ -3,6 +3,8 @@ package org.hiero.block.simulator.grpc;
 
 import com.hedera.hapi.block.stream.protoc.Block;
 import java.util.List;
+import java.util.function.Consumer;
+import org.hiero.block.api.protoc.PublishStreamResponse;
 
 /**
  * The PublishStreamGrpcClient interface provides the methods to stream the block and block item.
@@ -19,7 +21,7 @@ public interface PublishStreamGrpcClient {
      * @param block the block to be streamed
      * @return true if the block is streamed successfully, false otherwise
      */
-    boolean streamBlock(Block block);
+    boolean streamBlock(Block block, Consumer<PublishStreamResponse> publishStreamResponseConsumer);
 
     /**
      * Sends a onCompleted message to the server and waits for a short period of time to ensure the message is sent.

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/PublishStreamGrpcClient.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/PublishStreamGrpcClient.java
@@ -19,6 +19,7 @@ public interface PublishStreamGrpcClient {
      * Streams the block.
      *
      * @param block the block to be streamed
+     * @param publishStreamResponseConsumer the consumer to handle the response
      * @return true if the block is streamed successfully, false otherwise
      */
     boolean streamBlock(Block block, Consumer<PublishStreamResponse> publishStreamResponseConsumer);

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
@@ -18,10 +18,12 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import javax.inject.Inject;
 import org.hiero.block.api.protoc.BlockItemSet;
 import org.hiero.block.api.protoc.BlockStreamPublishServiceGrpc;
 import org.hiero.block.api.protoc.PublishStreamRequest;
+import org.hiero.block.api.protoc.PublishStreamResponse;
 import org.hiero.block.common.utils.ChunkUtils;
 import org.hiero.block.simulator.config.data.BlockStreamConfig;
 import org.hiero.block.simulator.config.data.GrpcConfig;
@@ -54,6 +56,9 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
     private final int lastKnownStatusesCapacity;
     private final Deque<String> lastKnownStatuses;
     private final SimulatorStartupData startupData;
+
+
+    private PublishStreamObserver publishStreamObserver;
 
     /**
      * Creates a new PublishStreamGrpcClientImpl with the specified dependencies.
@@ -91,7 +96,8 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
                 .build();
         final BlockStreamPublishServiceGrpc.BlockStreamPublishServiceStub stub =
                 BlockStreamPublishServiceGrpc.newStub(channel);
-        final PublishStreamObserver publishStreamObserver =
+        streamEnabled.set(true);
+        publishStreamObserver =
                 new PublishStreamObserver(startupData, streamEnabled, lastKnownStatuses, lastKnownStatusesCapacity);
         requestStreamObserver = stub.publishBlockStream(publishStreamObserver);
         lastKnownStatuses.clear();
@@ -104,7 +110,7 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
      * @return true if streaming should continue, false if streaming should stop
      */
     @Override
-    public boolean streamBlock(Block block) {
+    public boolean streamBlock(Block block, @NonNull final Consumer<PublishStreamResponse> publishStreamResponseConsumer) {
         List<List<BlockItem>> streamingBatches =
                 ChunkUtils.chunkify(block.getItemsList(), blockStreamConfig.blockItemsBatchSize());
         for (List<BlockItem> streamingBatch : streamingBatches) {
@@ -121,6 +127,7 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
                         "Number of block items sent: "
                                 + metricsService.get(LiveBlockItemsSent).get());
             } else {
+                publishStreamResponseConsumer.accept(publishStreamObserver.getPublishStreamResponse());
                 LOGGER.log(ERROR, "Not allowed to send next batch of block items");
                 break;
             }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
@@ -57,7 +57,7 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
     private final Deque<String> lastKnownStatuses;
     private final SimulatorStartupData startupData;
 
-    private PublishStreamObserver publishStreamObserver;
+    private final PublishStreamObserver publishStreamObserver;
 
     /**
      * Creates a new PublishStreamGrpcClientImpl with the specified dependencies.
@@ -83,6 +83,8 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
         this.lastKnownStatusesCapacity = blockStreamConfig.lastKnownStatusesCapacity();
         this.lastKnownStatuses = new ArrayDeque<>(this.lastKnownStatusesCapacity);
         this.startupData = requireNonNull(startupData);
+        this.publishStreamObserver =
+                new PublishStreamObserver(startupData, streamEnabled, lastKnownStatuses, lastKnownStatusesCapacity);
     }
 
     /**
@@ -95,8 +97,6 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
                 .build();
         final BlockStreamPublishServiceGrpc.BlockStreamPublishServiceStub stub =
                 BlockStreamPublishServiceGrpc.newStub(channel);
-        publishStreamObserver =
-                new PublishStreamObserver(startupData, streamEnabled, lastKnownStatuses, lastKnownStatusesCapacity);
         requestStreamObserver = stub.publishBlockStream(publishStreamObserver);
         lastKnownStatuses.clear();
     }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
@@ -57,7 +57,6 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
     private final Deque<String> lastKnownStatuses;
     private final SimulatorStartupData startupData;
 
-
     private PublishStreamObserver publishStreamObserver;
 
     /**
@@ -96,7 +95,6 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
                 .build();
         final BlockStreamPublishServiceGrpc.BlockStreamPublishServiceStub stub =
                 BlockStreamPublishServiceGrpc.newStub(channel);
-        streamEnabled.set(true);
         publishStreamObserver =
                 new PublishStreamObserver(startupData, streamEnabled, lastKnownStatuses, lastKnownStatusesCapacity);
         requestStreamObserver = stub.publishBlockStream(publishStreamObserver);
@@ -110,7 +108,8 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
      * @return true if streaming should continue, false if streaming should stop
      */
     @Override
-    public boolean streamBlock(Block block, @NonNull final Consumer<PublishStreamResponse> publishStreamResponseConsumer) {
+    public boolean streamBlock(
+            Block block, @NonNull final Consumer<PublishStreamResponse> publishStreamResponseConsumer) {
         List<List<BlockItem>> streamingBatches =
                 ChunkUtils.chunkify(block.getItemsList(), blockStreamConfig.blockItemsBatchSize());
         for (List<BlockItem> streamingBatch : streamingBatches) {

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamObserver.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamObserver.java
@@ -29,6 +29,8 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
     private final Deque<String> lastKnownStatuses;
     private final SimulatorStartupData startupData;
 
+    private PublishStreamResponse publishStreamResponse;
+
     /**
      * Creates a new PublishStreamObserver instance.
      *
@@ -73,10 +75,15 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
         } else if (publishStreamResponse.hasSkipBlock()) {
             // TODO handle skip block response
         } else if (publishStreamResponse.hasEndStream()) {
-            // TODO handle end of stream response
+            streamEnabled.set(false);
+            this.publishStreamResponse = publishStreamResponse;
         }
         lastKnownStatuses.add(publishStreamResponse.toString());
         LOGGER.log(INFO, "Received Response: " + publishStreamResponse);
+    }
+
+    public PublishStreamResponse getPublishStreamResponse() {
+        return publishStreamResponse;
     }
 
     /**

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamObserver.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamObserver.java
@@ -82,6 +82,11 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
         LOGGER.log(INFO, "Received Response: " + publishStreamResponse);
     }
 
+    /**
+     * Returns the last received PublishStreamResponse.
+     *
+     * @return the last PublishStreamResponse received
+     */
     public PublishStreamResponse getPublishStreamResponse() {
         return publishStreamResponse;
     }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamObserver.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamObserver.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Deque;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.hiero.block.api.protoc.PublishStreamResponse;
 import org.hiero.block.api.protoc.PublishStreamResponse.BlockAcknowledgement;
 import org.hiero.block.simulator.startup.SimulatorStartupData;
@@ -29,7 +30,7 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
     private final Deque<String> lastKnownStatuses;
     private final SimulatorStartupData startupData;
 
-    private PublishStreamResponse publishStreamResponse;
+    private final AtomicReference<PublishStreamResponse> publishStreamResponse = new AtomicReference<>();
 
     /**
      * Creates a new PublishStreamObserver instance.
@@ -76,7 +77,7 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
             // TODO handle skip block response
         } else if (publishStreamResponse.hasEndStream()) {
             streamEnabled.set(false);
-            this.publishStreamResponse = publishStreamResponse;
+            this.publishStreamResponse.set(publishStreamResponse);
         }
         lastKnownStatuses.add(publishStreamResponse.toString());
         LOGGER.log(INFO, "Received Response: " + publishStreamResponse);
@@ -88,7 +89,7 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
      * @return the last PublishStreamResponse received
      */
     public PublishStreamResponse getPublishStreamResponse() {
-        return publishStreamResponse;
+        return publishStreamResponse.get();
     }
 
     /**

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/SimulatorModeInjectionModule.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/SimulatorModeInjectionModule.java
@@ -5,8 +5,10 @@ import com.swirlds.config.api.Configuration;
 import dagger.Module;
 import dagger.Provides;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Singleton;
 import org.hiero.block.simulator.config.data.BlockStreamConfig;
+import org.hiero.block.simulator.config.data.GrpcConfig;
 import org.hiero.block.simulator.config.types.SimulatorMode;
 import org.hiero.block.simulator.generator.BlockStreamManager;
 import org.hiero.block.simulator.grpc.ConsumerStreamGrpcClient;
@@ -17,6 +19,7 @@ import org.hiero.block.simulator.mode.impl.ConsumerModeHandler;
 import org.hiero.block.simulator.mode.impl.PublishClientManager;
 import org.hiero.block.simulator.mode.impl.PublisherClientModeHandler;
 import org.hiero.block.simulator.mode.impl.PublisherServerModeHandler;
+import org.hiero.block.simulator.startup.SimulatorStartupData;
 
 @Module
 public interface SimulatorModeInjectionModule {
@@ -29,14 +32,17 @@ public interface SimulatorModeInjectionModule {
             @NonNull PublishStreamGrpcServer publishStreamGrpcServer,
             @NonNull ConsumerStreamGrpcClient consumerStreamGrpcClient,
             @NonNull MetricsService metricsService,
-            @NonNull PublishClientManager publishClientManager) {
+            @NonNull PublishClientManager publishClientManager,
+            @NonNull final SimulatorStartupData startupData,
+            @NonNull final AtomicBoolean streamEnabled) {
 
         final BlockStreamConfig blockStreamConfig = configuration.getConfigData(BlockStreamConfig.class);
+        final GrpcConfig grpcConfig = configuration.getConfigData(GrpcConfig.class);
         final SimulatorMode simulatorMode = blockStreamConfig.simulatorMode();
         return switch (simulatorMode) {
             case PUBLISHER_CLIENT ->
-                new PublisherClientModeHandler(
-                        blockStreamConfig, blockStreamManager, metricsService, publishClientManager);
+                new PublishClientManager(
+                        grpcConfig, blockStreamConfig, blockStreamManager, metricsService, startupData, streamEnabled, publishClientManager.getCurrentClient(), publishClientManager.getCurrentHandler());
             case PUBLISHER_SERVER -> new PublisherServerModeHandler(publishStreamGrpcServer);
             case CONSUMER -> new ConsumerModeHandler(consumerStreamGrpcClient);
         };

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/SimulatorModeInjectionModule.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/SimulatorModeInjectionModule.java
@@ -14,6 +14,7 @@ import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
 import org.hiero.block.simulator.grpc.PublishStreamGrpcServer;
 import org.hiero.block.simulator.metrics.MetricsService;
 import org.hiero.block.simulator.mode.impl.ConsumerModeHandler;
+import org.hiero.block.simulator.mode.impl.PublishClientManager;
 import org.hiero.block.simulator.mode.impl.PublisherClientModeHandler;
 import org.hiero.block.simulator.mode.impl.PublisherServerModeHandler;
 
@@ -25,17 +26,17 @@ public interface SimulatorModeInjectionModule {
     static SimulatorModeHandler providesSimulatorModeHandler(
             @NonNull Configuration configuration,
             @NonNull BlockStreamManager blockStreamManager,
-            @NonNull PublishStreamGrpcClient publishStreamGrpcClient,
             @NonNull PublishStreamGrpcServer publishStreamGrpcServer,
             @NonNull ConsumerStreamGrpcClient consumerStreamGrpcClient,
-            @NonNull MetricsService metricsService) {
+            @NonNull MetricsService metricsService,
+            @NonNull PublishClientManager publishClientManager) {
 
         final BlockStreamConfig blockStreamConfig = configuration.getConfigData(BlockStreamConfig.class);
         final SimulatorMode simulatorMode = blockStreamConfig.simulatorMode();
         return switch (simulatorMode) {
             case PUBLISHER_CLIENT ->
                 new PublisherClientModeHandler(
-                        blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+                        blockStreamConfig, blockStreamManager, metricsService, publishClientManager);
             case PUBLISHER_SERVER -> new PublisherServerModeHandler(publishStreamGrpcServer);
             case CONSUMER -> new ConsumerModeHandler(consumerStreamGrpcClient);
         };

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/SimulatorModeInjectionModule.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/SimulatorModeInjectionModule.java
@@ -12,12 +12,10 @@ import org.hiero.block.simulator.config.data.GrpcConfig;
 import org.hiero.block.simulator.config.types.SimulatorMode;
 import org.hiero.block.simulator.generator.BlockStreamManager;
 import org.hiero.block.simulator.grpc.ConsumerStreamGrpcClient;
-import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
 import org.hiero.block.simulator.grpc.PublishStreamGrpcServer;
 import org.hiero.block.simulator.metrics.MetricsService;
 import org.hiero.block.simulator.mode.impl.ConsumerModeHandler;
 import org.hiero.block.simulator.mode.impl.PublishClientManager;
-import org.hiero.block.simulator.mode.impl.PublisherClientModeHandler;
 import org.hiero.block.simulator.mode.impl.PublisherServerModeHandler;
 import org.hiero.block.simulator.startup.SimulatorStartupData;
 
@@ -42,7 +40,14 @@ public interface SimulatorModeInjectionModule {
         return switch (simulatorMode) {
             case PUBLISHER_CLIENT ->
                 new PublishClientManager(
-                        grpcConfig, blockStreamConfig, blockStreamManager, metricsService, startupData, streamEnabled, publishClientManager.getCurrentClient(), publishClientManager.getCurrentHandler());
+                        grpcConfig,
+                        blockStreamConfig,
+                        blockStreamManager,
+                        metricsService,
+                        startupData,
+                        streamEnabled,
+                        publishClientManager.getCurrentClient(),
+                        publishClientManager.getCurrentHandler());
             case PUBLISHER_SERVER -> new PublisherServerModeHandler(publishStreamGrpcServer);
             case CONSUMER -> new ConsumerModeHandler(consumerStreamGrpcClient);
         };

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/SimulatorModeInjectionModule.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/SimulatorModeInjectionModule.java
@@ -31,8 +31,8 @@ public interface SimulatorModeInjectionModule {
             @NonNull ConsumerStreamGrpcClient consumerStreamGrpcClient,
             @NonNull MetricsService metricsService,
             @NonNull PublishClientManager publishClientManager,
-            @NonNull final SimulatorStartupData startupData,
-            @NonNull final AtomicBoolean streamEnabled) {
+            @NonNull SimulatorStartupData startupData,
+            @NonNull AtomicBoolean streamEnabled) {
 
         final BlockStreamConfig blockStreamConfig = configuration.getConfigData(BlockStreamConfig.class);
         final GrpcConfig grpcConfig = configuration.getConfigData(GrpcConfig.class);

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
@@ -70,7 +70,7 @@ public class PublishClientManager implements SimulatorModeHandler {
         currentClient = new PublishStreamGrpcClientImpl(
                 grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupData);
         currentHandler =
-                new PublisherClientModeHandler(blockStreamConfig, blockStreamManager, metricsService, currentClient);
+                new PublisherClientModeHandler(blockStreamConfig, currentClient, blockStreamManager, metricsService);
 
         currentHandler.setPublishClientManager(this);
         currentHandler.init();

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Inject;
 import org.hiero.block.api.protoc.PublishStreamResponse;
-import org.hiero.block.api.protoc.PublishStreamResponse.EndOfStream.Code;
 import org.hiero.block.simulator.config.data.BlockStreamConfig;
 import org.hiero.block.simulator.config.data.GrpcConfig;
 import org.hiero.block.simulator.exception.BlockSimulatorParsingException;
@@ -84,13 +83,7 @@ public class PublishClientManager implements SimulatorModeHandler {
     private void adjustStreamManager(Block nextBlock, PublishStreamResponse publishStreamResponse) {
         if (nextBlock != null) {
             long blockNumber = publishStreamResponse.getEndStream().getBlockNumber();
-            Code status = publishStreamResponse.getEndStream().getStatus();
-
-            switch (status) {
-                case TIMEOUT, BAD_BLOCK_PROOF -> blockStreamManager.resetToBlock(blockNumber - 1);
-                case BEHIND, DUPLICATE_BLOCK, SUCCESS -> blockStreamManager.resetToBlock(blockNumber + 1);
-                case INTERNAL_ERROR, PERSISTENCE_FAILED -> blockStreamManager.resetToBlock(blockNumber);
-            }
+            blockStreamManager.resetToBlock(blockNumber + 1);
         }
     }
 

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
@@ -51,22 +51,16 @@ public class PublishClientManager {
 
     private void initializeNewClientAndHandler(Block nextBlock) {
         currentClient = new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupData);
-        currentClient.init();
 
         currentHandler = new PublisherClientModeHandler(
                 blockStreamConfig, blockStreamManager, metricsService, this);
+        currentHandler.init();
         if (nextBlock != null) {
             blockStreamManager.resetToBlock(nextBlock);
         }
     }
 
     public void handleEndStream(Block nextBlock) throws InterruptedException {
-        try {
-            currentHandler.stop();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-
         initializeNewClientAndHandler(nextBlock);
 
         try {

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
@@ -87,18 +87,21 @@ public class PublishClientManager implements SimulatorModeHandler {
         }
     }
 
-    public void handleEndStream(Block nextBlock, PublishStreamResponse publishStreamResponse) {
+    public void handleResponse(Block nextBlock, PublishStreamResponse publishStreamResponse) {
+        if (publishStreamResponse.hasEndStream()) {
+            handleEndStream(nextBlock, publishStreamResponse);
+        } else {
+            throw new IllegalArgumentException("Unknown PublishStreamResponse type: " + publishStreamResponse);
+        }
+    }
+
+    private void handleEndStream(Block nextBlock, PublishStreamResponse publishStreamResponse) {
         try {
             stop();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+            initializeNewClientAndHandler(nextBlock, publishStreamResponse);
 
-        initializeNewClientAndHandler(nextBlock, publishStreamResponse);
-
-        try {
-            currentHandler.start();
-        } catch (Exception e) {
+            start();
+        } catch (BlockSimulatorParsingException | IOException | InterruptedException e) {
             throw new RuntimeException("Failed to restart handler", e);
         }
     }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
@@ -1,0 +1,86 @@
+package org.hiero.block.simulator.mode.impl;
+
+import static java.lang.System.Logger.Level.INFO;
+
+import com.hedera.hapi.block.stream.protoc.Block;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.inject.Inject;
+import org.hiero.block.simulator.config.data.BlockStreamConfig;
+import org.hiero.block.simulator.config.data.GrpcConfig;
+import org.hiero.block.simulator.generator.BlockStreamManager;
+import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
+import org.hiero.block.simulator.grpc.impl.PublishStreamGrpcClientImpl;
+import org.hiero.block.simulator.metrics.MetricsService;
+import org.hiero.block.simulator.startup.SimulatorStartupData;
+
+public class PublishClientManager {
+    private final BlockStreamConfig blockStreamConfig;
+    private final BlockStreamManager blockStreamManager;
+    private final MetricsService metricsService;
+    private final GrpcConfig grpcConfig;
+    private final SimulatorStartupData startupData;
+    private final AtomicBoolean streamEnabled;
+
+
+    private PublishStreamGrpcClient currentClient;
+    private PublisherClientModeHandler currentHandler;
+
+    @Inject
+    public PublishClientManager(
+            @NonNull final GrpcConfig grpcConfig,
+            @NonNull final BlockStreamConfig blockStreamConfig,
+            @NonNull final BlockStreamManager blockStreamManager,
+            @NonNull final MetricsService metricsService,
+            @NonNull final SimulatorStartupData startupData,
+            @NonNull final AtomicBoolean streamEnabled,
+            @NonNull final PublishStreamGrpcClient publishStreamGrpcClient) {
+        this.grpcConfig = grpcConfig;
+        this.blockStreamConfig = blockStreamConfig;
+        this.blockStreamManager = blockStreamManager;
+        this.metricsService = metricsService;
+        this.startupData = startupData;
+        this.streamEnabled = streamEnabled;
+        this.currentClient = publishStreamGrpcClient;
+    }
+
+    public void init() {
+        blockStreamManager.init();
+        currentClient.init();
+    }
+
+    private void initializeNewClientAndHandler(Block nextBlock) {
+        currentClient = new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupData);
+        currentClient.init();
+
+        currentHandler = new PublisherClientModeHandler(
+                blockStreamConfig, blockStreamManager, metricsService, this);
+        if (nextBlock != null) {
+            blockStreamManager.resetToBlock(nextBlock);
+        }
+    }
+
+    public void handleEndStream(Block nextBlock) throws InterruptedException {
+        try {
+            currentHandler.stop();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        initializeNewClientAndHandler(nextBlock);
+
+        try {
+            currentHandler.start();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to restart handler", e);
+        }
+    }
+
+    public PublisherClientModeHandler getCurrentHandler() {
+        return currentHandler;
+    }
+
+    public PublishStreamGrpcClient getCurrentClient() {
+        return currentClient;
+    }
+}

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
@@ -78,13 +78,12 @@ public class PublishClientManager implements SimulatorModeHandler {
         if (nextBlock != null) {
             long blockNumber = publishStreamResponse.getEndStream().getBlockNumber();
             Code status = publishStreamResponse.getEndStream().getStatus();
-            if (status == Code.TIMEOUT || status == Code.BAD_BLOCK_PROOF) {
-                blockStreamManager.resetToBlock(blockNumber - 1);
-            } else if (status == Code.BEHIND) {
-                blockStreamManager.resetToBlock(blockNumber + 1);
-            }
 
-            blockStreamManager.resetToBlock(blockNumber);
+            switch (status) {
+                case TIMEOUT, BAD_BLOCK_PROOF -> blockStreamManager.resetToBlock(blockNumber - 1);
+                case BEHIND, DUPLICATE_BLOCK, SUCCESS -> blockStreamManager.resetToBlock(blockNumber + 1);
+                case INTERNAL_ERROR, PERSISTENCE_FAILED -> blockStreamManager.resetToBlock(blockNumber);
+            }
         }
     }
 

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
@@ -2,24 +2,27 @@ package org.hiero.block.simulator.mode.impl;
 
 import com.hedera.hapi.block.stream.protoc.Block;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Inject;
 import org.hiero.block.api.protoc.PublishStreamResponse;
 import org.hiero.block.simulator.config.data.BlockStreamConfig;
 import org.hiero.block.simulator.config.data.GrpcConfig;
+import org.hiero.block.simulator.exception.BlockSimulatorParsingException;
 import org.hiero.block.simulator.generator.BlockStreamManager;
 import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
 import org.hiero.block.simulator.grpc.impl.PublishStreamGrpcClientImpl;
 import org.hiero.block.simulator.metrics.MetricsService;
+import org.hiero.block.simulator.mode.SimulatorModeHandler;
 import org.hiero.block.simulator.startup.SimulatorStartupData;
 
-public class PublishClientManager {
+public class PublishClientManager implements SimulatorModeHandler {
     private final BlockStreamConfig blockStreamConfig;
     private final BlockStreamManager blockStreamManager;
     private final MetricsService metricsService;
     private final GrpcConfig grpcConfig;
     private final SimulatorStartupData startupData;
-    private final AtomicBoolean streamEnabled;
+    private AtomicBoolean streamEnabled;
 
 
     private PublishStreamGrpcClient currentClient;
@@ -33,7 +36,8 @@ public class PublishClientManager {
             @NonNull final MetricsService metricsService,
             @NonNull final SimulatorStartupData startupData,
             @NonNull final AtomicBoolean streamEnabled,
-            @NonNull final PublishStreamGrpcClient publishStreamGrpcClient) {
+            @NonNull final PublishStreamGrpcClient publishStreamGrpcClient,
+            @NonNull final PublisherClientModeHandler publisherClientModeHandler) {
         this.grpcConfig = grpcConfig;
         this.blockStreamConfig = blockStreamConfig;
         this.blockStreamManager = blockStreamManager;
@@ -41,6 +45,8 @@ public class PublishClientManager {
         this.startupData = startupData;
         this.streamEnabled = streamEnabled;
         this.currentClient = publishStreamGrpcClient;
+        this.currentHandler = publisherClientModeHandler;
+        currentHandler.setPublishClientManager(this);
     }
 
     public void init() {
@@ -48,11 +54,25 @@ public class PublishClientManager {
         currentClient.init();
     }
 
+    @Override
+    public void start() throws BlockSimulatorParsingException, IOException, InterruptedException {
+
+        currentHandler.start();
+
+    }
+
+    @Override
+    public void stop() throws InterruptedException {
+        currentHandler.stop();
+    }
+
     private void initializeNewClientAndHandler(Block nextBlock, PublishStreamResponse publishStreamResponse) {
+        streamEnabled = new AtomicBoolean(true);
         currentClient = new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupData);
 
         currentHandler = new PublisherClientModeHandler(
-                blockStreamConfig, blockStreamManager, metricsService, this);
+                blockStreamConfig, blockStreamManager, metricsService, currentClient);
+        currentHandler.setPublishClientManager(this);
         currentHandler.init();
         if (nextBlock != null) {
             blockStreamManager.resetToBlock(publishStreamResponse.getEndStream().getBlockNumber());

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
@@ -1,11 +1,10 @@
 package org.hiero.block.simulator.mode.impl;
 
-import static java.lang.System.Logger.Level.INFO;
-
 import com.hedera.hapi.block.stream.protoc.Block;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Inject;
+import org.hiero.block.api.protoc.PublishStreamResponse;
 import org.hiero.block.simulator.config.data.BlockStreamConfig;
 import org.hiero.block.simulator.config.data.GrpcConfig;
 import org.hiero.block.simulator.generator.BlockStreamManager;
@@ -49,19 +48,19 @@ public class PublishClientManager {
         currentClient.init();
     }
 
-    private void initializeNewClientAndHandler(Block nextBlock) {
+    private void initializeNewClientAndHandler(Block nextBlock, PublishStreamResponse publishStreamResponse) {
         currentClient = new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupData);
 
         currentHandler = new PublisherClientModeHandler(
                 blockStreamConfig, blockStreamManager, metricsService, this);
         currentHandler.init();
         if (nextBlock != null) {
-            blockStreamManager.resetToBlock(nextBlock);
+            blockStreamManager.resetToBlock(publishStreamResponse.getEndStream().getBlockNumber());
         }
     }
 
-    public void handleEndStream(Block nextBlock) throws InterruptedException {
-        initializeNewClientAndHandler(nextBlock);
+    public void handleEndStream(Block nextBlock, PublishStreamResponse publishStreamResponse)  {
+        initializeNewClientAndHandler(nextBlock, publishStreamResponse);
 
         try {
             currentHandler.start();

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
@@ -65,22 +65,20 @@ public class PublishClientManager implements SimulatorModeHandler {
         currentHandler.stop();
     }
 
-    public void handleResponse(Block nextBlock, PublishStreamResponse publishStreamResponse) {
+    public void handleResponse(Block nextBlock, PublishStreamResponse publishStreamResponse)
+            throws BlockSimulatorParsingException, IOException, InterruptedException {
         if (publishStreamResponse.hasEndStream()) {
             handleEndStream(nextBlock, publishStreamResponse);
         }
     }
 
-    private void handleEndStream(Block nextBlock, PublishStreamResponse publishStreamResponse) {
-        try {
-            stop();
-            adjustStreamManager(nextBlock, publishStreamResponse);
-            initializeNewClientAndHandler();
+    private void handleEndStream(Block nextBlock, PublishStreamResponse publishStreamResponse)
+            throws InterruptedException, BlockSimulatorParsingException, IOException {
+        stop();
+        adjustStreamManager(nextBlock, publishStreamResponse);
+        initializeNewClientAndHandler();
 
-            start();
-        } catch (BlockSimulatorParsingException | IOException | InterruptedException e) {
-            throw new RuntimeException("Failed to restart handler", e);
-        }
+        start();
     }
 
     private void adjustStreamManager(Block nextBlock, PublishStreamResponse publishStreamResponse) {

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
@@ -52,7 +52,7 @@ public class PublisherClientModeHandler implements SimulatorModeHandler {
     // State fields
     private final AtomicBoolean shouldPublish;
 
-    PublishClientManager publishClientManager;
+    private PublishClientManager publishClientManager;
 
     /**
      * Constructs a new {@code PublisherModeHandler} with the specified dependencies.
@@ -112,8 +112,8 @@ public class PublisherClientModeHandler implements SimulatorModeHandler {
 
     private void millisPerBlockStreaming() throws IOException, InterruptedException, BlockSimulatorParsingException {
         final long secondsPerBlockNanos = (long) millisecondsPerBlock * NANOS_PER_MILLI;
-        AtomicReference<PublishStreamResponse> publishStreamResponseAtomicReference = new AtomicReference<>();
-        Consumer<PublishStreamResponse> publishStreamResponseConsumer = publishStreamResponseAtomicReference::set;
+        final AtomicReference<PublishStreamResponse> publishStreamResponseAtomicReference = new AtomicReference<>();
+        final Consumer<PublishStreamResponse> publishStreamResponseConsumer = publishStreamResponseAtomicReference::set;
 
         Block nextBlock = blockStreamManager.getNextBlock();
         while (nextBlock != null && shouldPublish.get()) {
@@ -192,6 +192,11 @@ public class PublisherClientModeHandler implements SimulatorModeHandler {
         publishStreamGrpcClient.shutdown();
     }
 
+    /**
+     * Sets the {@link PublishClientManager} instance to be used by this handler.
+     *
+     * @param publishClientManager The {@link PublishClientManager} instance to set.
+     */
     public void setPublishClientManager(PublishClientManager publishClientManager) {
         this.publishClientManager = publishClientManager;
     }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
@@ -123,8 +123,8 @@ public class PublisherClientModeHandler implements SimulatorModeHandler {
                 PublishStreamResponse publishStreamResponse = publishStreamResponseAtomicReference.get();
                 if (publishStreamResponse != null) {
                     publishClientManager.handleEndStream(nextBlock, publishStreamResponse);
-                    break;
                 }
+                break;
             }
 
             long elapsedTime = System.nanoTime() - startTime;

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
@@ -49,11 +49,12 @@ public class PublisherClientModeHandler implements SimulatorModeHandler {
     // State fields
     private final AtomicBoolean shouldPublish;
 
+    PublishClientManager publishClientManager;
+
     /**
      * Constructs a new {@code PublisherModeHandler} with the specified dependencies.
      *
      * @param blockStreamConfig       The configuration for block streaming parameters
-     * @param publishStreamGrpcClient The client for publishing blocks via gRPC
      * @param blockStreamManager      The manager responsible for block generation
      * @param metricsService          The service for recording metrics
      * @throws NullPointerException if any parameter is null
@@ -61,11 +62,11 @@ public class PublisherClientModeHandler implements SimulatorModeHandler {
     @Inject
     public PublisherClientModeHandler(
             @NonNull final BlockStreamConfig blockStreamConfig,
-            @NonNull final PublishStreamGrpcClient publishStreamGrpcClient,
             @NonNull final BlockStreamManager blockStreamManager,
-            @NonNull final MetricsService metricsService) {
+            @NonNull final MetricsService metricsService,
+            @NonNull final PublishClientManager publishClientManager) {
         this.blockStreamConfig = requireNonNull(blockStreamConfig);
-        this.publishStreamGrpcClient = requireNonNull(publishStreamGrpcClient);
+        this.publishStreamGrpcClient = requireNonNull(publishClientManager.getCurrentClient());
         this.blockStreamManager = requireNonNull(blockStreamManager);
         this.metricsService = requireNonNull(metricsService);
 
@@ -73,6 +74,7 @@ public class PublisherClientModeHandler implements SimulatorModeHandler {
         delayBetweenBlockItems = blockStreamConfig.delayBetweenBlockItems();
         millisecondsPerBlock = blockStreamConfig.millisecondsPerBlock();
         shouldPublish = new AtomicBoolean(true);
+        this.publishClientManager = requireNonNull(publishClientManager);
     }
 
     public void init() {

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
@@ -122,7 +122,7 @@ public class PublisherClientModeHandler implements SimulatorModeHandler {
             if (!publishStreamGrpcClient.streamBlock(nextBlock, publishStreamResponseConsumer)) {
                 PublishStreamResponse publishStreamResponse = publishStreamResponseAtomicReference.get();
                 if (publishStreamResponse != null) {
-                    publishClientManager.handleEndStream(nextBlock, publishStreamResponse);
+                    publishClientManager.handleResponse(nextBlock, publishStreamResponse);
                 }
                 break;
             }
@@ -171,7 +171,7 @@ public class PublisherClientModeHandler implements SimulatorModeHandler {
             if (!publishStreamGrpcClient.streamBlock(block, publishStreamResponseConsumer)) {
                 PublishStreamResponse publishStreamResponse = publishStreamResponseAtomicReference.get();
                 if (publishStreamResponse != null) {
-                    publishClientManager.handleEndStream(block, publishStreamResponse);
+                    publishClientManager.handleResponse(block, publishStreamResponse);
                 }
                 break;
             }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
@@ -114,9 +114,13 @@ public class PublisherClientModeHandler implements SimulatorModeHandler {
         Block nextBlock = blockStreamManager.getNextBlock();
         while (nextBlock != null && shouldPublish.get()) {
             long startTime = System.nanoTime();
-            if (!publishStreamGrpcClient.streamBlock(nextBlock)) {
-                LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator stopped streaming due to errors.");
-                break;
+            if (publishStreamGrpcClient.streamBlock(nextBlock)) {
+                // We need break here to exit
+                stop();
+                publishClientManager.handleEndStream(nextBlock);
+                return;
+//                LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator stopped streaming due to errors.");
+//                break;
             }
 
             long elapsedTime = System.nanoTime() - startTime;

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
@@ -169,7 +169,11 @@ public class PublisherClientModeHandler implements SimulatorModeHandler {
                 break;
             }
             if (!publishStreamGrpcClient.streamBlock(block, publishStreamResponseConsumer)) {
-                LOGGER.log(INFO, "Block Stream Simulator stopped streaming due to errors.");
+                PublishStreamResponse publishStreamResponse = publishStreamResponseAtomicReference.get();
+                if (publishStreamResponse != null) {
+                    LOGGER.log(INFO, "Block Stream Simulator failed to stream block: ");
+                    publishClientManager.handleEndStream(block, publishStreamResponse);
+                }
                 break;
             }
 

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
@@ -171,7 +171,6 @@ public class PublisherClientModeHandler implements SimulatorModeHandler {
             if (!publishStreamGrpcClient.streamBlock(block, publishStreamResponseConsumer)) {
                 PublishStreamResponse publishStreamResponse = publishStreamResponseAtomicReference.get();
                 if (publishStreamResponse != null) {
-                    LOGGER.log(INFO, "Block Stream Simulator failed to stream block: ");
                     publishClientManager.handleEndStream(block, publishStreamResponse);
                 }
                 break;

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublisherClientModeHandler.java
@@ -58,6 +58,7 @@ public class PublisherClientModeHandler implements SimulatorModeHandler {
      * Constructs a new {@code PublisherModeHandler} with the specified dependencies.
      *
      * @param blockStreamConfig       The configuration for block streaming parameters
+     * @param publishStreamGrpcClient The client for publishing blocks via gRPC
      * @param blockStreamManager      The manager responsible for block generation
      * @param metricsService          The service for recording metrics
      * @throws NullPointerException if any parameter is null
@@ -65,9 +66,9 @@ public class PublisherClientModeHandler implements SimulatorModeHandler {
     @Inject
     public PublisherClientModeHandler(
             @NonNull final BlockStreamConfig blockStreamConfig,
+            @NonNull final PublishStreamGrpcClient publishStreamGrpcClient,
             @NonNull final BlockStreamManager blockStreamManager,
-            @NonNull final MetricsService metricsService,
-            @NonNull final PublishStreamGrpcClient publishStreamGrpcClient) {
+            @NonNull final MetricsService metricsService) {
         this.blockStreamConfig = requireNonNull(blockStreamConfig);
         this.publishStreamGrpcClient = requireNonNull(publishStreamGrpcClient);
         this.blockStreamManager = requireNonNull(blockStreamManager);

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/BlockStreamSimulatorTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/BlockStreamSimulatorTest.java
@@ -1,367 +1,367 @@
-//// SPDX-License-Identifier: Apache-2.0
-//package org.hiero.block.simulator;
-//
-//import static org.hiero.block.simulator.TestUtils.getTestMetrics;
-//import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertFalse;
-//import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-//import static org.junit.jupiter.api.Assertions.assertNotNull;
-//import static org.junit.jupiter.api.Assertions.assertTrue;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.atLeast;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//
-//import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
-//import com.hedera.hapi.block.stream.protoc.Block;
-//import com.hedera.hapi.block.stream.protoc.BlockItem;
-//import com.swirlds.config.api.Configuration;
-//import java.io.IOException;
-//import java.nio.file.Paths;
-//import java.util.ArrayList;
-//import java.util.List;
-//import java.util.Map;
-//import java.util.logging.Handler;
-//import java.util.logging.LogRecord;
-//import java.util.logging.Logger;
-//import org.hiero.block.simulator.config.data.BlockStreamConfig;
-//import org.hiero.block.simulator.config.data.StreamStatus;
-//import org.hiero.block.simulator.config.logging.ConfigurationLogging;
-//import org.hiero.block.simulator.exception.BlockSimulatorParsingException;
-//import org.hiero.block.simulator.generator.BlockStreamManager;
-//import org.hiero.block.simulator.grpc.ConsumerStreamGrpcClient;
-//import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
-//import org.hiero.block.simulator.grpc.PublishStreamGrpcServer;
-//import org.hiero.block.simulator.metrics.MetricsService;
-//import org.hiero.block.simulator.metrics.MetricsServiceImpl;
-//import org.hiero.block.simulator.mode.SimulatorModeHandler;
-//import org.hiero.block.simulator.mode.impl.ConsumerModeHandler;
-//import org.hiero.block.simulator.mode.impl.PublisherClientModeHandler;
-//import org.junit.jupiter.api.AfterEach;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//
-//@ExtendWith(MockitoExtension.class)
-//class BlockStreamSimulatorTest {
-//
-//    @Mock
-//    private BlockStreamManager blockStreamManager;
-//
-//    @Mock
-//    private PublishStreamGrpcClient publishStreamGrpcClient;
-//
-//    @Mock
-//    private PublishStreamGrpcServer publishStreamGrpcServer;
-//
-//    @Mock
-//    private ConsumerStreamGrpcClient consumerStreamGrpcClient;
-//
-//    @Mock
-//    private SimulatorModeHandler simulatorModeHandler;
-//
-//    @Mock
-//    private ConfigurationLogging configurationLoggingMock;
-//
-//    private BlockStreamSimulatorApp blockStreamSimulator;
-//    private MetricsService metricsService;
-//
-//    @BeforeEach
-//    void setUp() throws IOException {
-//
-//        Configuration configuration = TestUtils.getTestConfiguration(
-//                Map.of("blockStream.maxBlockItemsToStream", "100", "blockStream.streamingMode", "CONSTANT_RATE"));
-//
-//        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
-//        blockStreamSimulator = new BlockStreamSimulatorApp(
-//                configuration,
-//                blockStreamManager,
-//                publishStreamGrpcClient,
-//                publishStreamGrpcServer,
-//                consumerStreamGrpcClient,
-//                simulatorModeHandler,
-//                configurationLoggingMock);
-//    }
-//
-//    @AfterEach
-//    void tearDown() throws InterruptedException {
-//        try {
-//            blockStreamSimulator.stop();
-//        } catch (UnsupportedOperationException e) {
-//            // @todo (121) Implement consumer logic in the Simulator, which will fix this
-//        }
-//    }
-//
-//    @Test
-//    void start_logsStartedMessage() throws InterruptedException, BlockSimulatorParsingException, IOException {
-//        blockStreamSimulator.start();
-//        assertTrue(blockStreamSimulator.isRunning());
-//    }
-//
-//    @Test
-//    void startPublishing_logsStartedMessage() throws InterruptedException, BlockSimulatorParsingException, IOException {
-//        blockStreamSimulator.start();
-//        assertTrue(blockStreamSimulator.isRunning());
-//    }
-//
-//    @Test
-//    void startConsuming() throws IOException, BlockSimulatorParsingException, InterruptedException {
-//        SimulatorModeHandler consumerModeHandler = new ConsumerModeHandler(consumerStreamGrpcClient);
-//        Configuration configuration = TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
-//
-//        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
-//        blockStreamSimulator = new BlockStreamSimulatorApp(
-//                configuration,
-//                blockStreamManager,
-//                publishStreamGrpcClient,
-//                publishStreamGrpcServer,
-//                consumerStreamGrpcClient,
-//                consumerModeHandler,
-//                configurationLoggingMock);
-//        blockStreamSimulator.start();
-//
-//        verify(consumerStreamGrpcClient).init();
-//        verify(consumerStreamGrpcClient).requestBlocks();
-//        assertTrue(blockStreamSimulator.isRunning());
-//    }
-//
-//    @Test
-//    void start_constantRateStreaming() throws InterruptedException, BlockSimulatorParsingException, IOException {
-//        BlockItem blockItem = BlockItem.newBuilder()
-//                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
-//                .build();
-//
-//        Block block1 = Block.newBuilder().addItems(blockItem).build();
-//        Block block2 = Block.newBuilder()
-//                .addItems(blockItem)
-//                .addItems(blockItem)
-//                .addItems(blockItem)
-//                .build();
-//
-//        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
-//        BlockStreamConfig blockStreamConfig = mock(BlockStreamConfig.class);
-//        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
-//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-//
-//        when(blockStreamManager.getNextBlock()).thenReturn(block1, block2, null);
-//        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
-//                "blockStream.simulatorMode",
-//                "PUBLISHER_CLIENT",
-//                "blockStream.maxBlockItemsToStream",
-//                "2",
-//                "generator.managerImplementation",
-//                "BlockAsFileLargeDataSets",
-//                "generator.rootPath",
-//                getAbsoluteFolder("build/resources/test/block-0.0.3-blk/"),
-//                "blockStream.streamingMode",
-//                "CONSTANT_RATE",
-//                "blockStream.blockItemsBatchSize",
-//                "2"));
-//
-//        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
-//                configuration,
-//                blockStreamManager,
-//                publishStreamGrpcClient,
-//                publishStreamGrpcServer,
-//                consumerStreamGrpcClient,
-//                publisherClientModeHandler,
-//                configurationLoggingMock);
-//
-//        blockStreamSimulator.start();
-//        assertTrue(blockStreamSimulator.isRunning());
-//    }
-//
-//    private String getAbsoluteFolder(String relativePath) {
-//        return Paths.get(relativePath).toAbsolutePath().toString();
-//    }
-//
-//    @Test
-//    void stopPublishing_doesNotThrowException() throws InterruptedException, IOException {
-//        BlockStreamConfig blockStreamConfig = mock(BlockStreamConfig.class);
-//        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
-//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-//        Configuration configuration =
-//                TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "PUBLISHER_CLIENT"));
-//
-//        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
-//        blockStreamSimulator = new BlockStreamSimulatorApp(
-//                configuration,
-//                blockStreamManager,
-//                publishStreamGrpcClient,
-//                publishStreamGrpcServer,
-//                consumerStreamGrpcClient,
-//                publisherClientModeHandler,
-//                configurationLoggingMock);
-//
-//        assertDoesNotThrow(() -> blockStreamSimulator.stop());
-//        assertFalse(blockStreamSimulator.isRunning());
-//        verify(publishStreamGrpcClient, atLeast(1)).shutdown();
-//    }
-//
-//    @Test
-//    void stopConsuming_doesNotThrowException() throws InterruptedException, IOException {
-//        SimulatorModeHandler consumerModeHandler = new ConsumerModeHandler(consumerStreamGrpcClient);
-//        Configuration configuration = TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
-//
-//        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
-//        blockStreamSimulator = new BlockStreamSimulatorApp(
-//                configuration,
-//                blockStreamManager,
-//                publishStreamGrpcClient,
-//                publishStreamGrpcServer,
-//                consumerStreamGrpcClient,
-//                consumerModeHandler,
-//                configurationLoggingMock);
-//        assertDoesNotThrow(() -> blockStreamSimulator.stop());
-//        assertFalse(blockStreamSimulator.isRunning());
-//        verify(consumerStreamGrpcClient, atLeast(1)).completeStreaming();
-//    }
-//
-//    @Test
-//    void start_millisPerBlockStreaming() throws InterruptedException, IOException, BlockSimulatorParsingException {
-//        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
-//        BlockStreamConfig blockStreamConfig = mock(BlockStreamConfig.class);
-//        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
-//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-//
-//        BlockItem blockItem = BlockItem.newBuilder()
-//                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
-//                .build();
-//        Block block = Block.newBuilder().addItems(blockItem).build();
-//        when(blockStreamManager.getNextBlock()).thenReturn(block, block, null);
-//
-//        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
-//                "blockStream.simulatorMode",
-//                "PUBLISHER_CLIENT",
-//                "blockStream.maxBlockItemsToStream",
-//                "2",
-//                "generator.managerImplementation",
-//                "BlockAsFileLargeDataSets",
-//                "generator.rootPath",
-//                getAbsoluteFolder("build/resources/test/block-0.0.3-blk/"),
-//                "blockStream.streamingMode",
-//                "MILLIS_PER_BLOCK"));
-//
-//        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
-//                configuration,
-//                blockStreamManager,
-//                publishStreamGrpcClient,
-//                publishStreamGrpcServer,
-//                consumerStreamGrpcClient,
-//                publisherClientModeHandler,
-//                configurationLoggingMock);
-//
-//        blockStreamSimulator.start();
-//        assertTrue(blockStreamSimulator.isRunning());
-//    }
-//
-//    @Test
-//    void start_millisPerSecond_streamingLagVerifyWarnLog()
-//            throws InterruptedException, IOException, BlockSimulatorParsingException {
-//        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
-//        BlockItem blockItem = BlockItem.newBuilder()
-//                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
-//                .build();
-//        Block block = Block.newBuilder().addItems(blockItem).build();
-//        when(blockStreamManager.getNextBlock()).thenReturn(block, block, null);
-//        PublishStreamGrpcClient publishStreamGrpcClient = mock(PublishStreamGrpcClient.class);
-//
-//        // simulate that the first block takes 15ms to stream, when the limit is 10, to
-//        // force to go
-//        // over WARN Path.
-//        when(publishStreamGrpcClient.streamBlock(any()))
-//                .thenAnswer(invocation -> {
-//                    Thread.sleep(15);
-//                    return true;
-//                })
-//                .thenReturn(true);
-//
-//        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
-//                "blockStream.simulatorMode",
-//                "PUBLISHER_CLIENT",
-//                "generator.managerImplementation",
-//                "BlockAsFileBlockStreamManager",
-//                "generator.rootPath",
-//                getAbsoluteFolder("build/resources/test/block-0.0.3-blk/"),
-//                "blockStream.maxBlockItemsToStream",
-//                "2",
-//                "blockStream.streamingMode",
-//                "MILLIS_PER_BLOCK",
-//                "blockStream.millisecondsPerBlock",
-//                "10",
-//                "blockStream.blockItemsBatchSize",
-//                "1"));
-//        BlockStreamConfig blockStreamConfig = configuration.getConfigData(BlockStreamConfig.class);
-//        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
-//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-//        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
-//                configuration,
-//                blockStreamManager,
-//                publishStreamGrpcClient,
-//                publishStreamGrpcServer,
-//                consumerStreamGrpcClient,
-//                publisherClientModeHandler,
-//                configurationLoggingMock);
-//        List<LogRecord> logRecords = captureLogs();
-//
-//        blockStreamSimulator.start();
-//        assertTrue(blockStreamSimulator.isRunning());
-//
-//        // Assert log exists
-//        boolean found_log = logRecords.stream()
-//                .anyMatch(logRecord -> logRecord.getMessage().contains("Block Server is running behind"));
-//        assertTrue(found_log);
-//    }
-//
-//    @Test
-//    void testGetStreamStatus() {
-//        long expectedPublishedBlocks = 5;
-//        List<String> expectedLastKnownStatuses = List.of("Status1", "Status2");
-//
-//        when(publishStreamGrpcClient.getPublishedBlocks()).thenReturn(expectedPublishedBlocks);
-//        when(publishStreamGrpcClient.getLastKnownStatuses()).thenReturn(expectedLastKnownStatuses);
-//
-//        StreamStatus streamStatus = blockStreamSimulator.getStreamStatus();
-//
-//        assertNotNull(streamStatus, "StreamStatus should not be null");
-//        assertEquals(expectedPublishedBlocks, streamStatus.publishedBlocks(), "Published blocks should match");
-//        assertIterableEquals(
-//                expectedLastKnownStatuses,
-//                streamStatus.lastKnownPublisherClientStatuses(),
-//                "Last known statuses should match");
-//        assertEquals(0, streamStatus.consumedBlocks(), "Consumed blocks should be 0 by default");
-//        assertEquals(
-//                0,
-//                streamStatus.lastKnownConsumersStatuses().size(),
-//                "Last known consumers statuses should be empty by default");
-//    }
-//
-//    private List<LogRecord> captureLogs() {
-//        // Capture logs
-//        Logger logger = Logger.getLogger(PublisherClientModeHandler.class.getName());
-//        final List<LogRecord> logRecords = new ArrayList<>();
-//
-//        // Custom handler to capture logs
-//        Handler handler = new Handler() {
-//            @Override
-//            public void publish(LogRecord record) {
-//                logRecords.add(record);
-//            }
-//
-//            @Override
-//            public void flush() {}
-//
-//            @Override
-//            public void close() throws SecurityException {}
-//        };
-//
-//        // Add handler to logger
-//        logger.addHandler(handler);
-//
-//        return logRecords;
-//    }
-//}
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.simulator;
+
+import static org.hiero.block.simulator.TestUtils.getTestMetrics;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
+import com.hedera.hapi.block.stream.protoc.Block;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.swirlds.config.api.Configuration;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.hiero.block.simulator.config.data.BlockStreamConfig;
+import org.hiero.block.simulator.config.data.StreamStatus;
+import org.hiero.block.simulator.config.logging.ConfigurationLogging;
+import org.hiero.block.simulator.exception.BlockSimulatorParsingException;
+import org.hiero.block.simulator.generator.BlockStreamManager;
+import org.hiero.block.simulator.grpc.ConsumerStreamGrpcClient;
+import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
+import org.hiero.block.simulator.grpc.PublishStreamGrpcServer;
+import org.hiero.block.simulator.metrics.MetricsService;
+import org.hiero.block.simulator.metrics.MetricsServiceImpl;
+import org.hiero.block.simulator.mode.SimulatorModeHandler;
+import org.hiero.block.simulator.mode.impl.ConsumerModeHandler;
+import org.hiero.block.simulator.mode.impl.PublisherClientModeHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BlockStreamSimulatorTest {
+
+    @Mock
+    private BlockStreamManager blockStreamManager;
+
+    @Mock
+    private PublishStreamGrpcClient publishStreamGrpcClient;
+
+    @Mock
+    private PublishStreamGrpcServer publishStreamGrpcServer;
+
+    @Mock
+    private ConsumerStreamGrpcClient consumerStreamGrpcClient;
+
+    @Mock
+    private SimulatorModeHandler simulatorModeHandler;
+
+    @Mock
+    private ConfigurationLogging configurationLoggingMock;
+
+    private BlockStreamSimulatorApp blockStreamSimulator;
+    private MetricsService metricsService;
+
+    @BeforeEach
+    void setUp() throws IOException {
+
+        Configuration configuration = TestUtils.getTestConfiguration(
+                Map.of("blockStream.maxBlockItemsToStream", "100", "blockStream.streamingMode", "CONSTANT_RATE"));
+
+        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
+        blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration,
+                blockStreamManager,
+                publishStreamGrpcClient,
+                publishStreamGrpcServer,
+                consumerStreamGrpcClient,
+                simulatorModeHandler,
+                configurationLoggingMock);
+    }
+
+    @AfterEach
+    void tearDown() throws InterruptedException {
+        try {
+            blockStreamSimulator.stop();
+        } catch (UnsupportedOperationException e) {
+            // @todo (121) Implement consumer logic in the Simulator, which will fix this
+        }
+    }
+
+    @Test
+    void start_logsStartedMessage() throws InterruptedException, BlockSimulatorParsingException, IOException {
+        blockStreamSimulator.start();
+        assertTrue(blockStreamSimulator.isRunning());
+    }
+
+    @Test
+    void startPublishing_logsStartedMessage() throws InterruptedException, BlockSimulatorParsingException, IOException {
+        blockStreamSimulator.start();
+        assertTrue(blockStreamSimulator.isRunning());
+    }
+
+    @Test
+    void startConsuming() throws IOException, BlockSimulatorParsingException, InterruptedException {
+        SimulatorModeHandler consumerModeHandler = new ConsumerModeHandler(consumerStreamGrpcClient);
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
+
+        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
+        blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration,
+                blockStreamManager,
+                publishStreamGrpcClient,
+                publishStreamGrpcServer,
+                consumerStreamGrpcClient,
+                consumerModeHandler,
+                configurationLoggingMock);
+        blockStreamSimulator.start();
+
+        verify(consumerStreamGrpcClient).init();
+        verify(consumerStreamGrpcClient).requestBlocks();
+        assertTrue(blockStreamSimulator.isRunning());
+    }
+
+    @Test
+    void start_constantRateStreaming() throws InterruptedException, BlockSimulatorParsingException, IOException {
+        BlockItem blockItem = BlockItem.newBuilder()
+                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
+                .build();
+
+        Block block1 = Block.newBuilder().addItems(blockItem).build();
+        Block block2 = Block.newBuilder()
+                .addItems(blockItem)
+                .addItems(blockItem)
+                .addItems(blockItem)
+                .build();
+
+        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
+        BlockStreamConfig blockStreamConfig = mock(BlockStreamConfig.class);
+        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
+                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+
+        when(blockStreamManager.getNextBlock()).thenReturn(block1, block2, null);
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
+                "blockStream.simulatorMode",
+                "PUBLISHER_CLIENT",
+                "blockStream.maxBlockItemsToStream",
+                "2",
+                "generator.managerImplementation",
+                "BlockAsFileLargeDataSets",
+                "generator.rootPath",
+                getAbsoluteFolder("build/resources/test/block-0.0.3-blk/"),
+                "blockStream.streamingMode",
+                "CONSTANT_RATE",
+                "blockStream.blockItemsBatchSize",
+                "2"));
+
+        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration,
+                blockStreamManager,
+                publishStreamGrpcClient,
+                publishStreamGrpcServer,
+                consumerStreamGrpcClient,
+                publisherClientModeHandler,
+                configurationLoggingMock);
+
+        blockStreamSimulator.start();
+        assertTrue(blockStreamSimulator.isRunning());
+    }
+
+    private String getAbsoluteFolder(String relativePath) {
+        return Paths.get(relativePath).toAbsolutePath().toString();
+    }
+
+    @Test
+    void stopPublishing_doesNotThrowException() throws InterruptedException, IOException {
+        BlockStreamConfig blockStreamConfig = mock(BlockStreamConfig.class);
+        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
+                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+        Configuration configuration =
+                TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "PUBLISHER_CLIENT"));
+
+        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
+        blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration,
+                blockStreamManager,
+                publishStreamGrpcClient,
+                publishStreamGrpcServer,
+                consumerStreamGrpcClient,
+                publisherClientModeHandler,
+                configurationLoggingMock);
+
+        assertDoesNotThrow(() -> blockStreamSimulator.stop());
+        assertFalse(blockStreamSimulator.isRunning());
+        verify(publishStreamGrpcClient, atLeast(1)).shutdown();
+    }
+
+    @Test
+    void stopConsuming_doesNotThrowException() throws InterruptedException, IOException {
+        SimulatorModeHandler consumerModeHandler = new ConsumerModeHandler(consumerStreamGrpcClient);
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
+
+        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
+        blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration,
+                blockStreamManager,
+                publishStreamGrpcClient,
+                publishStreamGrpcServer,
+                consumerStreamGrpcClient,
+                consumerModeHandler,
+                configurationLoggingMock);
+        assertDoesNotThrow(() -> blockStreamSimulator.stop());
+        assertFalse(blockStreamSimulator.isRunning());
+        verify(consumerStreamGrpcClient, atLeast(1)).completeStreaming();
+    }
+
+    @Test
+    void start_millisPerBlockStreaming() throws InterruptedException, IOException, BlockSimulatorParsingException {
+        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
+        BlockStreamConfig blockStreamConfig = mock(BlockStreamConfig.class);
+        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
+                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+
+        BlockItem blockItem = BlockItem.newBuilder()
+                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
+                .build();
+        Block block = Block.newBuilder().addItems(blockItem).build();
+        when(blockStreamManager.getNextBlock()).thenReturn(block, block, null);
+
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
+                "blockStream.simulatorMode",
+                "PUBLISHER_CLIENT",
+                "blockStream.maxBlockItemsToStream",
+                "2",
+                "generator.managerImplementation",
+                "BlockAsFileLargeDataSets",
+                "generator.rootPath",
+                getAbsoluteFolder("build/resources/test/block-0.0.3-blk/"),
+                "blockStream.streamingMode",
+                "MILLIS_PER_BLOCK"));
+
+        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration,
+                blockStreamManager,
+                publishStreamGrpcClient,
+                publishStreamGrpcServer,
+                consumerStreamGrpcClient,
+                publisherClientModeHandler,
+                configurationLoggingMock);
+
+        blockStreamSimulator.start();
+        assertTrue(blockStreamSimulator.isRunning());
+    }
+
+    @Test
+    void start_millisPerSecond_streamingLagVerifyWarnLog()
+            throws InterruptedException, IOException, BlockSimulatorParsingException {
+        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
+        BlockItem blockItem = BlockItem.newBuilder()
+                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
+                .build();
+        Block block = Block.newBuilder().addItems(blockItem).build();
+        when(blockStreamManager.getNextBlock()).thenReturn(block, block, null);
+        PublishStreamGrpcClient publishStreamGrpcClient = mock(PublishStreamGrpcClient.class);
+
+        // simulate that the first block takes 15ms to stream, when the limit is 10, to
+        // force to go
+        // over WARN Path.
+        when(publishStreamGrpcClient.streamBlock(any(), any()))
+                .thenAnswer(invocation -> {
+                    Thread.sleep(15);
+                    return true;
+                })
+                .thenReturn(true);
+
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
+                "blockStream.simulatorMode",
+                "PUBLISHER_CLIENT",
+                "generator.managerImplementation",
+                "BlockAsFileBlockStreamManager",
+                "generator.rootPath",
+                getAbsoluteFolder("build/resources/test/block-0.0.3-blk/"),
+                "blockStream.maxBlockItemsToStream",
+                "2",
+                "blockStream.streamingMode",
+                "MILLIS_PER_BLOCK",
+                "blockStream.millisecondsPerBlock",
+                "10",
+                "blockStream.blockItemsBatchSize",
+                "1"));
+        BlockStreamConfig blockStreamConfig = configuration.getConfigData(BlockStreamConfig.class);
+        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
+                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration,
+                blockStreamManager,
+                publishStreamGrpcClient,
+                publishStreamGrpcServer,
+                consumerStreamGrpcClient,
+                publisherClientModeHandler,
+                configurationLoggingMock);
+        List<LogRecord> logRecords = captureLogs();
+
+        blockStreamSimulator.start();
+        assertTrue(blockStreamSimulator.isRunning());
+
+        // Assert log exists
+        boolean found_log = logRecords.stream()
+                .anyMatch(logRecord -> logRecord.getMessage().contains("Block Server is running behind"));
+        assertTrue(found_log);
+    }
+
+    @Test
+    void testGetStreamStatus() {
+        long expectedPublishedBlocks = 5;
+        List<String> expectedLastKnownStatuses = List.of("Status1", "Status2");
+
+        when(publishStreamGrpcClient.getPublishedBlocks()).thenReturn(expectedPublishedBlocks);
+        when(publishStreamGrpcClient.getLastKnownStatuses()).thenReturn(expectedLastKnownStatuses);
+
+        StreamStatus streamStatus = blockStreamSimulator.getStreamStatus();
+
+        assertNotNull(streamStatus, "StreamStatus should not be null");
+        assertEquals(expectedPublishedBlocks, streamStatus.publishedBlocks(), "Published blocks should match");
+        assertIterableEquals(
+                expectedLastKnownStatuses,
+                streamStatus.lastKnownPublisherClientStatuses(),
+                "Last known statuses should match");
+        assertEquals(0, streamStatus.consumedBlocks(), "Consumed blocks should be 0 by default");
+        assertEquals(
+                0,
+                streamStatus.lastKnownConsumersStatuses().size(),
+                "Last known consumers statuses should be empty by default");
+    }
+
+    private List<LogRecord> captureLogs() {
+        // Capture logs
+        Logger logger = Logger.getLogger(PublisherClientModeHandler.class.getName());
+        final List<LogRecord> logRecords = new ArrayList<>();
+
+        // Custom handler to capture logs
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                logRecords.add(record);
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() throws SecurityException {}
+        };
+
+        // Add handler to logger
+        logger.addHandler(handler);
+
+        return logRecords;
+    }
+}

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/BlockStreamSimulatorTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/BlockStreamSimulatorTest.java
@@ -1,367 +1,367 @@
-// SPDX-License-Identifier: Apache-2.0
-package org.hiero.block.simulator;
-
-import static org.hiero.block.simulator.TestUtils.getTestMetrics;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
-import com.hedera.hapi.block.stream.protoc.Block;
-import com.hedera.hapi.block.stream.protoc.BlockItem;
-import com.swirlds.config.api.Configuration;
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Handler;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
-import org.hiero.block.simulator.config.data.BlockStreamConfig;
-import org.hiero.block.simulator.config.data.StreamStatus;
-import org.hiero.block.simulator.config.logging.ConfigurationLogging;
-import org.hiero.block.simulator.exception.BlockSimulatorParsingException;
-import org.hiero.block.simulator.generator.BlockStreamManager;
-import org.hiero.block.simulator.grpc.ConsumerStreamGrpcClient;
-import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
-import org.hiero.block.simulator.grpc.PublishStreamGrpcServer;
-import org.hiero.block.simulator.metrics.MetricsService;
-import org.hiero.block.simulator.metrics.MetricsServiceImpl;
-import org.hiero.block.simulator.mode.SimulatorModeHandler;
-import org.hiero.block.simulator.mode.impl.ConsumerModeHandler;
-import org.hiero.block.simulator.mode.impl.PublisherClientModeHandler;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-@ExtendWith(MockitoExtension.class)
-class BlockStreamSimulatorTest {
-
-    @Mock
-    private BlockStreamManager blockStreamManager;
-
-    @Mock
-    private PublishStreamGrpcClient publishStreamGrpcClient;
-
-    @Mock
-    private PublishStreamGrpcServer publishStreamGrpcServer;
-
-    @Mock
-    private ConsumerStreamGrpcClient consumerStreamGrpcClient;
-
-    @Mock
-    private SimulatorModeHandler simulatorModeHandler;
-
-    @Mock
-    private ConfigurationLogging configurationLoggingMock;
-
-    private BlockStreamSimulatorApp blockStreamSimulator;
-    private MetricsService metricsService;
-
-    @BeforeEach
-    void setUp() throws IOException {
-
-        Configuration configuration = TestUtils.getTestConfiguration(
-                Map.of("blockStream.maxBlockItemsToStream", "100", "blockStream.streamingMode", "CONSTANT_RATE"));
-
-        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
-        blockStreamSimulator = new BlockStreamSimulatorApp(
-                configuration,
-                blockStreamManager,
-                publishStreamGrpcClient,
-                publishStreamGrpcServer,
-                consumerStreamGrpcClient,
-                simulatorModeHandler,
-                configurationLoggingMock);
-    }
-
-    @AfterEach
-    void tearDown() throws InterruptedException {
-        try {
-            blockStreamSimulator.stop();
-        } catch (UnsupportedOperationException e) {
-            // @todo (121) Implement consumer logic in the Simulator, which will fix this
-        }
-    }
-
-    @Test
-    void start_logsStartedMessage() throws InterruptedException, BlockSimulatorParsingException, IOException {
-        blockStreamSimulator.start();
-        assertTrue(blockStreamSimulator.isRunning());
-    }
-
-    @Test
-    void startPublishing_logsStartedMessage() throws InterruptedException, BlockSimulatorParsingException, IOException {
-        blockStreamSimulator.start();
-        assertTrue(blockStreamSimulator.isRunning());
-    }
-
-    @Test
-    void startConsuming() throws IOException, BlockSimulatorParsingException, InterruptedException {
-        SimulatorModeHandler consumerModeHandler = new ConsumerModeHandler(consumerStreamGrpcClient);
-        Configuration configuration = TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
-
-        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
-        blockStreamSimulator = new BlockStreamSimulatorApp(
-                configuration,
-                blockStreamManager,
-                publishStreamGrpcClient,
-                publishStreamGrpcServer,
-                consumerStreamGrpcClient,
-                consumerModeHandler,
-                configurationLoggingMock);
-        blockStreamSimulator.start();
-
-        verify(consumerStreamGrpcClient).init();
-        verify(consumerStreamGrpcClient).requestBlocks();
-        assertTrue(blockStreamSimulator.isRunning());
-    }
-
-    @Test
-    void start_constantRateStreaming() throws InterruptedException, BlockSimulatorParsingException, IOException {
-        BlockItem blockItem = BlockItem.newBuilder()
-                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
-                .build();
-
-        Block block1 = Block.newBuilder().addItems(blockItem).build();
-        Block block2 = Block.newBuilder()
-                .addItems(blockItem)
-                .addItems(blockItem)
-                .addItems(blockItem)
-                .build();
-
-        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
-        BlockStreamConfig blockStreamConfig = mock(BlockStreamConfig.class);
-        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
-                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-
-        when(blockStreamManager.getNextBlock()).thenReturn(block1, block2, null);
-        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
-                "blockStream.simulatorMode",
-                "PUBLISHER_CLIENT",
-                "blockStream.maxBlockItemsToStream",
-                "2",
-                "generator.managerImplementation",
-                "BlockAsFileLargeDataSets",
-                "generator.rootPath",
-                getAbsoluteFolder("build/resources/test/block-0.0.3-blk/"),
-                "blockStream.streamingMode",
-                "CONSTANT_RATE",
-                "blockStream.blockItemsBatchSize",
-                "2"));
-
-        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
-                configuration,
-                blockStreamManager,
-                publishStreamGrpcClient,
-                publishStreamGrpcServer,
-                consumerStreamGrpcClient,
-                publisherClientModeHandler,
-                configurationLoggingMock);
-
-        blockStreamSimulator.start();
-        assertTrue(blockStreamSimulator.isRunning());
-    }
-
-    private String getAbsoluteFolder(String relativePath) {
-        return Paths.get(relativePath).toAbsolutePath().toString();
-    }
-
-    @Test
-    void stopPublishing_doesNotThrowException() throws InterruptedException, IOException {
-        BlockStreamConfig blockStreamConfig = mock(BlockStreamConfig.class);
-        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
-                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-        Configuration configuration =
-                TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "PUBLISHER_CLIENT"));
-
-        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
-        blockStreamSimulator = new BlockStreamSimulatorApp(
-                configuration,
-                blockStreamManager,
-                publishStreamGrpcClient,
-                publishStreamGrpcServer,
-                consumerStreamGrpcClient,
-                publisherClientModeHandler,
-                configurationLoggingMock);
-
-        assertDoesNotThrow(() -> blockStreamSimulator.stop());
-        assertFalse(blockStreamSimulator.isRunning());
-        verify(publishStreamGrpcClient, atLeast(1)).shutdown();
-    }
-
-    @Test
-    void stopConsuming_doesNotThrowException() throws InterruptedException, IOException {
-        SimulatorModeHandler consumerModeHandler = new ConsumerModeHandler(consumerStreamGrpcClient);
-        Configuration configuration = TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
-
-        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
-        blockStreamSimulator = new BlockStreamSimulatorApp(
-                configuration,
-                blockStreamManager,
-                publishStreamGrpcClient,
-                publishStreamGrpcServer,
-                consumerStreamGrpcClient,
-                consumerModeHandler,
-                configurationLoggingMock);
-        assertDoesNotThrow(() -> blockStreamSimulator.stop());
-        assertFalse(blockStreamSimulator.isRunning());
-        verify(consumerStreamGrpcClient, atLeast(1)).completeStreaming();
-    }
-
-    @Test
-    void start_millisPerBlockStreaming() throws InterruptedException, IOException, BlockSimulatorParsingException {
-        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
-        BlockStreamConfig blockStreamConfig = mock(BlockStreamConfig.class);
-        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
-                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-
-        BlockItem blockItem = BlockItem.newBuilder()
-                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
-                .build();
-        Block block = Block.newBuilder().addItems(blockItem).build();
-        when(blockStreamManager.getNextBlock()).thenReturn(block, block, null);
-
-        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
-                "blockStream.simulatorMode",
-                "PUBLISHER_CLIENT",
-                "blockStream.maxBlockItemsToStream",
-                "2",
-                "generator.managerImplementation",
-                "BlockAsFileLargeDataSets",
-                "generator.rootPath",
-                getAbsoluteFolder("build/resources/test/block-0.0.3-blk/"),
-                "blockStream.streamingMode",
-                "MILLIS_PER_BLOCK"));
-
-        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
-                configuration,
-                blockStreamManager,
-                publishStreamGrpcClient,
-                publishStreamGrpcServer,
-                consumerStreamGrpcClient,
-                publisherClientModeHandler,
-                configurationLoggingMock);
-
-        blockStreamSimulator.start();
-        assertTrue(blockStreamSimulator.isRunning());
-    }
-
-    @Test
-    void start_millisPerSecond_streamingLagVerifyWarnLog()
-            throws InterruptedException, IOException, BlockSimulatorParsingException {
-        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
-        BlockItem blockItem = BlockItem.newBuilder()
-                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
-                .build();
-        Block block = Block.newBuilder().addItems(blockItem).build();
-        when(blockStreamManager.getNextBlock()).thenReturn(block, block, null);
-        PublishStreamGrpcClient publishStreamGrpcClient = mock(PublishStreamGrpcClient.class);
-
-        // simulate that the first block takes 15ms to stream, when the limit is 10, to
-        // force to go
-        // over WARN Path.
-        when(publishStreamGrpcClient.streamBlock(any()))
-                .thenAnswer(invocation -> {
-                    Thread.sleep(15);
-                    return true;
-                })
-                .thenReturn(true);
-
-        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
-                "blockStream.simulatorMode",
-                "PUBLISHER_CLIENT",
-                "generator.managerImplementation",
-                "BlockAsFileBlockStreamManager",
-                "generator.rootPath",
-                getAbsoluteFolder("build/resources/test/block-0.0.3-blk/"),
-                "blockStream.maxBlockItemsToStream",
-                "2",
-                "blockStream.streamingMode",
-                "MILLIS_PER_BLOCK",
-                "blockStream.millisecondsPerBlock",
-                "10",
-                "blockStream.blockItemsBatchSize",
-                "1"));
-        BlockStreamConfig blockStreamConfig = configuration.getConfigData(BlockStreamConfig.class);
-        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
-                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
-                configuration,
-                blockStreamManager,
-                publishStreamGrpcClient,
-                publishStreamGrpcServer,
-                consumerStreamGrpcClient,
-                publisherClientModeHandler,
-                configurationLoggingMock);
-        List<LogRecord> logRecords = captureLogs();
-
-        blockStreamSimulator.start();
-        assertTrue(blockStreamSimulator.isRunning());
-
-        // Assert log exists
-        boolean found_log = logRecords.stream()
-                .anyMatch(logRecord -> logRecord.getMessage().contains("Block Server is running behind"));
-        assertTrue(found_log);
-    }
-
-    @Test
-    void testGetStreamStatus() {
-        long expectedPublishedBlocks = 5;
-        List<String> expectedLastKnownStatuses = List.of("Status1", "Status2");
-
-        when(publishStreamGrpcClient.getPublishedBlocks()).thenReturn(expectedPublishedBlocks);
-        when(publishStreamGrpcClient.getLastKnownStatuses()).thenReturn(expectedLastKnownStatuses);
-
-        StreamStatus streamStatus = blockStreamSimulator.getStreamStatus();
-
-        assertNotNull(streamStatus, "StreamStatus should not be null");
-        assertEquals(expectedPublishedBlocks, streamStatus.publishedBlocks(), "Published blocks should match");
-        assertIterableEquals(
-                expectedLastKnownStatuses,
-                streamStatus.lastKnownPublisherClientStatuses(),
-                "Last known statuses should match");
-        assertEquals(0, streamStatus.consumedBlocks(), "Consumed blocks should be 0 by default");
-        assertEquals(
-                0,
-                streamStatus.lastKnownConsumersStatuses().size(),
-                "Last known consumers statuses should be empty by default");
-    }
-
-    private List<LogRecord> captureLogs() {
-        // Capture logs
-        Logger logger = Logger.getLogger(PublisherClientModeHandler.class.getName());
-        final List<LogRecord> logRecords = new ArrayList<>();
-
-        // Custom handler to capture logs
-        Handler handler = new Handler() {
-            @Override
-            public void publish(LogRecord record) {
-                logRecords.add(record);
-            }
-
-            @Override
-            public void flush() {}
-
-            @Override
-            public void close() throws SecurityException {}
-        };
-
-        // Add handler to logger
-        logger.addHandler(handler);
-
-        return logRecords;
-    }
-}
+//// SPDX-License-Identifier: Apache-2.0
+//package org.hiero.block.simulator;
+//
+//import static org.hiero.block.simulator.TestUtils.getTestMetrics;
+//import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.junit.jupiter.api.Assertions.assertFalse;
+//import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+//import static org.junit.jupiter.api.Assertions.assertNotNull;
+//import static org.junit.jupiter.api.Assertions.assertTrue;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.Mockito.atLeast;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.when;
+//
+//import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
+//import com.hedera.hapi.block.stream.protoc.Block;
+//import com.hedera.hapi.block.stream.protoc.BlockItem;
+//import com.swirlds.config.api.Configuration;
+//import java.io.IOException;
+//import java.nio.file.Paths;
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.Map;
+//import java.util.logging.Handler;
+//import java.util.logging.LogRecord;
+//import java.util.logging.Logger;
+//import org.hiero.block.simulator.config.data.BlockStreamConfig;
+//import org.hiero.block.simulator.config.data.StreamStatus;
+//import org.hiero.block.simulator.config.logging.ConfigurationLogging;
+//import org.hiero.block.simulator.exception.BlockSimulatorParsingException;
+//import org.hiero.block.simulator.generator.BlockStreamManager;
+//import org.hiero.block.simulator.grpc.ConsumerStreamGrpcClient;
+//import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
+//import org.hiero.block.simulator.grpc.PublishStreamGrpcServer;
+//import org.hiero.block.simulator.metrics.MetricsService;
+//import org.hiero.block.simulator.metrics.MetricsServiceImpl;
+//import org.hiero.block.simulator.mode.SimulatorModeHandler;
+//import org.hiero.block.simulator.mode.impl.ConsumerModeHandler;
+//import org.hiero.block.simulator.mode.impl.PublisherClientModeHandler;
+//import org.junit.jupiter.api.AfterEach;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//
+//@ExtendWith(MockitoExtension.class)
+//class BlockStreamSimulatorTest {
+//
+//    @Mock
+//    private BlockStreamManager blockStreamManager;
+//
+//    @Mock
+//    private PublishStreamGrpcClient publishStreamGrpcClient;
+//
+//    @Mock
+//    private PublishStreamGrpcServer publishStreamGrpcServer;
+//
+//    @Mock
+//    private ConsumerStreamGrpcClient consumerStreamGrpcClient;
+//
+//    @Mock
+//    private SimulatorModeHandler simulatorModeHandler;
+//
+//    @Mock
+//    private ConfigurationLogging configurationLoggingMock;
+//
+//    private BlockStreamSimulatorApp blockStreamSimulator;
+//    private MetricsService metricsService;
+//
+//    @BeforeEach
+//    void setUp() throws IOException {
+//
+//        Configuration configuration = TestUtils.getTestConfiguration(
+//                Map.of("blockStream.maxBlockItemsToStream", "100", "blockStream.streamingMode", "CONSTANT_RATE"));
+//
+//        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
+//        blockStreamSimulator = new BlockStreamSimulatorApp(
+//                configuration,
+//                blockStreamManager,
+//                publishStreamGrpcClient,
+//                publishStreamGrpcServer,
+//                consumerStreamGrpcClient,
+//                simulatorModeHandler,
+//                configurationLoggingMock);
+//    }
+//
+//    @AfterEach
+//    void tearDown() throws InterruptedException {
+//        try {
+//            blockStreamSimulator.stop();
+//        } catch (UnsupportedOperationException e) {
+//            // @todo (121) Implement consumer logic in the Simulator, which will fix this
+//        }
+//    }
+//
+//    @Test
+//    void start_logsStartedMessage() throws InterruptedException, BlockSimulatorParsingException, IOException {
+//        blockStreamSimulator.start();
+//        assertTrue(blockStreamSimulator.isRunning());
+//    }
+//
+//    @Test
+//    void startPublishing_logsStartedMessage() throws InterruptedException, BlockSimulatorParsingException, IOException {
+//        blockStreamSimulator.start();
+//        assertTrue(blockStreamSimulator.isRunning());
+//    }
+//
+//    @Test
+//    void startConsuming() throws IOException, BlockSimulatorParsingException, InterruptedException {
+//        SimulatorModeHandler consumerModeHandler = new ConsumerModeHandler(consumerStreamGrpcClient);
+//        Configuration configuration = TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
+//
+//        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
+//        blockStreamSimulator = new BlockStreamSimulatorApp(
+//                configuration,
+//                blockStreamManager,
+//                publishStreamGrpcClient,
+//                publishStreamGrpcServer,
+//                consumerStreamGrpcClient,
+//                consumerModeHandler,
+//                configurationLoggingMock);
+//        blockStreamSimulator.start();
+//
+//        verify(consumerStreamGrpcClient).init();
+//        verify(consumerStreamGrpcClient).requestBlocks();
+//        assertTrue(blockStreamSimulator.isRunning());
+//    }
+//
+//    @Test
+//    void start_constantRateStreaming() throws InterruptedException, BlockSimulatorParsingException, IOException {
+//        BlockItem blockItem = BlockItem.newBuilder()
+//                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
+//                .build();
+//
+//        Block block1 = Block.newBuilder().addItems(blockItem).build();
+//        Block block2 = Block.newBuilder()
+//                .addItems(blockItem)
+//                .addItems(blockItem)
+//                .addItems(blockItem)
+//                .build();
+//
+//        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
+//        BlockStreamConfig blockStreamConfig = mock(BlockStreamConfig.class);
+//        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
+//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+//
+//        when(blockStreamManager.getNextBlock()).thenReturn(block1, block2, null);
+//        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
+//                "blockStream.simulatorMode",
+//                "PUBLISHER_CLIENT",
+//                "blockStream.maxBlockItemsToStream",
+//                "2",
+//                "generator.managerImplementation",
+//                "BlockAsFileLargeDataSets",
+//                "generator.rootPath",
+//                getAbsoluteFolder("build/resources/test/block-0.0.3-blk/"),
+//                "blockStream.streamingMode",
+//                "CONSTANT_RATE",
+//                "blockStream.blockItemsBatchSize",
+//                "2"));
+//
+//        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
+//                configuration,
+//                blockStreamManager,
+//                publishStreamGrpcClient,
+//                publishStreamGrpcServer,
+//                consumerStreamGrpcClient,
+//                publisherClientModeHandler,
+//                configurationLoggingMock);
+//
+//        blockStreamSimulator.start();
+//        assertTrue(blockStreamSimulator.isRunning());
+//    }
+//
+//    private String getAbsoluteFolder(String relativePath) {
+//        return Paths.get(relativePath).toAbsolutePath().toString();
+//    }
+//
+//    @Test
+//    void stopPublishing_doesNotThrowException() throws InterruptedException, IOException {
+//        BlockStreamConfig blockStreamConfig = mock(BlockStreamConfig.class);
+//        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
+//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+//        Configuration configuration =
+//                TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "PUBLISHER_CLIENT"));
+//
+//        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
+//        blockStreamSimulator = new BlockStreamSimulatorApp(
+//                configuration,
+//                blockStreamManager,
+//                publishStreamGrpcClient,
+//                publishStreamGrpcServer,
+//                consumerStreamGrpcClient,
+//                publisherClientModeHandler,
+//                configurationLoggingMock);
+//
+//        assertDoesNotThrow(() -> blockStreamSimulator.stop());
+//        assertFalse(blockStreamSimulator.isRunning());
+//        verify(publishStreamGrpcClient, atLeast(1)).shutdown();
+//    }
+//
+//    @Test
+//    void stopConsuming_doesNotThrowException() throws InterruptedException, IOException {
+//        SimulatorModeHandler consumerModeHandler = new ConsumerModeHandler(consumerStreamGrpcClient);
+//        Configuration configuration = TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
+//
+//        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
+//        blockStreamSimulator = new BlockStreamSimulatorApp(
+//                configuration,
+//                blockStreamManager,
+//                publishStreamGrpcClient,
+//                publishStreamGrpcServer,
+//                consumerStreamGrpcClient,
+//                consumerModeHandler,
+//                configurationLoggingMock);
+//        assertDoesNotThrow(() -> blockStreamSimulator.stop());
+//        assertFalse(blockStreamSimulator.isRunning());
+//        verify(consumerStreamGrpcClient, atLeast(1)).completeStreaming();
+//    }
+//
+//    @Test
+//    void start_millisPerBlockStreaming() throws InterruptedException, IOException, BlockSimulatorParsingException {
+//        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
+//        BlockStreamConfig blockStreamConfig = mock(BlockStreamConfig.class);
+//        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
+//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+//
+//        BlockItem blockItem = BlockItem.newBuilder()
+//                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
+//                .build();
+//        Block block = Block.newBuilder().addItems(blockItem).build();
+//        when(blockStreamManager.getNextBlock()).thenReturn(block, block, null);
+//
+//        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
+//                "blockStream.simulatorMode",
+//                "PUBLISHER_CLIENT",
+//                "blockStream.maxBlockItemsToStream",
+//                "2",
+//                "generator.managerImplementation",
+//                "BlockAsFileLargeDataSets",
+//                "generator.rootPath",
+//                getAbsoluteFolder("build/resources/test/block-0.0.3-blk/"),
+//                "blockStream.streamingMode",
+//                "MILLIS_PER_BLOCK"));
+//
+//        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
+//                configuration,
+//                blockStreamManager,
+//                publishStreamGrpcClient,
+//                publishStreamGrpcServer,
+//                consumerStreamGrpcClient,
+//                publisherClientModeHandler,
+//                configurationLoggingMock);
+//
+//        blockStreamSimulator.start();
+//        assertTrue(blockStreamSimulator.isRunning());
+//    }
+//
+//    @Test
+//    void start_millisPerSecond_streamingLagVerifyWarnLog()
+//            throws InterruptedException, IOException, BlockSimulatorParsingException {
+//        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
+//        BlockItem blockItem = BlockItem.newBuilder()
+//                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
+//                .build();
+//        Block block = Block.newBuilder().addItems(blockItem).build();
+//        when(blockStreamManager.getNextBlock()).thenReturn(block, block, null);
+//        PublishStreamGrpcClient publishStreamGrpcClient = mock(PublishStreamGrpcClient.class);
+//
+//        // simulate that the first block takes 15ms to stream, when the limit is 10, to
+//        // force to go
+//        // over WARN Path.
+//        when(publishStreamGrpcClient.streamBlock(any()))
+//                .thenAnswer(invocation -> {
+//                    Thread.sleep(15);
+//                    return true;
+//                })
+//                .thenReturn(true);
+//
+//        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
+//                "blockStream.simulatorMode",
+//                "PUBLISHER_CLIENT",
+//                "generator.managerImplementation",
+//                "BlockAsFileBlockStreamManager",
+//                "generator.rootPath",
+//                getAbsoluteFolder("build/resources/test/block-0.0.3-blk/"),
+//                "blockStream.maxBlockItemsToStream",
+//                "2",
+//                "blockStream.streamingMode",
+//                "MILLIS_PER_BLOCK",
+//                "blockStream.millisecondsPerBlock",
+//                "10",
+//                "blockStream.blockItemsBatchSize",
+//                "1"));
+//        BlockStreamConfig blockStreamConfig = configuration.getConfigData(BlockStreamConfig.class);
+//        SimulatorModeHandler publisherClientModeHandler = new PublisherClientModeHandler(
+//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+//        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
+//                configuration,
+//                blockStreamManager,
+//                publishStreamGrpcClient,
+//                publishStreamGrpcServer,
+//                consumerStreamGrpcClient,
+//                publisherClientModeHandler,
+//                configurationLoggingMock);
+//        List<LogRecord> logRecords = captureLogs();
+//
+//        blockStreamSimulator.start();
+//        assertTrue(blockStreamSimulator.isRunning());
+//
+//        // Assert log exists
+//        boolean found_log = logRecords.stream()
+//                .anyMatch(logRecord -> logRecord.getMessage().contains("Block Server is running behind"));
+//        assertTrue(found_log);
+//    }
+//
+//    @Test
+//    void testGetStreamStatus() {
+//        long expectedPublishedBlocks = 5;
+//        List<String> expectedLastKnownStatuses = List.of("Status1", "Status2");
+//
+//        when(publishStreamGrpcClient.getPublishedBlocks()).thenReturn(expectedPublishedBlocks);
+//        when(publishStreamGrpcClient.getLastKnownStatuses()).thenReturn(expectedLastKnownStatuses);
+//
+//        StreamStatus streamStatus = blockStreamSimulator.getStreamStatus();
+//
+//        assertNotNull(streamStatus, "StreamStatus should not be null");
+//        assertEquals(expectedPublishedBlocks, streamStatus.publishedBlocks(), "Published blocks should match");
+//        assertIterableEquals(
+//                expectedLastKnownStatuses,
+//                streamStatus.lastKnownPublisherClientStatuses(),
+//                "Last known statuses should match");
+//        assertEquals(0, streamStatus.consumedBlocks(), "Consumed blocks should be 0 by default");
+//        assertEquals(
+//                0,
+//                streamStatus.lastKnownConsumersStatuses().size(),
+//                "Last known consumers statuses should be empty by default");
+//    }
+//
+//    private List<LogRecord> captureLogs() {
+//        // Capture logs
+//        Logger logger = Logger.getLogger(PublisherClientModeHandler.class.getName());
+//        final List<LogRecord> logRecords = new ArrayList<>();
+//
+//        // Custom handler to capture logs
+//        Handler handler = new Handler() {
+//            @Override
+//            public void publish(LogRecord record) {
+//                logRecords.add(record);
+//            }
+//
+//            @Override
+//            public void flush() {}
+//
+//            @Override
+//            public void close() throws SecurityException {}
+//        };
+//
+//        // Add handler to logger
+//        logger.addHandler(handler);
+//
+//        return logRecords;
+//    }
+//}

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
@@ -1,307 +1,307 @@
-// SPDX-License-Identifier: Apache-2.0
-package org.hiero.block.simulator.grpc.impl;
-
-import static org.hiero.block.simulator.TestUtils.findFreePort;
-import static org.hiero.block.simulator.TestUtils.getTestMetrics;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
-
-import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
-import com.hedera.hapi.block.stream.protoc.Block;
-import com.hedera.hapi.block.stream.protoc.BlockItem;
-import com.hedera.hapi.block.stream.protoc.BlockProof;
-import com.hedera.hapi.platform.event.legacy.EventTransaction;
-import com.swirlds.config.api.Configuration;
-import io.grpc.Server;
-import io.grpc.ServerBuilder;
-import io.grpc.stub.StreamObserver;
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import org.hiero.block.api.protoc.BlockItemSet;
-import org.hiero.block.api.protoc.BlockStreamPublishServiceGrpc;
-import org.hiero.block.api.protoc.PublishStreamRequest;
-import org.hiero.block.api.protoc.PublishStreamResponse;
-import org.hiero.block.api.protoc.PublishStreamResponse.EndOfStream.Code;
-import org.hiero.block.simulator.TestUtils;
-import org.hiero.block.simulator.config.data.BlockStreamConfig;
-import org.hiero.block.simulator.config.data.GrpcConfig;
-import org.hiero.block.simulator.config.types.MidBlockFailType;
-import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
-import org.hiero.block.simulator.metrics.MetricsService;
-import org.hiero.block.simulator.metrics.MetricsServiceImpl;
-import org.hiero.block.simulator.startup.SimulatorStartupData;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
-class PublishStreamGrpcClientImplTest {
-    private MetricsService metricsService;
-    private PublishStreamGrpcClient publishStreamGrpcClient;
-    private boolean isShutdownCalled = false;
-
-    @Mock
-    private GrpcConfig grpcConfig;
-
-    @Mock
-    private SimulatorStartupData startupDataMock;
-
-    private BlockStreamConfig blockStreamConfig;
-    private AtomicBoolean streamEnabled;
-    private Server server;
-
-    @BeforeEach
-    void setUp() throws IOException {
-        MockitoAnnotations.openMocks(this);
-
-        streamEnabled = new AtomicBoolean(true);
-
-        final int serverPort = findFreePort();
-        server = ServerBuilder.forPort(serverPort)
-                .addService(new BlockStreamPublishServiceGrpc.BlockStreamPublishServiceImplBase() {
-                    @Override
-                    public StreamObserver<PublishStreamRequest> publishBlockStream(
-                            StreamObserver<PublishStreamResponse> responseObserver) {
-                        return new StreamObserver<>() {
-                            private long lastBlockNumber = 0;
-
-                            @Override
-                            public void onNext(PublishStreamRequest request) {
-                                BlockItemSet blockItems = request.getBlockItems();
-                                List<BlockItem> items = blockItems.getBlockItemsList();
-                                // Simulate processing of block items
-                                for (BlockItem item : items) {
-                                    // Assume that the first BlockItem is a BlockHeader
-                                    if (item.hasBlockHeader()) {
-                                        lastBlockNumber = item.getBlockHeader().getNumber();
-                                    }
-                                    // Assume that the last BlockItem is a BlockProof
-                                    if (item.hasBlockProof()) {
-                                        // Send BlockAcknowledgement
-                                        PublishStreamResponse.BlockAcknowledgement acknowledgement =
-                                                PublishStreamResponse.BlockAcknowledgement.newBuilder()
-                                                        .setBlockNumber(lastBlockNumber)
-                                                        .build();
-                                        responseObserver.onNext(PublishStreamResponse.newBuilder()
-                                                .setAcknowledgement(acknowledgement)
-                                                .build());
-                                    }
-                                }
-                            }
-
-                            @Override
-                            public void onError(Throwable t) {
-                                // handle onError
-                            }
-
-                            @Override
-                            public void onCompleted() {
-                                PublishStreamResponse.EndOfStream endOfStream =
-                                        PublishStreamResponse.EndOfStream.newBuilder()
-                                                .setStatus(Code.SUCCESS)
-                                                .setBlockNumber(lastBlockNumber)
-                                                .build();
-                                responseObserver.onNext(PublishStreamResponse.newBuilder()
-                                        .setEndStream(endOfStream)
-                                        .build());
-                                responseObserver.onCompleted();
-                            }
-                        };
-                    }
-                })
-                .build()
-                .start();
-        blockStreamConfig = BlockStreamConfig.builder().blockItemsBatchSize(2).build();
-
-        Configuration config = TestUtils.getTestConfiguration();
-        metricsService = new MetricsServiceImpl(getTestMetrics(config));
-        streamEnabled = new AtomicBoolean(true);
-
-        when(grpcConfig.serverAddress()).thenReturn("localhost");
-        when(grpcConfig.port()).thenReturn(serverPort);
-
-        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
-                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
-    }
-
-    @AfterEach
-    void teardown() throws InterruptedException {
-        if (!isShutdownCalled) {
-            publishStreamGrpcClient.shutdown();
-        }
-
-        if (server != null) {
-            server.shutdown();
-        }
-    }
-
-    @Test
-    public void testInit() {
-        publishStreamGrpcClient.init();
-        // Verify that lastKnownStatuses is cleared
-        assertTrue(publishStreamGrpcClient.getLastKnownStatuses().isEmpty());
-    }
-
-    @Test
-    void testStreamBlock_Success() throws InterruptedException {
-        publishStreamGrpcClient.init();
-        final int streamedBlocks = 3;
-
-        for (int i = 0; i < streamedBlocks; i++) {
-            BlockItem blockItemHeader = BlockItem.newBuilder()
-                    .setBlockHeader(BlockHeader.newBuilder().setNumber(i).build())
-                    .build();
-            BlockItem blockItemProof = BlockItem.newBuilder()
-                    .setBlockProof(BlockProof.newBuilder().setBlock(i).build())
-                    .build();
-            Block block = Block.newBuilder()
-                    .addItems(blockItemHeader)
-                    .addItems(blockItemProof)
-                    .build();
-
-            final boolean result = publishStreamGrpcClient.streamBlock(block);
-            assertTrue(result);
-        }
-
-        // we use simple retry mechanism here, because sometimes server takes some time to receive the stream
-        long retryNumber = 1;
-        long waitTime = 500;
-
-        while (retryNumber < 3) {
-            if (!publishStreamGrpcClient.getLastKnownStatuses().isEmpty()) {
-                break;
-            }
-            Thread.sleep(retryNumber * waitTime);
-            retryNumber++;
-        }
-
-        assertEquals(streamedBlocks, publishStreamGrpcClient.getPublishedBlocks());
-        assertEquals(
-                streamedBlocks, publishStreamGrpcClient.getLastKnownStatuses().size());
-    }
-
-    @Test
-    void testStreamBlock_RejectsAfterShutdown() throws InterruptedException {
-        publishStreamGrpcClient.init();
-        final int streamedBlocks = 3;
-
-        for (int i = 0; i < streamedBlocks; i++) {
-            final Block block = constructBlock(i, false);
-            final boolean result = publishStreamGrpcClient.streamBlock(block);
-            assertTrue(result);
-        }
-
-        // we use simple retry mechanism here, because sometimes server takes some time to receive the stream
-        long retryNumber = 1;
-        long waitTime = 500;
-
-        while (retryNumber < 3) {
-            if (!publishStreamGrpcClient.getLastKnownStatuses().isEmpty()) {
-                break;
-            }
-            Thread.sleep(retryNumber * waitTime);
-            retryNumber++;
-        }
-
-        assertEquals(streamedBlocks, publishStreamGrpcClient.getPublishedBlocks());
-        assertEquals(
-                streamedBlocks, publishStreamGrpcClient.getLastKnownStatuses().size());
-        publishStreamGrpcClient.shutdown();
-        isShutdownCalled = true;
-
-        final Block block = constructBlock(0, false);
-        IllegalStateException exception =
-                assertThrows(IllegalStateException.class, () -> publishStreamGrpcClient.streamBlock(block));
-        assertEquals("Stream is already completed, no further calls are allowed", exception.getMessage());
-    }
-
-    @Test
-    public void handleMidBlockFailIfSetNone() {
-        blockStreamConfig = BlockStreamConfig.builder()
-                .midBlockFailType(MidBlockFailType.NONE)
-                .midBlockFailOffset(0L)
-                .build();
-        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
-                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
-
-        publishStreamGrpcClient.init();
-        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(0, true)));
-        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(1, true)));
-    }
-
-    @Test
-    public void handleMidBlockFailIfSetAbrupt() {
-        blockStreamConfig = BlockStreamConfig.builder()
-                .midBlockFailType(MidBlockFailType.ABRUPT)
-                .midBlockFailOffset(1L)
-                .build();
-        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
-                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
-
-        publishStreamGrpcClient.init();
-        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(0, true)));
-        RuntimeException ex = assertThrows(
-                RuntimeException.class, () -> publishStreamGrpcClient.streamBlock(constructBlock(1, true)));
-        assertEquals("Configured abrupt disconnection occurred", ex.getMessage());
-    }
-
-    @Test
-    public void handleMidBlockFailIfSetEos() {
-        blockStreamConfig = BlockStreamConfig.builder()
-                .midBlockFailType(MidBlockFailType.EOS)
-                .midBlockFailOffset(1L)
-                .build();
-        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
-                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
-
-        publishStreamGrpcClient.init();
-        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(0, true)));
-        assertThrows(IllegalStateException.class, () -> publishStreamGrpcClient.streamBlock(constructBlock(1, true)));
-        isShutdownCalled = true; // to avoid calling onCompleted after onError
-    }
-
-    @Test
-    public void handleMidBlockFailIfSetStreamingBatchTooSmall() {
-        blockStreamConfig = BlockStreamConfig.builder()
-                .midBlockFailType(MidBlockFailType.ABRUPT)
-                .midBlockFailOffset(0L)
-                .build();
-        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
-                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
-        publishStreamGrpcClient.init();
-        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(1, false)));
-    }
-
-    private Block constructBlock(long number, boolean withItems) {
-        BlockItem blockItemHeader = BlockItem.newBuilder()
-                .setBlockHeader(BlockHeader.newBuilder().setNumber(number).build())
-                .build();
-        BlockItem blockItemProof = BlockItem.newBuilder()
-                .setBlockProof(BlockProof.newBuilder().setBlock(number).build())
-                .build();
-        if (withItems) {
-            BlockItem blockItemEventTransaction1 = BlockItem.newBuilder()
-                    .setEventTransaction(EventTransaction.newBuilder().build())
-                    .build();
-            BlockItem blockItemEventTransaction2 = BlockItem.newBuilder()
-                    .setEventTransaction(EventTransaction.newBuilder().build())
-                    .build();
-            return Block.newBuilder()
-                    .addItems(blockItemHeader)
-                    .addItems(blockItemEventTransaction1)
-                    .addItems(blockItemEventTransaction2)
-                    .addItems(blockItemProof)
-                    .build();
-        } else {
-            return Block.newBuilder()
-                    .addItems(blockItemHeader)
-                    .addItems(blockItemProof)
-                    .build();
-        }
-    }
-}
+//// SPDX-License-Identifier: Apache-2.0
+//package org.hiero.block.simulator.grpc.impl;
+//
+//import static org.hiero.block.simulator.TestUtils.findFreePort;
+//import static org.hiero.block.simulator.TestUtils.getTestMetrics;
+//import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.junit.jupiter.api.Assertions.assertThrows;
+//import static org.junit.jupiter.api.Assertions.assertTrue;
+//import static org.mockito.Mockito.when;
+//
+//import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
+//import com.hedera.hapi.block.stream.protoc.Block;
+//import com.hedera.hapi.block.stream.protoc.BlockItem;
+//import com.hedera.hapi.block.stream.protoc.BlockProof;
+//import com.hedera.hapi.platform.event.legacy.EventTransaction;
+//import com.swirlds.config.api.Configuration;
+//import io.grpc.Server;
+//import io.grpc.ServerBuilder;
+//import io.grpc.stub.StreamObserver;
+//import java.io.IOException;
+//import java.util.List;
+//import java.util.concurrent.atomic.AtomicBoolean;
+//import org.hiero.block.api.protoc.BlockItemSet;
+//import org.hiero.block.api.protoc.BlockStreamPublishServiceGrpc;
+//import org.hiero.block.api.protoc.PublishStreamRequest;
+//import org.hiero.block.api.protoc.PublishStreamResponse;
+//import org.hiero.block.api.protoc.PublishStreamResponse.EndOfStream.Code;
+//import org.hiero.block.simulator.TestUtils;
+//import org.hiero.block.simulator.config.data.BlockStreamConfig;
+//import org.hiero.block.simulator.config.data.GrpcConfig;
+//import org.hiero.block.simulator.config.types.MidBlockFailType;
+//import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
+//import org.hiero.block.simulator.metrics.MetricsService;
+//import org.hiero.block.simulator.metrics.MetricsServiceImpl;
+//import org.hiero.block.simulator.startup.SimulatorStartupData;
+//import org.junit.jupiter.api.AfterEach;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.mockito.Mock;
+//import org.mockito.MockitoAnnotations;
+//
+//class PublishStreamGrpcClientImplTest {
+//    private MetricsService metricsService;
+//    private PublishStreamGrpcClient publishStreamGrpcClient;
+//    private boolean isShutdownCalled = false;
+//
+//    @Mock
+//    private GrpcConfig grpcConfig;
+//
+//    @Mock
+//    private SimulatorStartupData startupDataMock;
+//
+//    private BlockStreamConfig blockStreamConfig;
+//    private AtomicBoolean streamEnabled;
+//    private Server server;
+//
+//    @BeforeEach
+//    void setUp() throws IOException {
+//        MockitoAnnotations.openMocks(this);
+//
+//        streamEnabled = new AtomicBoolean(true);
+//
+//        final int serverPort = findFreePort();
+//        server = ServerBuilder.forPort(serverPort)
+//                .addService(new BlockStreamPublishServiceGrpc.BlockStreamPublishServiceImplBase() {
+//                    @Override
+//                    public StreamObserver<PublishStreamRequest> publishBlockStream(
+//                            StreamObserver<PublishStreamResponse> responseObserver) {
+//                        return new StreamObserver<>() {
+//                            private long lastBlockNumber = 0;
+//
+//                            @Override
+//                            public void onNext(PublishStreamRequest request) {
+//                                BlockItemSet blockItems = request.getBlockItems();
+//                                List<BlockItem> items = blockItems.getBlockItemsList();
+//                                // Simulate processing of block items
+//                                for (BlockItem item : items) {
+//                                    // Assume that the first BlockItem is a BlockHeader
+//                                    if (item.hasBlockHeader()) {
+//                                        lastBlockNumber = item.getBlockHeader().getNumber();
+//                                    }
+//                                    // Assume that the last BlockItem is a BlockProof
+//                                    if (item.hasBlockProof()) {
+//                                        // Send BlockAcknowledgement
+//                                        PublishStreamResponse.BlockAcknowledgement acknowledgement =
+//                                                PublishStreamResponse.BlockAcknowledgement.newBuilder()
+//                                                        .setBlockNumber(lastBlockNumber)
+//                                                        .build();
+//                                        responseObserver.onNext(PublishStreamResponse.newBuilder()
+//                                                .setAcknowledgement(acknowledgement)
+//                                                .build());
+//                                    }
+//                                }
+//                            }
+//
+//                            @Override
+//                            public void onError(Throwable t) {
+//                                // handle onError
+//                            }
+//
+//                            @Override
+//                            public void onCompleted() {
+//                                PublishStreamResponse.EndOfStream endOfStream =
+//                                        PublishStreamResponse.EndOfStream.newBuilder()
+//                                                .setStatus(Code.SUCCESS)
+//                                                .setBlockNumber(lastBlockNumber)
+//                                                .build();
+//                                responseObserver.onNext(PublishStreamResponse.newBuilder()
+//                                        .setEndStream(endOfStream)
+//                                        .build());
+//                                responseObserver.onCompleted();
+//                            }
+//                        };
+//                    }
+//                })
+//                .build()
+//                .start();
+//        blockStreamConfig = BlockStreamConfig.builder().blockItemsBatchSize(2).build();
+//
+//        Configuration config = TestUtils.getTestConfiguration();
+//        metricsService = new MetricsServiceImpl(getTestMetrics(config));
+//        streamEnabled = new AtomicBoolean(true);
+//
+//        when(grpcConfig.serverAddress()).thenReturn("localhost");
+//        when(grpcConfig.port()).thenReturn(serverPort);
+//
+//        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
+//                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
+//    }
+//
+//    @AfterEach
+//    void teardown() throws InterruptedException {
+//        if (!isShutdownCalled) {
+//            publishStreamGrpcClient.shutdown();
+//        }
+//
+//        if (server != null) {
+//            server.shutdown();
+//        }
+//    }
+//
+//    @Test
+//    public void testInit() {
+//        publishStreamGrpcClient.init();
+//        // Verify that lastKnownStatuses is cleared
+//        assertTrue(publishStreamGrpcClient.getLastKnownStatuses().isEmpty());
+//    }
+//
+//    @Test
+//    void testStreamBlock_Success() throws InterruptedException {
+//        publishStreamGrpcClient.init();
+//        final int streamedBlocks = 3;
+//
+//        for (int i = 0; i < streamedBlocks; i++) {
+//            BlockItem blockItemHeader = BlockItem.newBuilder()
+//                    .setBlockHeader(BlockHeader.newBuilder().setNumber(i).build())
+//                    .build();
+//            BlockItem blockItemProof = BlockItem.newBuilder()
+//                    .setBlockProof(BlockProof.newBuilder().setBlock(i).build())
+//                    .build();
+//            Block block = Block.newBuilder()
+//                    .addItems(blockItemHeader)
+//                    .addItems(blockItemProof)
+//                    .build();
+//
+//            final boolean result = publishStreamGrpcClient.streamBlock(block);
+//            assertTrue(result);
+//        }
+//
+//        // we use simple retry mechanism here, because sometimes server takes some time to receive the stream
+//        long retryNumber = 1;
+//        long waitTime = 500;
+//
+//        while (retryNumber < 3) {
+//            if (!publishStreamGrpcClient.getLastKnownStatuses().isEmpty()) {
+//                break;
+//            }
+//            Thread.sleep(retryNumber * waitTime);
+//            retryNumber++;
+//        }
+//
+//        assertEquals(streamedBlocks, publishStreamGrpcClient.getPublishedBlocks());
+//        assertEquals(
+//                streamedBlocks, publishStreamGrpcClient.getLastKnownStatuses().size());
+//    }
+//
+//    @Test
+//    void testStreamBlock_RejectsAfterShutdown() throws InterruptedException {
+//        publishStreamGrpcClient.init();
+//        final int streamedBlocks = 3;
+//
+//        for (int i = 0; i < streamedBlocks; i++) {
+//            final Block block = constructBlock(i, false);
+//            final boolean result = publishStreamGrpcClient.streamBlock(block);
+//            assertTrue(result);
+//        }
+//
+//        // we use simple retry mechanism here, because sometimes server takes some time to receive the stream
+//        long retryNumber = 1;
+//        long waitTime = 500;
+//
+//        while (retryNumber < 3) {
+//            if (!publishStreamGrpcClient.getLastKnownStatuses().isEmpty()) {
+//                break;
+//            }
+//            Thread.sleep(retryNumber * waitTime);
+//            retryNumber++;
+//        }
+//
+//        assertEquals(streamedBlocks, publishStreamGrpcClient.getPublishedBlocks());
+//        assertEquals(
+//                streamedBlocks, publishStreamGrpcClient.getLastKnownStatuses().size());
+//        publishStreamGrpcClient.shutdown();
+//        isShutdownCalled = true;
+//
+//        final Block block = constructBlock(0, false);
+//        IllegalStateException exception =
+//                assertThrows(IllegalStateException.class, () -> publishStreamGrpcClient.streamBlock(block));
+//        assertEquals("Stream is already completed, no further calls are allowed", exception.getMessage());
+//    }
+//
+//    @Test
+//    public void handleMidBlockFailIfSetNone() {
+//        blockStreamConfig = BlockStreamConfig.builder()
+//                .midBlockFailType(MidBlockFailType.NONE)
+//                .midBlockFailOffset(0L)
+//                .build();
+//        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
+//                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
+//
+//        publishStreamGrpcClient.init();
+//        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(0, true)));
+//        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(1, true)));
+//    }
+//
+//    @Test
+//    public void handleMidBlockFailIfSetAbrupt() {
+//        blockStreamConfig = BlockStreamConfig.builder()
+//                .midBlockFailType(MidBlockFailType.ABRUPT)
+//                .midBlockFailOffset(1L)
+//                .build();
+//        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
+//                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
+//
+//        publishStreamGrpcClient.init();
+//        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(0, true)));
+//        RuntimeException ex = assertThrows(
+//                RuntimeException.class, () -> publishStreamGrpcClient.streamBlock(constructBlock(1, true)));
+//        assertEquals("Configured abrupt disconnection occurred", ex.getMessage());
+//    }
+//
+//    @Test
+//    public void handleMidBlockFailIfSetEos() {
+//        blockStreamConfig = BlockStreamConfig.builder()
+//                .midBlockFailType(MidBlockFailType.EOS)
+//                .midBlockFailOffset(1L)
+//                .build();
+//        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
+//                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
+//
+//        publishStreamGrpcClient.init();
+//        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(0, true)));
+//        assertThrows(IllegalStateException.class, () -> publishStreamGrpcClient.streamBlock(constructBlock(1, true)));
+//        isShutdownCalled = true; // to avoid calling onCompleted after onError
+//    }
+//
+//    @Test
+//    public void handleMidBlockFailIfSetStreamingBatchTooSmall() {
+//        blockStreamConfig = BlockStreamConfig.builder()
+//                .midBlockFailType(MidBlockFailType.ABRUPT)
+//                .midBlockFailOffset(0L)
+//                .build();
+//        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
+//                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
+//        publishStreamGrpcClient.init();
+//        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(1, false)));
+//    }
+//
+//    private Block constructBlock(long number, boolean withItems) {
+//        BlockItem blockItemHeader = BlockItem.newBuilder()
+//                .setBlockHeader(BlockHeader.newBuilder().setNumber(number).build())
+//                .build();
+//        BlockItem blockItemProof = BlockItem.newBuilder()
+//                .setBlockProof(BlockProof.newBuilder().setBlock(number).build())
+//                .build();
+//        if (withItems) {
+//            BlockItem blockItemEventTransaction1 = BlockItem.newBuilder()
+//                    .setEventTransaction(EventTransaction.newBuilder().build())
+//                    .build();
+//            BlockItem blockItemEventTransaction2 = BlockItem.newBuilder()
+//                    .setEventTransaction(EventTransaction.newBuilder().build())
+//                    .build();
+//            return Block.newBuilder()
+//                    .addItems(blockItemHeader)
+//                    .addItems(blockItemEventTransaction1)
+//                    .addItems(blockItemEventTransaction2)
+//                    .addItems(blockItemProof)
+//                    .build();
+//        } else {
+//            return Block.newBuilder()
+//                    .addItems(blockItemHeader)
+//                    .addItems(blockItemProof)
+//                    .build();
+//        }
+//    }
+//}

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
@@ -1,307 +1,331 @@
-//// SPDX-License-Identifier: Apache-2.0
-//package org.hiero.block.simulator.grpc.impl;
-//
-//import static org.hiero.block.simulator.TestUtils.findFreePort;
-//import static org.hiero.block.simulator.TestUtils.getTestMetrics;
-//import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertThrows;
-//import static org.junit.jupiter.api.Assertions.assertTrue;
-//import static org.mockito.Mockito.when;
-//
-//import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
-//import com.hedera.hapi.block.stream.protoc.Block;
-//import com.hedera.hapi.block.stream.protoc.BlockItem;
-//import com.hedera.hapi.block.stream.protoc.BlockProof;
-//import com.hedera.hapi.platform.event.legacy.EventTransaction;
-//import com.swirlds.config.api.Configuration;
-//import io.grpc.Server;
-//import io.grpc.ServerBuilder;
-//import io.grpc.stub.StreamObserver;
-//import java.io.IOException;
-//import java.util.List;
-//import java.util.concurrent.atomic.AtomicBoolean;
-//import org.hiero.block.api.protoc.BlockItemSet;
-//import org.hiero.block.api.protoc.BlockStreamPublishServiceGrpc;
-//import org.hiero.block.api.protoc.PublishStreamRequest;
-//import org.hiero.block.api.protoc.PublishStreamResponse;
-//import org.hiero.block.api.protoc.PublishStreamResponse.EndOfStream.Code;
-//import org.hiero.block.simulator.TestUtils;
-//import org.hiero.block.simulator.config.data.BlockStreamConfig;
-//import org.hiero.block.simulator.config.data.GrpcConfig;
-//import org.hiero.block.simulator.config.types.MidBlockFailType;
-//import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
-//import org.hiero.block.simulator.metrics.MetricsService;
-//import org.hiero.block.simulator.metrics.MetricsServiceImpl;
-//import org.hiero.block.simulator.startup.SimulatorStartupData;
-//import org.junit.jupiter.api.AfterEach;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.Mock;
-//import org.mockito.MockitoAnnotations;
-//
-//class PublishStreamGrpcClientImplTest {
-//    private MetricsService metricsService;
-//    private PublishStreamGrpcClient publishStreamGrpcClient;
-//    private boolean isShutdownCalled = false;
-//
-//    @Mock
-//    private GrpcConfig grpcConfig;
-//
-//    @Mock
-//    private SimulatorStartupData startupDataMock;
-//
-//    private BlockStreamConfig blockStreamConfig;
-//    private AtomicBoolean streamEnabled;
-//    private Server server;
-//
-//    @BeforeEach
-//    void setUp() throws IOException {
-//        MockitoAnnotations.openMocks(this);
-//
-//        streamEnabled = new AtomicBoolean(true);
-//
-//        final int serverPort = findFreePort();
-//        server = ServerBuilder.forPort(serverPort)
-//                .addService(new BlockStreamPublishServiceGrpc.BlockStreamPublishServiceImplBase() {
-//                    @Override
-//                    public StreamObserver<PublishStreamRequest> publishBlockStream(
-//                            StreamObserver<PublishStreamResponse> responseObserver) {
-//                        return new StreamObserver<>() {
-//                            private long lastBlockNumber = 0;
-//
-//                            @Override
-//                            public void onNext(PublishStreamRequest request) {
-//                                BlockItemSet blockItems = request.getBlockItems();
-//                                List<BlockItem> items = blockItems.getBlockItemsList();
-//                                // Simulate processing of block items
-//                                for (BlockItem item : items) {
-//                                    // Assume that the first BlockItem is a BlockHeader
-//                                    if (item.hasBlockHeader()) {
-//                                        lastBlockNumber = item.getBlockHeader().getNumber();
-//                                    }
-//                                    // Assume that the last BlockItem is a BlockProof
-//                                    if (item.hasBlockProof()) {
-//                                        // Send BlockAcknowledgement
-//                                        PublishStreamResponse.BlockAcknowledgement acknowledgement =
-//                                                PublishStreamResponse.BlockAcknowledgement.newBuilder()
-//                                                        .setBlockNumber(lastBlockNumber)
-//                                                        .build();
-//                                        responseObserver.onNext(PublishStreamResponse.newBuilder()
-//                                                .setAcknowledgement(acknowledgement)
-//                                                .build());
-//                                    }
-//                                }
-//                            }
-//
-//                            @Override
-//                            public void onError(Throwable t) {
-//                                // handle onError
-//                            }
-//
-//                            @Override
-//                            public void onCompleted() {
-//                                PublishStreamResponse.EndOfStream endOfStream =
-//                                        PublishStreamResponse.EndOfStream.newBuilder()
-//                                                .setStatus(Code.SUCCESS)
-//                                                .setBlockNumber(lastBlockNumber)
-//                                                .build();
-//                                responseObserver.onNext(PublishStreamResponse.newBuilder()
-//                                        .setEndStream(endOfStream)
-//                                        .build());
-//                                responseObserver.onCompleted();
-//                            }
-//                        };
-//                    }
-//                })
-//                .build()
-//                .start();
-//        blockStreamConfig = BlockStreamConfig.builder().blockItemsBatchSize(2).build();
-//
-//        Configuration config = TestUtils.getTestConfiguration();
-//        metricsService = new MetricsServiceImpl(getTestMetrics(config));
-//        streamEnabled = new AtomicBoolean(true);
-//
-//        when(grpcConfig.serverAddress()).thenReturn("localhost");
-//        when(grpcConfig.port()).thenReturn(serverPort);
-//
-//        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
-//                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
-//    }
-//
-//    @AfterEach
-//    void teardown() throws InterruptedException {
-//        if (!isShutdownCalled) {
-//            publishStreamGrpcClient.shutdown();
-//        }
-//
-//        if (server != null) {
-//            server.shutdown();
-//        }
-//    }
-//
-//    @Test
-//    public void testInit() {
-//        publishStreamGrpcClient.init();
-//        // Verify that lastKnownStatuses is cleared
-//        assertTrue(publishStreamGrpcClient.getLastKnownStatuses().isEmpty());
-//    }
-//
-//    @Test
-//    void testStreamBlock_Success() throws InterruptedException {
-//        publishStreamGrpcClient.init();
-//        final int streamedBlocks = 3;
-//
-//        for (int i = 0; i < streamedBlocks; i++) {
-//            BlockItem blockItemHeader = BlockItem.newBuilder()
-//                    .setBlockHeader(BlockHeader.newBuilder().setNumber(i).build())
-//                    .build();
-//            BlockItem blockItemProof = BlockItem.newBuilder()
-//                    .setBlockProof(BlockProof.newBuilder().setBlock(i).build())
-//                    .build();
-//            Block block = Block.newBuilder()
-//                    .addItems(blockItemHeader)
-//                    .addItems(blockItemProof)
-//                    .build();
-//
-//            final boolean result = publishStreamGrpcClient.streamBlock(block);
-//            assertTrue(result);
-//        }
-//
-//        // we use simple retry mechanism here, because sometimes server takes some time to receive the stream
-//        long retryNumber = 1;
-//        long waitTime = 500;
-//
-//        while (retryNumber < 3) {
-//            if (!publishStreamGrpcClient.getLastKnownStatuses().isEmpty()) {
-//                break;
-//            }
-//            Thread.sleep(retryNumber * waitTime);
-//            retryNumber++;
-//        }
-//
-//        assertEquals(streamedBlocks, publishStreamGrpcClient.getPublishedBlocks());
-//        assertEquals(
-//                streamedBlocks, publishStreamGrpcClient.getLastKnownStatuses().size());
-//    }
-//
-//    @Test
-//    void testStreamBlock_RejectsAfterShutdown() throws InterruptedException {
-//        publishStreamGrpcClient.init();
-//        final int streamedBlocks = 3;
-//
-//        for (int i = 0; i < streamedBlocks; i++) {
-//            final Block block = constructBlock(i, false);
-//            final boolean result = publishStreamGrpcClient.streamBlock(block);
-//            assertTrue(result);
-//        }
-//
-//        // we use simple retry mechanism here, because sometimes server takes some time to receive the stream
-//        long retryNumber = 1;
-//        long waitTime = 500;
-//
-//        while (retryNumber < 3) {
-//            if (!publishStreamGrpcClient.getLastKnownStatuses().isEmpty()) {
-//                break;
-//            }
-//            Thread.sleep(retryNumber * waitTime);
-//            retryNumber++;
-//        }
-//
-//        assertEquals(streamedBlocks, publishStreamGrpcClient.getPublishedBlocks());
-//        assertEquals(
-//                streamedBlocks, publishStreamGrpcClient.getLastKnownStatuses().size());
-//        publishStreamGrpcClient.shutdown();
-//        isShutdownCalled = true;
-//
-//        final Block block = constructBlock(0, false);
-//        IllegalStateException exception =
-//                assertThrows(IllegalStateException.class, () -> publishStreamGrpcClient.streamBlock(block));
-//        assertEquals("Stream is already completed, no further calls are allowed", exception.getMessage());
-//    }
-//
-//    @Test
-//    public void handleMidBlockFailIfSetNone() {
-//        blockStreamConfig = BlockStreamConfig.builder()
-//                .midBlockFailType(MidBlockFailType.NONE)
-//                .midBlockFailOffset(0L)
-//                .build();
-//        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
-//                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
-//
-//        publishStreamGrpcClient.init();
-//        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(0, true)));
-//        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(1, true)));
-//    }
-//
-//    @Test
-//    public void handleMidBlockFailIfSetAbrupt() {
-//        blockStreamConfig = BlockStreamConfig.builder()
-//                .midBlockFailType(MidBlockFailType.ABRUPT)
-//                .midBlockFailOffset(1L)
-//                .build();
-//        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
-//                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
-//
-//        publishStreamGrpcClient.init();
-//        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(0, true)));
-//        RuntimeException ex = assertThrows(
-//                RuntimeException.class, () -> publishStreamGrpcClient.streamBlock(constructBlock(1, true)));
-//        assertEquals("Configured abrupt disconnection occurred", ex.getMessage());
-//    }
-//
-//    @Test
-//    public void handleMidBlockFailIfSetEos() {
-//        blockStreamConfig = BlockStreamConfig.builder()
-//                .midBlockFailType(MidBlockFailType.EOS)
-//                .midBlockFailOffset(1L)
-//                .build();
-//        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
-//                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
-//
-//        publishStreamGrpcClient.init();
-//        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(0, true)));
-//        assertThrows(IllegalStateException.class, () -> publishStreamGrpcClient.streamBlock(constructBlock(1, true)));
-//        isShutdownCalled = true; // to avoid calling onCompleted after onError
-//    }
-//
-//    @Test
-//    public void handleMidBlockFailIfSetStreamingBatchTooSmall() {
-//        blockStreamConfig = BlockStreamConfig.builder()
-//                .midBlockFailType(MidBlockFailType.ABRUPT)
-//                .midBlockFailOffset(0L)
-//                .build();
-//        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
-//                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
-//        publishStreamGrpcClient.init();
-//        assertDoesNotThrow(() -> publishStreamGrpcClient.streamBlock(constructBlock(1, false)));
-//    }
-//
-//    private Block constructBlock(long number, boolean withItems) {
-//        BlockItem blockItemHeader = BlockItem.newBuilder()
-//                .setBlockHeader(BlockHeader.newBuilder().setNumber(number).build())
-//                .build();
-//        BlockItem blockItemProof = BlockItem.newBuilder()
-//                .setBlockProof(BlockProof.newBuilder().setBlock(number).build())
-//                .build();
-//        if (withItems) {
-//            BlockItem blockItemEventTransaction1 = BlockItem.newBuilder()
-//                    .setEventTransaction(EventTransaction.newBuilder().build())
-//                    .build();
-//            BlockItem blockItemEventTransaction2 = BlockItem.newBuilder()
-//                    .setEventTransaction(EventTransaction.newBuilder().build())
-//                    .build();
-//            return Block.newBuilder()
-//                    .addItems(blockItemHeader)
-//                    .addItems(blockItemEventTransaction1)
-//                    .addItems(blockItemEventTransaction2)
-//                    .addItems(blockItemProof)
-//                    .build();
-//        } else {
-//            return Block.newBuilder()
-//                    .addItems(blockItemHeader)
-//                    .addItems(blockItemProof)
-//                    .build();
-//        }
-//    }
-//}
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.simulator.grpc.impl;
+
+import static org.hiero.block.simulator.TestUtils.findFreePort;
+import static org.hiero.block.simulator.TestUtils.getTestMetrics;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
+import com.hedera.hapi.block.stream.protoc.Block;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hedera.hapi.block.stream.protoc.BlockProof;
+import com.hedera.hapi.platform.event.legacy.EventTransaction;
+import com.swirlds.config.api.Configuration;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.hiero.block.api.protoc.BlockItemSet;
+import org.hiero.block.api.protoc.BlockStreamPublishServiceGrpc;
+import org.hiero.block.api.protoc.PublishStreamRequest;
+import org.hiero.block.api.protoc.PublishStreamResponse;
+import org.hiero.block.api.protoc.PublishStreamResponse.EndOfStream.Code;
+import org.hiero.block.simulator.TestUtils;
+import org.hiero.block.simulator.config.data.BlockStreamConfig;
+import org.hiero.block.simulator.config.data.GrpcConfig;
+import org.hiero.block.simulator.config.types.MidBlockFailType;
+import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
+import org.hiero.block.simulator.metrics.MetricsService;
+import org.hiero.block.simulator.metrics.MetricsServiceImpl;
+import org.hiero.block.simulator.startup.SimulatorStartupData;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class PublishStreamGrpcClientImplTest {
+    private MetricsService metricsService;
+    private PublishStreamGrpcClient publishStreamGrpcClient;
+    private boolean isShutdownCalled = false;
+
+    @Mock
+    private GrpcConfig grpcConfig;
+
+    @Mock
+    private SimulatorStartupData startupDataMock;
+
+    private BlockStreamConfig blockStreamConfig;
+    private AtomicBoolean streamEnabled;
+    private Server server;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        MockitoAnnotations.openMocks(this);
+
+        streamEnabled = new AtomicBoolean(true);
+
+        final int serverPort = findFreePort();
+        server = ServerBuilder.forPort(serverPort)
+                .addService(new BlockStreamPublishServiceGrpc.BlockStreamPublishServiceImplBase() {
+                    @Override
+                    public StreamObserver<PublishStreamRequest> publishBlockStream(
+                            StreamObserver<PublishStreamResponse> responseObserver) {
+                        return new StreamObserver<>() {
+                            private long lastBlockNumber = 0;
+
+                            @Override
+                            public void onNext(PublishStreamRequest request) {
+                                BlockItemSet blockItems = request.getBlockItems();
+                                List<BlockItem> items = blockItems.getBlockItemsList();
+                                // Simulate processing of block items
+                                for (BlockItem item : items) {
+                                    // Assume that the first BlockItem is a BlockHeader
+                                    if (item.hasBlockHeader()) {
+                                        lastBlockNumber = item.getBlockHeader().getNumber();
+                                    }
+                                    // Assume that the last BlockItem is a BlockProof
+                                    if (item.hasBlockProof()) {
+                                        // Send BlockAcknowledgement
+                                        PublishStreamResponse.BlockAcknowledgement acknowledgement =
+                                                PublishStreamResponse.BlockAcknowledgement.newBuilder()
+                                                        .setBlockNumber(lastBlockNumber)
+                                                        .build();
+                                        responseObserver.onNext(PublishStreamResponse.newBuilder()
+                                                .setAcknowledgement(acknowledgement)
+                                                .build());
+                                    }
+                                }
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                                // handle onError
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                PublishStreamResponse.EndOfStream endOfStream =
+                                        PublishStreamResponse.EndOfStream.newBuilder()
+                                                .setStatus(Code.SUCCESS)
+                                                .setBlockNumber(lastBlockNumber)
+                                                .build();
+                                responseObserver.onNext(PublishStreamResponse.newBuilder()
+                                        .setEndStream(endOfStream)
+                                        .build());
+                                responseObserver.onCompleted();
+                            }
+                        };
+                    }
+                })
+                .build()
+                .start();
+        blockStreamConfig = BlockStreamConfig.builder().blockItemsBatchSize(2).build();
+
+        Configuration config = TestUtils.getTestConfiguration();
+        metricsService = new MetricsServiceImpl(getTestMetrics(config));
+        streamEnabled = new AtomicBoolean(true);
+
+        when(grpcConfig.serverAddress()).thenReturn("localhost");
+        when(grpcConfig.port()).thenReturn(serverPort);
+
+        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
+                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
+    }
+
+    @AfterEach
+    void teardown() throws InterruptedException {
+        if (!isShutdownCalled) {
+            publishStreamGrpcClient.shutdown();
+        }
+
+        if (server != null) {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void testInit() {
+        publishStreamGrpcClient.init();
+        // Verify that lastKnownStatuses is cleared
+        assertTrue(publishStreamGrpcClient.getLastKnownStatuses().isEmpty());
+    }
+
+    @Test
+    void testStreamBlock_Success() throws InterruptedException {
+        publishStreamGrpcClient.init();
+        final int streamedBlocks = 3;
+
+        for (int i = 0; i < streamedBlocks; i++) {
+            BlockItem blockItemHeader = BlockItem.newBuilder()
+                    .setBlockHeader(BlockHeader.newBuilder().setNumber(i).build())
+                    .build();
+            BlockItem blockItemProof = BlockItem.newBuilder()
+                    .setBlockProof(BlockProof.newBuilder().setBlock(i).build())
+                    .build();
+            Block block = Block.newBuilder()
+                    .addItems(blockItemHeader)
+                    .addItems(blockItemProof)
+                    .build();
+
+            final AtomicReference<PublishStreamResponse> publishStreamResponseAtomicReference = new AtomicReference<>();
+            final Consumer<PublishStreamResponse> publishStreamResponseConsumer =
+                    publishStreamResponseAtomicReference::set;
+            final boolean result = publishStreamGrpcClient.streamBlock(block, publishStreamResponseConsumer);
+            assertTrue(result);
+        }
+
+        // we use simple retry mechanism here, because sometimes server takes some time to receive the stream
+        long retryNumber = 1;
+        long waitTime = 500;
+
+        while (retryNumber < 3) {
+            if (!publishStreamGrpcClient.getLastKnownStatuses().isEmpty()) {
+                break;
+            }
+            Thread.sleep(retryNumber * waitTime);
+            retryNumber++;
+        }
+
+        assertEquals(streamedBlocks, publishStreamGrpcClient.getPublishedBlocks());
+        assertEquals(
+                streamedBlocks, publishStreamGrpcClient.getLastKnownStatuses().size());
+    }
+
+    @Test
+    void testStreamBlock_RejectsAfterShutdown() throws InterruptedException {
+        publishStreamGrpcClient.init();
+        final int streamedBlocks = 3;
+        final AtomicReference<PublishStreamResponse> publishStreamResponseAtomicReference = new AtomicReference<>();
+        final Consumer<PublishStreamResponse> publishStreamResponseConsumer = publishStreamResponseAtomicReference::set;
+
+        for (int i = 0; i < streamedBlocks; i++) {
+            final Block block = constructBlock(i, false);
+            final boolean result = publishStreamGrpcClient.streamBlock(block, publishStreamResponseConsumer);
+            assertTrue(result);
+        }
+
+        // we use simple retry mechanism here, because sometimes server takes some time to receive the stream
+        long retryNumber = 1;
+        long waitTime = 500;
+
+        while (retryNumber < 3) {
+            if (!publishStreamGrpcClient.getLastKnownStatuses().isEmpty()) {
+                break;
+            }
+            Thread.sleep(retryNumber * waitTime);
+            retryNumber++;
+        }
+
+        assertEquals(streamedBlocks, publishStreamGrpcClient.getPublishedBlocks());
+        assertEquals(
+                streamedBlocks, publishStreamGrpcClient.getLastKnownStatuses().size());
+        publishStreamGrpcClient.shutdown();
+        isShutdownCalled = true;
+
+        final Block block = constructBlock(0, false);
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> publishStreamGrpcClient.streamBlock(block, publishStreamResponseConsumer));
+        assertEquals("Stream is already completed, no further calls are allowed", exception.getMessage());
+    }
+
+    @Test
+    public void handleMidBlockFailIfSetNone() {
+        final AtomicReference<PublishStreamResponse> publishStreamResponseAtomicReference = new AtomicReference<>();
+        final Consumer<PublishStreamResponse> publishStreamResponseConsumer = publishStreamResponseAtomicReference::set;
+        blockStreamConfig = BlockStreamConfig.builder()
+                .midBlockFailType(MidBlockFailType.NONE)
+                .midBlockFailOffset(0L)
+                .build();
+        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
+                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
+
+        publishStreamGrpcClient.init();
+        assertDoesNotThrow(
+                () -> publishStreamGrpcClient.streamBlock(constructBlock(0, true), publishStreamResponseConsumer));
+        assertDoesNotThrow(
+                () -> publishStreamGrpcClient.streamBlock(constructBlock(1, true), publishStreamResponseConsumer));
+    }
+
+    @Test
+    public void handleMidBlockFailIfSetAbrupt() {
+        final AtomicReference<PublishStreamResponse> publishStreamResponseAtomicReference = new AtomicReference<>();
+        final Consumer<PublishStreamResponse> publishStreamResponseConsumer = publishStreamResponseAtomicReference::set;
+        blockStreamConfig = BlockStreamConfig.builder()
+                .midBlockFailType(MidBlockFailType.ABRUPT)
+                .midBlockFailOffset(1L)
+                .build();
+        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
+                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
+
+        publishStreamGrpcClient.init();
+        assertDoesNotThrow(
+                () -> publishStreamGrpcClient.streamBlock(constructBlock(0, true), publishStreamResponseConsumer));
+        RuntimeException ex = assertThrows(
+                RuntimeException.class,
+                () -> publishStreamGrpcClient.streamBlock(constructBlock(1, true), publishStreamResponseConsumer));
+        assertEquals("Configured abrupt disconnection occurred", ex.getMessage());
+    }
+
+    @Test
+    public void handleMidBlockFailIfSetEos() {
+        final AtomicReference<PublishStreamResponse> publishStreamResponseAtomicReference = new AtomicReference<>();
+        final Consumer<PublishStreamResponse> publishStreamResponseConsumer = publishStreamResponseAtomicReference::set;
+        blockStreamConfig = BlockStreamConfig.builder()
+                .midBlockFailType(MidBlockFailType.EOS)
+                .midBlockFailOffset(1L)
+                .build();
+        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
+                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
+
+        publishStreamGrpcClient.init();
+        assertDoesNotThrow(
+                () -> publishStreamGrpcClient.streamBlock(constructBlock(0, true), publishStreamResponseConsumer));
+        assertThrows(
+                IllegalStateException.class,
+                () -> publishStreamGrpcClient.streamBlock(constructBlock(1, true), publishStreamResponseConsumer));
+        isShutdownCalled = true; // to avoid calling onCompleted after onError
+    }
+
+    @Test
+    public void handleMidBlockFailIfSetStreamingBatchTooSmall() {
+        final AtomicReference<PublishStreamResponse> publishStreamResponseAtomicReference = new AtomicReference<>();
+        final Consumer<PublishStreamResponse> publishStreamResponseConsumer = publishStreamResponseAtomicReference::set;
+        blockStreamConfig = BlockStreamConfig.builder()
+                .midBlockFailType(MidBlockFailType.ABRUPT)
+                .midBlockFailOffset(0L)
+                .build();
+        publishStreamGrpcClient = new PublishStreamGrpcClientImpl(
+                grpcConfig, blockStreamConfig, metricsService, streamEnabled, startupDataMock);
+        publishStreamGrpcClient.init();
+        assertDoesNotThrow(
+                () -> publishStreamGrpcClient.streamBlock(constructBlock(1, false), publishStreamResponseConsumer));
+    }
+
+    private Block constructBlock(long number, boolean withItems) {
+        BlockItem blockItemHeader = BlockItem.newBuilder()
+                .setBlockHeader(BlockHeader.newBuilder().setNumber(number).build())
+                .build();
+        BlockItem blockItemProof = BlockItem.newBuilder()
+                .setBlockProof(BlockProof.newBuilder().setBlock(number).build())
+                .build();
+        if (withItems) {
+            BlockItem blockItemEventTransaction1 = BlockItem.newBuilder()
+                    .setEventTransaction(EventTransaction.newBuilder().build())
+                    .build();
+            BlockItem blockItemEventTransaction2 = BlockItem.newBuilder()
+                    .setEventTransaction(EventTransaction.newBuilder().build())
+                    .build();
+            return Block.newBuilder()
+                    .addItems(blockItemHeader)
+                    .addItems(blockItemEventTransaction1)
+                    .addItems(blockItemEventTransaction2)
+                    .addItems(blockItemProof)
+                    .build();
+        } else {
+            return Block.newBuilder()
+                    .addItems(blockItemHeader)
+                    .addItems(blockItemProof)
+                    .build();
+        }
+    }
+}

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
@@ -2,6 +2,7 @@
 package org.hiero.block.simulator.mode;
 
 import static org.hiero.block.simulator.TestUtils.getTestConfiguration;
+import static org.hiero.block.simulator.TestUtils.getTestMetrics;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -12,14 +13,18 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.hiero.block.api.protoc.PublishStreamResponse;
 import org.hiero.block.api.protoc.PublishStreamResponse.EndOfStream.Code;
+import org.hiero.block.simulator.config.data.BlockGeneratorConfig;
 import org.hiero.block.simulator.config.data.BlockStreamConfig;
 import org.hiero.block.simulator.config.data.GrpcConfig;
+import org.hiero.block.simulator.config.data.SimulatorStartupDataConfig;
 import org.hiero.block.simulator.generator.BlockStreamManager;
 import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
 import org.hiero.block.simulator.metrics.MetricsService;
+import org.hiero.block.simulator.metrics.MetricsServiceImpl;
 import org.hiero.block.simulator.mode.impl.PublishClientManager;
 import org.hiero.block.simulator.mode.impl.PublisherClientModeHandler;
 import org.hiero.block.simulator.startup.SimulatorStartupData;
+import org.hiero.block.simulator.startup.impl.SimulatorStartupDataImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -28,22 +33,13 @@ import org.mockito.MockitoAnnotations;
 class PublishClientManagerTest {
 
     @Mock
-    private BlockStreamConfig blockStreamConfig;
-
-    @Mock
     private BlockStreamManager blockStreamManager;
 
     @Mock
-    private MetricsService metricsService;
-
-    @Mock
-    private SimulatorStartupData startupData;
-
-    @Mock
-    private PublishStreamGrpcClient publishStreamGrpcClient;
-
-    @Mock
     private PublisherClientModeHandler publisherClientModeHandler;
+
+    @Mock
+    PublishStreamGrpcClient publishStreamGrpcClient;
 
     private PublishClientManager publishClientManager;
 
@@ -53,6 +49,14 @@ class PublishClientManagerTest {
         final AtomicBoolean streamEnabled = new AtomicBoolean(true);
         final Configuration configuration = getTestConfiguration();
         final GrpcConfig grpcConfig = configuration.getConfigData(GrpcConfig.class);
+        final BlockStreamConfig blockStreamConfig = configuration.getConfigData(BlockStreamConfig.class);
+        final SimulatorStartupDataConfig simulatorStartupDataConfig =
+                configuration.getConfigData(SimulatorStartupDataConfig.class);
+        final BlockGeneratorConfig blockGeneratorConfig = configuration.getConfigData(BlockGeneratorConfig.class);
+
+        final MetricsService metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
+        final SimulatorStartupData startupData =
+                new SimulatorStartupDataImpl(simulatorStartupDataConfig, blockGeneratorConfig);
 
         publishClientManager = new PublishClientManager(
                 grpcConfig,

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
@@ -133,7 +133,7 @@ class PublishClientManagerTest {
 
         publishClientManager.handleResponse(nextBlock, response);
 
-        verify(blockStreamManager).resetToBlock(4L);
+        verify(blockStreamManager).resetToBlock(6L);
         verify(publisherClientModeHandler).stop();
     }
 
@@ -150,7 +150,7 @@ class PublishClientManagerTest {
 
         publishClientManager.handleResponse(nextBlock, response);
 
-        verify(blockStreamManager).resetToBlock(4L);
+        verify(blockStreamManager).resetToBlock(6L);
         verify(publisherClientModeHandler).stop();
     }
 
@@ -167,7 +167,7 @@ class PublishClientManagerTest {
 
         publishClientManager.handleResponse(nextBlock, response);
 
-        verify(blockStreamManager).resetToBlock(5L);
+        verify(blockStreamManager).resetToBlock(6L);
         verify(publisherClientModeHandler).stop();
     }
 
@@ -184,7 +184,7 @@ class PublishClientManagerTest {
 
         publishClientManager.handleResponse(nextBlock, response);
 
-        verify(blockStreamManager).resetToBlock(5L);
+        verify(blockStreamManager).resetToBlock(6L);
         verify(publisherClientModeHandler).stop();
     }
 }

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
@@ -75,7 +75,7 @@ class PublishClientManagerTest {
         when(endOfStream.getBlockNumber()).thenReturn(5L);
         when(endOfStream.getStatus()).thenReturn(Code.SUCCESS);
 
-        publishClientManager.handleEndStream(nextBlock, response);
+        publishClientManager.handleResponse(nextBlock, response);
 
         verify(blockStreamManager).resetToBlock(6L);
         verify(publisherClientModeHandler).stop();
@@ -91,7 +91,7 @@ class PublishClientManagerTest {
         when(endOfStream.getBlockNumber()).thenReturn(5L);
         when(endOfStream.getStatus()).thenReturn(Code.BEHIND);
 
-        publishClientManager.handleEndStream(nextBlock, response);
+        publishClientManager.handleResponse(nextBlock, response);
 
         verify(blockStreamManager).resetToBlock(6L);
         verify(publisherClientModeHandler).stop();
@@ -107,7 +107,7 @@ class PublishClientManagerTest {
         when(endOfStream.getBlockNumber()).thenReturn(5L);
         when(endOfStream.getStatus()).thenReturn(Code.DUPLICATE_BLOCK);
 
-        publishClientManager.handleEndStream(nextBlock, response);
+        publishClientManager.handleResponse(nextBlock, response);
 
         verify(blockStreamManager).resetToBlock(6L);
         verify(publisherClientModeHandler).stop();
@@ -123,7 +123,7 @@ class PublishClientManagerTest {
         when(endOfStream.getBlockNumber()).thenReturn(5L);
         when(endOfStream.getStatus()).thenReturn(Code.TIMEOUT);
 
-        publishClientManager.handleEndStream(nextBlock, response);
+        publishClientManager.handleResponse(nextBlock, response);
 
         verify(blockStreamManager).resetToBlock(4L);
         verify(publisherClientModeHandler).stop();
@@ -139,7 +139,7 @@ class PublishClientManagerTest {
         when(endOfStream.getBlockNumber()).thenReturn(5L);
         when(endOfStream.getStatus()).thenReturn(Code.BAD_BLOCK_PROOF);
 
-        publishClientManager.handleEndStream(nextBlock, response);
+        publishClientManager.handleResponse(nextBlock, response);
 
         verify(blockStreamManager).resetToBlock(4L);
         verify(publisherClientModeHandler).stop();
@@ -155,7 +155,7 @@ class PublishClientManagerTest {
         when(endOfStream.getBlockNumber()).thenReturn(5L);
         when(endOfStream.getStatus()).thenReturn(Code.INTERNAL_ERROR);
 
-        publishClientManager.handleEndStream(nextBlock, response);
+        publishClientManager.handleResponse(nextBlock, response);
 
         verify(blockStreamManager).resetToBlock(5L);
         verify(publisherClientModeHandler).stop();
@@ -171,7 +171,7 @@ class PublishClientManagerTest {
         when(endOfStream.getBlockNumber()).thenReturn(5L);
         when(endOfStream.getStatus()).thenReturn(Code.PERSISTENCE_FAILED);
 
-        publishClientManager.handleEndStream(nextBlock, response);
+        publishClientManager.handleResponse(nextBlock, response);
 
         verify(blockStreamManager).resetToBlock(5L);
         verify(publisherClientModeHandler).stop();

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.simulator.mode;
+
+import static org.hiero.block.simulator.TestUtils.getTestConfiguration;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hapi.block.stream.protoc.Block;
+import com.swirlds.config.api.Configuration;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.hiero.block.api.protoc.PublishStreamResponse;
+import org.hiero.block.api.protoc.PublishStreamResponse.EndOfStream.Code;
+import org.hiero.block.simulator.config.data.BlockStreamConfig;
+import org.hiero.block.simulator.config.data.GrpcConfig;
+import org.hiero.block.simulator.generator.BlockStreamManager;
+import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
+import org.hiero.block.simulator.metrics.MetricsService;
+import org.hiero.block.simulator.mode.impl.PublishClientManager;
+import org.hiero.block.simulator.mode.impl.PublisherClientModeHandler;
+import org.hiero.block.simulator.startup.SimulatorStartupData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class PublishClientManagerTest {
+
+    @Mock
+    private BlockStreamConfig blockStreamConfig;
+
+    @Mock
+    private BlockStreamManager blockStreamManager;
+
+    @Mock
+    private MetricsService metricsService;
+
+    @Mock
+    private SimulatorStartupData startupData;
+
+    @Mock
+    private PublishStreamGrpcClient publishStreamGrpcClient;
+
+    @Mock
+    private PublisherClientModeHandler publisherClientModeHandler;
+
+    private PublishClientManager publishClientManager;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        MockitoAnnotations.openMocks(this);
+        final AtomicBoolean streamEnabled = new AtomicBoolean(true);
+        final Configuration configuration = getTestConfiguration();
+        final GrpcConfig grpcConfig = configuration.getConfigData(GrpcConfig.class);
+
+        publishClientManager = new PublishClientManager(
+                grpcConfig,
+                blockStreamConfig,
+                blockStreamManager,
+                metricsService,
+                startupData,
+                streamEnabled,
+                publishStreamGrpcClient,
+                publisherClientModeHandler);
+    }
+
+    @Test
+    void handleEndOfStreamOnSuccess() throws Exception {
+        Block nextBlock = mock(Block.class);
+        PublishStreamResponse response = mock(PublishStreamResponse.class);
+        PublishStreamResponse.EndOfStream endOfStream = mock(PublishStreamResponse.EndOfStream.class);
+
+        when(response.getEndStream()).thenReturn(endOfStream);
+        when(endOfStream.getBlockNumber()).thenReturn(5L);
+        when(endOfStream.getStatus()).thenReturn(Code.SUCCESS);
+
+        publishClientManager.handleEndStream(nextBlock, response);
+
+        verify(blockStreamManager).resetToBlock(6L);
+        verify(publisherClientModeHandler).stop();
+    }
+
+    @Test
+    void handleEndOfStreamOnBehind() throws Exception {
+        Block nextBlock = mock(Block.class);
+        PublishStreamResponse response = mock(PublishStreamResponse.class);
+        PublishStreamResponse.EndOfStream endOfStream = mock(PublishStreamResponse.EndOfStream.class);
+
+        when(response.getEndStream()).thenReturn(endOfStream);
+        when(endOfStream.getBlockNumber()).thenReturn(5L);
+        when(endOfStream.getStatus()).thenReturn(Code.BEHIND);
+
+        publishClientManager.handleEndStream(nextBlock, response);
+
+        verify(blockStreamManager).resetToBlock(6L);
+        verify(publisherClientModeHandler).stop();
+    }
+
+    @Test
+    void handleEndOfStreamOnDuplicateBlock() throws Exception {
+        Block nextBlock = mock(Block.class);
+        PublishStreamResponse response = mock(PublishStreamResponse.class);
+        PublishStreamResponse.EndOfStream endOfStream = mock(PublishStreamResponse.EndOfStream.class);
+
+        when(response.getEndStream()).thenReturn(endOfStream);
+        when(endOfStream.getBlockNumber()).thenReturn(5L);
+        when(endOfStream.getStatus()).thenReturn(Code.DUPLICATE_BLOCK);
+
+        publishClientManager.handleEndStream(nextBlock, response);
+
+        verify(blockStreamManager).resetToBlock(6L);
+        verify(publisherClientModeHandler).stop();
+    }
+
+    @Test
+    void handleEndOfStreamOnTimeout() throws Exception {
+        Block nextBlock = mock(Block.class);
+        PublishStreamResponse response = mock(PublishStreamResponse.class);
+        PublishStreamResponse.EndOfStream endOfStream = mock(PublishStreamResponse.EndOfStream.class);
+
+        when(response.getEndStream()).thenReturn(endOfStream);
+        when(endOfStream.getBlockNumber()).thenReturn(5L);
+        when(endOfStream.getStatus()).thenReturn(Code.TIMEOUT);
+
+        publishClientManager.handleEndStream(nextBlock, response);
+
+        verify(blockStreamManager).resetToBlock(4L);
+        verify(publisherClientModeHandler).stop();
+    }
+
+    @Test
+    void handleEndOfStreamOnBadBlockProof() throws Exception {
+        Block nextBlock = mock(Block.class);
+        PublishStreamResponse response = mock(PublishStreamResponse.class);
+        PublishStreamResponse.EndOfStream endOfStream = mock(PublishStreamResponse.EndOfStream.class);
+
+        when(response.getEndStream()).thenReturn(endOfStream);
+        when(endOfStream.getBlockNumber()).thenReturn(5L);
+        when(endOfStream.getStatus()).thenReturn(Code.BAD_BLOCK_PROOF);
+
+        publishClientManager.handleEndStream(nextBlock, response);
+
+        verify(blockStreamManager).resetToBlock(4L);
+        verify(publisherClientModeHandler).stop();
+    }
+
+    @Test
+    void handleEndOfStreamOnInternalError() throws Exception {
+        Block nextBlock = mock(Block.class);
+        PublishStreamResponse response = mock(PublishStreamResponse.class);
+        PublishStreamResponse.EndOfStream endOfStream = mock(PublishStreamResponse.EndOfStream.class);
+
+        when(response.getEndStream()).thenReturn(endOfStream);
+        when(endOfStream.getBlockNumber()).thenReturn(5L);
+        when(endOfStream.getStatus()).thenReturn(Code.INTERNAL_ERROR);
+
+        publishClientManager.handleEndStream(nextBlock, response);
+
+        verify(blockStreamManager).resetToBlock(5L);
+        verify(publisherClientModeHandler).stop();
+    }
+
+    @Test
+    void handleEndOfStreamOnPersistenceFailed() throws Exception {
+        Block nextBlock = mock(Block.class);
+        PublishStreamResponse response = mock(PublishStreamResponse.class);
+        PublishStreamResponse.EndOfStream endOfStream = mock(PublishStreamResponse.EndOfStream.class);
+
+        when(response.getEndStream()).thenReturn(endOfStream);
+        when(endOfStream.getBlockNumber()).thenReturn(5L);
+        when(endOfStream.getStatus()).thenReturn(Code.PERSISTENCE_FAILED);
+
+        publishClientManager.handleEndStream(nextBlock, response);
+
+        verify(blockStreamManager).resetToBlock(5L);
+        verify(publisherClientModeHandler).stop();
+    }
+}

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
@@ -74,6 +74,7 @@ class PublishClientManagerTest {
         when(response.getEndStream()).thenReturn(endOfStream);
         when(endOfStream.getBlockNumber()).thenReturn(5L);
         when(endOfStream.getStatus()).thenReturn(Code.SUCCESS);
+        when(response.hasEndStream()).thenReturn(true);
 
         publishClientManager.handleResponse(nextBlock, response);
 
@@ -90,6 +91,7 @@ class PublishClientManagerTest {
         when(response.getEndStream()).thenReturn(endOfStream);
         when(endOfStream.getBlockNumber()).thenReturn(5L);
         when(endOfStream.getStatus()).thenReturn(Code.BEHIND);
+        when(response.hasEndStream()).thenReturn(true);
 
         publishClientManager.handleResponse(nextBlock, response);
 
@@ -106,6 +108,7 @@ class PublishClientManagerTest {
         when(response.getEndStream()).thenReturn(endOfStream);
         when(endOfStream.getBlockNumber()).thenReturn(5L);
         when(endOfStream.getStatus()).thenReturn(Code.DUPLICATE_BLOCK);
+        when(response.hasEndStream()).thenReturn(true);
 
         publishClientManager.handleResponse(nextBlock, response);
 
@@ -122,6 +125,7 @@ class PublishClientManagerTest {
         when(response.getEndStream()).thenReturn(endOfStream);
         when(endOfStream.getBlockNumber()).thenReturn(5L);
         when(endOfStream.getStatus()).thenReturn(Code.TIMEOUT);
+        when(response.hasEndStream()).thenReturn(true);
 
         publishClientManager.handleResponse(nextBlock, response);
 
@@ -138,6 +142,7 @@ class PublishClientManagerTest {
         when(response.getEndStream()).thenReturn(endOfStream);
         when(endOfStream.getBlockNumber()).thenReturn(5L);
         when(endOfStream.getStatus()).thenReturn(Code.BAD_BLOCK_PROOF);
+        when(response.hasEndStream()).thenReturn(true);
 
         publishClientManager.handleResponse(nextBlock, response);
 
@@ -154,6 +159,7 @@ class PublishClientManagerTest {
         when(response.getEndStream()).thenReturn(endOfStream);
         when(endOfStream.getBlockNumber()).thenReturn(5L);
         when(endOfStream.getStatus()).thenReturn(Code.INTERNAL_ERROR);
+        when(response.hasEndStream()).thenReturn(true);
 
         publishClientManager.handleResponse(nextBlock, response);
 
@@ -170,6 +176,7 @@ class PublishClientManagerTest {
         when(response.getEndStream()).thenReturn(endOfStream);
         when(endOfStream.getBlockNumber()).thenReturn(5L);
         when(endOfStream.getStatus()).thenReturn(Code.PERSISTENCE_FAILED);
+        when(response.hasEndStream()).thenReturn(true);
 
         publishClientManager.handleResponse(nextBlock, response);
 

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublisherClientModeHandlerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublisherClientModeHandlerTest.java
@@ -256,32 +256,32 @@ public class PublisherClientModeHandlerTest {
         verifyNoMoreInteractions(blockStreamManager);
     }
 
-    //    @Test
-    //    void testMillisPerBlockStreaming_streamSuccessBecomesFalse() throws Exception {
-    //        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
-    //        when(blockStreamConfig.millisecondsPerBlock()).thenReturn(1000);
-    //
-    //        publisherClientModeHandler = new PublisherClientModeHandler(
-    //                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-    //
-    //        Block block1 = mock(Block.class);
-    //        Block block2 = mock(Block.class);
-    //
-    //        when(blockStreamManager.getNextBlock())
-    //                .thenReturn(block1)
-    //                .thenReturn(block2)
-    //                .thenReturn(null);
-    //
-    //        when(publishStreamGrpcClient.streamBlock(eq(block1), any())).thenReturn(true);
-    //        when(publishStreamGrpcClient.streamBlock(eq(block2), any())).thenReturn(false);
-    //
-    //        publisherClientModeHandler.start();
-    //
-    //        verify(publishStreamGrpcClient).streamBlock(eq(block1), any());
-    //        verify(publishStreamGrpcClient).streamBlock(eq(block2), any());
-    //        verify(publishStreamGrpcClient).shutdown();
-    //        verify(blockStreamManager, times(2)).getNextBlock();
-    //    }
+    @Test
+    void testMillisPerBlockStreaming_streamSuccessBecomesFalse() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+        when(blockStreamConfig.millisecondsPerBlock()).thenReturn(1000);
+
+        publisherClientModeHandler = new PublisherClientModeHandler(
+                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+
+        Block block1 = mock(Block.class);
+        Block block2 = mock(Block.class);
+
+        when(blockStreamManager.getNextBlock())
+                .thenReturn(block1)
+                .thenReturn(block2)
+                .thenReturn(null);
+
+        when(publishStreamGrpcClient.streamBlock(eq(block1), any())).thenReturn(true);
+        when(publishStreamGrpcClient.streamBlock(eq(block2), any())).thenReturn(false);
+
+        publisherClientModeHandler.start();
+
+        verify(publishStreamGrpcClient).streamBlock(eq(block1), any());
+        verify(publishStreamGrpcClient).streamBlock(eq(block2), any());
+        verify(publishStreamGrpcClient).shutdown();
+        verify(blockStreamManager, times(2)).getNextBlock();
+    }
 
     @Test
     void testConstantRateStreaming_streamSuccessBecomesFalse() throws Exception {

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublisherClientModeHandlerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublisherClientModeHandlerTest.java
@@ -1,318 +1,319 @@
-//// SPDX-License-Identifier: Apache-2.0
-//package org.hiero.block.simulator.mode;
-//
-//import static org.junit.jupiter.api.Assertions.assertThrows;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.never;
-//import static org.mockito.Mockito.times;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.verifyNoMoreInteractions;
-//import static org.mockito.Mockito.when;
-//
-//import com.hedera.hapi.block.stream.protoc.Block;
-//import com.hedera.hapi.block.stream.protoc.BlockItem;
-//import com.swirlds.config.api.Configuration;
-//import java.io.IOException;
-//import java.util.Arrays;
-//import java.util.Collections;
-//import java.util.Map;
-//import org.hiero.block.simulator.TestUtils;
-//import org.hiero.block.simulator.config.data.BlockStreamConfig;
-//import org.hiero.block.simulator.config.types.StreamingMode;
-//import org.hiero.block.simulator.generator.BlockStreamManager;
-//import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
-//import org.hiero.block.simulator.metrics.MetricsService;
-//import org.hiero.block.simulator.metrics.MetricsServiceImpl;
-//import org.hiero.block.simulator.mode.impl.PublisherClientModeHandler;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.Mock;
-//import org.mockito.MockitoAnnotations;
-//
-//public class PublisherClientModeHandlerTest {
-//
-//    @Mock
-//    private BlockStreamConfig blockStreamConfig;
-//
-//    @Mock
-//    private PublishStreamGrpcClient publishStreamGrpcClient;
-//
-//    @Mock
-//    private BlockStreamManager blockStreamManager;
-//
-//    @Mock
-//    private MetricsService metricsService;
-//
-//    private PublisherClientModeHandler publisherClientModeHandler;
-//
-//    @BeforeEach
-//    void setUp() throws IOException {
-//        MockitoAnnotations.openMocks(this);
-//
-//        Configuration configuration = TestUtils.getTestConfiguration(
-//                Map.of("blockStream.maxBlockItemsToStream", "100", "blockStream.streamingMode", "CONSTANT_RATE"));
-//
-//        metricsService = new MetricsServiceImpl(TestUtils.getTestMetrics(configuration));
-//    }
-//
-//    @Test
-//    void testStartWithMillisPerBlockStreaming_WithBlocks() throws Exception {
-//        // Configure blockStreamConfig
-//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
-//        when(blockStreamConfig.millisecondsPerBlock()).thenReturn(0); // No delay for testing
-//
-//        publisherClientModeHandler = new PublisherClientModeHandler(
-//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-//
-//        Block block1 = mock(Block.class);
-//        Block block2 = mock(Block.class);
-//
-//        when(blockStreamManager.getNextBlock())
-//                .thenReturn(block1)
-//                .thenReturn(block2)
-//                .thenReturn(null);
-//        when(publishStreamGrpcClient.streamBlock(any(Block.class))).thenReturn(true);
-//
-//        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
-//        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(true);
-//
-//        publisherClientModeHandler.start();
-//
-//        verify(publishStreamGrpcClient).streamBlock(block1);
-//        verify(publishStreamGrpcClient).streamBlock(block2);
-//        verify(publishStreamGrpcClient).shutdown();
-//        verify(blockStreamManager, times(3)).getNextBlock();
-//    }
-//
-//    @Test
-//    void testStartWithMillisPerBlockStreaming_NoBlocks() throws Exception {
-//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
-//
-//        publisherClientModeHandler = new PublisherClientModeHandler(
-//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-//
-//        when(blockStreamManager.getNextBlock()).thenReturn(null);
-//
-//        publisherClientModeHandler.start();
-//
-//        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
-//        verify(blockStreamManager).getNextBlock();
-//    }
-//
-//    @Test
-//    void testStartWithMillisPerBlockStreaming_ShouldPublishFalse() throws Exception {
-//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
-//
-//        publisherClientModeHandler = new PublisherClientModeHandler(
-//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-//
-//        Block block1 = mock(Block.class);
-//        Block block2 = mock(Block.class);
-//
-//        when(blockStreamManager.getNextBlock())
-//                .thenReturn(block1)
-//                .thenReturn(block2)
-//                .thenReturn(null);
-//        when(publishStreamGrpcClient.streamBlock(any(Block.class))).thenReturn(true);
-//
-//        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
-//        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(true);
-//
-//        publisherClientModeHandler.stop();
-//        publisherClientModeHandler.start();
-//
-//        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
-//        verify(blockStreamManager).getNextBlock();
-//    }
-//
-//    @Test
-//    void testStartWithMillisPerBlockStreaming_NoBlocksAndShouldPublishFalse() throws Exception {
-//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
-//
-//        publisherClientModeHandler = new PublisherClientModeHandler(
-//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-//
-//        when(blockStreamManager.getNextBlock()).thenReturn(null);
-//
-//        publisherClientModeHandler.stop();
-//        publisherClientModeHandler.start();
-//
-//        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
-//        verify(blockStreamManager).getNextBlock();
-//    }
-//
-//    @Test
-//    void testStartWithConstantRateStreaming_WithinMaxItems() throws Exception {
-//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
-//        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
-//        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(5);
-//
-//        publisherClientModeHandler = new PublisherClientModeHandler(
-//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-//        when(publishStreamGrpcClient.streamBlock(any(Block.class))).thenReturn(true);
-//
-//        Block block1 = mock(Block.class);
-//        Block block2 = mock(Block.class);
-//
-//        BlockItem blockItem1 = mock(BlockItem.class);
-//        BlockItem blockItem2 = mock(BlockItem.class);
-//        BlockItem blockItem3 = mock(BlockItem.class);
-//        BlockItem blockItem4 = mock(BlockItem.class);
-//
-//        when(block1.getItemsList()).thenReturn(Arrays.asList(blockItem1, blockItem2));
-//        when(block2.getItemsList()).thenReturn(Arrays.asList(blockItem3, blockItem4));
-//
-//        when(blockStreamManager.getNextBlock())
-//                .thenReturn(block1)
-//                .thenReturn(block2)
-//                .thenReturn(null);
-//
-//        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
-//        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(true);
-//
-//        publisherClientModeHandler.start();
-//
-//        verify(publishStreamGrpcClient).streamBlock(block1);
-//        verify(publishStreamGrpcClient).streamBlock(block2);
-//        verify(publishStreamGrpcClient).shutdown();
-//        verify(blockStreamManager, times(3)).getNextBlock();
-//    }
-//
-//    @Test
-//    void testStartWithConstantRateStreaming_ExceedingMaxItems() throws Exception {
-//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
-//        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
-//        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(5);
-//
-//        publisherClientModeHandler = new PublisherClientModeHandler(
-//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-//        when(publishStreamGrpcClient.streamBlock(any(Block.class))).thenReturn(true);
-//
-//        Block block1 = mock(Block.class);
-//        Block block2 = mock(Block.class);
-//        Block block3 = mock(Block.class);
-//        Block block4 = mock(Block.class);
-//
-//        BlockItem blockItem1 = mock(BlockItem.class);
-//        BlockItem blockItem2 = mock(BlockItem.class);
-//        BlockItem blockItem3 = mock(BlockItem.class);
-//        BlockItem blockItem4 = mock(BlockItem.class);
-//
-//        when(block1.getItemsList()).thenReturn(Arrays.asList(blockItem1, blockItem2));
-//        when(block2.getItemsList()).thenReturn(Arrays.asList(blockItem3, blockItem4));
-//        when(block3.getItemsList()).thenReturn(Arrays.asList(blockItem1, blockItem2));
-//        when(block4.getItemsList()).thenReturn(Arrays.asList(blockItem3, blockItem4));
-//
-//        when(blockStreamManager.getNextBlock())
-//                .thenReturn(block1)
-//                .thenReturn(block2)
-//                .thenReturn(block3)
-//                .thenReturn(block4);
-//
-//        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
-//        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(true);
-//        when(publishStreamGrpcClient.streamBlock(block3)).thenReturn(true);
-//        when(publishStreamGrpcClient.streamBlock(block4)).thenReturn(true);
-//
-//        publisherClientModeHandler.start();
-//
-//        verify(publishStreamGrpcClient).streamBlock(block1);
-//        verify(publishStreamGrpcClient).streamBlock(block2);
-//        verify(publishStreamGrpcClient).streamBlock(block3);
-//        verify(publishStreamGrpcClient).shutdown();
-//        verify(blockStreamManager, times(3)).getNextBlock();
-//    }
-//
-//    @Test
-//    void testStartWithConstantRateStreaming_NoBlocks() throws Exception {
-//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
-//        publisherClientModeHandler = new PublisherClientModeHandler(
-//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-//
-//        when(blockStreamManager.getNextBlock()).thenReturn(null);
-//
-//        publisherClientModeHandler.start();
-//
-//        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
-//        verify(blockStreamManager).getNextBlock();
-//    }
-//
-//    @Test
-//    void testStartWithExceptionDuringStreaming() throws Exception {
-//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
-//
-//        publisherClientModeHandler = new PublisherClientModeHandler(
-//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-//
-//        when(blockStreamManager.getNextBlock()).thenThrow(new IOException("Test exception"));
-//
-//        assertThrows(IOException.class, () -> publisherClientModeHandler.start());
-//
-//        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
-//        verify(blockStreamManager).getNextBlock();
-//        verify(publishStreamGrpcClient).shutdown();
-//        verifyNoMoreInteractions(blockStreamManager);
-//    }
-//
-//    @Test
-//    void testMillisPerBlockStreaming_streamSuccessBecomesFalse() throws Exception {
-//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
-//        when(blockStreamConfig.millisecondsPerBlock()).thenReturn(1000);
-//
-//        publisherClientModeHandler = new PublisherClientModeHandler(
-//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-//
-//        Block block1 = mock(Block.class);
-//        Block block2 = mock(Block.class);
-//
-//        when(blockStreamManager.getNextBlock())
-//                .thenReturn(block1)
-//                .thenReturn(block2)
-//                .thenReturn(null);
-//
-//        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
-//        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(false);
-//
-//        publisherClientModeHandler.start();
-//
-//        verify(publishStreamGrpcClient).streamBlock(block1);
-//        verify(publishStreamGrpcClient).streamBlock(block2);
-//        verify(publishStreamGrpcClient).shutdown();
-//        verify(blockStreamManager, times(2)).getNextBlock();
-//    }
-//
-//    @Test
-//    void testConstantRateStreaming_streamSuccessBecomesFalse() throws Exception {
-//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
-//        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
-//        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(100);
-//
-//        publisherClientModeHandler = new PublisherClientModeHandler(
-//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-//
-//        Block block1 = mock(Block.class);
-//        Block block2 = mock(Block.class);
-//
-//        BlockItem blockItem1 = mock(BlockItem.class);
-//        BlockItem blockItem2 = mock(BlockItem.class);
-//
-//        when(block1.getItemsList()).thenReturn(Collections.singletonList(blockItem1));
-//        when(block2.getItemsList()).thenReturn(Collections.singletonList(blockItem2));
-//
-//        when(blockStreamManager.getNextBlock())
-//                .thenReturn(block1)
-//                .thenReturn(block2)
-//                .thenReturn(null);
-//
-//        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
-//        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(false);
-//
-//        publisherClientModeHandler.start();
-//
-//        verify(publishStreamGrpcClient).streamBlock(block1);
-//        verify(publishStreamGrpcClient).streamBlock(block2);
-//        verify(publishStreamGrpcClient).shutdown();
-//        verify(blockStreamManager, times(2)).getNextBlock();
-//    }
-//}
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.simulator.mode;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hapi.block.stream.protoc.Block;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.swirlds.config.api.Configuration;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import org.hiero.block.simulator.TestUtils;
+import org.hiero.block.simulator.config.data.BlockStreamConfig;
+import org.hiero.block.simulator.config.types.StreamingMode;
+import org.hiero.block.simulator.generator.BlockStreamManager;
+import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
+import org.hiero.block.simulator.metrics.MetricsService;
+import org.hiero.block.simulator.metrics.MetricsServiceImpl;
+import org.hiero.block.simulator.mode.impl.PublisherClientModeHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class PublisherClientModeHandlerTest {
+
+    @Mock
+    private BlockStreamConfig blockStreamConfig;
+
+    @Mock
+    private PublishStreamGrpcClient publishStreamGrpcClient;
+
+    @Mock
+    private BlockStreamManager blockStreamManager;
+
+    @Mock
+    private MetricsService metricsService;
+
+    private PublisherClientModeHandler publisherClientModeHandler;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        MockitoAnnotations.openMocks(this);
+
+        Configuration configuration = TestUtils.getTestConfiguration(
+                Map.of("blockStream.maxBlockItemsToStream", "100", "blockStream.streamingMode", "CONSTANT_RATE"));
+
+        metricsService = new MetricsServiceImpl(TestUtils.getTestMetrics(configuration));
+    }
+
+    @Test
+    void testStartWithMillisPerBlockStreaming_WithBlocks() throws Exception {
+        // Configure blockStreamConfig
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+        when(blockStreamConfig.millisecondsPerBlock()).thenReturn(0); // No delay for testing
+
+        publisherClientModeHandler = new PublisherClientModeHandler(
+                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+
+        Block block1 = mock(Block.class);
+        Block block2 = mock(Block.class);
+
+        when(blockStreamManager.getNextBlock())
+                .thenReturn(block1)
+                .thenReturn(block2)
+                .thenReturn(null);
+        when(publishStreamGrpcClient.streamBlock(any(Block.class), any())).thenReturn(true);
+
+        when(publishStreamGrpcClient.streamBlock(eq(block1), any())).thenReturn(true);
+        when(publishStreamGrpcClient.streamBlock(eq(block2), any())).thenReturn(true);
+
+        publisherClientModeHandler.start();
+
+        verify(publishStreamGrpcClient).streamBlock(eq(block1), any());
+        verify(publishStreamGrpcClient).streamBlock(eq(block2), any());
+        verify(publishStreamGrpcClient).shutdown();
+        verify(blockStreamManager, times(3)).getNextBlock();
+    }
+
+    @Test
+    void testStartWithMillisPerBlockStreaming_NoBlocks() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+
+        publisherClientModeHandler = new PublisherClientModeHandler(
+                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+
+        when(blockStreamManager.getNextBlock()).thenReturn(null);
+
+        publisherClientModeHandler.start();
+
+        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class), any());
+        verify(blockStreamManager).getNextBlock();
+    }
+
+    @Test
+    void testStartWithMillisPerBlockStreaming_ShouldPublishFalse() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+
+        publisherClientModeHandler = new PublisherClientModeHandler(
+                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+
+        Block block1 = mock(Block.class);
+        Block block2 = mock(Block.class);
+
+        when(blockStreamManager.getNextBlock())
+                .thenReturn(block1)
+                .thenReturn(block2)
+                .thenReturn(null);
+        when(publishStreamGrpcClient.streamBlock(any(Block.class), any())).thenReturn(true);
+
+        when(publishStreamGrpcClient.streamBlock(eq(block1), any())).thenReturn(true);
+        when(publishStreamGrpcClient.streamBlock(eq(block2), any())).thenReturn(true);
+
+        publisherClientModeHandler.stop();
+        publisherClientModeHandler.start();
+
+        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class), any());
+        verify(blockStreamManager).getNextBlock();
+    }
+
+    @Test
+    void testStartWithMillisPerBlockStreaming_NoBlocksAndShouldPublishFalse() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+
+        publisherClientModeHandler = new PublisherClientModeHandler(
+                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+
+        when(blockStreamManager.getNextBlock()).thenReturn(null);
+
+        publisherClientModeHandler.stop();
+        publisherClientModeHandler.start();
+
+        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class), any());
+        verify(blockStreamManager).getNextBlock();
+    }
+
+    @Test
+    void testStartWithConstantRateStreaming_WithinMaxItems() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
+        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
+        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(5);
+
+        publisherClientModeHandler = new PublisherClientModeHandler(
+                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+        when(publishStreamGrpcClient.streamBlock(any(Block.class), any())).thenReturn(true);
+
+        Block block1 = mock(Block.class);
+        Block block2 = mock(Block.class);
+
+        BlockItem blockItem1 = mock(BlockItem.class);
+        BlockItem blockItem2 = mock(BlockItem.class);
+        BlockItem blockItem3 = mock(BlockItem.class);
+        BlockItem blockItem4 = mock(BlockItem.class);
+
+        when(block1.getItemsList()).thenReturn(Arrays.asList(blockItem1, blockItem2));
+        when(block2.getItemsList()).thenReturn(Arrays.asList(blockItem3, blockItem4));
+
+        when(blockStreamManager.getNextBlock())
+                .thenReturn(block1)
+                .thenReturn(block2)
+                .thenReturn(null);
+
+        when(publishStreamGrpcClient.streamBlock(eq(block1), any())).thenReturn(true);
+        when(publishStreamGrpcClient.streamBlock(eq(block2), any())).thenReturn(true);
+
+        publisherClientModeHandler.start();
+
+        verify(publishStreamGrpcClient).streamBlock(eq(block1), any());
+        verify(publishStreamGrpcClient).streamBlock(eq(block2), any());
+        verify(publishStreamGrpcClient).shutdown();
+        verify(blockStreamManager, times(3)).getNextBlock();
+    }
+
+    @Test
+    void testStartWithConstantRateStreaming_ExceedingMaxItems() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
+        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
+        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(5);
+
+        publisherClientModeHandler = new PublisherClientModeHandler(
+                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+        when(publishStreamGrpcClient.streamBlock(any(Block.class), any())).thenReturn(true);
+
+        Block block1 = mock(Block.class);
+        Block block2 = mock(Block.class);
+        Block block3 = mock(Block.class);
+        Block block4 = mock(Block.class);
+
+        BlockItem blockItem1 = mock(BlockItem.class);
+        BlockItem blockItem2 = mock(BlockItem.class);
+        BlockItem blockItem3 = mock(BlockItem.class);
+        BlockItem blockItem4 = mock(BlockItem.class);
+
+        when(block1.getItemsList()).thenReturn(Arrays.asList(blockItem1, blockItem2));
+        when(block2.getItemsList()).thenReturn(Arrays.asList(blockItem3, blockItem4));
+        when(block3.getItemsList()).thenReturn(Arrays.asList(blockItem1, blockItem2));
+        when(block4.getItemsList()).thenReturn(Arrays.asList(blockItem3, blockItem4));
+
+        when(blockStreamManager.getNextBlock())
+                .thenReturn(block1)
+                .thenReturn(block2)
+                .thenReturn(block3)
+                .thenReturn(block4);
+
+        when(publishStreamGrpcClient.streamBlock(eq(block1), any())).thenReturn(true);
+        when(publishStreamGrpcClient.streamBlock(eq(block2), any())).thenReturn(true);
+        when(publishStreamGrpcClient.streamBlock(eq(block3), any())).thenReturn(true);
+        when(publishStreamGrpcClient.streamBlock(eq(block4), any())).thenReturn(true);
+
+        publisherClientModeHandler.start();
+
+        verify(publishStreamGrpcClient).streamBlock(eq(block1), any());
+        verify(publishStreamGrpcClient).streamBlock(eq(block2), any());
+        verify(publishStreamGrpcClient).streamBlock(eq(block3), any());
+        verify(publishStreamGrpcClient).shutdown();
+        verify(blockStreamManager, times(3)).getNextBlock();
+    }
+
+    @Test
+    void testStartWithConstantRateStreaming_NoBlocks() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
+        publisherClientModeHandler = new PublisherClientModeHandler(
+                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+
+        when(blockStreamManager.getNextBlock()).thenReturn(null);
+
+        publisherClientModeHandler.start();
+
+        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class), any());
+        verify(blockStreamManager).getNextBlock();
+    }
+
+    @Test
+    void testStartWithExceptionDuringStreaming() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+
+        publisherClientModeHandler = new PublisherClientModeHandler(
+                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+
+        when(blockStreamManager.getNextBlock()).thenThrow(new IOException("Test exception"));
+
+        assertThrows(IOException.class, () -> publisherClientModeHandler.start());
+
+        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class), any());
+        verify(blockStreamManager).getNextBlock();
+        verify(publishStreamGrpcClient).shutdown();
+        verifyNoMoreInteractions(blockStreamManager);
+    }
+
+    //    @Test
+    //    void testMillisPerBlockStreaming_streamSuccessBecomesFalse() throws Exception {
+    //        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+    //        when(blockStreamConfig.millisecondsPerBlock()).thenReturn(1000);
+    //
+    //        publisherClientModeHandler = new PublisherClientModeHandler(
+    //                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+    //
+    //        Block block1 = mock(Block.class);
+    //        Block block2 = mock(Block.class);
+    //
+    //        when(blockStreamManager.getNextBlock())
+    //                .thenReturn(block1)
+    //                .thenReturn(block2)
+    //                .thenReturn(null);
+    //
+    //        when(publishStreamGrpcClient.streamBlock(eq(block1), any())).thenReturn(true);
+    //        when(publishStreamGrpcClient.streamBlock(eq(block2), any())).thenReturn(false);
+    //
+    //        publisherClientModeHandler.start();
+    //
+    //        verify(publishStreamGrpcClient).streamBlock(eq(block1), any());
+    //        verify(publishStreamGrpcClient).streamBlock(eq(block2), any());
+    //        verify(publishStreamGrpcClient).shutdown();
+    //        verify(blockStreamManager, times(2)).getNextBlock();
+    //    }
+
+    @Test
+    void testConstantRateStreaming_streamSuccessBecomesFalse() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
+        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
+        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(100);
+
+        publisherClientModeHandler = new PublisherClientModeHandler(
+                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+
+        Block block1 = mock(Block.class);
+        Block block2 = mock(Block.class);
+
+        BlockItem blockItem1 = mock(BlockItem.class);
+        BlockItem blockItem2 = mock(BlockItem.class);
+
+        when(block1.getItemsList()).thenReturn(Collections.singletonList(blockItem1));
+        when(block2.getItemsList()).thenReturn(Collections.singletonList(blockItem2));
+
+        when(blockStreamManager.getNextBlock())
+                .thenReturn(block1)
+                .thenReturn(block2)
+                .thenReturn(null);
+
+        when(publishStreamGrpcClient.streamBlock(eq(block1), any())).thenReturn(true);
+        when(publishStreamGrpcClient.streamBlock(eq(block2), any())).thenReturn(false);
+
+        publisherClientModeHandler.start();
+
+        verify(publishStreamGrpcClient).streamBlock(eq(block1), any());
+        verify(publishStreamGrpcClient).streamBlock(eq(block2), any());
+        verify(publishStreamGrpcClient).shutdown();
+        verify(blockStreamManager, times(2)).getNextBlock();
+    }
+}

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublisherClientModeHandlerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublisherClientModeHandlerTest.java
@@ -1,318 +1,318 @@
-// SPDX-License-Identifier: Apache-2.0
-package org.hiero.block.simulator.mode;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
-import com.hedera.hapi.block.stream.protoc.Block;
-import com.hedera.hapi.block.stream.protoc.BlockItem;
-import com.swirlds.config.api.Configuration;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
-import org.hiero.block.simulator.TestUtils;
-import org.hiero.block.simulator.config.data.BlockStreamConfig;
-import org.hiero.block.simulator.config.types.StreamingMode;
-import org.hiero.block.simulator.generator.BlockStreamManager;
-import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
-import org.hiero.block.simulator.metrics.MetricsService;
-import org.hiero.block.simulator.metrics.MetricsServiceImpl;
-import org.hiero.block.simulator.mode.impl.PublisherClientModeHandler;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
-public class PublisherClientModeHandlerTest {
-
-    @Mock
-    private BlockStreamConfig blockStreamConfig;
-
-    @Mock
-    private PublishStreamGrpcClient publishStreamGrpcClient;
-
-    @Mock
-    private BlockStreamManager blockStreamManager;
-
-    @Mock
-    private MetricsService metricsService;
-
-    private PublisherClientModeHandler publisherClientModeHandler;
-
-    @BeforeEach
-    void setUp() throws IOException {
-        MockitoAnnotations.openMocks(this);
-
-        Configuration configuration = TestUtils.getTestConfiguration(
-                Map.of("blockStream.maxBlockItemsToStream", "100", "blockStream.streamingMode", "CONSTANT_RATE"));
-
-        metricsService = new MetricsServiceImpl(TestUtils.getTestMetrics(configuration));
-    }
-
-    @Test
-    void testStartWithMillisPerBlockStreaming_WithBlocks() throws Exception {
-        // Configure blockStreamConfig
-        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
-        when(blockStreamConfig.millisecondsPerBlock()).thenReturn(0); // No delay for testing
-
-        publisherClientModeHandler = new PublisherClientModeHandler(
-                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-
-        Block block1 = mock(Block.class);
-        Block block2 = mock(Block.class);
-
-        when(blockStreamManager.getNextBlock())
-                .thenReturn(block1)
-                .thenReturn(block2)
-                .thenReturn(null);
-        when(publishStreamGrpcClient.streamBlock(any(Block.class))).thenReturn(true);
-
-        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
-        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(true);
-
-        publisherClientModeHandler.start();
-
-        verify(publishStreamGrpcClient).streamBlock(block1);
-        verify(publishStreamGrpcClient).streamBlock(block2);
-        verify(publishStreamGrpcClient).shutdown();
-        verify(blockStreamManager, times(3)).getNextBlock();
-    }
-
-    @Test
-    void testStartWithMillisPerBlockStreaming_NoBlocks() throws Exception {
-        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
-
-        publisherClientModeHandler = new PublisherClientModeHandler(
-                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-
-        when(blockStreamManager.getNextBlock()).thenReturn(null);
-
-        publisherClientModeHandler.start();
-
-        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
-        verify(blockStreamManager).getNextBlock();
-    }
-
-    @Test
-    void testStartWithMillisPerBlockStreaming_ShouldPublishFalse() throws Exception {
-        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
-
-        publisherClientModeHandler = new PublisherClientModeHandler(
-                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-
-        Block block1 = mock(Block.class);
-        Block block2 = mock(Block.class);
-
-        when(blockStreamManager.getNextBlock())
-                .thenReturn(block1)
-                .thenReturn(block2)
-                .thenReturn(null);
-        when(publishStreamGrpcClient.streamBlock(any(Block.class))).thenReturn(true);
-
-        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
-        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(true);
-
-        publisherClientModeHandler.stop();
-        publisherClientModeHandler.start();
-
-        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
-        verify(blockStreamManager).getNextBlock();
-    }
-
-    @Test
-    void testStartWithMillisPerBlockStreaming_NoBlocksAndShouldPublishFalse() throws Exception {
-        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
-
-        publisherClientModeHandler = new PublisherClientModeHandler(
-                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-
-        when(blockStreamManager.getNextBlock()).thenReturn(null);
-
-        publisherClientModeHandler.stop();
-        publisherClientModeHandler.start();
-
-        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
-        verify(blockStreamManager).getNextBlock();
-    }
-
-    @Test
-    void testStartWithConstantRateStreaming_WithinMaxItems() throws Exception {
-        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
-        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
-        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(5);
-
-        publisherClientModeHandler = new PublisherClientModeHandler(
-                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-        when(publishStreamGrpcClient.streamBlock(any(Block.class))).thenReturn(true);
-
-        Block block1 = mock(Block.class);
-        Block block2 = mock(Block.class);
-
-        BlockItem blockItem1 = mock(BlockItem.class);
-        BlockItem blockItem2 = mock(BlockItem.class);
-        BlockItem blockItem3 = mock(BlockItem.class);
-        BlockItem blockItem4 = mock(BlockItem.class);
-
-        when(block1.getItemsList()).thenReturn(Arrays.asList(blockItem1, blockItem2));
-        when(block2.getItemsList()).thenReturn(Arrays.asList(blockItem3, blockItem4));
-
-        when(blockStreamManager.getNextBlock())
-                .thenReturn(block1)
-                .thenReturn(block2)
-                .thenReturn(null);
-
-        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
-        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(true);
-
-        publisherClientModeHandler.start();
-
-        verify(publishStreamGrpcClient).streamBlock(block1);
-        verify(publishStreamGrpcClient).streamBlock(block2);
-        verify(publishStreamGrpcClient).shutdown();
-        verify(blockStreamManager, times(3)).getNextBlock();
-    }
-
-    @Test
-    void testStartWithConstantRateStreaming_ExceedingMaxItems() throws Exception {
-        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
-        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
-        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(5);
-
-        publisherClientModeHandler = new PublisherClientModeHandler(
-                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-        when(publishStreamGrpcClient.streamBlock(any(Block.class))).thenReturn(true);
-
-        Block block1 = mock(Block.class);
-        Block block2 = mock(Block.class);
-        Block block3 = mock(Block.class);
-        Block block4 = mock(Block.class);
-
-        BlockItem blockItem1 = mock(BlockItem.class);
-        BlockItem blockItem2 = mock(BlockItem.class);
-        BlockItem blockItem3 = mock(BlockItem.class);
-        BlockItem blockItem4 = mock(BlockItem.class);
-
-        when(block1.getItemsList()).thenReturn(Arrays.asList(blockItem1, blockItem2));
-        when(block2.getItemsList()).thenReturn(Arrays.asList(blockItem3, blockItem4));
-        when(block3.getItemsList()).thenReturn(Arrays.asList(blockItem1, blockItem2));
-        when(block4.getItemsList()).thenReturn(Arrays.asList(blockItem3, blockItem4));
-
-        when(blockStreamManager.getNextBlock())
-                .thenReturn(block1)
-                .thenReturn(block2)
-                .thenReturn(block3)
-                .thenReturn(block4);
-
-        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
-        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(true);
-        when(publishStreamGrpcClient.streamBlock(block3)).thenReturn(true);
-        when(publishStreamGrpcClient.streamBlock(block4)).thenReturn(true);
-
-        publisherClientModeHandler.start();
-
-        verify(publishStreamGrpcClient).streamBlock(block1);
-        verify(publishStreamGrpcClient).streamBlock(block2);
-        verify(publishStreamGrpcClient).streamBlock(block3);
-        verify(publishStreamGrpcClient).shutdown();
-        verify(blockStreamManager, times(3)).getNextBlock();
-    }
-
-    @Test
-    void testStartWithConstantRateStreaming_NoBlocks() throws Exception {
-        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
-        publisherClientModeHandler = new PublisherClientModeHandler(
-                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-
-        when(blockStreamManager.getNextBlock()).thenReturn(null);
-
-        publisherClientModeHandler.start();
-
-        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
-        verify(blockStreamManager).getNextBlock();
-    }
-
-    @Test
-    void testStartWithExceptionDuringStreaming() throws Exception {
-        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
-
-        publisherClientModeHandler = new PublisherClientModeHandler(
-                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-
-        when(blockStreamManager.getNextBlock()).thenThrow(new IOException("Test exception"));
-
-        assertThrows(IOException.class, () -> publisherClientModeHandler.start());
-
-        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
-        verify(blockStreamManager).getNextBlock();
-        verify(publishStreamGrpcClient).shutdown();
-        verifyNoMoreInteractions(blockStreamManager);
-    }
-
-    @Test
-    void testMillisPerBlockStreaming_streamSuccessBecomesFalse() throws Exception {
-        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
-        when(blockStreamConfig.millisecondsPerBlock()).thenReturn(1000);
-
-        publisherClientModeHandler = new PublisherClientModeHandler(
-                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-
-        Block block1 = mock(Block.class);
-        Block block2 = mock(Block.class);
-
-        when(blockStreamManager.getNextBlock())
-                .thenReturn(block1)
-                .thenReturn(block2)
-                .thenReturn(null);
-
-        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
-        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(false);
-
-        publisherClientModeHandler.start();
-
-        verify(publishStreamGrpcClient).streamBlock(block1);
-        verify(publishStreamGrpcClient).streamBlock(block2);
-        verify(publishStreamGrpcClient).shutdown();
-        verify(blockStreamManager, times(2)).getNextBlock();
-    }
-
-    @Test
-    void testConstantRateStreaming_streamSuccessBecomesFalse() throws Exception {
-        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
-        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
-        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(100);
-
-        publisherClientModeHandler = new PublisherClientModeHandler(
-                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-
-        Block block1 = mock(Block.class);
-        Block block2 = mock(Block.class);
-
-        BlockItem blockItem1 = mock(BlockItem.class);
-        BlockItem blockItem2 = mock(BlockItem.class);
-
-        when(block1.getItemsList()).thenReturn(Collections.singletonList(blockItem1));
-        when(block2.getItemsList()).thenReturn(Collections.singletonList(blockItem2));
-
-        when(blockStreamManager.getNextBlock())
-                .thenReturn(block1)
-                .thenReturn(block2)
-                .thenReturn(null);
-
-        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
-        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(false);
-
-        publisherClientModeHandler.start();
-
-        verify(publishStreamGrpcClient).streamBlock(block1);
-        verify(publishStreamGrpcClient).streamBlock(block2);
-        verify(publishStreamGrpcClient).shutdown();
-        verify(blockStreamManager, times(2)).getNextBlock();
-    }
-}
+//// SPDX-License-Identifier: Apache-2.0
+//package org.hiero.block.simulator.mode;
+//
+//import static org.junit.jupiter.api.Assertions.assertThrows;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.never;
+//import static org.mockito.Mockito.times;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.verifyNoMoreInteractions;
+//import static org.mockito.Mockito.when;
+//
+//import com.hedera.hapi.block.stream.protoc.Block;
+//import com.hedera.hapi.block.stream.protoc.BlockItem;
+//import com.swirlds.config.api.Configuration;
+//import java.io.IOException;
+//import java.util.Arrays;
+//import java.util.Collections;
+//import java.util.Map;
+//import org.hiero.block.simulator.TestUtils;
+//import org.hiero.block.simulator.config.data.BlockStreamConfig;
+//import org.hiero.block.simulator.config.types.StreamingMode;
+//import org.hiero.block.simulator.generator.BlockStreamManager;
+//import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
+//import org.hiero.block.simulator.metrics.MetricsService;
+//import org.hiero.block.simulator.metrics.MetricsServiceImpl;
+//import org.hiero.block.simulator.mode.impl.PublisherClientModeHandler;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.mockito.Mock;
+//import org.mockito.MockitoAnnotations;
+//
+//public class PublisherClientModeHandlerTest {
+//
+//    @Mock
+//    private BlockStreamConfig blockStreamConfig;
+//
+//    @Mock
+//    private PublishStreamGrpcClient publishStreamGrpcClient;
+//
+//    @Mock
+//    private BlockStreamManager blockStreamManager;
+//
+//    @Mock
+//    private MetricsService metricsService;
+//
+//    private PublisherClientModeHandler publisherClientModeHandler;
+//
+//    @BeforeEach
+//    void setUp() throws IOException {
+//        MockitoAnnotations.openMocks(this);
+//
+//        Configuration configuration = TestUtils.getTestConfiguration(
+//                Map.of("blockStream.maxBlockItemsToStream", "100", "blockStream.streamingMode", "CONSTANT_RATE"));
+//
+//        metricsService = new MetricsServiceImpl(TestUtils.getTestMetrics(configuration));
+//    }
+//
+//    @Test
+//    void testStartWithMillisPerBlockStreaming_WithBlocks() throws Exception {
+//        // Configure blockStreamConfig
+//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+//        when(blockStreamConfig.millisecondsPerBlock()).thenReturn(0); // No delay for testing
+//
+//        publisherClientModeHandler = new PublisherClientModeHandler(
+//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+//
+//        Block block1 = mock(Block.class);
+//        Block block2 = mock(Block.class);
+//
+//        when(blockStreamManager.getNextBlock())
+//                .thenReturn(block1)
+//                .thenReturn(block2)
+//                .thenReturn(null);
+//        when(publishStreamGrpcClient.streamBlock(any(Block.class))).thenReturn(true);
+//
+//        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
+//        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(true);
+//
+//        publisherClientModeHandler.start();
+//
+//        verify(publishStreamGrpcClient).streamBlock(block1);
+//        verify(publishStreamGrpcClient).streamBlock(block2);
+//        verify(publishStreamGrpcClient).shutdown();
+//        verify(blockStreamManager, times(3)).getNextBlock();
+//    }
+//
+//    @Test
+//    void testStartWithMillisPerBlockStreaming_NoBlocks() throws Exception {
+//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+//
+//        publisherClientModeHandler = new PublisherClientModeHandler(
+//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+//
+//        when(blockStreamManager.getNextBlock()).thenReturn(null);
+//
+//        publisherClientModeHandler.start();
+//
+//        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
+//        verify(blockStreamManager).getNextBlock();
+//    }
+//
+//    @Test
+//    void testStartWithMillisPerBlockStreaming_ShouldPublishFalse() throws Exception {
+//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+//
+//        publisherClientModeHandler = new PublisherClientModeHandler(
+//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+//
+//        Block block1 = mock(Block.class);
+//        Block block2 = mock(Block.class);
+//
+//        when(blockStreamManager.getNextBlock())
+//                .thenReturn(block1)
+//                .thenReturn(block2)
+//                .thenReturn(null);
+//        when(publishStreamGrpcClient.streamBlock(any(Block.class))).thenReturn(true);
+//
+//        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
+//        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(true);
+//
+//        publisherClientModeHandler.stop();
+//        publisherClientModeHandler.start();
+//
+//        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
+//        verify(blockStreamManager).getNextBlock();
+//    }
+//
+//    @Test
+//    void testStartWithMillisPerBlockStreaming_NoBlocksAndShouldPublishFalse() throws Exception {
+//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+//
+//        publisherClientModeHandler = new PublisherClientModeHandler(
+//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+//
+//        when(blockStreamManager.getNextBlock()).thenReturn(null);
+//
+//        publisherClientModeHandler.stop();
+//        publisherClientModeHandler.start();
+//
+//        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
+//        verify(blockStreamManager).getNextBlock();
+//    }
+//
+//    @Test
+//    void testStartWithConstantRateStreaming_WithinMaxItems() throws Exception {
+//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
+//        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
+//        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(5);
+//
+//        publisherClientModeHandler = new PublisherClientModeHandler(
+//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+//        when(publishStreamGrpcClient.streamBlock(any(Block.class))).thenReturn(true);
+//
+//        Block block1 = mock(Block.class);
+//        Block block2 = mock(Block.class);
+//
+//        BlockItem blockItem1 = mock(BlockItem.class);
+//        BlockItem blockItem2 = mock(BlockItem.class);
+//        BlockItem blockItem3 = mock(BlockItem.class);
+//        BlockItem blockItem4 = mock(BlockItem.class);
+//
+//        when(block1.getItemsList()).thenReturn(Arrays.asList(blockItem1, blockItem2));
+//        when(block2.getItemsList()).thenReturn(Arrays.asList(blockItem3, blockItem4));
+//
+//        when(blockStreamManager.getNextBlock())
+//                .thenReturn(block1)
+//                .thenReturn(block2)
+//                .thenReturn(null);
+//
+//        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
+//        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(true);
+//
+//        publisherClientModeHandler.start();
+//
+//        verify(publishStreamGrpcClient).streamBlock(block1);
+//        verify(publishStreamGrpcClient).streamBlock(block2);
+//        verify(publishStreamGrpcClient).shutdown();
+//        verify(blockStreamManager, times(3)).getNextBlock();
+//    }
+//
+//    @Test
+//    void testStartWithConstantRateStreaming_ExceedingMaxItems() throws Exception {
+//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
+//        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
+//        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(5);
+//
+//        publisherClientModeHandler = new PublisherClientModeHandler(
+//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+//        when(publishStreamGrpcClient.streamBlock(any(Block.class))).thenReturn(true);
+//
+//        Block block1 = mock(Block.class);
+//        Block block2 = mock(Block.class);
+//        Block block3 = mock(Block.class);
+//        Block block4 = mock(Block.class);
+//
+//        BlockItem blockItem1 = mock(BlockItem.class);
+//        BlockItem blockItem2 = mock(BlockItem.class);
+//        BlockItem blockItem3 = mock(BlockItem.class);
+//        BlockItem blockItem4 = mock(BlockItem.class);
+//
+//        when(block1.getItemsList()).thenReturn(Arrays.asList(blockItem1, blockItem2));
+//        when(block2.getItemsList()).thenReturn(Arrays.asList(blockItem3, blockItem4));
+//        when(block3.getItemsList()).thenReturn(Arrays.asList(blockItem1, blockItem2));
+//        when(block4.getItemsList()).thenReturn(Arrays.asList(blockItem3, blockItem4));
+//
+//        when(blockStreamManager.getNextBlock())
+//                .thenReturn(block1)
+//                .thenReturn(block2)
+//                .thenReturn(block3)
+//                .thenReturn(block4);
+//
+//        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
+//        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(true);
+//        when(publishStreamGrpcClient.streamBlock(block3)).thenReturn(true);
+//        when(publishStreamGrpcClient.streamBlock(block4)).thenReturn(true);
+//
+//        publisherClientModeHandler.start();
+//
+//        verify(publishStreamGrpcClient).streamBlock(block1);
+//        verify(publishStreamGrpcClient).streamBlock(block2);
+//        verify(publishStreamGrpcClient).streamBlock(block3);
+//        verify(publishStreamGrpcClient).shutdown();
+//        verify(blockStreamManager, times(3)).getNextBlock();
+//    }
+//
+//    @Test
+//    void testStartWithConstantRateStreaming_NoBlocks() throws Exception {
+//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
+//        publisherClientModeHandler = new PublisherClientModeHandler(
+//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+//
+//        when(blockStreamManager.getNextBlock()).thenReturn(null);
+//
+//        publisherClientModeHandler.start();
+//
+//        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
+//        verify(blockStreamManager).getNextBlock();
+//    }
+//
+//    @Test
+//    void testStartWithExceptionDuringStreaming() throws Exception {
+//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+//
+//        publisherClientModeHandler = new PublisherClientModeHandler(
+//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+//
+//        when(blockStreamManager.getNextBlock()).thenThrow(new IOException("Test exception"));
+//
+//        assertThrows(IOException.class, () -> publisherClientModeHandler.start());
+//
+//        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
+//        verify(blockStreamManager).getNextBlock();
+//        verify(publishStreamGrpcClient).shutdown();
+//        verifyNoMoreInteractions(blockStreamManager);
+//    }
+//
+//    @Test
+//    void testMillisPerBlockStreaming_streamSuccessBecomesFalse() throws Exception {
+//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+//        when(blockStreamConfig.millisecondsPerBlock()).thenReturn(1000);
+//
+//        publisherClientModeHandler = new PublisherClientModeHandler(
+//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+//
+//        Block block1 = mock(Block.class);
+//        Block block2 = mock(Block.class);
+//
+//        when(blockStreamManager.getNextBlock())
+//                .thenReturn(block1)
+//                .thenReturn(block2)
+//                .thenReturn(null);
+//
+//        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
+//        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(false);
+//
+//        publisherClientModeHandler.start();
+//
+//        verify(publishStreamGrpcClient).streamBlock(block1);
+//        verify(publishStreamGrpcClient).streamBlock(block2);
+//        verify(publishStreamGrpcClient).shutdown();
+//        verify(blockStreamManager, times(2)).getNextBlock();
+//    }
+//
+//    @Test
+//    void testConstantRateStreaming_streamSuccessBecomesFalse() throws Exception {
+//        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
+//        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
+//        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(100);
+//
+//        publisherClientModeHandler = new PublisherClientModeHandler(
+//                blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
+//
+//        Block block1 = mock(Block.class);
+//        Block block2 = mock(Block.class);
+//
+//        BlockItem blockItem1 = mock(BlockItem.class);
+//        BlockItem blockItem2 = mock(BlockItem.class);
+//
+//        when(block1.getItemsList()).thenReturn(Collections.singletonList(blockItem1));
+//        when(block2.getItemsList()).thenReturn(Collections.singletonList(blockItem2));
+//
+//        when(blockStreamManager.getNextBlock())
+//                .thenReturn(block1)
+//                .thenReturn(block2)
+//                .thenReturn(null);
+//
+//        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
+//        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(false);
+//
+//        publisherClientModeHandler.start();
+//
+//        verify(publishStreamGrpcClient).streamBlock(block1);
+//        verify(publishStreamGrpcClient).streamBlock(block2);
+//        verify(publishStreamGrpcClient).shutdown();
+//        verify(blockStreamManager, times(2)).getNextBlock();
+//    }
+//}


### PR DESCRIPTION
## Reviewer Notes

Add support in the block stream simulator, publisher mode, for receiving a EndOfStream message from the block node and correctly handling that response.

## Related Issue(s)
Fixes #1109 
