### PR TITLE
build: bump Gradle plugins to 0.5.1

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import org.gradlex.javamodule.moduleinfo.ExtraJavaModuleInfoPluginExtension
 
-plugins { id("org.hiero.gradle.build") version "0.5.0" }
+plugins { id("org.hiero.gradle.build") version "0.5.1" }
 
 val hieroGroup = "org.hiero.block"
 


### PR DESCRIPTION
## Reviewer Notes

⚠️ There is a silent breaking change in the **Gradle Shadow Plugin** update that came with `0.5.0` (see https://github.com/hiero-ledger/hiero-gradle-conventions/pull/300). As the plugin is used in this repository, please update asap.
