### PR TITLE
fix(tests): Fixes UT Flaky Unit Tests by Replacing sleep by dynamic polling.

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/GrpcPluginTestBase.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/GrpcPluginTestBase.java
@@ -11,11 +11,11 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.helidon.webserver.http.HttpService;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.ScheduledExecutorService;
@@ -40,7 +40,7 @@ public abstract class GrpcPluginTestBase<
     private record ReqOptions(Optional<String> authority, boolean isProtobuf, boolean isJson, String contentType)
             implements ServiceInterface.RequestOptions {}
     /** The GRPC bytes received from the plugin. */
-    protected List<Bytes> fromPluginBytes = new ArrayList<>();
+    protected List<Bytes> fromPluginBytes = new CopyOnWriteArrayList<>();
     /** The pipeline for GRPC bytes to the plugin. */
     protected Pipeline<? super Bytes> toPluginPipe;
     /** The pipeline for GRPC bytes from the plugin. */

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
@@ -304,7 +304,7 @@ class StreamPublisherPluginTest {
     @DisplayName("Plugin Tests Pre Earliest Managed Block")
     class PluginTestsPreEarliestManagedBlock
             extends GrpcPluginTestBase<StreamPublisherPlugin, ExecutorService, ScheduledBlockingExecutor> {
-        private static final long PARK_DURATION = 1_000_000_000L;
+        private static final long RESPONSE_TIMEOUT_NS = 5_000_000_000L; // 5 seconds
         /** The historical block facility to use when testing. */
         private final SimpleInMemoryHistoricalBlockFacility historicalBlockFacility;
 
@@ -314,6 +314,18 @@ class StreamPublisherPluginTest {
         PluginTestsPreEarliestManagedBlock() {
             super(Executors.newSingleThreadExecutor(), new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
             historicalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
+        }
+
+        /**
+         * Polls until {@code fromPluginBytes} reaches the expected size or the
+         * 5-second timeout expires. Uses short polling intervals instead of a
+         * fixed sleep to avoid timing-based test flakiness.
+         */
+        private void awaitResponse(final int expectedCount) {
+            final long deadline = System.nanoTime() + RESPONSE_TIMEOUT_NS;
+            while (fromPluginBytes.size() < expectedCount && System.nanoTime() < deadline) {
+                parkNanos(1_000_000L);
+            }
         }
 
         private void activatePlugin(final long earliestManagedBlock) {
@@ -349,7 +361,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
             endThisBlock(toPluginPipe, block.number());
             // Await to ensure async execution and assert response
-            parkNanos(PARK_DURATION);
+            awaitResponse(1);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -394,7 +406,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
             endThisBlock(toPluginPipe, blockNumber);
             // Await to ensure async execution and assert response
-            parkNanos(PARK_DURATION);
+            awaitResponse(1);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -441,7 +453,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
             endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
-            parkNanos(PARK_DURATION);
+            awaitResponse(1);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -490,7 +502,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
             endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
-            parkNanos(PARK_DURATION);
+            awaitResponse(1);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -533,7 +545,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
             endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
-            parkNanos(PARK_DURATION);
+            awaitResponse(1);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -565,7 +577,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(firstRequest));
             endThisBlock(toPluginPipe, block0.number());
             // Await to ensure async execution and assert response
-            parkNanos(PARK_DURATION);
+            awaitResponse(1);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -584,7 +596,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(secondRequest));
             endThisBlock(toPluginPipe, block1.number());
             // Await to ensure async execution and assert response
-            parkNanos(PARK_DURATION);
+            awaitResponse(1);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -621,7 +633,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(firstRequest));
             endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
-            parkNanos(PARK_DURATION);
+            awaitResponse(1);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -673,7 +685,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(firstRequest));
             endThisBlock(toPluginPipe, 0L);
             // Await to ensure async execution and assert response
-            parkNanos(PARK_DURATION);
+            awaitResponse(1);
             // Assert that the block has been successfully streamed
             assertThat(fromPluginBytes)
                     .hasSize(1)
@@ -687,7 +699,7 @@ class StreamPublisherPluginTest {
             // Now attempt to send the same request again, that should not be possible
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(firstRequest));
             // Await to ensure async execution and assert response
-            parkNanos(PARK_DURATION);
+            awaitResponse(1);
             // Assert end stream
             assertThat(fromPluginBytes)
                     .hasSize(1)


### PR DESCRIPTION
## Summary

- Use `CopyOnWriteArrayList` for `GrpcPluginTestBase.fromPluginBytes` to guarantee cross-thread visibility between the plugin thread (writer) and the test thread (reader)
- Replace fixed 1s `parkNanos` sleeps in `PluginTestsPreEarliestManagedBlock` with a polling helper `awaitResponse(int)` that exits as soon as the expected response arrives (up to 5s timeout)

These two changes together eliminate flaky failures in `StreamPublisherPluginTest` caused by races between async plugin execution and test assertions.

## Related Issue(s)
Fixes #2254 