### PR TITLE
feat: Add Support for the EndOfBlock Message in Stream Publisher Plugin

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/GrpcPluginTestBase.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/GrpcPluginTestBase.java
@@ -47,6 +47,8 @@ public abstract class GrpcPluginTestBase<
     protected Pipeline<Bytes> fromPluginPipe;
     /** The GRPC service interface for the plugin. */
     protected ServiceInterface serviceInterface;
+    /// The gRPC method used
+    protected Method method;
 
     protected GrpcPluginTestBase(@NonNull final E executorService, @NonNull final S scheduledExecutorService) {
         super(executorService, scheduledExecutorService);
@@ -71,6 +73,12 @@ public abstract class GrpcPluginTestBase<
             @NonNull final HistoricalBlockFacility historicalBlockFacility,
             @Nullable final Map<String, String> configOverrides) {
         super.start(plugin, historicalBlockFacility, configOverrides);
+        this.method = Objects.requireNonNull(method);
+        setupNewPipelines();
+    }
+
+    /// Setup new pipelines to be used.
+    public void setupNewPipelines() {
         // setup to receive bytes from the plugin
         fromPluginPipe = new Pipeline<>() {
             @Override

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -199,8 +199,10 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
         if (blockNumber != expectedBlockNumber) {
             final String message = "Expected to close block {0}, but received close for block {1}.";
             LOGGER.log(Level.INFO, message, expectedBlockNumber, blockNumber);
+            // @todo(2159) should we take another action as part of the additional handling of the end of block message?
         }
         metrics.receiveBlockTimeLatencyNs.add(System.nanoTime() - currentStreamingBlockHeaderReceivedTime);
+        publisherManager.endOfBlock(blockNumber);
         publisherManager.closeBlock(handlerId);
         unacknowledgedStreamedBlocks.add(blockNumber);
         resetState();

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
@@ -48,6 +48,9 @@ public interface StreamPublisherManager extends BlockNotificationHandler {
      */
     void closeBlock(final long handlerId);
 
+    ///  Calling this method indicates that the end of block message is received for said block.
+    void endOfBlock(final long blockNumber);
+
     /**
      * Return the latest known valid and persisted block number.
      * <p>

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -40,6 +40,7 @@ import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBloc
 import org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceLoaderFunction;
+import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
@@ -360,6 +361,7 @@ class LiveStreamPublisherManagerTest {
                 // We send the request to the publisher handler.
                 // This will queue the messaging forwarder to run and update the current streaming block number.
                 publisherHandler.onNext(request);
+                endThisBlock(publisherHandler, streamedBlockNumber);
                 // We run the queued messaging forwarder to update the current streaming block number.
                 // We need to run the task async, because the loop (managed by config) is way too big to block on.
                 // We will however wait for one second to ensure the task is run.
@@ -1154,15 +1156,21 @@ class LiveStreamPublisherManagerTest {
                 // We will however wait for one second to ensure the task is run.
                 threadPoolManager.executor().executeAsync(1_000L, false);
                 // Assert that items were propagated to the publisher handler.
-                assertThat(messagingFacility.getSentBlockItems())
+                final List<BlockItems> sentBlockItems = messagingFacility.getSentBlockItems();
+                // We expect 2 batches sent
+                assertThat(sentBlockItems).isNotNull().isNotEmpty().hasSize(2);
+                // First batch is the block, just before the proof
+                assertThat(sentBlockItems.getFirst().blockItems())
                         .isNotNull()
                         .isNotEmpty()
-                        .hasSize(1);
-                assertThat(messagingFacility.getSentBlockItems().getFirst().blockItems())
+                        .hasSize(block.length - 1)
+                        .containsExactly(Arrays.copyOfRange(block, 0, block.length - 1));
+                // Second batch is only the proof after the end of block is received
+                assertThat(sentBlockItems.getLast().blockItems())
                         .isNotNull()
                         .isNotEmpty()
-                        .hasSize(block.length)
-                        .containsExactly(block);
+                        .hasSize(1)
+                        .containsExactly(block[block.length - 1]);
             }
         }
 
@@ -1363,7 +1371,11 @@ class LiveStreamPublisherManagerTest {
              * This test aims to assert that the
              * {@link LiveStreamPublisherManager#handlerIsEnding(long, long)}
              * will correctly handle an end stream request when the handler
-             * has not completed it's current streaming block.
+             * has not completed it's current streaming block. This test runs
+             * the message forwarder task only in the end. If the message
+             * forwarder task is run at the beginning, we could be seeing
+             * different end results (i.e. more items streamed), but that is
+             * expected and should be another test.
              */
             @ParameterizedTest()
             @EnumSource(EndStream.Code.class)
@@ -1415,17 +1427,27 @@ class LiveStreamPublisherManagerTest {
                         .blockItems(fullBlockSet)
                         .build();
                 publisherHandler2.onNext(requestFullBlock);
-                endThisBlock(publisherHandler, testBlock.number());
+                endThisBlock(publisherHandler2, testBlock.number());
                 // We run the queued messaging forwarder to update the current streaming block number.
                 // We need to run the task async, because the loop (managed by config) is way too big to block on.
                 // We will however wait for one second to ensure the task is run.
                 threadPoolManager.executor().executeAsync(1_000L, false);
                 // Assert that the second request has been accepted and the block items were sent.
-                assertThat(messagingFacility.getSentBlockItems().getFirst().blockItems())
+                final List<BlockItems> sentBlockItems = messagingFacility.getSentBlockItems();
+                // We expect 2 batches sent
+                assertThat(sentBlockItems).isNotNull().isNotEmpty().hasSize(2);
+                // First batch is the block, just before the proof
+                assertThat(sentBlockItems.getFirst().blockItems())
                         .isNotNull()
                         .isNotEmpty()
-                        .hasSize(block.length)
-                        .containsExactly(block);
+                        .hasSize(block.length - 1)
+                        .containsExactly(Arrays.copyOfRange(block, 0, block.length - 1));
+                // Second batch is only the proof after the end of block is received
+                assertThat(sentBlockItems.getLast().blockItems())
+                        .isNotNull()
+                        .isNotEmpty()
+                        .hasSize(1)
+                        .containsExactly(block[block.length - 1]);
             }
         }
 

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
@@ -9,18 +9,14 @@ import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.e
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.UncheckedParseException;
-import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Function;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -91,58 +87,6 @@ class StreamPublisherPluginTest {
             historicalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
             final StreamPublisherPlugin toTest = new StreamPublisherPlugin();
             start(toTest, toTest.methods().getFirst(), historicalBlockFacility);
-        }
-
-        private void reopenPublishStream() {
-            fromPluginBytes = new ArrayList<>();
-            fromPluginPipe = new Pipeline<>() {
-                @Override
-                public void clientEndStreamReceived() {
-                    LOGGER.log(System.Logger.Level.TRACE, "clientEndStreamReceived");
-                }
-
-                @Override
-                public void onNext(Bytes item) {
-                    fromPluginBytes.add(item);
-                }
-
-                @Override
-                public void onSubscribe(Subscription subscription) {
-                    LOGGER.log(System.Logger.Level.TRACE, "onSubscribe");
-                }
-
-                @Override
-                public void onError(Throwable throwable) {
-                    throw new AssertionError("Unexpected error from plugin", throwable);
-                }
-
-                @Override
-                public void onComplete() {
-                    LOGGER.log(System.Logger.Level.TRACE, "onComplete");
-                }
-            };
-            final ServiceInterface.RequestOptions options = new ServiceInterface.RequestOptions() {
-                @Override
-                public Optional<String> authority() {
-                    return Optional.empty();
-                }
-
-                @Override
-                public boolean isProtobuf() {
-                    return true;
-                }
-
-                @Override
-                public boolean isJson() {
-                    return false;
-                }
-
-                @Override
-                public String contentType() {
-                    return "application/grpc";
-                }
-            };
-            toPluginPipe = serviceInterface.open(plugin.methods().getFirst(), options, fromPluginPipe);
         }
 
         /**
@@ -276,14 +220,15 @@ class StreamPublisherPluginTest {
         void testResendBlockAfterIncompleteStreamReconnect() {
             // Stream block 0 to completion and verify the acknowledgement. This establishes
             // normal behaviour before we simulate a mid-stream disconnect.
-            final BlockUnparsed firstBlock =
-                    TestBlockBuilder.generateBlockWithNumber(0).blockUnparsed();
+            final TestBlock block0 = TestBlockBuilder.generateBlockWithNumber(0);
+            final BlockUnparsed firstBlock = block0.blockUnparsed();
             final PublishStreamRequestUnparsed firstRequest = PublishStreamRequestUnparsed.newBuilder()
                     .blockItems(BlockItemSetUnparsed.newBuilder()
                             .blockItems(firstBlock.blockItems())
                             .build())
                     .build();
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(firstRequest));
+            endThisBlock(toPluginPipe, block0.number());
             parkNanos(500_000_000L);
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -293,14 +238,12 @@ class StreamPublisherPluginTest {
                     .returns(ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor)
                     .returns(0L, acknowledgementBlockNumberExtractor);
             fromPluginBytes.clear();
-
             // Begin streaming block 1 but stop before the proof to mimic the publisher
             // dropping the connection mid-block. The in-memory historical facility is
             // temporarily disabled so it will ignore the partial block.
             historicalBlockFacility.setDisablePlugin();
-
-            final BlockUnparsed secondBlock =
-                    TestBlockBuilder.generateBlockWithNumber(1).blockUnparsed();
+            final TestBlock block1 = TestBlockBuilder.generateBlockWithNumber(1);
+            final BlockUnparsed secondBlock = block1.blockUnparsed();
             final List<BlockItemUnparsed> secondBlockItems = secondBlock.blockItems();
             final PublishStreamRequestUnparsed secondBlockHeaderRequest = PublishStreamRequestUnparsed.newBuilder()
                     .blockItems(BlockItemSetUnparsed.newBuilder()
@@ -321,7 +264,7 @@ class StreamPublisherPluginTest {
             historicalBlockFacility.clearDisablePlugin();
             // Open a fresh stream to simulate a new publisher connection carrying on with
             // block 1.
-            reopenPublishStream();
+            setupNewPipelines();
             // Resend block 1 in the usual three batches (header, round, proof). With the bug
             // fixed the plugin should now accept the resend and acknowledge block 1.
             final PublishStreamRequestUnparsed retryHeaderRequest = PublishStreamRequestUnparsed.newBuilder()
@@ -342,8 +285,8 @@ class StreamPublisherPluginTest {
                             .build())
                     .build();
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(retryProofRequest));
+            endThisBlock(toPluginPipe, block1.number());
             parkNanos(500_000_000L);
-
             assertThat(fromPluginBytes).isNotEmpty();
             final PublishStreamResponse response = bytesToPublishStreamResponseMapper.apply(fromPluginBytes.getLast());
             assertThat(response)
@@ -361,6 +304,7 @@ class StreamPublisherPluginTest {
     @DisplayName("Plugin Tests Pre Earliest Managed Block")
     class PluginTestsPreEarliestManagedBlock
             extends GrpcPluginTestBase<StreamPublisherPlugin, ExecutorService, ScheduledBlockingExecutor> {
+        private static final long PARK_DURATION = 1_000_000_000L;
         /** The historical block facility to use when testing. */
         private final SimpleInMemoryHistoricalBlockFacility historicalBlockFacility;
 
@@ -403,9 +347,9 @@ class StreamPublisherPluginTest {
                     .build();
             // Send the request to the pipeline
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
-            endThisBlock(toPluginPipe, 0L);
+            endThisBlock(toPluginPipe, block.number());
             // Await to ensure async execution and assert response
-            parkNanos(500_000_000L);
+            parkNanos(PARK_DURATION);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -441,16 +385,16 @@ class StreamPublisherPluginTest {
                             .contains(0, 5))
                     .isTrue();
             // Build a PublishStreamRequest with a valid block as items prior to earliestManagedBlock && after history
-            final long blockNumber = 6L;
-            final TestBlock block = TestBlockBuilder.generateBlockWithNumber(blockNumber);
+            final TestBlock block = TestBlockBuilder.generateBlockWithNumber(6L);
+            final long blockNumber = block.number();
             final PublishStreamRequestUnparsed request = PublishStreamRequestUnparsed.newBuilder()
                     .blockItems(block.asItemSetUnparsed())
                     .build();
             // Send the request to the pipeline
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
-            endThisBlock(toPluginPipe, 0L);
+            endThisBlock(toPluginPipe, blockNumber);
             // Await to ensure async execution and assert response
-            parkNanos(500_000_000L);
+            parkNanos(PARK_DURATION);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -497,7 +441,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
             endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
-            parkNanos(500_000_000L);
+            parkNanos(PARK_DURATION);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -546,7 +490,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
             endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
-            parkNanos(500_000_000L);
+            parkNanos(PARK_DURATION);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -589,7 +533,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
             endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
-            parkNanos(500_000_000L);
+            parkNanos(PARK_DURATION);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -611,21 +555,17 @@ class StreamPublisherPluginTest {
         @DisplayName(
                 "Test publish a valid block as items prior to earliestManagedBlock, next blocks continue the chain")
         void testStreamPriorToEarliestManagedBlockFollowUpContinuesChain() {
-            final BlockUnparsed block0 =
-                    TestBlockBuilder.generateBlockWithNumber(0).blockUnparsed();
+            final TestBlock block0 = TestBlockBuilder.generateBlockWithNumber(0);
             // Activate the plugin with the earliest managed block of 10.
             activatePlugin(10L);
             // Then, we need to stream the first block
-            final BlockItemSetUnparsed firstRequestSet = BlockItemSetUnparsed.newBuilder()
-                    .blockItems(block0.blockItems())
-                    .build();
             final PublishStreamRequestUnparsed firstRequest = PublishStreamRequestUnparsed.newBuilder()
-                    .blockItems(firstRequestSet)
+                    .blockItems(block0.asItemSetUnparsed())
                     .build();
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(firstRequest));
-            endThisBlock(toPluginPipe, 0L);
+            endThisBlock(toPluginPipe, block0.number());
             // Await to ensure async execution and assert response
-            parkNanos(500_000_000L);
+            parkNanos(PARK_DURATION);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -637,17 +577,14 @@ class StreamPublisherPluginTest {
             // Clear the plugin pipe
             fromPluginBytes.clear();
             // Now attempt to send the next block
-            final BlockUnparsed block1 =
-                    TestBlockBuilder.generateBlockWithNumber(1).blockUnparsed();
-            final BlockItemSetUnparsed secondRequestSet = BlockItemSetUnparsed.newBuilder()
-                    .blockItems(block1.blockItems())
-                    .build();
+            final TestBlock block1 = TestBlockBuilder.generateBlockWithNumber(1);
             final PublishStreamRequestUnparsed secondRequest = PublishStreamRequestUnparsed.newBuilder()
-                    .blockItems(secondRequestSet)
+                    .blockItems(block1.asItemSetUnparsed())
                     .build();
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(secondRequest));
+            endThisBlock(toPluginPipe, block1.number());
             // Await to ensure async execution and assert response
-            parkNanos(500_000_000L);
+            parkNanos(PARK_DURATION);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -684,7 +621,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(firstRequest));
             endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
-            parkNanos(500_000_000L);
+            parkNanos(PARK_DURATION);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -736,7 +673,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(firstRequest));
             endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
-            parkNanos(500_000_000L);
+            parkNanos(PARK_DURATION);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -750,7 +687,7 @@ class StreamPublisherPluginTest {
             // Now attempt to send the same request again, that should not be possible
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(firstRequest));
             // Await to ensure async execution and assert response
-            parkNanos(500_000_000L);
+            parkNanos(PARK_DURATION);
             // Assert end stream
             assertThat(fromPluginBytes)
                     .hasSize(1)

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/utils/BlockItemBuilderUtils.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/utils/BlockItemBuilderUtils.java
@@ -65,8 +65,10 @@ public final class BlockItemBuilderUtils {
         TssSignedBlockProof tssSignedBlockProof = TssSignedBlockProof.newBuilder()
                 .blockSignature(Bytes.wrap("block_signature"))
                 .build();
-        BlockProof blockProof =
-                BlockProof.newBuilder().signedBlockProof(tssSignedBlockProof).build();
+        BlockProof blockProof = BlockProof.newBuilder()
+                .signedBlockProof(tssSignedBlockProof)
+                .block(blockNumber)
+                .build();
         return blockProof;
     }
 


### PR DESCRIPTION
## Reviewer Notes

- This PR changes the way we forward items to internal messaging
- We will send all received items, up to the block proof
- Once proof is received, we will store it and await for the end of block message
- Once the end of block message is received, we will propagate the block proof to internal messaging    

**NOTE**: some tests failed because they lacked the condition that they had to send the end of block request. They passed before, because we did not await for the end of block message, but had the old handling prior to this, where we expect the proof and used that to determine the end of the block.

**NOTE**: #2200 will introduce even further improvements and more complete handling of the EndOfBlock message.

## Related Issue(s)

Closes #2159
