### PR TITLE
chore: Standardize first 4 terminal code API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
 [![Development Branch](https://img.shields.io/badge/docs-quickstart-green.svg)](docs/overview.md)
 [![License](https://img.shields.io/badge/license-apache2-blue.svg)](LICENSE)
 
-The Preview Hiero Block Node is the implementation of [HIP 1081](https://hips.hedera.com/hip/hip-1081) and serves as the
-decentralized data lake for the Hiero ledger block and state information.
+The Beta Hiero Block Node is the implementation of [HIP 1081](https://hips.hedera.com/hip/hip-1081) and serves as the
+decentralized data lake for the Hiero ledgers block and state information.
 
 The Block Node is responsible for consuming the block streams (defined in [HIP 1056](https://hips.hedera.com/hip/hip-1056)),
-verifying each block’s integrity, storing the block chain, distributing blocks to downstream clients and maintaining a
+verifying each block’s integrity, storing the blockchain, distributing blocks to downstream clients and maintaining a
 copy of consensus network state.
 
-The Block Node also exposes additional targeted value adding APIs to the Hiero community.
+The Block Node will also expose additional targeted value adding APIs to the Hiero community such as Proofs.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,5 @@
 # Hiero Block Node
 
-Implementation of the Hiero Block Node, which is responsible for consuming the block streams, maintaining state and exposing additional targeted value adding APIs to the Hiero community.
-
-## Table of Contents
-
-1. [Project Links](#project-links)
-2. [Prerequisites](#prerequisites)
-3. [Overview of child modules](#overview-of-child-modules)
-4. [Getting Started](#getting-started)
-5. [Contributing](#contributing)
-6. [Code of Conduct](#code-of-conduct)
-7. [License](#license)
-
-## Project Links
-
 [![Build Application](https://github.com/hiero-ledger/hiero-block-node/actions/workflows/build-application.yaml/badge.svg?branch=main)](https://github.com/hiero-ledger/hiero-block-node/actions/workflows/build-application.yaml)
 [![E2E Test Suites](https://github.com/hiero-ledger/hiero-block-node/actions/workflows/e2e-tests.yaml/badge.svg?branch=main)](https://github.com/hiero-ledger/hiero-block-node/actions/workflows/e2e-tests.yaml)
 [![codecov](https://codecov.io/github/hiero-ledger/hiero-block-node/graph/badge.svg?token=OF6T6E8V7U)](https://codecov.io/github/hiero-ledger/hiero-block-node)
@@ -24,6 +10,24 @@ Implementation of the Hiero Block Node, which is responsible for consuming the b
 [![Made With](https://img.shields.io/badge/made_with-java-blue)](https://github.com/hiero-ledger/hiero-block-node/)
 [![Development Branch](https://img.shields.io/badge/docs-quickstart-green.svg)](docs/overview.md)
 [![License](https://img.shields.io/badge/license-apache2-blue.svg)](LICENSE)
+
+The Preview Hiero Block Node is the implementation of [HIP 1081](https://hips.hedera.com/hip/hip-1081) and serves as the
+decentralized data lake for the Hiero ledger block and state information.
+
+The Block Node is responsible for consuming the block streams (defined in [HIP 1056](https://hips.hedera.com/hip/hip-1056)),
+verifying each block’s integrity, storing the block chain, distributing blocks to downstream clients and maintaining a
+copy of consensus network state.
+
+The Block Node also exposes additional targeted value adding APIs to the Hiero community.
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Overview of child modules](#overview-of-child-modules)
+3. [Getting Started](#getting-started)
+4. [Contributing](#contributing)
+5. [Code of Conduct](#code-of-conduct)
+6. [License](#license)
 
 ## Prerequisites
 

--- a/protobuf-sources/src/main/proto/block-node/api/block_access_service.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/block_access_service.proto
@@ -78,20 +78,25 @@ message BlockResponse {
         INVALID_REQUEST = 2;
 
         /**
+         * The Block Node encountered an error.
+         */
+        ERROR = 3;
+
+        /**
          * The requested block was not found.<br/>
          * Something failed and a block that SHOULD be available was
          * not found.<br/>
          * The client MAY retry the request; if this result is repeated the
          * request SHOULD be directed to a different block node server.
          */
-        NOT_FOUND = 3;
+        NOT_FOUND = 4;
 
         /**
          * The requested block is not available on this block node server.<br/>
          * The client SHOULD send a `serverStatus` request to determine the
          * lowest and highest block numbers available at this block node server.
          */
-        NOT_AVAILABLE = 4;
+        NOT_AVAILABLE = 5;
     }
 
     /**

--- a/protobuf-sources/src/main/proto/block-node/api/block_stream_publish_service.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/block_stream_publish_service.proto
@@ -367,11 +367,26 @@ message PublishStreamResponse {
             SUCCESS = 1;
 
             /**
+             * The request cannot be fulfilled.<br/>
+             * The client sent a malformed or structurally incorrect request.
+             * <p>
+             * The client MAY retry the request after correcting the form and
+             * structure.
+             */
+            INVALID_REQUEST = 2;
+
+            /**
+             * The Block-Node had an error and cannot continue processing.<br/>
+             * The Publisher may retry again later.
+             */
+            ERROR = 3;
+
+            /**
              * The delay between items was too long.
              * <p>
              * The source MUST start a new stream before the failed block.
              */
-            TIMEOUT = 2;
+            TIMEOUT = 4;
 
             /**
              * An item received is already stored.<br/>
@@ -379,13 +394,13 @@ message PublishStreamResponse {
              * The source MUST start a new stream after the last persisted and
              * verified block.
              */
-            DUPLICATE_BLOCK = 3;
+            DUPLICATE_BLOCK = 5;
 
             /**
              * A block state proof item could not be validated.<br/>
              * The source MUST start a new stream before the failed block.
              */
-            BAD_BLOCK_PROOF = 4;
+            BAD_BLOCK_PROOF = 6;
 
             /**
              * The Block-Node is "behind" the Publisher.<br/>
@@ -398,13 +413,7 @@ message PublishStreamResponse {
              * blocks from another Block-Node or other source of recent historical
              * block stream data.
              */
-            BEHIND = 5;
-
-            /**
-             * The Block-Node had an internal error and cannot continue processing.<br/>
-             * The Publisher may retry again later.
-             */
-            INTERNAL_ERROR = 6;
+            BEHIND = 7;
 
             /**
              * The Block-Node failed to store the block persistently.
@@ -414,7 +423,7 @@ message PublishStreamResponse {
              * The Publisher MUST NOT discard the block until it is successfully
              * persisted and verified (and acknowledged) by at least one Block-Node.
              */
-            PERSISTENCE_FAILED = 7;
+            PERSISTENCE_FAILED = 8;
         }
 
     }

--- a/protobuf-sources/src/main/proto/block-node/api/block_stream_subscribe_service.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/block_stream_subscribe_service.proto
@@ -102,13 +102,28 @@ message SubscribeStreamResponse {
         SUCCESS = 1;
 
         /**
+         * The request cannot be fulfilled.<br/>
+         * The client sent a malformed or structurally incorrect request.
+         * <p>
+         * The client MAY retry the request after correcting the form and
+         * structure.
+         */
+        INVALID_REQUEST = 2;
+
+        /**
+         * The Block-Node had an error and cannot continue processing.<br/>
+         * The Subscriber may retry again later.
+         */
+        ERROR = 3;
+
+        /**
          * The requested start block number is not valid.<br/>
          * The start block number is after the end block number, less
          * than `0`, or otherwise invalid.<br/>
          * The client MAY retry this request, but MUST change the
          * `start_block_number` field to a valid start block.
          */
-        INVALID_START_BLOCK_NUMBER = 2;
+        INVALID_START_BLOCK_NUMBER = 4;
 
         /**
          * The requested end block number is not valid.<br/>
@@ -117,13 +132,13 @@ message SubscribeStreamResponse {
          * The client MAY retry this request, but MUST change the
          * `end_block_number` field to a valid end block.
          */
-        INVALID_END_BLOCK_NUMBER = 3;
+        INVALID_END_BLOCK_NUMBER = 5;
 
         /**
          * The requested stream is not available.<br/>
          * The client MAY retry again later.
          */
-        NOT_AVAILABLE = 4;
+        NOT_AVAILABLE = 6;
     }
 
     oneof response {

--- a/protobuf-sources/src/main/proto/block-node/api/proof_service.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/proof_service.proto
@@ -118,20 +118,35 @@ message BlockContentsProofResponse {
         SUCCESS = 1;
 
         /**
+         * The request cannot be fulfilled.<br/>
+         * The client sent a malformed or structurally incorrect request.
+         * <p>
+         * The client MAY retry the request after correcting the form and
+         * structure.
+         */
+        INVALID_REQUEST = 2;
+
+        /**
+         * The Block-Node had an error and cannot continue processing.<br/>
+         * The client may retry again later.
+         */
+        ERROR = 3;
+
+        /**
          * The specified block item was not found.
          */
-        ITEM_NOT_FOUND = 2;
+        ITEM_NOT_FOUND = 4;
 
         /**
          * The block content proof is not available for the specified block.
          */
-        NOT_AVAILABLE = 3;
+        NOT_AVAILABLE = 5;
 
         /**
          * Duplicate hash items were found, causing ambiguity.
          * Clients MUST use the block item index to resolve the ambiguity.
          */
-        DUPLICATE_HASH_ITEM_FOUND = 4;
+        DUPLICATE_HASH_ITEM_FOUND = 6;
     }
 
     /**

--- a/protobuf-sources/src/main/proto/block-node/api/state_service.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/state_service.proto
@@ -71,6 +71,21 @@ message StateSnapshotResponse {
          * `snapshot_reference` field for the duration specified.
          */
         SUCCESS = 1;
+
+        /**
+         * The request cannot be fulfilled.<br/>
+         * The client sent a malformed or structurally incorrect request.
+         * <p>
+         * The client MAY retry the request after correcting the form and
+         * structure.
+         */
+        INVALID_REQUEST = 2;
+
+        /**
+         * The Block-Node had an error and cannot continue processing.<br/>
+         * The Publisher may retry again later.
+         */
+        ERROR = 3;
     }
 
     /**

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
@@ -162,7 +162,7 @@ class PublishClientManagerTest {
 
         when(response.getEndStream()).thenReturn(endOfStream);
         when(endOfStream.getBlockNumber()).thenReturn(5L);
-        when(endOfStream.getStatus()).thenReturn(Code.INTERNAL_ERROR);
+        when(endOfStream.getStatus()).thenReturn(Code.ERROR);
         when(response.hasEndStream()).thenReturn(true);
 
         publishClientManager.handleResponse(nextBlock, response);


### PR DESCRIPTION
## Reviewer Notes

Standardize first 4 terminal code API responses
- Add to all terminal proto response message
- Update references to `INTERNAL_ERROR`
- Update README.md with references to Beta and HIP
- Move repo scorecard and shields links to top so it's more apparent for open source community 

## Related Issue(s)
Fixes #1399
