### PR TITLE
refactor(build): Bake .core-modules.txt into Docker image at build time to improve cold start-up time

### DIFF
--- a/block-node/app/docker/Dockerfile
+++ b/block-node/app/docker/Dockerfile
@@ -91,6 +91,14 @@ COPY --from=distributions app-${VERSION}.tar .
 # Extract the TAR file
 RUN tar -xvf app-${VERSION}.tar
 
+# Generate JPMS module list from core jars (used at runtime to deduplicate plugin jars)
+RUN for jar in app-${VERSION}/lib/*.jar; do \
+      [ -f "$jar" ] || continue; \
+      mod=$(/usr/local/java/bin/jar --describe-module --file="$jar" 2>/dev/null | head -1 | sed 's/@.*//' | awk '{print $1}'); \
+      case "$mod" in ""|No|releases:*) continue;; esac; \
+      echo "$mod"; \
+    done > app-${VERSION}/lib/.core-modules.txt
+
 # Create a log directory
 RUN mkdir -p ${BN_WORKDIR}/logs/config
 

--- a/charts/block-node-server/templates/statefulset.yaml
+++ b/charts/block-node-server/templates/statefulset.yaml
@@ -73,24 +73,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if .Values.plugins.names }}
-        - name: list-core-modules
+        - name: copy-core-modules
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command:
-            - sh
-            - -c
-            - |
-              set -e
-              APP_DIR="/opt/hiero/block-node/app-{{ include "hiero-block-node.appVersion" . }}"
-              echo "Listing JPMS modules from core jars in ${APP_DIR}/lib/ ..."
-              : > /plugins/.core-modules.txt
-              for jar in "${APP_DIR}"/lib/*.jar; do
-                [ -f "$jar" ] || continue
-                mod=$(jar --describe-module --file="$jar" 2>/dev/null | head -1 | sed 's/@.*//' | awk '{print $1}')
-                if [ -n "$mod" ] && [ "$mod" != "No" ]; then
-                  echo "$mod" >> /plugins/.core-modules.txt
-                fi
-              done
-              echo "Found $(wc -l < /plugins/.core-modules.txt | tr -d ' ') core modules"
+          command: ["cp", "/opt/hiero/block-node/app-{{ include "hiero-block-node.appVersion" . }}/lib/.core-modules.txt", "/plugins/.core-modules.txt"]
           volumeMounts:
             - name: {{ default "plugins" .Values.plugins.volumeName }}
               mountPath: /plugins


### PR DESCRIPTION
- Generate JPMS core module list during docker build instead of at pod startup
- Replace list-core-modules init container (jar introspection loop) with a single cp
- Eliminates ~10-30s of startup latency from repeated JVM invocations

## Reviewer Notes

The .core-modules.txt only lists what's already inside the image — the core lib/*.jar modules. It doesn't include any plugin dependencies.                                                                                                                                       
                                                                                                                                                                                                                                                                                 
  The flow is:                                                                                                                                                                                                                                                                     
                                                                                                              
  1. Build time (Dockerfile): scan core jars in lib/ → write .core-modules.txt                                                                                                                                                                                                     
  2. Runtime (resolve-plugins): download plugin jars from Maven → filter out any that duplicate a core module                                                                                                                                                                      

  The core jars are fixed per image build. Plugins (configured via plugins.names in Helm values) are resolved at runtime and can be anything — first-party, third-party, whatever. The deduplication compares downloaded plugin jars against the core list to avoid module path
  conflicts.

## Related Issue(s)
Quick follow-up, quick gain optimization of recently merged PR that introduces Pikachu (Plugins Pick and Choose).  #1657 
