### PR TITLE
test: Multi-Publisher Plugin Unit Tests - Interim PR

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/blocks/SimpleTestBlockItemBuilder.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/blocks/SimpleTestBlockItemBuilder.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.app.fixtures.blocks;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.BlockItem.ItemOneOfType;
@@ -86,6 +88,17 @@ public final class SimpleTestBlockItemBuilder {
                 .build();
     }
 
+    private static BlockItemUnparsed sampleBrokenBlockHeaderUnparsed(final long blockNumber) {
+        final Bytes valid = createBlockHeaderUnparsed(blockNumber);
+        final byte[] arr = valid.toByteArray();
+        arr[0] = (byte) (arr[0] ^ 0xFF); // flip the first byte to break the header
+        return BlockItemUnparsed.newBuilder().blockHeader(Bytes.wrap(arr)).build();
+    }
+
+    private static BlockItemUnparsed sampleNullBlockHeaderUnparsed() {
+        return BlockItemUnparsed.newBuilder().blockHeader(null).build();
+    }
+
     /**
      * Creates a sample BlockItem representing a block header with the given block number and consensus time.
      */
@@ -139,6 +152,13 @@ public final class SimpleTestBlockItemBuilder {
                 .build();
     }
 
+    public static BlockItemUnparsed sampleBrokenBlockProofUnparsed(final long blockNumber) {
+        final Bytes valid = createBlockProofUnparsed(blockNumber);
+        final byte[] arr = valid.toByteArray();
+        arr[0] = (byte) (arr[0] ^ 0xFF); // flip the first byte to break the proof
+        return BlockItemUnparsed.newBuilder().blockProof(Bytes.wrap(arr)).build();
+    }
+
     /**
      * Creates an array of BlockItem objects representing a very simple block stream of N blocks.
      *
@@ -158,8 +178,8 @@ public final class SimpleTestBlockItemBuilder {
      * @return an array of BlockItem objects
      */
     public static BlockItem[] createNumberOfVerySimpleBlocks(final long startBlockNumber, final long endBlockNumber) {
-        assert startBlockNumber <= endBlockNumber;
-        assert startBlockNumber >= 0;
+        assertTrue(startBlockNumber <= endBlockNumber);
+        assertTrue(startBlockNumber >= 0);
         final int numberOfBlocks = (int) (endBlockNumber - startBlockNumber + 1);
         final BlockItem[] blockItems = new BlockItem[numberOfBlocks * 3];
         for (int blockNumber = (int) startBlockNumber; blockNumber <= endBlockNumber; blockNumber++) {
@@ -180,8 +200,8 @@ public final class SimpleTestBlockItemBuilder {
      * @return an array of BlockItem objects
      */
     public static BlockItem[] createNumberOfLargeBlocks(final long startBlockNumber, final long endBlockNumber) {
-        assert startBlockNumber <= endBlockNumber;
-        assert startBlockNumber >= 0;
+        assertTrue(startBlockNumber <= endBlockNumber);
+        assertTrue(startBlockNumber >= 0);
         final int numberOfBlocks = (int) (endBlockNumber - startBlockNumber + 1);
         final BlockItem[] blockItems = new BlockItem[numberOfBlocks * 8];
         for (int blockNumber = (int) startBlockNumber; blockNumber <= endBlockNumber; blockNumber++) {
@@ -213,8 +233,8 @@ public final class SimpleTestBlockItemBuilder {
             final long endBlockNumber,
             Instant firstBlockConsensusTime,
             Duration consensusTimeBetweenBlocks) {
-        assert startBlockNumber <= endBlockNumber;
-        assert startBlockNumber >= 0;
+        assertTrue(startBlockNumber <= endBlockNumber);
+        assertTrue(startBlockNumber >= 0);
         final int numberOfBlocks = (int) (endBlockNumber - startBlockNumber + 1);
         final BlockItemUnparsed[] blockItems = new BlockItemUnparsed[numberOfBlocks * 3];
         Instant blockTime = firstBlockConsensusTime;
@@ -270,8 +290,8 @@ public final class SimpleTestBlockItemBuilder {
 
     public static BlockItemUnparsed[] createNumberOfVerySimpleBlocksUnparsed(
             final int startBlockNumber, final int endBlockNumber) {
-        assert startBlockNumber < endBlockNumber;
-        assert startBlockNumber >= 0;
+        assertTrue(startBlockNumber <= endBlockNumber);
+        assertTrue(startBlockNumber >= 0);
         final int numberOfBlocks = endBlockNumber - startBlockNumber;
         final BlockItemUnparsed[] blockItems = new BlockItemUnparsed[numberOfBlocks * 3];
         for (int i = 0; i < blockItems.length; i += 3) {
@@ -283,13 +303,58 @@ public final class SimpleTestBlockItemBuilder {
         return blockItems;
     }
 
+    public static BlockItemUnparsed[] createNumberOfVerySimpleBlocksUnparsedWithBrokenHeaders(
+            final int startBlockNumber, final int endBlockNumber) {
+        assertTrue(startBlockNumber <= endBlockNumber);
+        assertTrue(startBlockNumber >= 0);
+        final int numberOfBlocks = endBlockNumber - startBlockNumber;
+        final BlockItemUnparsed[] blockItems = new BlockItemUnparsed[numberOfBlocks * 3];
+        for (int i = 0; i < blockItems.length; i += 3) {
+            long blockNumber = i / 3;
+            blockItems[i] = sampleBrokenBlockHeaderUnparsed(blockNumber);
+            blockItems[i + 1] = sampleRoundHeaderUnparsed(blockNumber * 10);
+            blockItems[i + 2] = sampleBlockProofUnparsed(blockNumber);
+        }
+        return blockItems;
+    }
+
+    public static BlockItemUnparsed[] createNumberOfVerySimpleBlocksUnparsedWithBrokenProofs(
+            final int startBlockNumber, final int endBlockNumber) {
+        assertTrue(startBlockNumber <= endBlockNumber);
+        assertTrue(startBlockNumber >= 0);
+        final int numberOfBlocks = endBlockNumber - startBlockNumber;
+        final BlockItemUnparsed[] blockItems = new BlockItemUnparsed[numberOfBlocks * 3];
+        for (int i = 0; i < blockItems.length; i += 3) {
+            long blockNumber = i / 3;
+            blockItems[i] = sampleBlockHeaderUnparsed(blockNumber);
+            blockItems[i + 1] = sampleRoundHeaderUnparsed(blockNumber * 10);
+            blockItems[i + 2] = sampleBrokenBlockProofUnparsed(blockNumber);
+        }
+        return blockItems;
+    }
+
+    public static BlockItemUnparsed[] createNumberOfVerySimpleBlocksUnparsedWithNullHeaderBytes(
+            final int startBlockNumber, final int endBlockNumber) {
+        assertTrue(startBlockNumber <= endBlockNumber);
+        assertTrue(startBlockNumber >= 0);
+        final int numberOfBlocks = endBlockNumber - startBlockNumber;
+        final BlockItemUnparsed[] blockItems = new BlockItemUnparsed[numberOfBlocks * 3];
+        for (int i = 0; i < blockItems.length; i += 3) {
+            long blockNumber = i / 3;
+            blockItems[i] = sampleNullBlockHeaderUnparsed();
+            blockItems[i + 1] = sampleRoundHeaderUnparsed(blockNumber * 10);
+            blockItems[i + 2] = sampleBlockProofUnparsed(blockNumber);
+        }
+        return blockItems;
+    }
+
     public static BlockItems[] createNumberOfSimpleBlockBatches(final int numberOfBatches) {
         return createNumberOfSimpleBlockBatches(0, numberOfBatches);
     }
 
     public static BlockItems[] createNumberOfSimpleBlockBatches(final int startBlockNumber, final int endBlockNumber) {
-        assert startBlockNumber < endBlockNumber;
-        assert startBlockNumber >= 0;
+        assertTrue(startBlockNumber <= endBlockNumber);
+        assertTrue(startBlockNumber >= 0);
         final int numberOfBatches = endBlockNumber - startBlockNumber;
         final BlockItems[] batches = new BlockItems[numberOfBatches];
         for (int i = startBlockNumber; i < endBlockNumber; i++) {

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
@@ -8,8 +8,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.node.app.fixtures.async.BlockingSerialExecutor;
 import org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder;
 import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleBlockRangeSet;
@@ -24,7 +26,7 @@ import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class BackfillPluginTest extends PluginTestBase<BackfillPlugin> {
+class BackfillPluginTest extends PluginTestBase<BackfillPlugin, BlockingSerialExecutor> {
 
     /** The historical block facility. */
     private final SimpleInMemoryHistoricalBlockFacility historicalBlockFacility;
@@ -44,6 +46,7 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin> {
             "1000");
 
     public BackfillPluginTest() {
+        super(new BlockingSerialExecutor(new LinkedBlockingQueue<>()));
         // we will create a BN Mock with port number 8081 and blocks from 0 to 400
         final SimpleInMemoryHistoricalBlockFacility secondBNBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
         for (int i = 0; i < 400; i++) {

--- a/block-node/block-access/src/test/java/org/hiero/block/node/access/service/BlockAccessServicePluginTest.java
+++ b/block-node/block-access/src/test/java/org/hiero/block/node/access/service/BlockAccessServicePluginTest.java
@@ -13,9 +13,11 @@ import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
 import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
 import org.hiero.block.api.BlockRequest;
 import org.hiero.block.api.BlockResponse;
 import org.hiero.block.api.BlockResponse.Code;
+import org.hiero.block.node.app.fixtures.async.BlockingSerialExecutor;
 import org.hiero.block.node.app.fixtures.plugintest.GrpcPluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
@@ -23,11 +25,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class BlockAccessServicePluginTest extends GrpcPluginTestBase<BlockAccessServicePlugin> {
+public class BlockAccessServicePluginTest extends GrpcPluginTestBase<BlockAccessServicePlugin, BlockingSerialExecutor> {
     private final BlockAccessServicePlugin plugin = new BlockAccessServicePlugin();
 
     public BlockAccessServicePluginTest() {
-        super();
+        super(new BlockingSerialExecutor(new LinkedBlockingQueue<>()));
         start(plugin, plugin.methods().getFirst(), new SimpleInMemoryHistoricalBlockFacility());
     }
 

--- a/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
+++ b/block-node/block-providers/files.historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlocksFilesHistoricPluginTest.java
@@ -140,7 +140,7 @@ class BlocksFilesHistoricPluginTest {
      */
     @Nested
     @DisplayName("Plugin Tests")
-    final class PluginTests extends PluginTestBase<BlocksFilesHistoricPlugin> {
+    final class PluginTests extends PluginTestBase<BlocksFilesHistoricPlugin, BlockingSerialExecutor> {
         /** The test block serial executor service to use for the plugin. */
         private final BlockingSerialExecutor pluginExecutor;
 
@@ -148,6 +148,7 @@ class BlocksFilesHistoricPluginTest {
          * Construct plugin base.
          */
         PluginTests() {
+            super(new BlockingSerialExecutor(new LinkedBlockingQueue<>()));
             // match overrides to the test config
             final Map<String, String> configOverrides = getConfigOverrides();
             pluginExecutor = testThreadPoolManager.executor();

--- a/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPluginTest.java
+++ b/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPluginTest.java
@@ -18,8 +18,10 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.node.app.fixtures.async.BlockingSerialExecutor;
 import org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder;
 import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
@@ -64,12 +66,13 @@ class BlockFileRecentPluginTest {
      */
     @Nested
     @DisplayName("Plugin Tests")
-    final class PluginTest extends PluginTestBase<BlocksFilesRecentPlugin> {
+    final class PluginTest extends PluginTestBase<BlocksFilesRecentPlugin, BlockingSerialExecutor> {
 
         /**
          * Test Constructor.
          */
         PluginTest() {
+            super(new BlockingSerialExecutor(new LinkedBlockingQueue<>()));
             start(blocksFilesRecentPlugin, historicalBlockFacility);
         }
 

--- a/block-node/s3-archive/src/test/java/org/hiero/block/node/archive/s3/S3ArchivePluginTest.java
+++ b/block-node/s3-archive/src/test/java/org/hiero/block/node/archive/s3/S3ArchivePluginTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.hiero.block.internal.BlockItemUnparsed;
@@ -43,7 +44,7 @@ import org.testcontainers.containers.GenericContainer;
  * Unit tests for the {@link S3ArchivePlugin} class.
  */
 @SuppressWarnings("SameParameterValue")
-class S3ArchivePluginTest extends PluginTestBase<S3ArchivePlugin> {
+class S3ArchivePluginTest extends PluginTestBase<S3ArchivePlugin, BlockingSerialExecutor> {
     private static final Instant START_TIME =
             ZonedDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant();
     private static final String BUCKET_NAME = "test-bucket";
@@ -56,6 +57,7 @@ class S3ArchivePluginTest extends PluginTestBase<S3ArchivePlugin> {
 
     @SuppressWarnings("resource")
     public S3ArchivePluginTest() throws Exception {
+        super(new BlockingSerialExecutor(new LinkedBlockingQueue<>()));
         // Start MinIO container
         GenericContainer<?> minioContainer = new GenericContainer<>("minio/minio:latest")
                 .withCommand("server /data")

--- a/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java
+++ b/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java
@@ -13,8 +13,10 @@ import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
 import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
 import org.hiero.block.api.ServerStatusRequest;
 import org.hiero.block.api.ServerStatusResponse;
+import org.hiero.block.node.app.fixtures.async.BlockingSerialExecutor;
 import org.hiero.block.node.app.fixtures.plugintest.GrpcPluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
@@ -27,11 +29,12 @@ import org.junit.jupiter.api.Test;
  * Validates the functionality of the server status service and its responses
  * under different conditions.
  */
-public class ServerStatusServicePluginTest extends GrpcPluginTestBase<ServerStatusServicePlugin> {
+public class ServerStatusServicePluginTest
+        extends GrpcPluginTestBase<ServerStatusServicePlugin, BlockingSerialExecutor> {
     private final ServerStatusServicePlugin plugin = new ServerStatusServicePlugin();
 
     public ServerStatusServicePluginTest() {
-        super();
+        super(new BlockingSerialExecutor(new LinkedBlockingQueue<>()));
         start(plugin, plugin.methods().getFirst(), new SimpleInMemoryHistoricalBlockFacility());
     }
 

--- a/block-node/stream-publisher/build.gradle.kts
+++ b/block-node/stream-publisher/build.gradle.kts
@@ -17,6 +17,7 @@ mainModuleInfo {
 testModuleInfo {
     requires("com.swirlds.metrics.impl")
     requires("org.junit.jupiter.api")
+    requires("org.junit.jupiter.params")
     requires("org.assertj.core")
     requires("org.hiero.block.node.app.test.fixtures")
 }

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.stream.publisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hiero.block.node.app.fixtures.TestUtils.enableDebugLogging;
+
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.UncheckedParseException;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Function;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.hiero.block.api.BlockItemSet;
+import org.hiero.block.api.PublishStreamRequest;
+import org.hiero.block.api.PublishStreamResponse;
+import org.hiero.block.api.PublishStreamResponse.EndOfStream.Code;
+import org.hiero.block.api.PublishStreamResponse.ResponseOneOfType;
+import org.hiero.block.node.app.fixtures.async.BlockingSerialExecutor;
+import org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder;
+import org.hiero.block.node.app.fixtures.plugintest.GrpcPluginTestBase;
+import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the {@link StreamPublisherPlugin}.
+ */
+@DisplayName("StreamPublisherPlugin Tests")
+class StreamPublisherPluginTest {
+    /**
+     * Enable debug logging for each test.
+     */
+    @BeforeEach
+    protected void setup() {
+        enableDebugLogging();
+    }
+
+    /**
+     * Test for the {@link StreamPublisherPlugin} plugin.
+     */
+    @Nested
+    @DisplayName("Plugin Tests")
+    class PluginTest extends GrpcPluginTestBase<StreamPublisherPlugin, BlockingSerialExecutor> {
+        // ASSERTION MAPPERS
+        private final Function<Bytes, PublishStreamResponse> bytesToPublishStreamResponseMapper = bytes -> {
+            try {
+                return PublishStreamResponse.PROTOBUF.parse(bytes);
+            } catch (final ParseException e) {
+                throw new UncheckedParseException(e);
+            }
+        };
+        // ASSERTION EXTRACTORS
+        private final Function<PublishStreamResponse, ResponseOneOfType> responseKindExtractor =
+                response -> response.response().kind();
+        private final Function<PublishStreamResponse, Code> endStreamResponseCodeExtractor =
+                response -> Objects.requireNonNull(response.endStream()).status();
+
+        /**
+         * Constructor for the plugin tests.
+         */
+        PluginTest() {
+            super(new BlockingSerialExecutor(new LinkedBlockingQueue<>()));
+            final StreamPublisherPlugin toTest = new StreamPublisherPlugin();
+            final SimpleInMemoryHistoricalBlockFacility historicalBlockFacility =
+                    new SimpleInMemoryHistoricalBlockFacility();
+            start(toTest, toTest.methods().getFirst(), historicalBlockFacility);
+        }
+
+        /**
+         * Verifies that the service interface correctly registers and exposes
+         * the server status method.
+         */
+        @Test
+        @DisplayName("Test verify correct method/s registered for StreamPublisherPlugin in test base")
+        void testVerifyCorrectMethodRegistered() {
+            assertThat(serviceInterface)
+                    .isNotNull()
+                    .extracting(ServiceInterface::methods)
+                    .asInstanceOf(InstanceOfAssertFactories.LIST)
+                    .hasSize(1)
+                    .containsExactly(plugin.methods().getFirst())
+                    .actual()
+                    .forEach(m -> System.out.println("Methods registered for plugin tests: " + m));
+        }
+
+        /**
+         * This test aims to verify that when null block items are published to
+         * the pipeline, an
+         * {@link PublishStreamResponse.EndOfStream}
+         * response is returned with code {@link Code#INVALID_REQUEST}.
+         */
+        @Test
+        @DisplayName("Test publish null block items")
+        void testPublishNullItems() {
+            // Build a PublishStreamRequest with null block items
+            final PublishStreamRequest request = PublishStreamRequest.newBuilder()
+                    .blockItems(BlockItemSet.newBuilder()
+                            .blockItems((List<BlockItem>) null)
+                            .build())
+                    .build();
+            // Send the request to the pipeline
+            toPluginPipe.onNext(PublishStreamRequest.PROTOBUF.toBytes(request));
+            // Assert response
+            assertThat(fromPluginBytes)
+                    .hasSize(1)
+                    .first()
+                    .extracting(bytesToPublishStreamResponseMapper)
+                    .isNotNull()
+                    .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
+                    .returns(Code.INVALID_REQUEST, endStreamResponseCodeExtractor);
+        }
+
+        /**
+         * This test aims to verify that when empty block items are published to
+         * the pipeline, an
+         * {@link PublishStreamResponse.EndOfStream}
+         * response is returned with code {@link Code#INVALID_REQUEST}.
+         */
+        @Test
+        @DisplayName("Test publish empty block items")
+        void testPublishEmptyItems() {
+            // Build a PublishStreamRequest with empty block items
+            final PublishStreamRequest request = PublishStreamRequest.newBuilder()
+                    .blockItems(BlockItemSet.newBuilder()
+                            .blockItems(Collections.emptyList())
+                            .build())
+                    .build();
+            // Send the request to the pipeline
+            toPluginPipe.onNext(PublishStreamRequest.PROTOBUF.toBytes(request));
+            // Assert response
+            assertThat(fromPluginBytes)
+                    .hasSize(1)
+                    .first()
+                    .extracting(bytesToPublishStreamResponseMapper)
+                    .isNotNull()
+                    .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
+                    .returns(Code.INVALID_REQUEST, endStreamResponseCodeExtractor);
+        }
+
+        /**
+         * This test aims to verify that when empty block items are published to
+         * the pipeline, an
+         * {@link PublishStreamResponse.EndOfStream}
+         * response is returned with code {@link Code#ERROR}.
+         */
+        @Test
+        @DisplayName("Test publish unset oneOf")
+        void testPublishUnsetOneOf() {
+            // Build a PublishStreamRequest with an unset oneOf
+            final PublishStreamRequest request =
+                    PublishStreamRequest.newBuilder().build();
+            // Send the request to the pipeline
+            toPluginPipe.onNext(PublishStreamRequest.PROTOBUF.toBytes(request));
+            // Assert response
+            assertThat(fromPluginBytes)
+                    .hasSize(1)
+                    .first()
+                    .extracting(bytesToPublishStreamResponseMapper)
+                    .isNotNull()
+                    .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
+                    .returns(Code.ERROR, endStreamResponseCodeExtractor);
+        }
+
+        /**
+         * This test aims to verify that when a valid block is published to the
+         * pipeline, an
+         * {@link PublishStreamResponse.BlockAcknowledgement} response is returned.
+         */
+        @Disabled("This requires GH issue #1374 to be resolved, otherwise we will get DUPLICATE_BLOCK")
+        @Test
+        @DisplayName("Test publish a valid block as items")
+        void testPublishValidBlock() {
+            final BlockItem[] block = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocks(0, 1);
+            // Build a PublishStreamRequest with a valid block as items
+            final PublishStreamRequest request = PublishStreamRequest.newBuilder()
+                    .blockItems(BlockItemSet.newBuilder().blockItems(block).build())
+                    .build();
+            // Send the request to the pipeline
+            toPluginPipe.onNext(PublishStreamRequest.PROTOBUF.toBytes(request));
+            // @todo(1435) we cannot use blocking executor here because the plugin config
+            //   for max iterations min value is way too high for us to block in this test
+            //   we need to execute this async and assert after some time
+            final BlockingSerialExecutor executor = testThreadPoolManager.executor();
+            final boolean taskSubmitted = executor.wasAnyTaskSubmitted();
+            // Assert that a task was submitted to the executor
+            assertThat(taskSubmitted).isTrue();
+            // Execute task serially (blocking)
+            executor.executeSerially();
+            // Assert response
+            assertThat(fromPluginBytes)
+                    .hasSize(1)
+                    .first()
+                    .extracting(bytesToPublishStreamResponseMapper)
+                    .isNotNull()
+                    .returns(ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor);
+        }
+    }
+}

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberTest.java
@@ -16,17 +16,16 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.grpc.ServiceInterface.Method;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.assertj.core.api.SoftAssertions;
 import org.hiero.block.api.SubscribeStreamRequest;
 import org.hiero.block.api.SubscribeStreamResponse;
 import org.hiero.block.api.SubscribeStreamResponse.ResponseOneOfType;
 import org.hiero.block.internal.BlockItemUnparsed;
-import org.hiero.block.node.app.fixtures.async.TestThreadPoolManager;
 import org.hiero.block.node.app.fixtures.plugintest.GrpcPluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
-import org.hiero.block.node.spi.threading.ThreadPoolManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -36,7 +35,7 @@ import org.junit.jupiter.api.Test;
  * plugin.
  */
 @SuppressWarnings("DataFlowIssue")
-public class SubscriberTest extends GrpcPluginTestBase<SubscriberServicePlugin> {
+public class SubscriberTest extends GrpcPluginTestBase<SubscriberServicePlugin, ExecutorService> {
     private static final int RESPONSE_WAIT_LIMIT = 1000;
 
     private final SubscriberServicePlugin activePlugin;
@@ -46,10 +45,10 @@ public class SubscriberTest extends GrpcPluginTestBase<SubscriberServicePlugin> 
      * Constructor that creates new subscriber plugin and in-memory block facility.
      */
     public SubscriberTest() {
+        super(Executors.newVirtualThreadPerTaskExecutor());
         historicalFacility = new SimpleInMemoryHistoricalBlockFacility();
         activePlugin = new SubscriberServicePlugin();
-        ThreadPoolManager virtualTaskThreads = new TestThreadPoolManager<>(Executors.newVirtualThreadPerTaskExecutor());
-        start(activePlugin, subscribeBlockStream, historicalFacility, virtualTaskThreads, null);
+        start(activePlugin, subscribeBlockStream, historicalFacility, null);
     }
 
     /**

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginTest.java
@@ -14,8 +14,10 @@ import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.ParseException;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockItemUnparsed.ItemOneOfType;
+import org.hiero.block.node.app.fixtures.async.BlockingSerialExecutor;
 import org.hiero.block.node.app.fixtures.blocks.BlockUtils;
 import org.hiero.block.node.app.fixtures.plugintest.NoBlocksHistoricalBlockFacility;
 import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
@@ -29,9 +31,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit test for {@link VerificationServicePlugin}.
  */
-class VerificationServicePluginTest extends PluginTestBase<VerificationServicePlugin> {
+class VerificationServicePluginTest extends PluginTestBase<VerificationServicePlugin, BlockingSerialExecutor> {
 
     public VerificationServicePluginTest() {
+        super(new BlockingSerialExecutor(new LinkedBlockingQueue<>()));
         start(new VerificationServicePlugin(), new NoBlocksHistoricalBlockFacility());
     }
 


### PR DESCRIPTION
## Reviewer Notes

* Added unit tests:
  * PublisherHandler:
    * test onNext receives subsequent requests if previous one expected a header but did not receive
    * tests for broken header supplied
    * tests for null header bytes supplied
    * test for sending acknowledgements
    * tests for closeBlock called
    * tests for handling block proof
  * StreamPublisherPlugin:
    * test for null items
    * test for empty items
    * test for unset oneOf
    * test for valid block (disabled, finish in a follow up)
* Updated Publisher Manager test fixture:
  * added implementation for handlePersisted
  * added implementation for closeBlock
  * added the ability to add a handler to send notifications to
* Extended Test Block Items Builder
  * added the ability to create blocks with broken headers
  * added the ability to create blocks with broken proofs
* Test Dependencies:
  * added jupiter params

**UPDATE**:
In order to unblock progress for simulator tasks, we will stop with tests here and make part 2: #1435
Note that some tests will be disabled because they require additional logic which will further complicate this and slow down simulator tasks even more.
Mainly, we need to tackle #1374 as it becomes even more problematic, we cannot test properly the plugin itself.

