### PR TITLE
fix(e2e): skip relay and explorer deployment in all topologies

### DIFF
--- a/tools-and-tests/scripts/solo-e2e-test/topologies/2cn-2bn-backfill.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/topologies/2cn-2bn-backfill.yaml
@@ -42,10 +42,6 @@ mirror_nodes:
   mirror-1:
     block_nodes: [block-node-1, block-node-2]
 
-relay_nodes:
-  relay-1:
-    mirror_nodes: [mirror-1]
-
-explorer_nodes:
-  explorer-1:
-    mirror_nodes: [mirror-1]
+# Empty sections = skip deployment (relay chart readiness issues with Solo 0.54.0)
+relay_nodes: {}
+explorer_nodes: {}

--- a/tools-and-tests/scripts/solo-e2e-test/topologies/3cn-1bn.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/topologies/3cn-1bn.yaml
@@ -27,10 +27,6 @@ mirror_nodes:
   mirror-1:
     block_nodes: [block-node-1]
 
-relay_nodes:
-  relay-1:
-    mirror_nodes: [mirror-1]
-
-explorer_nodes:
-  explorer-1:
-    mirror_nodes: [mirror-1]
+# Empty sections = skip deployment (relay chart readiness issues with Solo 0.54.0)
+relay_nodes: {}
+explorer_nodes: {}

--- a/tools-and-tests/scripts/solo-e2e-test/topologies/7cn-3bn-distributed.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/topologies/7cn-3bn-distributed.yaml
@@ -64,8 +64,6 @@ mirror_nodes:
   mirror-1:
     block_nodes: [block-node-1, block-node-2, block-node-3]
 
-relay_nodes:
-  relay-1:
-    mirror_nodes: [mirror-1]
-
+# Empty sections = skip deployment (relay chart readiness issues with Solo 0.54.0)
+relay_nodes: {}
 explorer_nodes: {}

--- a/tools-and-tests/scripts/solo-e2e-test/topologies/fan-out-3cn-2bn.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/topologies/fan-out-3cn-2bn.yaml
@@ -45,10 +45,6 @@ mirror_nodes:
   mirror-1:
     block_nodes: [block-node-1, block-node-2]
 
-relay_nodes:
-  relay-1:
-    mirror_nodes: [mirror-1]
-
-explorer_nodes:
-  explorer-1:
-    mirror_nodes: [mirror-1]
+# Empty sections = skip deployment (relay chart readiness issues with Solo 0.54.0)
+relay_nodes: {}
+explorer_nodes: {}

--- a/tools-and-tests/scripts/solo-e2e-test/topologies/paired-3.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/topologies/paired-3.yaml
@@ -51,10 +51,6 @@ mirror_nodes:
   mirror-1:
     block_nodes: [block-node-1, block-node-2, block-node-3]
 
-relay_nodes:
-  relay-1:
-    mirror_nodes: [mirror-1]
-
-explorer_nodes:
-  explorer-1:
-    mirror_nodes: [mirror-1]
+# Empty sections = skip deployment (relay chart readiness issues with Solo 0.54.0)
+relay_nodes: {}
+explorer_nodes: {}

--- a/tools-and-tests/scripts/solo-e2e-test/topologies/single.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/topologies/single.yaml
@@ -23,10 +23,6 @@ mirror_nodes:
   mirror-1:
     block_nodes: [block-node-1]
 
-relay_nodes:
-  relay-1:
-    mirror_nodes: [mirror-1]
-
-explorer_nodes:
-  explorer-1:
-    mirror_nodes: [mirror-1]
+# Empty sections = skip deployment (relay chart readiness issues with Solo 0.54.0)
+relay_nodes: {}
+explorer_nodes: {}


### PR DESCRIPTION
## Summary

- Skip relay and explorer deployment in all topology files by setting `relay_nodes: {}` and `explorer_nodes: {}`
- The relay Helm chart (v0.73.0 via Solo CLI 0.54.0) consistently fails its Kubernetes readiness probe within the 100-attempt limit, blocking all CI runs
- No test assertions depend on relay or explorer — all tests (smoke-test, basic-load, node-restart-resilience, full-history-backfill) validate Block Node functionality only
- Uses the existing skip mechanism already established in `minimal.yaml`

Fixes CI failures introduced when the tag `v0.28.0-rc1` was pushed: https://github.com/hiero-ledger/hiero-block-node/actions/runs/22157263073

## Test plan

- [x] Verified locally with `task up TOPOLOGY=single` — relay and explorer correctly skipped, all other components (BN, CN, MN) deployed and healthy
- [ ] Dry-Run on CI. Pending/In-Progress https://github.com/hiero-ledger/hiero-block-node/actions/runs/22163579527
## Related Issue(s)
Fix #2221 