### PR TITLE
feat(backfill): On-Demand Backfilling and other improvements

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
@@ -13,6 +13,7 @@ import org.hiero.block.node.spi.blockmessaging.BlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
+import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.NoBackPressureBlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
@@ -222,6 +223,14 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
         LOGGER.log(Level.TRACE, "Sending backfilled block notification " + notification);
         for (BlockNotificationHandler handler : blockNotificationHandlers) {
             handler.handleBackfilled(notification);
+        }
+    }
+
+    @Override
+    public void sendNewestBlockKnownToNetwork(NewestBlockKnownToNetworkNotification notification) {
+        LOGGER.log(Level.TRACE, "Sending NewestBlockKnownToNetworkNotification block notification " + notification);
+        for (BlockNotificationHandler handler : blockNotificationHandlers) {
+            handler.handleNewestBlockKnownToNetwork(notification);
         }
     }
 

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
@@ -14,6 +14,7 @@ import org.hiero.block.api.SubscribeStreamResponse;
 import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
 
 public class TestBlockNodeServer {
+    private final WebServer webServer;
 
     public TestBlockNodeServer(int port, HistoricalBlockFacility historicalBlockFacility) {
         // Override the default message size in PBJ
@@ -52,7 +53,7 @@ public class TestBlockNodeServer {
                 });
 
         // start the web server with the PBJ configuration and routing
-        WebServer webServer = WebServerConfig.builder()
+        webServer = WebServerConfig.builder()
                 .port(port)
                 .addProtocol(pbjConfig)
                 .addRouting(pbjRoutingBuilder)
@@ -63,5 +64,14 @@ public class TestBlockNodeServer {
                 .build();
 
         webServer.start();
+    }
+
+    /**
+     * Stop the web server.
+     */
+    public void stop() {
+        if (webServer != null) {
+            webServer.stop();
+        }
     }
 }

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillConfiguration.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillConfiguration.java
@@ -28,6 +28,6 @@ public record BackfillConfiguration(
         @Loggable @ConfigProperty(defaultValue = "60000") @Min(100) int scanIntervalMs,
         @Loggable @ConfigProperty(defaultValue = "3") @Min(0) @Max(10) int maxRetries,
         @Loggable @ConfigProperty(defaultValue = "5000") @Min(500) int initialRetryDelayMs,
-        @Loggable @ConfigProperty(defaultValue = "100") @Min(1) @Max(10_000) int fetchBatchSize,
+        @Loggable @ConfigProperty(defaultValue = "25") @Min(1) @Max(10_000) int fetchBatchSize,
         @Loggable @ConfigProperty(defaultValue = "1000") @Min(100) int delayBetweenBatchesMs,
         @Loggable @ConfigProperty(defaultValue = "15000") @Min(5) int initialDelayMs) {}

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillConfiguration.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillConfiguration.java
@@ -13,21 +13,24 @@ import org.hiero.block.node.base.Loggable;
  * @param startBlock The first block that this BN deploy wants to have available
  * @param endBlock For some historical-purpose–specific BNs, there could be a maximum number of blocks, -1 means no limit.
  * @param blockNodeSourcesPath File path for a yaml configuration for the BN sources.
- * @param scanIntervalMs Interval in minutes to scan for missing gaps (skips if the previous task is running)
+ * @param scanInterval Interval in minutes to scan for missing gaps (skips if the previous task is running)
  * @param maxRetries Maximum number of retries to fetch a missing block (with exponential back-off)
- * @param initialRetryDelayMs Initial cooldown time between retries in milliseconds, will be multiplied by number of retry on each attempt
+ * @param initialRetryDelay Initial cooldown time between retries in milliseconds, will be multiplied by number of retry on each attempt
  * @param fetchBatchSize Number of blocks to fetch in a single gRPC call
- * @param delayBetweenBatchesMs Cool downtime in milliseconds between batches of blocks to fetch
- * @param initialDelayMs Initial delay in seconds before starting the backfill process, to give time for the system to stabilize
+ * @param delayBetweenBatches Cool downtime in milliseconds between batches of blocks to fetch
+ * @param initialDelay Initial delay in seconds before starting the backfill process, to give time for the system to stabilize
+ * @param perBlockProcessingTimeout Timeout in milliseconds for processing each block, to avoid blocking the backfill
+ *                                  process indefinitely in case something unexpected happens, this would allow for self-recovery
  */
 @ConfigData("backfill")
 public record BackfillConfiguration(
         @Loggable @ConfigProperty(defaultValue = "0") @Min(0) long startBlock,
         @Loggable @ConfigProperty(defaultValue = "-1") @Min(-1) long endBlock,
         @Loggable @ConfigProperty(defaultValue = "") String blockNodeSourcesPath,
-        @Loggable @ConfigProperty(defaultValue = "60000") @Min(100) int scanIntervalMs,
+        @Loggable @ConfigProperty(defaultValue = "60000") @Min(100) int scanInterval,
         @Loggable @ConfigProperty(defaultValue = "3") @Min(0) @Max(10) int maxRetries,
-        @Loggable @ConfigProperty(defaultValue = "5000") @Min(500) int initialRetryDelayMs,
+        @Loggable @ConfigProperty(defaultValue = "5000") @Min(500) int initialRetryDelay,
         @Loggable @ConfigProperty(defaultValue = "25") @Min(1) @Max(10_000) int fetchBatchSize,
-        @Loggable @ConfigProperty(defaultValue = "1000") @Min(100) int delayBetweenBatchesMs,
-        @Loggable @ConfigProperty(defaultValue = "15000") @Min(5) int initialDelayMs) {}
+        @Loggable @ConfigProperty(defaultValue = "1000") @Min(100) int delayBetweenBatches,
+        @Loggable @ConfigProperty(defaultValue = "15000") @Min(5) int initialDelay,
+        @Loggable @ConfigProperty(defaultValue = "1000") @Min(500) int perBlockProcessingTimeout) {}

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
@@ -2,11 +2,13 @@
 package org.hiero.block.node.backfill;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import java.util.ArrayList;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -17,114 +19,59 @@ import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleBlockRangeSet;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
 import org.hiero.block.node.app.fixtures.server.TestBlockNodeServer;
+import org.hiero.block.node.backfill.client.BackfillSource;
+import org.hiero.block.node.backfill.client.BackfillSourceConfig;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
+import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class BackfillPluginTest extends PluginTestBase<BackfillPlugin, BlockingExecutor> {
 
-    /** The historical block facility. */
-    private final SimpleInMemoryHistoricalBlockFacility historicalBlockFacility;
+    /** TempDir for the current test */
+    private final Path testTempDir;
 
-    private final TestBlockNodeServer testBlockNodeServer;
-
-    private final List<TestBlockNodeServer> blockNodeServerMocks = new ArrayList();
-
-    private final Map<String, String> defaultConfig = Map.of(
-            "backfill.blockNodeSourcesPath",
-            getClass().getClassLoader().getResource("block-nodes.json").getFile(),
-            "backfill.fetchBatchSize",
-            "5",
-            "backfill.delayBetweenBatchesMs",
-            "100",
-            "backfill.initialDelayMs",
-            "1000");
-
-    public BackfillPluginTest() {
+    public BackfillPluginTest(@TempDir final Path tempDir) {
         super(new BlockingExecutor(new LinkedBlockingQueue<>()));
-        // we will create a BN Mock with port number 8081 and blocks from 0 to 400
-        final SimpleInMemoryHistoricalBlockFacility secondBNBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
-        for (int i = 0; i < 400; i++) {
-            final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-            secondBNBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
-        }
-
-        this.historicalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
-        this.testBlockNodeServer = new TestBlockNodeServer(8081, secondBNBlockFacility);
-
-        // we create another BN Server Mock that is available at port 8082 but has no useful blocks
-        final SimpleInMemoryHistoricalBlockFacility emptyBNBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
-        for (int i = 10000; i < 10001; i++) {
-            final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-            emptyBNBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
-        }
-        blockNodeServerMocks.add(new TestBlockNodeServer(8082, emptyBNBlockFacility));
+        this.testTempDir = Objects.requireNonNull(tempDir);
     }
 
     @Test
     @DisplayName("Backfill Happy Test")
     void testBackfillPlugin() throws InterruptedException {
 
+        // Block Node sources
         String blockNodeSourcesPath =
                 getClass().getClassLoader().getResource("block-nodes.json").getFile();
 
-        start(
-                new BackfillPlugin(),
-                this.historicalBlockFacility,
-                Map.of(
-                        "backfill.blockNodeSourcesPath",
-                        blockNodeSourcesPath,
-                        "backfill.fetchBatchSize",
-                        "5",
-                        "backfill.delayBetweenBatchesMs",
-                        "100",
-                        "backfill.initialDelaySeconds",
-                        "5"));
+        // BN 1
+        final HistoricalBlockFacility historicalBlockFacilityForServer = getHistoricalBlockFacility(0, 400);
+        TestBlockNodeServer testBlockNodeServer = new TestBlockNodeServer(40800, historicalBlockFacilityForServer);
 
-        // insert a GAP in the historical block facility
-        final SimpleBlockRangeSet temporaryAvailableBlocks = new SimpleBlockRangeSet();
-        temporaryAvailableBlocks.add(10, 20);
-        this.historicalBlockFacility.setTemporaryAvailableBlocks(temporaryAvailableBlocks);
+        // Config Override
+        Map<String, String> configOverride = BackfillConfigBuilder.NewBuilder()
+                .backfillSourcePath(blockNodeSourcesPath)
+                .fetchBatchSize(20)
+                .build();
+
+        // create a historical block facility for the plugin (should have a GAP)
+        final HistoricalBlockFacility historicalBlockFacilityForPlugin = getHistoricalBlockFacility(10, 20);
+
+        // start the plugin
+        start(new BackfillPlugin(), historicalBlockFacilityForPlugin, configOverride);
+
         CountDownLatch countDownLatch = new CountDownLatch(10); // 0 to 9 inclusive, so 10 blocks
-
-        this.blockMessaging.registerBlockNotificationHandler(
-                new BlockNotificationHandler() {
-                    @Override
-                    public void handleBackfilled(BackfilledBlockNotification notification) {
-                        blockNodeContext
-                                .blockMessaging()
-                                .sendBlockVerification(new VerificationNotification(
-                                        true,
-                                        notification.blockNumber(),
-                                        Bytes.wrap("123"),
-                                        notification.block(),
-                                        BlockSource.BACKFILL));
-                    }
-                },
-                false,
-                "test-backfill-handler");
-
-        this.blockMessaging.registerBlockNotificationHandler(
-                new BlockNotificationHandler() {
-                    @Override
-                    public void handleVerification(VerificationNotification notification) {
-                        blockNodeContext
-                                .blockMessaging()
-                                .sendBlockPersisted(new PersistedNotification(
-                                        notification.blockNumber(),
-                                        notification.blockNumber(),
-                                        10,
-                                        notification.source()));
-                        countDownLatch.countDown();
-                    }
-                },
-                false,
-                "test-backfill-handler");
+        // register the backfill handler
+        registerDefaultTestBackfillHandler();
+        // register the verification handler
+        registerDefaultTestVerificationHandler(countDownLatch);
 
         boolean backfillSuccess =
                 countDownLatch.await(5, TimeUnit.MINUTES); // Wait until countDownLatch.countDown() is called
@@ -143,70 +90,58 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, BlockingExecutor
                 blockMessaging.getSentVerificationNotifications().size(),
                 "Should have sent 11 verification notifications");
 
+        // clean up
+        testBlockNodeServer.stop(); // Stop the mock server
         plugin.stop();
     }
 
     @Test
     @DisplayName("Priority 1 BN is unavailable, fallback to 2nd priority BN")
     void testSecondarySourceBakcfill() throws InterruptedException {
-        // lets re-initialize the plugin with a different config
-        String blockNodeSourcesPath =
-                getClass().getClassLoader().getResource("block-nodes-2.json").getFile();
 
-        start(
-                new BackfillPlugin(),
-                this.historicalBlockFacility,
-                Map.of(
-                        "backfill.blockNodeSourcesPath",
-                        blockNodeSourcesPath,
-                        "backfill.fetchBatchSize",
-                        "5",
-                        "backfill.delayBetweenBatchesMs",
-                        "100",
-                        "backfill.initialDelaySeconds",
-                        "5",
-                        "backfill.initialRetryDelayMs",
-                        "500"));
+        // Block Node sources
+        // Set up a backfill source with two nodes, one primary and one secondary
+        // The primary node is at port 8082 and the secondary node is at port 40800
+        BackfillSourceConfig backfillSourceConfig = BackfillSourceConfig.newBuilder()
+                .address("localhost")
+                .port(8082)
+                .priority(1)
+                .build();
+        BackfillSourceConfig secondaryBackfillSourceConfig = BackfillSourceConfig.newBuilder()
+                .address("localhost")
+                .port(40800)
+                .priority(2)
+                .build();
+        BackfillSource backfillSource = BackfillSource.newBuilder()
+                .nodes(backfillSourceConfig, secondaryBackfillSourceConfig)
+                .build();
+        String backfillSourcePath = testTempDir + "/backfill-source-2.json";
+        createTestBlockNodeSourcesFile(backfillSource, backfillSourcePath);
+
+        // BN 2
+        final HistoricalBlockFacility historicalBlockFacilityForServer = getHistoricalBlockFacility(0, 400);
+        TestBlockNodeServer testBlockNodeServer = new TestBlockNodeServer(40800, historicalBlockFacilityForServer);
+
+        // Config Override
+        Map<String, String> configOverride = BackfillConfigBuilder.NewBuilder()
+                .backfillSourcePath(backfillSourcePath)
+                .maxRetries(2)
+                .initialDelayMs(600) // start quickly
+                .build();
+
+        // create a historical block facility for the plugin (should have a GAP)
+        final HistoricalBlockFacility historicalBlockFacilityForPlugin = getHistoricalBlockFacility(10, 20);
+
+        // start the plugin
+        start(new BackfillPlugin(), historicalBlockFacilityForPlugin, configOverride);
 
         // insert a GAP in the historical block facility
-        final SimpleBlockRangeSet temporaryAvailableBlocks = new SimpleBlockRangeSet();
-        temporaryAvailableBlocks.add(10, 20);
-        this.historicalBlockFacility.setTemporaryAvailableBlocks(temporaryAvailableBlocks);
         CountDownLatch countDownLatch = new CountDownLatch(10); // 0 to 9 inclusive, so 10 blocks
 
-        this.blockMessaging.registerBlockNotificationHandler(
-                new BlockNotificationHandler() {
-                    @Override
-                    public void handleBackfilled(BackfilledBlockNotification notification) {
-                        blockNodeContext
-                                .blockMessaging()
-                                .sendBlockVerification(new VerificationNotification(
-                                        true,
-                                        notification.blockNumber(),
-                                        Bytes.wrap("123"),
-                                        notification.block(),
-                                        BlockSource.BACKFILL));
-                    }
-                },
-                false,
-                "test-backfill-handler");
-
-        this.blockMessaging.registerBlockNotificationHandler(
-                new BlockNotificationHandler() {
-                    @Override
-                    public void handleVerification(VerificationNotification notification) {
-                        blockNodeContext
-                                .blockMessaging()
-                                .sendBlockPersisted(new PersistedNotification(
-                                        notification.blockNumber(),
-                                        notification.blockNumber(),
-                                        10,
-                                        notification.source()));
-                        countDownLatch.countDown();
-                    }
-                },
-                false,
-                "test-backfill-handler");
+        // register the backfill handler
+        registerDefaultTestBackfillHandler();
+        // register the verification handler
+        registerDefaultTestVerificationHandler(countDownLatch);
 
         boolean backfillSuccess =
                 countDownLatch.await(5, TimeUnit.MINUTES); // Wait until countDownLatch.countDown() is called
@@ -224,34 +159,36 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, BlockingExecutor
                 10,
                 blockMessaging.getSentVerificationNotifications().size(),
                 "Should have sent 11 verification notifications");
+
+        // clean up
+        testBlockNodeServer.stop(); // Stop the mock server
+        plugin.stop();
     }
 
     @Test
     @DisplayName("Backfill found no available block-nodes, should not backfill")
     void testBackfillNoAvailableBlockNodes() throws InterruptedException {
-        // lets re-initialize the plugin with a different config
-        String blockNodeSourcesPath =
-                getClass().getClassLoader().getResource("block-nodes-3.json").getFile();
+        // Block Node sources
+        // let's create a config with a non-existing block-node source
+        String blockNodeSourcesPath = testTempDir + "/backfill-source-3.json";
+        BackfillSourceConfig backfillSourceConfig = BackfillSourceConfig.newBuilder()
+                .address("non-existing-block-node.example.node") // non-existing address
+                .port(80840) // non-existing port
+                .priority(1)
+                .build();
+        BackfillSource backfillSource =
+                BackfillSource.newBuilder().nodes(backfillSourceConfig).build();
+        // Create a temporary file for the backfill source configuration
+        createTestBlockNodeSourcesFile(backfillSource, blockNodeSourcesPath);
 
-        start(
-                new BackfillPlugin(),
-                this.historicalBlockFacility,
-                Map.of(
-                        "backfill.blockNodeSourcesPath",
-                        blockNodeSourcesPath,
-                        "backfill.fetchBatchSize",
-                        "5",
-                        "backfill.delayBetweenBatchesMs",
-                        "100",
-                        "backfill.initialDelaySeconds",
-                        "5",
-                        "backfill.initialRetryDelayMs",
-                        "500"));
-
-        // insert a GAP in the historical block facility
-        final SimpleBlockRangeSet temporaryAvailableBlocks = new SimpleBlockRangeSet();
-        temporaryAvailableBlocks.add(10, 20);
-        this.historicalBlockFacility.setTemporaryAvailableBlocks(temporaryAvailableBlocks);
+        // create a historical block facility for the plugin (should have a GAP)
+        final HistoricalBlockFacility historicalBlockFacility = getHistoricalBlockFacility(10, 20);
+        final Map<String, String> configOverride = BackfillConfigBuilder.NewBuilder()
+                .backfillSourcePath(blockNodeSourcesPath)
+                .maxRetries(1)
+                .build();
+        // start the plugin
+        start(new BackfillPlugin(), historicalBlockFacility, configOverride);
 
         // give 10 seconds to allow processing to finish...
         TimeUnit.SECONDS.sleep(10);
@@ -262,5 +199,409 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, BlockingExecutor
                 0,
                 blockMessaging.getSentVerificationNotifications().size(),
                 "Should have sent 0 verification notifications");
+
+        // clean up
+        plugin.stop();
+    }
+
+    @Test
+    @DisplayName("Backfill On-Demand Happy path test")
+    void testBackfillOnDemand() throws InterruptedException {
+        // Block Node sources
+        BackfillSourceConfig config = BackfillSourceConfig.newBuilder()
+                .address("localhost")
+                .port(40844)
+                .priority(1)
+                .build();
+        BackfillSource backfillSource =
+                BackfillSource.newBuilder().nodes(config).build();
+        // Create a temporary file for the backfill source configuration
+        String backfillSourcePath = testTempDir + "/backfill-source-4.json";
+        createTestBlockNodeSourcesFile(backfillSource, backfillSourcePath);
+        // using the same port, start a BN mock that has blocks from 0 to 50
+        final HistoricalBlockFacility blockNodeServerBlockFacility = getHistoricalBlockFacility(0, 50);
+        TestBlockNodeServer testBlockNodeServer = new TestBlockNodeServer(config.port(), blockNodeServerBlockFacility);
+
+        // config override for test
+        final Map<String, String> configOverride = BackfillConfigBuilder.NewBuilder()
+                .backfillSourcePath(backfillSourcePath)
+                .build();
+
+        // create a historical block facility for the plugin (should have a GAP)
+        final HistoricalBlockFacility historicalBlockFacility = getHistoricalBlockFacility(0, 30);
+
+        // start block-node with blocks from 0 to 30
+        start(new BackfillPlugin(), historicalBlockFacility, configOverride);
+
+        // We will backfill blocks from 31 to 50 inclusive, so we expect 20 blocks to be backfilled
+        CountDownLatch countDownLatch = new CountDownLatch(20); // from 31 to 50 inclusive, so 20 blocks
+        // register the backfill handler
+        registerDefaultTestBackfillHandler();
+        // register the verification handler
+        registerDefaultTestVerificationHandler(countDownLatch);
+        // Trigger the backfill on-demand by sending a NewestBlockKnownToNetworkNotification
+        // to the block messaging system
+        NewestBlockKnownToNetworkNotification newestBlockNotification = new NewestBlockKnownToNetworkNotification(50L);
+        this.blockMessaging.sendNewestBlockKnownToNetwork(newestBlockNotification);
+        // Wait for the backfill to complete
+        boolean backfillSuccess =
+                countDownLatch.await(5, TimeUnit.MINUTES); // Wait until countDownLatch.countDown() is called
+
+        // assertions
+        assertTrue(backfillSuccess);
+        assertEquals(0, countDownLatch.getCount(), "Count down latch should be 0 after backfill");
+
+        // Verify sent verifications
+        assertEquals(
+                20,
+                blockMessaging.getSentPersistedNotifications().size(),
+                "Should have sent 20 persisted notifications");
+        assertEquals(
+                20,
+                blockMessaging.getSentVerificationNotifications().size(),
+                "Should have sent 20 verification notifications");
+
+        // clean up
+        testBlockNodeServer.stop();
+        plugin.stop();
+    }
+
+    @Test
+    @DisplayName("Backfill on-demand while historical (autonomous) backfill is running")
+    void testBackfillOnDemandWhileAutonomousBackfillRunning() throws InterruptedException {
+        // Prepare a backfill source configuration
+        // Create a test configuration
+        BackfillSourceConfig config = BackfillSourceConfig.newBuilder()
+                .address("localhost")
+                .port(40845)
+                .priority(1)
+                .build();
+        BackfillSource backfillSource =
+                BackfillSource.newBuilder().nodes(config).build();
+        // Create a temporary file for the backfill source configuration
+        String backfillSourcePath = testTempDir + "/backfill-source-5.json";
+        createTestBlockNodeSourcesFile(backfillSource, backfillSourcePath);
+
+        // BN mock server
+        HistoricalBlockFacility blockFacilityServer = getHistoricalBlockFacility(0, 201);
+        TestBlockNodeServer testBlockNodeServer = new TestBlockNodeServer(config.port(), blockFacilityServer);
+
+        // config override for test
+        final Map<String, String> configOverride = BackfillConfigBuilder.NewBuilder()
+                .backfillSourcePath(backfillSourcePath)
+                .build();
+
+        // create a historical block facility for the plugin (should have a GAP)
+        final HistoricalBlockFacility historicalBlockFacility = getHistoricalBlockFacility(50, 100);
+
+        // start block-node with blocks from 50 to 100
+        // needs to backfilled from 0 to 50 autonomously
+        // and then on-demand from 101 to 200
+        start(new BackfillPlugin(), historicalBlockFacility, configOverride);
+
+        // 3 latches, one for making sure the autonomous backfill is mid-way through
+        // one for the total backfill from 0 to 200
+        // and one for the on-demand backfill from 501 to 200
+        CountDownLatch latch1 = new CountDownLatch(10); // mid-way through the autonomous backfill
+        CountDownLatch latchHistorical = new CountDownLatch(50); // historical blocks from 0 to 49
+        CountDownLatch latchLive = new CountDownLatch(100); // live blocks from 101 to 200
+
+        // register the backfill handler
+        registerDefaultTestBackfillHandler();
+        // register the verification handler
+        this.blockMessaging.registerBlockNotificationHandler(
+                new BlockNotificationHandler() {
+                    @Override
+                    public void handleVerification(VerificationNotification notification) {
+                        blockNodeContext
+                                .blockMessaging()
+                                .sendBlockPersisted(new PersistedNotification(
+                                        notification.blockNumber(),
+                                        notification.blockNumber(),
+                                        10,
+                                        notification.source()));
+                        latch1.countDown();
+                        if (notification.blockNumber() < 50) {
+                            latchHistorical.countDown(); // Count down for historical blocks
+                        } else if (notification.blockNumber() >= 100) {
+                            latchLive.countDown(); // Count down for live blocks
+                        }
+                    }
+                },
+                false,
+                "test-backfill-handler");
+
+        boolean startOnDemand = latch1.await(1, TimeUnit.MINUTES); // Wait until latch1.countDown() is called
+        assertTrue(startOnDemand, "Should have started on-demand backfill while autonomous backfill is running");
+        // Trigger the on-demand backfill by sending a NewestBlockKnownToNetworkNotification
+        NewestBlockKnownToNetworkNotification newestBlockNotification = new NewestBlockKnownToNetworkNotification(200L);
+        this.blockMessaging.sendNewestBlockKnownToNetwork(newestBlockNotification);
+        // Wait for the backfill to complete
+        boolean backfillSuccess = latchHistorical.await(2, TimeUnit.MINUTES); // Wait until latch2.countDown() is called
+        assertTrue(backfillSuccess, "Should have completed the backfill successfully");
+        assertEquals(0, latchHistorical.getCount(), "Count down latch should be 0 after backfill");
+
+        // Wait for the on-demand backfill to complete
+        boolean onDemandSuccess = latchLive.await(2, TimeUnit.MINUTES); // Wait until latch3.countDown() is called
+        assertTrue(onDemandSuccess, "Should have completed the on-demand backfill successfully");
+
+        // Verify sent verifications
+        assertEquals(
+                150,
+                blockMessaging.getSentPersistedNotifications().size(),
+                "Should have sent 150 persisted notifications");
+        assertEquals(
+                150,
+                blockMessaging.getSentVerificationNotifications().size(),
+                "Should have sent 150 verification notifications");
+
+        // clean-up after test.
+        // stop the mock server
+        testBlockNodeServer.stop();
+
+        // Stop the plugin
+        plugin.stop();
+    }
+
+    @Test
+    @DisplayName("Backfill Autonomous, GAP available within 2 different backfill sources")
+    void testBackfillPartialAvailableSourcesForGap() throws InterruptedException {
+
+        // Set up 2 backfill sources with two nodes, one primary and one secondary
+        // primary node will have blocks from 0 to 100
+        // secondary node will have blocks from 50 to 150
+        BackfillSourceConfig backfillSourceConfig = BackfillSourceConfig.newBuilder()
+                .address("localhost")
+                .port(40841)
+                .priority(2)
+                .build();
+        BackfillSourceConfig secondaryBackfillSourceConfig = BackfillSourceConfig.newBuilder()
+                .address("localhost")
+                .port(40842)
+                .priority(1)
+                .build();
+        BackfillSource backfillSource = BackfillSource.newBuilder()
+                .nodes(backfillSourceConfig, secondaryBackfillSourceConfig)
+                .build();
+        // Create a temporary file for the backfill source configuration
+        String backfillSourcePath = testTempDir + "/backfill-source-7.json";
+        createTestBlockNodeSourcesFile(backfillSource, backfillSourcePath);
+        // create storage for source 1
+        final SimpleInMemoryHistoricalBlockFacility storage1 = getHistoricalBlockFacility(0, 101);
+
+        // create storage for source 2
+        final SimpleInMemoryHistoricalBlockFacility storage2 = getHistoricalBlockFacility(50, 151);
+
+        // start block-node mocks
+        TestBlockNodeServer testBlockNodeServer1 = new TestBlockNodeServer(backfillSourceConfig.port(), storage1);
+        TestBlockNodeServer testBlockNodeServer2 =
+                new TestBlockNodeServer(secondaryBackfillSourceConfig.port(), storage2);
+
+        // config override
+        Map<String, String> config = BackfillConfigBuilder.NewBuilder()
+                .backfillSourcePath(backfillSourcePath)
+                .initialDelayMs(100) // start quickly
+                .scanIntervalMs(500000) // scan every 500 seconds
+                .build();
+
+        // create a historical block facility for the plugin (should have a GAP from 0 to 124)
+        final SimpleInMemoryHistoricalBlockFacility historicalBlockFacility = getHistoricalBlockFacility(125, 175);
+
+        // start with plugin configuration
+        start(new BackfillPlugin(), historicalBlockFacility, config);
+
+        CountDownLatch backfillLatch = new CountDownLatch(125); // 0 to 124 inclusive, so 125 blocks
+
+        // register the backfill handler
+        registerDefaultTestBackfillHandler();
+        // register the verification handler
+        this.blockMessaging.registerBlockNotificationHandler(
+                new BlockNotificationHandler() {
+                    @Override
+                    public void handleVerification(VerificationNotification notification) {
+                        blockNodeContext
+                                .blockMessaging()
+                                .sendBlockPersisted(new PersistedNotification(
+                                        notification.blockNumber(),
+                                        notification.blockNumber(),
+                                        10,
+                                        notification.source()));
+                        backfillLatch.countDown();
+
+                        // Add the block number to the historical block facility's available blocks
+                        // since next iteration we will only fill remaining blocks
+                        SimpleBlockRangeSet newRange =
+                                ((SimpleBlockRangeSet) historicalBlockFacility.availableBlocks());
+                        newRange.add(notification.blockNumber());
+                        historicalBlockFacility.setTemporaryAvailableBlocks(newRange);
+                    }
+                },
+                false,
+                "test-backfill-handler");
+
+        boolean backfillSuccess =
+                backfillLatch.await(2, TimeUnit.MINUTES); // Wait until countDownLatch.countDown() is called
+
+        // Continue with your assertions or test logic/BlockItems blockItems = mock(BlockItems.class);
+        assertTrue(backfillSuccess);
+        assertEquals(0, backfillLatch.getCount(), "Count down latch should be 0 after backfill");
+        // Verify sent verifications
+        assertEquals(
+                125,
+                blockMessaging.getSentPersistedNotifications().size(),
+                "Should have sent 125 persisted notifications");
+        assertEquals(
+                125,
+                blockMessaging.getSentVerificationNotifications().size(),
+                "Should have sent 125 verification notifications");
+
+        // clean-up after test.
+        // stop the mock servers
+        testBlockNodeServer1.stop();
+        testBlockNodeServer2.stop();
+        // Stop the plugin
+        plugin.stop();
+    }
+
+    private void createTestBlockNodeSourcesFile(BackfillSource backfillSource, String configPath) {
+        String jsonString = BackfillSource.JSON.toJSON(backfillSource);
+        // Write the JSON string to the specified file path
+        try {
+            java.nio.file.Files.write(java.nio.file.Paths.get(configPath), jsonString.getBytes());
+        } catch (java.io.IOException e) {
+            throw new RuntimeException("Failed to write config to file: " + configPath, e);
+        }
+    }
+
+    private SimpleInMemoryHistoricalBlockFacility getHistoricalBlockFacility(long startBlock, long endBlock) {
+        // Create a new historical block facility with the specified start and end blocks
+        SimpleInMemoryHistoricalBlockFacility historicalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
+        for (long i = startBlock; i <= endBlock; i++) {
+            final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
+            historicalBlockFacility.handleBlockItemsReceived(new BlockItems(List.of(block), i), false);
+        }
+        return historicalBlockFacility;
+    }
+
+    private void registerDefaultTestBackfillHandler() {
+        this.blockMessaging.registerBlockNotificationHandler(
+                new BlockNotificationHandler() {
+                    @Override
+                    public void handleBackfilled(BackfilledBlockNotification notification) {
+                        blockNodeContext
+                                .blockMessaging()
+                                .sendBlockVerification(new VerificationNotification(
+                                        true,
+                                        notification.blockNumber(),
+                                        Bytes.wrap("123"),
+                                        notification.block(),
+                                        BlockSource.BACKFILL));
+                    }
+                },
+                false,
+                "test-backfill-handler");
+    }
+
+    private void registerDefaultTestVerificationHandler(CountDownLatch countDownLatch) {
+        this.blockMessaging.registerBlockNotificationHandler(
+                new BlockNotificationHandler() {
+                    @Override
+                    public void handleVerification(VerificationNotification notification) {
+                        blockNodeContext
+                                .blockMessaging()
+                                .sendBlockPersisted(new PersistedNotification(
+                                        notification.blockNumber(),
+                                        notification.blockNumber(),
+                                        10,
+                                        notification.source()));
+                        countDownLatch.countDown();
+                    }
+                },
+                false,
+                "test-backfill-handler");
+    }
+
+    private static class BackfillConfigBuilder {
+
+        // Fields with default valuess
+        private String backfillSourcePath;
+        private int fetchBatchSize = 10;
+        private int delayBetweenBatchesMs = 100;
+        private int initialDelayMs = 1000;
+        private int initialRetryDelayMs = 1000;
+        private int maxRetries = 3;
+        private int scanIntervalMs = 60000; // 60 seconds
+        private long startBlock = 0L;
+        private long endBlock = -1L; // -1 means no end block, backfill until the latest block
+
+        private BackfillConfigBuilder() {
+            // private to force use of NewBuilder()
+        }
+
+        public static BackfillConfigBuilder NewBuilder() {
+            return new BackfillConfigBuilder();
+        }
+
+        public BackfillConfigBuilder backfillSourcePath(String path) {
+            this.backfillSourcePath = path;
+            return this;
+        }
+
+        public BackfillConfigBuilder fetchBatchSize(int value) {
+            this.fetchBatchSize = value;
+            return this;
+        }
+
+        public BackfillConfigBuilder delayBetweenBatchesMs(int value) {
+            this.delayBetweenBatchesMs = value;
+            return this;
+        }
+
+        public BackfillConfigBuilder initialDelayMs(int value) {
+            this.initialDelayMs = value;
+            return this;
+        }
+
+        public BackfillConfigBuilder initialRetryDelayMs(int value) {
+            this.initialRetryDelayMs = value;
+            return this;
+        }
+
+        public BackfillConfigBuilder maxRetries(int value) {
+            this.maxRetries = value;
+            return this;
+        }
+
+        public BackfillConfigBuilder scanIntervalMs(int value) {
+            this.scanIntervalMs = value;
+            return this;
+        }
+
+        public BackfillConfigBuilder startBlock(long value) {
+            this.startBlock = value;
+            return this;
+        }
+
+        public BackfillConfigBuilder endBlock(long value) {
+            this.endBlock = value;
+            return this;
+        }
+
+        public Map<String, String> build() {
+            if (backfillSourcePath == null || backfillSourcePath.isBlank()) {
+                throw new IllegalStateException("backfillSourcePath is required");
+            }
+
+            return Map.of(
+                    "backfill.blockNodeSourcesPath", backfillSourcePath,
+                    "backfill.fetchBatchSize", String.valueOf(fetchBatchSize),
+                    "backfill.delayBetweenBatchesMs", String.valueOf(delayBetweenBatchesMs),
+                    "backfill.initialDelayMs", String.valueOf(initialDelayMs),
+                    "backfill.initialRetryDelayMs", String.valueOf(initialRetryDelayMs),
+                    "backfill.maxRetries", String.valueOf(maxRetries),
+                    "backfill.scanIntervalMs", String.valueOf(scanIntervalMs),
+                    "backfill.startBlock", String.valueOf(startBlock),
+                    "backfill.endBlock", String.valueOf(endBlock));
+        }
     }
 }

--- a/block-node/backfill/src/test/resources/block-nodes-2.json
+++ b/block-node/backfill/src/test/resources/block-nodes-2.json
@@ -1,8 +1,0 @@
-{
-  "nodes": [
-    { "address": "node2.example.com", "port": 8082, "priority": 1 },
-    { "address": "localhost", "port": 8082, "priority": 1 },
-    { "address": "localhost", "port": 8081, "priority": 2 }
-
-  ]
-}

--- a/block-node/backfill/src/test/resources/block-nodes-3.json
+++ b/block-node/backfill/src/test/resources/block-nodes-3.json
@@ -1,5 +1,0 @@
-{
-  "nodes": [
-    { "address": "node2.example.com", "port": 8082, "priority": 1 }
-  ]
-}

--- a/block-node/backfill/src/test/resources/block-nodes.json
+++ b/block-node/backfill/src/test/resources/block-nodes.json
@@ -1,8 +1,8 @@
 {
   "nodes": [
-    { "address": "localhost", "port": 8081, "priority": 1 },
-    { "address": "node2.example.com", "port": 8082, "priority": 2 },
-    { "address": "node3.example.com", "port": 8083, "priority": 2 },
-    { "address": "node4.example.com", "port": 8084, "priority": 2 }
+    { "address": "localhost", "port": 40800, "priority": 1 },
+    { "address": "node2.example.com", "port": 40902, "priority": 2 },
+    { "address": "node3.example.com", "port": 40903, "priority": 2 },
+    { "address": "node4.example.com", "port": 40904, "priority": 3 }
   ]
 }

--- a/block-node/messaging/src/main/java/org/hiero/block/node/messaging/BlockNotificationRingEvent.java
+++ b/block-node/messaging/src/main/java/org/hiero/block/node/messaging/BlockNotificationRingEvent.java
@@ -2,6 +2,7 @@
 package org.hiero.block.node.messaging;
 
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
+import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 
@@ -15,6 +16,8 @@ public class BlockNotificationRingEvent {
     private PersistedNotification persistedNotification;
     /** The Backfilled block notification to be published to downstream subscribers through the LMAX Disruptor. */
     private BackfilledBlockNotification backfilledBlockNotification;
+    /** The Newest block known to network notification to be published to downstream subscribers through the LMAX Disruptor. */
+    private NewestBlockKnownToNetworkNotification newestBlockKnownToNetworkNotification;
 
     /** Constructor for the BlockNotificationRingEvent class. */
     public BlockNotificationRingEvent() {}
@@ -28,6 +31,7 @@ public class BlockNotificationRingEvent {
         this.verificationNotification = verificationNotification;
         this.persistedNotification = null;
         this.backfilledBlockNotification = null;
+        this.newestBlockKnownToNetworkNotification = null;
     }
 
     /**
@@ -39,6 +43,7 @@ public class BlockNotificationRingEvent {
         this.verificationNotification = null;
         this.persistedNotification = persistedNotification;
         this.backfilledBlockNotification = null;
+        this.newestBlockKnownToNetworkNotification = null;
     }
 
     /**
@@ -48,6 +53,14 @@ public class BlockNotificationRingEvent {
      */
     public void set(final BackfilledBlockNotification backfilledBlockNotification) {
         this.backfilledBlockNotification = backfilledBlockNotification;
+        this.verificationNotification = null;
+        this.persistedNotification = null;
+        this.newestBlockKnownToNetworkNotification = null;
+    }
+
+    public void set(final NewestBlockKnownToNetworkNotification newestBlockKnownToNetworkNotification) {
+        this.newestBlockKnownToNetworkNotification = newestBlockKnownToNetworkNotification;
+        this.backfilledBlockNotification = null;
         this.verificationNotification = null;
         this.persistedNotification = null;
     }
@@ -80,5 +93,15 @@ public class BlockNotificationRingEvent {
      */
     public BackfilledBlockNotification getBackfilledBlockNotification() {
         return backfilledBlockNotification;
+    }
+
+    /**
+     * Gets the newest block known to network notification of the event from the LMAX Disruptor on the consumer side. If
+     * the event is a verification, persisted or backfilled block notification, this will return null.
+     *
+     * @return the value of the event
+     */
+    public NewestBlockKnownToNetworkNotification getNewestBlockKnownToNetworkNotification() {
+        return newestBlockKnownToNetworkNotification;
     }
 }

--- a/block-node/messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationRingEventTest.java
+++ b/block-node/messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationRingEventTest.java
@@ -8,6 +8,7 @@ import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.messaging.BlockNotificationRingEvent;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
+import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.junit.jupiter.api.DisplayName;
@@ -45,6 +46,9 @@ class BlockNotificationRingEventTest {
         assertEquals(notification, event.getVerificationNotification());
         assertNull(event.getPersistedNotification(), "Persisted notification should be null");
         assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
+        assertNull(
+                event.getNewestBlockKnownToNetworkNotification(),
+                "Newest block known to network notification should be null");
     }
 
     /**
@@ -61,6 +65,9 @@ class BlockNotificationRingEventTest {
         assertEquals(notification, event.getPersistedNotification());
         assertNull(event.getVerificationNotification(), "Verification notification should be null");
         assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
+        assertNull(
+                event.getNewestBlockKnownToNetworkNotification(),
+                "Newest block known to network notification should be null");
     }
 
     /**
@@ -78,6 +85,26 @@ class BlockNotificationRingEventTest {
         assertEquals(notification, event.getBackfilledBlockNotification());
         assertNull(event.getVerificationNotification(), "Verification notification should be null");
         assertNull(event.getPersistedNotification(), "Persisted notification should be null");
+        assertNull(
+                event.getNewestBlockKnownToNetworkNotification(),
+                "Newest block known to network notification should be null");
+    }
+
+    /**
+     * Tests setting and getting a backfilled notification.
+     */
+    @Test
+    @DisplayName("Should set and get NewestBlockKnownToNetworkNotification notification correctly")
+    void shouldSetAndGetNewestBlockKnownToNetworkNotification() {
+        final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
+        final NewestBlockKnownToNetworkNotification notification = new NewestBlockKnownToNetworkNotification(10L);
+
+        event.set(notification);
+
+        assertEquals(notification, event.getNewestBlockKnownToNetworkNotification());
+        assertNull(event.getVerificationNotification(), "Verification notification should be null");
+        assertNull(event.getPersistedNotification(), "Persisted notification should be null");
+        assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
     }
 
     /**

--- a/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
+++ b/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
@@ -80,6 +80,14 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
     void sendBackfilledBlockNotification(BackfilledBlockNotification notification);
 
     /**
+     * Use this method to notify the system about a new block known to the network.
+     * This is used to inform the system that a new block header is known to the network,
+     * and our node should attempt to get up to date with the latest block.
+     * @param notification the notification containing the block number.
+     */
+    void sendNewestBlockKnownToNetwork(NewestBlockKnownToNetworkNotification notification);
+
+    /**
      * Use this method to register a block notification handler. The handler will be called every time new block
      * notifications arrive. The calls will be on its own thread, every handler registered has its own thread. It can
      * consume block notifications at its own pace, if it is too slow then it will apply back pressure to block

--- a/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockNotificationHandler.java
+++ b/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockNotificationHandler.java
@@ -34,4 +34,12 @@ public interface BlockNotificationHandler {
      * @param notification the backfilled block notification to handle
      */
     default void handleBackfilled(BackfilledBlockNotification notification) {}
+
+    /**
+     * Handle a new block known to the network notification. Always called on handler thread. Each registered handler
+     * will have its own virtual thread.
+     *
+     * @param notification the new block known to the network notification to handle
+     */
+    default void handleNewestBlockKnownToNetwork(NewestBlockKnownToNetworkNotification notification) {}
 }

--- a/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/NewestBlockKnownToNetworkNotification.java
+++ b/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/NewestBlockKnownToNetworkNotification.java
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.blockmessaging;
+
+public record NewestBlockKnownToNetworkNotification(long blockNumber) {}

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -24,11 +24,13 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.atomic.AtomicLong;
+import org.hiero.block.api.PublishStreamRequest;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.internal.BlockItemSetUnparsed;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
+import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.hiero.block.node.spi.threading.ThreadPoolManager;
@@ -250,6 +252,47 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         return threadManager
                 .getVirtualThreadExecutor()
                 .submit(new MessagingForwarderTask(serverContext, this, queueByBlockMap));
+    }
+
+    /***
+     * todo(1236) Temporal method to handle end of stream specifically to test On-Demand backfill.
+     * This should be improved and completed by 1236.
+     */
+    @Override
+    public void handleEndStreamRequest(final PublishStreamRequest.EndStream endStream) {
+        PublishStreamRequest.EndStream.Code endStreamCode = endStream.endCode();
+        long endStreamLatestBlockNumber = endStream.latestBlockNumber();
+        long endStreamEarliestBlockNumber = endStream.earliestBlockNumber();
+
+        // log the end stream received
+        LOGGER.log(
+                TRACE,
+                "Received end stream request with code: {0}, latest block number: {1}, earliest block number: {2}",
+                endStreamCode,
+                endStreamLatestBlockNumber,
+                endStreamEarliestBlockNumber);
+
+        // Handle too far behind case
+        if (endStreamCode.equals(PublishStreamRequest.EndStream.Code.TOO_FAR_BEHIND)) {
+            // make sure we are really behind?
+            if (endStreamLatestBlockNumber <= getLatestBlockNumber()) {
+                // No need to do anything, we are not really behind.
+                return;
+            }
+
+            // create a NewestBlockKnownToNetwork and sent it to the messaging facility
+            NewestBlockKnownToNetworkNotification notification =
+                    new NewestBlockKnownToNetworkNotification(endStreamLatestBlockNumber);
+
+            // send the notification
+            serverContext.blockMessaging().sendNewestBlockKnownToNetwork(notification);
+
+            // log the newest block known to network
+            LOGGER.log(
+                    TRACE,
+                    "Attempted to recover from TOO_FAR_BEHIND end stream request, latest block number: {0}, sending NewestBlockKnownToNetworkNotification",
+                    endStreamLatestBlockNumber);
+        }
     }
 
     @Override

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -154,6 +154,10 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
             }
         } else if (request.hasEndStream()) {
             // @todo(1236) handle an endStream potentially received from publisher, for now we simply shutdown
+
+            // handle end stream request
+            publisherManager.handleEndStreamRequest(request.endStream());
+
             shutdown();
         } else {
             // this should never happen

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
@@ -5,6 +5,7 @@ import com.hedera.hapi.block.stream.BlockProof;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import org.hiero.block.api.PublishStreamRequest;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 
@@ -56,6 +57,8 @@ public interface StreamPublisherManager extends BlockNotificationHandler {
      * @return the latest known valid and persisted block number.
      */
     long getLatestBlockNumber();
+
+    void handleEndStreamRequest(PublishStreamRequest.EndStream endStream);
 
     /**
      * The action to take within the PublisherHandler for a block.

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
@@ -5,7 +5,6 @@ import com.hedera.hapi.block.stream.BlockProof;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import org.hiero.block.api.PublishStreamRequest;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 
@@ -58,7 +57,15 @@ public interface StreamPublisherManager extends BlockNotificationHandler {
      */
     long getLatestBlockNumber();
 
-    void handleEndStreamRequest(PublishStreamRequest.EndStream endStream);
+    /**
+     * Notify the publisher manager that they are too far behind the latest block number.
+     * <p>
+     * This is used to notify the system that they are too far behind the latest
+     * block number and should take appropriate action.
+     *
+     * @param newestKnownBlockNumber the newest known block number
+     */
+    void notifyTooFarBehind(final long newestKnownBlockNumber);
 
     /**
      * The action to take within the PublisherHandler for a block.

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestStreamPublisherManager.java
@@ -9,6 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.hiero.block.api.PublishStreamRequest;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
@@ -73,6 +74,11 @@ public class TestStreamPublisherManager implements StreamPublisherManager {
     @Override
     public long getLatestBlockNumber() {
         return latestBlockNumber;
+    }
+
+    @Override
+    public void handleEndStreamRequest(PublishStreamRequest.EndStream endStream) {
+        // Do nothing.
     }
 
     @Override

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestStreamPublisherManager.java
@@ -9,7 +9,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import org.hiero.block.api.PublishStreamRequest;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
@@ -77,7 +76,7 @@ public class TestStreamPublisherManager implements StreamPublisherManager {
     }
 
     @Override
-    public void handleEndStreamRequest(PublishStreamRequest.EndStream endStream) {
+    public void notifyTooFarBehind(long newestKnownBlockNumber) {
         // Do nothing.
     }
 


### PR DESCRIPTION
- Added On-Demand Backfill flow
- Modified Backfill plugin to support both flows to run at the same time.
- Improved UTs to make them simpler and less repetitive, also improved reliability and all tests are 100% independent from one another.
- Added several new UTs related to Backfilling
- Allowed for partial chunks to be fetched instead of the complete batch (however this will required several scan iterations to complete a batch in certain scenarios)
- Added a new UT where a single gap has to be fetched from several BNs. 
- Modified publisherHandler to add capability to handle `TOO_FAR_BEHIND`, *EndStream* type message Request.
- Gave publisher MessagingFacility to be able to send Notifications. (minimal modifications of tests)
- Added missing metrics for new Block notifications types

Fixes #1355 