### PR TITLE
chore: fix tests and clean up java docs

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/downloadlive/LiveDownloader.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/downloadlive/LiveDownloader.java
@@ -268,8 +268,9 @@ public class LiveDownloader {
             final Process p = pb.start();
             final int exit = p.waitFor();
             if (exit != 0) {
-                System.err.printf("[download] tar command failed for day %s entries=%d with exit=%d%n",
-                    dayKey, entryNames.size(), exit);
+                System.err.printf(
+                        "[download] tar command failed for day %s entries=%d with exit=%d%n",
+                        dayKey, entryNames.size(), exit);
             } else {
                 for (String entryName : entryNames) {
                     System.out.printf("[download] appended %s to %s%n", entryName, tarPath);

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/download/DownloadDayLiveImplTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/download/DownloadDayLiveImplTest.java
@@ -942,7 +942,7 @@ public class DownloadDayLiveImplTest {
                     lr, mostCommonFiles, "2025-12-01T00_00_04.319226458Z.rcd_sig");
 
             assertTrue(result.toString().contains("node_"));
-            assertTrue(result.toString().endsWith(".rcs_sig"));
+            assertTrue(result.toString().endsWith(".rcd_sig"));
         }
 
         @Test
@@ -984,9 +984,9 @@ public class DownloadDayLiveImplTest {
             Path result = DownloadDayLiveImpl.computeNewFilePath(
                     lr, mostCommonFiles, "2025-12-01T00_00_04.319226458Z.rcd_sig");
 
-            // For signature files, node directory is extracted from parent directory (2025-12-01)
+            // For signature files, node directory is extracted from the parent directory (2025-12-01)
             assertTrue(result.toString().contains("node_"));
-            assertTrue(result.toString().endsWith(".rcs_sig"));
+            assertTrue(result.toString().endsWith(".rcd_sig"));
         }
 
         @Test
@@ -1001,7 +1001,7 @@ public class DownloadDayLiveImplTest {
 
             // For signature files with date subdirectory, node directory becomes the date folder name
             assertTrue(result.toString().contains("node_"));
-            assertTrue(result.toString().endsWith(".rcs_sig"));
+            assertTrue(result.toString().endsWith(".rcd_sig"));
         }
 
         @Test


### PR DESCRIPTION
This is a pr to fix a few download-live tests due to signature file extension mismatch. 