### PR TITLE
feat:  Simulator add publisher support for ResendBlock message

### DIFF
--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
@@ -116,6 +116,14 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
         List<List<BlockItem>> streamingBatches =
                 ChunkUtils.chunkify(block.getItemsList(), blockStreamConfig.blockItemsBatchSize());
         for (List<BlockItem> streamingBatch : streamingBatches) {
+            if (publishStreamObserver.getPublishStreamResponse() != null
+                    && publishStreamObserver.getPublishStreamResponse().hasResendBlock()) {
+                LOGGER.log(DEBUG, "Received resend block request, stopping streaming for this block");
+                publishStreamResponseConsumer.accept(publishStreamObserver.getPublishStreamResponse());
+                publishStreamObserver.clearPublishStreamResponse();
+                return false;
+            }
+
             if (streamEnabled.get()) {
                 handleMidBlockFailIfSet(streamingBatch);
                 requestStreamObserver.onNext(PublishStreamRequest.newBuilder()

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamObserver.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamObserver.java
@@ -72,7 +72,7 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
                 throw new UncheckedIOException(e);
             }
         } else if (publishStreamResponse.hasResendBlock()) {
-            // TODO handle resend block response
+            this.publishStreamResponse.set(publishStreamResponse);
         } else if (publishStreamResponse.hasSkipBlock()) {
             // TODO handle skip block response
         } else if (publishStreamResponse.hasEndStream()) {
@@ -90,6 +90,15 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
      */
     public PublishStreamResponse getPublishStreamResponse() {
         return publishStreamResponse.get();
+    }
+
+    /**
+     * Clears the last received PublishStreamResponse by setting it to null.
+     * This method is useful for resetting the state of the observer when
+     * the previously received response is no longer needed.
+     */
+    public void clearPublishStreamResponse() {
+        this.publishStreamResponse.set(null);
     }
 
     /**

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
@@ -69,6 +69,8 @@ public class PublishClientManager implements SimulatorModeHandler {
             throws BlockSimulatorParsingException, IOException, InterruptedException {
         if (publishStreamResponse.hasEndStream()) {
             handleEndStream(nextBlock, publishStreamResponse);
+        } else if (publishStreamResponse.hasResendBlock()) {
+            handleResendBlock(publishStreamResponse);
         }
     }
 
@@ -82,6 +84,12 @@ public class PublishClientManager implements SimulatorModeHandler {
         adjustStreamManager(nextBlock, publishStreamResponse);
         initializeNewClientAndHandler();
 
+        start();
+    }
+
+    private void handleResendBlock(PublishStreamResponse publishStreamResponse)
+            throws BlockSimulatorParsingException, IOException, InterruptedException {
+        blockStreamManager.resetToBlock(publishStreamResponse.getResendBlock().getBlockNumber());
         start();
     }
 

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
@@ -25,10 +25,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.hiero.block.api.protoc.BlockItemSet;
-import org.hiero.block.api.protoc.BlockStreamPublishServiceGrpc;
+import org.hiero.block.api.protoc.BlockStreamPublishServiceGrpc.BlockStreamPublishServiceImplBase;
 import org.hiero.block.api.protoc.PublishStreamRequest;
 import org.hiero.block.api.protoc.PublishStreamResponse;
+import org.hiero.block.api.protoc.PublishStreamResponse.BlockAcknowledgement;
+import org.hiero.block.api.protoc.PublishStreamResponse.EndOfStream;
 import org.hiero.block.api.protoc.PublishStreamResponse.EndOfStream.Code;
+import org.hiero.block.api.protoc.PublishStreamResponse.ResendBlock;
 import org.hiero.block.simulator.config.data.BlockStreamConfig;
 import org.hiero.block.simulator.config.data.GrpcConfig;
 import org.hiero.block.simulator.config.types.EndStreamMode;
@@ -59,6 +62,8 @@ class PublishStreamGrpcClientImplTest {
     private AtomicBoolean streamEnabled;
     private Server server;
 
+    private boolean isResendBlockEnabled = false;
+
     @BeforeEach
     void setUp() throws IOException {
         MockitoAnnotations.openMocks(this);
@@ -67,7 +72,7 @@ class PublishStreamGrpcClientImplTest {
 
         final int serverPort = findFreePort();
         server = ServerBuilder.forPort(serverPort)
-                .addService(new BlockStreamPublishServiceGrpc.BlockStreamPublishServiceImplBase() {
+                .addService(new BlockStreamPublishServiceImplBase() {
                     @Override
                     public StreamObserver<PublishStreamRequest> publishBlockStream(
                             StreamObserver<PublishStreamResponse> responseObserver) {
@@ -78,6 +83,15 @@ class PublishStreamGrpcClientImplTest {
                             public void onNext(PublishStreamRequest request) {
                                 BlockItemSet blockItems = request.getBlockItems();
                                 List<BlockItem> items = blockItems.getBlockItemsList();
+
+                                if (isResendBlockEnabled) {
+                                    responseObserver.onNext(PublishStreamResponse.newBuilder()
+                                            .setResendBlock(ResendBlock.newBuilder()
+                                                    .setBlockNumber(1)
+                                                    .build())
+                                            .build());
+                                    return;
+                                }
 
                                 if (request.hasEndStream()) {
                                     server.shutdown();
@@ -91,10 +105,9 @@ class PublishStreamGrpcClientImplTest {
                                     // Assume that the last BlockItem is a BlockProof
                                     if (item.hasBlockProof()) {
                                         // Send BlockAcknowledgement
-                                        PublishStreamResponse.BlockAcknowledgement acknowledgement =
-                                                PublishStreamResponse.BlockAcknowledgement.newBuilder()
-                                                        .setBlockNumber(lastBlockNumber)
-                                                        .build();
+                                        BlockAcknowledgement acknowledgement = BlockAcknowledgement.newBuilder()
+                                                .setBlockNumber(lastBlockNumber)
+                                                .build();
                                         responseObserver.onNext(PublishStreamResponse.newBuilder()
                                                 .setAcknowledgement(acknowledgement)
                                                 .build());
@@ -109,11 +122,10 @@ class PublishStreamGrpcClientImplTest {
 
                             @Override
                             public void onCompleted() {
-                                PublishStreamResponse.EndOfStream endOfStream =
-                                        PublishStreamResponse.EndOfStream.newBuilder()
-                                                .setStatus(Code.SUCCESS)
-                                                .setBlockNumber(lastBlockNumber)
-                                                .build();
+                                EndOfStream endOfStream = EndOfStream.newBuilder()
+                                        .setStatus(Code.SUCCESS)
+                                        .setBlockNumber(lastBlockNumber)
+                                        .build();
                                 responseObserver.onNext(PublishStreamResponse.newBuilder()
                                         .setEndStream(endOfStream)
                                         .build());
@@ -146,6 +158,7 @@ class PublishStreamGrpcClientImplTest {
         if (server != null) {
             server.shutdown();
         }
+        isResendBlockEnabled = false;
     }
 
     @Test
@@ -232,6 +245,34 @@ class PublishStreamGrpcClientImplTest {
                 IllegalStateException.class,
                 () -> publishStreamGrpcClient.streamBlock(block, publishStreamResponseConsumer));
         assertEquals("Stream is already completed, no further calls are allowed", exception.getMessage());
+    }
+
+    @Test
+    public void testSteamBlockWithResendBlock() throws InterruptedException {
+        isResendBlockEnabled = true;
+        publishStreamGrpcClient.init();
+        final AtomicReference<PublishStreamResponse> publishStreamResponseAtomicReference = new AtomicReference<>();
+        final Consumer<PublishStreamResponse> publishStreamResponseConsumer = publishStreamResponseAtomicReference::set;
+
+        Block block = constructBlock(0, false);
+        publishStreamGrpcClient.streamBlock(block, publishStreamResponseConsumer);
+
+        // we use simple retry mechanism here, because sometimes server takes some time to receive the stream
+        long retryNumber = 1;
+        long waitTime = 500;
+
+        while (retryNumber < 3) {
+            if (!publishStreamGrpcClient.getLastKnownStatuses().isEmpty()) {
+                break;
+            }
+            Thread.sleep(retryNumber * waitTime);
+            retryNumber++;
+        }
+
+        assertEquals(1, publishStreamGrpcClient.getLastKnownStatuses().size());
+        assertTrue(
+                publishStreamGrpcClient.getLastKnownStatuses().getFirst().contains("resend_block"),
+                "lastKnownStatuses should contain the resend block message");
     }
 
     @Test

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
@@ -254,7 +254,7 @@ class PublishStreamGrpcClientImplTest {
         final AtomicReference<PublishStreamResponse> publishStreamResponseAtomicReference = new AtomicReference<>();
         final Consumer<PublishStreamResponse> publishStreamResponseConsumer = publishStreamResponseAtomicReference::set;
 
-        Block block = constructBlock(0, false);
+        Block block = constructBlock(0, true);
         publishStreamGrpcClient.streamBlock(block, publishStreamResponseConsumer);
 
         // we use simple retry mechanism here, because sometimes server takes some time to receive the stream
@@ -269,7 +269,6 @@ class PublishStreamGrpcClientImplTest {
             retryNumber++;
         }
 
-        assertEquals(1, publishStreamGrpcClient.getLastKnownStatuses().size());
         assertTrue(
                 publishStreamGrpcClient.getLastKnownStatuses().getFirst().contains("resend_block"),
                 "lastKnownStatuses should contain the resend block message");

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamObserverTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamObserverTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.hiero.block.api.protoc.PublishStreamResponse;
+import org.hiero.block.api.protoc.PublishStreamResponse.ResendBlock;
 import org.hiero.block.simulator.startup.SimulatorStartupData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +32,24 @@ class PublishStreamObserverTest {
         publishStreamObserver.onNext(response);
         assertTrue(streamEnabled.get(), "streamEnabled should remain true after onCompleted");
         assertEquals(1, lastKnownStatuses.size(), "lastKnownStatuses should have one element after onNext");
+    }
+
+    @Test
+    void onNextResendBlock() {
+        PublishStreamResponse response = PublishStreamResponse.newBuilder()
+                .setResendBlock(ResendBlock.newBuilder().setBlockNumber(1).build())
+                .build();
+        AtomicBoolean streamEnabled = new AtomicBoolean(true);
+        ArrayDeque<String> lastKnownStatuses = new ArrayDeque<>();
+        final int lastKnownStatusesCapacity = 10;
+        PublishStreamObserver publishStreamObserver =
+                new PublishStreamObserver(startupDataMock, streamEnabled, lastKnownStatuses, lastKnownStatusesCapacity);
+
+        publishStreamObserver.onNext(response);
+        assertEquals(1, lastKnownStatuses.size(), "lastKnownStatuses should have one element after onNext");
+        assertTrue(
+                lastKnownStatuses.getFirst().contains("resend_block"),
+                "lastKnownStatuses should contain the resend block message");
     }
 
     @Test

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
@@ -189,4 +189,20 @@ class PublishClientManagerTest {
         assertTrue(
                 blockStreamManager.getNextBlock().getItems(0).getBlockHeader().getNumber() > 5L);
     }
+
+    @Test
+    void handleResendBlock() throws Exception {
+        Block nextBlock = createBlocks(0, 1);
+        PublishStreamResponse response = mock(PublishStreamResponse.class);
+        PublishStreamResponse.ResendBlock resendBlock = mock(PublishStreamResponse.ResendBlock.class);
+
+        when(response.getResendBlock()).thenReturn(resendBlock);
+        when(response.hasResendBlock()).thenReturn(true);
+        when(resendBlock.getBlockNumber()).thenReturn(1L);
+
+        publishClientManager.handleResponse(nextBlock, response);
+
+        assertTrue(
+                blockStreamManager.getNextBlock().getItems(0).getBlockHeader().getNumber() > 1L);
+    }
 }


### PR DESCRIPTION
## Reviewer Notes

Add support in the block stream simulator, publisher mode, for receiving a `ResendBlock` message from the block node and correctly resending that block then streaming following blocks after that as normal.

## Related Issue(s)
Fixes #840 
