### PR TITLE
feat: Add end-of-block message to the BN Publisher API and internal messaging (#1626)

### DIFF
--- a/protobuf-sources/src/main/proto/block-node/api/block_stream_publish_service.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/block_stream_publish_service.proto
@@ -50,6 +50,11 @@ message PublishStreamRequest {
          * when sending this message for any non-error condition.
          */
         EndStream end_stream = 2;
+
+        /**
+         * A message indicating the end of a block.
+         */
+        BlockEnd end_of_block = 3;
     }
 
     /**

--- a/protobuf-sources/src/main/proto/block-node/api/block_stream_subscribe_service.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/block_stream_subscribe_service.proto
@@ -156,6 +156,16 @@ message SubscribeStreamResponse {
          * followed by a single `status` message.
          */
         BlockItemSet block_items = 2;
+
+        /**
+         * A message indicating the end of a block.
+         * <p>
+         * This message SHALL be sent exactly once for each block.
+         * The next message after a `BlockEnd` SHALL be either a
+         * status message to indicate the stream is closed, or a
+         * `BlockItemSet` message starting with a `BlockHeader`.
+         */
+        BlockEnd end_of_block = 3;
     }
 }
 

--- a/protobuf-sources/src/main/proto/block-node/api/shared_message_types.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/shared_message_types.proto
@@ -31,3 +31,14 @@ message BlockItemSet {
      */
     repeated com.hedera.hapi.block.stream.BlockItem block_items = 1;
 }
+
+message BlockEnd {
+    /**
+     * A Block Number.<br/>
+     * This is the block number of the completed block.
+     * <p>
+     * This MUST match the block number of corresponding `BlockHeader` block
+     * item that started this block.
+     */
+    uint64 block_number = 1;
+}

--- a/protobuf-sources/src/main/proto/internal/unparsed.proto
+++ b/protobuf-sources/src/main/proto/internal/unparsed.proto
@@ -10,11 +10,13 @@ option java_multiple_files = true;
 import "block-node/api/block_access_service.proto";
 import "block-node/api/block_stream_subscribe_service.proto";
 import "block-node/api/block_stream_publish_service.proto";
+import "block-node/api/shared_message_types.proto";
 
 message PublishStreamRequestUnparsed {
     oneof request {
         BlockItemSetUnparsed block_items = 1;
         org.hiero.block.api.PublishStreamRequest.EndStream end_stream = 2;
+        org.hiero.block.api.BlockEnd end_of_block = 3;
     }
 }
 
@@ -34,6 +36,7 @@ message SubscribeStreamResponseUnparsed {
          * followed by a single `status` message.
          */
         BlockItemSetUnparsed block_items = 2;
+        org.hiero.block.api.BlockEnd end_of_block = 3;
     }
 }
 


### PR DESCRIPTION
## Reviewer Notes
 * Added `BlockEnd` message to shared message types
 * Added `end_of_block` field to oneof in publisher and subscriber APIs.
