### PR TITLE
feat(proto): Update CN Proto version to latest 0.65 release

### DIFF
--- a/block-node/protobuf-pbj/src/main/java/module-info.java
+++ b/block-node/protobuf-pbj/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module org.hiero.block.protobuf.pbj {
     exports com.hedera.hapi.block.stream;
     exports com.hedera.hapi.block.stream.input;
     exports com.hedera.hapi.block.stream.output;
+    exports com.hedera.hapi.block.stream.trace;
     exports com.hedera.hapi.platform.event;
     exports com.hedera.hapi.node.base;
     exports com.hedera.hapi.node.base.codec;

--- a/protobuf-sources/build.gradle.kts
+++ b/protobuf-sources/build.gradle.kts
@@ -16,7 +16,7 @@ val generateBlockNodeProtoArtifact: TaskProvider<Exec> =
         group = "protobuf"
 
         workingDir(layout.projectDirectory)
-        val cnTagHash = "c86619410f0e0da3719c39c9447a96438200166d" // v0.63.9
+        val cnTagHash = "6d02f279f471431d6c8911a7094779c3212c3159" // v0.64.0
 
         // run build-bn-proto.sh skipping inclusion of BN API as it messes up proto considerations
         commandLine(

--- a/protobuf-sources/build.gradle.kts
+++ b/protobuf-sources/build.gradle.kts
@@ -16,7 +16,7 @@ val generateBlockNodeProtoArtifact: TaskProvider<Exec> =
         group = "protobuf"
 
         workingDir(layout.projectDirectory)
-        val cnTagHash = "6d02f279f471431d6c8911a7094779c3212c3159" // v0.64.0
+        val cnTagHash = "fc9627097d20e50fa50e460b90913e8b4f76d9da" // v0.65.0
 
         // run build-bn-proto.sh skipping inclusion of BN API as it messes up proto considerations
         commandLine(

--- a/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
+++ b/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
@@ -14,6 +14,8 @@ open module org.hiero.block.protobuf.protoc {
     exports com.hedera.hapi.platform.state.legacy;
     exports org.hiero.block.api.protoc;
     exports org.hiero.block.internal.protoc;
+    exports com.hedera.hapi.node.state.hooks.legacy;
+    exports com.hedera.hapi.node.hooks.legacy;
 
     requires transitive com.google.common;
     requires transitive com.google.protobuf;

--- a/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
+++ b/tools-and-tests/protobuf-protoc/src/main/java/module-info.java
@@ -9,6 +9,7 @@ open module org.hiero.block.protobuf.protoc {
     exports com.hedera.hapi.block.stream.protoc;
     exports com.hedera.hapi.block.stream.input.protoc;
     exports com.hedera.hapi.block.stream.output.protoc;
+    exports com.hedera.hapi.block.stream.trace.protoc;
     exports com.hedera.hapi.platform.event.legacy;
     exports com.hedera.hapi.platform.state.legacy;
     exports org.hiero.block.api.protoc;

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/itemhandler/EventHeaderHandler.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/itemhandler/EventHeaderHandler.java
@@ -26,7 +26,6 @@ public class EventHeaderHandler extends AbstractBlockItemHandler {
     private EventCore createEventCore() {
         return EventCore.newBuilder()
                 .setCreatorNodeId(generateRandomValue(1, 32))
-                .setVersion(getSemanticVersion())
                 .build();
     }
 }

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/itemhandler/EventTransactionHandler.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/generator/itemhandler/EventTransactionHandler.java
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.simulator.generator.itemhandler;
 
+import com.google.protobuf.ByteString;
 import com.hedera.hapi.block.stream.protoc.BlockItem;
-import com.hedera.hapi.platform.event.legacy.EventTransaction;
 
 /**
  * Handler for event transactions in the block stream.
@@ -13,16 +13,9 @@ public class EventTransactionHandler extends AbstractBlockItemHandler {
     public BlockItem getItem() {
         if (blockItem == null) {
             blockItem = BlockItem.newBuilder()
-                    .setEventTransaction(createEventTransaction())
+                    .setSignedTransaction(ByteString.EMPTY)
                     .build();
         }
         return blockItem;
-    }
-
-    private EventTransaction createEventTransaction() {
-        // For now, we stick with empty EventTransaction, because otherwise we need to provide encoded transaction,
-        // which we don't have.
-        // This transaction data should correspond with the results in the transaction result item and others.
-        return EventTransaction.newBuilder().build();
     }
 }

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/itemhandler/EventHeaderHandlerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/itemhandler/EventHeaderHandlerTest.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.simulator.generator.itemhandler;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -9,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.hedera.hapi.block.stream.input.protoc.EventHeader;
 import com.hedera.hapi.block.stream.protoc.BlockItem;
 import com.hedera.hapi.platform.event.legacy.EventCore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class EventHeaderHandlerTest {
@@ -26,7 +26,6 @@ class EventHeaderHandlerTest {
 
         EventCore core = header.getEventCore();
         assertTrue(core.getCreatorNodeId() >= 1 && core.getCreatorNodeId() < 32);
-        assertNotNull(core.getVersion());
     }
 
     @Test
@@ -38,13 +37,11 @@ class EventHeaderHandlerTest {
         assertSame(item1, item2, "getItem should return cached instance");
     }
 
+    // @todo(12345) need to make sense with new BlockStream protobuf Spec
+    @Disabled
     @Test
     void testSemanticVersion() {
         EventHeaderHandler handler = new EventHeaderHandler();
         EventCore core = handler.getItem().getEventHeader().getEventCore();
-
-        assertEquals(0, core.getVersion().getMajor());
-        assertEquals(1, core.getVersion().getMinor());
-        assertEquals(0, core.getVersion().getPatch());
     }
 }

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/itemhandler/EventTransactionHandlerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/generator/itemhandler/EventTransactionHandlerTest.java
@@ -6,7 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.hapi.block.stream.protoc.BlockItem;
-import com.hedera.hapi.platform.event.legacy.EventTransaction;
+import com.hedera.hapi.node.transaction.SignedTransaction;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import org.junit.jupiter.api.Test;
 
 class EventTransactionHandlerTest {
@@ -17,9 +18,11 @@ class EventTransactionHandlerTest {
         BlockItem item = handler.getItem();
 
         assertNotNull(item);
-        assertTrue(item.hasEventTransaction());
+        assertTrue(item.hasSignedTransaction());
 
-        EventTransaction transaction = item.getEventTransaction();
+        SignedTransaction transaction = SignedTransaction.newBuilder()
+                .bodyBytes(Bytes.wrap(item.getSignedTransaction().toByteArray()))
+                .build();
         assertNotNull(transaction);
     }
 

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
@@ -10,11 +10,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import com.google.protobuf.ByteString;
 import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
 import com.hedera.hapi.block.stream.protoc.Block;
 import com.hedera.hapi.block.stream.protoc.BlockItem;
 import com.hedera.hapi.block.stream.protoc.BlockProof;
-import com.hedera.hapi.platform.event.legacy.EventTransaction;
+import com.hedera.hapi.node.transaction.SignedTransaction;
 import com.swirlds.config.api.Configuration;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -419,10 +420,12 @@ class PublishStreamGrpcClientImplTest {
                 .build();
         if (withItems) {
             BlockItem blockItemEventTransaction1 = BlockItem.newBuilder()
-                    .setEventTransaction(EventTransaction.newBuilder().build())
+                    .setSignedTransaction(ByteString.copyFrom(
+                            SignedTransaction.newBuilder().build().bodyBytes().toByteArray()))
                     .build();
             BlockItem blockItemEventTransaction2 = BlockItem.newBuilder()
-                    .setEventTransaction(EventTransaction.newBuilder().build())
+                    .setSignedTransaction(ByteString.copyFrom(
+                            SignedTransaction.newBuilder().build().bodyBytes().toByteArray()))
                     .build();
             return Block.newBuilder()
                     .addItems(blockItemHeader)

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/commands/ConvertToJson.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/commands/ConvertToJson.java
@@ -107,7 +107,7 @@ public class ConvertToJson implements Runnable {
             final Block block = Block.PROTOBUF.parse(Bytes.wrap(uncompressedData));
             writeJsonBlock(block, outputFile);
             final long numOfTransactions = block.items().stream()
-                    .filter(BlockItem::hasEventTransaction)
+                    .filter(BlockItem::hasSignedTransaction)
                     .count();
             final String blockNumber =
                     block.items().size() > 1 && block.items().getFirst().hasBlockHeader()
@@ -135,16 +135,15 @@ public class ConvertToJson implements Runnable {
             String blockJson = Block.JSON.toJSON(block);
             // get iterator over all transactions
             final Iterator<String> transactionBodyJsonIterator = block.items().stream()
-                    .filter(BlockItem::hasEventTransaction)
-                    .filter(item -> item.eventTransaction().hasApplicationTransaction())
+                    .filter(BlockItem::hasSignedTransaction)
+                    .filter(item -> item.signedTransaction().length() > 0)
                     .map(item -> {
                         try {
                             return "          "
                                     + TransactionBody.JSON
                                             .toJSON(TransactionBody.PROTOBUF.parse(SignedTransaction.PROTOBUF
                                                     .parse(Transaction.PROTOBUF
-                                                            .parse(item.eventTransaction()
-                                                                    .applicationTransaction())
+                                                            .parse(item.signedTransaction())
                                                             .signedTransactionBytes())
                                                     .bodyBytes()))
                                             .replaceAll("\n", "\n          ");


### PR DESCRIPTION
## Reviewer Notes

- using hash tag from latest commit on https://github.com/hiero-ledger/hiero-consensus-node/tree/release/0.65
- Brute Force changed everything that said EventTransaction for SignedTransaction, and just removed the semantic version thing completely. (this affects both the simulator and the block node tools cli)
- Might still need a deeper review, but made so I can test with solo integration a snapshot version

## Related Issue(s)

Fixes #1386

Related: 
https://github.com/hiero-ledger/hiero-block-node/pull/1408
