### PR TITLE
fix: Handle retrieveLatest NullException Issue

### DIFF
--- a/block-node/block-access/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
+++ b/block-node/block-access/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
@@ -2,8 +2,8 @@
 package org.hiero.block.node.access.service;
 
 import static java.lang.System.Logger.Level.ERROR;
-import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.INFO;
+import static java.lang.System.Logger.Level.TRACE;
 
 import com.hedera.hapi.block.stream.Block;
 import com.swirlds.metrics.api.Counter;
@@ -55,10 +55,11 @@ public class BlockAccessServicePlugin implements BlockNodePlugin, BlockAccessSer
             if (request.hasBlockNumber() && request.blockNumber() >= 0) {
                 blockNumberToRetrieve = request.blockNumber();
                 LOGGER.log(TRACE, "Received `block_number` BlockRequest, retrieving block: {0}", blockNumberToRetrieve);
-            } else if ((request.hasRetrieveLatest() && request.retrieveLatest()) ||
-                       (request.hasBlockNumber() && request.blockNumber() == -1)) {
+            } else if ((request.hasRetrieveLatest() && request.retrieveLatest())
+                    || (request.hasBlockNumber() && request.blockNumber() == -1)) {
                 blockNumberToRetrieve = blockProvider.availableBlocks().max();
-                LOGGER.log(TRACE, "Received 'retrieveLatest' BlockRequest, retrieving block: {0}", blockNumberToRetrieve);
+                LOGGER.log(
+                        TRACE, "Received 'retrieveLatest' BlockRequest, retrieving block: {0}", blockNumberToRetrieve);
             } else {
                 LOGGER.log(INFO, "Invalid request, 'retrieve_latest' or a valid 'block number' is required.");
                 return new BlockResponse(Code.INVALID_REQUEST, null);

--- a/block-node/block-access/src/test/java/org/hiero/block/node/access/service/BlockAccessServicePluginTest.java
+++ b/block-node/block-access/src/test/java/org/hiero/block/node/access/service/BlockAccessServicePluginTest.java
@@ -116,7 +116,7 @@ public class BlockAccessServicePluginTest extends GrpcPluginTestBase<BlockAccess
         start(plugin, plugin.methods().getFirst(), new SimpleInMemoryHistoricalBlockFacility());
 
         final BlockRequest request =
-          BlockRequest.newBuilder().retrieveLatest(true).build();
+                BlockRequest.newBuilder().retrieveLatest(true).build();
         toPluginPipe.onNext(BlockRequest.PROTOBUF.toBytes(request));
         // Check we get a response
         assertEquals(1, fromPluginBytes.size());
@@ -130,7 +130,7 @@ public class BlockAccessServicePluginTest extends GrpcPluginTestBase<BlockAccess
     @DisplayName("Invalid Request Latest Block")
     void testInvalidRequestLatestBlock() throws ParseException {
         final BlockRequest request =
-          BlockRequest.newBuilder().retrieveLatest(false).build();
+                BlockRequest.newBuilder().retrieveLatest(false).build();
         toPluginPipe.onNext(BlockRequest.PROTOBUF.toBytes(request));
         // Check we get a response
         assertEquals(1, fromPluginBytes.size());
@@ -150,23 +150,22 @@ public class BlockAccessServicePluginTest extends GrpcPluginTestBase<BlockAccess
         // parse the response
         BlockResponse response = BlockResponse.PROTOBUF.parse(fromPluginBytes.get(0));
         // check that the status is success
-      assertEquals(Code.SUCCESS, response.status());
-      // check that the block number is correct
-      assertEquals(24, response.block().items().getFirst().blockHeader().number());
+        assertEquals(Code.SUCCESS, response.status());
+        // check that the block number is correct
+        assertEquals(24, response.block().items().getFirst().blockHeader().number());
     }
 
     @Test
     @DisplayName("Invalid Request")
     void testInvalidRequest() throws ParseException {
-      final BlockRequest request =
-        BlockRequest.newBuilder().build();
-      toPluginPipe.onNext(BlockRequest.PROTOBUF.toBytes(request));
-      // Check we get a response
-      assertEquals(1, fromPluginBytes.size());
-      // parse the response
-      BlockResponse response = BlockResponse.PROTOBUF.parse(fromPluginBytes.get(0));
-      // check that the status is NOT_AVAILABLE
-      assertEquals(Code.INVALID_REQUEST, response.status());
+        final BlockRequest request = BlockRequest.newBuilder().build();
+        toPluginPipe.onNext(BlockRequest.PROTOBUF.toBytes(request));
+        // Check we get a response
+        assertEquals(1, fromPluginBytes.size());
+        // parse the response
+        BlockResponse response = BlockResponse.PROTOBUF.parse(fromPluginBytes.get(0));
+        // check that the status is NOT_AVAILABLE
+        assertEquals(Code.INVALID_REQUEST, response.status());
     }
 
     private void sendBlocks(int numberOfBlocks) {

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/block/access/GetBlockApiTests.java
@@ -130,13 +130,12 @@ public class GetBlockApiTests extends BaseSuite {
     @Test
     @DisplayName("Get a Single Block using API - Request with no valid fields")
     void requestWithNoFieldsFromOneOf() {
-      // Request the latest block
-      BlockRequest request =
-        BlockRequest.newBuilder().build();
-      final BlockResponse response = blockAccessStub.getBlock(request);
+        // Request the latest block
+        BlockRequest request = BlockRequest.newBuilder().build();
+        final BlockResponse response = blockAccessStub.getBlock(request);
 
-      // Verify the response
-      assertNotNull(response, "Response should not be null");
-      assertEquals(Code.NOT_FOUND, response.getStatus(), "Block retrieval should fail with invalid");
+        // Verify the response
+        assertNotNull(response, "Response should not be null");
+        assertEquals(Code.INVALID_REQUEST, response.getStatus(), "Block retrieval should fail with invalid");
     }
 }


### PR DESCRIPTION
## Reviewer Notes

In 0.18.0 we observed instances of a NullException when making a getBlock with retrieveLatest in use.
Additionally the "Latest available block number is not available, this should not be possible." message wasn't as clear to a node operator or user

- Update `BlockAccessServicePlugin` 
  - `getBlock` main log message to highlight request and block that will be retrieved
  - request parsing logic to handle 3 cases - i) retrieveLatest = true or Max Long ii) valid block number iii) invalid request
- Updated `BlockAccessServicePluginTest` with additional tests for long.Max, retrieveLatest on empty store and invalid retrieve latest
- Update `GetBlockApiTests` with E2E test for retrieveLatest=false and no block number

## Related Issue(s)
Fixes #1740 
