### PR TITLE
fix: Update PublishHandler to close only the stream on BEHIND

### DIFF
--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -620,7 +620,7 @@ class LiveStreamPublisherManagerTest {
 
                 // After forwarder completion, batches should have increased and facility should contain messages.
                 assertThat(managerMetrics.blocksClosedComplete().get()).isEqualTo(beforeBatches + 2);
-                assertThat(managerMetrics.currentPublisherCount().get()).isEqualTo(beforeBatches + 1);
+                assertThat(managerMetrics.currentPublisherCount().get()).isEqualTo(beforeBatches + 2);
                 // The in-memory messaging facility should now have reset the block number to -1.
                 assertThat(toTest.getLatestBlockNumber()).isEqualTo(-1);
             }


### PR DESCRIPTION
## Reviewer Notes
Currently the handler closes both the stream and connection when handling BEHIND code.
However, the expectation is the publisher would follow up either with more appropriate block items or a TOO_FAR_BEHIND.
When the publisher does it experiences a socket closed exception

- Update BatchHandleResult to separate shutdown, reset and close stream
- Update `handleBlockActionResult()` to manage 3 cases in a more coordinate fashion and not call either unnecessarily
- Add API Test scenario that shows publisher no longer observes socket exception

Partially address #1914 but does not attempt to fix the protocol definition as that requires CN coordination and larger changes

## Related Issue(s)
 Use keywords `Fix, Fixes, Fixed, Close, Closes, Closed, Resolve, Resolves, Resolved`
to connect an issue to be closed by this pull request.
