### PR TITLE
fix(backfill): Fix Backfill HTTP/2 Connection Fails on Virtual Threads in Container Environments

### DIFF
--- a/block-node/app/src/main/java/org/hiero/block/node/app/DefaultThreadPoolManager.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/DefaultThreadPoolManager.java
@@ -118,4 +118,18 @@ final class DefaultThreadPoolManager implements ThreadPoolManager {
             return Executors.newScheduledThreadPool(corePoolSize, factory);
         }
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public ScheduledExecutorService createSingleThreadScheduledExecutor(
+            @NonNull final String threadName, @NonNull final Thread.UncaughtExceptionHandler uncaughtExceptionHandler) {
+        Preconditions.requireNotBlank(threadName);
+        final OfPlatform factoryBuilder = Thread.ofPlatform();
+        factoryBuilder.name(threadName);
+        factoryBuilder.uncaughtExceptionHandler(uncaughtExceptionHandler);
+        return Executors.newSingleThreadScheduledExecutor(factoryBuilder.factory());
+    }
 }

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/async/TestThreadPoolManager.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/async/TestThreadPoolManager.java
@@ -67,6 +67,16 @@ public class TestThreadPoolManager<T extends ExecutorService, S extends Schedule
         return scheduledExecutor;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public ScheduledExecutorService createSingleThreadScheduledExecutor(
+            @NonNull String threadName, @NonNull UncaughtExceptionHandler uncaughtExceptionHandler) {
+        return scheduledExecutor;
+    }
+
     @NonNull
     public final T executor() {
         return executor;

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillFetcher.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillFetcher.java
@@ -169,6 +169,12 @@ public class BackfillFetcher implements PriorityHealthBasedStrategy.NodeHealthPr
      * @return a BlockNodeClient for the specified node
      */
     protected BlockNodeClient getNodeClient(BackfillSourceConfig node) {
+        // Check if existing client is unreachable and remove it to allow recreation
+        BlockNodeClient existingClient = nodeClientMap.get(node);
+        if (existingClient != null && !existingClient.isNodeReachable()) {
+            nodeClientMap.remove(node);
+            LOGGER.log(DEBUG, "Removed unreachable client for node [{0}], will attempt to recreate", node.address());
+        }
         return nodeClientMap.computeIfAbsent(
                 node, n -> new BlockNodeClient(n, globalGrpcTimeoutMs, enableTls, n.grpcWebclientTuning()));
     }

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/threading/ThreadPoolManager.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/threading/ThreadPoolManager.java
@@ -118,4 +118,17 @@ public interface ThreadPoolManager {
             int corePoolSize,
             @Nullable final String threadName,
             @Nullable final Thread.UncaughtExceptionHandler uncaughtExceptionHandler);
+
+    /**
+     * Factory method for a single thread scheduled executor using platform threads.
+     * Platform threads are required for certain operations where virtual threads
+     * have compatibility issues (e.g., Helidon WebClient HTTP/2 in containers).
+     *
+     * @param threadName the thread's name for debugging, must not be blank
+     * @param uncaughtExceptionHandler the uncaught exception handler
+     * @return a new single thread scheduled executor service using platform threads
+     */
+    @NonNull
+    ScheduledExecutorService createSingleThreadScheduledExecutor(
+            @NonNull final String threadName, @NonNull final Thread.UncaughtExceptionHandler uncaughtExceptionHandler);
 }


### PR DESCRIPTION
## Reviewer Notes

### Primary Fix: Use Platform Threads for All Backfill Executors

**File:** `block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java`

All three executors must use platform threads:
- `autonomousExecutor` - runs gap detection
- `historicalExecutor` - runs historical backfill (makes gRPC calls)
- `liveTailExecutor` - runs live tail backfill (makes gRPC calls)

### Secondary Fix: Allow Client Reconnection

**File:** `block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillFetcher.java`

Remove unreachable clients from cache to allow reconnection attempts, this helps clients recover faster.

### Minor Improvements

**File:** `block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/BlockNodeClient.java`

- Change `priorKnowledge` default to `false` for better compatibility
- Add exception logging in `initializeClient()`

## Testing

1. Deploy topology with 2 Block Nodes where one backfills from another and only one CN is present and streams to a single bn1.
2. Verify blocks are successfully fetched and persisted on BN1
3. Verify blocks are backfilled successfully as expected on BN2

## Related

- Consensus Node uses platform threads: `BlockNodeConnectionManager.java:451`
- PBJ gRPC client establishes connection in constructor: `PbjGrpcClient.java`

## Related Issue(s)

Fixes #2091 
