### PR TITLE
chore: Enhance rolling log logic

### DIFF
--- a/block-node/app/src/main/java/module-info.java
+++ b/block-node/app/src/main/java/module-info.java
@@ -29,5 +29,6 @@ module org.hiero.block.node.app {
     requires static transitive com.github.spotbugs.annotations;
     requires static java.compiler;
 
-    exports org.hiero.block.node.app.logging to java.logging;
+    exports org.hiero.block.node.app.logging to
+            java.logging;
 }

--- a/block-node/app/src/main/java/module-info.java
+++ b/block-node/app/src/main/java/module-info.java
@@ -28,4 +28,6 @@ module org.hiero.block.node.app {
     requires java.logging; // javax.annotation.processing.Generated
     requires static transitive com.github.spotbugs.annotations;
     requires static java.compiler;
+
+    exports org.hiero.block.node.app.logging to java.logging;
 }

--- a/block-node/app/src/main/java/org/hiero/block/node/app/logging/RollingFileHandler.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/logging/RollingFileHandler.java
@@ -2,8 +2,9 @@
 package org.hiero.block.node.app.logging;
 
 import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.logging.FileHandler;
 import java.util.logging.LogManager;
 
@@ -16,14 +17,17 @@ public class RollingFileHandler extends FileHandler {
 
     public RollingFileHandler() throws IOException {
         super(
-            fileName(LogManager.getLogManager().getProperty("java.util.logging.FileHandler.pattern")),
-            Integer.parseInt(LogManager.getLogManager().getProperty("java.util.logging.FileHandler.limit")),
-            Integer.parseInt(LogManager.getLogManager().getProperty("java.util.logging.FileHandler.count")),
-            Boolean.parseBoolean(LogManager.getLogManager().getProperty("java.util.logging.FileHandler.append")));
+                fileName(LogManager.getLogManager().getProperty("java.util.logging.FileHandler.pattern")),
+                Integer.parseInt(LogManager.getLogManager().getProperty("java.util.logging.FileHandler.limit")),
+                Integer.parseInt(LogManager.getLogManager().getProperty("java.util.logging.FileHandler.count")),
+                Boolean.parseBoolean(LogManager.getLogManager().getProperty("java.util.logging.FileHandler.append")));
     }
 
     private static String fileName(String pattern) {
-        final String fileName = pattern.replace("%d", new SimpleDateFormat("yyyy-MM-dd").format(new Date()));
+        DateTimeFormatter formatter =
+                DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
+
+        final String fileName = pattern.replace("%d", formatter.format(Instant.now()));
 
         // check if the directory exists, if not create it
         final java.io.File file = new java.io.File(fileName);

--- a/block-node/app/src/main/java/org/hiero/block/node/app/logging/RollingFileHandler.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/logging/RollingFileHandler.java
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.app.logging;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.logging.FileHandler;
+import java.util.logging.LogManager;
+
+/**
+ * A FileHandler that rolls over the log file based on date in addition to size.
+ * The log file name pattern can include %1$t to include the current date in
+ * yyyy-MM-dd format.
+ */
+public class RollingFileHandler extends FileHandler {
+
+    public RollingFileHandler() throws IOException {
+        super(
+            fileName(LogManager.getLogManager().getProperty("java.util.logging.FileHandler.pattern")),
+            Integer.parseInt(LogManager.getLogManager().getProperty("java.util.logging.FileHandler.limit")),
+            Integer.parseInt(LogManager.getLogManager().getProperty("java.util.logging.FileHandler.count")),
+            Boolean.parseBoolean(LogManager.getLogManager().getProperty("java.util.logging.FileHandler.append")));
+    }
+
+    private static String fileName(String pattern) {
+        final String fileName = pattern.replace("%d", new SimpleDateFormat("yyyy-MM-dd").format(new Date()));
+
+        // check if the directory exists, if not create it
+        final java.io.File file = new java.io.File(fileName);
+        final java.io.File parentDir = file.getParentFile();
+        if (parentDir != null && !parentDir.exists()) {
+            parentDir.mkdirs();
+        }
+
+        return fileName;
+    }
+}

--- a/block-node/app/src/main/resources/logging.properties
+++ b/block-node/app/src/main/resources/logging.properties
@@ -44,7 +44,7 @@ com.sun.net.httpserver.ExchangeImpl.level = WARNING
 ################################################################################
 # Handlers configuration
 ################################################################################
-#handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
+#handlers = java.util.logging.ConsoleHandler, org.hiero.block.node.app.logging.RollingFileHandler
 handlers = java.util.logging.ConsoleHandler
 
 ################################################################################
@@ -52,6 +52,11 @@ handlers = java.util.logging.ConsoleHandler
 ################################################################################
 java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = org.hiero.block.node.app.logging.CleanColorfulFormatter
+# 50 MB log file limit, 20 rotating files max a day. Uses %d for date and %g for generation number in pattern.
+java.util.logging.FileHandler.limit = 50000000
+java.util.logging.FileHandler.count = 20
+java.util.logging.FileHandler.append = true
+java.util.logging.FileHandler.pattern = logs/block-node-%d-%g.log
 #org.hiero.block.node.app.logging.CleanColorfulFormatter.format = %TF %<TT.%<TL%<Tz %4$-7s [%2$s] %5$s%6$s%n
 
 ################################################################################

--- a/block-node/app/src/main/resources/logging.properties
+++ b/block-node/app/src/main/resources/logging.properties
@@ -52,11 +52,12 @@ handlers = java.util.logging.ConsoleHandler
 ################################################################################
 java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = org.hiero.block.node.app.logging.CleanColorfulFormatter
+# Uncomment to utilize FileHandler/RollingFileHandler logic
 # 50 MB log file limit, 20 rotating files max a day. Uses %d for date and %g for generation number in pattern.
-java.util.logging.FileHandler.limit = 50000000
-java.util.logging.FileHandler.count = 20
-java.util.logging.FileHandler.append = true
-java.util.logging.FileHandler.pattern = logs/block-node-%d-%g.log
+#java.util.logging.FileHandler.limit = 50000000
+#java.util.logging.FileHandler.count = 20
+#java.util.logging.FileHandler.append = true
+#java.util.logging.FileHandler.pattern = logs/block-node-%d-%g.log
 #org.hiero.block.node.app.logging.CleanColorfulFormatter.format = %TF %<TT.%<TL%<Tz %4$-7s [%2$s] %5$s%6$s%n
 
 ################################################################################

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -169,13 +169,13 @@ blockNode:
       io.helidon.config.level: "SEVERE"
       io.helidon.security.level: "INFO"
       io.helidon.common.level: "INFO"
-      handlers: "java.util.logging.ConsoleHandler, java.util.logging.FileHandler"
+      handlers: "java.util.logging.ConsoleHandler, org.hiero.block.node.app.logging.RollingFileHandler"
       java.util.logging.ConsoleHandler.level: "FINEST"
       java.util.logging.ConsoleHandler.formatter: "java.util.logging.SimpleFormatter"
-      java.util.logging.FileHandler.pattern: "/opt/hiero/block-node/logs/blocknode-%g.log"
+      # FileHandler pattern uses %d for adding date, %g for generation number when rotating
+      java.util.logging.FileHandler.pattern: "/opt/hiero/block-node/logs/block-node-%d-%g.log"
       java.util.logging.FileHandler.append: "true"
       java.util.logging.FileHandler.limit: "5000000"
-      java.util.logging.FileHandler.count: "5"
       java.util.logging.FileHandler.level: "FINEST"
       java.util.logging.FileHandler.formatter: "java.util.logging.SimpleFormatter"
       # Override the chatty HTTP server internals


### PR DESCRIPTION
## Reviewer Notes

Add support for date based rolling log files.
Node operators engaging in load tests and trace logs will observe large multiple log files.
This is a node operator experience improvement to make management and configuration easier.


## Related Issue(s)
Fixes #1774 