### PR TITLE
chore: cherry-pick 1531 into release/0.17

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -45,9 +45,14 @@ jobs:
           VERSION=$(cat version.txt)
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: "temurin"
+          java-version: "21.0.6"
+
       - name: Produce artifact
-        working-directory: protobuf-sources
-        run: scripts/build-bn-proto.sh -t "efb0134e921b32ed6302da9c93874d65492e876f" -v ${{ env.VERSION }} -o "block-node-protobuf" -i true -b "../src/main/proto/" # CN 0.62.2
+        run: ${GRADLE_EXEC} :block-node-protobuf-sources:generateBlockNodeProtoArtifact
 
   compile:
     timeout-minutes: 20

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -42,17 +42,8 @@ env:
   BUILDKIT_VERSION: "v0.22.0"
 
 jobs:
-  check-gradle:
-    name: Gradle
-    uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
-    with:
-      ref: ${{ github.event.inputs.ref || '' }}
-      java-distribution: ${{ inputs.java-distribution || 'temurin' }}
-      java-version: ${{ inputs.java-version || '21.0.6' }}
-
   package-protobuf-source:
     timeout-minutes: 5
-    needs: [check-gradle]
     runs-on: hiero-block-node-linux-medium
 
     steps:
@@ -72,9 +63,14 @@ jobs:
           VERSION=$(cat version.txt)
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: "temurin"
+          java-version: "21.0.6"
+
       - name: Produce artifact
-        working-directory: protobuf-sources
-        run: scripts/build-bn-proto.sh -t "efb0134e921b32ed6302da9c93874d65492e876f" -v ${{ env.VERSION }} -o "block-node-protobuf" -i true -b "../src/main/proto/" # CN 0.62.2
+        run: ${GRADLE_EXEC} :block-node-protobuf-sources:generateBlockNodeProtoArtifact
 
       - name: Upload artifact
         if: "${{ github.event_name != 'workflow_dispatch' || github.event.inputs.publish == 'true' }}"
@@ -86,7 +82,6 @@ jobs:
 
   publish-app:
     timeout-minutes: 30
-    needs: [check-gradle]
     runs-on: hiero-block-node-linux-medium
 
     steps:
@@ -158,7 +153,6 @@ jobs:
 
   publish-protobuf-jar:
     timeout-minutes: 30
-    needs: [check-gradle]
     runs-on: hiero-block-node-linux-medium
 
     steps:
@@ -220,7 +214,6 @@ jobs:
 
   publish-simulator:
     timeout-minutes: 30
-    needs: [check-gradle]
     runs-on: hiero-block-node-linux-medium
 
     steps:


### PR DESCRIPTION
## Reviewer Notes

This brings the latest bug squashed that is affecting all releases to the upcoming release.
With this we should be good to cut a GA version.
