### PR TITLE
feat(performance): Fine tune HTTP2 Config for better High TPS Network Capacity

### DIFF
--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ServerConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ServerConfig.java
@@ -18,7 +18,7 @@ import org.hiero.block.node.base.Loggable;
  */
 @ConfigData("server")
 public record ServerConfig(
-        @Loggable @ConfigProperty(defaultValue = "4_194_304") @Min(10_240) @Max(16_777_215) int maxMessageSizeBytes,
+        @Loggable @ConfigProperty(defaultValue = "16_777_215") @Min(10_240) @Max(16_777_215) int maxMessageSizeBytes,
         @Loggable @ConfigProperty(defaultValue = "32768") @Min(32768) @Max(Integer.MAX_VALUE)
                 int socketSendBufferSizeBytes,
         @Loggable @ConfigProperty(defaultValue = "32768") @Min(32768) @Max(Integer.MAX_VALUE)

--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/WebServerHttp2Config.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/WebServerHttp2Config.java
@@ -22,11 +22,11 @@ import org.hiero.block.node.base.Loggable;
  */
 @ConfigData("server.http2")
 public record WebServerHttp2Config(
-        @Loggable @ConfigProperty(defaultValue = "50") int flowControlTimeout,
-        @Loggable @ConfigProperty(defaultValue = "1048576") int initialWindowSize,
+        @Loggable @ConfigProperty(defaultValue = "250") int flowControlTimeout,
+        @Loggable @ConfigProperty(defaultValue = "8_388_608") int initialWindowSize,
         @Loggable @ConfigProperty(defaultValue = "8") long maxConcurrentStreams,
         @Loggable @ConfigProperty(defaultValue = "10") int maxEmptyFrames,
-        @Loggable @ConfigProperty(defaultValue = "524288") int maxFrameSize,
+        @Loggable @ConfigProperty(defaultValue = "524_288") int maxFrameSize,
         @Loggable @ConfigProperty(defaultValue = "8192") long maxHeaderListSize,
         @Loggable @ConfigProperty(defaultValue = "50") int maxRapidResets,
         @Loggable @ConfigProperty(defaultValue = "10000") int rapidResetCheckPeriod) {}


### PR DESCRIPTION
## Reviewer Notes

- First pass at improving the HTTP2 Default config for High TPS loads over the network.

```
2025-10-17 01:36:29.060+0000 INFO    [org.hiero.block.node.app.logging.ConfigLogger log]     server.http2.flowControlTimeout = 250

2025-10-17 01:36:29.060+0000 INFO    [org.hiero.block.node.app.logging.ConfigLogger log]     server.http2.initialWindowSize = 8388608

2025-10-17 01:36:29.060+0000 INFO    [org.hiero.block.node.app.logging.ConfigLogger log]     server.http2.maxConcurrentStreams = 8

2025-10-17 01:36:29.060+0000 INFO    [org.hiero.block.node.app.logging.ConfigLogger log]     server.http2.maxEmptyFrames = 10

2025-10-17 01:36:29.060+0000 INFO    [org.hiero.block.node.app.logging.ConfigLogger log]     server.http2.maxFrameSize = 524288

2025-10-17 01:36:29.060+0000 INFO    [org.hiero.block.node.app.logging.ConfigLogger log]     server.http2.maxHeaderListSize = 8192

2025-10-17 01:36:29.061+0000 INFO    [org.hiero.block.node.app.logging.ConfigLogger log]     server.http2.maxRapidResets = 50

2025-10-17 01:36:29.061+0000 INFO    [org.hiero.block.node.app.logging.ConfigLogger log]     server.http2.rapidResetCheckPeriod = 10000

2025-10-17 01:36:29.061+0000 INFO    [org.hiero.block.node.app.logging.ConfigLogger log]     server.maxMessageSizeBytes = 16777215
```

<img width="1300" height="964" alt="image" src="https://github.com/user-attachments/assets/cf4eb7f5-aed3-4d55-8a6c-b283069acad5" />
