### PR TITLE
fix: Increase sidecar file parsing limit from 2MB to 8MB

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/parsed/ParsedRecordBlock.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/parsed/ParsedRecordBlock.java
@@ -30,6 +30,9 @@ import org.hiero.block.tools.records.model.unparsed.UnparsedRecordBlock;
 public record ParsedRecordBlock(
         ParsedRecordFile recordFile, List<ParsedSignatureFile> signatureFiles, List<SidecarFile> sidecarFiles) {
 
+    /** Maximum size for parsing sidecar files (8MB). Some mainnet blocks have large sidecars. */
+    private static final int MAX_SIDECAR_SIZE = 8 * 1024 * 1024;
+
     /**
      * Get the consensus time of the block.
      *
@@ -63,7 +66,7 @@ public record ParsedRecordBlock(
                 recordFileBlock.primarySidecarFiles().stream()
                         .map(ps -> {
                             try {
-                                return SidecarFile.PROTOBUF.parse(Bytes.wrap(ps.data()));
+                                return SidecarFile.PROTOBUF.parse(Bytes.wrap(ps.data()), false, MAX_SIDECAR_SIZE);
                             } catch (ParseException e) {
                                 throw new RuntimeException(e);
                             }


### PR DESCRIPTION
  Some mainnet sidecar files exceed PBJ's default 2MB max size limit
  (e.g., block 48168427 has a 4.5MB sidecar with 1,166 transactions).

  Add MAX_SIDECAR_SIZE constant (8MB) and use it when parsing sidecar
  files to handle high-throughput blocks.

  Fixes #2218

