### PR TITLE
2148 Remove the possibility to prevent overwriting existing block batch zips

### DIFF
--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
@@ -411,60 +411,16 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
             // this pre-check asserts the min and max are contained however,
             // not the whole range, this will be asserted when we gather the batch
             final boolean blocksAvailablePreCheck = availableStagedBlocks.contains(minBlockNumber, maxBlockNumber);
-            // avoid zipping same batch twice
-            final boolean alreadyZipped = isRangeAlreadyZipped(minBlockNumber, maxBlockNumber);
+
             if (isValidStart && blocksAvailablePreCheck) {
-                if (!config.overwriteExistingArchives() && alreadyZipped) {
-                    LOGGER.log(INFO, "Batch [{0}, {1}] already zipped, skipping", minBlockNumber, maxBlockNumber);
-                } else {
-                    final LongRange batchRange = new LongRange(minBlockNumber, maxBlockNumber);
-                    // move the batch of blocks to a zip file
-                    startMovingBatchOfBlocksToZipFile(batchRange);
-                }
+                final LongRange batchRange = new LongRange(minBlockNumber, maxBlockNumber);
+                // move the batch of blocks to a zip file
+                startMovingBatchOfBlocksToZipFile(batchRange);
             }
             // try the next batch just in case there is more than one that became available
             minBlockNumber += numberOfBlocksPerZipFile;
             maxBlockNumber += numberOfBlocksPerZipFile;
         }
-    }
-
-    /**
-     * Checks if a range of blocks has already been archived to a zip file.
-     * This method performs a two-tier check to ensure data consistency:
-     * <ol>
-     *   <li>Fast path: Checks the in-memory {@link #availableBlocks} cache</li>
-     *   <li>Fallback: Verifies the zip file exists on disk for data integrity</li>
-     * </ol>
-     *
-     * <p>If a zip file exists on disk but is not tracked in {@code availableBlocks},
-     * the in-memory cache is automatically reconciled to reflect the actual state.
-     * This handles scenarios such as:
-     * <ul>
-     *   <li>Plugin restart where disk state was not fully loaded</li>
-     *   <li>Manual file operations that bypassed the plugin</li>
-     *   <li>Recovery from partial failures during initialization</li>
-     * </ul>
-     *
-     * @param minBlockNumber The first block number in the range to check (inclusive)
-     * @param maxBlockNumber The last block number in the range to check (inclusive)
-     * @return {@code true} if the range is already archived in a zip file,
-     *         {@code false} if the range needs to be zipped
-     */
-    private boolean isRangeAlreadyZipped(final long minBlockNumber, final long maxBlockNumber) {
-        // Check in-memory tracking first (fast)
-        if (availableBlocks.contains(minBlockNumber, maxBlockNumber)) {
-            return true;
-        }
-
-        // Additional check: verify zip file exists on disk (slower but more reliable)
-        final Path zipPath = BlockPath.computeBlockPath(config, minBlockNumber).zipFilePath();
-        if (Files.exists(zipPath)) {
-            // Update availableBlocks in-memory cache to reflect reality
-            availableBlocks.add(minBlockNumber, maxBlockNumber);
-            return true;
-        }
-
-        return false;
     }
 
     private void cleanup() {
@@ -572,9 +528,8 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
 
                 // create staging area directories if they don't exist
                 Files.createDirectories(firstBlockPath.dirPath());
-                if (config.overwriteExistingArchives()) {
-                    Files.deleteIfExists(firstBlockPath.zipFilePath());
-                }
+                Files.deleteIfExists(firstBlockPath.zipFilePath());
+
                 // move the file from the work zip area to the data area by creating a hard link
                 // and then deleting the source file
                 Files.createLink(firstBlockPath.zipFilePath(), zipWorkPath);

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
@@ -24,10 +24,6 @@ import org.hiero.block.node.base.Loggable;
  * {@link #powersOfTenPerZipFileContents} is set to 3, then this means that 5 zips will be retained and these zips
  * contain 10^3 blocks, i.e. 5_000 blocks effectively retained. If set to 0 (zero), blocks will be retained
  * indefinitely.
- * @param overwriteExistingArchives controls whether already-archived block batches can be overwritten with new
- * versions. When {@code false} (default), the plugin maintains idempotent behavior - each batch is archived exactly
- * once and duplicate block verification notifications are ignored. When {@code true}, duplicate notifications will
- * trigger re-archiving, replacing the existing zip file.
  */
 @ConfigData("files.historic")
 public record FilesHistoricConfig(
@@ -36,7 +32,6 @@ public record FilesHistoricConfig(
         @Loggable @ConfigProperty(defaultValue = "ZSTD") CompressionType compression,
         @Loggable @ConfigProperty(defaultValue = "4") @Min(1) @Max(6) int powersOfTenPerZipFileContents,
         @Loggable @ConfigProperty(defaultValue = "0") @Min(0) long blockRetentionThreshold,
-        @Loggable @ConfigProperty(defaultValue = "3") @Min(1) int maxFilesPerDir,
-        @Loggable @ConfigProperty(defaultValue = "true") boolean overwriteExistingArchives) {
+        @Loggable @ConfigProperty(defaultValue = "3") @Min(1) int maxFilesPerDir) {
         // spotless:on
 }

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
@@ -17,8 +17,8 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -77,7 +77,7 @@ class BlockFileHistoricPluginTest {
         // use 10 blocks per zip, assuming that the first zip file will contain
         // for example blocks 0-9, the second zip file will contain blocks 10-19
         // also we will not use compression, and we will use the jUnit temp dir
-        testConfig = new FilesHistoricConfig(dataRoot, CompressionType.NONE, 1, 10L, 3, false);
+        testConfig = new FilesHistoricConfig(dataRoot, CompressionType.NONE, 1, 10L, 3);
         // build the plugin using the test environment
         toTest = new BlockFileHistoricPlugin();
         // initialize an in memory historical block facility to use for testing
@@ -285,14 +285,7 @@ class BlockFileHistoricPluginTest {
                     String.valueOf(testConfig.powersOfTenPerZipFileContents()));
             final Entry<String, String> blockRetentionThreshold = Map.entry(
                     "files.historic.blockRetentionThreshold", String.valueOf(testConfig.blockRetentionThreshold()));
-            final Entry<String, String> overwriteExistingArchives = Map.entry(
-                    "files.historic.overwriteExistingArchives", String.valueOf(testConfig.overwriteExistingArchives()));
-            return Map.ofEntries(
-                    rootPath,
-                    compression,
-                    powersOfTenPerZipFileContents,
-                    blockRetentionThreshold,
-                    overwriteExistingArchives);
+            return Map.ofEntries(rootPath, compression, powersOfTenPerZipFileContents, blockRetentionThreshold);
         }
 
         /**
@@ -775,14 +768,14 @@ class BlockFileHistoricPluginTest {
             // compute the path to the zip file that would be created
             final Path targetZipFilePath =
                     BlockPath.computeBlockPath(testConfig, 0).zipFilePath();
-            Files.createDirectories(targetZipFilePath.getParent());
-            Files.createFile(targetZipFilePath);
-            Files.setPosixFilePermissions(targetZipFilePath, Collections.emptySet()); // no permissions
+            final Path targetZipDir = targetZipFilePath.getParent();
+            Files.createDirectories(targetZipDir);
+            // Remove write permissions from the parent directory to simulate IOException
+            Files.setPosixFilePermissions(targetZipDir, PosixFilePermissions.fromString("r-xr-xr-x"));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
             // assert that no blocks are zipped/available
             for (int i = 0; i < 10; i++) {
-                assertThat(targetZipFilePath).isRegularFile().isEmptyFile();
                 assertThat(toTest.availableBlocks().contains(i)).isFalse();
             }
             assertThat(zipWorkRoot).exists().isDirectory().isEmptyDirectory();
@@ -929,15 +922,14 @@ class BlockFileHistoricPluginTest {
             }
             // calculate the target zip path that we expect the plugin to create
             final Path targetZipPath = BlockPath.computeBlockPath(testConfig, 0).zipFilePath();
-            Files.createDirectories(targetZipPath.getParent());
-            // create the file with no permissions to simulate a failure later on
-            Files.createFile(targetZipPath);
-            Files.setPosixFilePermissions(targetZipPath, Collections.emptySet());
+            final Path targetZipDir = targetZipPath.getParent();
+            Files.createDirectories(targetZipDir);
+            // Remove write permissions from the parent directory to simulate a failure
+            Files.setPosixFilePermissions(targetZipDir, PosixFilePermissions.fromString("r-xr-xr-x"));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
-            // assert that the first 10 blocks are not zipped, but revert proper
-            // perms so we can assert the file is deleted
-            assertThat(targetZipPath).isEmptyFile();
+            // assert that the first 10 blocks are not zipped
+            assertThat(targetZipPath).doesNotExist();
         }
 
         /**
@@ -960,10 +952,10 @@ class BlockFileHistoricPluginTest {
             }
             // calculate the target zip path that we expect the plugin to create
             final Path targetZipPath = BlockPath.computeBlockPath(testConfig, 0).zipFilePath();
-            Files.createDirectories(targetZipPath.getParent());
-            // create the file with no permissions to simulate a failure later on
-            Files.createFile(targetZipPath);
-            Files.setPosixFilePermissions(targetZipPath, Collections.emptySet());
+            final Path targetZipDir = targetZipPath.getParent();
+            Files.createDirectories(targetZipDir);
+            // Remove write permissions from the parent directory to simulate a failure
+            Files.setPosixFilePermissions(targetZipDir, PosixFilePermissions.fromString("r-xr-xr-x"));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
             // assert that no accessor will be returned for the blocks
@@ -993,13 +985,13 @@ class BlockFileHistoricPluginTest {
             }
             // calculate the target zip path that we expect the plugin to create
             final Path targetZipPath = BlockPath.computeBlockPath(testConfig, 0).zipFilePath();
-            Files.createDirectories(targetZipPath.getParent());
-            // create the file with no permissions to simulate a failure later on
-            Files.createFile(targetZipPath);
-            Files.setPosixFilePermissions(targetZipPath, Collections.emptySet());
+            final Path targetZipDir = targetZipPath.getParent();
+            Files.createDirectories(targetZipDir);
+            // Remove write permissions from the parent directory to simulate a failure
+            Files.setPosixFilePermissions(targetZipDir, PosixFilePermissions.fromString("r-xr-xr-x"));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
-            // asser that available blocks do not contain any of the blocks
+            // assert that available blocks do not contain any of the blocks
             for (int i = 0; i < 10; i++) {
                 assertThat(toTest.availableBlocks().contains(i)).isFalse();
             }
@@ -1025,13 +1017,13 @@ class BlockFileHistoricPluginTest {
             }
             // calculate the target zip path that we expect the plugin to create
             final Path targetZipPath = BlockPath.computeBlockPath(testConfig, 0).zipFilePath();
-            Files.createDirectories(targetZipPath.getParent());
-            // create the file with no permissions to simulate a failure later on
-            Files.createFile(targetZipPath);
-            Files.setPosixFilePermissions(targetZipPath, Collections.emptySet());
+            final Path targetZipDir = targetZipPath.getParent();
+            Files.createDirectories(targetZipDir);
+            // Remove write permissions from the parent directory to simulate a failure
+            Files.setPosixFilePermissions(targetZipDir, PosixFilePermissions.fromString("r-xr-xr-x"));
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
-            // assert that no notification was sent to the block messaging,
+            // assert that no notification was sent to the block messaging
             final int totalSentNotifications =
                     blockMessaging.getSentPersistedNotifications().size();
             assertThat(totalSentNotifications).isEqualTo(0);
@@ -1129,7 +1121,7 @@ class BlockFileHistoricPluginTest {
         @DisplayName("Test retention policy threshold disabled")
         void testRetentionPolicyThresholdDisabled() throws IOException {
             // change the retention policy to be disabled
-            testConfig = new FilesHistoricConfig(dataRoot, CompressionType.NONE, 1, 0L, 3, false);
+            testConfig = new FilesHistoricConfig(dataRoot, CompressionType.NONE, 1, 0L, 3);
             // override the config in the plugin
             start(toTest, testHistoricalBlockFacility, getConfigOverrides());
             // generate first 150 blocks from numbers 0-149 and add them to the
@@ -1174,61 +1166,6 @@ class BlockFileHistoricPluginTest {
         }
 
         /**
-         * This test aims to verify that the plugin enforces idempotency by
-         * ensuring that a batch of blocks is archived only once. When duplicate
-         * block verification notifications are received for blocks that have
-         * already been zipped, the plugin should detect that the batch is already archived,
-         * skip submitting a new archival task and leave the existing zip file unmodified
-         */
-        @Test
-        @DisplayName("Test batch is zipped only once and duplicate notifications are ignored")
-        void testBatchIsZippedOnlyOnce() throws IOException {
-            // Send the first set of block verification notifications (blocks 0-9).
-            // This represents the initial arrival of blocks that need to be archived.
-            for (int i = 0; i < 10; i++) {
-                final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(List.of(block)), BlockSource.PUBLISHER));
-            }
-
-            // Execute all pending archival tasks. This should zip blocks 0-9 into a single archive.
-            pluginExecutor.executeSerially();
-
-            // Verify that the batch was successfully archived: all blocks should have zip paths
-            // and should be tracked in the plugin's available blocks range.
-            for (int i = 0; i < 10; i++) {
-                assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNotNull();
-                assertThat(plugin.availableBlocks().contains(i)).isTrue();
-            }
-
-            // Capture the zip file's last modified timestamp. This will be used to verify
-            // that the file is not modified when duplicate notifications arrive.
-            final FileTime lastModifiedTime = Files.getLastModifiedTime(
-                    BlockPath.computeExistingBlockPath(testConfig, 0).zipFilePath());
-
-            // Send duplicate verification notifications for the same blocks (0-9).
-            // This simulates scenarios like plugin restart, retry logic, or receiving
-            // the same blocks from multiple sources.
-            for (int i = 0; i < 10; i++) {
-                final BlockItemUnparsed[] block = SimpleTestBlockItemBuilder.createSimpleBlockUnparsedWithNumber(i);
-                blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(List.of(block)), BlockSource.PUBLISHER));
-            }
-
-            // Verify that no new archival tasks were submitted to the executor.
-            // The plugin should detect that blocks 0-9 are already archived and skip
-            // creating duplicate work.
-            assertThat(pluginExecutor.getTaskCount()).isZero();
-
-            // Verify that the zip file was not modified by checking its timestamp.
-            // The last modified time should be identical to the original, confirming
-            // that the plugin preserved the immutability of the existing archive.
-            final FileTime lastModifiedTimeSecondPass = Files.getLastModifiedTime(
-                    BlockPath.computeExistingBlockPath(testConfig, 0).zipFilePath());
-            assertThat(lastModifiedTime).isEqualTo(lastModifiedTimeSecondPass);
-        }
-
-        /**
          * This test verifies that when the plugin is configured to allow zipping multiple times,
          * duplicate block verification notifications will result in re-archiving the batch,
          * which updates the zip file's modification timestamp. This behavior is controlled by
@@ -1241,7 +1178,7 @@ class BlockFileHistoricPluginTest {
             // Configure plugin with allowZippingMultipleTimes = true (last parameter).
             // This special configuration allows the same batch to be re-archived when
             // duplicate notifications arrive, unlike the default idempotent behavior.
-            testConfig = new FilesHistoricConfig(dataRoot, CompressionType.NONE, 1, 10L, 3, true);
+            testConfig = new FilesHistoricConfig(dataRoot, CompressionType.NONE, 1, 10L, 3);
             start(toTest, testHistoricalBlockFacility, getConfigOverrides());
 
             // Send the first set of block verification notifications (blocks 0-9).
@@ -1326,7 +1263,7 @@ class BlockFileHistoricPluginTest {
         @DisplayName("init moves corrupted zip file without shutting down")
         void initMovesCorruptedZipWithoutShutdown() throws IOException {
             final Path corruptedRoot = dataRoot.resolve("corrupted-zip-root");
-            testConfig = new FilesHistoricConfig(corruptedRoot, CompressionType.NONE, 1, 10L, 3, false);
+            testConfig = new FilesHistoricConfig(corruptedRoot, CompressionType.NONE, 1, 10L, 3);
 
             final BlockPath corruptedZipLocation = BlockPath.computeBlockPath(testConfig, 0L);
             Files.createDirectories(corruptedZipLocation.dirPath());

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
@@ -231,7 +231,7 @@ class BlockPathTest {
             final Path expectedDirPath = expectedZipFilePath.getParent();
             // create the config to use for the test, resolve paths with jimfs
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3, false);
+                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3);
             final BlockPath actual = BlockPath.computeBlockPath(testConfig, blockNumber);
             assertThat(actual)
                     .isNotNull()
@@ -267,7 +267,7 @@ class BlockPathTest {
             // create the config to use for the test, resolve paths temp dir as jimfs does not support
             // the File abstraction
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3, false);
+                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3);
             // create the zip file and directory and add entry
             createZipAndAddEntry(expectedDirPath, expectedZipFilePath, expectedBlockFileName);
             // call
@@ -315,7 +315,7 @@ class BlockPathTest {
             // create the config to use for the test, resolve paths temp dir as jimfs does not support
             // the File abstraction
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, differentCompressionType, digitsPerZipFileContents, 0L, 3, false);
+                    new FilesHistoricConfig(dataRoot, differentCompressionType, digitsPerZipFileContents, 0L, 3);
             // create the zip file and directory and add entry
             createZipAndAddEntry(expectedDirPath, expectedZipFilePath, expectedBlockFileName);
             // call
@@ -346,7 +346,7 @@ class BlockPathTest {
             final CompressionType expectedCompressionType = argAccessor.get(4, CompressionType.class);
             final int digitsPerZipFileContents = argAccessor.getInteger(5);
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3, false);
+                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3);
             // call
             final BlockPath actual = BlockPath.computeExistingBlockPath(testConfig, blockNumber);
             assertThat(actual).isNull();
@@ -374,7 +374,7 @@ class BlockPathTest {
             final Path expectedDirPath = expectedZipFilePath.getParent();
             // create the config to use for the test
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3, false);
+                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3);
             // create the zip file and directory and add entry
             createZipAndAddEntry(expectedDirPath, expectedZipFilePath, "nonexistent.blk.zstd");
             // call

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
@@ -517,8 +517,7 @@ class ZipBlockAccessorTest {
                 compressionType,
                 localDefaultConfig.powersOfTenPerZipFileContents(),
                 localDefaultConfig.blockRetentionThreshold(),
-                localDefaultConfig.maxFilesPerDir(),
-                false);
+                localDefaultConfig.maxFilesPerDir());
     }
 
     private FilesHistoricConfig getDefaultConfiguration() {

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
@@ -491,7 +491,7 @@ class ZipBlockArchiveTest {
     private FilesHistoricConfig createTestConfiguration(
             final Path blocksRoot, final int powersOfTenPerZipFileContents) {
         // for simplicity let's use no compression
-        return new FilesHistoricConfig(blocksRoot, CompressionType.NONE, powersOfTenPerZipFileContents, 0L, 3, false);
+        return new FilesHistoricConfig(blocksRoot, CompressionType.NONE, powersOfTenPerZipFileContents, 0L, 3);
     }
 
     /**


### PR DESCRIPTION
## Reviewer Notes

This PR removes the `overwriteExistingArchives` configuration option and simplifies the Files Historic Plugin behavior to always allow overwriting existing block batch archives.

Modified 5 failing tests that were simulating IOExceptions by removing file permissions. Since `Files.deleteIfExists()` only requires write permission on the parent directory (not on the file itself), the tests now remove write permissions from the parent directory instead of the file to properly simulate permission-based failures.

## Related Issue(s)

Closes #2148 
