### PR TITLE
chore(config): Improve configs defaults and chart overrides regarding queueSize and backfillBatchSize

### DIFF
--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillConfiguration.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillConfiguration.java
@@ -32,9 +32,9 @@ public record BackfillConfiguration(
         @Loggable @ConfigProperty(defaultValue = "60000") @Min(100) int scanInterval,
         @Loggable @ConfigProperty(defaultValue = "3") @Min(0) @Max(10) int maxRetries,
         @Loggable @ConfigProperty(defaultValue = "5000") @Min(500) int initialRetryDelay,
-        @Loggable @ConfigProperty(defaultValue = "25") @Min(1) @Max(10_000) int fetchBatchSize,
+        @Loggable @ConfigProperty(defaultValue = "10") @Min(1) @Max(1024) int fetchBatchSize,
         @Loggable @ConfigProperty(defaultValue = "1000") @Min(100) int delayBetweenBatches,
         @Loggable @ConfigProperty(defaultValue = "15000") @Min(5) int initialDelay,
         @Loggable @ConfigProperty(defaultValue = "1000") @Min(500) int perBlockProcessingTimeout,
-        @Loggable @ConfigProperty(defaultValue = "30000") @Min(10000) int grpcOverallTimeout,
+        @Loggable @ConfigProperty(defaultValue = "60000") @Min(10000) int grpcOverallTimeout,
         @Loggable @ConfigProperty(defaultValue = "false") boolean enableTLS) {}

--- a/block-node/messaging/src/main/java/org/hiero/block/node/messaging/MessagingConfig.java
+++ b/block-node/messaging/src/main/java/org/hiero/block/node/messaging/MessagingConfig.java
@@ -26,7 +26,7 @@ import org.hiero.block.node.base.Loggable;
 @ConfigData("messaging")
 public record MessagingConfig(
         @Loggable @ConfigProperty(defaultValue = "512") int blockItemQueueSize,
-        @Loggable @ConfigProperty(defaultValue = "16") int blockNotificationQueueSize) {
+        @Loggable @ConfigProperty(defaultValue = "32") int blockNotificationQueueSize) {
     /**
      * Constructor.
      */

--- a/charts/block-node-server/values-overrides/backfill.yaml
+++ b/charts/block-node-server/values-overrides/backfill.yaml
@@ -1,7 +1,7 @@
 blockNode:
   config:
     BACKFILL_BLOCK_NODE_SOURCES_PATH: "/opt/hiero/block-node/backfill/block-node-sources.json"
-    BACKFILL_FETCH_BATCH_SIZE: "25"
+    BACKFILL_FETCH_BATCH_SIZE: "10"
   backfill:
       # The path to the block-node-sources.json file must match the path property in
       # blockNode.config.BACKFILL_BLOCK_NODE_SOURCES_PATH

--- a/charts/block-node-server/values-overrides/mid-size.yaml
+++ b/charts/block-node-server/values-overrides/mid-size.yaml
@@ -6,9 +6,9 @@ resources:
 blockNode:
   config:
     JAVA_OPTS: '-Xms8G -Xmx8G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
-    MESSAGING_BLOCK_ITEM_QUEUE_SIZE: "256"
-    MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE: "16"
-    BACKFILL_FETCH_BATCH_SIZE: "8"
+    MESSAGING_BLOCK_ITEM_QUEUE_SIZE: "1024"
+    MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE: "64"
+    BACKFILL_FETCH_BATCH_SIZE: "20"
   persistence:
     archive:
       size: 16Gi

--- a/charts/block-node-server/values-overrides/mini.yaml
+++ b/charts/block-node-server/values-overrides/mini.yaml
@@ -12,9 +12,9 @@ resources:
 blockNode:
   config:
     JAVA_OPTS: '-Xms4G -Xmx4G  -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
-    MESSAGING_BLOCK_ITEM_QUEUE_SIZE: "64"
-    MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE: "8"
-    BACKFILL_FETCH_BATCH_SIZE: "4"
+    MESSAGING_BLOCK_ITEM_QUEUE_SIZE: "512"
+    MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE: "32"
+    BACKFILL_FETCH_BATCH_SIZE: "10"
   persistence:
     archive:
       size: 6Gi

--- a/charts/block-node-server/values-overrides/nano.yaml
+++ b/charts/block-node-server/values-overrides/nano.yaml
@@ -14,10 +14,10 @@ resources:
 
 blockNode:
   config:
-    JAVA_OPTS: '-Xms4G -Xmx4G  -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
-    MESSAGING_BLOCK_ITEM_QUEUE_SIZE: "64"
-    MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE: "8"
-    BACKFILL_FETCH_BATCH_SIZE: "4"
+    JAVA_OPTS: '-Xms1G -Xmx1G  -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
+    MESSAGING_BLOCK_ITEM_QUEUE_SIZE: "128"
+    MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE: "16"
+    BACKFILL_FETCH_BATCH_SIZE: "5"
   persistence:
     archive:
       size: 1Gi


### PR DESCRIPTION
## Reviewer Notes

- As we noted on ticket https://github.com/hiero-ledger/hiero-block-node/issues/1576 we have sometimes a deadlock under certain circustances, even when there is another ticket to prevent that from happening, it makes sense to improve the default properties values and also con helm charts overrides to improve performance and minimize the risk of queues getting filled.

## Related Issue(s)
 Use keywords `Fix, Fixes, Fixed, Close, Closes, Closed, Resolve, Resolves, Resolved`
to connect an issue to be closed by this pull request.
