### PR TITLE
feat: implement autonomous start-block discovery in Simulator

### DIFF
--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/config/data/ConsumerConfig.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/config/data/ConsumerConfig.java
@@ -11,6 +11,7 @@ import org.hiero.block.simulator.config.types.SlowDownType;
  *
  * @param startBlockNumber the block number from which to start consuming
  * @param endBlockNumber the block number at which to stop consuming
+ * @param enableAutoStartBlockDiscovery whether to automatically discover the start block if startBlockNumber is -1
  * @param slowDownType the type of slowdown to apply while consuming
  * @param slowDownMilliseconds the slowdown in milliseconds
  * @param slowDownForBlockRange the range of blocks to apply the slowdown
@@ -19,6 +20,7 @@ import org.hiero.block.simulator.config.types.SlowDownType;
 public record ConsumerConfig(
         @Loggable @ConfigProperty(defaultValue = "-1") long startBlockNumber,
         @Loggable @ConfigProperty(defaultValue = "-1") long endBlockNumber,
+        @Loggable @ConfigProperty(defaultValue = "true") boolean enableAutoStartBlockDiscovery,
         @Loggable @ConfigProperty(defaultValue = "NONE") SlowDownType slowDownType,
         @Loggable @ConfigProperty(defaultValue = "2") long slowDownMilliseconds,
         @Loggable @ConfigProperty(defaultValue = "10-30") String slowDownForBlockRange) {}


### PR DESCRIPTION
This PR implements autonomous start-block discovery for the Block Node Simulator's consumer client, addressing the requirements of issue [#12264 ](https://github.com/hiero-ledger/hiero-mirror-node/issues/12264) (adapted for Simulator).

## Changes
- **ConsumerConfig**: Added `enableAutoStartBlockDiscovery` (default: `true`).
- **ConsumerStreamGrpcClientImpl**: 
  - Implemented logic to query `BlockNodeService.serverStatus` when `startBlockNumber` is `-1` and auto-discovery is enabled.
  - Automatically sets the start block to the `firstAvailableBlock` returned by the Block Node.
- **Tests**: Added unit tests in `ConsumerStreamGrpcClientImplTest` to verify the auto-discovery flow using a mock Block Node server.

## Motivation
Currently, operators must manually configure the start block. This change allows the consumer to automatically discover the earliest available block from the Block Node, simplifying operations and testing.

## Testing
- Added `requestBlocks_AutoDiscovery` test case.
- Verified that the client correctly queries `serverStatus` and uses the returned block number.

## Notes
- This implementation assumes the `BlockNodeService` is available on the same channel as the `BlockStreamSubscribeService`.
- Fallback logic is implicit (if `serverStatus` fails, the client initialization will fail, which is appropriate for a simulator/test tool).
