### PR TITLE
test:  Add e2e test for socket closing

### DIFF
--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -546,6 +546,8 @@ public class BlockNodeAPITests {
 
         // This asserts that UncheckedIOException is thrown and its cause is a SocketException with "socket closed"
         UncheckedIOException ex = assertThrows(UncheckedIOException.class, () -> {
+            // Expected exception to be thrown on the onNext() due to closed socket
+            // from previous duplicate block publish
             requestStream.onNext(request1);
             publishCompleteCountDownLatch.await(); // wait
             endBlock(blockNumber1, requestStream);


### PR DESCRIPTION
## Reviewer Notes

Add e2e test verifying that after the latest changes we successfully close sockets with publishers in the required cases.

## Related Issue(s)
Fixes #1862 
