### PR TITLE
fix: Unable to Upload Archive Block Batch

### DIFF
--- a/block-node/base/src/main/java/org/hiero/block/node/base/s3/S3Client.java
+++ b/block-node/base/src/main/java/org/hiero/block/node/base/s3/S3Client.java
@@ -141,11 +141,9 @@ public final class S3Client implements AutoCloseable {
 
     /**
      * Closes the HTTP client.
-     *
-     * @throws Exception if an error occurs while closing the client
      */
     @Override
-    public void close() throws Exception {
+    public void close() {
         this.httpClient.close();
     }
 
@@ -595,7 +593,8 @@ public final class S3Client implements AutoCloseable {
                 case PUT -> requestBuilder.PUT(HttpRequest.BodyPublishers.ofByteArray(requestBody));
                 case GET -> requestBuilder.GET();
                 case DELETE -> requestBuilder.DELETE();
-                default -> throw new IllegalArgumentException("Unsupported HTTP method: " + httpMethod);};
+                default -> throw new IllegalArgumentException("Unsupported HTTP method: " + httpMethod);
+            };
             requestBuilder = requestBuilder.headers(localHeaders.entrySet().stream()
                     .flatMap(entry -> Stream.of(entry.getKey(), entry.getValue()))
                     .toArray(String[]::new));

--- a/block-node/s3-archive/src/main/java/module-info.java
+++ b/block-node/s3-archive/src/main/java/module-info.java
@@ -18,7 +18,6 @@ module org.hiero.block.node.archive.s3cloud {
     requires org.hiero.block.node.base;
     requires org.hiero.block.protobuf.pbj;
     requires com.github.spotbugs.annotations;
-    requires java.logging;
     requires java.management;
     requires java.net.http;
     requires java.xml;


### PR DESCRIPTION
* Refactored the plugin and extracted an upload task
* Tests now run async
* We no longer silence exceptions from an upload run
* Introduced an executor service to help us manage uploads
* Cleaned up message formatting
* Best effort attempt (for now) to mitigate NPEs when gaps are detected
* Added tests:
  * Test for not throwing exceptions when an upload task completed
    exceptionally

Explores #1629 
Fixes: #1805  

## Reviewer Notes

With this PR I aim to refactor the plugin so we no longer silence exceptions and we have a much cleaner plugin to run with.

Here is an artificially induced NPE (I hard-coded `null` as the value for the block iterator in the tarred iterator) just to showcase what we will start seeing from now on:

<img width="1489" height="404" alt="image" src="https://github.com/user-attachments/assets/0b5c29ec-fa6a-4c22-a6ac-630eadb83d42" />

Since we do not know yet the actual cause of the NPE (my guess is that a block was missing so a block accessor was mapped to null), we cannot really solve the issue, we see the log for the missing block accessor, but also a simple null afterwards which has no stacktrace.

We should probably proceed with this intermediate improvement and run the deployments again where we expect to hit the actual exception.
