### PR TITLE
test: add test for DUPLICATE_BLOCK status with starting block number 0

### DIFF
--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
@@ -419,6 +419,7 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
     private static Stream<Arguments> provideDataForErrorResponses() {
         return Stream.of(
                 Arguments.of(Map.of("generator.startBlockNumber", Long.toString(15)), "status: BEHIND"),
-                Arguments.of(Map.of("generator.startBlockNumber", Long.toString(4)), "status: DUPLICATE_BLOCK"));
+                Arguments.of(Map.of("generator.startBlockNumber", Long.toString(4)), "status: DUPLICATE_BLOCK"),
+                Arguments.of(Map.of("generator.startBlockNumber", Long.toString(0)), "status: DUPLICATE_BLOCK"));
     }
 }


### PR DESCRIPTION
## Reviewer Notes

>At another test the BN was already with 23 blocks, and CN attempted to send block 0.
>BN responded with BEHIND, when we should have expected to respond with Duplicate Block.

Verifying that the bug is not reproducible with a test.

## Related Issue(s)
Closes #1449 
