### PR TITLE
refactor: Files Historic Plugin Retention Improvements

### DIFF
--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
@@ -31,6 +31,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Deque;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
@@ -76,6 +77,8 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
     private final Deque<LongRange> inProgressZipRanges = new ConcurrentLinkedDeque<>();
     /** Running total of bytes stored in the historic tier */
     private final AtomicLong totalBytesStored = new AtomicLong(0);
+    /** The total number of zip files stored in the historic tier */
+    private final AtomicLong totalZipFiles = new AtomicLong(0);
     /** The config used for this plugin */
     private FilesHistoricConfig config;
     /** The Storage Retention Policy Threshold */
@@ -168,6 +171,10 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
 
                 // Initialize total bytes stored by querying the zip block archive
                 totalBytesStored.set(zipBlockArchive.calculateTotalStoredBytes());
+                totalZipFiles.set(zipBlockArchive.count());
+                // At the moment we will store 0 count if for some reason the count method produces
+                // an error. In the future we will implement better handling of such situation with
+                // a more sophisticated plugin health mechanism
             }
             // Register gauge updater
             context.metrics().addUpdater(this::updateGauges);
@@ -298,7 +305,6 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
         }
         try {
             attemptZipping();
-            cleanup();
         } catch (final RuntimeException e) {
             final String message = "Failed to handle persistence notification due to %s".formatted(e);
             LOGGER.log(WARNING, message, e);
@@ -425,15 +431,11 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
     private void cleanup() {
         // we only take action if the threshold is greater than 0L
         if (blockRetentionThreshold > 0L) {
-            final long totalStored = availableBlocks.size();
+            final long totalStored = totalZipFiles.get();
             // calculate excess blocks to delete, the retention threshold
             // is the number of zips (archived batches) to retain
-            long excess = totalStored - (blockRetentionThreshold * numberOfBlocksPerZipFile);
-            // the numberOfBlocksPerZipFile should generally be immutable once set
-            // for the first time when the block node was originally started
-            // we can rely on the check below to ensure we are deleting the correct
-            // number of blocks
-            while (excess >= numberOfBlocksPerZipFile) {
+            long excess = totalStored - blockRetentionThreshold;
+            while (excess > 0) {
                 // if we have passed the above check, we can delete at least one zip file
                 // we assume there are no gaps in the zips, the number of blocks per zip file
                 // setting is not possible to change after starting the system for the first time,
@@ -445,27 +447,35 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
                 // no need to compute existing below, we need the path to the zip file, we do not need to
                 // check if the minBlockNumberStored exists, moreover we do not need to know actual block compression
                 // type.
-                final Path zipToDelete =
-                        BlockPath.computeBlockPath(config, minBlockNumberStored).zipFilePath();
-                if (Files.exists(zipToDelete)) {
-                    try {
-                        // since we keep track of the whole zip file size, that is
-                        // what we should decrement the total bytes stored by
-                        final long zipFileSize = Files.size(zipToDelete);
-                        Files.delete(zipToDelete);
-                        totalBytesStored.addAndGet(-zipFileSize);
-                        // we know that the minBlockNumberStored is for sure the beginning of the batch
-                        // of blocks that we are deleting, also we know that the numberOfBlocksPerZipFile
-                        // is immutable once set originally when we first started the block node,
-                        // so we can safely calculate and remove the range of blocks from the available blocks
-                        availableBlocks.remove(
-                                minBlockNumberStored, minBlockNumberStored + numberOfBlocksPerZipFile - 1);
-                    } catch (final IOException e) {
-                        LOGGER.log(INFO, "Failed to delete zip file: %s".formatted(zipToDelete), e);
-                        zipsDeletedFailedCounter.increment();
+                try {
+                    final Optional<Path> zipToDeleteOpt = zipBlockArchive.minStoredArchive();
+                    if (zipToDeleteOpt.isPresent()) {
+                        final Path zipToDelete = zipToDeleteOpt.get();
+                        try {
+                            // since we keep track of the whole zip file size, that is
+                            // what we should decrement the total bytes stored by
+                            final long zipFileSize = Files.size(zipToDelete);
+                            Files.delete(zipToDelete);
+                            totalBytesStored.addAndGet(-zipFileSize);
+                            availableBlocks.remove(
+                                    minBlockNumberStored, minBlockNumberStored + numberOfBlocksPerZipFile - 1);
+                            final long currentNumberOfZips = totalZipFiles.decrementAndGet();
+                            if (currentNumberOfZips <= 0) {
+                                break;
+                            }
+                        } catch (final IOException e) {
+                            // TODO(2235) Report plugin unhealthy if minimal block cannot be deleted
+                            LOGGER.log(INFO, "Failed to delete zip file: %s".formatted(zipToDelete), e);
+                            zipsDeletedFailedCounter.increment();
+                        }
                     }
+                } catch (final IOException e) {
+                    // TODO(2235) Report plugin unhealthy if minimal block cannot be determined
+                    LOGGER.log(INFO, "Failed to determine minimal block to delete.", e);
+                    zipsDeletedFailedCounter.increment();
+                    break;
                 }
-                excess -= numberOfBlocksPerZipFile;
+                excess--;
             }
             updateGauges();
         }
@@ -575,6 +585,7 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
                     // zipped and the staging files removed.
                     // Now we need to update the first and last block numbers
                     plugin.availableBlocks.add(batchFirstBlockNumber, batchLastBlockNumber);
+                    plugin.totalZipFiles.incrementAndGet();
                     final String successMessage = "Successfully moved batch of blocks[{0} -> {1}] to zip file.";
                     plugin.LOGGER.log(TRACE, successMessage, batchFirstBlockNumber, batchLastBlockNumber);
                     // now all the blocks are in the zip file and accessible, send notification
@@ -583,6 +594,7 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
                             .blockMessaging()
                             .sendBlockPersisted(
                                     new PersistedNotification(batchLastBlockNumber, true, 1_000, BlockSource.HISTORY));
+                    plugin.cleanup();
                 }
             } catch (final IOException e) {
                 final String failMessage = "Failed to move batch of blocks [%d -> %d] to zip file"

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchive.java
@@ -240,6 +240,64 @@ class ZipBlockArchive {
         return -1;
     }
 
+    Optional<Path> minStoredArchive() throws IOException {
+        return findMinArchive(config.rootPath());
+    }
+
+    private Optional<Path> findMinArchive(Path currentPath) throws IOException {
+        try (Stream<Path> childrenStream = Files.list(currentPath)) {
+            List<Path> children = childrenStream.toList();
+
+            // Get numeric directories sorted by their numeric value (minimum first)
+            List<Path> numericDirs = children.stream()
+                    .filter(this::isNumericDirectory)
+                    .sorted(Comparator.comparingLong(
+                            path -> Long.parseLong(path.getFileName().toString())))
+                    .toList();
+
+            // Get zip files sorted by their numeric value (minimum first)
+            List<Path> zipFiles = children.stream()
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().endsWith(".zip"))
+                    .filter(path -> isNumericDirectory(path.getParent()))
+                    .sorted(Comparator.comparingLong(filePath -> {
+                        String fileName = filePath.getFileName().toString();
+                        return Long.parseLong(fileName.substring(0, fileName.lastIndexOf('.')));
+                    }))
+                    .toList();
+
+            // If this directory has zip files, return the minimum
+            if (!zipFiles.isEmpty()) {
+                return Optional.of(zipFiles.getFirst());
+            }
+
+            // Otherwise, recursively search numeric subdirectories in order (minimum first)
+            for (Path dir : numericDirs) {
+                Optional<Path> result = findMinArchive(dir);
+                if (result.isPresent()) {
+                    return result;
+                }
+                // Directory (and its subtree) was empty, continue to next sibling
+            }
+
+            return Optional.empty();
+        }
+    }
+
+    long count() {
+        try (Stream<Path> pathStream = Files.walk(config.rootPath())) {
+            return pathStream
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().endsWith(".zip"))
+                    .filter(path -> isNumericDirectory(path.getParent()))
+                    .count();
+        } catch (final IOException e) {
+            // TODO(2235) Report plugin unhealthy if number of zip files cannot be determined
+            LOGGER.log(INFO, "Error walking directory structure to count zip files", e);
+            return 0;
+        }
+    }
+
     /**
      * Attempt to quarantine a corrupted zip file and decide whether processing can continue.
      *

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
@@ -12,10 +12,12 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.metrics.api.Metrics;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
@@ -27,11 +29,14 @@ import java.util.Objects;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import org.hiero.block.api.BlockNodeVersions;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.app.fixtures.async.BlockingExecutor;
 import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
 import org.hiero.block.node.app.fixtures.async.TestThreadPoolManager;
+import org.hiero.block.node.app.fixtures.blocks.TestBlock;
 import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
 import org.hiero.block.node.app.fixtures.plugintest.NoOpServiceBuilder;
 import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
@@ -1104,7 +1109,7 @@ class BlockFileHistoricPluginTest {
             }
             // assert that none of the first 150 blocks are zipped yet and are
             // not present in the available blocks
-            assertThat(plugin.availableBlocks().size()).isEqualTo(0);
+            assertThat(plugin.availableBlocks().size()).isZero();
             for (int i = 0; i < 150; i++) {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
                 assertThat(plugin.availableBlocks().contains(i)).isFalse();
@@ -1113,8 +1118,12 @@ class BlockFileHistoricPluginTest {
             pluginExecutor.executeSerially();
             // assert that all blocks are now zipped and the available blocks
             // is updated accordingly (this is just before applying the retention)
-            assertThat(plugin.availableBlocks().size()).isEqualTo(150);
-            for (int i = 0; i < 150; i++) {
+            assertThat(plugin.availableBlocks().size()).isEqualTo(100);
+            for (int i = 0; i < 50; i++) {
+                assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
+                assertThat(plugin.availableBlocks().contains(i)).isFalse();
+            }
+            for (int i = 50; i < 150; i++) {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNotNull();
                 assertThat(plugin.availableBlocks().contains(i)).isTrue();
             }
@@ -1192,6 +1201,103 @@ class BlockFileHistoricPluginTest {
         }
 
         /**
+         * This test verifies that the retention policy correctly manages available blocks when
+         * blocks are added in multiple batches that exceed the retention threshold. The test
+         * simulates a scenario where an initial large set of blocks (100-199) is archived,
+         * followed by an additional smaller batch (200-209) that triggers the retention policy
+         * to clean up the oldest blocks while maintaining the configured threshold of 100 blocks.
+         * This ensures that the plugin properly prunes old archives while keeping the most recent
+         * blocks within the retention limit.
+         */
+        @Test
+        @DisplayName("Test retention policy with complex block additions spanning multiple batches")
+        void testRetentionPolicyWithComplexBlockAdditions() throws IOException {
+            // Add first batch of 100 blocks (100-199) to simulate an initial archive
+            // set that fills the retention threshold exactly
+            for (int i = 100; i < 200; i++) {
+                final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
+                blockMessaging.sendBlockVerification(new VerificationNotification(
+                        true, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
+            }
+
+            // Execute all pending archival tasks to zip the first batch
+            pluginExecutor.executeSerially();
+
+            // Verify that all 100 blocks from the first batch are now archived and available.
+            // At this point, we are exactly at the retention threshold (100 blocks).
+            assertThat(plugin.availableBlocks().size()).isEqualTo(100);
+            for (int i = 100; i < 200; i++) {
+                assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNotNull();
+                assertThat(plugin.availableBlocks().contains(i)).isTrue();
+            }
+
+            // Add a second batch of 10 blocks (200-209). This will push us over the
+            // retention threshold, triggering cleanup of the oldest blocks.
+            for (int i = 200; i < 210; i++) {
+                final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
+                blockMessaging.sendBlockVerification(new VerificationNotification(
+                        true, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
+            }
+
+            // Execute all pending archival tasks. The retention policy should kick in
+            // and remove the oldest 10 blocks (100-109) to maintain the 100-block threshold.
+            pluginExecutor.executeSerially();
+
+            // Calculate the total blocks and range after retention policy cleanup
+            final long totalBlocksAfterRetention = plugin.availableBlocks().size();
+            final long minAvailableBlock =
+                    plugin.availableBlocks().stream().min().orElse(-1);
+            final long maxAvailableBlock =
+                    plugin.availableBlocks().stream().max().orElse(-1);
+
+            // Verify retention policy worked correctly: exactly 100 blocks should remain,
+            // ranging from 110 (oldest retained) to 209 (newest), with blocks 100-109 removed.
+            assertThat(totalBlocksAfterRetention).isEqualTo(100);
+            assertThat(minAvailableBlock).isEqualTo(110);
+            assertThat(maxAvailableBlock).isEqualTo(209);
+        }
+
+        /**
+         * This test verifies that the retention policy correctly handles pre-existing archived
+         * blocks that were created before plugin startup, combined with newly added blocks.
+         */
+        @Test
+        @DisplayName("Test retention policy with pre-existing archives and incremental additions")
+        void testRetentionPolicyWithPreExistingArchives() throws IOException {
+            // Create 90 pre-existing zip entries to simulate blocks that were archived
+            // in a previous session before this plugin instance started
+            for (int i = 0; i < 90; i++) {
+                createPreExistingZipEntry(i);
+            }
+
+            // Verify that all pre-existing zip files were created successfully on disk
+            for (int i = 0; i < 90; i++) {
+                final Path zipPath = BlockPath.computeBlockPath(testConfig, i).zipFilePath();
+                assertThat(zipPath).exists().isRegularFile();
+            }
+
+            // Start the plugin. It should discover and register the 90 pre-existing archives.
+            start(toTest, testHistoricalBlockFacility, getConfigOverrides());
+            verifyBlocksAreAvailableAndArchived(0, 90, 90L);
+
+            // Add blocks to reach retention threshold
+            sendBlockVerificationNotifications(90, 100);
+            pluginExecutor.executeSerially();
+            verifyBlocksAreAvailableAndArchived(0, 100, 100L);
+
+            // Add blocks to exceed retention threshold
+            sendBlockVerificationNotifications(100, 110);
+            pluginExecutor.executeSerially();
+
+            // Verify retention policy maintained the 100-block limit
+            verifyBlocksAreAvailableAndArchived(100, 110, 100L);
+            for (int i = 0; i < 10; i++) {
+                assertThat(plugin.availableBlocks().contains(i)).isFalse();
+                assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
+            }
+        }
+
+        /**
          * This test verifies that when the plugin is configured to allow zipping multiple times,
          * duplicate block verification notifications will result in re-archiving the batch,
          * which updates the zip file's modification timestamp. This behavior is controlled by
@@ -1210,10 +1316,9 @@ class BlockFileHistoricPluginTest {
             // Send the first set of block verification notifications (blocks 0-9).
             // This represents the initial arrival of blocks that need to be archived.
             for (int i = 0; i < 10; i++) {
-                final BlockUnparsed block =
-                        TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
+                final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             }
 
             // Execute all pending archival tasks. This should zip blocks 0-9 into a single archive.
@@ -1236,10 +1341,9 @@ class BlockFileHistoricPluginTest {
             // With allowZippingMultipleTimes enabled, this should trigger re-archiving
             // instead of being skipped as it would be with the default configuration.
             for (int i = 0; i < 10; i++) {
-                final BlockUnparsed block =
-                        TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
+                final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             }
 
             // Execute pending tasks. With allowZippingMultipleTimes = true, this should
@@ -1254,6 +1358,87 @@ class BlockFileHistoricPluginTest {
             // confirms that with allowZippingMultipleTimes enabled, the plugin does re-archive
             // batches instead of maintaining idempotent behavior.
             assertThat(lastModifiedTime).isLessThan(lastModifiedTimeSecondPass);
+        }
+
+        /**
+         * Sends block verification notifications for a range of blocks.
+         *
+         * @param startInclusive start block number (inclusive)
+         * @param endExclusive end block number (exclusive)
+         */
+        private void sendBlockVerificationNotifications(final int startInclusive, final int endExclusive) {
+            for (int i = startInclusive; i < endExclusive; i++) {
+                final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
+                blockMessaging.sendBlockVerification(new VerificationNotification(
+                        true, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
+            }
+        }
+
+        /**
+         * Verifies that blocks in a range are available and archived.
+         *
+         * @param startInclusive start block number (inclusive)
+         * @param endExclusive end block number (exclusive)
+         * @param expectedTotalSize expected total size of available blocks (null to skip check)
+         */
+        private void verifyBlocksAreAvailableAndArchived(
+                final int startInclusive, final int endExclusive, final long expectedTotalSize) throws IOException {
+            assertThat(plugin.availableBlocks().size()).isEqualTo(expectedTotalSize);
+            for (int i = startInclusive; i < endExclusive; i++) {
+                assertThat(plugin.availableBlocks().contains(i)).isTrue();
+                assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNotNull();
+            }
+        }
+
+        /**
+         * Helper method to create a pre-existing zip entry for a block before plugin startup.
+         * This simulates blocks that were previously archived.
+         *
+         * @param blockNumber the block number to create
+         * @throws IOException if an error occurs creating the zip file
+         */
+        private void createPreExistingZipEntry(final long blockNumber) throws IOException {
+            final BlockPath blockPath = BlockPath.computeBlockPath(testConfig, blockNumber);
+            final TestBlock block = TestBlockBuilder.generateBlockWithNumber(blockNumber);
+            final Bytes blockBytes = block.bytes();
+            final byte[] bytesToWrite = blockBytes.toByteArray();
+
+            // Create directory structure
+            Files.createDirectories(blockPath.dirPath());
+
+            // Create or append to zip file
+            if (Files.notExists(blockPath.zipFilePath())) {
+                // Create new zip file
+                Files.createFile(blockPath.zipFilePath());
+                try (final ZipOutputStream zipOut =
+                        new ZipOutputStream(Files.newOutputStream(blockPath.zipFilePath()))) {
+                    final ZipEntry zipEntry = new ZipEntry(blockPath.blockFileName());
+                    zipOut.putNextEntry(zipEntry);
+                    zipOut.write(bytesToWrite);
+                    zipOut.closeEntry();
+                }
+            } else {
+                // Append to existing zip file
+                final Path tempZip = blockPath.zipFilePath().resolveSibling("temp.zip");
+                try (final FileSystem zipFs = FileSystems.newFileSystem(blockPath.zipFilePath());
+                        final Stream<Path> entriesStream = Files.list(zipFs.getPath("/"));
+                        final ZipOutputStream zipOut = new ZipOutputStream(Files.newOutputStream(tempZip))) {
+                    // Copy existing entries
+                    for (final Path entry : entriesStream.toList()) {
+                        zipOut.putNextEntry(new ZipEntry(entry.getFileName().toString()));
+                        try (final InputStream inputStream = Files.newInputStream(entry)) {
+                            inputStream.transferTo(zipOut);
+                        }
+                        zipOut.closeEntry();
+                    }
+                    // Add the new entry
+                    final ZipEntry newEntry = new ZipEntry(blockPath.blockFileName());
+                    zipOut.putNextEntry(newEntry);
+                    zipOut.write(bytesToWrite);
+                    zipOut.closeEntry();
+                }
+                Files.move(tempZip, blockPath.zipFilePath(), StandardCopyOption.REPLACE_EXISTING);
+            }
         }
     }
 

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
@@ -339,6 +340,217 @@ class ZipBlockArchiveTest {
                     .isExactlyInstanceOf(ZipBlockAccessor.class)
                     .extracting(BlockAccessor::blockUnparsed)
                     .isEqualTo(expected.blockUnparsed());
+        }
+
+        /**
+         * This test aims to assert that the
+         * {@link ZipBlockArchive#minStoredArchive()} returns empty Optional when no zip files are present.
+         */
+        @Test
+        @DisplayName("Test minStoredArchive() returns empty when no zip files present")
+        void testMinStoredArchiveNoZipFiles() throws IOException {
+            // call
+            final Optional<Path> actual = toTest.minStoredArchive();
+            // assert empty result and server still running
+            assertThat(actual).isEmpty();
+            assertThat(testContext.serverHealth().isRunning()).isTrue();
+        }
+
+        /**
+         * This test aims to assert that the
+         * {@link ZipBlockArchive#minStoredArchive()} returns the only zip file when a single zip file exists.
+         */
+        @Test
+        @DisplayName("Test minStoredArchive() returns single zip file")
+        void testMinStoredArchiveSingleZipFile() throws IOException {
+            // create test environment with one zip file
+            createAndAddBlockEntry(5L);
+            final Path expectedZip = BlockPath.computeBlockPath(testConfig, 5L).zipFilePath();
+            // call
+            final Optional<Path> actual = toTest.minStoredArchive();
+            // assert
+            assertThat(actual).isPresent().hasValue(expectedZip);
+            assertThat(testContext.serverHealth().isRunning()).isTrue();
+        }
+
+        /**
+         * This test aims to assert that the
+         * {@link ZipBlockArchive#minStoredArchive()} returns the minimum zip file
+         * when multiple zip files exist in the same directory.
+         */
+        @Test
+        @DisplayName("Test minStoredArchive() returns minimum from same directory")
+        void testMinStoredArchiveMultipleZipsSameDirectory() throws IOException {
+            // create test environment with multiple zip files in same directory
+            // Using powersOfTenPerZipFileContents=1, blocks 3 and 7 will be in the same directory
+            createAndAddBlockEntry(3L);
+            createAndAddBlockEntry(5L);
+            createAndAddBlockEntry(7L);
+            final Path expectedZip = BlockPath.computeBlockPath(testConfig, 3L).zipFilePath();
+            // call
+            final Optional<Path> actual = toTest.minStoredArchive();
+            // assert returns the minimum (3)
+            assertThat(actual).isPresent().hasValue(expectedZip);
+        }
+
+        /**
+         * This test aims to assert that the
+         * {@link ZipBlockArchive#minStoredArchive()} returns the zip file from the
+         * minimum directory when zip files exist in different directories.
+         */
+        @Test
+        @DisplayName("Test minStoredArchive() returns minimum across different directories")
+        void testMinStoredArchiveMultipleDirectories() throws IOException {
+            // create test environment with zip files in different nested directories
+            // Using powersOfTenPerZipFileContents=1, these will be in different directories
+            createAndAddBlockEntry(13L); // In a lower directory
+            createAndAddBlockEntry(103L); // In a higher directory
+            createAndAddBlockEntry(1003L); // In an even higher directory
+            final Path expectedZip = BlockPath.computeBlockPath(testConfig, 13L).zipFilePath();
+            // call
+            final var actual = toTest.minStoredArchive();
+            // assert returns the one from the minimum directory path (13)
+            assertThat(actual).isPresent().hasValue(expectedZip);
+        }
+
+        /**
+         * This test aims to assert that the
+         * {@link ZipBlockArchive#minStoredArchive()} skips empty directories and
+         * returns the minimum zip file from the next non-empty directory.
+         */
+        @Test
+        @DisplayName("Test minStoredArchive() skips empty directories")
+        void testMinStoredArchiveSkipsEmptyDirectories() throws IOException {
+            // create test environment with empty directories
+            // Create block files and then delete them to simulate empty directories
+            createAndAddBlockEntry(3L);
+            final Path zip3 = BlockPath.computeBlockPath(testConfig, 3L).zipFilePath();
+            Files.delete(zip3);
+            createAndAddBlockEntry(13L);
+            final Path zip13 = BlockPath.computeBlockPath(testConfig, 13L).zipFilePath();
+            Files.delete(zip13);
+            // Create a zip file in a higher directory than the empty ones
+            createAndAddBlockEntry(33L);
+            final Path expectedZip = BlockPath.computeBlockPath(testConfig, 33L).zipFilePath();
+            // call
+            final var actual = toTest.minStoredArchive();
+            // assert returns the zip from the first non-empty directory
+            assertThat(actual).isPresent().hasValue(expectedZip);
+        }
+
+        /**
+         * This test aims to assert that the
+         * {@link ZipBlockArchive#minStoredArchive()} handles deeply nested directory structures
+         * and returns the minimum zip file.
+         */
+        @Test
+        @DisplayName("Test minStoredArchive() handles deeply nested structure")
+        void testMinStoredArchiveDeeplyNested() throws IOException {
+            // create test environment with deeply nested directories
+            // Using powersOfTenPerZipFileContents=1 creates nested structure
+            createAndAddBlockEntry(1234L);
+            createAndAddBlockEntry(5678L);
+            createAndAddBlockEntry(123L);
+            final Path expectedZip =
+                    BlockPath.computeBlockPath(testConfig, 123L).zipFilePath();
+            // call
+            final var actual = toTest.minStoredArchive();
+            // assert returns the minimum (123)
+            assertThat(actual).isPresent().hasValue(expectedZip);
+        }
+
+        /**
+         * This test aims to assert that the
+         * {@link ZipBlockArchive#count()} returns 0L when no zip files are present.
+         */
+        @Test
+        @DisplayName("Test count() returns 0 when no zip files are present")
+        void testCountNoZipFiles() {
+            final long actual = toTest.count();
+            // assert that server is still running and 0 is returned
+            assertThat(actual).isZero();
+            assertThat(testContext.serverHealth().isRunning()).isTrue();
+        }
+
+        /**
+         * This test aims to assert that the
+         * {@link ZipBlockArchive#count()} correctly returns 1 when a single zip file exists.
+         */
+        @Test
+        @DisplayName("Test count() returns 1 for single zip file")
+        void testCountSingleZipFile() throws IOException {
+            // create test environment, for this test we need one zip file
+            createAndAddBlockEntry(3L);
+            // call
+            final long actual = toTest.count();
+            // assert expected result
+            assertThat(actual).isEqualTo(1L);
+        }
+
+        /**
+         * This test aims to assert that the
+         * {@link ZipBlockArchive#count()} correctly returns the count of multiple zip files.
+         */
+        @Test
+        @DisplayName("Test count() returns correct count for multiple zip files")
+        void testCountMultipleZipFiles() throws IOException {
+            // create test environment, for this test we need two zip files
+            createAndAddBlockEntry(3L);
+            createAndAddBlockEntry(4L);
+            // zip size are 10 blocks, so the following 2 will be in another file in the same directory
+            createAndAddBlockEntry(13L);
+            createAndAddBlockEntry(14L);
+            // call
+            final long actual = toTest.count();
+            // assert expected result and still running server - should be 2 zip files
+            assertThat(actual).isEqualTo(2L);
+            assertThat(testContext.serverHealth().isRunning()).isTrue();
+        }
+
+        /**
+         * This test aims to assert that the
+         * {@link ZipBlockArchive#count()} only counts zip files in numeric directories,
+         * excluding files in special directories like "stage" or "links".
+         */
+        @Test
+        @DisplayName("Test count() only counts zip files in numeric directories")
+        void testCountOnlyNumericDirectories() throws IOException {
+            // create test environment with zip files in numeric directories
+            createAndAddBlockEntry(3L);
+            createAndAddBlockEntry(13L);
+            // create a zip file in a non-numeric directory (should not be counted)
+            final Path stage = testConfig.rootPath().resolve("stage");
+            Files.createDirectories(stage);
+            final Path stageZip = stage.resolve("0.zip");
+            Files.createFile(stageZip);
+            // create a zip file in the links directory (should not be counted)
+            final Path linksZip = linksTempDir.resolve("0.zip");
+            Files.createFile(linksZip);
+            // assert that server is running before we call actual
+            assertThat(testContext.serverHealth().isRunning()).isTrue();
+            // call
+            final long actual = toTest.count();
+            // assert expected result - should only count 2 zip files in numeric directories
+            assertThat(actual).isEqualTo(2L);
+        }
+
+        /**
+         * This test aims to assert that the
+         * {@link ZipBlockArchive#count()} correctly counts zip files across different nested directories.
+         */
+        @Test
+        @DisplayName("Test count() counts zip files in different nested directories")
+        void testCountDifferentDirectories() throws IOException {
+            // create test environment with zip files in different nested directories
+            // Using testConfig with powersOfTenPerZipFileContents = 1, so each power of 10 gets its own directory
+            createAndAddBlockEntry(3L);
+            createAndAddBlockEntry(13L);
+            createAndAddBlockEntry(103L);
+            createAndAddBlockEntry(1003L);
+            // call
+            final long actual = toTest.count();
+            // assert expected result - should count 4 zip files across different directories
+            assertThat(actual).isEqualTo(4L);
         }
 
         /**


### PR DESCRIPTION
## Reviewer Notes                                                                                                                                    
                                                                                                                                                       
This change improves the retention policy implementation by tracking the number of zip archives directly rather than inferring it from individual blocks. The key improvements include:

**Core Changes:**
  - Added `totalZipFiles` atomic counter to track the number of zip archives
  - Introduced `ZipBlockArchive.count()` to count zip files at initialization
  - Introduced `ZipBlockArchive.minStoredArchive()` to efficiently find the oldest archive for deletion
  - Simplified retention calculation from `excess = totalStored - (threshold * blocksPerZip)` to `excess = totalStored - threshold`
  - Moved cleanup execution to occur after each successful zip creation (inside the try block) rather than before zipping

**Test Coverage:**
  - Added comprehensive tests for retention with multiple batch additions
  - Added tests for handling pre-existing archives discovered at startup
  - Added extensive tests for `minStoredArchive()`: empty directories, single/multiple zips, nested structures
  - Added tests for `count()`: empty state, single/multiple files, directory filtering, error handling

## Related Issue(s)

Closes #1372