### PR TITLE
chore: Enable zip overwrite by default

### DIFF
--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
@@ -37,6 +37,6 @@ public record FilesHistoricConfig(
         @Loggable @ConfigProperty(defaultValue = "4") @Min(1) @Max(6) int powersOfTenPerZipFileContents,
         @Loggable @ConfigProperty(defaultValue = "0") @Min(0) long blockRetentionThreshold,
         @Loggable @ConfigProperty(defaultValue = "3") @Min(1) int maxFilesPerDir,
-        @Loggable @ConfigProperty(defaultValue = "false") boolean overwriteExistingArchives) {
+        @Loggable @ConfigProperty(defaultValue = "true") boolean overwriteExistingArchives) {
         // spotless:on
 }

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -97,14 +97,13 @@ Currently, no specific options.
 
 ### Files Historic Plugin Configuration
 
-| ENV Variable                               | Description                                                              |                             Default |
-|:-------------------------------------------|:-------------------------------------------------------------------------|------------------------------------:|
-| FILES_HISTORIC_ROOT_PATH                   | Root path for saving historic blocks.                                    | /opt/hiero/block-node/data/historic |
-| FILES_HISTORIC_COMPRESSION                 | Compression type (e.g., ZSTD).                                           |                                     |
-| FILES_HISTORIC_POWERS_OF_TEN               | Files per zip in powers of ten (1=10, 2=100, …, 6=1,000,000).            |                                   4 |
-| FILES_HISTORIC_BLOCK_RETENTION_THRESHOLD   | Number of zips to retain. 0 means keep indefinitely.                     |                                   0 |
-| FILES_HISTORIC_MAX_FILES_PER_DIR           | Max files per directory to avoid filesystem issues.                      |                                   3 |
-| FILES_HISTORIC_OVERWRITE_EXISTING_ARCHIVES | Overwrite existing already archived block batches if new version arives. |                               false |
+| ENV Variable                             | Description                                                   |                             Default |
+|:-----------------------------------------|:--------------------------------------------------------------|------------------------------------:|
+| FILES_HISTORIC_ROOT_PATH                 | Root path for saving historic blocks.                         | /opt/hiero/block-node/data/historic |
+| FILES_HISTORIC_COMPRESSION               | Compression type (e.g., ZSTD).                                |                                     |
+| FILES_HISTORIC_POWERS_OF_TEN             | Files per zip in powers of ten (1=10, 2=100, …, 6=1,000,000). |                                   4 |
+| FILES_HISTORIC_BLOCK_RETENTION_THRESHOLD | Number of zips to retain. 0 means keep indefinitely.          |                                   0 |
+| FILES_HISTORIC_MAX_FILES_PER_DIR         | Max files per directory to avoid filesystem issues.           |                                   3 |
 
 ### Files Recent Plugin Configuration
 


### PR DESCRIPTION
## Reviewer Notes

This PR changes the default behavior of the `overwriteExistingArchives` configuration option from `false` to `true` in the Files Historic Plugin. This means that when new versions of already archived block batches arrive, they will now be overwritten by default instead of being skipped.

Additionally, the configuration documentation has been updated to remove the explicit entry for this option.

## Related Issue(s)

Closes #2135 
