### PR TITLE
build(deps): bump com.hedera.pbj.pbj-compiler from 0.12.5 to 0.12.10

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
@@ -91,7 +91,8 @@ public abstract class PluginTestBase<
                 .withConfigDataType(org.hiero.block.node.app.config.node.NodeConfig.class)
                 .withConfigDataTypes(plugin.configDataTypes().toArray(new Class[0]))
                 .withConfigDataType(com.swirlds.common.metrics.platform.prometheus.PrometheusConfig.class)
-                .withConfigDataType(org.hiero.block.node.app.config.ServerConfig.class);
+                .withConfigDataType(org.hiero.block.node.app.config.ServerConfig.class)
+                .withValue("prometheus.endpointEnabled", "false");
         if (configOverrides != null) {
             for (Entry<String, String> override : configOverrides.entrySet()) {
                 configurationBuilder = configurationBuilder.withValue(override.getKey(), override.getValue());

--- a/block-node/messaging/src/test/java/org/hiero/block/server/messaging/TestConfig.java
+++ b/block-node/messaging/src/test/java/org/hiero/block/server/messaging/TestConfig.java
@@ -54,7 +54,8 @@ public class TestConfig {
     public static Metrics getMetrics() {
         ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
                 .withConfigDataType(com.swirlds.common.metrics.config.MetricsConfig.class)
-                .withConfigDataType(com.swirlds.common.metrics.platform.prometheus.PrometheusConfig.class);
+                .withConfigDataType(com.swirlds.common.metrics.platform.prometheus.PrometheusConfig.class)
+                .withValue("prometheus.endpointEnabled", "false");
         final Configuration configuration = configurationBuilder.build();
         // create metrics provider
         final DefaultMetricsProvider metricsProvider;

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginTest.java
@@ -14,6 +14,7 @@ import com.hedera.hapi.block.stream.output.BlockHeader;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.ParseException;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
@@ -79,8 +80,11 @@ class VerificationServicePluginTest
 
         BlockUtils.SampleBlockInfo sampleBlockInfo =
                 BlockUtils.getSampleBlockInfo(BlockUtils.SAMPLE_BLOCKS.HAPI_0_68_0_BLOCK_14);
+        // get the original block items
+        List<BlockItemUnparsed> originalItems = sampleBlockInfo.blockUnparsed().blockItems();
+        // make a mutable copy
+        List<BlockItemUnparsed> blockItems = new ArrayList<>(originalItems);
 
-        List<BlockItemUnparsed> blockItems = sampleBlockInfo.blockUnparsed().blockItems();
         // remove one block item, so the hash is no longer valid
         blockItems.remove(3);
         long blockNumber = sampleBlockInfo.blockNumber();
@@ -111,7 +115,11 @@ class VerificationServicePluginTest
         BlockUtils.SampleBlockInfo sampleBlockInfo =
                 BlockUtils.getSampleBlockInfo(BlockUtils.SAMPLE_BLOCKS.HAPI_0_68_0_BLOCK_14);
         long blockNumber = sampleBlockInfo.blockNumber();
-        List<BlockItemUnparsed> blockItems = sampleBlockInfo.blockUnparsed().blockItems();
+        List<BlockItemUnparsed> originalItems = sampleBlockInfo.blockUnparsed().blockItems();
+
+        // make a mutable copy
+        List<BlockItemUnparsed> blockItems = new ArrayList<>(originalItems);
+
         // remove the header to simulate a case where receive items and have never received a header
         blockItems.removeFirst();
         // send some items to the plugin, they should be ignored

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,7 +3,7 @@ import org.gradlex.javamodule.moduleinfo.ExtraJavaModuleInfoPluginExtension
 
 plugins {
     id("org.hiero.gradle.build") version "0.6.3"
-    id("com.hedera.pbj.pbj-compiler") version "0.12.5" apply false
+    id("com.hedera.pbj.pbj-compiler") version "0.12.10" apply false
 }
 
 val hieroGroup = "org.hiero.block"


### PR DESCRIPTION
## Reviewer Notes
- There are significant gains in performance in new version from PBJ `0.12.8`
- Nice to have test case improvements
- Fixed 2 tests that failed due to the update, due to new PBJ returning immutable lists when Parsing.

## Related Issue(s)
Cherry-pick of  #1916
