### PR TITLE
chore: (release 0.23) Bump helidon from 4.3.1 to 4.3.2

### DIFF
--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
 dependencies.constraints {
     val daggerVersion = "2.57.2"
     val grpcIoVersion = "1.76.0"
-    val helidonVersion = "4.3.1"
+    val helidonVersion = "4.3.2"
     val pbjVersion = pluginVersions.version("com.hedera.pbj.pbj-compiler")
     val protobufVersion = "4.33.0"
     val swirldsVersion = "0.61.3"


### PR DESCRIPTION
## Reviewer Notes

## Related Issue(s)
Fixes #1867 
