### PR TITLE
fix: Add initial no-op handling of `EndOfBlock` message.

### DIFF
--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -175,6 +175,8 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
             } finally {
                 shutdown();
             }
+        } else if (request.hasEndOfBlock()) {
+            // @todo(1626) Do nothing for now.
         } else {
             // this should never happen
             sendEndAndResetState(Code.ERROR);


### PR DESCRIPTION
## Reviewer Notes
* Added a trivial no-op handling to the stream publisher plugin to accept an `EndOfBlock` message without error.

Fixes #1787 