### PR TITLE
chore: Followup to Issue 1626

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
@@ -34,6 +34,7 @@ public class TestBlockNodeServer {
                     if (historicalBlockFacility
                             .availableBlocks()
                             .contains(request.startBlockNumber(), request.endBlockNumber())) {
+                        // publishes one set of block items and an EndOfBlock response for each block
                         for (long i = request.startBlockNumber(); i <= request.endBlockNumber(); i++) {
                             replies.onNext(SubscribeStreamResponse.newBuilder()
                                     .blockItems(BlockItemSet.newBuilder()

--- a/block-node/base/src/test/java/org/hiero/block/node/base/ranges/ConcurrentLongRangeSetThreadingTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/ranges/ConcurrentLongRangeSetThreadingTest.java
@@ -7,11 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +37,7 @@ class ConcurrentLongRangeSetThreadingTest {
     @Test
     @DisplayName("Concurrent additions should not lose or corrupt data")
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
-    void testConcurrentAdditions() throws Exception {
+    void testConcurrentAdditions() throws ExecutionException, InterruptedException {
         final ConcurrentLongRangeSet set = new ConcurrentLongRangeSet();
         final CountDownLatch startLatch = new CountDownLatch(1);
         final List<Future<?>> futures = new ArrayList<>();
@@ -89,7 +91,7 @@ class ConcurrentLongRangeSetThreadingTest {
     @Test
     @DisplayName("Concurrent removals should not corrupt data")
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
-    void testConcurrentRemovals() throws Exception {
+    void testConcurrentRemovals() throws ExecutionException, InterruptedException {
         // Initialize with a large continuous range
         final ConcurrentLongRangeSet set = new ConcurrentLongRangeSet(0, THREAD_COUNT * OPERATIONS_PER_THREAD * 2L - 1);
 
@@ -135,7 +137,7 @@ class ConcurrentLongRangeSetThreadingTest {
     @Test
     @DisplayName("Concurrent mixed operations should not corrupt data")
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
-    void testConcurrentMixedOperations() throws Exception {
+    void testConcurrentMixedOperations() throws ExecutionException, InterruptedException {
         final ConcurrentLongRangeSet set = new ConcurrentLongRangeSet();
         final CountDownLatch startLatch = new CountDownLatch(1);
         final List<Future<?>> futures = new ArrayList<>();
@@ -192,7 +194,7 @@ class ConcurrentLongRangeSetThreadingTest {
     @Test
     @DisplayName("High contention operations should complete without deadlock or corruption")
     @Timeout(value = 15, unit = TimeUnit.SECONDS)
-    void testHighContention() throws Exception {
+    void testHighContention() throws ExecutionException, InterruptedException {
         final ConcurrentLongRangeSet set = new ConcurrentLongRangeSet();
         final CountDownLatch startLatch = new CountDownLatch(1);
         final List<Future<?>> futures = new ArrayList<>();
@@ -247,7 +249,7 @@ class ConcurrentLongRangeSetThreadingTest {
     @Test
     @DisplayName("Operations should be lock-free")
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
-    void testOperationsAreLockFree() throws Exception {
+    void testOperationsAreLockFree() throws ExecutionException, InterruptedException, TimeoutException {
         final ConcurrentLongRangeSet set = new ConcurrentLongRangeSet();
         final AtomicBoolean slowThreadRunning = new AtomicBoolean(true);
         final AtomicInteger completedOperations = new AtomicInteger(0);
@@ -313,7 +315,7 @@ class ConcurrentLongRangeSetThreadingTest {
     @ValueSource(ints = {1, 2, 4, 8, 16})
     @DisplayName("Performance should scale reasonably with thread count")
     @Timeout(value = 30, unit = TimeUnit.SECONDS)
-    void testConcurrentPerformance(int threadCount) throws Exception {
+    void testConcurrentPerformance(int threadCount) throws ExecutionException, InterruptedException {
         // Skip this test if we don't have enough cores for the higher thread counts
         if (threadCount > Runtime.getRuntime().availableProcessors() * 2) {
             return;

--- a/block-node/base/src/test/java/org/hiero/block/node/base/s3/S3ClientTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/s3/S3ClientTest.java
@@ -11,8 +11,11 @@ import io.minio.ListObjectsArgs;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
+import io.minio.errors.MinioException;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -43,7 +46,7 @@ public class S3ClientTest {
 
     @SuppressWarnings({"resource", "HttpUrlsUsage"})
     @BeforeAll
-    void setup() throws Exception {
+    void setup() throws S3ClientException, IOException, GeneralSecurityException, MinioException {
         // Start MinIO container
         minioContainer = new GenericContainer<>("minio/minio:latest")
                 .withCommand("server /data")
@@ -75,7 +78,7 @@ public class S3ClientTest {
      */
     @Test
     @DisplayName("Test listObjects() correctly returns existing objects in a bucket")
-    void testList() throws Exception {
+    void testList() throws S3ClientException, IOException, GeneralSecurityException, MinioException {
         // Setup
         final String content = "Hello, MinIO!";
         final String keyPrefix = "block-";
@@ -121,7 +124,7 @@ public class S3ClientTest {
      */
     @Test
     @DisplayName("Test listObjects() returns empty  when no objects are found")
-    void testListNonExistentObjects() throws Exception {
+    void testListNonExistentObjects() throws S3ClientException, IOException {
         try (final S3Client s3Client = client()) {
             // Call
             final List<String> actual = s3Client.listObjects("non-existent-prefix", 100);
@@ -140,7 +143,7 @@ public class S3ClientTest {
      */
     @Test
     @DisplayName("Test multipart upload")
-    void testMultipartUpload() throws Exception {
+    void testMultipartUpload() throws S3ClientException, IOException, GeneralSecurityException, MinioException {
         // Setup
         final String key = "testMultipartUploadSuccess.txt";
         // check that the object does not exist before the test
@@ -190,7 +193,7 @@ public class S3ClientTest {
      */
     @Test
     @DisplayName("Test upload of a large file")
-    void testUploadFile() throws Exception {
+    void testUploadFile() throws S3ClientException, IOException, GeneralSecurityException, MinioException {
         // Setup
         final int testContentSize = 8 * 1024 * 1024 + 826;
         final String key = "uploadOfLargeFileSuccessful.txt";
@@ -251,7 +254,8 @@ public class S3ClientTest {
      */
     @Test
     @DisplayName("Test upload and download of a text file")
-    void testTextFileUploadAndDownload() throws Exception {
+    void testTextFileUploadAndDownload()
+            throws S3ClientException, IOException, GeneralSecurityException, MinioException {
         // Setup
         final String key = "uploadSimpleTextFile.txt";
         final String expected = "Hello, MinIO!";
@@ -292,7 +296,7 @@ public class S3ClientTest {
      */
     @Test
     @DisplayName("Test listMultipartUpload() will correctly return existing multipart uploads")
-    void testListMultipartUploads() throws Exception {
+    void testListMultipartUploads() throws S3ClientException, IOException, GeneralSecurityException, MinioException {
         // Setup
         final String key = "testListMultipartUploads.txt";
         try (final S3Client s3Client = client()) {
@@ -327,7 +331,8 @@ public class S3ClientTest {
      */
     @Test
     @DisplayName("Test listMultipartUpload() will correctly return existing multipart uploads")
-    void testListMultipartUploadsMultiKeyValue() throws Exception {
+    void testListMultipartUploadsMultiKeyValue()
+            throws S3ClientException, IOException, GeneralSecurityException, MinioException {
         // Setup
         final String key1 = "testListMultipartUploads1.txt";
         final String key2 = "testListMultipartUploads2.txt";
@@ -362,7 +367,7 @@ public class S3ClientTest {
      */
     @Test
     @DisplayName("Test abortMultipartUpload() will correctly abort an existing multipart upload")
-    void testAbortMultipartUpload() throws Exception {
+    void testAbortMultipartUpload() throws S3ClientException, IOException, GeneralSecurityException, MinioException {
         // Setup
         final String key = "testAbortMultipartUpload.txt";
         try (final S3Client s3Client = client()) {
@@ -404,7 +409,8 @@ public class S3ClientTest {
      */
     @Test
     @DisplayName("Test abortMultipartUpload() will correctly abort an existing multipart upload with multiple parts")
-    void testAbortMultipartUploadMultiKeyValue() throws Exception {
+    void testAbortMultipartUploadMultiKeyValue()
+            throws S3ClientException, IOException, GeneralSecurityException, MinioException {
         // Setup
         final String key1 = "testAbortMultipartUploads1.txt";
         final String key2 = "testAbortMultipartUploads2.txt";
@@ -456,7 +462,7 @@ public class S3ClientTest {
      */
     @Test
     @DisplayName("Test fetching a non-existent object")
-    void testFetchNonExistentObject() throws Exception {
+    void testFetchNonExistentObject() throws S3ClientException, IOException {
         try (final S3Client s3Client = client()) {
             assertNull(s3Client.downloadTextFile("non-existent-object.txt"));
         }

--- a/block-node/messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -688,9 +688,8 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
          * @param sequence   of the event being processed
          * @param endOfBatch flag to indicate if this is the last event in a batch from the {@link RingBuffer}
          * @param percentageBehindRingHead percentage 0.0 to 100.0 behind the ring head this handler is
-         * @throws Exception if the EventHandler would like the exception handled further up the chain.
          */
-        void onEvent(T event, long sequence, boolean endOfBatch, double percentageBehindRingHead) throws Exception;
+        void onEvent(T event, long sequence, boolean endOfBatch, double percentageBehindRingHead);
     }
 
     /**

--- a/block-node/s3-archive/src/test/java/org/hiero/block/node/archive/s3/S3ArchivePluginTest.java
+++ b/block-node/s3-archive/src/test/java/org/hiero/block/node/archive/s3/S3ArchivePluginTest.java
@@ -17,11 +17,13 @@ import io.minio.ListObjectsArgs;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 import io.minio.RemoveBucketArgs;
+import io.minio.errors.MinioException;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.GeneralSecurityException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -66,7 +68,7 @@ class S3ArchivePluginTest extends PluginTestBase<S3ArchivePlugin, ExecutorServic
     private final MinioClient minioClient;
 
     @SuppressWarnings("resource")
-    public S3ArchivePluginTest() throws Exception {
+    public S3ArchivePluginTest() throws GeneralSecurityException, IOException, MinioException {
         super(Executors.newSingleThreadExecutor());
         // Start MinIO container
         GenericContainer<?> minioContainer = new GenericContainer<>("minio/minio:latest")
@@ -97,7 +99,7 @@ class S3ArchivePluginTest extends PluginTestBase<S3ArchivePlugin, ExecutorServic
 
     @Test
     @DisplayName("ArchivePlugin should upload a tar file for single batch of blocks")
-    void startWithSingleBatch(@TempDir Path tempDir) throws Exception {
+    void startWithSingleBatch(@TempDir Path tempDir) throws IOException, InterruptedException {
         // create 10 sample blocks, this should trigger the plugin to archive them
         sendBlocks(START_TIME, 0, 9);
         // await archive task to complete
@@ -214,17 +216,17 @@ class S3ArchivePluginTest extends PluginTestBase<S3ArchivePlugin, ExecutorServic
         });
     }
 
-    private void createTestBucket() throws Exception {
+    private void createTestBucket() throws GeneralSecurityException, IOException, MinioException {
         minioClient.makeBucket(MakeBucketArgs.builder().bucket(BUCKET_NAME).build());
         assertTrue(testBucketExists());
     }
 
-    private void removeTestBucket() throws Exception {
+    private void removeTestBucket() throws GeneralSecurityException, IOException, MinioException {
         minioClient.removeBucket(RemoveBucketArgs.builder().bucket(BUCKET_NAME).build());
         assertFalse(testBucketExists());
     }
 
-    private boolean testBucketExists() throws Exception {
+    private boolean testBucketExists() throws GeneralSecurityException, IOException, MinioException {
         return minioClient.bucketExists(
                 BucketExistsArgs.builder().bucket(BUCKET_NAME).build());
     }

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamObserverTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamObserverTest.java
@@ -106,7 +106,7 @@ class PublishStreamObserverTest {
     }
 
     @Test
-    void verifyUpdateLatestAckBlockStartupDataHandlesIOException() throws Exception {
+    void verifyUpdateLatestAckBlockStartupDataHandlesIOException() throws IOException {
         PublishStreamResponse response = PublishStreamResponse.newBuilder()
                 .setAcknowledgement(
                         PublishStreamResponse.BlockAcknowledgement.newBuilder().setBlockNumber(12345L))

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublishClientManagerTest.java
@@ -27,6 +27,7 @@ import org.hiero.block.simulator.config.data.GrpcConfig;
 import org.hiero.block.simulator.config.data.SimulatorStartupDataConfig;
 import org.hiero.block.simulator.config.data.UnorderedStreamConfig;
 import org.hiero.block.simulator.config.types.EndStreamMode;
+import org.hiero.block.simulator.exception.BlockSimulatorParsingException;
 import org.hiero.block.simulator.generator.BlockStreamManager;
 import org.hiero.block.simulator.generator.CraftBlockStreamManager;
 import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
@@ -83,7 +84,7 @@ class PublishClientManagerTest {
     }
 
     @Test
-    void handleEndOfStreamOnSuccess() throws Exception {
+    void handleEndOfStreamOnSuccess() throws BlockSimulatorParsingException, IOException, InterruptedException {
         Block nextBlock = createBlocks(0, 1);
         PublishStreamResponse response = mock(PublishStreamResponse.class);
         PublishStreamResponse.EndOfStream endOfStream = mock(PublishStreamResponse.EndOfStream.class);
@@ -100,7 +101,7 @@ class PublishClientManagerTest {
     }
 
     @Test
-    void handleEndOfStreamOnBehind() throws Exception {
+    void handleEndOfStreamOnBehind() throws BlockSimulatorParsingException, IOException, InterruptedException {
         Block nextBlock = createBlocks(0, 1);
         PublishStreamResponse response = mock(PublishStreamResponse.class);
         PublishStreamResponse.EndOfStream endOfStream = mock(PublishStreamResponse.EndOfStream.class);
@@ -117,7 +118,7 @@ class PublishClientManagerTest {
     }
 
     @Test
-    void handleEndOfStreamOnDuplicateBlock() throws Exception {
+    void handleEndOfStreamOnDuplicateBlock() throws BlockSimulatorParsingException, IOException, InterruptedException {
         Block nextBlock = createBlocks(0, 1);
         PublishStreamResponse response = mock(PublishStreamResponse.class);
         PublishStreamResponse.EndOfStream endOfStream = mock(PublishStreamResponse.EndOfStream.class);
@@ -134,7 +135,7 @@ class PublishClientManagerTest {
     }
 
     @Test
-    void handleEndOfStreamOnTimeout() throws Exception {
+    void handleEndOfStreamOnTimeout() throws BlockSimulatorParsingException, IOException, InterruptedException {
         Block nextBlock = createBlocks(0, 1);
         PublishStreamResponse response = mock(PublishStreamResponse.class);
         PublishStreamResponse.EndOfStream endOfStream = mock(PublishStreamResponse.EndOfStream.class);
@@ -151,7 +152,7 @@ class PublishClientManagerTest {
     }
 
     @Test
-    void handleEndOfStreamOnBadBlockProof() throws Exception {
+    void handleEndOfStreamOnBadBlockProof() throws BlockSimulatorParsingException, IOException, InterruptedException {
         Block nextBlock = createBlocks(0, 1);
         PublishStreamResponse response = mock(PublishStreamResponse.class);
         PublishStreamResponse.EndOfStream endOfStream = mock(PublishStreamResponse.EndOfStream.class);
@@ -168,7 +169,7 @@ class PublishClientManagerTest {
     }
 
     @Test
-    void handleEndOfStreamOnInternalError() throws Exception {
+    void handleEndOfStreamOnInternalError() throws BlockSimulatorParsingException, IOException, InterruptedException {
         Block nextBlock = createBlocks(0, 1);
         PublishStreamResponse response = mock(PublishStreamResponse.class);
         PublishStreamResponse.EndOfStream endOfStream = mock(PublishStreamResponse.EndOfStream.class);
@@ -185,7 +186,8 @@ class PublishClientManagerTest {
     }
 
     @Test
-    void handleEndOfStreamOnPersistenceFailed() throws Exception {
+    void handleEndOfStreamOnPersistenceFailed()
+            throws BlockSimulatorParsingException, IOException, InterruptedException {
         Block nextBlock = createBlocks(0, 1);
         PublishStreamResponse response = mock(PublishStreamResponse.class);
         PublishStreamResponse.EndOfStream endOfStream = mock(PublishStreamResponse.EndOfStream.class);
@@ -202,7 +204,7 @@ class PublishClientManagerTest {
     }
 
     @Test
-    void handleResendBlock() throws Exception {
+    void handleResendBlock() throws BlockSimulatorParsingException, IOException, InterruptedException {
         Block nextBlock = createBlocks(0, 1);
         PublishStreamResponse response = mock(PublishStreamResponse.class);
         PublishStreamResponse.ResendBlock resendBlock = mock(PublishStreamResponse.ResendBlock.class);
@@ -218,7 +220,7 @@ class PublishClientManagerTest {
     }
 
     @Test
-    void handleSkipBlock() throws Exception {
+    void handleSkipBlock() throws BlockSimulatorParsingException, IOException, InterruptedException {
         Block nextBlock = createBlocks(0, 1);
         PublishStreamResponse response = mock(PublishStreamResponse.class);
         PublishStreamResponse.SkipBlock skipBlock = mock(PublishStreamResponse.SkipBlock.class);
@@ -235,7 +237,8 @@ class PublishClientManagerTest {
 
     @ParameterizedTest
     @MethodSource("provideEndStreamMode")
-    void sendEndStream(EndStreamMode endStreamMode, EndStream.Code endStreamCode) throws Exception {
+    void sendEndStream(EndStreamMode endStreamMode, EndStream.Code endStreamCode)
+            throws BlockSimulatorParsingException, IOException, InterruptedException {
         publishClientManager.sendEndStream(endStreamMode);
         verify(publishStreamGrpcClient).handleEndStreamModeIfSet(endStreamCode);
     }

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublisherClientModeHandlerTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/mode/PublisherClientModeHandlerTest.java
@@ -16,6 +16,7 @@ import com.swirlds.config.api.Configuration;
 import java.io.IOException;
 import java.util.Map;
 import org.hiero.block.simulator.config.data.BlockStreamConfig;
+import org.hiero.block.simulator.exception.BlockSimulatorParsingException;
 import org.hiero.block.simulator.fixtures.TestUtils;
 import org.hiero.block.simulator.generator.BlockStreamManager;
 import org.hiero.block.simulator.grpc.PublishStreamGrpcClient;
@@ -53,7 +54,8 @@ public class PublisherClientModeHandlerTest {
     }
 
     @Test
-    void testStartWithMillisPerBlockStreaming_WithBlocks() throws Exception {
+    void testStartWithMillisPerBlockStreamingWithBlocks()
+            throws InterruptedException, BlockSimulatorParsingException, IOException {
         blockStreamManager = getTestBlockStreamManager(2);
         publisherClientModeHandler = new PublisherClientModeHandler(
                 blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
@@ -71,7 +73,8 @@ public class PublisherClientModeHandlerTest {
     }
 
     @Test
-    void testStartWithMillisPerBlockStreaming_NoBlocks() throws Exception {
+    void testStartWithMillisPerBlockStreamingNoBlocks()
+            throws InterruptedException, BlockSimulatorParsingException, IOException {
         blockStreamManager = getTestBlockStreamManager(0);
         publisherClientModeHandler = new PublisherClientModeHandler(
                 blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
@@ -82,7 +85,8 @@ public class PublisherClientModeHandlerTest {
     }
 
     @Test
-    void testStartWithMillisPerBlockStreaming_ShouldPublishFalse() throws Exception {
+    void testStartWithMillisPerBlockStreamingShouldPublishFalse()
+            throws InterruptedException, BlockSimulatorParsingException, IOException {
         blockStreamManager = getTestBlockStreamManager(2);
         publisherClientModeHandler = new PublisherClientModeHandler(
                 blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
@@ -96,7 +100,8 @@ public class PublisherClientModeHandlerTest {
     }
 
     @Test
-    void testStartWithMillisPerBlockStreaming_NoBlocksAndShouldPublishFalse() throws Exception {
+    void testStartWithMillisPerBlockStreamingNoBlocksAndShouldPublishFalse()
+            throws InterruptedException, BlockSimulatorParsingException, IOException {
         blockStreamManager = getTestBlockStreamManager(0);
         publisherClientModeHandler = new PublisherClientModeHandler(
                 blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
@@ -108,7 +113,8 @@ public class PublisherClientModeHandlerTest {
     }
 
     @Test
-    void testStartWithConstantRateStreaming_WithinMaxItems() throws Exception {
+    void testStartWithConstantRateStreamingWithinMaxItems()
+            throws InterruptedException, BlockSimulatorParsingException, IOException {
         blockStreamManager = getTestBlockStreamManager(2);
         Configuration configuration = TestUtils.getTestConfiguration(Map.of(
                 "blockStream.streamingMode",
@@ -134,7 +140,8 @@ public class PublisherClientModeHandlerTest {
     }
 
     @Test
-    void testStartWithConstantRateStreaming_ExceedingMaxItems() throws Exception {
+    void testStartWithConstantRateStreamingExceedingMaxItems()
+            throws InterruptedException, BlockSimulatorParsingException, IOException {
         blockStreamManager = getTestBlockStreamManager(4);
         Configuration configuration = TestUtils.getTestConfiguration(Map.of(
                 "blockStream.streamingMode",
@@ -163,7 +170,8 @@ public class PublisherClientModeHandlerTest {
     }
 
     @Test
-    void testStartWithConstantRateStreaming_NoBlocks() throws Exception {
+    void testStartWithConstantRateStreamingNoBlocks()
+            throws InterruptedException, BlockSimulatorParsingException, IOException {
         blockStreamManager = getTestBlockStreamManager(0);
         Configuration configuration =
                 TestUtils.getTestConfiguration(Map.of("blockStream.streamingMode", "CONSTANT_RATE"));
@@ -177,7 +185,8 @@ public class PublisherClientModeHandlerTest {
     }
 
     @Test
-    void testStartWithExceptionDuringStreaming() throws Exception {
+    void testStartWithExceptionDuringStreaming()
+            throws InterruptedException, BlockSimulatorParsingException, IOException {
         blockStreamManager = mock(BlockStreamManager.class);
         publisherClientModeHandler = new PublisherClientModeHandler(
                 blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
@@ -192,7 +201,8 @@ public class PublisherClientModeHandlerTest {
     }
 
     @Test
-    void testMillisPerBlockStreaming_streamSuccessBecomesFalse() throws Exception {
+    void testMillisPerBlockStreamingStreamSuccessBecomesFalse()
+            throws InterruptedException, BlockSimulatorParsingException, IOException {
         blockStreamManager = getTestBlockStreamManager(2);
         publisherClientModeHandler = new PublisherClientModeHandler(
                 blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
@@ -210,7 +220,8 @@ public class PublisherClientModeHandlerTest {
     }
 
     @Test
-    void testConstantRateStreaming_streamSuccessBecomesFalse() throws Exception {
+    void testConstantRateStreamingStreamSuccessBecomesFalse()
+            throws InterruptedException, BlockSimulatorParsingException, IOException {
         blockStreamManager = getTestBlockStreamManager(2);
         Configuration configuration = TestUtils.getTestConfiguration(Map.of(
                 "blockStream.streamingMode",

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/grpc/positive/PositiveServerAvailabilityTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/grpc/positive/PositiveServerAvailabilityTests.java
@@ -4,6 +4,7 @@ package org.hiero.block.suites.grpc.positive;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import org.hiero.block.suites.BaseSuite;
 import org.junit.jupiter.api.DisplayName;
@@ -58,11 +59,10 @@ public class PositiveServerAvailabilityTests extends BaseSuite {
      * <p>The test asserts that /healthz/readyz REST endpoint returns HTTP 200 Status</p>
      * <p>The test asserts that /healthz/livez REST endpoint returns HTTP 200 Status</p>
      *
-     * @throws Exception catch all exceptions
      */
     @Test
     @DisplayName("Verify /healthz endpoints")
-    public void verifyHealthzEndpoints() throws Exception {
+    public void verifyHealthzEndpoints() throws IOException {
         final String host = "localhost";
         final int port = blockNodeContainer.getExposedPorts().getFirst();
         final String baseUrl = String.format("http://%s:%d", host, port);
@@ -85,11 +85,10 @@ public class PositiveServerAvailabilityTests extends BaseSuite {
     /**
      * Test should verify the metrics endpoints of the REST API.
      *
-     * @throws Exception catch all exceptions
      */
     @Test
     @DisplayName("Verify /metrics endpoint")
-    public void verifyMetricsEndpoint() throws Exception {
+    public void verifyMetricsEndpoint() throws IOException {
         final String host = "localhost";
         final int port = 16007;
         final String baseUrl = String.format("http://%s:%d", host, port);

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/commands/NetworkCapacityTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/commands/NetworkCapacityTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -22,13 +23,13 @@ class NetworkCapacityTest {
     private Path configFile;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() throws IOException {
         configFile = Files.createTempFile(tempDir, "network-capacity-config", ".json");
         Files.writeString(configFile, "{}");
     }
 
     @Test
-    void serverModeWithoutPortPrintsHelpfulError() throws Exception {
+    void serverModeWithoutPortPrintsHelpfulError() {
         ExecutionResult result = executeCommand("--mode", "server", "--config", configFile.toString());
 
         assertEquals(0, result.exitCode());
@@ -38,7 +39,7 @@ class NetworkCapacityTest {
     }
 
     @Test
-    void clientModeWithoutRecordingFolderPrintsHelpfulError() throws Exception {
+    void clientModeWithoutRecordingFolderPrintsHelpfulError() {
         ExecutionResult result = executeCommand(
                 "--mode",
                 "client",
@@ -58,7 +59,7 @@ class NetworkCapacityTest {
     }
 
     @Test
-    void clientModeWithMissingFolderReportsError() throws Exception {
+    void clientModeWithMissingFolderReportsError() {
         Path missingFolder = tempDir.resolve("missing-recordings");
 
         ExecutionResult result = executeCommand(
@@ -82,7 +83,7 @@ class NetworkCapacityTest {
     }
 
     @Test
-    void clientModeWithoutServerAddressPrintsHelpfulError() throws Exception {
+    void clientModeWithoutServerAddressPrintsHelpfulError() throws IOException {
         Path recordings = Files.createDirectory(tempDir.resolve("recordings"));
 
         ExecutionResult result = executeCommand(
@@ -103,7 +104,7 @@ class NetworkCapacityTest {
     }
 
     @Test
-    void missingConfigFileIsReported() throws Exception {
+    void missingConfigFileIsReported() {
         Path missingConfig = tempDir.resolve("missing-config.json");
 
         ExecutionResult result =
@@ -116,7 +117,7 @@ class NetworkCapacityTest {
     }
 
     @Test
-    void invalidModeIsReported() throws Exception {
+    void invalidModeIsReported() {
         ExecutionResult result = executeCommand("--mode", "invalid", "--config", configFile.toString());
 
         assertEquals(0, result.exitCode());
@@ -146,9 +147,7 @@ class NetworkCapacityTest {
         }
 
         return new ExecutionResult(
-                exitCode,
-                new String(stdout.toByteArray(), StandardCharsets.UTF_8),
-                new String(stderr.toByteArray(), StandardCharsets.UTF_8));
+                exitCode, stdout.toString(StandardCharsets.UTF_8), stderr.toString(StandardCharsets.UTF_8));
     }
 
     private static final class ExecutionResult {


### PR DESCRIPTION
## Reviewer Notes
* Added explanatory comment
* Removed many cases of `throws Exception` in tests that could (should) be specific so we catch new exceptions or unhandled failures
* Removed `throws Exception` from `S3Client.close()` that was forcing all users to catch or declare `Exception`.
    * This was particularly pernicious because the method did not actually throw _any_ checked exceptions.
* Replaced `new String(stdout, charset)` with `stdout.toString(charset)`.
