### PR TITLE
fix: Socket leak BN->CN on port 40840

### DIFF
--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -726,7 +726,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
             try {
                 // onComplete call in finally block to ensure it is called
                 replies.onComplete();
-                // @todo(1757) How do we terminate the connection and ensure the socket is closed?
+                replies.closeConnection();
             } catch (final RuntimeException e) {
                 LOGGER.log(DEBUG, "Exception during calling onComplete for handler %d".formatted(handlerId), e);
             }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,7 +3,7 @@ import org.gradlex.javamodule.moduleinfo.ExtraJavaModuleInfoPluginExtension
 
 plugins {
     id("org.hiero.gradle.build") version "0.6.0"
-    id("com.hedera.pbj.pbj-compiler") version "0.12.4" apply false
+    id("com.hedera.pbj.pbj-compiler") version "0.12.5" apply false
 }
 
 val hieroGroup = "org.hiero.block"

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -331,8 +331,10 @@ public class BlockNodeAPITests {
 
         // use a new client to publish block 1 as the existing client was closed on duplicate block publish.
         ResponsePipelineUtils<PublishStreamResponse> responseObserver2 = new ResponsePipelineUtils<>();
+        BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient blockStreamPublishServiceClient2 =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(createGrpcClient(), OPTIONS);
         final Pipeline<? super PublishStreamRequest> requestStream2 =
-                blockStreamPublishServiceClient.publishBlockStream(responseObserver2);
+                blockStreamPublishServiceClient2.publishBlockStream(responseObserver2);
         final CountDownLatch blockItemsPublish2Latch = responseObserver2.setAndGetOnNextLatch(1);
         requestStream2.onNext(request2);
         endBlock(blockNumber1, requestStream2);


### PR DESCRIPTION
## Reviewer Notes
- update pbj to 0.12.5 to use closeConnection()
- use closeConnection() on shutdown
- adjust BlockNodeAPITests

## Related Issue(s)
Fixes #1757 
