### PR TITLE
chore: Remove overwrite existing zip config

### DIFF
--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
@@ -411,60 +411,16 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
             // this pre-check asserts the min and max are contained however,
             // not the whole range, this will be asserted when we gather the batch
             final boolean blocksAvailablePreCheck = availableStagedBlocks.contains(minBlockNumber, maxBlockNumber);
-            // avoid zipping same batch twice
-            final boolean alreadyZipped = isRangeAlreadyZipped(minBlockNumber, maxBlockNumber);
+
             if (isValidStart && blocksAvailablePreCheck) {
-                if (!config.overwriteExistingArchives() && alreadyZipped) {
-                    LOGGER.log(INFO, "Batch [{0}, {1}] already zipped, skipping", minBlockNumber, maxBlockNumber);
-                } else {
-                    final LongRange batchRange = new LongRange(minBlockNumber, maxBlockNumber);
-                    // move the batch of blocks to a zip file
-                    startMovingBatchOfBlocksToZipFile(batchRange);
-                }
+                final LongRange batchRange = new LongRange(minBlockNumber, maxBlockNumber);
+                // move the batch of blocks to a zip file
+                startMovingBatchOfBlocksToZipFile(batchRange);
             }
             // try the next batch just in case there is more than one that became available
             minBlockNumber += numberOfBlocksPerZipFile;
             maxBlockNumber += numberOfBlocksPerZipFile;
         }
-    }
-
-    /**
-     * Checks if a range of blocks has already been archived to a zip file.
-     * This method performs a two-tier check to ensure data consistency:
-     * <ol>
-     *   <li>Fast path: Checks the in-memory {@link #availableBlocks} cache</li>
-     *   <li>Fallback: Verifies the zip file exists on disk for data integrity</li>
-     * </ol>
-     *
-     * <p>If a zip file exists on disk but is not tracked in {@code availableBlocks},
-     * the in-memory cache is automatically reconciled to reflect the actual state.
-     * This handles scenarios such as:
-     * <ul>
-     *   <li>Plugin restart where disk state was not fully loaded</li>
-     *   <li>Manual file operations that bypassed the plugin</li>
-     *   <li>Recovery from partial failures during initialization</li>
-     * </ul>
-     *
-     * @param minBlockNumber The first block number in the range to check (inclusive)
-     * @param maxBlockNumber The last block number in the range to check (inclusive)
-     * @return {@code true} if the range is already archived in a zip file,
-     *         {@code false} if the range needs to be zipped
-     */
-    private boolean isRangeAlreadyZipped(final long minBlockNumber, final long maxBlockNumber) {
-        // Check in-memory tracking first (fast)
-        if (availableBlocks.contains(minBlockNumber, maxBlockNumber)) {
-            return true;
-        }
-
-        // Additional check: verify zip file exists on disk (slower but more reliable)
-        final Path zipPath = BlockPath.computeBlockPath(config, minBlockNumber).zipFilePath();
-        if (Files.exists(zipPath)) {
-            // Update availableBlocks in-memory cache to reflect reality
-            availableBlocks.add(minBlockNumber, maxBlockNumber);
-            return true;
-        }
-
-        return false;
     }
 
     private void cleanup() {
@@ -572,9 +528,8 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
 
                 // create staging area directories if they don't exist
                 Files.createDirectories(firstBlockPath.dirPath());
-                if (config.overwriteExistingArchives()) {
-                    Files.deleteIfExists(firstBlockPath.zipFilePath());
-                }
+                Files.deleteIfExists(firstBlockPath.zipFilePath());
+
                 // move the file from the work zip area to the data area by creating a hard link
                 // and then deleting the source file
                 Files.createLink(firstBlockPath.zipFilePath(), zipWorkPath);

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
@@ -24,10 +24,6 @@ import org.hiero.block.node.base.Loggable;
  * {@link #powersOfTenPerZipFileContents} is set to 3, then this means that 5 zips will be retained and these zips
  * contain 10^3 blocks, i.e. 5_000 blocks effectively retained. If set to 0 (zero), blocks will be retained
  * indefinitely.
- * @param overwriteExistingArchives controls whether already-archived block batches can be overwritten with new
- * versions. When {@code false} (default), the plugin maintains idempotent behavior - each batch is archived exactly
- * once and duplicate block verification notifications are ignored. When {@code true}, duplicate notifications will
- * trigger re-archiving, replacing the existing zip file.
  */
 @ConfigData("files.historic")
 public record FilesHistoricConfig(
@@ -36,7 +32,6 @@ public record FilesHistoricConfig(
         @Loggable @ConfigProperty(defaultValue = "ZSTD") CompressionType compression,
         @Loggable @ConfigProperty(defaultValue = "4") @Min(1) @Max(6) int powersOfTenPerZipFileContents,
         @Loggable @ConfigProperty(defaultValue = "0") @Min(0) long blockRetentionThreshold,
-        @Loggable @ConfigProperty(defaultValue = "3") @Min(1) int maxFilesPerDir,
-        @Loggable @ConfigProperty(defaultValue = "true") boolean overwriteExistingArchives) {
+        @Loggable @ConfigProperty(defaultValue = "3") @Min(1) int maxFilesPerDir) {
         // spotless:on
 }

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
@@ -231,7 +231,7 @@ class BlockPathTest {
             final Path expectedDirPath = expectedZipFilePath.getParent();
             // create the config to use for the test, resolve paths with jimfs
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3, false);
+                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3);
             final BlockPath actual = BlockPath.computeBlockPath(testConfig, blockNumber);
             assertThat(actual)
                     .isNotNull()
@@ -267,7 +267,7 @@ class BlockPathTest {
             // create the config to use for the test, resolve paths temp dir as jimfs does not support
             // the File abstraction
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3, false);
+                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3);
             // create the zip file and directory and add entry
             createZipAndAddEntry(expectedDirPath, expectedZipFilePath, expectedBlockFileName);
             // call
@@ -315,7 +315,7 @@ class BlockPathTest {
             // create the config to use for the test, resolve paths temp dir as jimfs does not support
             // the File abstraction
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, differentCompressionType, digitsPerZipFileContents, 0L, 3, false);
+                    new FilesHistoricConfig(dataRoot, differentCompressionType, digitsPerZipFileContents, 0L, 3);
             // create the zip file and directory and add entry
             createZipAndAddEntry(expectedDirPath, expectedZipFilePath, expectedBlockFileName);
             // call
@@ -346,7 +346,7 @@ class BlockPathTest {
             final CompressionType expectedCompressionType = argAccessor.get(4, CompressionType.class);
             final int digitsPerZipFileContents = argAccessor.getInteger(5);
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3, false);
+                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3);
             // call
             final BlockPath actual = BlockPath.computeExistingBlockPath(testConfig, blockNumber);
             assertThat(actual).isNull();
@@ -374,7 +374,7 @@ class BlockPathTest {
             final Path expectedDirPath = expectedZipFilePath.getParent();
             // create the config to use for the test
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3, false);
+                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3);
             // create the zip file and directory and add entry
             createZipAndAddEntry(expectedDirPath, expectedZipFilePath, "nonexistent.blk.zstd");
             // call

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
@@ -517,8 +517,7 @@ class ZipBlockAccessorTest {
                 compressionType,
                 localDefaultConfig.powersOfTenPerZipFileContents(),
                 localDefaultConfig.blockRetentionThreshold(),
-                localDefaultConfig.maxFilesPerDir(),
-                false);
+                localDefaultConfig.maxFilesPerDir());
     }
 
     private FilesHistoricConfig getDefaultConfiguration() {

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
@@ -491,7 +491,7 @@ class ZipBlockArchiveTest {
     private FilesHistoricConfig createTestConfiguration(
             final Path blocksRoot, final int powersOfTenPerZipFileContents) {
         // for simplicity let's use no compression
-        return new FilesHistoricConfig(blocksRoot, CompressionType.NONE, powersOfTenPerZipFileContents, 0L, 3, false);
+        return new FilesHistoricConfig(blocksRoot, CompressionType.NONE, powersOfTenPerZipFileContents, 0L, 3);
     }
 
     /**


### PR DESCRIPTION
## Reviewer Notes

This PR removes the overwriteExistingArchives configuration option and simplifies the Files Historic Plugin behavior to always allow overwriting existing block batch archives.

Modified 5 failing tests that were simulating IOExceptions by removing file permissions. Since Files.deleteIfExists() only requires write permission on the parent directory (not on the file itself), the tests now remove write permissions from the parent directory instead of the file to properly simulate permission-based failures.

## Related Issue(s)

Closes #2148
