### PR TITLE
feat: Send notifications from `stream-publisher` plugin to inform other plugins when a publisher disconnects

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
@@ -16,6 +16,7 @@ import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.NoBackPressureBlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
+import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 
 /**
@@ -46,6 +47,9 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
     private final List<PersistedNotification> sentPersistedNotifications = new CopyOnWriteArrayList<>();
     /** List of all sent backfilled block notifications */
     private final List<NewestBlockKnownToNetworkNotification> sentNewestBlockKnownToNetworkNotifications =
+            new CopyOnWriteArrayList<>();
+    /** List of all sent publisher status update notifications */
+    private final List<PublisherStatusUpdateNotification> sentPublisherStatusUpdateNotifications =
             new CopyOnWriteArrayList<>();
     /** Set of handlers for which we must simulate a handler that is behind and producing backpressure. */
     private final Set<BlockItemHandler> handlersWithBackpressure =
@@ -85,6 +89,15 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
      */
     public List<NewestBlockKnownToNetworkNotification> getSentNewestBlockKnownToNetworkNotifications() {
         return sentNewestBlockKnownToNetworkNotifications;
+    }
+
+    /**
+     * Get all publisher status update notifications sent to the block messaging facility.
+     *
+     * @return the list of sent publisher status update notifications
+     */
+    public List<PublisherStatusUpdateNotification> getSentPublisherStatusUpdateNotifications() {
+        return sentPublisherStatusUpdateNotifications;
     }
 
     /**
@@ -244,6 +257,15 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
         sentNewestBlockKnownToNetworkNotifications.add(notification);
         for (BlockNotificationHandler handler : blockNotificationHandlers) {
             handler.handleNewestBlockKnownToNetwork(notification);
+        }
+    }
+
+    @Override
+    public void sendPublisherStatusUpdate(final PublisherStatusUpdateNotification notification) {
+        LOGGER.log(Level.TRACE, "Sending PublisherStatusUpdateNotification block notification " + notification);
+        sentPublisherStatusUpdateNotifications.add(notification);
+        for (final BlockNotificationHandler handler : blockNotificationHandlers) {
+            handler.handlePublisherStatusUpdate(notification);
         }
     }
 

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockNotificationRingEvent.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockNotificationRingEvent.java
@@ -4,70 +4,101 @@ package org.hiero.block.node.messaging;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
+import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 
 /**
- * Simple mutable container for batch of block items. The ring buffer is made up of these events.
+ * Simple mutable container for notifications. The notifications ring buffer is
+ * made up of these events. Only one of the fields should be set at any time.
+ * These notifications are published to downstream subscribers through the LMAX
+ * Disruptor.
  */
-public class BlockNotificationRingEvent {
+public final class BlockNotificationRingEvent {
     /** The block verification notification to be published to downstream subscribers through the LMAX Disruptor. */
     private VerificationNotification verificationNotification;
     /** The block persistence notification to be published to downstream subscribers through the LMAX Disruptor. */
     private PersistedNotification persistedNotification;
     /** The Backfilled block notification to be published to downstream subscribers through the LMAX Disruptor. */
     private BackfilledBlockNotification backfilledBlockNotification;
-    /** The Newest block known to network notification to be published to downstream subscribers through the LMAX Disruptor. */
+    /** The newest block known to network notification to be published to downstream subscribers through the LMAX Disruptor. */
     private NewestBlockKnownToNetworkNotification newestBlockKnownToNetworkNotification;
-
-    /** Constructor for the BlockNotificationRingEvent class. */
-    public BlockNotificationRingEvent() {}
+    /** The publisher status update notification to be published to downstream subscribers through the LMAX Disruptor. */
+    private PublisherStatusUpdateNotification publisherStatusUpdateNotification;
 
     /**
-     * Sets the given value to be published to downstream subscribers through the LMAX Disruptor.
+     * Sets the given notification to be published to downstream subscribers
+     * through the LMAX Disruptor.
      *
-     * @param verificationNotification the value to set
+     * @param notification to set
      */
-    public void set(final VerificationNotification verificationNotification) {
-        this.verificationNotification = verificationNotification;
+    public void set(final VerificationNotification notification) {
+        this.verificationNotification = notification;
         this.persistedNotification = null;
         this.backfilledBlockNotification = null;
         this.newestBlockKnownToNetworkNotification = null;
+        this.publisherStatusUpdateNotification = null;
     }
 
     /**
-     * Sets the given value to be published to downstream subscribers through the LMAX Disruptor.
+     * Sets the given notification to be published to downstream subscribers
+     * through the LMAX Disruptor.
      *
-     * @param persistedNotification the value to set
+     * @param notification to set
      */
-    public void set(final PersistedNotification persistedNotification) {
+    public void set(final PersistedNotification notification) {
+        this.persistedNotification = notification;
         this.verificationNotification = null;
-        this.persistedNotification = persistedNotification;
         this.backfilledBlockNotification = null;
         this.newestBlockKnownToNetworkNotification = null;
+        this.publisherStatusUpdateNotification = null;
     }
 
     /**
-     * Sets the given value to be published to downstream subscribers through the LMAX Disruptor.
+     * Sets the given notification to be published to downstream subscribers
+     * through the LMAX Disruptor.
      *
-     * @param backfilledBlockNotification the value to set
+     * @param notification to set
      */
-    public void set(final BackfilledBlockNotification backfilledBlockNotification) {
-        this.backfilledBlockNotification = backfilledBlockNotification;
+    public void set(final BackfilledBlockNotification notification) {
+        this.backfilledBlockNotification = notification;
         this.verificationNotification = null;
         this.persistedNotification = null;
         this.newestBlockKnownToNetworkNotification = null;
+        this.publisherStatusUpdateNotification = null;
     }
 
-    public void set(final NewestBlockKnownToNetworkNotification newestBlockKnownToNetworkNotification) {
-        this.newestBlockKnownToNetworkNotification = newestBlockKnownToNetworkNotification;
+    /**
+     * Sets the given notification to be published to downstream subscribers
+     * through the LMAX Disruptor.
+     *
+     * @param notification to set
+     */
+    public void set(final NewestBlockKnownToNetworkNotification notification) {
+        this.newestBlockKnownToNetworkNotification = notification;
+        this.backfilledBlockNotification = null;
+        this.verificationNotification = null;
+        this.persistedNotification = null;
+        this.publisherStatusUpdateNotification = null;
+    }
+    /**
+     * Sets the given notification to be published to downstream subscribers
+     * through the LMAX Disruptor.
+     *
+     * @param notification to set
+     */
+    public void set(final PublisherStatusUpdateNotification notification) {
+        this.publisherStatusUpdateNotification = notification;
+        this.newestBlockKnownToNetworkNotification = null;
         this.backfilledBlockNotification = null;
         this.verificationNotification = null;
         this.persistedNotification = null;
     }
 
     /**
-     * Gets the verification notification of the event from the LMAX Disruptor on the consumer side. If the event is a
-     * persisted notification, this will return null.
+     * Gets the verification notification of the event from the LMAX Disruptor
+     * on the consumer side.
+     * If the event is not a {@link VerificationNotification}, this
+     * will return null.
      *
      * @return the value of the event
      */
@@ -76,8 +107,10 @@ public class BlockNotificationRingEvent {
     }
 
     /**
-     * Gets the persisted notification of the event from the LMAX Disruptor on the consumer side. If the event is a
-     * verification notification, this will return null.
+     * Gets the persisted notification of the event from the LMAX Disruptor on
+     * the consumer side.
+     * If the event is not a {@link PersistedNotification}, this
+     * will return null.
      *
      * @return the value of the event
      */
@@ -86,8 +119,10 @@ public class BlockNotificationRingEvent {
     }
 
     /**
-     * Gets the backfilled block notification of the event from the LMAX Disruptor on the consumer side. If the event is
-     * a verification or persisted notification, this will return null.
+     * Gets the backfilled block notification of the event from the LMAX
+     * Disruptor on the consumer side.
+     * If the event is not a {@link BackfilledBlockNotification}, this
+     * will return null.
      *
      * @return the value of the event
      */
@@ -96,12 +131,26 @@ public class BlockNotificationRingEvent {
     }
 
     /**
-     * Gets the newest block known to network notification of the event from the LMAX Disruptor on the consumer side. If
-     * the event is a verification, persisted or backfilled block notification, this will return null.
+     * Gets the newest block known to network notification of the event from the
+     * LMAX Disruptor on the consumer side.
+     * If the event is not a {@link NewestBlockKnownToNetworkNotification}, this
+     * will return null.
      *
      * @return the value of the event
      */
     public NewestBlockKnownToNetworkNotification getNewestBlockKnownToNetworkNotification() {
         return newestBlockKnownToNetworkNotification;
+    }
+
+    /**
+     * Gets the publisher status update notification of the event from the LMAX
+     * Disruptor on the consumer side.
+     * If the event is not a {@link PublisherStatusUpdateNotification}, this
+     * will return null.
+     *
+     * @return the value of the event
+     */
+    public PublisherStatusUpdateNotification getPublisherStatusUpdateNotification() {
+        return publisherStatusUpdateNotification;
     }
 }

--- a/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationRingEventTest.java
+++ b/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationRingEventTest.java
@@ -10,6 +10,8 @@ import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
+import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification;
+import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification.UpdateType;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,7 +20,6 @@ import org.junit.jupiter.api.Test;
  * Unit tests for the {@link BlockNotificationRingEvent} class.
  */
 class BlockNotificationRingEventTest {
-
     /**
      * Tests that a new BlockNotificationRingEvent has null values for both notification types.
      */
@@ -26,9 +27,11 @@ class BlockNotificationRingEventTest {
     @DisplayName("New BlockNotificationRingEvent should have null values")
     void newEventShouldHaveNullValues() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
-
         assertNull(event.getVerificationNotification());
         assertNull(event.getPersistedNotification());
+        assertNull(event.getBackfilledBlockNotification());
+        assertNull(event.getNewestBlockKnownToNetworkNotification());
+        assertNull(event.getPublisherStatusUpdateNotification());
     }
 
     /**
@@ -40,12 +43,11 @@ class BlockNotificationRingEventTest {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
         final VerificationNotification notification =
                 new VerificationNotification(true, 1, null, null, BlockSource.PUBLISHER);
-
         event.set(notification);
-
         assertEquals(notification, event.getVerificationNotification());
         assertNull(event.getPersistedNotification(), "Persisted notification should be null");
         assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
+        assertNull(event.getPublisherStatusUpdateNotification(), "Publisher status update notification should be null");
         assertNull(
                 event.getNewestBlockKnownToNetworkNotification(),
                 "Newest block known to network notification should be null");
@@ -59,12 +61,11 @@ class BlockNotificationRingEventTest {
     void shouldSetAndGetPersistedNotification() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
         final PersistedNotification notification = new PersistedNotification(2, true, 10, BlockSource.PUBLISHER);
-
         event.set(notification);
-
         assertEquals(notification, event.getPersistedNotification());
         assertNull(event.getVerificationNotification(), "Verification notification should be null");
         assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
+        assertNull(event.getPublisherStatusUpdateNotification(), "Publisher status update notification should be null");
         assertNull(
                 event.getNewestBlockKnownToNetworkNotification(),
                 "Newest block known to network notification should be null");
@@ -79,12 +80,11 @@ class BlockNotificationRingEventTest {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
         final BackfilledBlockNotification notification =
                 new BackfilledBlockNotification(1, BlockUnparsed.newBuilder().build());
-
         event.set(notification);
-
         assertEquals(notification, event.getBackfilledBlockNotification());
         assertNull(event.getVerificationNotification(), "Verification notification should be null");
         assertNull(event.getPersistedNotification(), "Persisted notification should be null");
+        assertNull(event.getPublisherStatusUpdateNotification(), "Publisher status update notification should be null");
         assertNull(
                 event.getNewestBlockKnownToNetworkNotification(),
                 "Newest block known to network notification should be null");
@@ -98,13 +98,31 @@ class BlockNotificationRingEventTest {
     void shouldSetAndGetNewestBlockKnownToNetworkNotification() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
         final NewestBlockKnownToNetworkNotification notification = new NewestBlockKnownToNetworkNotification(10L);
-
         event.set(notification);
-
         assertEquals(notification, event.getNewestBlockKnownToNetworkNotification());
         assertNull(event.getVerificationNotification(), "Verification notification should be null");
         assertNull(event.getPersistedNotification(), "Persisted notification should be null");
         assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
+        assertNull(event.getPublisherStatusUpdateNotification(), "Publisher status update notification should be null");
+    }
+
+    /**
+     * Tests setting and getting a publisher status update notification.
+     */
+    @Test
+    @DisplayName("Should set and get publisher status update notification correctly")
+    void shouldSetAndGetPublisherStatusUpdateNotification() {
+        final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
+        final PublisherStatusUpdateNotification notification =
+                new PublisherStatusUpdateNotification(UpdateType.PUBLISHER_CONNECTED, 1);
+        event.set(notification);
+        assertEquals(notification, event.getPublisherStatusUpdateNotification());
+        assertNull(event.getVerificationNotification(), "Verification notification should be null");
+        assertNull(event.getPersistedNotification(), "Persisted notification should be null");
+        assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
+        assertNull(
+                event.getNewestBlockKnownToNetworkNotification(),
+                "Newest block known to network notification should be null");
     }
 
     /**

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
@@ -19,7 +19,7 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
      *
      * @param blockItems the block items to send
      */
-    void sendBlockItems(BlockItems blockItems);
+    void sendBlockItems(final BlockItems blockItems);
 
     /**
      * Use this method to register a block item handler. The handler will be called every time new block items arrive.
@@ -33,7 +33,8 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
      * @param handlerName         the name of the handler, used for thread name and logging
      * @throws IllegalStateException if the service is already started
      */
-    void registerBlockItemHandler(BlockItemHandler handler, boolean cpuIntensiveHandler, String handlerName);
+    void registerBlockItemHandler(
+            final BlockItemHandler handler, final boolean cpuIntensiveHandler, final String handlerName);
 
     /**
      * Use this method to dynamically register a block item handler. The handler will be called every time new block
@@ -47,7 +48,7 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
      * @param handlerName         the name of the handler, used for thread name and logging
      */
     void registerNoBackpressureBlockItemHandler(
-            NoBackPressureBlockItemHandler handler, boolean cpuIntensiveHandler, String handlerName);
+            final NoBackPressureBlockItemHandler handler, final boolean cpuIntensiveHandler, final String handlerName);
 
     /**
      * Use this method to unregister any block item handler. The handler will no longer be called when new block
@@ -56,36 +57,44 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
      *
      * @param handler the block item handler to unregister
      */
-    void unregisterBlockItemHandler(BlockItemHandler handler);
+    void unregisterBlockItemHandler(final BlockItemHandler handler);
 
     /**
      * Use this method to send block verification notifications to all registered handlers.
      *
      * @param notification the block verification notification to send
      */
-    void sendBlockVerification(VerificationNotification notification);
+    void sendBlockVerification(final VerificationNotification notification);
 
     /**
      * Use this method to send block persisted notifications to all registered handlers.
      *
      * @param notification the block persisted notification to send
      */
-    void sendBlockPersisted(PersistedNotification notification);
+    void sendBlockPersisted(final PersistedNotification notification);
 
     /**
      * Use this method to send backfilled block notifications to all registered handlers.
      *
      * @param notification the backfilled block notification to send
      */
-    void sendBackfilledBlockNotification(BackfilledBlockNotification notification);
+    void sendBackfilledBlockNotification(final BackfilledBlockNotification notification);
 
     /**
      * Use this method to notify the system about a new block known to the network.
      * This is used to inform the system that a new block header is known to the network,
      * and our node should attempt to get up to date with the latest block.
+     *
      * @param notification the notification containing the block number.
      */
-    void sendNewestBlockKnownToNetwork(NewestBlockKnownToNetworkNotification notification);
+    void sendNewestBlockKnownToNetwork(final NewestBlockKnownToNetworkNotification notification);
+
+    /**
+     * Use this method to send a publisher status update to all registered handlers.
+     *
+     * @param notification the publisher status update notification to send
+     */
+    void sendPublisherStatusUpdate(final PublisherStatusUpdateNotification notification);
 
     /**
      * Use this method to register a block notification handler. The handler will be called every time new block

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockNotificationHandler.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockNotificationHandler.java
@@ -13,7 +13,7 @@ public interface BlockNotificationHandler {
      *
      * @param notification the block verification notification to handle
      */
-    default void handleVerification(VerificationNotification notification) {}
+    default void handleVerification(final VerificationNotification notification) {}
 
     /**
      * Handle a block persisted notification.
@@ -23,7 +23,7 @@ public interface BlockNotificationHandler {
      *
      * @param notification the block persisted notification to handle
      */
-    default void handlePersisted(PersistedNotification notification) {}
+    default void handlePersisted(final PersistedNotification notification) {}
 
     /**
      * Handle a backfilled block notification.
@@ -33,7 +33,7 @@ public interface BlockNotificationHandler {
      *
      * @param notification the backfilled block notification to handle
      */
-    default void handleBackfilled(BackfilledBlockNotification notification) {}
+    default void handleBackfilled(final BackfilledBlockNotification notification) {}
 
     /**
      * Handle a new block known to the network notification. Always called on handler thread. Each registered handler
@@ -41,5 +41,13 @@ public interface BlockNotificationHandler {
      *
      * @param notification the new block known to the network notification to handle
      */
-    default void handleNewestBlockKnownToNetwork(NewestBlockKnownToNetworkNotification notification) {}
+    default void handleNewestBlockKnownToNetwork(final NewestBlockKnownToNetworkNotification notification) {}
+
+    /**
+     * Handle a publisher status update notification. Always called on handler thread. Each registered handler
+     * will have its own virtual thread.
+     *
+     * @param notification the publisher status update notification to handle
+     */
+    default void handlePublisherStatusUpdate(final PublisherStatusUpdateNotification notification) {}
 }

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/PublisherStatusUpdateNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/PublisherStatusUpdateNotification.java
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.blockmessaging;
+
+/**
+ * A notification indicating a change in publisher status.
+ */
+public record PublisherStatusUpdateNotification(UpdateType type, int activePublishers) {
+
+    public enum UpdateType {
+        PUBLISHER_CONNECTED,
+        PUBLISHER_DISCONNECTED,
+    }
+}


### PR DESCRIPTION
* Created PublisherStatusUpdateNotification
  * This notification includes an UpdateType and active publishers count
* Changed the active publisher count metric to IntegerGauge
* Added tests
  * Added tests for add/remove publishers
  * Added tests for ring buffer event

## Reviewer Notes

- This PR introduces the new publisher status update notification
- This PR will not handle all cases where the notification must be reacted on
- This PR will fire this notification only when a publisher connects/disconnects currently, to be expanded in follow ups

## Related Issue(s)

Closes #1237 
