### PR TITLE
fix: Handle missing nodes in address book gracefully during wrap

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/parsed/ParsedSignatureFile.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/parsed/ParsedSignatureFile.java
@@ -295,10 +295,21 @@ public class ParsedSignatureFile {
      *
      * @param hash the file hash to validate against (expected SHA-384)
      * @param addressBook the address book used to resolve the public key for the signature
-     * @return true if the provided hash matches the embedded hash and the RSA signature verifies; false otherwise
+     * @return true if the provided hash matches the embedded hash and the RSA signature verifies; false otherwise.
+     *         Returns false if the node is not in the address book (with a warning logged).
      */
     public boolean isValid(byte[] hash, NodeAddressBook addressBook) {
-        return isValid(hash, getRsaPubKey(addressBook));
+        String rsaPubKey;
+        try {
+            rsaPubKey = getRsaPubKey(addressBook);
+        } catch (RuntimeException e) {
+            // Node not in address book - log warning and return false so this signature is skipped
+            System.err.println(
+                    "Warning: Skipping signature from node 0.0." + accountNum + " - not found in address book with "
+                            + addressBook.nodeAddress().size() + " nodes");
+            return false;
+        }
+        return isValid(hash, rsaPubKey);
     }
 
     /**

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/records/model/parsed/ParsedSignatureFileTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/records/model/parsed/ParsedSignatureFileTest.java
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.records.model.parsed;
+
+import static org.hiero.block.tools.utils.TestBlocks.loadV6SignatureFiles;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.NodeAddress;
+import com.hedera.hapi.node.base.NodeAddressBook;
+import com.hedera.hapi.node.base.ServiceEndpoint;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ParsedSignatureFile}.
+ */
+class ParsedSignatureFileTest {
+
+    @Nested
+    @DisplayName("isValid with AddressBook Tests")
+    class IsValidWithAddressBookTests {
+
+        @Test
+        @DisplayName("Returns false when node is not in address book")
+        void returnsFalseWhenNodeNotInAddressBook() {
+            // Load a real signature file from node 3 (from V6 test data)
+            List<ParsedSignatureFile> sigFiles = loadV6SignatureFiles();
+            ParsedSignatureFile sigFileFromNode3 = sigFiles.stream()
+                    .filter(sf -> sf.accountNum() == 3)
+                    .findFirst()
+                    .orElseThrow();
+
+            // Create an address book that does NOT include node 3 (only nodes 100, 101)
+            NodeAddressBook addressBookWithoutNode3 = createAddressBookWithNodes(100, 101);
+
+            // Should return false (not throw) when node 3 is not in address book
+            byte[] someHash = new byte[48];
+            boolean result = sigFileFromNode3.isValid(someHash, addressBookWithoutNode3);
+
+            assertFalse(result, "isValid should return false when node is not in address book");
+        }
+
+        @Test
+        @DisplayName("Returns false when address book is empty")
+        void returnsFalseWhenAddressBookEmpty() {
+            // Load a real signature file
+            List<ParsedSignatureFile> sigFiles = loadV6SignatureFiles();
+            ParsedSignatureFile sigFile = sigFiles.get(0);
+
+            // Create an empty address book
+            NodeAddressBook emptyAddressBook = new NodeAddressBook(List.of());
+
+            // Should return false (not throw) when address book is empty
+            byte[] someHash = new byte[48];
+            boolean result = sigFile.isValid(someHash, emptyAddressBook);
+
+            assertFalse(result, "isValid should return false when address book is empty");
+        }
+    }
+
+    /**
+     * Creates a minimal address book with the specified node account numbers.
+     */
+    private static NodeAddressBook createAddressBookWithNodes(int... nodeAccountNums) {
+        List<NodeAddress> addresses = new java.util.ArrayList<>();
+        for (int i = 0; i < nodeAccountNums.length; i++) {
+            int accountNum = nodeAccountNums[i];
+            NodeAddress nodeAddress = NodeAddress.newBuilder()
+                    .nodeId(i)
+                    .nodeAccountId(AccountID.newBuilder()
+                            .shardNum(0)
+                            .realmNum(0)
+                            .accountNum(accountNum)
+                            .build())
+                    .rsaPubKey("MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA" + accountNum)
+                    .serviceEndpoint(List.of(ServiceEndpoint.newBuilder()
+                            .ipAddressV4(Bytes.wrap(new byte[] {127, 0, 0, 1}))
+                            .port(50211)
+                            .build()))
+                    .build();
+            addresses.add(nodeAddress);
+        }
+        return new NodeAddressBook(addresses);
+    }
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                   
  - Fix wrap command failing when signature files exist from nodes not in the address book                                                                                                                                                         
  - Change `ParsedSignatureFile.isValid()` to return `false` instead of throwing when node is missing                                                                                                                                              
  - Log warning when skipping signatures from unknown nodes                                                                                                                                                                                        
  - Add test coverage for the graceful handling                                                                                                                                                                                                    
   
  ## Problem                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                 
  The wrap command fails when processing record files from dates like 2020-12-03 with:
  No RSA public key found for 0.0.16 in address book with 13 nodes;
  file node_0.0.16.rcd_sig (enable debug logging to see full address book)

  This occurs when a signature file exists from a node that isn't in the address book for that timestamp (likely due to address book timing mismatches during node additions/removals).

  ## Solution

  Modified `ParsedSignatureFile.isValid(hash, addressBook)` to catch the exception and return `false` instead of throwing. This allows the signature to be filtered out gracefully while logging a warning. Processing continues as long as enough
  valid signatures (>1/3) exist from nodes that ARE in the address book.

  ## Test plan

  - [x] Added unit tests for `isValid` returning false when node not in address book
  - [x] Added unit test for empty address book case
  - [x] All 1061 existing tests pass
  
  
  fixes pr: https://github.com/hiero-ledger/hiero-block-node/issues/2182