### PR TITLE
chore(verification): Making HAPI 0.68.0 VerificationSession always succeed while Final implementation is in the works.

### DIFF
--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeVerificationSessionV0680.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeVerificationSessionV0680.java
@@ -5,8 +5,11 @@ import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.TRACE;
 
 import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.ArrayList;
 import java.util.List;
 import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.hiero.block.node.verification.session.BlockVerificationSession;
@@ -16,21 +19,37 @@ public class ExtendedMerkleTreeVerificationSessionV0680 implements BlockVerifica
 
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
 
+    /** The block number being verified. */
+    protected final long blockNumber;
+
+    /** The source of the block, used to construct the final notification. */
+    private final BlockSource blockSource;
+
+    /**
+     * The block items for the block this session is responsible for. We collect them here so we can provide the
+     * complete block in the final notification.
+     */
+    protected final List<BlockItemUnparsed> blockItems = new ArrayList<>();
+
     public ExtendedMerkleTreeVerificationSessionV0680(
             final long blockNumber, final BlockSource blockSource, final String extraBytes) {
-        LOGGER.log(
-                TRACE,
-                "ExtendedMerkleTreeVerificationSessionV0680 created for block number: %d from source: %s with extra bytes: %s"
-                        .formatted(blockNumber, blockSource, extraBytes));
+        this.blockNumber = blockNumber;
+        this.blockSource = blockSource;
+        LOGGER.log(INFO, "Created ExtendedMerkleTreeVerificationSessionV0680 for block {}", blockNumber);
     }
 
+    // todo(1661) implement the real logic here, for now just return true if last item has block proof.
     @Override
     public VerificationNotification processBlockItems(List<BlockItemUnparsed> blockItems) throws ParseException {
-        LOGGER.log(
-                INFO,
-                "HAPI VERSION NOT IMPLEMENTED YET. %d block items in ExtendedMerkleTreeVerificationSessionV0680"
-                        .formatted(blockItems.size()));
-
-        throw new UnsupportedOperationException("Not implemented yet");
+        this.blockItems.addAll(blockItems);
+        LOGGER.log(TRACE, "Processed {} block items for block {}", blockItems.size(), blockNumber);
+        if (blockItems.getLast().hasBlockProof()) {
+            BlockUnparsed block =
+                    BlockUnparsed.newBuilder().blockItems(this.blockItems).build();
+            Bytes blockHash = Bytes.wrap("0x00");
+            LOGGER.log(TRACE, "Returning always True verification notification for block {}", blockNumber);
+            return new VerificationNotification(true, blockNumber, blockHash, block, blockSource);
+        }
+        return null;
     }
 }

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeVerificationSessionV0680Test.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeVerificationSessionV0680Test.java
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.verification.session.impl;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hapi.block.stream.output.BlockHeader;
+import com.hedera.pbj.runtime.ParseException;
+import java.io.IOException;
+import java.util.List;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.node.app.fixtures.blocks.BlockUtils;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ExtendedMerkleTreeVerificationSessionV0680Test {
+    BlockUtils.SampleBlockInfo sampleBlockInfo;
+    List<BlockItemUnparsed> blockItems;
+
+    @BeforeEach
+    void setUp() throws IOException, ParseException {
+        sampleBlockInfo = BlockUtils.getSampleBlockInfo(BlockUtils.SAMPLE_BLOCKS.HAPI_0_64_0_BLOCK_14);
+        blockItems = sampleBlockInfo.blockUnparsed().blockItems();
+    }
+
+    /**
+     * Happy path test for the BlockVerificationSession class.
+     * */
+    @Test
+    void happyPath() throws ParseException {
+        BlockHeader blockHeader =
+                BlockHeader.PROTOBUF.parse(blockItems.getFirst().blockHeaderOrThrow());
+
+        long blockNumber = blockHeader.number();
+
+        ExtendedMerkleTreeVerificationSessionV0680 session =
+                new ExtendedMerkleTreeVerificationSessionV0680(blockNumber, BlockSource.PUBLISHER, "");
+
+        VerificationNotification blockNotification = session.processBlockItems(blockItems);
+
+        assertArrayEquals(
+                blockItems.toArray(),
+                session.blockItems.toArray(),
+                "The internal block items should be the same as ones sent in");
+
+        assertArrayEquals(
+                blockItems.toArray(),
+                blockNotification.block().blockItems().toArray(),
+                "The notification's block items should be the same as ones sent in");
+
+        assertEquals(
+                blockNumber,
+                blockNotification.blockNumber(),
+                "The block number should be the same as the one in the block header");
+
+        // todo(1661): this should be fixed on follow-up task (1661). As Session is not really implemented.
+        // in the mean time Hash will always be the same. no need to verify it.
+        //    assertEquals(
+        //      sampleBlockInfo.blockRootHash(),
+        //      blockNotification.blockHash(),
+        //      "The block hash should be the same as the one in the block header");
+
+        assertTrue(blockNotification.success(), "The block notification should be successful");
+
+        assertEquals(
+                sampleBlockInfo.blockUnparsed(),
+                blockNotification.block(),
+                "The block should be the same as the one sent");
+    }
+}


### PR DESCRIPTION

## Reviewer Notes

Currently CN Main is already streaming `0.68.0` even though that version of the HAPI blockstream from CN expects a lot of changes to be made on how to calculate the root hash of the block.

For now we are using a VerificationSession that is not yet implemented and failing with Not Implemented Exception.

With this change we revert the behaviour and instead of always fail, we always succeed. 

This is aimed at not breaking the integration testing while we are finishing the latest `0.68.0` Hashing and verification implementation.



## Related Issue(s)
Fixes #1730 
