### PR TITLE
refactor: Files Historic Plugin Extract Zipping Logic Into a Standalone Task

### DIFF
--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
@@ -22,7 +22,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.lang.System.Logger.Level;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
@@ -577,7 +576,7 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
                     // Now we need to update the first and last block numbers
                     plugin.availableBlocks.add(batchFirstBlockNumber, batchLastBlockNumber);
                     final String successMessage = "Successfully moved batch of blocks[{0} -> {1}] to zip file.";
-                    plugin.LOGGER.log(Level.TRACE, successMessage, batchFirstBlockNumber, batchLastBlockNumber);
+                    plugin.LOGGER.log(TRACE, successMessage, batchFirstBlockNumber, batchLastBlockNumber);
                     // now all the blocks are in the zip file and accessible, send notification
                     // @todo is this needed? Does anything actually care when a zip file is completed?
                     plugin.context


### PR DESCRIPTION
## Reviewer Notes

This PR refactors the lambda function used for moving batches of blocks to zip files into a static final inner class BatchToZipFileMover.

The refactoring improves code organization by:
  - Converting the lambda in zipMoveExecutorService.submit() to a proper Runnable implementation
  - Encapsulating the moveBatchOfBlocksToZipFile logic within the new class
  - Moving related helper methods (gatherAccessors and cleanupZipWorkFiles) into the class scope
  - Improving code readability and maintainability without changing the functional behavior

## Related Issue(s)

Closes #1292 
