### PR TITLE
fix: Send Acknowledgements Only On Successful Persistence

### DIFF
--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -566,13 +566,15 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     public void handlePersisted(@NonNull final PersistedNotification notification) {
         if (notification != null) {
             final long newLastPersistedBlock = notification.blockNumber();
-            if (newLastPersistedBlock > lastPersistedBlockNumber.get()) {
-                handlers.values().parallelStream().unordered().forEach(handler -> {
-                    // _Important_, we only need the last persisted block number
-                    // all previous blocks are implicitly acknowledged.
-                    handler.sendAcknowledgement(newLastPersistedBlock);
-                });
-                lastPersistedBlockNumber.set(newLastPersistedBlock);
+            if (notification.succeeded()) {
+                if (newLastPersistedBlock > lastPersistedBlockNumber.get()) {
+                    handlers.values().parallelStream().unordered().forEach(handler -> {
+                        // _Important_, we only need the last persisted block number
+                        // all previous blocks are implicitly acknowledged.
+                        handler.sendAcknowledgement(newLastPersistedBlock);
+                    });
+                    lastPersistedBlockNumber.set(newLastPersistedBlock);
+                }
             }
         }
     }

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -962,6 +962,64 @@ class LiveStreamPublisherManagerTest {
                 // Assert that the latest known block number is now set to the notification's end block number.
                 assertThat(toTest.getLatestBlockNumber()).isEqualTo(expectedLatestBlockNumber);
             }
+
+            /**
+             * This test aims to assert that the
+             * {@link LiveStreamPublisherManager#handlePersisted(PersistedNotification)}
+             * will not send acknowledgement to registered publisher handlers
+             * when the persistence has failed, i.e.
+             * {@link PersistedNotification#succeeded()} is false.
+             */
+            @Test
+            @DisplayName(
+                    "handlePersisted() does not send acknowledgement with latest block number to all registered handlers when persistence failed")
+            void testHandlePersistedNotificationFailedPersistence() {
+                // As a precondition, assert that the responses pipeline is empty (nothing has been sent yet).
+                // Also, assert that the latest known block number is -1L (initial state in order to compare later).
+                assertThat(responsePipeline.getOnNextCalls()).isEmpty();
+                final long expectedLatestPersistedFromManager = -1L;
+                assertThat(toTest.getLatestBlockNumber()).isEqualTo(expectedLatestPersistedFromManager);
+                final PersistedNotification notification =
+                        new PersistedNotification(10L, false, 0, BlockSource.PUBLISHER);
+                // Call
+                toTest.handlePersisted(notification);
+                // Assert that the response pipeline has not received any responses.
+                assertThat(responsePipeline.getOnNextCalls()).isEmpty();
+                // Assert that the latest known block number is still -1L, it was not updated
+                assertThat(toTest.getLatestBlockNumber()).isEqualTo(expectedLatestPersistedFromManager);
+                // Assert no other responses sent
+                assertThat(responsePipeline.getOnErrorCalls()).isEmpty();
+                assertThat(responsePipeline.getOnSubscriptionCalls()).isEmpty();
+                assertThat(responsePipeline.getOnCompleteCalls().get()).isEqualTo(0);
+                assertThat(responsePipeline.getClientEndStreamCalls().get()).isEqualTo(0);
+            }
+
+            /**
+             * This test aims to assert that the
+             * {@link LiveStreamPublisherManager#handlePersisted(PersistedNotification)}
+             * will not send acknowledgement to registered publisher handlers
+             * when the notification is null.
+             */
+            @Test
+            @DisplayName("handlePersisted() does nothing when notification is null")
+            void testHandlePersistedNotificationNull() {
+                // As a precondition, assert that the responses pipeline is empty (nothing has been sent yet).
+                // Also, assert that the latest known block number is -1L (initial state in order to compare later).
+                assertThat(responsePipeline.getOnNextCalls()).isEmpty();
+                final long expectedLatestPersistedFromManager = -1L;
+                assertThat(toTest.getLatestBlockNumber()).isEqualTo(expectedLatestPersistedFromManager);
+                // Call
+                toTest.handlePersisted(null);
+                // Assert that the response pipeline has not received any responses.
+                assertThat(responsePipeline.getOnNextCalls()).isEmpty();
+                // Assert that the latest known block number is still -1L, it was not updated
+                assertThat(toTest.getLatestBlockNumber()).isEqualTo(expectedLatestPersistedFromManager);
+                // Assert no other responses sent
+                assertThat(responsePipeline.getOnErrorCalls()).isEmpty();
+                assertThat(responsePipeline.getOnSubscriptionCalls()).isEmpty();
+                assertThat(responsePipeline.getOnCompleteCalls().get()).isEqualTo(0);
+                assertThat(responsePipeline.getClientEndStreamCalls().get()).isEqualTo(0);
+            }
         }
 
         /**


### PR DESCRIPTION
## Reviewer Notes

* Adding success check when handling a persistence notifications
* Adding tests for this logic

## Related Issue(s)

Fixes #1718
