### PR TITLE
test(messaging): Fix broken test on main

### DIFF
--- a/block-node/messaging/src/test/java/org/hiero/block/server/messaging/BlockMessagingFacilityExceptionTest.java
+++ b/block-node/messaging/src/test/java/org/hiero/block/server/messaging/BlockMessagingFacilityExceptionTest.java
@@ -43,7 +43,7 @@ public class BlockMessagingFacilityExceptionTest {
         System.out.println("logger = " + logger);
         logHandler = new TestLogHandler();
         logger.addHandler(logHandler);
-        logger.setLevel(java.util.logging.Level.ALL);
+        logger.setLevel(java.util.logging.Level.INFO);
     }
 
     /**


### PR DESCRIPTION
## Reviewer Notes

This test did not really broke, and it passed on the PR that broke it, since sometimes it does pass, but most of the time, fails.

By Setting the logger to INFO, we ignore the TRACE level logs and the assertions are able to find the logs that they are expecting to see when an exception happens.

## Related Issue(s)
Fixes #1470