### PR TITLE
fix: Setting property generator.endBlockNumber is not stopping simulator

### DIFF
--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/CraftBlockStreamManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/CraftBlockStreamManager.java
@@ -57,6 +57,7 @@ public class CraftBlockStreamManager implements BlockStreamManager {
     private final int minTransactionsPerEvent;
     private final int maxTransactionsPerEvent;
     private final boolean invalidBlockHash;
+    private final int endBlockNumber;
 
     // State
     private final GenerationMode generationMode;
@@ -95,6 +96,7 @@ public class CraftBlockStreamManager implements BlockStreamManager {
         this.minTransactionsPerEvent = blockGeneratorConfig.minTransactionsPerEvent();
         this.maxTransactionsPerEvent = blockGeneratorConfig.maxTransactionsPerEvent();
         this.invalidBlockHash = blockGeneratorConfig.invalidBlockHash();
+        this.endBlockNumber = blockGeneratorConfig.endBlockNumber();
         this.random = new Random();
         this.previousStateRootHash = new byte[StreamingTreeHasher.HASH_LENGTH];
         this.currentBlockHash = new byte[StreamingTreeHasher.HASH_LENGTH];
@@ -162,6 +164,10 @@ public class CraftBlockStreamManager implements BlockStreamManager {
      */
     @Override
     public Block getNextBlock() throws IOException, BlockSimulatorParsingException {
+        if (endBlockNumber > 0 && currentBlockNumber > endBlockNumber) {
+            return null;
+        }
+
         if (unorderedStreamingEnabled) {
             if (unorderedStreamIterator.hasNext()) {
                 return unorderedStreamIterator.next();

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/CraftBlockStreamManagerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/CraftBlockStreamManagerTest.java
@@ -4,6 +4,7 @@ package org.hiero.block.simulator.generator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -61,6 +62,17 @@ class CraftBlockStreamManagerTest {
         assertThrows(
                 NullPointerException.class,
                 () -> new CraftBlockStreamManager(generatorConfigMock, startupDataMock, null));
+    }
+
+    @Test
+    void testEndBlockNumber() throws BlockSimulatorParsingException, IOException {
+        Mockito.when(generatorConfigMock.endBlockNumber()).thenReturn(3);
+        manager = new CraftBlockStreamManager(generatorConfigMock, startupDataMock, unorderedStreamConfigMock);
+        final Block block2 = manager.getNextBlock();
+        final Block block3 = manager.getNextBlock();
+        assertNotNull(block2);
+        assertNotNull(block3);
+        assertNull(manager.getNextBlock());
     }
 
     @Test


### PR DESCRIPTION
## Reviewer Notes

Setting the property `generator.endBlockNumber` prevents the simulator from continuing to stream blocks indefinitely.

## Related Issue(s)
Fixes #1459 
