### PR TITLE
feat(backfill): Backfill Plugin - Part 1 Autonomous Flow

### DIFF
--- a/block-node/app/build.gradle.kts
+++ b/block-node/app/build.gradle.kts
@@ -62,6 +62,7 @@ mainModuleInfo {
     runtimeOnly("org.hiero.block.node.blocks.files.recent")
     runtimeOnly("org.hiero.block.node.access.service")
     runtimeOnly("org.hiero.block.node.server.status")
+    runtimeOnly("org.hiero.block.node.backfill")
 }
 
 testModuleInfo {

--- a/block-node/app/src/main/resources/app.properties
+++ b/block-node/app/src/main/resources/app.properties
@@ -18,3 +18,4 @@ server.port=40840
 #persistence.storage.type=BLOCK_AS_LOCAL_FILE
 #persistence.storage.compression=ZSTD
 #persistence.storage.archiveGroupSize=1_000
+#backfill.blockNodeSourcesPath=/Users/user/Projects/hiero-block-node/block-node/backfill/src/test/resources/block-nodes.json

--- a/block-node/app/src/testFixtures/java/module-info.java
+++ b/block-node/app/src/testFixtures/java/module-info.java
@@ -4,7 +4,10 @@ module org.hiero.block.node.app.test.fixtures {
     exports org.hiero.block.node.app.fixtures.async;
     exports org.hiero.block.node.app.fixtures.blocks;
     exports org.hiero.block.node.app.fixtures.plugintest;
+    exports org.hiero.block.node.app.fixtures.server;
 
+    requires com.hedera.pbj.grpc.helidon.config;
+    requires com.hedera.pbj.grpc.helidon;
     requires com.hedera.pbj.runtime;
     requires com.swirlds.common;
     requires com.swirlds.config.api;

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/SimpleInMemoryHistoricalBlockFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/SimpleInMemoryHistoricalBlockFacility.java
@@ -17,6 +17,7 @@ import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.blockmessaging.BlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 import org.hiero.block.node.spi.historicalblocks.BlockRangeSet;
@@ -49,7 +50,8 @@ public class SimpleInMemoryHistoricalBlockFacility implements HistoricalBlockFac
         handleBlockItemsReceived(blockItems, true);
     }
 
-    public void handleBlockItemsReceived(BlockItems blockItems, final boolean sendNotification) {
+    public void handleBlockItemsReceived(
+            BlockItems blockItems, final boolean sendNotification, int priority, BlockSource source) {
         if (!disablePlugin.get()) {
             if (blockItems.isStartOfNewBlock()) {
                 if (!partialBlock.isEmpty()) {
@@ -74,12 +76,15 @@ public class SimpleInMemoryHistoricalBlockFacility implements HistoricalBlockFac
                 if (sendNotification) {
                     blockNodeContext
                             .blockMessaging()
-                            .sendBlockPersisted(new PersistedNotification(blockNumber, blockNumber, 2000));
+                            .sendBlockPersisted(new PersistedNotification(blockNumber, blockNumber, priority, source));
                 }
             }
         }
     }
 
+    public void handleBlockItemsReceived(BlockItems blockItems, final boolean sendNotification) {
+        handleBlockItemsReceived(blockItems, sendNotification, 2000, BlockSource.UNKNOWN);
+    }
     /**
      * {@inheritDoc}
      */

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.RejectedExecutionException;
+import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
@@ -210,6 +211,17 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
         sentPersistedNotifications.add(notification);
         for (BlockNotificationHandler handler : blockNotificationHandlers) {
             handler.handlePersisted(notification);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendBackfilledBlockNotification(BackfilledBlockNotification notification) {
+        LOGGER.log(Level.TRACE, "Sending backfilled block notification " + notification);
+        for (BlockNotificationHandler handler : blockNotificationHandlers) {
+            handler.handleBackfilled(notification);
         }
     }
 

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.app.fixtures.server;
+
+import com.hedera.pbj.grpc.helidon.PbjRouting;
+import com.hedera.pbj.grpc.helidon.config.PbjConfig;
+import io.helidon.webserver.ConnectionConfig;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import org.hiero.block.api.BlockItemSet;
+import org.hiero.block.api.BlockNodeServiceInterface;
+import org.hiero.block.api.BlockStreamSubscribeServiceInterface;
+import org.hiero.block.api.ServerStatusResponse;
+import org.hiero.block.api.SubscribeStreamResponse;
+import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
+
+public class TestBlockNodeServer {
+
+    public TestBlockNodeServer(int port, HistoricalBlockFacility historicalBlockFacility) {
+        // Override the default message size in PBJ
+        final PbjConfig pbjConfig =
+                PbjConfig.builder().name("pbj").maxMessageSizeBytes(4_194_304).build();
+
+        // Create the service builder
+        final PbjRouting.Builder pbjRoutingBuilder = PbjRouting.builder()
+                .service((BlockNodeServiceInterface) request -> ServerStatusResponse.newBuilder()
+                        .firstAvailableBlock(
+                                historicalBlockFacility.availableBlocks().min())
+                        .lastAvailableBlock(
+                                historicalBlockFacility.availableBlocks().max())
+                        .build())
+                .service((BlockStreamSubscribeServiceInterface) (request, replies) -> {
+                    if (historicalBlockFacility
+                            .availableBlocks()
+                            .contains(request.startBlockNumber(), request.endBlockNumber())) {
+                        for (long i = request.startBlockNumber(); i <= request.endBlockNumber(); i++) {
+                            replies.onNext(SubscribeStreamResponse.newBuilder()
+                                    .blockItems(BlockItemSet.newBuilder()
+                                            .blockItems(historicalBlockFacility
+                                                    .block(i)
+                                                    .block()
+                                                    .items())
+                                            .build())
+                                    .build());
+                        }
+
+                        replies.onNext(SubscribeStreamResponse.newBuilder()
+                                .status(SubscribeStreamResponse.Code.SUCCESS)
+                                .build());
+
+                        replies.onComplete();
+                    }
+                });
+
+        // start the web server with the PBJ configuration and routing
+        WebServer webServer = WebServerConfig.builder()
+                .port(port)
+                .addProtocol(pbjConfig)
+                .addRouting(pbjRoutingBuilder)
+                .connectionConfig(ConnectionConfig.builder()
+                        .sendBufferSize(32768)
+                        .receiveBufferSize(32768)
+                        .build())
+                .build();
+
+        webServer.start();
+    }
+}

--- a/block-node/backfill/build.gradle.kts
+++ b/block-node/backfill/build.gradle.kts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+plugins {
+    id("org.hiero.gradle.module.library")
+    id("com.hedera.pbj.pbj-compiler") version "0.11.9"
+}
+
+description = "Hiero Block Node Backfill Plugin"
+
+// Remove the following line to enable all 'javac' lint checks that we have turned on by default
+// and then fix the reported issues.
+tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
+
+tasks.javadoc {
+    options {
+        this as StandardJavadocDocletOptions
+        // There are violations in the generated pbj code
+        addStringOption("Xdoclint:-reference,-html", "-quiet")
+    }
+}
+
+pbj { generateTestClasses = false }
+
+mainModuleInfo {
+    runtimeOnly("com.swirlds.config.impl")
+    runtimeOnly("org.apache.logging.log4j.slf4j2.impl")
+    runtimeOnly("io.helidon.logging.jul")
+    runtimeOnly("com.hedera.pbj.grpc.helidon.config")
+}
+
+testModuleInfo {
+    requires("org.junit.jupiter.api")
+    requires("org.hiero.block.node.app.test.fixtures")
+}
+
+sourceSets {
+    main {
+        pbj {
+            srcDir(
+                layout.projectDirectory.dir(
+                    "src/main/java/org/hiero/block/node/backfill/client/proto"
+                )
+            )
+        }
+    }
+}

--- a/block-node/backfill/src/main/java/module-info.java
+++ b/block-node/backfill/src/main/java/module-info.java
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.backfill.BackfillPlugin;
+
+// SPDX-License-Identifier: Apache-2.0
+module org.hiero.block.node.backfill {
+    uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
+
+    // export configuration classes to the config module and app
+    exports org.hiero.block.node.backfill to
+            com.swirlds.config.impl,
+            com.swirlds.config.extensions,
+            org.hiero.block.node.app;
+    exports org.hiero.block.node.backfill.client to
+            com.swirlds.config.extensions,
+            com.swirlds.config.impl,
+            org.hiero.block.node.app;
+
+    requires transitive com.hedera.pbj.runtime;
+    requires transitive com.swirlds.config.api;
+    requires transitive com.swirlds.metrics.api;
+    requires transitive org.hiero.block.node.spi;
+    requires transitive org.hiero.block.protobuf.pbj;
+    requires transitive io.grpc.stub;
+    requires transitive io.grpc;
+    requires transitive io.helidon.grpc.core;
+    requires transitive io.helidon.webclient.grpc;
+    requires org.hiero.block.node.base;
+    requires io.helidon.common.tls;
+    requires io.helidon.webclient.api;
+    requires org.antlr.antlr4.runtime;
+    requires static transitive com.github.spotbugs.annotations;
+
+    provides org.hiero.block.node.spi.BlockNodePlugin with
+            BackfillPlugin;
+}

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillConfiguration.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillConfiguration.java
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.backfill;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import com.swirlds.config.api.validation.annotation.Max;
+import com.swirlds.config.api.validation.annotation.Min;
+import org.hiero.block.node.base.Loggable;
+
+/**
+ * Configuration for the Backfill module.
+ *
+ * @param startBlock The first block that this BN deploy wants to have available
+ * @param endBlock For some historical-purpose–specific BNs, there could be a maximum number of blocks, -1 means no limit.
+ * @param blockNodeSourcesPath File path for a yaml configuration for the BN sources.
+ * @param scanIntervalMs Interval in minutes to scan for missing gaps (skips if the previous task is running)
+ * @param maxRetries Maximum number of retries to fetch a missing block (with exponential back-off)
+ * @param initialRetryDelayMs Initial cooldown time between retries in milliseconds, will be multiplied by number of retry on each attempt
+ * @param fetchBatchSize Number of blocks to fetch in a single gRPC call
+ * @param delayBetweenBatchesMs Cool downtime in milliseconds between batches of blocks to fetch
+ * @param initialDelayMs Initial delay in seconds before starting the backfill process, to give time for the system to stabilize
+ */
+@ConfigData("backfill")
+public record BackfillConfiguration(
+        @Loggable @ConfigProperty(defaultValue = "0") @Min(0) long startBlock,
+        @Loggable @ConfigProperty(defaultValue = "-1") @Min(-1) long endBlock,
+        @Loggable @ConfigProperty(defaultValue = "") String blockNodeSourcesPath,
+        @Loggable @ConfigProperty(defaultValue = "60000") @Min(100) int scanIntervalMs,
+        @Loggable @ConfigProperty(defaultValue = "3") @Min(0) @Max(10) int maxRetries,
+        @Loggable @ConfigProperty(defaultValue = "5000") @Min(500) int initialRetryDelayMs,
+        @Loggable @ConfigProperty(defaultValue = "100") @Min(1) @Max(10_000) int fetchBatchSize,
+        @Loggable @ConfigProperty(defaultValue = "1000") @Min(100) int delayBetweenBatchesMs,
+        @Loggable @ConfigProperty(defaultValue = "15000") @Min(5) int initialDelayMs) {}

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillGrpcClient.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillGrpcClient.java
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.backfill;
+
+import static java.lang.System.Logger.Level.INFO;
+
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.metrics.api.Counter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.node.backfill.client.BackfillSource;
+import org.hiero.block.node.backfill.client.BackfillSourceConfig;
+import org.hiero.block.node.backfill.client.BlockNodeClient;
+import org.hiero.block.node.spi.historicalblocks.LongRange;
+
+/**
+ * Client for fetching blocks from block nodes using gRPC.
+ * This client handles retries and manages the status of block nodes.
+ * It uses a round-robin approach to try different block nodes based on their priority.
+ * It also maintains a map of node statuses to avoid hitting unavailable nodes repeatedly.
+ * <p>
+ * The client fetches blocks in a specified range and retries fetching from different nodes
+ * if the initial node does not have the required blocks or is unavailable.
+ * It also implements exponential backoff for retries to avoid overwhelming the nodes.
+ * <p>
+ * The client is initialized with a path to a block node preference file, which contains
+ * */
+public class BackfillGrpcClient {
+    private static final System.Logger LOGGER = System.getLogger(BackfillGrpcClient.class.getName());
+
+    /** Metric for Number of retries during the backfill process. */
+    private final Counter backfillRetries;
+    /** Source of block node configurations. */
+    private final BackfillSource blockNodeSource;
+    /**
+     * Maximum number of retries to fetch blocks from a block node.
+     * This is used to avoid infinite loops in case of persistent failures.
+     */
+    private final int maxRetries;
+    /**
+     * Initial delay in milliseconds before retrying to fetch blocks from a block node.
+     * This is used for exponential backoff in case of failures.
+     */
+    private final int initialRetryDelayMs;
+
+    /** Current status of the Block Node Clients */
+    private ConcurrentHashMap<BackfillSourceConfig, Status> nodeStatusMap = new ConcurrentHashMap<>();
+    /**
+     * Map of BackfillSourceConfig to BlockNodeClient instances.
+     * This allows us to reuse clients for the same node configuration.
+     */
+    private ConcurrentHashMap<BackfillSourceConfig, BlockNodeClient> nodeClientMap = new ConcurrentHashMap<>();
+
+    /**
+     * Constructor for BackfillGrpcClient.
+     *
+     * @param blockNodePreferenceFilePath the path to the block node preference file
+     */
+    public BackfillGrpcClient(
+            Path blockNodePreferenceFilePath, int maxRetries, Counter backfillRetriesCounter, int retryInitialDelayMs)
+            throws IOException, ParseException {
+        this.blockNodeSource = BackfillSource.JSON.parse(Bytes.wrap(Files.readAllBytes(blockNodePreferenceFilePath)));
+        this.maxRetries = maxRetries;
+        this.initialRetryDelayMs = retryInitialDelayMs;
+        this.backfillRetries = backfillRetriesCounter;
+
+        for (BackfillSourceConfig node : blockNodeSource.nodes()) {
+            LOGGER.log(INFO, "Address: {0}, Port: {1}, Priority: {2}", node.address(), node.port(), node.priority());
+        }
+    }
+
+    /**
+     * Checks if the specified block range is available in the given block node.
+     * @param node the block node to check
+     * @param blockRange the block range to check
+     * @return true if the range is available in the node, false otherwise
+     */
+    private boolean isRangeAvailableInNode(BlockNodeClient node, LongRange blockRange) {
+        long firstAvailableBlock =
+                node.getBlockNodeServerStatusClient().getServerStatus().firstAvailableBlock();
+        long lastAvailableBlock =
+                node.getBlockNodeServerStatusClient().getServerStatus().lastAvailableBlock();
+
+        return blockRange.start() >= firstAvailableBlock && blockRange.end() <= lastAvailableBlock;
+
+        // @todo(1411): there might be some cases when BlockGap is available between more than 1 node.
+        // ie: Gap from 0 to 100, 0-50 is available in node A, 51-100 is available in node B.
+        // in this case we should return the available gap in the node instead and null when not a single block of given
+        // gap is available.
+    }
+
+    /**
+     * Fetches missing blocks for the given block range.
+     *
+     * @param blockRange The block range to fetch
+     * @return A list of blocks fetched from the block nodes, or an empty list if no blocks were found
+     */
+    public List<BlockUnparsed> fetchBlocks(LongRange blockRange) {
+        LOGGER.log(INFO, "Requesting blocks for range: {0} to {1}", blockRange.start(), blockRange.end());
+
+        // only use nodes that are ACTIVE or UNKNOWN
+        List<BackfillSourceConfig> activeOrUnknownNodes = new ArrayList<>();
+        for (BackfillSourceConfig node : blockNodeSource.nodes()) {
+            Status currentStatus = nodeStatusMap.getOrDefault(node, Status.UNKNOWN);
+            if (currentStatus == Status.AVAILABLE || currentStatus == Status.UNKNOWN) {
+                activeOrUnknownNodes.add(node);
+            }
+        }
+        // Randomize order to avoid always hitting the same node first
+        Collections.shuffle(activeOrUnknownNodes);
+        // Sort by priority
+        activeOrUnknownNodes.sort(Comparator.comparingInt(BackfillSourceConfig::priority));
+
+        // Try each node in priority order
+        for (BackfillSourceConfig node : activeOrUnknownNodes) {
+            LOGGER.log(INFO, "Trying Block Node: {0}:{1}", node.address(), node.port());
+
+            for (int attempt = 1; attempt <= maxRetries; attempt++) {
+                try {
+                    BlockNodeClient currentNodeClient = getNodeClient(node);
+                    // Check if the node has the blocks we need
+                    if (!isRangeAvailableInNode(currentNodeClient, blockRange)) {
+                        LOGGER.log(
+                                INFO,
+                                "Block range not available in node {0}:{1}, trying next node",
+                                node.address(),
+                                node.port());
+                        break;
+                    }
+                    // if we reach here, the node is available
+                    nodeStatusMap.put(node, Status.AVAILABLE);
+
+                    // Try to fetch blocks from this node
+                    return currentNodeClient
+                            .getBlockNodeSubscribeClient()
+                            .getBatchOfBlocks(blockRange.start(), blockRange.end());
+                } catch (Exception e) {
+                    if (attempt == maxRetries) {
+                        // If we reach the max retries, mark the node as UNAVAILABLE
+                        nodeStatusMap.put(node, Status.UNAVAILABLE);
+
+                        LOGGER.log(
+                                INFO,
+                                "Failed to fetch blocks from node {0}:{1}, error: {2}",
+                                node.address(),
+                                node.port(),
+                                e.getMessage());
+
+                    } else {
+                        long delay = Math.multiplyExact(initialRetryDelayMs, attempt);
+                        LOGGER.log(INFO, "Attempt {0} failed. Retrying in {1} milliseconds...", attempt, delay);
+                        try {
+                            TimeUnit.MILLISECONDS.sleep(delay);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            break;
+                        }
+                        // update metrics
+                        backfillRetries.increment();
+                    }
+                }
+            }
+        }
+
+        LOGGER.log(
+                INFO,
+                "No configured Block Node had the missing blocks for range: {0} to {1}",
+                blockRange.start(),
+                blockRange.end());
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns a BlockNodeClient for the given BackfillSourceConfig.
+     * If a client for the node already exists, it returns that client.
+     * Otherwise, it creates a new client and stores it in the map.
+     *
+     * @param node the BackfillSourceConfig to get the client for
+     * @return a BlockNodeClient for the specified node
+     */
+    private BlockNodeClient getNodeClient(BackfillSourceConfig node) {
+        return nodeClientMap.computeIfAbsent(node, BlockNodeClient::new);
+    }
+
+    /**
+     * Resets the status of all block nodes to UNKNOWN.
+     * This is useful for scenarios where the status of nodes may change,
+     * such as after a network outage or when nodes are restarted.
+     */
+    public void resetStatus() {
+        for (BackfillSourceConfig node : blockNodeSource.nodes()) {
+            nodeStatusMap.put(node, Status.UNKNOWN);
+        }
+    }
+
+    /**
+     * Enum representing the status of a block node:
+     * <ul>
+     *     <li>UNKNOWN: The status of the node is unknown.</li>
+     *     <li>AVAILABLE: The node is available and can serve requests.</li>
+     *     <li>UNAVAILABLE: The node is not available, either due to an error or because it does not have the requested blocks.</li>
+     * </ul>>
+     */
+    public enum Status {
+        UNKNOWN,
+        AVAILABLE,
+        UNAVAILABLE
+    }
+}

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.backfill;
+
+import static java.lang.System.Logger.Level.INFO;
+import static java.lang.System.Logger.Level.WARNING;
+
+import com.hedera.hapi.block.stream.output.BlockHeader;
+import com.hedera.pbj.runtime.ParseException;
+import com.swirlds.metrics.api.Counter;
+import com.swirlds.metrics.api.LongGauge;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.node.spi.BlockNodeContext;
+import org.hiero.block.node.spi.BlockNodePlugin;
+import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
+import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
+import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.block.node.spi.historicalblocks.LongRange;
+
+/**
+ * BackfillPlugin is a BlockNodePlugin that detects gaps in historical blocks and
+ * live blocks and fetches missing blocks from configured block nodes using gRPC.
+ * It runs periodically to ensure that all historical blocks are available for
+ * historical blocks, and on-demand for live blocks.
+ */
+public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler {
+
+    private static final String METRICS_CATEGORY = "backfill";
+
+    /** The logger for this class. */
+    private final System.Logger LOGGER = System.getLogger(getClass().getName());
+
+    // Plugin infrastructure
+    private BlockNodeContext context;
+    private BackfillConfiguration backfillConfiguration;
+    private boolean hasBNSourcesPath = false;
+    private ScheduledExecutorService scheduler;
+
+    // Backfill state
+    private List<LongRange> detectedGaps = new ArrayList<>();
+    private BackfillGrpcClient backfillGrpcClient;
+    private AtomicLong backfillPendingBlocks = new AtomicLong(0);
+    private volatile boolean isDetectingGaps = false;
+    private CountDownLatch pendingVerificationAndPersistenceLatch;
+
+    // Metrics
+    private Counter backfillGapsDetected;
+    private Counter backfillFetchedBlocks;
+    private Counter backfillBlocksBackfilled;
+    private Counter backfillFetchErrors;
+    private Counter backfillRetries;
+    private LongGauge backfillStatus;
+    private LongGauge backfillPendingBlocksGauge;
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public List<Class<? extends Record>> configDataTypes() {
+        return List.of(BackfillConfiguration.class);
+    }
+
+    /***
+     * Initializes the metrics for the backfill process.
+     */
+    private void initMetrics() {
+        final var metrics = context.metrics();
+        backfillGapsDetected = metrics.getOrCreate(new Counter.Config(METRICS_CATEGORY, "backfill_gaps_detected")
+                .withDescription("Number of gaps detected during the backfill process."));
+        backfillFetchedBlocks = metrics.getOrCreate(new Counter.Config(METRICS_CATEGORY, "backfill_blocks_fetched")
+                .withDescription("Number of blocks fetched during the backfill process."));
+        backfillBlocksBackfilled =
+                metrics.getOrCreate(new Counter.Config(METRICS_CATEGORY, "backfill_blocks_backfilled")
+                        .withDescription("Number of blocks backfilled during the backfill process."));
+        backfillFetchErrors = metrics.getOrCreate(new Counter.Config(METRICS_CATEGORY, "backfill_fetch_errors")
+                .withDescription("Number of errors encountered during the backfill process."));
+        backfillRetries = metrics.getOrCreate(new Counter.Config(METRICS_CATEGORY, "backfill_retries")
+                .withDescription("Number of retries during the backfill process."));
+        backfillStatus = metrics.getOrCreate(new LongGauge.Config(METRICS_CATEGORY, "backfill_status")
+                .withDescription("Current status of the backfill process (e.g., idle = 0, running = 1, error = 2)."));
+        backfillPendingBlocksGauge =
+                metrics.getOrCreate(new LongGauge.Config(METRICS_CATEGORY, "backfill_pending_blocks")
+                        .withDescription("Current amount of blocks pending to be backfilled."));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
+        this.context = context;
+        backfillConfiguration = context.configuration().getConfigData(BackfillConfiguration.class);
+
+        // Initialize metrics
+        initMetrics();
+        backfillStatus.set(0); // 0 = idle
+
+        // Validate block node sources configuration
+        final String sourcesPath = backfillConfiguration.blockNodeSourcesPath();
+        if (sourcesPath == null || sourcesPath.isBlank()) {
+            LOGGER.log(INFO, "No block node sources path configured, backfill will not run");
+            return;
+        }
+
+        Path blockNodeSourcesPath = Path.of(backfillConfiguration.blockNodeSourcesPath());
+        if (!Files.isRegularFile(blockNodeSourcesPath)) {
+            LOGGER.log(
+                    INFO,
+                    "Block node sources path file does not exist: {0}, backfill will not run",
+                    backfillConfiguration.blockNodeSourcesPath());
+            return;
+        }
+
+        // Initialize the gRPC client
+        try {
+            backfillGrpcClient = new BackfillGrpcClient(
+                    blockNodeSourcesPath,
+                    backfillConfiguration.maxRetries(),
+                    this.backfillRetries,
+                    backfillConfiguration.initialRetryDelayMs());
+            LOGGER.log(INFO, "Initialized gRPC client with sources path: {0}", blockNodeSourcesPath);
+        } catch (Exception e) {
+            LOGGER.log(WARNING, "Failed to initialize gRPC client: {0}", e.getMessage());
+            hasBNSourcesPath = false;
+            return;
+        }
+
+        // set the flag indicating that we have a valid block node sources path
+        hasBNSourcesPath = true;
+        // Register the service
+        context.blockMessaging().registerBlockNotificationHandler(this, false, "BackfillPlugin");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void start() {
+        if (!hasBNSourcesPath) {
+            return;
+        }
+        LOGGER.log(
+                INFO,
+                "Scheduling backfill process to start in {0} milliseconds",
+                backfillConfiguration.initialDelayMs());
+        scheduler = Executors.newSingleThreadScheduledExecutor();
+        scheduler.scheduleAtFixedRate(
+                this::detectGaps,
+                backfillConfiguration.initialDelayMs(),
+                backfillConfiguration.scanIntervalMs(),
+                TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void stop() {
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+            try {
+                if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                    LOGGER.log(INFO, "Scheduler did not terminate in time");
+                    // terminate forcefully
+                    scheduler.shutdown();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            LOGGER.log(INFO, "Stopped backfill process");
+        }
+    }
+
+    private void detectGaps() {
+        // Skip if already running
+        if (isDetectingGaps) {
+            LOGGER.log(INFO, "Gap detection already in progress, skipping this execution");
+            return;
+        }
+
+        // Set running state
+        isDetectingGaps = true;
+        backfillStatus.set(1); // 1 = running
+
+        try {
+            LOGGER.log(INFO, "Detecting gaps in historical blocks");
+            detectedGaps = new ArrayList<>();
+
+            // Get the configured first block available
+            long expectedFirstBlock = backfillConfiguration.startBlock();
+            long previousRangeEnd = expectedFirstBlock - 1;
+
+            // Check for gaps between ranges
+            List<LongRange> blockRanges = context.historicalBlockProvider()
+                    .availableBlocks()
+                    .streamRanges()
+                    .toList();
+
+            // Calculate total missing blocks
+            long pendingBlocks = 0;
+
+            for (LongRange range : blockRanges) {
+                if (range.start() > previousRangeEnd + 1) {
+                    LongRange gap = new LongRange(previousRangeEnd + 1, range.start() - 1);
+                    detectedGaps.add(gap);
+                    pendingBlocks += gap.size();
+                    LOGGER.log(INFO, "Detected gap in historical blocks from {0} to {1}", gap.start(), gap.end());
+                }
+                previousRangeEnd = range.end();
+            }
+
+            // Update metrics
+            backfillPendingBlocks.set(pendingBlocks);
+            backfillPendingBlocksGauge.set(pendingBlocks);
+            backfillGapsDetected.add(detectedGaps.size());
+
+            LOGGER.log(INFO, "Detected {0} gaps with {1} total missing blocks", detectedGaps.size(), pendingBlocks);
+
+            // Process detected gaps
+            if (!detectedGaps.isEmpty()) {
+                processDetectedGaps();
+            } else {
+                LOGGER.log(INFO, "No gaps detected in historical blocks");
+            }
+            backfillStatus.set(0); // 0 = idle
+        } catch (Exception e) {
+            LOGGER.log(INFO, "Error during backfill autonomous process: {0}", e.getMessage());
+            backfillStatus.set(2); // 2 = error
+        } finally {
+            isDetectingGaps = false;
+        }
+    }
+
+    private void processDetectedGaps() {
+        // Process each gap
+        for (LongRange gap : detectedGaps) {
+            LOGGER.log(INFO, "Fetching blocks from {0} to {1}", gap.start(), gap.end());
+            try {
+                backfillGap(gap);
+            } catch (Exception e) {
+                LOGGER.log(INFO, "Error fetching blocks for gap {0}: {1}", gap, e.getMessage());
+                backfillFetchErrors.add(1);
+            }
+        }
+    }
+
+    /**
+     * Backfills a specific gap by fetching blocks from the gRPC client and
+     * sends backfilled block notifications for each missing block.
+     *
+     * @param gap the range of blocks to backfill
+     * @throws InterruptedException if the thread is interrupted while waiting
+     * @throws ParseException if there is an error parsing the block header
+     */
+    private void backfillGap(LongRange gap) throws InterruptedException, ParseException {
+        // Reset client status to retry previously unavailable nodes
+        backfillGrpcClient.resetStatus();
+
+        // Process gap in smaller chunks
+        List<LongRange> chunks = chunkifyGap(gap);
+
+        for (LongRange chunk : chunks) {
+            List<BlockUnparsed> batchOfBlocks;
+
+            try {
+                batchOfBlocks = backfillGrpcClient.fetchBlocks(chunk);
+            } catch (Exception e) {
+                LOGGER.log(INFO, "Error fetching blocks for chunk {0}: {1}", chunk, e.getMessage());
+                backfillFetchErrors.add(1);
+                continue;
+            }
+
+            // Set up latch for verification and persistence tracking
+            // normally will be decremented only by persisted notifications
+            // however if it fails verification, it will be decremented as well
+            // to avoid deadlocks, since blocks that fail verification are not persisted
+            pendingVerificationAndPersistenceLatch = new CountDownLatch(batchOfBlocks.size());
+
+            // Process each fetched block
+            for (BlockUnparsed blockUnparsed : batchOfBlocks) {
+                long blockNumber = extractBlockNumber(blockUnparsed);
+                context.blockMessaging()
+                        .sendBackfilledBlockNotification(new BackfilledBlockNotification(blockNumber, blockUnparsed));
+
+                LOGGER.log(INFO, "Backfilling block {0}", blockNumber);
+                backfillFetchedBlocks.increment();
+            }
+
+            // Wait for verification and persistence to complete
+            pendingVerificationAndPersistenceLatch.await();
+
+            // Cooldown between batches
+            Thread.sleep(backfillConfiguration.delayBetweenBatchesMs());
+        }
+    }
+
+    /**
+     * Extracts the block number from the BlockUnparsed object.
+     *
+     * @param blockUnparsed the BlockUnparsed object containing the block header
+     * @return the block number
+     * @throws ParseException if there is an error parsing the block header
+     */
+    private long extractBlockNumber(BlockUnparsed blockUnparsed) throws ParseException {
+        return BlockHeader.PROTOBUF
+                .parse(blockUnparsed.blockItems().getFirst().blockHeaderOrThrow())
+                .number();
+    }
+
+    /**
+     * Chunks a gap into smaller ranges based on the configured fetch batch size.
+     * @param gap the LongRange representing the gap to be chunked
+     * @return a list of LongRange chunks
+     */
+    private List<LongRange> chunkifyGap(LongRange gap) {
+        long start = gap.start();
+        long end = gap.end();
+        long batchSize = backfillConfiguration.fetchBatchSize();
+        List<LongRange> chunks = new ArrayList<>();
+
+        while (start <= end) {
+            long chunkEnd = Math.min(start + batchSize - 1, end);
+            chunks.add(new LongRange(start, chunkEnd));
+            start += batchSize;
+        }
+        return chunks;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void handlePersisted(PersistedNotification notification) {
+        if (notification.blockSource() == BlockSource.BACKFILL) {
+            final long pendingBlocks = backfillPendingBlocks.decrementAndGet();
+            backfillPendingBlocksGauge.set(pendingBlocks);
+            backfillBlocksBackfilled.increment();
+            // lastly, count down the latch to signal that this block has been processed
+            pendingVerificationAndPersistenceLatch.countDown();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void handleVerification(VerificationNotification notification) {
+        if (notification.source() == BlockSource.BACKFILL) {
+            if (!notification.success()) {
+                LOGGER.log(WARNING, "Block {0} verification failed", notification.blockNumber());
+                backfillFetchErrors.increment();
+                // lastly, count down the latch to signal that this block has been processed
+                pendingVerificationAndPersistenceLatch.countDown();
+            }
+        }
+    }
+}

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/BlockNodeClient.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/BlockNodeClient.java
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.backfill.client;
+
+import io.helidon.common.tls.Tls;
+import io.helidon.webclient.grpc.GrpcClient;
+import io.helidon.webclient.grpc.GrpcClientProtocolConfig;
+import java.time.Duration;
+
+public class BlockNodeClient {
+    private final BlockNodeServerStatusClient blockNodeServerStatusClient;
+    private final BlockNodeSubscribeClient blockNodeSubscribeClient;
+
+    public BlockNodeClient(BackfillSourceConfig blockNodeConfig) {
+
+        // Initialize gRPC client with the block node configuration
+        GrpcClient grpcClient = GrpcClient.builder()
+                .tls(Tls.builder().enabled(false).build())
+                .baseUri("http://" + blockNodeConfig.address() + ":" + blockNodeConfig.port())
+                .protocolConfig(GrpcClientProtocolConfig.builder()
+                        .abortPollTimeExpired(false)
+                        .pollWaitTime(Duration.ofSeconds(30))
+                        .build())
+                .keepAlive(true)
+                .build();
+        // Initialize clients for server status and block subscription
+        this.blockNodeServerStatusClient = new BlockNodeServerStatusClient(grpcClient);
+        this.blockNodeSubscribeClient = new BlockNodeSubscribeClient(grpcClient);
+    }
+
+    public BlockNodeServerStatusClient getBlockNodeServerStatusClient() {
+        return blockNodeServerStatusClient;
+    }
+
+    public BlockNodeSubscribeClient getBlockNodeSubscribeClient() {
+        return blockNodeSubscribeClient;
+    }
+}

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/BlockNodeServerStatusClient.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/BlockNodeServerStatusClient.java
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.backfill.client;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.grpc.MethodDescriptor;
+import io.grpc.stub.StreamObserver;
+import io.helidon.grpc.core.MarshallerSupplier;
+import io.helidon.webclient.grpc.GrpcClient;
+import io.helidon.webclient.grpc.GrpcClientMethodDescriptor;
+import io.helidon.webclient.grpc.GrpcServiceClient;
+import io.helidon.webclient.grpc.GrpcServiceDescriptor;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hiero.block.api.BlockNodeServiceInterface;
+import org.hiero.block.api.ServerStatusRequest;
+import org.hiero.block.api.ServerStatusResponse;
+
+public class BlockNodeServerStatusClient implements StreamObserver<ServerStatusResponse> {
+    private final GrpcServiceClient serverStatusServiceClient;
+    private final String methodName = BlockNodeServiceInterface.BlockNodeServiceMethod.serverStatus.name();
+    // Per Request State
+    private AtomicReference<ServerStatusResponse> replyRef;
+    private AtomicReference<Throwable> errorRef;
+    private CountDownLatch latch;
+
+    public BlockNodeServerStatusClient(final GrpcClient grpcClient) {
+        // create service client for server status
+        this.serverStatusServiceClient = grpcClient.serviceClient(GrpcServiceDescriptor.builder()
+                .serviceName(BlockNodeServiceInterface.FULL_NAME)
+                .putMethod(
+                        methodName,
+                        GrpcClientMethodDescriptor.unary(BlockNodeServiceInterface.FULL_NAME, methodName)
+                                .requestType(ServerStatusRequest.class)
+                                .responseType(ServerStatusResponse.class)
+                                .marshallerSupplier(
+                                        new BlockNodeServerStatusClient.ServerStatusRequestResponseMarshaller
+                                                .Supplier())
+                                .build())
+                .build());
+    }
+
+    public ServerStatusResponse getServerStatus() {
+        // reset state for the request
+        replyRef = new AtomicReference<>();
+        errorRef = new AtomicReference<>();
+        latch = new CountDownLatch(1);
+        // Call
+        serverStatusServiceClient.unary(methodName, new ServerStatusRequest(), this);
+        // wait for response or error
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        // Check for error
+        if (errorRef.get() != null) {
+            if (errorRef.get() instanceof RuntimeException re) {
+                throw re;
+            }
+            throw new RuntimeException(errorRef.get());
+        }
+        // Check for reply
+        if (replyRef.get() != null) {
+            return replyRef.get();
+        }
+        // If we reach here, it means we did not receive a reply or an error
+        throw new RuntimeException("Call to serverStatus completed w/o receiving a reply or an error explicitly.");
+    }
+
+    @Override
+    public void onNext(ServerStatusResponse serverStatusResponse) {
+        if (replyRef.get() != null) {
+            throw new IllegalStateException(
+                    "serverStatus is unary, but received more than one reply. The latest reply is: "
+                            + serverStatusResponse);
+        }
+        replyRef.set(serverStatusResponse);
+        latch.countDown();
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        errorRef.set(throwable);
+        latch.countDown();
+    }
+
+    @Override
+    public void onCompleted() {
+        latch.countDown();
+    }
+
+    public static class ServerStatusRequestResponseMarshaller<T> implements MethodDescriptor.Marshaller<T> {
+        private final Codec<T> codec;
+
+        ServerStatusRequestResponseMarshaller(@NonNull final Class<T> clazz) {
+            requireNonNull(clazz);
+
+            if (clazz == ServerStatusRequest.class) {
+                this.codec = (Codec<T>) ServerStatusRequest.PROTOBUF;
+            } else if (clazz == ServerStatusResponse.class) {
+                this.codec = (Codec<T>) ServerStatusResponse.PROTOBUF;
+            } else {
+                throw new IllegalArgumentException("Unsupported class: " + clazz.getName());
+            }
+        }
+
+        @Override
+        public InputStream stream(@NonNull final T obj) {
+            requireNonNull(obj);
+            return codec.toBytes(obj).toInputStream();
+        }
+
+        @Override
+        public T parse(@NonNull final InputStream inputStream) {
+            requireNonNull(inputStream);
+
+            try (inputStream) {
+                return codec.parse(Bytes.wrap(inputStream.readAllBytes()));
+            } catch (final ParseException | IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public static class Supplier implements MarshallerSupplier {
+            @Override
+            public <T> MethodDescriptor.Marshaller<T> get(@NonNull final Class<T> clazz) {
+                return new ServerStatusRequestResponseMarshaller<>(clazz);
+            }
+        }
+    }
+}

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/BlockNodeSubscribeClient.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/BlockNodeSubscribeClient.java
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.backfill.client;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.block.stream.output.BlockHeader;
+import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.grpc.MethodDescriptor;
+import io.grpc.stub.StreamObserver;
+import io.helidon.grpc.core.MarshallerSupplier;
+import io.helidon.webclient.grpc.GrpcClient;
+import io.helidon.webclient.grpc.GrpcClientMethodDescriptor;
+import io.helidon.webclient.grpc.GrpcServiceClient;
+import io.helidon.webclient.grpc.GrpcServiceDescriptor;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hiero.block.api.BlockStreamSubscribeServiceInterface;
+import org.hiero.block.api.SubscribeStreamRequest;
+import org.hiero.block.api.SubscribeStreamResponse;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.internal.SubscribeStreamResponseUnparsed;
+
+public class BlockNodeSubscribeClient implements StreamObserver<SubscribeStreamResponseUnparsed> {
+    private final GrpcServiceClient blockStreamSubscribeServiceClient;
+    private final String methodName =
+            BlockStreamSubscribeServiceInterface.BlockStreamSubscribeServiceMethod.subscribeBlockStream.name();
+    // Per Request State
+    private List<BlockItemUnparsed> currentBlockItems;
+    private AtomicLong currentBlockNumber;
+    private AtomicReference<List<BlockUnparsed>> replyRef;
+    private AtomicReference<Throwable> errorRef;
+    private CountDownLatch latch;
+
+    public BlockNodeSubscribeClient(GrpcClient grpcClient) {
+        // create service client for server status
+        this.blockStreamSubscribeServiceClient = grpcClient.serviceClient(GrpcServiceDescriptor.builder()
+                .serviceName(BlockStreamSubscribeServiceInterface.FULL_NAME)
+                .putMethod(
+                        methodName,
+                        GrpcClientMethodDescriptor.serverStreaming(
+                                        BlockStreamSubscribeServiceInterface.FULL_NAME, methodName)
+                                .requestType(SubscribeStreamRequest.class)
+                                .responseType(SubscribeStreamResponseUnparsed.class)
+                                .marshallerSupplier(new BlockStreamSubscribeMarshaller.Supplier())
+                                .build())
+                .build());
+    }
+
+    public List<BlockUnparsed> getBatchOfBlocks(long startBlockNumber, long endBlockNumber) {
+        // Validate input parameters
+        if (startBlockNumber < 0 || endBlockNumber < 0 || startBlockNumber > endBlockNumber) {
+            throw new IllegalArgumentException("Invalid block range: " + startBlockNumber + " to " + endBlockNumber);
+        }
+        // reset state for the request
+        currentBlockItems = new ArrayList<>();
+        currentBlockNumber = new AtomicLong(startBlockNumber);
+        replyRef = new AtomicReference<>();
+        errorRef = new AtomicReference<>();
+        latch = new CountDownLatch(1);
+        // Create request
+        SubscribeStreamRequest request = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(startBlockNumber)
+                .endBlockNumber(endBlockNumber)
+                .build();
+        // Call
+        blockStreamSubscribeServiceClient.serverStream(methodName, request, this);
+
+        // wait for response or error
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting for blocks", e);
+        }
+        if (errorRef.get() != null) {
+            throw new RuntimeException("Error fetching blocks", errorRef.get());
+        }
+        return replyRef.get();
+    }
+
+    @Override
+    public void onNext(SubscribeStreamResponseUnparsed subscribeStreamResponse) {
+        if (subscribeStreamResponse.hasBlockItems()) {
+            List<BlockItemUnparsed> blockItems =
+                    subscribeStreamResponse.blockItems().blockItems();
+            // Check if is new Block
+            if (blockItems.getFirst().hasBlockHeader()) {
+                // verify is the expected block number
+                long expectedBlockNumber = currentBlockNumber.get();
+                long actualBlockNumber = 0;
+                try {
+                    actualBlockNumber = BlockHeader.PROTOBUF
+                            .parse(blockItems.getFirst().blockHeaderOrThrow())
+                            .number();
+                } catch (ParseException e) {
+                    throw new RuntimeException(e);
+                }
+                if (actualBlockNumber != expectedBlockNumber) {
+                    throw new IllegalStateException(
+                            "Expected block number " + expectedBlockNumber + " but received " + actualBlockNumber);
+                }
+                // Create new Block and add to current block items
+                currentBlockItems = new ArrayList<>(blockItems);
+            } else {
+                // Add items to current block
+                currentBlockItems.addAll(blockItems);
+            }
+
+            // Check if response contains block proof (end of block)
+            if (blockItems.getLast().hasBlockProof()) {
+                // Create Block from current items
+                BlockUnparsed block =
+                        BlockUnparsed.newBuilder().blockItems(currentBlockItems).build();
+                // Add to reply
+                List<BlockUnparsed> blocks = replyRef.get();
+                if (blocks == null) {
+                    blocks = new ArrayList<>();
+                    replyRef.set(blocks);
+                }
+                blocks.add(block);
+                // Reset current block items and number for next block
+                currentBlockItems = new ArrayList<>();
+                currentBlockNumber.incrementAndGet();
+            }
+
+        } else if (subscribeStreamResponse.hasStatus()) {
+            // If response has code, set the status
+            SubscribeStreamResponse.Code codeStatus = subscribeStreamResponse.status();
+            if (codeStatus != SubscribeStreamResponse.Code.SUCCESS) {
+                errorRef.set(new RuntimeException("Received error code: " + codeStatus));
+            }
+        } else {
+            // If no block items and no code, this is unexpected
+            errorRef.set(new RuntimeException("Received unexpected response without block items or code"));
+        }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        errorRef.set(throwable);
+        replyRef.set(null);
+        latch.countDown();
+    }
+
+    @Override
+    public void onCompleted() {
+        latch.countDown();
+    }
+
+    public static class BlockStreamSubscribeMarshaller<T> implements MethodDescriptor.Marshaller<T> {
+        private final Codec<T> codec;
+
+        public BlockStreamSubscribeMarshaller(@NonNull final Class<T> clazz) {
+            requireNonNull(clazz);
+
+            if (clazz == SubscribeStreamRequest.class) {
+                this.codec = (Codec<T>) SubscribeStreamRequest.PROTOBUF;
+            } else if (clazz == SubscribeStreamResponseUnparsed.class) {
+                this.codec = (Codec<T>) SubscribeStreamResponseUnparsed.PROTOBUF;
+            } else {
+                throw new IllegalArgumentException("Unsupported class: " + clazz.getName());
+            }
+        }
+
+        @Override
+        public InputStream stream(@NonNull final T obj) {
+            requireNonNull(obj);
+            return codec.toBytes(obj).toInputStream();
+        }
+
+        @Override
+        public T parse(@NonNull final InputStream inputStream) {
+            requireNonNull(inputStream);
+
+            try (inputStream) {
+                return codec.parse(Bytes.wrap(inputStream.readAllBytes()));
+            } catch (final ParseException | IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public static class Supplier implements MarshallerSupplier {
+            @Override
+            public <T> MethodDescriptor.Marshaller<T> get(@NonNull final Class<T> clazz) {
+                return new BlockStreamSubscribeMarshaller<>(clazz);
+            }
+        }
+    }
+}

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/proto/block_node_source.proto
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/proto/block_node_source.proto
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+syntax = "proto3";
+
+package org.hiero.block.node.backfill.client.proto;
+
+option java_package = "org.hiero.block.node.backfill.client";
+
+message BackfillSource {
+  repeated BackfillSourceConfig nodes = 1; // Array of BlockNode messages
+}
+
+message BackfillSourceConfig {
+  string address = 1; // Address as a string (either hostname or IP)
+  uint32 port = 2; // Port number
+  uint32 priority = 3; // Priority for each node
+}

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/proto/block_node_source.proto
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/proto/block_node_source.proto
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 syntax = "proto3";
 
-package org.hiero.block.node.backfill.client.proto;
-
-option java_package = "org.hiero.block.node.backfill.client";
+package org.hiero.block.node.backfill.client;
 
 message BackfillSource {
   repeated BackfillSourceConfig nodes = 1; // Array of BlockNode messages

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.backfill;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder;
+import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
+import org.hiero.block.node.app.fixtures.plugintest.SimpleBlockRangeSet;
+import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
+import org.hiero.block.node.app.fixtures.server.TestBlockNodeServer;
+import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
+import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
+import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BackfillPluginTest extends PluginTestBase<BackfillPlugin> {
+
+    /** The historical block facility. */
+    private final SimpleInMemoryHistoricalBlockFacility historicalBlockFacility;
+
+    private final TestBlockNodeServer testBlockNodeServer;
+
+    private final List<TestBlockNodeServer> blockNodeServerMocks = new ArrayList();
+
+    private final Map<String, String> defaultConfig = Map.of(
+            "backfill.blockNodeSourcesPath",
+            getClass().getClassLoader().getResource("block-nodes.json").getFile(),
+            "backfill.fetchBatchSize",
+            "5",
+            "backfill.delayBetweenBatchesMs",
+            "100",
+            "backfill.initialDelayMs",
+            "1000");
+
+    public BackfillPluginTest() {
+        // we will create a BN Mock with port number 8081 and blocks from 0 to 400
+        final SimpleInMemoryHistoricalBlockFacility secondBNBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
+        for (int i = 0; i < 400; i++) {
+            final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
+            secondBNBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
+        }
+
+        this.historicalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
+        this.testBlockNodeServer = new TestBlockNodeServer(8081, secondBNBlockFacility);
+
+        // we create another BN Server Mock that is available at port 8082 but has no useful blocks
+        final SimpleInMemoryHistoricalBlockFacility emptyBNBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
+        for (int i = 10000; i < 10001; i++) {
+            final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
+            emptyBNBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
+        }
+        blockNodeServerMocks.add(new TestBlockNodeServer(8082, emptyBNBlockFacility));
+    }
+
+    @Test
+    @DisplayName("Backfill Happy Test")
+    void testBackfillPlugin() throws InterruptedException {
+
+        String blockNodeSourcesPath =
+                getClass().getClassLoader().getResource("block-nodes.json").getFile();
+
+        start(
+                new BackfillPlugin(),
+                this.historicalBlockFacility,
+                Map.of(
+                        "backfill.blockNodeSourcesPath",
+                        blockNodeSourcesPath,
+                        "backfill.fetchBatchSize",
+                        "5",
+                        "backfill.delayBetweenBatchesMs",
+                        "100",
+                        "backfill.initialDelaySeconds",
+                        "5"));
+
+        // insert a GAP in the historical block facility
+        final SimpleBlockRangeSet temporaryAvailableBlocks = new SimpleBlockRangeSet();
+        temporaryAvailableBlocks.add(10, 20);
+        this.historicalBlockFacility.setTemporaryAvailableBlocks(temporaryAvailableBlocks);
+        CountDownLatch countDownLatch = new CountDownLatch(10); // 0 to 9 inclusive, so 10 blocks
+
+        this.blockMessaging.registerBlockNotificationHandler(
+                new BlockNotificationHandler() {
+                    @Override
+                    public void handleBackfilled(BackfilledBlockNotification notification) {
+                        blockNodeContext
+                                .blockMessaging()
+                                .sendBlockVerification(new VerificationNotification(
+                                        true,
+                                        notification.blockNumber(),
+                                        Bytes.wrap("123"),
+                                        notification.block(),
+                                        BlockSource.BACKFILL));
+                    }
+                },
+                false,
+                "test-backfill-handler");
+
+        this.blockMessaging.registerBlockNotificationHandler(
+                new BlockNotificationHandler() {
+                    @Override
+                    public void handleVerification(VerificationNotification notification) {
+                        blockNodeContext
+                                .blockMessaging()
+                                .sendBlockPersisted(new PersistedNotification(
+                                        notification.blockNumber(),
+                                        notification.blockNumber(),
+                                        10,
+                                        notification.source()));
+                        countDownLatch.countDown();
+                    }
+                },
+                false,
+                "test-backfill-handler");
+
+        boolean backfillSuccess =
+                countDownLatch.await(5, TimeUnit.MINUTES); // Wait until countDownLatch.countDown() is called
+
+        // Continue with your assertions or test logic/BlockItems blockItems = mock(BlockItems.class);
+        assertEquals(true, backfillSuccess);
+        assertEquals(0, countDownLatch.getCount(), "Count down latch should be 0 after backfill");
+
+        // Verify sent verifications
+        assertEquals(
+                10,
+                blockMessaging.getSentPersistedNotifications().size(),
+                "Should have sent 11 persisted notifications");
+        assertEquals(
+                10,
+                blockMessaging.getSentVerificationNotifications().size(),
+                "Should have sent 11 verification notifications");
+
+        plugin.stop();
+    }
+
+    @Test
+    @DisplayName("Priority 1 BN is unavailable, fallback to 2nd priority BN")
+    void testSecondarySourceBakcfill() throws InterruptedException {
+        // lets re-initialize the plugin with a different config
+        String blockNodeSourcesPath =
+                getClass().getClassLoader().getResource("block-nodes-2.json").getFile();
+
+        start(
+                new BackfillPlugin(),
+                this.historicalBlockFacility,
+                Map.of(
+                        "backfill.blockNodeSourcesPath",
+                        blockNodeSourcesPath,
+                        "backfill.fetchBatchSize",
+                        "5",
+                        "backfill.delayBetweenBatchesMs",
+                        "100",
+                        "backfill.initialDelaySeconds",
+                        "5",
+                        "backfill.initialRetryDelayMs",
+                        "500"));
+
+        // insert a GAP in the historical block facility
+        final SimpleBlockRangeSet temporaryAvailableBlocks = new SimpleBlockRangeSet();
+        temporaryAvailableBlocks.add(10, 20);
+        this.historicalBlockFacility.setTemporaryAvailableBlocks(temporaryAvailableBlocks);
+        CountDownLatch countDownLatch = new CountDownLatch(10); // 0 to 9 inclusive, so 10 blocks
+
+        this.blockMessaging.registerBlockNotificationHandler(
+                new BlockNotificationHandler() {
+                    @Override
+                    public void handleBackfilled(BackfilledBlockNotification notification) {
+                        blockNodeContext
+                                .blockMessaging()
+                                .sendBlockVerification(new VerificationNotification(
+                                        true,
+                                        notification.blockNumber(),
+                                        Bytes.wrap("123"),
+                                        notification.block(),
+                                        BlockSource.BACKFILL));
+                    }
+                },
+                false,
+                "test-backfill-handler");
+
+        this.blockMessaging.registerBlockNotificationHandler(
+                new BlockNotificationHandler() {
+                    @Override
+                    public void handleVerification(VerificationNotification notification) {
+                        blockNodeContext
+                                .blockMessaging()
+                                .sendBlockPersisted(new PersistedNotification(
+                                        notification.blockNumber(),
+                                        notification.blockNumber(),
+                                        10,
+                                        notification.source()));
+                        countDownLatch.countDown();
+                    }
+                },
+                false,
+                "test-backfill-handler");
+
+        boolean backfillSuccess =
+                countDownLatch.await(5, TimeUnit.MINUTES); // Wait until countDownLatch.countDown() is called
+
+        // Continue with your assertions or test logic/BlockItems blockItems = mock(BlockItems.class);
+        assertEquals(true, backfillSuccess);
+        assertEquals(0, countDownLatch.getCount(), "Count down latch should be 0 after backfill");
+
+        // Verify sent verifications
+        assertEquals(
+                10,
+                blockMessaging.getSentPersistedNotifications().size(),
+                "Should have sent 11 persisted notifications");
+        assertEquals(
+                10,
+                blockMessaging.getSentVerificationNotifications().size(),
+                "Should have sent 11 verification notifications");
+    }
+
+    @Test
+    @DisplayName("Backfill found no available block-nodes, should not backfill")
+    void testBackfillNoAvailableBlockNodes() throws InterruptedException {
+        // lets re-initialize the plugin with a different config
+        String blockNodeSourcesPath =
+                getClass().getClassLoader().getResource("block-nodes-3.json").getFile();
+
+        start(
+                new BackfillPlugin(),
+                this.historicalBlockFacility,
+                Map.of(
+                        "backfill.blockNodeSourcesPath",
+                        blockNodeSourcesPath,
+                        "backfill.fetchBatchSize",
+                        "5",
+                        "backfill.delayBetweenBatchesMs",
+                        "100",
+                        "backfill.initialDelaySeconds",
+                        "5",
+                        "backfill.initialRetryDelayMs",
+                        "500"));
+
+        // insert a GAP in the historical block facility
+        final SimpleBlockRangeSet temporaryAvailableBlocks = new SimpleBlockRangeSet();
+        temporaryAvailableBlocks.add(10, 20);
+        this.historicalBlockFacility.setTemporaryAvailableBlocks(temporaryAvailableBlocks);
+
+        // give 10 seconds to allow processing to finish...
+        TimeUnit.SECONDS.sleep(10);
+
+        assertEquals(
+                0, blockMessaging.getSentPersistedNotifications().size(), "Should have sent 0 persisted notifications");
+        assertEquals(
+                0,
+                blockMessaging.getSentVerificationNotifications().size(),
+                "Should have sent 0 verification notifications");
+    }
+}

--- a/block-node/backfill/src/test/resources/block-nodes-2.json
+++ b/block-node/backfill/src/test/resources/block-nodes-2.json
@@ -1,0 +1,8 @@
+{
+  "nodes": [
+    { "address": "node2.example.com", "port": 8082, "priority": 1 },
+    { "address": "localhost", "port": 8082, "priority": 1 },
+    { "address": "localhost", "port": 8081, "priority": 2 }
+
+  ]
+}

--- a/block-node/backfill/src/test/resources/block-nodes-3.json
+++ b/block-node/backfill/src/test/resources/block-nodes-3.json
@@ -1,0 +1,5 @@
+{
+  "nodes": [
+    { "address": "node2.example.com", "port": 8082, "priority": 1 }
+  ]
+}

--- a/block-node/backfill/src/test/resources/block-nodes.json
+++ b/block-node/backfill/src/test/resources/block-nodes.json
@@ -1,0 +1,8 @@
+{
+  "nodes": [
+    { "address": "localhost", "port": 8081, "priority": 1 },
+    { "address": "node2.example.com", "port": 8082, "priority": 2 },
+    { "address": "node3.example.com", "port": 8083, "priority": 2 },
+    { "address": "node4.example.com", "port": 8084, "priority": 2 }
+  ]
+}

--- a/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
+++ b/block-node/block-providers/files.historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPlugin.java
@@ -24,6 +24,7 @@ import org.hiero.block.node.base.ranges.ConcurrentLongRangeSet;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 import org.hiero.block.node.spi.historicalblocks.BlockProviderPlugin;
@@ -397,7 +398,7 @@ public final class BlocksFilesHistoricPlugin implements BlockProviderPlugin, Blo
                 // now all the blocks are in the zip file and accessible, send notification
                 context.blockMessaging()
                         .sendBlockPersisted(new PersistedNotification(
-                                batchFirstBlockNumber, batchLastBlockNumber, defaultPriority()));
+                                batchFirstBlockNumber, batchLastBlockNumber, defaultPriority(), BlockSource.HISTORY));
             }
         } finally {
             // always make sure to remove the batch of blocks from in progress ranges

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
@@ -38,6 +38,7 @@ import org.hiero.block.node.base.CompressionType;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 import org.hiero.block.node.spi.historicalblocks.BlockRangeSet;
@@ -190,7 +191,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 9, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
             // assert that the first 10 blocks are zipped now
@@ -224,7 +226,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 19, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 19, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
             // assert that the first 20 blocks are zipped now
@@ -258,7 +261,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 14, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 14, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
             // assert that the first 10 blocks are zipped now
@@ -298,7 +302,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 9, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
             // assert the contents of the zip file
@@ -347,7 +352,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 4, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 4, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // assert that no task has been submitted to the pool because we have
             // not yet reached the desired amount of blocks we want to archive
             final boolean anyTaskSubmitted = pluginExecutor.wasAnyTaskSubmitted();
@@ -367,7 +373,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(5, 9, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(5, 9, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
             // assert that the first 10 blocks are zipped now
@@ -397,7 +404,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority() - 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 9, toTest.defaultPriority() - 1, BlockSource.PUBLISHER));
             // assert that no zipping task was submitted
             final boolean anyTaskSubmitted = pluginExecutor.wasAnyTaskSubmitted();
             assertThat(anyTaskSubmitted).isFalse();
@@ -428,7 +436,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority()));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 9, toTest.defaultPriority(), BlockSource.PUBLISHER));
             // assert that no zipping task was submitted
             final boolean anyTaskSubmitted = pluginExecutor.wasAnyTaskSubmitted();
             assertThat(anyTaskSubmitted).isFalse();
@@ -471,7 +480,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
             // send a block persisted notification for the range we last created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(5, 9, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(5, 9, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // assert that no zipping task was submitted
             final boolean anyTaskSubmitted = pluginExecutor.wasAnyTaskSubmitted();
             assertThat(anyTaskSubmitted).isFalse();
@@ -520,7 +530,8 @@ class BlocksFilesHistoricPluginTest {
             temporaryAvailableBlocks.add(0, 10);
             testHistoricalBlockFacility.setTemporaryAvailableBlocks(temporaryAvailableBlocks);
             // send a block persisted notification for the range we last created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(5, 9, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(5, 9, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // assert that no zipping task was submitted
             final boolean anyTaskSubmitted = pluginExecutor.wasAnyTaskSubmitted();
             assertThat(anyTaskSubmitted).isTrue();
@@ -560,7 +571,8 @@ class BlocksFilesHistoricPluginTest {
             Files.createFile(targetZipFilePath);
             Files.setPosixFilePermissions(targetZipFilePath, Collections.emptySet()); // no permissions
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 9, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
             // assert that no blocks are zipped/available
@@ -588,7 +600,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(toTest.block(i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 9, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
             // assert that the first 10 blocks will have an accessor
@@ -618,7 +631,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(toTest.block(i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 9, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
             // assert the contents of the now available block accessors
@@ -648,7 +662,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 9, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
             // assert that a persistence notification was sent, we expect 2
@@ -683,7 +698,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(toTest.availableBlocks().contains(i)).isFalse();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 9, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
             // assert that the first 10 blocks now appear in the available range
@@ -713,7 +729,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 9, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // calculate the target zip path that we expect the plugin to create
             final Path targetZipPath = BlockPath.computeBlockPath(testConfig, 0).zipFilePath();
             Files.createDirectories(targetZipPath.getParent());
@@ -745,7 +762,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 9, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // calculate the target zip path that we expect the plugin to create
             final Path targetZipPath = BlockPath.computeBlockPath(testConfig, 0).zipFilePath();
             Files.createDirectories(targetZipPath.getParent());
@@ -779,7 +797,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 9, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // calculate the target zip path that we expect the plugin to create
             final Path targetZipPath = BlockPath.computeBlockPath(testConfig, 0).zipFilePath();
             Files.createDirectories(targetZipPath.getParent());
@@ -812,7 +831,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 9, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 9, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // calculate the target zip path that we expect the plugin to create
             final Path targetZipPath = BlockPath.computeBlockPath(testConfig, 0).zipFilePath();
             Files.createDirectories(targetZipPath.getParent());
@@ -881,7 +901,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(plugin.availableBlocks().contains(i)).isFalse();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 149, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 149, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
             // assert that all blocks are now zipped and the available blocks
@@ -893,7 +914,8 @@ class BlocksFilesHistoricPluginTest {
             }
             // send another notification to trigger the retention policy, we do
             // not need to actually persist the block
-            blockMessaging.sendBlockPersisted(new PersistedNotification(150, 150, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(150, 150, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // assert that the size of the available blocks is now 100 (post retention policy cleanup)
             assertThat(plugin.availableBlocks().size()).isEqualTo(100);
             // assert that the first 50 blocks were cleaned up and that the
@@ -936,7 +958,8 @@ class BlocksFilesHistoricPluginTest {
                 assertThat(plugin.availableBlocks().contains(i)).isFalse();
             }
             // send a block persisted notification for the range we just created
-            blockMessaging.sendBlockPersisted(new PersistedNotification(0, 149, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(0, 149, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
             // assert that all blocks are now zipped and the available blocks
@@ -948,7 +971,8 @@ class BlocksFilesHistoricPluginTest {
             }
             // send another notification to trigger the retention policy, we do
             // not need to actually persist the block
-            blockMessaging.sendBlockPersisted(new PersistedNotification(150, 150, toTest.defaultPriority() + 1));
+            blockMessaging.sendBlockPersisted(
+                    new PersistedNotification(150, 150, toTest.defaultPriority() + 1, BlockSource.PUBLISHER));
             // assert that the size of the available blocks is still 150 (post retention policy cleanup)
             assertThat(plugin.availableBlocks().size()).isEqualTo(150);
             // assert that all the blocks are still zipped and that

--- a/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPluginTest.java
+++ b/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPluginTest.java
@@ -25,6 +25,7 @@ import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
 import org.hiero.block.node.base.BlockFile;
 import org.hiero.block.node.base.CompressionType;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
 import org.junit.jupiter.api.AfterEach;
@@ -104,7 +105,11 @@ class BlockFileRecentPluginTest {
             assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().min());
             // send verified block notification
             blockMessaging.sendBlockVerification(new VerificationNotification(
-                    true, blockNumber, Bytes.EMPTY, new BlockUnparsed(toBlockItemsUnparsed(blockBlockItems))));
+                    true,
+                    blockNumber,
+                    Bytes.EMPTY,
+                    new BlockUnparsed(toBlockItemsUnparsed(blockBlockItems)),
+                    BlockSource.PUBLISHER));
             // now try and read it back
             final Block block = plugin.block(blockNumber).block();
             // check we got the correct block
@@ -135,7 +140,7 @@ class BlockFileRecentPluginTest {
             assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().min());
             // send verified block notification
             blockMessaging.sendBlockVerification(
-                    new VerificationNotification(true, blockNumber, Bytes.EMPTY, blockOrig));
+                    new VerificationNotification(true, blockNumber, Bytes.EMPTY, blockOrig, BlockSource.PUBLISHER));
             // now try and read it back
             final Block block = plugin.block(blockNumber).block();
             // check we got the correct block
@@ -158,8 +163,8 @@ class BlockFileRecentPluginTest {
                 // generate the next block
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
                 // send the block items to the plugin
-                blockMessaging.sendBlockVerification(
-                        new VerificationNotification(true, i, Bytes.EMPTY, new BlockUnparsed(List.of(block))));
+                blockMessaging.sendBlockVerification(new VerificationNotification(
+                        true, i, Bytes.EMPTY, new BlockUnparsed(List.of(block)), BlockSource.PUBLISHER));
                 // assert that the block is persisted
                 final Path persistedBlock = BlockFile.nestedDirectoriesBlockFilePath(
                         testPath, i, filesRecentConfig.compression(), filesRecentConfig.maxFilesPerDir());
@@ -205,8 +210,8 @@ class BlockFileRecentPluginTest {
                 // generate the next block
                 final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
                 // send the block items to the plugin
-                blockMessaging.sendBlockVerification(
-                        new VerificationNotification(true, i, Bytes.EMPTY, new BlockUnparsed(List.of(block))));
+                blockMessaging.sendBlockVerification(new VerificationNotification(
+                        true, i, Bytes.EMPTY, new BlockUnparsed(List.of(block)), BlockSource.PUBLISHER));
                 // assert that the block is persisted
                 final Path persistedBlock = BlockFile.nestedDirectoriesBlockFilePath(
                         testPath,

--- a/block-node/messaging/src/main/java/org/hiero/block/node/messaging/BlockNotificationRingEvent.java
+++ b/block-node/messaging/src/main/java/org/hiero/block/node/messaging/BlockNotificationRingEvent.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.messaging;
 
+import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 
@@ -12,6 +13,8 @@ public class BlockNotificationRingEvent {
     private VerificationNotification verificationNotification;
     /** The block persistence notification to be published to downstream subscribers through the LMAX Disruptor. */
     private PersistedNotification persistedNotification;
+    /** The Backfilled block notification to be published to downstream subscribers through the LMAX Disruptor. */
+    private BackfilledBlockNotification backfilledBlockNotification;
 
     /** Constructor for the BlockNotificationRingEvent class. */
     public BlockNotificationRingEvent() {}
@@ -24,6 +27,7 @@ public class BlockNotificationRingEvent {
     public void set(final VerificationNotification verificationNotification) {
         this.verificationNotification = verificationNotification;
         this.persistedNotification = null;
+        this.backfilledBlockNotification = null;
     }
 
     /**
@@ -34,6 +38,18 @@ public class BlockNotificationRingEvent {
     public void set(final PersistedNotification persistedNotification) {
         this.verificationNotification = null;
         this.persistedNotification = persistedNotification;
+        this.backfilledBlockNotification = null;
+    }
+
+    /**
+     * Sets the given value to be published to downstream subscribers through the LMAX Disruptor.
+     *
+     * @param backfilledBlockNotification the value to set
+     */
+    public void set(final BackfilledBlockNotification backfilledBlockNotification) {
+        this.backfilledBlockNotification = backfilledBlockNotification;
+        this.verificationNotification = null;
+        this.persistedNotification = null;
     }
 
     /**
@@ -54,5 +70,15 @@ public class BlockNotificationRingEvent {
      */
     public PersistedNotification getPersistedNotification() {
         return persistedNotification;
+    }
+
+    /**
+     * Gets the backfilled block notification of the event from the LMAX Disruptor on the consumer side. If the event is
+     * a verification or persisted notification, this will return null.
+     *
+     * @return the value of the event
+     */
+    public BackfilledBlockNotification getBackfilledBlockNotification() {
+        return backfilledBlockNotification;
     }
 }

--- a/block-node/messaging/src/test/java/org/hiero/block/server/messaging/BlockMessagingFacilityExceptionTest.java
+++ b/block-node/messaging/src/test/java/org/hiero/block/server/messaging/BlockMessagingFacilityExceptionTest.java
@@ -10,10 +10,13 @@ import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockItemUnparsed.ItemOneOfType;
+import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.messaging.BlockMessagingFacilityImpl;
+import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.junit.jupiter.api.BeforeEach;
@@ -120,6 +123,12 @@ public class BlockMessagingFacilityExceptionTest {
                         // Simulate an exception
                         throw new RuntimeException("Simulated exception");
                     }
+
+                    @Override
+                    public void handleBackfilled(BackfilledBlockNotification notification) {
+                        // Simulate an exception
+                        throw new RuntimeException("Simulated exception");
+                    }
                 },
                 false,
                 null);
@@ -130,8 +139,10 @@ public class BlockMessagingFacilityExceptionTest {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-        service.sendBlockVerification(new VerificationNotification(true, 1, null, null));
-        service.sendBlockPersisted(new PersistedNotification(1, 1, 1));
+        service.sendBlockVerification(new VerificationNotification(true, 1, null, null, BlockSource.PUBLISHER));
+        service.sendBlockPersisted(new PersistedNotification(1, 1, 1, BlockSource.PUBLISHER));
+        service.sendBackfilledBlockNotification(
+                new BackfilledBlockNotification(1, BlockUnparsed.newBuilder().build()));
         service.stop();
         // wait for the log handler to process the log messages
         for (int i = 0; i < 10 && logHandler.getLogMessages().isEmpty(); i++) {

--- a/block-node/messaging/src/test/java/org/hiero/block/server/messaging/BlockMessagingServiceBlockNotificationTest.java
+++ b/block-node/messaging/src/test/java/org/hiero/block/server/messaging/BlockMessagingServiceBlockNotificationTest.java
@@ -23,6 +23,7 @@ import org.hiero.block.node.messaging.BlockMessagingFacilityImpl;
 import org.hiero.block.node.messaging.MessagingConfig;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.junit.jupiter.api.Test;
 
@@ -226,7 +227,8 @@ public class BlockMessagingServiceBlockNotificationTest {
                 // wait for a bit to let the handler unregister
                 LockSupport.parkNanos(500_000);
             }
-            messagingService.sendBlockVerification(new VerificationNotification(true, i, null, null));
+            messagingService.sendBlockVerification(
+                    new VerificationNotification(true, i, null, null, BlockSource.PUBLISHER));
             // have to slow down production to make test reliable
             LockSupport.parkNanos(500_000);
         }
@@ -303,7 +305,8 @@ public class BlockMessagingServiceBlockNotificationTest {
         @Override
         public void run() {
             for (int i = 0; i < TEST_DATA_COUNT; i++) {
-                messagingService.sendBlockVerification(new VerificationNotification(true, i, null, null));
+                messagingService.sendBlockVerification(
+                        new VerificationNotification(true, i, null, null, BlockSource.PUBLISHER));
                 int totalSent = sentCounter.incrementAndGet();
                 if (pauseControl != null) {
                     // release the pause control occasionally, to slow a handler by some amount.

--- a/block-node/messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationRingEventTest.java
+++ b/block-node/messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationRingEventTest.java
@@ -4,7 +4,10 @@ package org.hiero.block.server.messaging;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.messaging.BlockNotificationRingEvent;
+import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.junit.jupiter.api.DisplayName;
@@ -34,12 +37,14 @@ class BlockNotificationRingEventTest {
     @DisplayName("Should set and get verification notification correctly")
     void shouldSetAndGetVerificationNotification() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
-        final VerificationNotification notification = new VerificationNotification(true, 1, null, null);
+        final VerificationNotification notification =
+                new VerificationNotification(true, 1, null, null, BlockSource.PUBLISHER);
 
         event.set(notification);
 
         assertEquals(notification, event.getVerificationNotification());
         assertNull(event.getPersistedNotification(), "Persisted notification should be null");
+        assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
     }
 
     /**
@@ -49,12 +54,30 @@ class BlockNotificationRingEventTest {
     @DisplayName("Should set and get persisted notification correctly")
     void shouldSetAndGetPersistedNotification() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
-        final PersistedNotification notification = new PersistedNotification(1, 2, 10);
+        final PersistedNotification notification = new PersistedNotification(1, 2, 10, BlockSource.PUBLISHER);
 
         event.set(notification);
 
         assertEquals(notification, event.getPersistedNotification());
         assertNull(event.getVerificationNotification(), "Verification notification should be null");
+        assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
+    }
+
+    /**
+     * Tests setting and getting a backfilled notification.
+     */
+    @Test
+    @DisplayName("Should set and get backfilled notification correctly")
+    void shouldSetAndGetBackfilledNotification() {
+        final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
+        final BackfilledBlockNotification notification =
+                new BackfilledBlockNotification(1, BlockUnparsed.newBuilder().build());
+
+        event.set(notification);
+
+        assertEquals(notification, event.getBackfilledBlockNotification());
+        assertNull(event.getVerificationNotification(), "Verification notification should be null");
+        assertNull(event.getPersistedNotification(), "Persisted notification should be null");
     }
 
     /**
@@ -64,8 +87,9 @@ class BlockNotificationRingEventTest {
     @DisplayName("Setting verification notification should clear persisted notification")
     void settingVerificationNotificationShouldClearPersistedNotification() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
-        final PersistedNotification persistedNotification = new PersistedNotification(1, 2, 10);
-        final VerificationNotification verificationNotification = new VerificationNotification(true, 1, null, null);
+        final PersistedNotification persistedNotification = new PersistedNotification(1, 2, 10, BlockSource.PUBLISHER);
+        final VerificationNotification verificationNotification =
+                new VerificationNotification(true, 1, null, null, BlockSource.PUBLISHER);
 
         // First set persisted notification
         event.set(persistedNotification);
@@ -85,8 +109,9 @@ class BlockNotificationRingEventTest {
     @DisplayName("Setting persisted notification should clear verification notification")
     void settingPersistedNotificationShouldClearVerificationNotification() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
-        final VerificationNotification verificationNotification = new VerificationNotification(true, 1, null, null);
-        final PersistedNotification persistedNotification = new PersistedNotification(1, 2, 10);
+        final VerificationNotification verificationNotification =
+                new VerificationNotification(true, 1, null, null, BlockSource.PUBLISHER);
+        final PersistedNotification persistedNotification = new PersistedNotification(1, 2, 10, BlockSource.PUBLISHER);
 
         // First set verification notification
         event.set(verificationNotification);
@@ -106,8 +131,10 @@ class BlockNotificationRingEventTest {
     @DisplayName("Should allow reuse with different verification notifications")
     void shouldAllowReuseWithDifferentVerificationNotifications() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
-        final VerificationNotification notification1 = new VerificationNotification(true, 1, null, null);
-        final VerificationNotification notification2 = new VerificationNotification(true, 1, null, null);
+        final VerificationNotification notification1 =
+                new VerificationNotification(true, 1, null, null, BlockSource.PUBLISHER);
+        final VerificationNotification notification2 =
+                new VerificationNotification(true, 1, null, null, BlockSource.PUBLISHER);
 
         event.set(notification1);
         assertEquals(notification1, event.getVerificationNotification());
@@ -125,8 +152,8 @@ class BlockNotificationRingEventTest {
     @DisplayName("Should allow reuse with different persisted notifications")
     void shouldAllowReuseWithDifferentPersistedNotifications() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
-        final PersistedNotification notification1 = new PersistedNotification(1, 2, 10);
-        final PersistedNotification notification2 = new PersistedNotification(1, 2, 10);
+        final PersistedNotification notification1 = new PersistedNotification(1, 2, 10, BlockSource.PUBLISHER);
+        final PersistedNotification notification2 = new PersistedNotification(1, 2, 10, BlockSource.PUBLISHER);
 
         event.set(notification1);
         assertEquals(notification1, event.getPersistedNotification());

--- a/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/BackfilledBlockNotification.java
+++ b/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/BackfilledBlockNotification.java
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.blockmessaging;
+
+public record BackfilledBlockNotification(long blockNumber, org.hiero.block.internal.BlockUnparsed block) {}

--- a/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
+++ b/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
@@ -73,6 +73,13 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
     void sendBlockPersisted(PersistedNotification notification);
 
     /**
+     * Use this method to send backfilled block notifications to all registered handlers.
+     *
+     * @param notification the backfilled block notification to send
+     */
+    void sendBackfilledBlockNotification(BackfilledBlockNotification notification);
+
+    /**
      * Use this method to register a block notification handler. The handler will be called every time new block
      * notifications arrive. The calls will be on its own thread, every handler registered has its own thread. It can
      * consume block notifications at its own pace, if it is too slow then it will apply back pressure to block

--- a/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockNotificationHandler.java
+++ b/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockNotificationHandler.java
@@ -20,4 +20,12 @@ public interface BlockNotificationHandler {
      * @param notification the block persisted notification to handle
      */
     default void handlePersisted(PersistedNotification notification) {}
+
+    /**
+     * Handle a backfilled block notification. Always called on handler thread. Each registered handler will have its
+     * own virtual thread.
+     *
+     * @param notification the backfilled block notification to handle
+     */
+    default void handleBackfilled(BackfilledBlockNotification notification) {}
 }

--- a/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockSource.java
+++ b/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockSource.java
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.blockmessaging;
+
+/**
+ * Enum representing the source of a block in the block messaging system.
+ * This is used to differentiate the origin of the block data.
+ */
+public enum BlockSource {
+    UNKNOWN,
+    PUBLISHER,
+    BACKFILL,
+    HISTORY
+}

--- a/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/PersistedNotification.java
+++ b/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/PersistedNotification.java
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.spi.blockmessaging;
 
-public record PersistedNotification(long startBlockNumber, long endBlockNumber, int blockProviderPriority) {
+public record PersistedNotification(
+        long startBlockNumber, long endBlockNumber, int blockProviderPriority, BlockSource blockSource) {
     /**
      * Constructor for PersistedNotification. Validates the start and end block numbers.
      *

--- a/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/VerificationNotification.java
+++ b/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/VerificationNotification.java
@@ -12,4 +12,8 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
  * @param block       the block, if the type is BLOCK_VERIFIED
  */
 public record VerificationNotification(
-        boolean success, long blockNumber, Bytes blockHash, org.hiero.block.internal.BlockUnparsed block) {}
+        boolean success,
+        long blockNumber,
+        Bytes blockHash,
+        org.hiero.block.internal.BlockUnparsed block,
+        BlockSource source) {}

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -266,11 +266,6 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
 
     @Override
     public void handlePersisted(@NonNull final PersistedNotification notification) {
-        if (notification.blockSource() != BlockSource.PUBLISHER) {
-            // We only handle notifications from the publisher.
-            return;
-        }
-
         // update the latest known verified and persisted block number
         // and signal all handlers to send acknowledgements
         // @todo(1417) is the below correct/sufficient? Is it ok to block here?

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -29,7 +29,6 @@ import org.hiero.block.internal.BlockItemSetUnparsed;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
-import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.hiero.block.node.spi.threading.ThreadPoolManager;

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -266,7 +266,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
 
     @Override
     public void handlePersisted(@NonNull final PersistedNotification notification) {
-        if(notification.blockSource() != BlockSource.PUBLISHER) {
+        if (notification.blockSource() != BlockSource.PUBLISHER) {
             // We only handle notifications from the publisher.
             return;
         }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -29,6 +29,7 @@ import org.hiero.block.internal.BlockItemSetUnparsed;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.hiero.block.node.spi.threading.ThreadPoolManager;
@@ -265,6 +266,11 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
 
     @Override
     public void handlePersisted(@NonNull final PersistedNotification notification) {
+        if(notification.blockSource() != BlockSource.PUBLISHER) {
+            // We only handle notifications from the publisher.
+            return;
+        }
+
         // update the latest known verified and persisted block number
         // and signal all handlers to send acknowledgements
         // @todo(1417) is the below correct/sufficient? Is it ok to block here?

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/BlockVerificationSession.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/BlockVerificationSession.java
@@ -10,11 +10,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.hiero.block.common.hasher.HashingUtilities;
 import org.hiero.block.common.hasher.NaiveStreamingTreeHasher;
 import org.hiero.block.common.hasher.StreamingTreeHasher;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 
 /**
@@ -35,6 +37,9 @@ public class BlockVerificationSession {
     private final StreamingTreeHasher stateChangesHasher;
     /** The tree hasher for trace data hashes. */
     private final StreamingTreeHasher traceDataHasher;
+    /** The source of the block, used to construct the final notification. */
+    private final BlockSource blockSource;
+
     /**
      * The block items for the block this session is responsible for. We collect them here so we can provide the
      * complete block in the final notification.
@@ -47,7 +52,7 @@ public class BlockVerificationSession {
      * @param blockNumber the block number to verify, we pass it in even though we could extract from block items to
      *                    avoid having to duplicate parsing work of the block header.
      */
-    protected BlockVerificationSession(final long blockNumber) {
+    protected BlockVerificationSession(final long blockNumber, @NonNull final BlockSource blockSource) {
         this.blockNumber = blockNumber;
         // using NaiveStreamingTreeHasher as we should only need single threaded
         this.inputTreeHasher = new NaiveStreamingTreeHasher();
@@ -55,6 +60,7 @@ public class BlockVerificationSession {
         this.consensusHeaderHasher = new NaiveStreamingTreeHasher();
         this.stateChangesHasher = new NaiveStreamingTreeHasher();
         this.traceDataHasher = new NaiveStreamingTreeHasher();
+        this.blockSource = Objects.requireNonNull(blockSource, "BlockSource must not be null");
     }
 
     /**
@@ -109,7 +115,7 @@ public class BlockVerificationSession {
                 traceDataHasher);
         final boolean verified = verifySignature(blockHash, blockProof.blockSignature());
         return new VerificationNotification(
-                verified, blockNumber, blockHash, verified ? new BlockUnparsed(blockItems) : null);
+                verified, blockNumber, blockHash, verified ? new BlockUnparsed(blockItems) : null, blockSource);
     }
 
     /**

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/BlockVerificationSessionTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/BlockVerificationSessionTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.hiero.block.common.utils.ChunkUtils;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.node.app.fixtures.blocks.BlockUtils;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +35,7 @@ class BlockVerificationSessionTest {
 
         long blockNumber = blockHeader.number();
 
-        BlockVerificationSession session = new BlockVerificationSession(blockNumber);
+        BlockVerificationSession session = new BlockVerificationSession(blockNumber, BlockSource.PUBLISHER);
 
         VerificationNotification blockNotification = session.processBlockItems(blockItems);
 
@@ -75,7 +76,7 @@ class BlockVerificationSessionTest {
         int currentChunk = 0;
         long blockNumber = sampleBlockInfo.blockNumber();
 
-        BlockVerificationSession session = new BlockVerificationSession(blockNumber);
+        BlockVerificationSession session = new BlockVerificationSession(blockNumber, BlockSource.PUBLISHER);
 
         VerificationNotification blockNotification = session.processBlockItems(chunkifiedItems.get(currentChunk));
 
@@ -116,7 +117,7 @@ class BlockVerificationSessionTest {
         blockItems.remove(5);
 
         long blockNumber = sampleBlockInfo.blockNumber();
-        BlockVerificationSession session = new BlockVerificationSession(blockNumber);
+        BlockVerificationSession session = new BlockVerificationSession(blockNumber, BlockSource.PUBLISHER);
         VerificationNotification blockNotification = session.processBlockItems(blockItems);
 
         Assertions.assertEquals(
@@ -144,7 +145,7 @@ class BlockVerificationSessionTest {
         int currentChunk = 0;
         long blockNumber = sampleBlockInfo.blockNumber();
 
-        BlockVerificationSession session = new BlockVerificationSession(blockNumber);
+        BlockVerificationSession session = new BlockVerificationSession(blockNumber, BlockSource.PUBLISHER);
         VerificationNotification blockNotification = session.processBlockItems(chunkifiedItems.get(currentChunk));
 
         while (blockNotification == null) {

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginTest.java
@@ -20,6 +20,7 @@ import org.hiero.block.node.app.fixtures.blocks.BlockUtils;
 import org.hiero.block.node.app.fixtures.plugintest.NoBlocksHistoricalBlockFacility;
 import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.TestHealthFacility;
+import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.junit.jupiter.api.DisplayName;
@@ -134,5 +135,40 @@ class VerificationServicePluginTest extends PluginTestBase<VerificationServicePl
         assertTrue(
                 ((TestHealthFacility) blockNodeContext.serverHealth()).shutdownCalled.get(),
                 "The server should be shutdown after an exception is thrown");
+    }
+
+    @Test
+    @DisplayName("Test handleBackfilled with a valid backfilled block")
+    void testHandleBackfilledNotification() throws IOException, ParseException {
+
+        // prepare test data
+        BlockUtils.SampleBlockInfo sampleBlockInfo =
+                BlockUtils.getSampleBlockInfo(BlockUtils.SAMPLE_BLOCKS.GENERATED_14);
+
+        List<BlockItemUnparsed> blockItems = sampleBlockInfo.blockUnparsed().blockItems();
+        long blockNumber = sampleBlockInfo.blockNumber();
+        BackfilledBlockNotification notification =
+                new BackfilledBlockNotification(blockNumber, sampleBlockInfo.blockUnparsed());
+
+        // call the method with a valid backfilled block notification
+        plugin.handleBackfilled(notification);
+
+        // check we received a block verification notification
+        VerificationNotification blockNotification =
+                blockMessaging.getSentVerificationNotifications().getFirst();
+        assertNotNull(blockNotification);
+        assertEquals(
+                blockNumber,
+                blockNotification.blockNumber(),
+                "The block number should be the same as the one in the block header");
+        assertTrue(blockNotification.success(), "The verification should be successful");
+        assertEquals(
+                sampleBlockInfo.blockRootHash(),
+                blockNotification.blockHash(),
+                "The block hash should be the same as the one in the block header");
+        assertEquals(
+                sampleBlockInfo.blockUnparsed(),
+                blockNotification.block(),
+                "The block should be the same as the one sent");
     }
 }

--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -53,6 +53,13 @@ dependencies.constraints {
     api("io.helidon.webserver:helidon-webserver:$helidonVersion") {
         because("io.helidon.webserver")
     }
+
+    api("io.helidon.webclient:helidon-webclient-grpc:$helidonVersion") {
+        because("io.helidon.webclient.grpc")
+    }
+    api("io.helidon.webclient:helidon-webclient:$helidonVersion") {
+        because("io.helidon.webclient")
+    }
     api("org.jetbrains:annotations:26.0.2") { because("org.jetbrains.annotations") }
 
     // gRPC dependencies

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ javaModules {
         group = hieroGroup
         module("app") { artifact = "block-node-app" }
         module("app-config") { artifact = "block-node-app-config" }
+        module("backfill") { artifact = "block-node-backfill" }
         module("base") { artifact = "block-node-base" }
         module("block-access") { artifact = "block-access-service" }
         module("block-providers/files.historic") { artifact = "block-node-blocks-file-historic" }


### PR DESCRIPTION
## Reviewer Notes

- Added a new sub-project **backfill[block-node-backfill]**
  - This includes changes to gradle settings, new folder, its own `build.gradle.kts`, `module-info.java` file, `BackfillConfiguraion.java`, initial `BackfillPlugin.java` and added to `block-node/app/build.gradle.kts` as a runtimeOnly dependency so it can be picked up by the plugin system.
- Added `proto` definition to match `block-node.json` file example from CN and MN, to use same schema and file and wired up the PBJ Compiler for that proto and generate "POJO" Classes `BlockNodeSources` and `BlockNodeConfig` that can be used to serialize and deseralize its corresponding json files.
  - added an example of such file to be used in testing resources of the `backfill plugin` project: `block-node.json`
  - includes the configuration of the PBJ Compiler on the `build.gradle.kts` file of the backfill plugin.
- gRPC Client or "Blocks Fetcher", this is the classes that allow the backfill plugin to connect to the list of block-nodes, and probe for the requested blocks using the serverStatus API endpoint and then the `subscribeBlockStream` endpoint to fetch the actual blocks.
  - BackfillGrpcClient: is the top level "gRPC Client" class, it contains the BlockNodeSources list and is responsible for instantiating new BlockNodeClients and managing their lifetime cycle, and current status, as well as to implement retry mechanism with exponential backoff.
  - BlockNodeClient: the class represents a given BN, holds a single GrpcClient that gets re-used over the lifetime of the application, and shared across all the different services that the BlockNodeClient uses, in this case 2:
  - BlockNodeServerStatusClient: is a convenient abstraction that uses the same GrpcClient for the host but provides access to serverStatus endpoint.
  - BlockNodeSubscribeClient, same as above but for `subscribeBlockStream` API service endpoint. abstracts away receiving the blocks and exposes an intuitive api that based on the request start and end returns a list of the blocks requested.
- Add new notification type: BackfilledBlockNotification
- Add BlockSource Enum to distinguish between Verification and Persistence Notifications by source
- extend VerificationPlugin & PersistencePlugin to respect BlockSource enum (no breaking changes for publishers)
- added autonomous loop scheduler, when starting the backfill plugin it schedules an autonomous task that will be running and trying to detect missing gaps and backfill them if found.
- Initial set of metrics defined in design document (however on a follow-up PR when doing dashboard we might review, improve and add more metrics)

**Testing:**
- BN Server Mock on text fixtures to allow the retrieval of blocks from another BN on the test.
- Fixed `SimpleBlockRangeSet` used in Testing Fixtures and UTs, specifically the method `streamRanges` that was not working as expected.
- Happy Path Unit Test
- Missing E2E tests, this will be added on a folllow-up PR.

## Related Issue(s)
Fixes #1351 
Fixes #1352 
Fixes #1353 
Fixes #1354
