### PR TITLE
fix(deps): bump PBJ compiler version to 0.13.2

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,7 +3,7 @@ import org.gradlex.javamodule.moduleinfo.ExtraJavaModuleInfoPluginExtension
 
 plugins {
     id("org.hiero.gradle.build") version "0.6.4"
-    id("com.hedera.pbj.pbj-compiler") version "0.13.1" apply false
+    id("com.hedera.pbj.pbj-compiler") version "0.13.2" apply false
 }
 
 val hieroGroup = "org.hiero.block-node"


### PR DESCRIPTION
## Reviewer Notes

## Related Issue(s)

Fixes #1964

## Description

Bumps PBJ compiler plugin from `0.13.1` to `0.13.2`.

This version includes fix for `IllegalStateException` on Block Node startup caused by missing `feature-metadata.properties` in generated service provider files.

## References

- hashgraph/pbj#716
