### PR TITLE
fix: Use 5-arg parse to correctly pass maxSize for sidecar files

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/parsed/ParsedRecordBlock.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/parsed/ParsedRecordBlock.java
@@ -74,7 +74,7 @@ public record ParsedRecordBlock(
                                 return SidecarFile.PROTOBUF.parse(
                                         Bytes.wrap(ps.data()).toReadableSequentialData(),
                                         false, // strictMode
-                                        false, // parseUnknownFields
+                                        true, // parseUnknownFields
                                         MAX_DEPTH, // maxDepth
                                         MAX_SIDECAR_SIZE); // maxSize
                             } catch (ParseException e) {


### PR DESCRIPTION
The 3-arg `Codec.parse(Bytes, boolean, int)` method incorrectly passes
the int parameter as `maxDepth`, then hardcodes the default 2MB `maxSize`.
This caused `ParseException` for blocks with large sidecars (>2MB).

Switch to the 5-arg `parse(ReadableSequentialData, boolean, boolean,
int, int)` to explicitly set both `maxDepth (512)` and `maxSize (8MB)`

this closes #2218 