### PR TITLE
chore: Update CN proto to 0.65.0-rc1

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -78,16 +78,6 @@ jobs:
           distribution: "temurin"
           java-version: "21.0.6"
 
-      - name: Cache Gradle packages
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: Build
         id: gradle-build
         run: ${GRADLE_EXEC} clean assemble

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -78,19 +78,9 @@ jobs:
           distribution: "temurin"
           java-version: "21.0.6"
 
-      - name: Cache Gradle packages
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: Build
         id: gradle-build
-        run: ${GRADLE_EXEC} assemble
+        run: ${GRADLE_EXEC} clean assemble
 
       - name: Style Check
         id: spotless-check

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -78,6 +78,16 @@ jobs:
           distribution: "temurin"
           java-version: "21.0.6"
 
+      - name: Cache Gradle packages
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Build
         id: gradle-build
         run: ${GRADLE_EXEC} clean assemble

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -24,14 +24,30 @@ permissions:
   packages: write
 
 jobs:
-  check-gradle:
-    name: Gradle
-    if: ${{ github.base_ref == 'main' || startsWith(github.base_ref, 'release/') }}
-    uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
-    with:
-      ref: ${{ github.event.inputs.ref || '' }}
-      java-distribution: ${{ inputs.java-distribution || 'temurin' }}
-      java-version: ${{ inputs.java-version || '21.0.6' }}
+  package-protobuf-source:
+    timeout-minutes: 5
+    runs-on: hiero-block-node-linux-medium
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Extract version
+        id: extract_version
+        run: |
+          VERSION=$(cat version.txt)
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Produce artifact
+        working-directory: protobuf-sources
+        run: scripts/build-bn-proto.sh -t "efb0134e921b32ed6302da9c93874d65492e876f" -v ${{ env.VERSION }} -o "block-node-protobuf" -i true -b "../src/main/proto/" # CN 0.62.2
 
   compile:
     timeout-minutes: 20

--- a/block-node/protobuf-pbj/src/main/java/module-info.java
+++ b/block-node/protobuf-pbj/src/main/java/module-info.java
@@ -4,8 +4,6 @@ module org.hiero.block.protobuf.pbj {
     exports com.hedera.hapi.block.stream.input;
     exports com.hedera.hapi.block.stream.output;
     exports com.hedera.hapi.block.stream.trace;
-    exports com.hedera.hapi.block.stream.trace.codec;
-    exports com.hedera.hapi.block.stream.trace.schema;
     exports com.hedera.hapi.platform.event;
     exports com.hedera.hapi.node.base;
     exports com.hedera.hapi.node.base.codec;

--- a/block-node/protobuf-pbj/src/main/java/module-info.java
+++ b/block-node/protobuf-pbj/src/main/java/module-info.java
@@ -26,6 +26,9 @@ module org.hiero.block.protobuf.pbj {
     exports com.hedera.hapi.node.scheduled;
     exports com.hedera.hapi.node.scheduled.codec;
     exports com.hedera.hapi.node.scheduled.schema;
+    exports com.hedera.hapi.node.state.hooks;
+    exports com.hedera.hapi.node.state.hooks.codec;
+    exports com.hedera.hapi.node.state.hooks.schema;
     exports com.hedera.hapi.node.token;
     exports com.hedera.hapi.node.token.codec;
     exports com.hedera.hapi.node.token.schema;

--- a/block-node/protobuf-pbj/src/main/java/module-info.java
+++ b/block-node/protobuf-pbj/src/main/java/module-info.java
@@ -4,6 +4,8 @@ module org.hiero.block.protobuf.pbj {
     exports com.hedera.hapi.block.stream.input;
     exports com.hedera.hapi.block.stream.output;
     exports com.hedera.hapi.block.stream.trace;
+    exports com.hedera.hapi.block.stream.trace.codec;
+    exports com.hedera.hapi.block.stream.trace.schema;
     exports com.hedera.hapi.platform.event;
     exports com.hedera.hapi.node.base;
     exports com.hedera.hapi.node.base.codec;
@@ -26,9 +28,9 @@ module org.hiero.block.protobuf.pbj {
     exports com.hedera.hapi.node.scheduled;
     exports com.hedera.hapi.node.scheduled.codec;
     exports com.hedera.hapi.node.scheduled.schema;
-    exports com.hedera.hapi.node.state.hooks;
-    exports com.hedera.hapi.node.state.hooks.codec;
-    exports com.hedera.hapi.node.state.hooks.schema;
+    exports com.hedera.hapi.node.hooks;
+    exports com.hedera.hapi.node.hooks.codec;
+    exports com.hedera.hapi.node.hooks.schema;
     exports com.hedera.hapi.node.token;
     exports com.hedera.hapi.node.token.codec;
     exports com.hedera.hapi.node.token.schema;

--- a/block-node/protobuf-pbj/src/main/java/module-info.java
+++ b/block-node/protobuf-pbj/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module org.hiero.block.protobuf.pbj {
     exports com.hedera.hapi.block.stream;
     exports com.hedera.hapi.block.stream.input;
     exports com.hedera.hapi.block.stream.output;
+    exports com.hedera.hapi.block.stream.trace;
     exports com.hedera.hapi.platform.event;
     exports com.hedera.hapi.node.base;
     exports com.hedera.hapi.node.base.codec;

--- a/protobuf-sources/build.gradle.kts
+++ b/protobuf-sources/build.gradle.kts
@@ -16,7 +16,7 @@ val generateBlockNodeProtoArtifact: TaskProvider<Exec> =
         group = "protobuf"
 
         workingDir(layout.projectDirectory)
-        val cnTagHash = "c86619410f0e0da3719c39c9447a96438200166d" // v0.63.9
+        val cnTagHash = "6d02f279f471431d6c8911a7094779c3212c3159" // v0.64.0
 
         // run build-bn-proto.sh skipping inclusion of BN API as it messes up proto considerations
         commandLine(

--- a/protobuf-sources/build.gradle.kts
+++ b/protobuf-sources/build.gradle.kts
@@ -16,7 +16,7 @@ val generateBlockNodeProtoArtifact: TaskProvider<Exec> =
         group = "protobuf"
 
         workingDir(layout.projectDirectory)
-        val cnTagHash = "6d02f279f471431d6c8911a7094779c3212c3159" // v0.64.0
+        val cnTagHash = "437d131d67d9ca60ba60fff5ae59692c45bc44cd" // v0.65.0-rc1
 
         // run build-bn-proto.sh skipping inclusion of BN API as it messes up proto considerations
         commandLine(

--- a/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
+++ b/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
@@ -4,6 +4,7 @@ open module org.hiero.block.protobuf.protoc {
     exports com.hedera.hapi.services.auxiliary.tss.legacy;
     exports com.hedera.hapi.services.auxiliary.history.legacy;
     exports com.hedera.hapi.node.hooks.legacy;
+    exports com.hedera.hapi.node.state.hooks.legacy;
     exports com.hedera.hapi.node.state.tss.legacy;
     exports com.hedera.services.stream.proto;
     exports com.hederahashgraph.api.proto.java;

--- a/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
+++ b/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
@@ -10,6 +10,7 @@ open module org.hiero.block.protobuf.protoc {
     exports com.hedera.hapi.block.stream.protoc;
     exports com.hedera.hapi.block.stream.input.protoc;
     exports com.hedera.hapi.block.stream.output.protoc;
+    exports com.hedera.hapi.block.stream.trace.protoc;
     exports com.hedera.hapi.platform.event.legacy;
     exports com.hedera.hapi.platform.state.legacy;
     exports org.hiero.block.api.protoc;

--- a/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
+++ b/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
@@ -3,15 +3,12 @@ open module org.hiero.block.protobuf.protoc {
     exports com.hedera.hapi.services.auxiliary.hints.legacy;
     exports com.hedera.hapi.services.auxiliary.tss.legacy;
     exports com.hedera.hapi.services.auxiliary.history.legacy;
-    exports com.hedera.hapi.node.hooks.legacy;
-    exports com.hedera.hapi.node.state.hooks.legacy;
     exports com.hedera.hapi.node.state.tss.legacy;
     exports com.hedera.services.stream.proto;
     exports com.hederahashgraph.api.proto.java;
     exports com.hedera.hapi.block.stream.protoc;
     exports com.hedera.hapi.block.stream.input.protoc;
     exports com.hedera.hapi.block.stream.output.protoc;
-    exports com.hedera.hapi.block.stream.trace.protoc;
     exports com.hedera.hapi.platform.event.legacy;
     exports com.hedera.hapi.platform.state.legacy;
     exports org.hiero.block.api.protoc;

--- a/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
+++ b/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
@@ -3,6 +3,8 @@ open module org.hiero.block.protobuf.protoc {
     exports com.hedera.hapi.services.auxiliary.hints.legacy;
     exports com.hedera.hapi.services.auxiliary.tss.legacy;
     exports com.hedera.hapi.services.auxiliary.history.legacy;
+    exports com.hedera.hapi.node.hooks.legacy;
+    exports com.hedera.hapi.node.state.hooks.legacy;
     exports com.hedera.hapi.node.state.tss.legacy;
     exports com.hedera.services.stream.proto;
     exports com.hederahashgraph.api.proto.java;

--- a/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
+++ b/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
@@ -3,6 +3,7 @@ open module org.hiero.block.protobuf.protoc {
     exports com.hedera.hapi.services.auxiliary.hints.legacy;
     exports com.hedera.hapi.services.auxiliary.tss.legacy;
     exports com.hedera.hapi.services.auxiliary.history.legacy;
+    exports com.hedera.hapi.node.hooks.legacy;
     exports com.hedera.hapi.node.state.tss.legacy;
     exports com.hedera.services.stream.proto;
     exports com.hederahashgraph.api.proto.java;

--- a/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
+++ b/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
@@ -9,6 +9,7 @@ open module org.hiero.block.protobuf.protoc {
     exports com.hedera.hapi.block.stream.protoc;
     exports com.hedera.hapi.block.stream.input.protoc;
     exports com.hedera.hapi.block.stream.output.protoc;
+    exports com.hedera.hapi.block.stream.trace.protoc;
     exports com.hedera.hapi.platform.event.legacy;
     exports com.hedera.hapi.platform.state.legacy;
     exports org.hiero.block.api.protoc;

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/CraftBlockStreamManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/CraftBlockStreamManager.java
@@ -36,8 +36,8 @@ import org.hiero.block.simulator.exception.BlockSimulatorParsingException;
 import org.hiero.block.simulator.generator.itemhandler.BlockHeaderHandler;
 import org.hiero.block.simulator.generator.itemhandler.BlockProofHandler;
 import org.hiero.block.simulator.generator.itemhandler.EventHeaderHandler;
-import org.hiero.block.simulator.generator.itemhandler.EventTransactionHandler;
 import org.hiero.block.simulator.generator.itemhandler.ItemHandler;
+import org.hiero.block.simulator.generator.itemhandler.SignedTransactionHandler;
 import org.hiero.block.simulator.generator.itemhandler.TransactionResultHandler;
 import org.hiero.block.simulator.startup.SimulatorStartupData;
 
@@ -202,7 +202,7 @@ public class CraftBlockStreamManager implements BlockStreamManager {
 
             final int transactionsNumber = random.nextInt(minTransactionsPerEvent, maxTransactionsPerEvent);
             for (int j = 0; j < transactionsNumber; j++) {
-                final ItemHandler eventTransactionHandler = new EventTransactionHandler();
+                final ItemHandler eventTransactionHandler = new SignedTransactionHandler();
                 items.add(eventTransactionHandler);
                 blockItemsUnparsed.add(eventTransactionHandler.unparseBlockItem());
 

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/itemhandler/EventHeaderHandler.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/itemhandler/EventHeaderHandler.java
@@ -26,7 +26,6 @@ public class EventHeaderHandler extends AbstractBlockItemHandler {
     private EventCore createEventCore() {
         return EventCore.newBuilder()
                 .setCreatorNodeId(generateRandomValue(1, 32))
-                .setVersion(getSemanticVersion())
                 .build();
     }
 }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/itemhandler/SignedTransactionHandler.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/itemhandler/SignedTransactionHandler.java
@@ -1,28 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.simulator.generator.itemhandler;
 
+import com.google.protobuf.ByteString;
 import com.hedera.hapi.block.stream.protoc.BlockItem;
-import com.hedera.hapi.platform.event.legacy.EventTransaction;
+import com.hedera.hapi.node.transaction.SignedTransaction;
 
 /**
  * Handler for event transactions in the block stream.
  * Creates and manages event transaction items representing blockchain transactions.
  */
-public class EventTransactionHandler extends AbstractBlockItemHandler {
+public class SignedTransactionHandler extends AbstractBlockItemHandler {
     @Override
     public BlockItem getItem() {
         if (blockItem == null) {
             blockItem = BlockItem.newBuilder()
-                    .setEventTransaction(createEventTransaction())
+                    .setSignedTransaction(ByteString.copyFrom(
+                            createSignedTransaction().bodyBytes().toByteArray()))
                     .build();
         }
         return blockItem;
     }
 
-    private EventTransaction createEventTransaction() {
+    private SignedTransaction createSignedTransaction() {
         // For now, we stick with empty EventTransaction, because otherwise we need to provide encoded transaction,
         // which we don't have.
         // This transaction data should correspond with the results in the transaction result item and others.
-        return EventTransaction.newBuilder().build();
+        return SignedTransaction.newBuilder().build();
     }
 }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/itemhandler/SignedTransactionHandler.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/itemhandler/SignedTransactionHandler.java
@@ -4,6 +4,11 @@ package org.hiero.block.simulator.generator.itemhandler;
 import com.google.protobuf.ByteString;
 import com.hedera.hapi.block.stream.protoc.BlockItem;
 import com.hedera.hapi.node.transaction.SignedTransaction;
+import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 /**
  * Handler for event transactions in the block stream.
@@ -13,9 +18,18 @@ public class SignedTransactionHandler extends AbstractBlockItemHandler {
     @Override
     public BlockItem getItem() {
         if (blockItem == null) {
+            final var out = new ByteArrayOutputStream();
+            WritableSequentialData data = new WritableStreamingData(out);
+            try {
+                SignedTransaction.PROTOBUF.write(createSignedTransaction(), data);
+            } catch (IOException e) {
+                throw new AssertionError("Failed to get transaction bytes", e);
+            }
+
+            // Create a new BlockItem with the signed transaction
+            // Note: The SignedTransaction is created with an empty body for now
             blockItem = BlockItem.newBuilder()
-                    .setSignedTransaction(ByteString.copyFrom(
-                            createSignedTransaction().bodyBytes().toByteArray()))
+                    .setSignedTransaction(ByteString.copyFrom(out.toByteArray()))
                     .build();
         }
         return blockItem;

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/itemhandler/SignedTransactionHandler.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/itemhandler/SignedTransactionHandler.java
@@ -6,7 +6,6 @@ import com.hedera.hapi.block.stream.protoc.BlockItem;
 import com.hedera.hapi.node.transaction.SignedTransaction;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/itemhandler/EventHeaderHandlerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/itemhandler/EventHeaderHandlerTest.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.simulator.generator.itemhandler;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,7 +25,6 @@ class EventHeaderHandlerTest {
 
         EventCore core = header.getEventCore();
         assertTrue(core.getCreatorNodeId() >= 1 && core.getCreatorNodeId() < 32);
-        assertNotNull(core.getVersion());
     }
 
     @Test
@@ -36,15 +34,5 @@ class EventHeaderHandlerTest {
         BlockItem item2 = handler.getItem();
 
         assertSame(item1, item2, "getItem should return cached instance");
-    }
-
-    @Test
-    void testSemanticVersion() {
-        EventHeaderHandler handler = new EventHeaderHandler();
-        EventCore core = handler.getItem().getEventHeader().getEventCore();
-
-        assertEquals(0, core.getVersion().getMajor());
-        assertEquals(1, core.getVersion().getMinor());
-        assertEquals(0, core.getVersion().getPatch());
     }
 }

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/itemhandler/SignedTransactionHandlerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/itemhandler/SignedTransactionHandlerTest.java
@@ -5,27 +5,27 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.protobuf.ByteString;
 import com.hedera.hapi.block.stream.protoc.BlockItem;
-import com.hedera.hapi.platform.event.legacy.EventTransaction;
 import org.junit.jupiter.api.Test;
 
-class EventTransactionHandlerTest {
+class SignedTransactionHandlerTest {
 
     @Test
     void testGetItem() {
-        EventTransactionHandler handler = new EventTransactionHandler();
+        SignedTransactionHandler handler = new SignedTransactionHandler();
         BlockItem item = handler.getItem();
 
         assertNotNull(item);
-        assertTrue(item.hasEventTransaction());
+        assertTrue(item.hasSignedTransaction());
 
-        EventTransaction transaction = item.getEventTransaction();
+        ByteString transaction = item.getSignedTransaction();
         assertNotNull(transaction);
     }
 
     @Test
     void testGetItemCaching() {
-        EventTransactionHandler handler = new EventTransactionHandler();
+        SignedTransactionHandler handler = new SignedTransactionHandler();
         BlockItem item1 = handler.getItem();
         BlockItem item2 = handler.getItem();
 

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
@@ -17,6 +17,7 @@ import com.hedera.hapi.block.stream.protoc.BlockItem;
 import com.hedera.hapi.block.stream.protoc.BlockProof;
 import com.hedera.hapi.node.transaction.SignedTransaction;
 import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.swirlds.config.api.Configuration;
 import io.grpc.Server;
@@ -443,28 +444,14 @@ class PublishStreamGrpcClientImplTest {
     }
 
     // Converts a transaction to bytes using the provided codec.
-    // Inspired by hiero-ledger/hiero-consensus-node testFixtures TransactionHelper.java
-    <T> ByteString asBytes(T tx, Codec<T> codec) {
+    private <T> ByteString asBytes(T tx, Codec<T> codec) {
+        final var out = new ByteArrayOutputStream();
+        WritableSequentialData data = new WritableStreamingData(out);
         try {
-            final var out = new ByteArrayOutputStream();
-            final var dataOut = new ByteArrayDataOutput(out);
-            codec.write(tx, dataOut);
-            return ByteString.copyFrom(dataOut.getByteArray());
+            codec.write(tx, data);
+            return ByteString.copyFrom(out.toByteArray());
         } catch (IOException e) {
             throw new AssertionError("Failed to get transaction bytes", e);
-        }
-    }
-
-    static final class ByteArrayDataOutput extends WritableStreamingData {
-        private final ByteArrayOutputStream out;
-
-        public ByteArrayDataOutput(ByteArrayOutputStream out) {
-            super(out);
-            this.out = out;
-        }
-
-        public byte[] getByteArray() {
-            return out.toByteArray();
         }
     }
 }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/commands/ConvertToJson.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/commands/ConvertToJson.java
@@ -107,7 +107,7 @@ public class ConvertToJson implements Runnable {
             final Block block = Block.PROTOBUF.parse(Bytes.wrap(uncompressedData));
             writeJsonBlock(block, outputFile);
             final long numOfTransactions = block.items().stream()
-                    .filter(BlockItem::hasEventTransaction)
+                    .filter(BlockItem::hasSignedTransaction)
                     .count();
             final String blockNumber =
                     block.items().size() > 1 && block.items().getFirst().hasBlockHeader()
@@ -135,16 +135,14 @@ public class ConvertToJson implements Runnable {
             String blockJson = Block.JSON.toJSON(block);
             // get iterator over all transactions
             final Iterator<String> transactionBodyJsonIterator = block.items().stream()
-                    .filter(BlockItem::hasEventTransaction)
-                    .filter(item -> item.eventTransaction().hasApplicationTransaction())
+                    .filter(BlockItem::hasSignedTransaction)
                     .map(item -> {
                         try {
                             return "          "
                                     + TransactionBody.JSON
                                             .toJSON(TransactionBody.PROTOBUF.parse(SignedTransaction.PROTOBUF
                                                     .parse(Transaction.PROTOBUF
-                                                            .parse(item.eventTransaction()
-                                                                    .applicationTransaction())
+                                                            .parse(item.signedTransaction())
                                                             .signedTransactionBytes())
                                                     .bodyBytes()))
                                             .replaceAll("\n", "\n          ");


### PR DESCRIPTION
## Reviewer Notes

CN proto was update to 0.65.0-rc1 and contains notable updates around TraceData and other items

- Bump CN proto to 0.65.0-rc1 in git clone gradle task
- Add export for `com.hedera.hapi.block.stream.trace` in `block-node/protobuf-pbj/src/main/java/module-info.java` to ensure classes are available
- Add export for  `com.hedera.hapi.block.stream.trace.protoc` to `tools-and-tests/protobuf-protoc/src/main/java/module-info.java` to ensure classes are available

## Related Issue(s)
Fixes #1386 
Fixes #1525

**Note for reviewers**
Once there's a 0.65.0 tag we can easily update the hash and there shouldn't be other changes but it's worthwhile to get this fixed to unblock testing with Solo

I'm still investigating the UT failure below. Can't seem to repro it locally 
```
* What went wrong:
Execution failed for task ':protobuf-protoc:compileJava'.
> Compilation failed; see the compiler output below.
  /home/runner/_work/hiero-block-node/hiero-block-node/tools-and-tests/protobuf-protoc/src/main/java/module-info.java:12: error: package is empty or does not exist: com.hedera.hapi.block.stream.trace.protoc
      exports com.hedera.hapi.block.stream.trace.protoc;
                                                ^
  1 error
```
