### PR TITLE
fix: Fix flaky test by removing order in directories

### DIFF
--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
@@ -137,7 +137,7 @@ class BlockFileHistoricPluginTest {
             try (final Stream<Path> subDirectoriesStream = Files.list(dataRoot)) {
                 assertThat(subDirectoriesStream.toList())
                         .hasSize(3)
-                        .containsExactly(zipWorkRoot, linksRoot, stagingRoot);
+                        .containsExactlyInAnyOrder(zipWorkRoot, linksRoot, stagingRoot);
             }
         }
     }


### PR DESCRIPTION
## Reviewer Notes

Fix flaky test, which was relying on directory order. But this is different on different OS filesystems

