### PR TITLE
test: Refactor wildcard imports in Simulator

### DIFF
--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/config/data/BlockStreamConfigTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/config/data/BlockStreamConfigTest.java
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.simulator.config.data;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/config/data/UnorderedStreamConfigTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/config/data/UnorderedStreamConfigTest.java
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.simulator.config.data;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/config/types/GenerationModeTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/config/types/GenerationModeTest.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.simulator.config.types;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/config/types/StreamingModeTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/config/types/StreamingModeTest.java
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.simulator.config.types;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class StreamingModeTest {
 

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/BlockAsFileBlockStreamManagerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/BlockAsFileBlockStreamManagerTest.java
@@ -2,7 +2,9 @@
 package org.hiero.block.simulator.generator;
 
 import static org.hiero.block.simulator.fixtures.TestUtils.getAbsoluteFolder;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import org.hiero.block.simulator.config.data.BlockGeneratorConfig;

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/CraftBlockStreamManagerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/CraftBlockStreamManagerTest.java
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.simulator.generator;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.hapi.block.stream.protoc.Block;
 import java.io.IOException;

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/GeneratorInjectionModuleTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/GeneratorInjectionModuleTest.java
@@ -2,7 +2,7 @@
 package org.hiero.block.simulator.generator;
 
 import static org.hiero.block.simulator.fixtures.TestUtils.getAbsoluteFolder;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.Map;

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcServerImplTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcServerImplTest.java
@@ -3,7 +3,9 @@ package org.hiero.block.simulator.grpc.impl;
 
 import static org.hiero.block.simulator.fixtures.TestUtils.findFreePort;
 import static org.hiero.block.simulator.fixtures.TestUtils.getTestMetrics;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.block.stream.output.protoc.BlockHeader;

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamServerObserverTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamServerObserverTest.java
@@ -2,8 +2,13 @@
 package org.hiero.block.simulator.grpc.impl;
 
 import static org.hiero.block.simulator.fixtures.TestUtils.getTestMetrics;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.hedera.hapi.block.stream.protoc.BlockItem;
 import com.hedera.hapi.block.stream.protoc.BlockProof;

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublisherServerModeHandlerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublisherServerModeHandlerTest.java
@@ -2,7 +2,8 @@
 package org.hiero.block.simulator.mode;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 
 import org.hiero.block.simulator.grpc.PublishStreamGrpcServer;
 import org.hiero.block.simulator.mode.impl.PublisherServerModeHandler;


### PR DESCRIPTION
## Reviewer Notes

Currently, we have some tests in Sumulator that use imports with wildcards. Instead, all imports should explicitly specify the classes or static members they bring in.

## Related Issue(s)
Fixes #1401 
