### PR TITLE
ci(publish): Revert chart rename to preserve backwards and forwards compatibility

### DIFF
--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -317,7 +317,7 @@ jobs:
       - name: Push helm chart
         if: "${{ github.event_name != 'workflow_dispatch' || github.event.inputs.publish == 'true' }}"
         run: |
-          helm push block-node-server-${{ env.VERSION }}.tgz oci://ghcr.io/hiero-ledger/hiero-block-node
+          helm push block-node-helm-chart-${{ env.VERSION }}.tgz oci://ghcr.io/hiero-ledger/hiero-block-node
 
   helm-chart-release-simulator:
     timeout-minutes: 15

--- a/charts/block-node-server/Chart.yaml
+++ b/charts/block-node-server/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
 maintainers:
   - name: Hiero Block Node Team
     email: blocknode@hashgraph.com
-name: block-node-server
+name: block-node-helm-chart
 sources:
   - https://github.com/hiero-ledger/hiero-block-node
 version: 0.20.0-SNAPSHOT

--- a/charts/block-node-server/README.md
+++ b/charts/block-node-server/README.md
@@ -40,13 +40,13 @@ helm pull oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-helm-chart --ve
 To install the chart with default values:
 
 ```bash
-helm install "${RELEASE}" block-node-server/charts/block-node-server-$VERSION.tgz
+helm install "${RELEASE}" block-node-server/charts/block-node-helm-chart-$VERSION.tgz
 ```
 
 To install the chart with custom values:
 
 ```bash
-helm install "${RELEASE}" block-node-server/charts/block-node-server-$VERSION.tgz -f <path-to-custom-values-file>
+helm install "${RELEASE}" block-node-server/charts/block-node-helm-chart-$VERSION.tgz -f <path-to-custom-values-file>
 ```
 
 *Note:* If using the chart directly after cloning the github repo, there is no need to add the repo. and install can be directly.


### PR DESCRIPTION
## Reviewer Notes

As part of an extensive set of improvements made on PR: https://github.com/hiero-ledger/hiero-block-node/pull/1602
BlockNode **Chart Name, was changed** to keep consistency with its parent folder and simplify the name.

This broke the Publish workflow which was expecting one chart package name and was not finding it.

This PR fixed that and improve another thing. https://github.com/hiero-ledger/hiero-block-node/pull/1641

As a result we where able to publish sucessfully but potentially breaking solo and even if fixing solo, making it hard to do backwards and forwards compatibility, so **this PR aims to revert those 2 changes mentioned in the respective PRs and return the BN Chart name to its previous one to preserve stability.**

## Related Issue(s)

#1602 
#1641 

Fixes #1645 
