### PR TITLE
fix: Reduce the CPU time spent waiting for new block data

### DIFF
--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -44,8 +44,7 @@ import org.hiero.block.node.spi.threading.ThreadPoolManager;
  */
 public final class LiveStreamPublisherManager implements StreamPublisherManager {
     private static final String QUEUE_ID_FORMAT = "Q%016d";
-    private static final int DATA_READY_WAIT_MICROSECONDS = 500;
-    // @todo(1413) utilize the logger
+    private static final int DATA_READY_WAIT_MICROSECONDS = 5000;
     private final System.Logger LOGGER = System.getLogger(LiveStreamPublisherManager.class.getName());
     private final MetricsHolder metrics;
     private final BlockNodeContext serverContext;

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.stream.publisher;
 
+import static java.util.concurrent.locks.LockSupport.parkNanos;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.block.node.app.fixtures.TestUtils.enableDebugLogging;
 
@@ -14,7 +15,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.hiero.block.api.BlockItemSet;
@@ -179,7 +179,7 @@ class StreamPublisherPluginTest {
          */
         @Test
         @DisplayName("Test publish a valid block as items")
-        void testPublishValidBlock() throws InterruptedException {
+        void testPublishValidBlock() {
             final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createNumberOfVerySimpleBlocksUnparsed(0, 1);
             // Build a PublishStreamRequest with a valid block as items
             final BlockItemSetUnparsed blockItems =
@@ -189,7 +189,7 @@ class StreamPublisherPluginTest {
                     .build();
             // Send the request to the pipeline
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
-            TimeUnit.MILLISECONDS.sleep(500L);
+            parkNanos(500_000_000L);
             // Await to ensure async execution and assert response
             assertThat(fromPluginBytes)
                     .hasSize(1)


### PR DESCRIPTION
## Reviewer Notes
* Changed the timeout on the condition wait from 500 microseconds to 5 milliseconds.
* Replaced a sleep with parkNanos in a unit test to improve reliability
