### PR TITLE
fix(backfill): Backfill edge cases when BN has empty store. (#1986)

### DIFF
--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillGrpcClient.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillGrpcClient.java
@@ -132,19 +132,19 @@ public class BackfillGrpcClient {
                 earliestPeerBlock,
                 latestPeerBlock);
 
+        // Determine the earliest block we can actually fetch from peers
+        long startBlock = Math.max(latestStoredBlockNumber + 1, earliestPeerBlock);
         // confirm next block is available if not we still can't backfill
-        if (latestStoredBlockNumber + 1 < earliestPeerBlock
-                || latestStoredBlockNumber > latestPeerBlock
-                || latestStoredBlockNumber + 1 > latestPeerBlock) {
+        if (startBlock > latestPeerBlock) {
             return null;
         }
 
         LOGGER.log(
                 INFO,
                 "Determined available range from peer blocks nodes start={0,number,#} to end={1,number,#}",
-                latestStoredBlockNumber + 1,
+                startBlock,
                 latestPeerBlock);
-        return new LongRange(latestStoredBlockNumber + 1, latestPeerBlock);
+        return new LongRange(startBlock, latestPeerBlock);
     }
 
     /**

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -285,7 +285,8 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
         try {
             LOGGER.log(TRACE, "Greedy backfilling recent blocks to stay close to network");
             detectedGaps = new ArrayList<>();
-            LongRange detectedRecentGapRange = backfillGrpcClientAutonomous.getNewAvailableRange(lastAcknowledgedBlock);
+            long baselineBlock = Math.max(lastAcknowledgedBlock, backfillConfiguration.startBlock() - 1);
+            LongRange detectedRecentGapRange = backfillGrpcClientAutonomous.getNewAvailableRange(baselineBlock);
 
             if (detectedRecentGapRange != null
                     && detectedRecentGapRange.size() > 0


### PR DESCRIPTION
## Reviewer Notes

Cherry-picks #1986 into `release/0.24` branch for cutting version `0.24.2`

