### PR TITLE
fix: Failing `testBackfillOnDemand` After Publisher Correctly Closes Handler Connection

### DIFF
--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/mode/impl/PublishClientManager.java
@@ -80,17 +80,15 @@ public class PublishClientManager implements SimulatorModeHandler {
 
     private void handleEndStream(Block nextBlock, PublishStreamResponse publishStreamResponse)
             throws InterruptedException, BlockSimulatorParsingException, IOException {
+        stop();
+        adjustStreamManager(nextBlock, publishStreamResponse);
+        initializeNewClientAndHandler();
         if (publishStreamResponse.getEndStream().getStatus() == Code.BEHIND) {
             if (blockStreamConfig.endStreamMode() == TOO_FAR_BEHIND) {
                 currentClient.handleEndStreamModeIfSet();
                 return;
             }
         }
-
-        stop();
-        adjustStreamManager(nextBlock, publishStreamResponse);
-        initializeNewClientAndHandler();
-
         start();
     }
 

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
@@ -64,9 +64,7 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
         simulators.clear();
     }
 
-    // @todo(1498)
     @Test
-    @Disabled("@todo(1498) - the test is disabled because failure is seen after block node closes connection correctly")
     @DisplayName("Publisher should send TOO_FAR_BEHIND to activate backfill on demand")
     @Timeout(30)
     public void testBackfillOnDemand() throws IOException, InterruptedException {


### PR DESCRIPTION
## Reviewer Notes

* Fix simulator reuses closed pipeline to send messages
* Re-enabled E2E test: `testBacfkillOnDemand`

Update:
- as suspected, the issue was indeed with the simulator
  - in cases where the block node returns an `EndOfStream`, the simulator must assume that the connection is already closed and needs to open a new one before sending any new requests.
  - by reordering the end stream code handling to be after the setting up of a new connection, we are able to observe the desired result

## Related Issue(s)

Fixes #1498
