### PR TITLE
fix(verification): Update CN Proto to latest GA Tag and Fix unparsed.proto file

### DIFF
--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/BlockVerificationSession.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/BlockVerificationSession.java
@@ -81,7 +81,7 @@ public class BlockVerificationSession {
             final ByteBuffer hash = getBlockItemHash(item);
             switch (kind) {
                 case ROUND_HEADER, EVENT_HEADER -> consensusHeaderHasher.addLeaf(hash);
-                case EVENT_TRANSACTION -> inputTreeHasher.addLeaf(hash);
+                case SIGNED_TRANSACTION -> inputTreeHasher.addLeaf(hash);
                 case TRANSACTION_RESULT, TRANSACTION_OUTPUT, BLOCK_HEADER -> outputTreeHasher.addLeaf(hash);
                 case STATE_CHANGES -> stateChangesHasher.addLeaf(hash);
                 case TRACE_DATA -> traceDataHasher.addLeaf(hash);

--- a/common/src/main/java/org/hiero/block/common/hasher/HashingUtilities.java
+++ b/common/src/main/java/org/hiero/block/common/hasher/HashingUtilities.java
@@ -131,7 +131,7 @@ public final class HashingUtilities {
             final BlockItemUnparsed.ItemOneOfType kind = item.item().kind();
             switch (kind) {
                 case ROUND_HEADER, EVENT_HEADER -> numConsensusHeaders++;
-                case EVENT_TRANSACTION -> numInputs++;
+                case SIGNED_TRANSACTION -> numInputs++;
                 case TRANSACTION_RESULT, TRANSACTION_OUTPUT, BLOCK_HEADER -> numOutputs++;
                 case STATE_CHANGES -> numStateChanges++;
                 case TRACE_DATA -> numTraceData++;
@@ -152,7 +152,7 @@ public final class HashingUtilities {
                 case ROUND_HEADER, EVENT_HEADER ->
                     consensusHeaderHashes.put(digest.digest(
                             BlockItemUnparsed.PROTOBUF.toBytes(item).toByteArray()));
-                case EVENT_TRANSACTION ->
+                case SIGNED_TRANSACTION ->
                     inputHashes.put(digest.digest(
                             BlockItemUnparsed.PROTOBUF.toBytes(item).toByteArray()));
                 case TRANSACTION_RESULT, TRANSACTION_OUTPUT, BLOCK_HEADER ->

--- a/protobuf-sources/build.gradle.kts
+++ b/protobuf-sources/build.gradle.kts
@@ -16,7 +16,11 @@ val generateBlockNodeProtoArtifact: TaskProvider<Exec> =
         group = "protobuf"
 
         workingDir(layout.projectDirectory)
-        val cnTagHash = "437d131d67d9ca60ba60fff5ae59692c45bc44cd" // v0.65.0-rc1
+        // When upgrading the CN proto version, always check that the file:
+        // proto/internal/unparsed.proto matches structure for
+        // block-node-protobuf/block/stream/block_item.proto after update otherwise Verification
+        // might fail
+        val cnTagHash = "d7cb85ac7384f809a15489635122504661131af4" // v0.65.0
 
         // run build-bn-proto.sh skipping inclusion of BN API as it messes up proto considerations
         commandLine(

--- a/protobuf-sources/src/main/proto/internal/unparsed.proto
+++ b/protobuf-sources/src/main/proto/internal/unparsed.proto
@@ -55,13 +55,13 @@ message BlockItemUnparsed {
         bytes block_header = 1;
         bytes event_header = 2;
         bytes round_header = 3;
-        bytes event_transaction = 4;
+        bytes signed_transaction = 4;
         bytes transaction_result = 5;
         bytes transaction_output = 6;
         bytes state_changes = 7;
         bytes filtered_item_hash = 8;
         bytes block_proof = 9;
         bytes record_file = 10;
-        bytes trace_data = 16;
+        bytes trace_data = 11;
     }
 }


### PR DESCRIPTION
- Update CN Proto to latest GA Tag
- Fixing verification hash by updating the unparsed.proto with the right Ids and names

## Reviewer Notes

## Related Issue(s)
Fixes #1569 
Fixes #1560 
Fixes #1522 
