### PR TITLE
chore(tools): Update default config to match BN server to `network-capacity-tool`

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/capacity/NetworkCapacityServer.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/capacity/NetworkCapacityServer.java
@@ -62,6 +62,8 @@ public class NetworkCapacityServer {
                         .receiveBufferSize(config.receiveBufferSize())
                         .tcpNoDelay(config.tcpNoDelay())
                         .build())
+                .backlog(config.backlogSize())
+                .writeQueueLength(config.writeQueueLength())
                 .build();
 
         webServer.start();

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/config/proto/network_capacity_config.proto
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/config/proto/network_capacity_config.proto
@@ -29,5 +29,7 @@ message HelidonWebServerConfig {
   uint32 maxEmptyFrames = 9;
   uint32 maxRapidResets = 10;
   uint32 rapidResetTimeWindowMillis = 11;
+  uint32 backlogSize = 12;
+  uint32 writeQueueLength = 13;
 }
 

--- a/tools-and-tests/tools/src/main/resources/serverDefaultConfig.json
+++ b/tools-and-tests/tools/src/main/resources/serverDefaultConfig.json
@@ -4,11 +4,13 @@
   "maxHeaderListSize": 8192,
   "maxConcurrentStreams": 8,
   "flowControlTimeoutMillis": 250,
-  "sendBufferSize": 32768,
-  "receiveBufferSize": 32768,
+  "sendBufferSize": 131072,
+  "receiveBufferSize": 131072,
   "maxMessageSizeBytes": 16777215,
   "tcpNoDelay": true,
   "maxEmptyFrames": 10,
   "maxRapidResets": 50,
-  "rapidResetTimeWindowMillis": 10000
+  "rapidResetTimeWindowMillis": 10000,
+  "backlogSize": 8192,
+  "writeQueueLength": 8192
 }


### PR DESCRIPTION
## Reviewer Notes

This PR aims to allow testing with a real 10K recording using the networkCapactity tool.

Results with `0.23.1` or Helidon `4.3.2` applied:


**Over docker VM Network**
=== FINAL CLIENT THROUGHPUT REPORT ===
Total bytes: 3,160,495,545 (3,086,421 KB)
Total time (first->last byte): 42,725 milliseconds
Average throughput: 72,239 KB/s
Total blocks sent: 83
Total blocks ACKed: 82
Average time per block:   0.514 seconds

<img width="1200" height="837" alt="image" src="https://github.com/user-attachments/assets/ff449856-07ab-478e-9531-2858bfbf8906" />


**Over real wifi network:**

=== FINAL CLIENT THROUGHPUT REPORT ===
Total bytes: 3,160,495,545 (3,086,421 KB)
Total time (first->last byte): 73,370 milliseconds
Average throughput: 42,066 KB/s
Total blocks sent: 83
Total blocks ACKed: 82
Average time per block:   0.883 seconds