### PR TITLE
feat: Change telemetry defaults to false

### DIFF
--- a/charts/block-node-server/values-overrides/nano.yaml
+++ b/charts/block-node-server/values-overrides/nano.yaml
@@ -32,7 +32,6 @@ blockNode:
       # Optionally specify an existing PVC name instead of creating via volumeClaimTemplate
       # existingClaim: "nano-logging-pvc"
 
-# Setting the PVC size for the Observability stack to mini claims of 1 Gigabyte
 kubepromstack:
   enabled: false
 

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -206,7 +206,7 @@ blockNode:
     #     priority: 1
 
 kubepromstack:
-  enabled: true
+  enabled: false
   prometheus:
     prometheusSpec:
       retention: 90d
@@ -240,12 +240,11 @@ kubepromstack:
       enabled: true
       type: pvc
       size: 10Gi
-
   nodeExporter:
     enabled: true
 
 loki:
-  enabled: true
+  enabled: false
   isDefault: true
   url: http://{{(include "loki.serviceName" .)}}:{{ .Values.loki.service.port }}
   readinessProbe:
@@ -267,7 +266,7 @@ loki:
     # storageClassName: ""
 
 promtail:
-  enabled: true
+  enabled: false
   config:
     logLevel: info
     serverPort: 3101


### PR DESCRIPTION
Sets all telemetry defaults to false as per recent meeting discussion. Telemetry dependencies have not been removed and have been kept around for dev testing purposes.

**Reference:** https://github.com/hiero-ledger/hiero-block-node/issues/1625