### PR TITLE
fix: Preserve subdirectory structure in temp block files for tar.zstd…

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/download/DownloadDayImplV2.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/download/DownloadDayImplV2.java
@@ -160,7 +160,7 @@ public class DownloadDayImplV2 {
                 new java.io.DataOutputStream(new java.io.BufferedOutputStream(Files.newOutputStream(blockFile)))) {
             dos.writeInt(files.size());
             for (InMemoryFile imf : files) {
-                String filename = imf.path().getFileName().toString();
+                String filename = imf.path().toString();
                 byte[] filenameBytes = filename.getBytes(java.nio.charset.StandardCharsets.UTF_8);
                 dos.writeInt(filenameBytes.length);
                 dos.write(filenameBytes);

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/download/DownloadDayLiveImpl.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/download/DownloadDayLiveImpl.java
@@ -77,7 +77,7 @@ public class DownloadDayLiveImpl {
                 new java.io.DataOutputStream(new java.io.BufferedOutputStream(Files.newOutputStream(blockFile)))) {
             dos.writeInt(files.size());
             for (InMemoryFile imf : files) {
-                String filename = imf.path().getFileName().toString();
+                String filename = imf.path().toString();
                 byte[] filenameBytes = filename.getBytes(java.nio.charset.StandardCharsets.UTF_8);
                 dos.writeInt(filenameBytes.length);
                 dos.write(filenameBytes);


### PR DESCRIPTION
### Summary                                       
  - Fix `writeBlockToTempDir()` in both `DownloadDayImplV2` and `DownloadDayLiveImpl` to preserve the full file path including the timestamp subdirectory when writing to intermediate `.block` temp files
  - `getFileName()` was stripping the parent directory, causing tar.zstd archives to have a flat file structure (e.g., `node_0.0.3.rcd_sig`) instead of the expected nested structure (e.g., `2026-02-05T00_00_00Z/node_0.0.3.rcd_sig`)
  - The `days validate` command expects files nested under their timestamp directory and fails with "No signature files found" when they are at the root.
  
 The part of the work for #2154 