### PR TITLE
feat: Add end-of-block messages to subscriber and publisher plugins.

### DIFF
--- a/block-node/app/docker/Dockerfile
+++ b/block-node/app/docker/Dockerfile
@@ -23,9 +23,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
+# Copy the repro sources list shell script file, don't use a bind mount because that
+# is sensitive to local (real) user umask and file permissions.
+COPY --chmod=755 repro-sources-list.sh /usr/local/bin/repro-sources-list.sh
+# The script will be removed after it is run.
 # Install basic OS utilities for building
-RUN --mount=type=bind,source=./repro-sources-list.sh,target=/usr/local/bin/repro-sources-list.sh \
-    repro-sources-list.sh && \
+RUN repro-sources-list.sh && \
+    rm -rf /usr/local/bin/repro-sources-list.sh && \
     apt-get update && \
     apt-get install --yes --no-install-recommends tar gzip curl ca-certificates sudo && \
     apt-get autoclean --yes && \

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
@@ -6,6 +6,7 @@ import com.hedera.pbj.grpc.helidon.config.PbjConfig;
 import io.helidon.webserver.ConnectionConfig;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
+import org.hiero.block.api.BlockEnd;
 import org.hiero.block.api.BlockItemSet;
 import org.hiero.block.api.BlockNodeServiceInterface;
 import org.hiero.block.api.BlockStreamSubscribeServiceInterface;
@@ -41,6 +42,10 @@ public class TestBlockNodeServer {
                                                     .block()
                                                     .items())
                                             .build())
+                                    .build());
+                            replies.onNext(SubscribeStreamResponse.newBuilder()
+                                    .endOfBlock(
+                                            BlockEnd.newBuilder().blockNumber(i).build())
                                     .build());
                         }
 

--- a/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockItems.java
+++ b/block-node/spi/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockItems.java
@@ -38,6 +38,8 @@ public record BlockItems(List<BlockItemUnparsed> blockItems, long blockNumber) {
     /**
      * Helper method to check if this set of items is the end of a block, this is true of last item is a block proof.
      *
+     * Note, this will change at some future point, when we fully handle multiple block proofs.
+     *
      * @return true if last item is a block proof, false otherwise.
      */
     public boolean isEndOfBlock() {

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -8,7 +8,6 @@ import static java.lang.System.Logger.Level.WARNING;
 import static org.hiero.block.node.spi.BlockNodePlugin.METRICS_CATEGORY;
 import static org.hiero.block.node.spi.BlockNodePlugin.UNKNOWN_BLOCK_NUMBER;
 
-import com.hedera.hapi.block.stream.BlockProof;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.swirlds.metrics.api.Counter;
 import com.swirlds.metrics.api.LongGauge;
@@ -321,6 +320,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
      * when interrupt is used as a signal rather than signaling the `Condition`
      * variable.</blockquote>
      */
+    @SuppressWarnings("AwaitNotInLoop")
     private void waitForDataReady() {
         dataReadyLock.lock();
         try {
@@ -374,31 +374,14 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     // fails to parse. This _is not an error_ and we should still forward
     // the block to messaging and treat the block as completed, we just
     // won't do anything that requires parsing the block proof. It is
-    // possible the parsing failed in the publisher but will still
-    // succeed in the verification plugin.
+    // possible the parsing failed in the publisher or that we are simply
+    // responding to a `EndOfBlock` message.
     @Override
-    public void closeBlock(final BlockProof blockEndProof, final long handlerId) {
+    public void closeBlock(final long handlerId) {
         checkLogAndRestartForwarderTask();
-        if (blockEndProof == null) {
-            // No point logging here, as the handler would have done that.
-            // here we just update metrics.
-            metrics.blocksClosedIncomplete.increment();
-        } else {
-            metrics.blocksClosedComplete.increment();
-            // @todo(1239) Also check if we have incomplete blocks lower than the
-            //     block that completed, and possibly enter the resend process to
-            //     have handlers go back and get the block that was too slow resent
-            //     from a different publisher (don't forget to keep/track last
-            //     completed block, and retain data in queue(s) for
-            //     completed-but-not-forwarded blocks).
-
-            // @todo(1415) Remove this log when the related tickets are done.
-            LOGGER.log(
-                    DEBUG,
-                    "Completed blocks: {0}, Incompleted blocks: {1}",
-                    metrics.blocksClosedComplete.get(),
-                    metrics.blocksClosedIncomplete.get());
-        }
+        metrics.blocksClosedComplete.increment();
+        // @todo(1415) Remove this log when the related tickets are done.
+        LOGGER.log(DEBUG, "Completed blocks {0}", metrics.blocksClosedComplete.get());
     }
 
     /// Check the queue forwarder task and start, or restart, if it is
@@ -772,8 +755,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
      * lowestBlockNumber - Lowest incoming block number
      * highestBlockNumber - Highest incoming block number
      * latestBlockNumberAcknowledged - The latest block number acknowledged
-     * blocksClosedComplete - Number of blocks received complete (with both header and proof)
-     * blocksClosedIncomplete - Number of blocks received incomplete (missing header or proof)
+     * blocksClosedComplete - Number of blocks received complete (with both header and end of block)
      */
     public record MetricsHolder(
             Counter blockItemsMessaged,
@@ -782,8 +764,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             LongGauge lowestBlockNumber,
             LongGauge highestBlockNumber,
             LongGauge latestBlockNumberAcknowledged,
-            Counter blocksClosedComplete,
-            Counter blocksClosedIncomplete) {
+            Counter blocksClosedComplete) {
         /**
          * todo(1420) add documentation
          */
@@ -797,9 +778,6 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             final Counter blocksClosedComplete =
                     metrics.getOrCreate(new Counter.Config(METRICS_CATEGORY, "publisher_blocks_closed_complete")
                             .withDescription("Blocks received complete (with both header and proof) by any Handler"));
-            final Counter blocksClosedIncomplete =
-                    metrics.getOrCreate(new Counter.Config(METRICS_CATEGORY, "publisher_blocks_closed_incomplete")
-                            .withDescription("Blocks received incomplete (missing header or proof) by any Handler"));
             final LongGauge numberOfProducers =
                     metrics.getOrCreate(new LongGauge.Config(METRICS_CATEGORY, "publisher_open_connections")
                             .withDescription("Connected publishers"));
@@ -819,8 +797,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                     lowestBlockNumber,
                     highestBlockNumber,
                     latestBlockNumberAcknowledged,
-                    blocksClosedComplete,
-                    blocksClosedIncomplete);
+                    blocksClosedComplete);
         }
     }
 }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.stream.publisher;
 
-import com.hedera.hapi.block.stream.BlockProof;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -47,7 +46,7 @@ public interface StreamPublisherManager extends BlockNotificationHandler {
     /**
      * Close a block for a handler.
      */
-    void closeBlock(@Nullable final BlockProof blockEndProof, final long handlerId);
+    void closeBlock(final long handlerId);
 
     /**
      * Return the latest known valid and persisted block number.

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -4,8 +4,8 @@ package org.hiero.block.node.stream.publisher;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.endThisBlock;
 
-import com.hedera.hapi.block.stream.BlockProof;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
 import java.util.Arrays;
@@ -485,7 +485,7 @@ class LiveStreamPublisherManagerTest {
         }
 
         /**
-         * Tests for {@link LiveStreamPublisherManager#closeBlock(BlockProof, long)}.
+         * Tests for {@link LiveStreamPublisherManager#closeBlock(long)}.
          */
         @Nested
         @DisplayName("closeBlock() Tests")
@@ -528,6 +528,7 @@ class LiveStreamPublisherManagerTest {
                 // manager for a block action for block 0L and at that point it
                 // was the next expected block.
                 publisherHandler.onNext(request);
+                endThisBlock(publisherHandler, streamedBlockNumber);
                 // Build a verification notification with passed verification.
                 // Source must be publisher.
                 final VerificationNotification notification =
@@ -574,6 +575,7 @@ class LiveStreamPublisherManagerTest {
                 // manager for a block action for block 0L and at that point it
                 // was the next expected block.
                 publisherHandler.onNext(request);
+                endThisBlock(publisherHandler, streamedBlockNumber);
                 // Now we need to send a PersistedNotification, so that the
                 // latest known block number will be updated to 0L.
                 final PersistedNotification persistedNotification =
@@ -633,6 +635,7 @@ class LiveStreamPublisherManagerTest {
                 // manager for a block action for block 0L and at that point it
                 // was the next expected block.
                 publisherHandler.onNext(request);
+                endThisBlock(publisherHandler, streamedBlockNumber);
                 // We need to send a PersistedNotification first, so that the latest known block number will be updated
                 // to 0L.
                 final PersistedNotification persistedNotification =
@@ -744,6 +747,7 @@ class LiveStreamPublisherManagerTest {
                 // manager for a block action for block 0L and at that point it
                 // was the next expected block.
                 publisherHandler.onNext(request);
+                endThisBlock(publisherHandler, streamedBlockNumber);
                 // Now, the publisher has sent the targeted block with broken proof.
                 // We can now build a verification notification with failed verification.
                 final VerificationNotification notification =
@@ -798,6 +802,7 @@ class LiveStreamPublisherManagerTest {
                 // manager for a block action for block 0L and at that point it
                 // was the next expected block.
                 publisherHandler2.onNext(request);
+                endThisBlock(publisherHandler2, streamedBlockNumber);
                 // Build a verification notification with failed verification.
                 final VerificationNotification notification =
                         new VerificationNotification(false, streamedBlockNumber, null, null, BlockSource.PUBLISHER);
@@ -865,6 +870,7 @@ class LiveStreamPublisherManagerTest {
                 // manager for a block action for block 0L and at that point it
                 // was the next expected block.
                 publisherHandler2.onNext(request);
+                endThisBlock(publisherHandler2, streamedBlockNumber);
                 // Then, we need to simulate that the publisher has sent a block with invalid proof, i.e. call
                 // handleVerification with failed verification.
                 // Build a verification notification with failed verification.
@@ -910,6 +916,7 @@ class LiveStreamPublisherManagerTest {
                 assertThat(messagingFacility.getSentBlockItems()).isNotNull().isEmpty();
                 // We send the request to the publisher handler.
                 publisherHandler.onNext(request);
+                endThisBlock(publisherHandler, streamedBlockNumber);
                 // We run the queued messaging forwarder to update the current streaming block number.
                 // We need to run the task async, because the loop (managed by config) is way too big to block on.
                 // We will however wait for one second to ensure the task is run.
@@ -1083,6 +1090,7 @@ class LiveStreamPublisherManagerTest {
                         .build();
                 // We send the request to the publisher handler.
                 publisherHandler.onNext(request);
+                endThisBlock(publisherHandler, streamedBlockNumber);
                 // Now we need to build an end stream request
                 final EndStream endStream = EndStream.newBuilder()
                         .endCode(code)
@@ -1107,6 +1115,7 @@ class LiveStreamPublisherManagerTest {
                 // we expect to get a SKIP, the block was complete, next expected is +1L.
                 // We use the second publisher as the first one is already shut down.
                 publisherHandler2.onNext(request);
+                endThisBlock(publisherHandler, streamedBlockNumber);
                 assertThat(responsePipeline2.getOnNextCalls())
                         .hasSize(1)
                         .first()
@@ -1176,6 +1185,7 @@ class LiveStreamPublisherManagerTest {
                         .blockItems(fullBlockSet)
                         .build();
                 publisherHandler2.onNext(requestFullBlock);
+                endThisBlock(publisherHandler, streamedBlockNumber);
                 // We run the queued messaging forwarder to update the current streaming block number.
                 // We need to run the task async, because the loop (managed by config) is way too big to block on.
                 // We will however wait for one second to ensure the task is run.

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
@@ -5,6 +5,7 @@ import static java.util.concurrent.locks.LockSupport.parkNanos;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.block.node.app.fixtures.TestUtils.enableDebugLogging;
 import static org.hiero.block.node.app.fixtures.blocks.SimpleTestBlockItemBuilder.toBlockItems;
+import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.endThisBlock;
 
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
@@ -257,6 +258,7 @@ class StreamPublisherPluginTest {
                     .build();
             // Send the request to the pipeline
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
+            endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
             parkNanos(500_000_000L);
             assertThat(fromPluginBytes)
@@ -398,6 +400,7 @@ class StreamPublisherPluginTest {
                     .build();
             // Send the request to the pipeline
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
+            endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
             parkNanos(500_000_000L);
             // Assert that the block has been successfully streamed
@@ -443,6 +446,7 @@ class StreamPublisherPluginTest {
                     .build();
             // Send the request to the pipeline
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
+            endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
             parkNanos(500_000_000L);
             // Assert that the block has been successfully streamed
@@ -491,6 +495,7 @@ class StreamPublisherPluginTest {
                     .build();
             // Send the request to the pipeline
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
+            endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
             parkNanos(500_000_000L);
             // Assert that the block has been successfully streamed
@@ -541,6 +546,7 @@ class StreamPublisherPluginTest {
                     .build();
             // Send the request to the pipeline
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
+            endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
             parkNanos(500_000_000L);
             // Assert that the block has been successfully streamed
@@ -588,6 +594,7 @@ class StreamPublisherPluginTest {
                     .build();
             // Send the request to the pipeline
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
+            endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
             parkNanos(500_000_000L);
             // Assert that the block has been successfully streamed
@@ -621,6 +628,7 @@ class StreamPublisherPluginTest {
                     .blockItems(firstRequestSet)
                     .build();
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(firstRequest));
+            endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
             parkNanos(500_000_000L);
             // Assert that the block has been successfully streamed
@@ -675,6 +683,7 @@ class StreamPublisherPluginTest {
                     .blockItems(firstRequestSet)
                     .build();
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(firstRequest));
+            endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
             parkNanos(500_000_000L);
             // Assert that the block has been successfully streamed
@@ -724,6 +733,7 @@ class StreamPublisherPluginTest {
                     .blockItems(firstRequestSet)
                     .build();
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(firstRequest));
+            endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
             parkNanos(500_000_000L);
             // Assert that the block has been successfully streamed

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/PublishApiUtility.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/PublishApiUtility.java
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.stream.publisher.fixtures;
+
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import org.hiero.block.api.BlockEnd;
+import org.hiero.block.internal.PublishStreamRequestUnparsed;
+import org.hiero.block.node.stream.publisher.PublisherHandler;
+
+/**
+ * Utility class to assist with publish API testing.
+ */
+public final class PublishApiUtility {
+
+    /**
+     * Utility class, do not permit constructing instances.
+     */
+    private PublishApiUtility() {}
+
+    /**
+     * Send an `EndOfBlock` message for a given block number.
+     * @param publisherHandler A publisher handler to be tested.
+     * @param blockNumber A block number to close.
+     */
+    public static void endThisBlock(final PublisherHandler publisherHandler, final long blockNumber) {
+        final BlockEnd endOfBlock =
+                BlockEnd.newBuilder().blockNumber(blockNumber).build();
+        final PublishStreamRequestUnparsed request =
+                PublishStreamRequestUnparsed.newBuilder().endOfBlock(endOfBlock).build();
+        publisherHandler.onNext(request);
+    }
+
+    /**
+     * Send an `EndOfBlock` message for a given block number.
+     * @param pluginPipe A publisher plugin pipeline to send requests.
+     * @param blockNumber A block number to close.
+     */
+    public static void endThisBlock(final Pipeline<? super Bytes> pluginPipe, final long blockNumber) {
+        final BlockEnd endOfBlock =
+                BlockEnd.newBuilder().blockNumber(blockNumber).build();
+        final PublishStreamRequestUnparsed request =
+                PublishStreamRequestUnparsed.newBuilder().endOfBlock(endOfBlock).build();
+        pluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
+    }
+}

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestStreamPublisherManager.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.stream.publisher.fixtures;
 
-import com.hedera.hapi.block.stream.BlockProof;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
@@ -32,8 +31,6 @@ public class TestStreamPublisherManager implements StreamPublisherManager {
     """;
     /** The map of calls to closeBlock, with the handler id as key and the number of calls as value. */
     final Map<Long, Integer> closeBlockCalls = new LinkedHashMap<>();
-    /** The map of calls to closeBlock with null proof bytes, with the handler id as key and the number of calls as value. */
-    final Map<Long, Integer> nullCloseBlockCalls = new LinkedHashMap<>();
     /** The list of publisher handlers managed by this manager. This could be a map with handler id as key if needed */
     private final List<PublisherHandler> publisherHandlers = new ArrayList<>();
     /** The test block messaging facility used by this manager. */
@@ -69,13 +66,9 @@ public class TestStreamPublisherManager implements StreamPublisherManager {
     }
 
     @Override
-    public void closeBlock(final BlockProof blockEndProof, final long handlerId) {
+    public void closeBlock(final long handlerId) {
         // Increment the number of calls for the handler id
-        if (blockEndProof == null) {
-            nullCloseBlockCalls.merge(handlerId, 1, Integer::sum);
-        } else {
-            closeBlockCalls.merge(handlerId, 1, Integer::sum);
-        }
+        closeBlockCalls.merge(handlerId, 1, Integer::sum);
     }
 
     @Override
@@ -130,24 +123,12 @@ public class TestStreamPublisherManager implements StreamPublisherManager {
     /**
      * Fixture method to get the number of calls to closeBlock for a handler.
      * <p>
-     * Returns the number of calls to {@link #closeBlock(BlockProof, long)}
+     * Returns the number of calls to {@link #closeBlock(long)}
      * made by the handler with the given ID. If the handler ID is not found,
      * returns -1.
      */
     public int closeBlockCallsForHandler(final long handlerId) {
         return closeBlockCalls.getOrDefault(handlerId, -1);
-    }
-
-    /**
-     * Fixture method to get the number of calls to closeBlock with null proof
-     * for a handler.
-     * <p>
-     * Returns the number of calls to {@link #closeBlock(BlockProof, long)}
-     * made by the handler with the given ID, where the proof was null.
-     * If the handler ID is not found, returns -1.
-     */
-    public int nullCloseBlockCallsForHandler(final long handlerId) {
-        return nullCloseBlockCalls.getOrDefault(handlerId, -1);
     }
 
     /**

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
@@ -112,6 +112,7 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
     @Override
     public boolean streamBlock(
             Block block, @NonNull final Consumer<PublishStreamResponse> publishStreamResponseConsumer) {
+        final long blockNumber = block.getItems(0).getBlockHeader().getNumber();
         List<List<BlockItem>> streamingBatches =
                 ChunkUtils.chunkify(block.getItemsList(), blockStreamConfig.blockItemsBatchSize());
         for (List<BlockItem> streamingBatch : streamingBatches) {
@@ -142,6 +143,11 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
                 break;
             }
         }
+        requestStreamObserver.onNext(PublishStreamRequest.newBuilder()
+                .setEndOfBlock(org.hiero.block.api.protoc.BlockEnd.newBuilder()
+                        .setBlockNumber(blockNumber)
+                        .build())
+                .build());
         metricsService.get(LiveBlocksSent).increment();
         return streamEnabled.get();
     }

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/ConsumerStreamGrpcClientImplTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/ConsumerStreamGrpcClientImplTest.java
@@ -16,6 +16,7 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
+import org.hiero.block.api.protoc.BlockEnd;
 import org.hiero.block.api.protoc.BlockItemSet;
 import org.hiero.block.api.protoc.BlockStreamSubscribeServiceGrpc;
 import org.hiero.block.api.protoc.SubscribeStreamRequest;
@@ -77,6 +78,11 @@ public class ConsumerStreamGrpcClientImplTest {
 
                             responseObserver.onNext(SubscribeStreamResponse.newBuilder()
                                     .setBlockItems(blockItems)
+                                    .build());
+                            final BlockEnd endOfBlock =
+                                    BlockEnd.newBuilder().setBlockNumber(i).build();
+                            responseObserver.onNext(SubscribeStreamResponse.newBuilder()
+                                    .setEndOfBlock(endOfBlock)
                                     .build());
                         }
 


### PR DESCRIPTION
## Reviewer Notes
* Added sending an EndBlock message after each block in the Subscriber plugin.
* Added end of block support to publisher
* Removed block proof handling from publisher
    * We no longer need to look for block proofs; just the end of block message.
* Added `EndOfBlock` requests to `LiveStreamPublisherManagerTest`
* Added `EndOfBlock` requests to `StreamPublisherPluginTest`
* Updated `SubscriberServicePluginTest` to account for end of block messages.

## Related Issue(s)
 Resolves #1626
