### PR TITLE
fix(build): Fix protobuf project folder path

### DIFF
--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 dependencies {
-    published(project(":protobuf-sources"))
+    published(project(":protobuf-pbj"))
     published(project(":app"))
     published(project(":app-config"))
     published(project(":backfill"))


### PR DESCRIPTION
## Reviewer Notes

When the renaming of the plugins project folder was made, this was not updated hence is failing build.

## Related Issue(s)
Fixes #1979 
