### PR TITLE
feat: Add Support to Stream-Publisher for Handling `EndStream` Messages

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
@@ -44,6 +44,9 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
     private final List<VerificationNotification> sentVerificationNotifications = new CopyOnWriteArrayList<>();
     /** list of all sent block persistence notifications */
     private final List<PersistedNotification> sentPersistedNotifications = new CopyOnWriteArrayList<>();
+    /** List of all sent backfilled block notifications */
+    private final List<NewestBlockKnownToNetworkNotification> sentNewestBlockKnownToNetworkNotifications =
+            new CopyOnWriteArrayList<>();
     /** Set of handlers for which we must simulate a handler that is behind and producing backpressure. */
     private final Set<BlockItemHandler> handlersWithBackpressure =
             new ConcurrentSkipListSet<>(Comparator.comparingInt(Object::hashCode));
@@ -73,6 +76,15 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
      */
     public List<PersistedNotification> getSentPersistedNotifications() {
         return sentPersistedNotifications;
+    }
+
+    /**
+     * Get all backfilled block notifications sent to the block messaging facility.
+     *
+     * @return the list of sent backfilled block notifications
+     */
+    public List<NewestBlockKnownToNetworkNotification> getSentNewestBlockKnownToNetworkNotifications() {
+        return sentNewestBlockKnownToNetworkNotifications;
     }
 
     /**
@@ -229,6 +241,7 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
     @Override
     public void sendNewestBlockKnownToNetwork(NewestBlockKnownToNetworkNotification notification) {
         LOGGER.log(Level.TRACE, "Sending NewestBlockKnownToNetworkNotification block notification " + notification);
+        sentNewestBlockKnownToNetworkNotifications.add(notification);
         for (BlockNotificationHandler handler : blockNotificationHandlers) {
             handler.handleNewestBlockKnownToNetwork(notification);
         }

--- a/block-node/block-providers/files.recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlocksFilesRecentPlugin.java
+++ b/block-node/block-providers/files.recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlocksFilesRecentPlugin.java
@@ -247,23 +247,25 @@ public final class BlocksFilesRecentPlugin implements BlockProviderPlugin, Block
      */
     @Override
     public void handleVerification(VerificationNotification notification) {
-        // write the block to the live path and send notification of block persisted
-        writeBlockToLivePath(notification.block(), notification.blockNumber(), notification.source());
-        // we do a round of retention only if the retention threshold is set to
-        // a positive value, otherwise we do not run it
-        if (blockRetentionThreshold > 0L) {
-            // after writing the block, we need to trigger the retention policy
-            // calculate excess
-            final long excess = availableBlocks.size() - blockRetentionThreshold;
-            final long firstBlockToDelete = availableBlocks.min();
-            // determine how many blocks to delete, up to the retention round limit
-            final long blocksToDelete = Math.min(excess, RETENTION_ROUND_LIMIT);
-            // delete the blocks from the lowest block number up to calculated max
-            // gaps will be retried on subsequent retention runs, which are very
-            // frequent
-            final long lastBlockToDelete = firstBlockToDelete + blocksToDelete;
-            for (long i = firstBlockToDelete; i < lastBlockToDelete; i++) {
-                delete(i);
+        if (notification.success()) {
+            // write the block to the live path and send notification of block persisted
+            writeBlockToLivePath(notification.block(), notification.blockNumber(), notification.source());
+            // we do a round of retention only if the retention threshold is set to
+            // a positive value, otherwise we do not run it
+            if (blockRetentionThreshold > 0L) {
+                // after writing the block, we need to trigger the retention policy
+                // calculate excess
+                final long excess = availableBlocks.size() - blockRetentionThreshold;
+                final long firstBlockToDelete = availableBlocks.min();
+                // determine how many blocks to delete, up to the retention round limit
+                final long blocksToDelete = Math.min(excess, RETENTION_ROUND_LIMIT);
+                // delete the blocks from the lowest block number up to calculated max
+                // gaps will be retried on subsequent retention runs, which are very
+                // frequent
+                final long lastBlockToDelete = firstBlockToDelete + blocksToDelete;
+                for (long i = firstBlockToDelete; i < lastBlockToDelete; i++) {
+                    delete(i);
+                }
             }
         }
     }

--- a/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPluginTest.java
+++ b/block-node/block-providers/files.recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPluginTest.java
@@ -122,6 +122,37 @@ class BlockFileRecentPluginTest {
         }
 
         /**
+         * Test that the plugin does not store a block if verification has
+         * failed.
+         */
+        @SuppressWarnings("DataFlowIssue")
+        @Test
+        @DisplayName("Test send/retrieve failed verification")
+        void testSendingBlockAndReadingBackFailedVerification() {
+            // create sample block of block items
+            final BlockItem[] blockBlockItems = createNumberOfVerySimpleBlocks(1);
+            final long blockNumber = blockBlockItems[0].blockHeader().number();
+            // check the block is not stored yet
+            assertNull(plugin.block(blockNumber));
+            assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().max());
+            assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().min());
+            // check if we try to read we get null as nothing is verified yet
+            assertNull(plugin.block(blockNumber));
+            assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().max());
+            assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().min());
+            // send verified block notification with failure
+            blockMessaging.sendBlockVerification(new VerificationNotification(
+                    false,
+                    blockNumber,
+                    Bytes.EMPTY,
+                    new BlockUnparsed(toBlockItemsUnparsed(blockBlockItems)),
+                    BlockSource.PUBLISHER));
+            assertNull(plugin.block(blockNumber));
+            assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().max());
+            assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().min());
+        }
+
+        /**
          * Test that the plugin works to store and retrieve a block but receive
          * verification first.
          */

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
@@ -68,6 +68,16 @@ public interface StreamPublisherManager extends BlockNotificationHandler {
     void notifyTooFarBehind(final long newestKnownBlockNumber);
 
     /**
+     * This method is called when a handler is ending in an unfinished state.
+     * This means that the block, currently streamed by this handler is not yet
+     * streamed in full.
+     *
+     * @param blockNumber the block number that has not finished streaming
+     * @param handlerId the id of the handler that is ending
+     */
+    void handlerIsEnding(final long blockNumber, final long handlerId);
+
+    /**
      * The action to take within the PublisherHandler for a block.
      */
     enum BlockAction {

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
@@ -64,7 +64,9 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
         simulators.clear();
     }
 
+    // @todo(1498)
     @Test
+    @Disabled("@todo(1498) - the test is disabled because failure is seen after block node closes connection correctly")
     @DisplayName("Publisher should send TOO_FAR_BEHIND to activate backfill on demand")
     @Timeout(30)
     public void testBackfillOnDemand() throws IOException, InterruptedException {


### PR DESCRIPTION
## Reviewer Notes

* Added handling for EndStream requests
* Added tests for end stream requests
* Improved shutdown logic to call onComplete
* Improved manager reliability when removing queues
* Disabled failing e2e test for on demand backfill
  * Opened GH issue #1498 to tackle this

## Related Issue(s)

Closes #1236
