### PR TITLE
fix(1523): Prevent Unexpected OutOfMemoryError under high load

### DIFF
--- a/block-node/app/docker/update-env.sh
+++ b/block-node/app/docker/update-env.sh
@@ -24,12 +24,10 @@ echo "BACKFILL_BLOCK_NODE_SOURCES_PATH=/opt/hiero/block-node/backfill/backfill-s
 
 if [ true = "$is_smoke_test" ]; then
   # add smoke test variables
-  echo "MEDIATOR_RING_BUFFER_SIZE=1024" >> .env
-  echo "NOTIFIER_RING_BUFFER_SIZE=1024" >> .env
   echo "JAVA_OPTS='-Xms4G -Xmx4G'" >> .env
 else
   # Set the production default values
-  echo "JAVA_OPTS='-Xms16G -Xmx16G'" >> .env
+  echo "JAVA_OPTS='-Xms16G -Xmx16G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/dump.hprof'" >> .env
 fi
 
 if [ true = "$is_debug" ]; then

--- a/block-node/messaging/src/main/java/org/hiero/block/node/messaging/MessagingConfig.java
+++ b/block-node/messaging/src/main/java/org/hiero/block/node/messaging/MessagingConfig.java
@@ -9,21 +9,24 @@ import org.hiero.block.node.base.Loggable;
 /**
  * Configuration for the messaging system.
  *
- * @param blockItemQueueSize The maximum number of messages that can be queued for processing. This is used to limit the
- *                           number of block item batches that can be in messing queue at any time. Each batch is
- *                           expected to be approximately 100 block items. The bigger the queue, the more memory is use
- *                           but also the more flexibility of subscribers to be out of sync with each other. The queue
- *                           size must be a power of two.
- * @param blockNotificationQueueSize The maximum number of block notifications that can be queued for processing. This is
- *                                   used to limit the number of block notifications that can be in the queue at any time.
- *                                   Notifications can contain a reference to a whole block of data and hence keep a
- *                                   whole block in memory. The bigger the queue, the more memory is used. There should
- *                                   be no reason to have a big queue. The queue size must be a power of two.
+ * @param blockItemQueueSize The maximum number of messages that can be queued
+ *     for processing. This is used to limit the number of block item batches
+ *     that can be in messing queue at any time. Each batch is expected to be
+ *     approximately 100 block items. The bigger the queue, the more memory is
+ *     used but also the more flexibility of subscribers to be out of sync with
+ *     each other. The queue size must be a power of two.
+ * @param blockNotificationQueueSize The maximum number of block notifications
+ *     that can be queued for processing. This is used to limit the number of
+ *     block notifications that can be in the queue at any time. Notifications
+ *     can contain a reference to a whole block of data and hence keep a whole
+ *     block in memory. The bigger the queue, the more memory is used. There
+ *     should be no reason to have a big queue. The queue size must be a power
+ *     of two.
  */
 @ConfigData("messaging")
 public record MessagingConfig(
-        @Loggable @ConfigProperty(defaultValue = "1024") int blockItemQueueSize,
-        @Loggable @ConfigProperty(defaultValue = "256") int blockNotificationQueueSize) {
+        @Loggable @ConfigProperty(defaultValue = "512") int blockItemQueueSize,
+        @Loggable @ConfigProperty(defaultValue = "16") int blockNotificationQueueSize) {
     /**
      * Constructor.
      */

--- a/block-node/messaging/src/test/java/org/hiero/block/server/messaging/BlockMessagingServiceBlockNotificationTest.java
+++ b/block-node/messaging/src/test/java/org/hiero/block/server/messaging/BlockMessagingServiceBlockNotificationTest.java
@@ -37,8 +37,11 @@ public class BlockMessagingServiceBlockNotificationTest {
      * The number of items to send to the messaging service. This is twice the size of the ring buffer, so that we can
      * test the back pressure and the slow handler.
      */
-    public static final int TEST_DATA_COUNT =
+    private static final int TEST_DATA_COUNT =
             TestConfig.getConfig().getConfigData(MessagingConfig.class).blockItemQueueSize() * 2;
+
+    private static final int MAX_NOTIFICATION_COUNT =
+            TestConfig.getConfig().getConfigData(MessagingConfig.class).blockNotificationQueueSize();
 
     /**
      * Simple test to verify that the messaging service can handle multiple block notification handlers and that
@@ -161,9 +164,10 @@ public class BlockMessagingServiceBlockNotificationTest {
         assertNotEquals(State.RUNNABLE, stateAfter, "Sender thread should not be runnable.");
         assertNotEquals(State.TERMINATED, stateAfter, "Sender thread should not be terminated.");
         int amountSent = sentCounter.get();
-        // roughly 250 ish notifications should have been sent to the messaging service
+        // enough notifications should have been sent to the messaging service, avoid fixed numbers
+        // because that breaks if the config changes.
         final String tooFewMessage = "sentCounter should be at least %d, but is %d.";
-        assertTrue(amountSent > 100, tooFewMessage.formatted(100, amountSent));
+        assertTrue(amountSent > MAX_NOTIFICATION_COUNT, tooFewMessage.formatted(MAX_NOTIFICATION_COUNT, amountSent));
         final String tooManyMessage = "sentCounter should be less than %d, but is %d.";
         assertTrue(amountSent < TEST_DATA_COUNT, tooManyMessage.formatted(TEST_DATA_COUNT, amountSent));
         // mark sending finished and release the slow handler

--- a/charts/block-node-server/values-overrides/mid-size.yaml
+++ b/charts/block-node-server/values-overrides/mid-size.yaml
@@ -1,4 +1,18 @@
 resources:
   requests:
-    cpu: "4"
+    cpu: "8"
     memory: "12Gi"
+
+blockNode:
+  config:
+    JAVA_OPTS: '-Xms8G -Xmx8G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
+    MESSAGING_BLOCK_ITEM_QUEUE_SIZE: "256"
+    MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE: "16"
+    BACKFILL_FETCH_BATCH_SIZE: "8"
+  persistence:
+    archive:
+      size: 16Gi
+    live:
+      size: 4Gi
+    logging:
+      size: 2Gi

--- a/charts/block-node-server/values-overrides/mini.yaml
+++ b/charts/block-node-server/values-overrides/mini.yaml
@@ -6,13 +6,15 @@
 
 resources:
   requests:
-    cpu: "3"
+    cpu: "4"
     memory: "8Gi"
 
 blockNode:
   config:
-    JAVA_OPTS: "-Xms5G -Xmx5G"
-    MEDIATOR_RING_BUFFER_SIZE: "2048"
+    JAVA_OPTS: '-Xms4G -Xmx4G  -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
+    MESSAGING_BLOCK_ITEM_QUEUE_SIZE: "64"
+    MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE: "8"
+    BACKFILL_FETCH_BATCH_SIZE: "4"
   persistence:
     archive:
       size: 6Gi

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -98,18 +98,19 @@ blockNode:
     # Add any additional env configuration here
     # key: value
     JAVA_TOOL_OPTIONS: "-Djava.util.logging.config.file=/opt/hiero/block-node/logs/config/logging.properties"
-    JAVA_OPTS: "-Xms16G -Xmx16G"
+    JAVA_OPTS: '-Xms16G -Xmx16G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
     # PRODUCER_TYPE: "NO_OP"
     # PERSISTENCE_STORAGE_TYPE: "NO_OP"
     # VERIFICATION_TYPE: "NO_OP"
-    # MEDIATOR_TYPE: "NO_OP"
-    MEDIATOR_RING_BUFFER_SIZE: "8192"
+    # MESSAGING_BLOCK_ITEM_QUEUE_SIZE: "512"
+    # MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE: "16"
     PROMETHEUS_ENDPOINT_ENABLED: true
     PROMETHEUS_ENDPOINT_PORT_NUMBER: "16007"
     SERVER_PORT: "40840"
     # The path to the block-node-sources.json file must match the path property in the backfill.sources.path
     # if using the backfill sources created with this helm chart
     # BACKFILL_BLOCK_NODE_SOURCES_PATH: "/opt/hiero/block-node/backfill/block-node-sources.json"
+    # BACKFILL_FETCH_BATCH_SIZE: "25"
   persistence:
     archive:
       # name of the volume within the deploymeent

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -28,18 +28,18 @@ Each plugin has its own properties, but this focuses on core options and core pl
 ## Core Configuration Options
 
 | ENV Variable                      | Description                                                                                 | Default |
-|:----------------------------------|:--------------------------------------------------------------------------------------------|:-------:|
-| BLOCK_NODE_EARLIEST_MANAGED_BLOCK | Earliest block managed by this node. Older blocks may exist but won’t be fetched or stored. |    0    |
+|:----------------------------------|:--------------------------------------------------------------------------------------------|--------:|
+| BLOCK_NODE_EARLIEST_MANAGED_BLOCK | Earliest block managed by this node. Older blocks may exist but won’t be fetched or stored. |       0 |
 
 ### Server Configuration
 
-| ENV Variable                            | Description                          |  Default  |
-|:----------------------------------------|:-------------------------------------|:---------:|
+| ENV Variable                            | Description                          |   Default |
+|:----------------------------------------|:-------------------------------------|----------:|
 | SERVER_MAX_MESSAGE_SIZE_BYTES           | Max message size (bytes) for HTTP/2. | 4,194,304 |
-| SERVER_SOCKET_SEND_BUFFER_SIZE_BYTES    | Send buffer size (bytes).            |   32768   |
-| SERVER_SOCKET_RECEIVE_BUFFER_SIZE_BYTES | Receive buffer size (bytes).         |   32768   |
-| SERVER_PORT                             | Server listening port.               |   40840   |
-| SERVER_SHUTDOWN_DELAY_MILLIS            | Delay before shutdown (ms).          |    500    |
+| SERVER_SOCKET_SEND_BUFFER_SIZE_BYTES    | Send buffer size (bytes).            |     32768 |
+| SERVER_SOCKET_RECEIVE_BUFFER_SIZE_BYTES | Receive buffer size (bytes).         |     32768 |
+| SERVER_PORT                             | Server listening port.               |     40840 |
+| SERVER_SHUTDOWN_DELAY_MILLIS            | Delay before shutdown (ms).          |       500 |
 
 ### Metrics Endpoint Configuration
 
@@ -54,19 +54,19 @@ Each plugin has its own properties, but this focuses on core options and core pl
 ### Backfill Plugin Configuration
 
 | ENV Variable                          | Description                                   | Default |
-|:--------------------------------------|:----------------------------------------------|:-------:|
-| BACKFILL_START_BLOCK                  | First block this BN deploy wants.             |    0    |
-| BACKFILL_END_BLOCK                    | Max block number, -1 means no limit.          |   -1    |
-| BACKFILL_BLOCK_NODE_SOURCES_PATH      | File path for BN sources (yaml).              |   ""    |
-| BACKFILL_SCAN_INTERVAL                | Scan interval for gaps (minutes).             |   60    |
-| BACKFILL_MAX_RETRIES                  | Max retries to fetch a block.                 |    3    |
-| BACKFILL_INITIAL_RETRY_DELAY          | Initial retry delay (ms), grows linearly.     |  5000   |
-| BACKFILL_FETCH_BATCH_SIZE             | Number of blocks per gRPC call.               |   25    |
-| BACKFILL_DELAY_BETWEEN_BATCHES        | Delay (ms) between block batches.             |  1000   |
-| BACKFILL_INITIAL_DELAY                | Initial delay (s) before starting backfill.   |   15    |
-| BACKFILL_PER_BLOCK_PROCESSING_TIMEOUT | Timeout (ms) per block to allow recovery.     |  1000   |
-| BACKFILL_GRPC_OVERALL_TIMEOUT         | Overall gRPC timeout (connect, read, poll).   |  30000  |
-| BACKFILL_ENABLE_TLS                   | Enable TLS if supported by block-node client. |  false  |
+|:--------------------------------------|:----------------------------------------------|--------:|
+| BACKFILL_START_BLOCK                  | First block this BN deploy wants.             |       0 |
+| BACKFILL_END_BLOCK                    | Max block number, -1 means no limit.          |      -1 |
+| BACKFILL_BLOCK_NODE_SOURCES_PATH      | File path for BN sources (yaml).              |      "" |
+| BACKFILL_SCAN_INTERVAL                | Scan interval for gaps (minutes).             |      60 |
+| BACKFILL_MAX_RETRIES                  | Max retries to fetch a block.                 |       3 |
+| BACKFILL_INITIAL_RETRY_DELAY          | Initial retry delay (ms), grows linearly.     |    5000 |
+| BACKFILL_FETCH_BATCH_SIZE             | Number of blocks per gRPC call.               |      25 |
+| BACKFILL_DELAY_BETWEEN_BATCHES        | Delay (ms) between block batches.             |    1000 |
+| BACKFILL_INITIAL_DELAY                | Initial delay (s) before starting backfill.   |      15 |
+| BACKFILL_PER_BLOCK_PROCESSING_TIMEOUT | Timeout (ms) per block to allow recovery.     |    1000 |
+| BACKFILL_GRPC_OVERALL_TIMEOUT         | Overall gRPC timeout (connect, read, poll).   |   30000 |
+| BACKFILL_ENABLE_TLS                   | Enable TLS if supported by block-node client. |   false |
 
 ### Block Access Plugin Configuration
 
@@ -74,21 +74,21 @@ Currently, no specific options.
 
 ### Files Historic Plugin Configuration
 
-| ENV Variable                             | Description                                                   |               Default               |
-|:-----------------------------------------|:--------------------------------------------------------------|:-----------------------------------:|
+| ENV Variable                             | Description                                                   |                             Default |
+|:-----------------------------------------|:--------------------------------------------------------------|------------------------------------:|
 | FILES_HISTORIC_ROOT_PATH                 | Root path for saving historic blocks.                         | /opt/hiero/block-node/data/historic |
 | FILES_HISTORIC_COMPRESSION               | Compression type (e.g., ZSTD).                                |                                     |
-| FILES_HISTORIC_POWERS_OF_TEN             | Files per zip in powers of ten (1=10, 2=100, …, 6=1,000,000). |                  4                  |
-| FILES_HISTORIC_BLOCK_RETENTION_THRESHOLD | Number of zips to retain. 0 means keep indefinitely.          |                  0                  |
+| FILES_HISTORIC_POWERS_OF_TEN             | Files per zip in powers of ten (1=10, 2=100, …, 6=1,000,000). |                                   4 |
+| FILES_HISTORIC_BLOCK_RETENTION_THRESHOLD | Number of zips to retain. 0 means keep indefinitely.          |                                   0 |
 
 ### Files Recent Plugin Configuration
 
-| ENV Variable                           | Description                                         |             Default             |
-|:---------------------------------------|:----------------------------------------------------|:-------------------------------:|
+| ENV Variable                           | Description                                         |                         Default |
+|:---------------------------------------|:----------------------------------------------------|--------------------------------:|
 | FILES_RECENT_LIVE_ROOT_PATH            | Root path for saving live blocks.                   | /opt/hiero/block-node/data/live |
-| FILES_RECENT_COMPRESSION               | Compression type (e.g., ZSTD).                      |              ZSTD               |
-| FILES_RECENT_MAX_FILES_PER_DIR         | Max files per directory to avoid filesystem issues. |                3                |
-| FILES_RECENT_BLOCK_RETENTION_THRESHOLD | Block retention count. `0` means keep indefinitely. |             96,000              |
+| FILES_RECENT_COMPRESSION               | Compression type (e.g., ZSTD).                      |                            ZSTD |
+| FILES_RECENT_MAX_FILES_PER_DIR         | Max files per directory to avoid filesystem issues. |                               3 |
+| FILES_RECENT_BLOCK_RETENTION_THRESHOLD | Block retention count. `0` means keep indefinitely. |                          96,000 |
 
 ### Health Plugin Configuration
 
@@ -97,22 +97,22 @@ Currently, no specific options.
 ### Messaging Plugin Configuration
 
 | ENV Variable                            | Description                                                                               | Default |
-|:----------------------------------------|:------------------------------------------------------------------------------------------|:-------:|
-| MESSAGING_BLOCK_ITEM_QUEUE_SIZE         | Max messages in block item queue. Each batch ~100 items. Must be power of 2.              |  1024   |
-| MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE | Max block notifications queued. Each may hold a full block in memory. Must be power of 2. |   256   |
+|:----------------------------------------|:------------------------------------------------------------------------------------------|--------:|
+| MESSAGING_BLOCK_ITEM_QUEUE_SIZE         | Max messages in block item queue. Each batch ~100 items. Must be power of 2.              |     512 |
+| MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE | Max block notifications queued. Each may hold a full block in memory. Must be power of 2. |      16 |
 
 ### Archive Plugin Configuration (S3 Archive)
 
-| ENV Variable            | Description                                                                 |      Default       |
-|:------------------------|:----------------------------------------------------------------------------|:------------------:|
-| ARCHIVE_BLOCKS_PER_FILE | Number of blocks per archive file. Must be a positive power of 10.          |       100000       |
-| ARCHIVE_ENDPOINT_URL    | Endpoint URL for the archive service (e.g., `https://s3.amazonaws.com/`).   |         ""         |
+| ENV Variable            | Description                                                                 |            Default |
+|:------------------------|:----------------------------------------------------------------------------|-------------------:|
+| ARCHIVE_BLOCKS_PER_FILE | Number of blocks per archive file. Must be a positive power of 10.          |             100000 |
+| ARCHIVE_ENDPOINT_URL    | Endpoint URL for the archive service (e.g., `https://s3.amazonaws.com/`).   |                 "" |
 | ARCHIVE_BUCKET_NAME     | Bucket name where archive files are stored.                                 | block-node-archive |
-| ARCHIVE_BASE_PATH       | Base path inside the bucket for archive files.                              |       blocks       |
-| ARCHIVE_STORAGE_CLASS   | Storage class (e.g., STANDARD, INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE). |      STANDARD      |
-| ARCHIVE_REGION_NAME     | Region for the archive service (e.g., `us-east-1`).                         |     us-east-1      |
-| ARCHIVE_ACCESS_KEY      | Access key for the archive service.                                         |         ""         |
-| ARCHIVE_SECRET_KEY      | Secret key for the archive service.                                         |         ""         |
+| ARCHIVE_BASE_PATH       | Base path inside the bucket for archive files.                              |             blocks |
+| ARCHIVE_STORAGE_CLASS   | Storage class (e.g., STANDARD, INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE). |           STANDARD |
+| ARCHIVE_REGION_NAME     | Region for the archive service (e.g., `us-east-1`).                         |          us-east-1 |
+| ARCHIVE_ACCESS_KEY      | Access key for the archive service.                                         |                 "" |
+| ARCHIVE_SECRET_KEY      | Secret key for the archive service.                                         |                 "" |
 
 ### Server Status Plugin Configuration
 
@@ -120,17 +120,17 @@ Currently, no specific options.
 
 ### Publisher Plugin Configuration
 
-| ENV Variable                 | Description                                                    |          Default          |
-|:-----------------------------|:---------------------------------------------------------------|:-------------------------:|
+| ENV Variable                 | Description                                                    |                   Default |
+|:-----------------------------|:---------------------------------------------------------------|--------------------------:|
 | PRODUCER_BATCH_FORWARD_LIMIT | Max number of blocks to forward in a batch. Must be ≥ 100,000. | 9,223,372,036,854,775,807 |
 
 ### Subscriber Plugin Configuration
 
 | ENV Variable                           | Description                                                                                            | Default |
-|:---------------------------------------|:-------------------------------------------------------------------------------------------------------|:-------:|
-| SUBSCRIBER_LIVE_QUEUE_SIZE             | Queue size (in batches) for transferring live data between messaging and client threads. Must be ≥100. |  4000   |
-| SUBSCRIBER_MAXIMUM_FUTURE_REQUEST      | Max blocks ahead of latest "live" block a request can start from. Must be ≥10.                         |  4000   |
-| SUBSCRIBER_MINIMUM_LIVE_QUEUE_CAPACITY | Minimum free capacity in the live queue before dropping oldest blocks. Typically ~10% of queue size.   |   400   |
+|:---------------------------------------|:-------------------------------------------------------------------------------------------------------|--------:|
+| SUBSCRIBER_LIVE_QUEUE_SIZE             | Queue size (in batches) for transferring live data between messaging and client threads. Must be ≥100. |    4000 |
+| SUBSCRIBER_MAXIMUM_FUTURE_REQUEST      | Max blocks ahead of latest "live" block a request can start from. Must be ≥10.                         |    4000 |
+| SUBSCRIBER_MINIMUM_LIVE_QUEUE_CAPACITY | Minimum free capacity in the live queue before dropping oldest blocks. Typically ~10% of queue size.   |     400 |
 
 ### Verification Plugin Configuration
 


### PR DESCRIPTION
## Reviewer Notes
* Reduced default queue sizes for block items and block notifications.
   * Notifications, in particular, need to be smaller, mostly because
     blocks at high TPS can be 400M or larger.
* Adjusted values files for helm charts in the
  base values, mini values, and mid-size values files.
* Automatic HPROF dump on error
   * Added requested command line flags


## Related Issue(s)
 May address #1523 and #1540.
