### PR TITLE
feat: Files Historic Plugin Retention Policy Granularity Update

### DIFF
--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
@@ -271,7 +271,9 @@ public final class BlocksFilesHistoricPlugin implements BlockProviderPlugin, Blo
         // we only take action if the threshold is greater than 0L
         if (blockRetentionThreshold > 0L) {
             final long totalStored = availableBlocks.size();
-            long excess = totalStored - blockRetentionThreshold;
+            // calculate excess blocks to delete, the retention threshold
+            // is the number of zips (archived batches) to retain
+            long excess = totalStored - (blockRetentionThreshold * numberOfBlocksPerZipFile);
             // the numberOfBlocksPerZipFile should generally be immutable once set
             // for the first time when the block node was originally started
             // we can rely on the check below to ensure we are deleting the correct

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
@@ -21,8 +21,11 @@ import org.hiero.block.node.base.Loggable;
  * 1 = 10, 2 = 100, 3 = 1000, 4 = 10,000, 5 = 100,000, or 6 = 1,000,000 files per
  * zip. Changing this is handy for testing, as having to wait for 10,000 blocks to be
  * created is a long time.
- * @param blockRetentionThreshold the retention policy threshold (count of blocks to keep). If set to 0 (zero),
- * blocks will be retained indefinitely.
+ * @param blockRetentionThreshold the retention policy threshold (count of blocks to keep). For the historic
+ * plugin, this value determines how many zips (archived batches) to retain. For instance if set to 5 and if the
+ * {@link #powersOfTenPerZipFileContents} is set to 3, then this means that 5 zips will be retained and these zips
+ * contain 10^3 blocks, i.e. 5_000 blocks effectively retained. If set to 0 (zero), blocks will be retained
+ * indefinitely.
  */
 @ConfigData("files.historic")
 public record FilesHistoricConfig(

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
@@ -70,7 +70,7 @@ class BlocksFilesHistoricPluginTest {
         // use 10 blocks per zip, assuming that the first zip file will contain
         // for example blocks 0-9, the second zip file will contain blocks 10-19
         // also we will not use compression, and we will use the jUnit temp dir
-        testConfig = new FilesHistoricConfig(this.testTempDir, CompressionType.NONE, 1, 100L);
+        testConfig = new FilesHistoricConfig(this.testTempDir, CompressionType.NONE, 1, 10L);
         // build the plugin using the test environment
         toTest = new BlocksFilesHistoricPlugin();
         // initialize an in memory historical block facility to use for testing

--- a/docs/design/persistence/block-node-retention-policy.md
+++ b/docs/design/persistence/block-node-retention-policy.md
@@ -66,7 +66,10 @@ The `Files Recent Persistence` implements the Retention Policy:
 
 The `Files Historic Persistence` implements the Retention Policy:
 
-- A configurable parameter defines how many blocks to keep in storage.
+- A configurable parameter defines how many blocks to keep in storage. This
+  parameter determines how many zips (archived batches blocks) will be retained
+  at any given time. Multiplying this value by the archive batch size gives us
+  the total number of individual blocks that that will be effectively retained.
 - The Policy is implemented by removing the oldest N amount of blocks (based on
   the configured threshold).
 - Blocks are removed only when new data is received.


### PR DESCRIPTION
## Reviewer Notes

- updating the retention policy granularity setting to be zips retained rather than blocks retained
- this is easier to setup and less error prone

## Related Issue(s)

Resolves #1364 
