### PR TITLE
feat: Multi-Publisher Responds with `BAD_BLOCK_PROOF` if Verification Fails

### DIFF
--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestResponsePipeline.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestResponsePipeline.java
@@ -2,9 +2,9 @@
 package org.hiero.block.node.stream.publisher.fixtures;
 
 import com.hedera.pbj.runtime.grpc.Pipeline;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hiero.block.api.PublishStreamResponse;
@@ -17,9 +17,9 @@ import org.hiero.block.api.PublishStreamResponse;
 public class TestResponsePipeline implements Pipeline<PublishStreamResponse> {
     private final AtomicInteger clientEndStreamCalls = new AtomicInteger(0);
     private final AtomicInteger onCompleteCalls = new AtomicInteger(0);
-    private final List<PublishStreamResponse> onNextCalls = new ArrayList<>();
-    private final List<Subscription> onSubscriptionCalls = new ArrayList<>();
-    private final List<Throwable> onErrorCalls = new ArrayList<>();
+    private final List<PublishStreamResponse> onNextCalls = new CopyOnWriteArrayList<>();
+    private final List<Subscription> onSubscriptionCalls = new CopyOnWriteArrayList<>();
+    private final List<Throwable> onErrorCalls = new CopyOnWriteArrayList<>();
 
     @Override
     public void clientEndStreamReceived() {
@@ -64,5 +64,16 @@ public class TestResponsePipeline implements Pipeline<PublishStreamResponse> {
 
     public List<Throwable> getOnErrorCalls() {
         return onErrorCalls;
+    }
+
+    /**
+     * Fixture method, clears all recorded calls.
+     */
+    public void clear() {
+        clientEndStreamCalls.set(0);
+        onCompleteCalls.set(0);
+        onNextCalls.clear();
+        onSubscriptionCalls.clear();
+        onErrorCalls.clear();
     }
 }


### PR DESCRIPTION
## Reviewer Notes

* Added wrapping logic for calling onNext on the response pipeline
* Added a way to track and determine if a given handler has streamed a given block number
* Added logic to send BAD_BLOCK_PROOF
* Added logic to flush queues in case of a failed verification
* Added descriptive documentation
* Added tests:
  * LiveStreamPublisherManagerTest:
    * Added tests for no activity if handle condition does not pass
    * Added tests for BAD_BLOCK_PROOF sent to publisher that published the failed block
    * Added tests for RESEND sent to publishers that did not publish the failed block
    * Added tests for continued normal operation after a failed block proof
  * PublisherHandlerTest:
    * Added tests for BAD_BLOCK_PROOF when publisher has streamed the failed block
    * Added tests for RESEND when publisher has not streamed the failed block

## Related Issue(s)

Closes #1422 
