### PR TITLE
fix: Fix NoSuchElement case on greedy backfill in empty store (0.24)

### DIFF
--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -269,7 +269,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
             return;
         }
 
-        // Skip if lack acknowledged block observed has increased
+        // Skip if last acknowledged block observed has increased
         if (lastAcknowledgedBlockObserved > 0 && lastAcknowledgedBlock > lastAcknowledgedBlockObserved) {
             LOGGER.log(
                     TRACE,
@@ -351,10 +351,10 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
                     .toList();
 
             // greedy backfill newer blocks available from peer BN sources to prioritize staying close to the network
-            greedyBackfillRecentBlocks(
-                    lastAcknowledgedBlockObserved.get(), blockRanges.getLast().end());
-            lastAcknowledgedBlockObserved.set(
-                    blockRanges.getLast().end()); // update the last observed acknowledged block
+            long blockRangesLastValue =
+                    blockRanges.isEmpty() ? -1 : blockRanges.getLast().end();
+            greedyBackfillRecentBlocks(lastAcknowledgedBlockObserved.get(), blockRangesLastValue);
+            lastAcknowledgedBlockObserved.set(blockRangesLastValue); // update the last observed acknowledged block
 
             // backfill missing historical blocks from peer BN sources
             detectedGaps = new ArrayList<>();
@@ -389,7 +389,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
 
             autonomousError = false;
         } catch (Exception e) {
-            LOGGER.log(TRACE, "Error during backfill autonomous process: {0}", e);
+            LOGGER.log(TRACE, "Error during backfill autonomous process", e);
             autonomousError = true;
             autonomousBackfillEndBlock.set(-1);
         }


### PR DESCRIPTION
Cherry-pick #1933 

With latest greedy backfill logic the logic trips on startup when no blocks are on the BN. `.end()` was being called on `blockRanges.getLast()` when the list was empty causing a `NoSuchElementException`

- Add logic to check for empty list and use default `-1` for end
- Fix log message
- Add UTs for no gaps and empty store for both autonomous, greedy autonomous and on-demand

## Reviewer Notes

## Related Issue(s)
 Use keywords `Fix, Fixes, Fixed, Close, Closes, Closed, Resolve, Resolves, Resolved`
to connect an issue to be closed by this pull request.
