### PR TITLE
chore: Update gradle plugins to use 0.4.5

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import org.gradlex.javamodule.moduleinfo.ExtraJavaModuleInfoPluginExtension
 
-plugins { id("org.hiero.gradle.build") version "0.4.3" }
+plugins { id("org.hiero.gradle.build") version "0.4.5" }
 
 val hieroGroup = "org.hiero.block"
 


### PR DESCRIPTION
## Description

This pull request includes a minor update to the `settings.gradle.kts` file, upgrading the `org.hiero.gradle.build` plugin from version `0.4.3` to `0.4.5`.

## Related Issue(s)

closes #1347
