### PR TITLE
chore: Disable FileHandler for Java System Logger for E2E Tests

### DIFF
--- a/block-node/app/docker/ci-logging.properties
+++ b/block-node/app/docker/ci-logging.properties
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Log Level Values
+#
+# SEVERE: indicates a critical error or failure
+# WARNING: warns of potential issues or errors
+# INFO: reports normal operational information
+# CONFIG: provides configuration-related information
+# FINE: provides detailed debugging information
+# FINER: provides finer-grained debugging information
+# FINEST: provides the most detailed debugging information
+
+# Set the default logging level
+# Available Levels are (from most verbose to least verbose):
+# ALL FINEST FINER FINE CONFIG INFO WARNING SEVERE OFF
+.level=INFO
+# logs for Block Node components FINEST temporarily
+org.hiero.block.level=FINEST
+# Helidon loggers
+io.helidon.level=INFO
+io.helidon.webserver.level=INFO
+io.helidon.config.level=SEVERE
+io.helidon.security.level=INFO
+io.helidon.common.level=INFO
+# Override the chatty HTTP server internals
+com.sun.net.httpserver.level = WARNING
+com.sun.net.httpserver.ServerImpl.level = WARNING
+com.sun.net.httpserver.ExchangeImpl.level = WARNING
+
+# Configure the app log level
+#org.hiero.block.level=FINE
+#org.hiero.block.server.level=FINE
+
+# Configure the configuration logging - OFF will suppress all configuration logging
+#org.hiero.block.server.config.logging.ConfigurationLoggingImpl.level=OFF
+
+# Configure specific Block Node loggers
+#org.hiero.block.server.producer.ProducerBlockItemObserver.level=FINE
+#org.hiero.block.server.mediator.LiveStreamMediatorImpl.level=FINE
+#org.hiero.block.server.mediator.LiveStreamPoller.level=FINE
+#org.hiero.block.server.consumer.level=FINE
+#org.hiero.block.server.pbj.PbjBlockStreamServiceProxy.level=FINE
+
+# Configure specific Block Node Consumer loggers
+#org.hiero.block.server.consumer.ConsumerStreamResponseObserver.level=FINE
+#org.hiero.block.server.consumer.HistoricBlockStreamSupplier.level=FINE
+
+# Configure specific stream service loggers
+#org.hiero.block.server.pbj.PbjBlockStreamServiceProxy.level=FINE
+#org.hiero.block.server.persistence.StreamPersistenceHandlerImpl.level=FINE
+#org.hiero.block.server.persistence.storage.write.level=FINE
+#org.hiero.block.server.persistence.storage.archive.LocalGroupZipArchiveTask.level=FINE
+
+# Helidon PBJ Plugin loggers
+#org.hiero.pbj.grpc.helidon.PbjProtocolHandler.level=FINE
+
+################################################################################
+# Handlers configuration
+################################################################################
+handlers = java.util.logging.ConsoleHandler
+
+################################################################################
+# ConsoleHandler configuration
+################################################################################
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+################################################################################
+# SimpleFormatter single-line format configuration
+################################################################################
+# The format syntax uses java.util.Formatter.
+# The parameters are:
+#   %1$ - date/time (java.util.Date)
+#   %2$ - source (usually class and method)
+#   %3$ - logger name
+#   %4$ - log level
+#   %5$ - log message
+#   %6$ - throwable trace
+#
+# Example to produce a line such as:
+# 2025-02-25 21:07:36.281+0000 INFO    [org.hiero.block.server.Server main] Starting BlockNode Server
+# 21:07:36.281+0000 - Indicates UTC time since there's no offset
+# Log level is padded to 7 chars
+java.util.logging.SimpleFormatter.format = %TF %<TT.%<TL%<Tz %4$-7s [%2$s] %5$s%6$s%n

--- a/tools-and-tests/suites/build.gradle.kts
+++ b/tools-and-tests/suites/build.gradle.kts
@@ -25,7 +25,7 @@ tasks.register<Test>("runSuites") {
 
     // @todo(#813) All of the docker processing belongs here, not in block-node-app.
     //    This might mean duplication, which is perfectly fine.
-    dependsOn(":block-node-app:createDockerImage")
+    dependsOn(":block-node-app:createDockerImageCI")
 
     useJUnitPlatform()
     testLogging { events("passed", "skipped", "failed") }


### PR DESCRIPTION
## Reviewer Notes

* Add the ability to overwrite the default logging properties when running in CI

## Related Issue(s)

Resolves #1633 