### PR TITLE
test(config): Improving Combined Backfill by Config

### DIFF
--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
@@ -212,8 +212,7 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
                 "BACKFILL_DELAY_BETWEEN_BATCHES",
                 "500",
                 "BLOCK_NODE_EARLIEST_MANAGED_BLOCK",
-                "50"
-          );
+                "50");
 
         launchBlockNodes(List.of(
                 new BlockNodeContainerConfig(8082, 9989, "/resources/block-nodes.json", bnSubjectConfigOverride)));
@@ -247,7 +246,8 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
         startSimulatorInstance(secondSimulator); // Subject
 
         // Wait until both simulators have published their blocks
-        while(firstSimulator.getStreamStatus().publishedBlocks() < 101 || secondSimulator.getStreamStatus().publishedBlocks() < 21) {
+        while (firstSimulator.getStreamStatus().publishedBlocks() < 101
+                || secondSimulator.getStreamStatus().publishedBlocks() < 21) {
             Thread.sleep(1000);
         }
 
@@ -274,21 +274,21 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
         // polling the latest block until we reach block 200 (backfill on demand is completed)
         Thread.sleep(5_000);
         long latestBlockNumber = getLatestBlock(blockAccessStubs.get(8082))
-          .getBlock()
-          .getItemsList()
-          .getFirst()
-          .getBlockHeader()
-          .getNumber();
+                .getBlock()
+                .getItemsList()
+                .getFirst()
+                .getBlockHeader()
+                .getNumber();
 
         while (latestBlockNumber < 100) {
             System.out.println("Latest Block Number: " + latestBlockNumber);
             Thread.sleep(1000);
             latestBlockNumber = getLatestBlock(blockAccessStubs.get(8082))
-              .getBlock()
-              .getItemsList()
-              .getFirst()
-              .getBlockHeader()
-              .getNumber();
+                    .getBlock()
+                    .getItemsList()
+                    .getFirst()
+                    .getBlockHeader()
+                    .getNumber();
         }
 
         // Verify that Backfill on Demand Worked.


### PR DESCRIPTION
- Improving E2E test of combined backfill by not only increasing the amount of blocks that are going to be backfilled, but also by making it more resilient and flexible, getting rid of unnesary workarounds (delete files and restart a BN) since we did not had earliestManagedBlock property before
- adding better randomized verification
- adding a polling mechanism instead of hardcoded wait sleep times.
- Test takes around 40secs on M1 when previously used to take around 1 min and 20 secs (on the edge of timeout).
- increased the timeout to 2mins in case is run on slow hardware or the CI gets slow as it can happen.

Fixes #1707 


Currently E2E tests are a bit flakey since test might take longer on CI than timeout, this PR aims to fix this.

<img width="1512" height="841" alt="image" src="https://github.com/user-attachments/assets/8b7c7905-c273-4f61-a7b8-6ada71ffe812" />
