### PR TITLE
feat: Add `--network` flag to CLI tools for multi-network support

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/BlockStreamTool.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/BlockStreamTool.java
@@ -3,6 +3,7 @@ package org.hiero.block.tools;
 
 import org.hiero.block.tools.blocks.BlocksCommand;
 import org.hiero.block.tools.commands.NetworkCapacity;
+import org.hiero.block.tools.config.NetworkConfig;
 import org.hiero.block.tools.days.DaysCommand;
 import org.hiero.block.tools.metadata.MetadataCommand;
 import org.hiero.block.tools.mirrornode.MirrorNodeCommand;
@@ -10,6 +11,8 @@ import org.hiero.block.tools.records.RecordsCommand;
 import org.hiero.block.tools.states.StatesCommand;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ScopeType;
 
 /**
  * Command line tool for working with Hedera block stream files
@@ -34,6 +37,22 @@ public final class BlockStreamTool {
      * Empty Default constructor to remove Javadoc warning
      */
     public BlockStreamTool() {}
+
+    /**
+     * Sets the active network configuration. This option is inherited by all subcommands
+     * via {@code scope = ScopeType.INHERIT}, so it can be specified at any level of the
+     * command hierarchy (e.g., {@code tools days download-days-v3 --network testnet}).
+     *
+     * @param network the network name: "mainnet" (default) or "testnet"
+     */
+    @Option(
+            names = "--network",
+            description = "Network to use: mainnet (default), testnet",
+            defaultValue = "mainnet",
+            scope = ScopeType.INHERIT)
+    void setNetwork(final String network) {
+        NetworkConfig.setCurrent(NetworkConfig.fromName(network));
+    }
 
     /**
      * Main entry point for the app

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/config/NetworkConfig.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/config/NetworkConfig.java
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.config;
+
+import java.time.LocalDate;
+
+/**
+ * Network-specific configuration for the Hedera block stream tools.
+ *
+ * <p>Provides all network-specific parameters needed by the CLI commands, such as
+ * the GCS bucket name, mirror node URL, genesis date, node range, and total HBAR supply.
+ * Factory methods are provided for known networks (mainnet, testnet). The static
+ * {@link #current()} method returns the currently active configuration, which defaults
+ * to mainnet and can be changed via the {@code --network} CLI option.
+ *
+ * @param networkName              human-readable network name (e.g. "mainnet", "testnet")
+ * @param gcsBucketName            GCS bucket containing record streams
+ * @param bucketPathPrefix         path prefix within the GCS bucket (e.g. "recordstreams/")
+ * @param mirrorNodeApiUrl         base URL for the mirror node REST API (must end with '/')
+ * @param genesisDate              first calendar day of the network
+ * @param genesisTimestamp         first block timestamp in record-file format (underscores for colons)
+ * @param minNodeAccountId         minimum consensus node account ID number
+ * @param maxNodeAccountId         maximum consensus node account ID number
+ * @param totalHbarSupplyTinybar   total HBAR supply in tinybar
+ * @param genesisAddressBookResource classpath resource name for the genesis address book
+ */
+public record NetworkConfig(
+        String networkName,
+        String gcsBucketName,
+        String bucketPathPrefix,
+        String mirrorNodeApiUrl,
+        LocalDate genesisDate,
+        String genesisTimestamp,
+        int minNodeAccountId,
+        int maxNodeAccountId,
+        long totalHbarSupplyTinybar,
+        String genesisAddressBookResource) {
+
+    /** The currently active network configuration. Defaults to mainnet. */
+    private static volatile NetworkConfig current = mainnet();
+
+    /**
+     * Returns the currently active network configuration.
+     *
+     * @return the current {@link NetworkConfig}
+     */
+    public static NetworkConfig current() {
+        return current;
+    }
+
+    /**
+     * Sets the currently active network configuration.
+     *
+     * @param config the {@link NetworkConfig} to use
+     */
+    public static void setCurrent(final NetworkConfig config) {
+        current = config;
+    }
+
+    /**
+     * Returns the mainnet configuration.
+     *
+     * @return a {@link NetworkConfig} for Hedera mainnet
+     */
+    public static NetworkConfig mainnet() {
+        return new NetworkConfig(
+                "mainnet",
+                "hedera-mainnet-streams",
+                "recordstreams/",
+                "https://mainnet-public.mirrornode.hedera.com/api/v1/",
+                LocalDate.of(2019, 9, 13),
+                "2019-09-13T21_53_51.396440Z",
+                3,
+                37,
+                5_000_000_000_000_000_000L,
+                "mainnet-genesis-address-book.proto.bin");
+    }
+
+    /**
+     * Returns the testnet configuration.
+     *
+     * <p>Based on the current testnet instance (reset February 2024). Testnet has 7 consensus
+     * nodes with account IDs 0.0.3 through 0.0.9.
+     *
+     * @return a {@link NetworkConfig} for Hedera testnet
+     */
+    public static NetworkConfig testnet() {
+        return new NetworkConfig(
+                "testnet",
+                "hedera-testnet-streams",
+                "recordstreams/",
+                "https://testnet.mirrornode.hedera.com/api/v1/",
+                LocalDate.of(2024, 2, 1),
+                "2024-02-01T18_35_20.644859297Z",
+                3,
+                9,
+                5_000_000_000_000_000_000L,
+                "testnet-genesis-address-book.proto.bin");
+    }
+
+    /**
+     * Creates a {@link NetworkConfig} from a network name.
+     *
+     * @param name the network name (case-insensitive): "mainnet" or "testnet"
+     * @return the corresponding {@link NetworkConfig}
+     * @throws IllegalArgumentException if the network name is not recognized
+     */
+    public static NetworkConfig fromName(final String name) {
+        return switch (name.toLowerCase()) {
+            case "mainnet" -> mainnet();
+            case "testnet" -> testnet();
+            default ->
+                throw new IllegalArgumentException(
+                        "Unknown network: " + name + ". Supported networks: mainnet, testnet");
+        };
+    }
+}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/download/DownloadConstants.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/download/DownloadConstants.java
@@ -6,6 +6,11 @@ package org.hiero.block.tools.days.download;
  *
  * <p>This utility class provides configuration values for accessing the Hedera mainnet
  * streams bucket, including bucket name, path prefix, and GCP project ID for requester-pays billing.
+ *
+ * <p><b>Note:</b> For network-aware code, prefer using
+ * {@link org.hiero.block.tools.config.NetworkConfig#current()} to obtain the bucket name
+ * and path prefix. The constants in this class are retained for the GCP project ID
+ * (which is not network-specific) and for backward compatibility.
  */
 public final class DownloadConstants {
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/download/DownloadDayImplV2.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/download/DownloadDayImplV2.java
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.days.download;
 
-import static org.hiero.block.tools.days.download.DownloadConstants.BUCKET_NAME;
-import static org.hiero.block.tools.days.download.DownloadConstants.BUCKET_PATH_PREFIX;
+import static org.hiero.block.tools.config.NetworkConfig.current;
 import static org.hiero.block.tools.days.listing.DayListingFileReader.loadRecordsFileForDay;
 import static org.hiero.block.tools.records.RecordFileUtils.extractRecordFileTimeStrFromPath;
 import static org.hiero.block.tools.records.RecordFileUtils.findMostCommonByType;
@@ -54,11 +53,15 @@ public class DownloadDayImplV2 {
     /** Maximum number of retries for parsing/validation failures (e.g., corrupted downloads). */
     private static final int MAX_PARSE_RETRIES = 3;
 
-    /** Minimum node account ID to try when fetching missing record files */
-    private static final int MIN_NODE_ID = 3;
+    /** Minimum node account ID to try when fetching missing record files. Sourced from active {@link org.hiero.block.tools.config.NetworkConfig}. */
+    private static int minNodeId() {
+        return current().minNodeAccountId();
+    }
 
-    /** Maximum node account ID to try when fetching missing record files */
-    private static final int MAX_NODE_ID = 37;
+    /** Maximum node account ID to try when fetching missing record files. Sourced from active {@link org.hiero.block.tools.config.NetworkConfig}. */
+    private static int maxNodeId() {
+        return current().maxNodeAccountId();
+    }
 
     /** Formatter for GCS record file timestamps: 2026-02-02T23_58_48.420820000Z */
     private static final DateTimeFormatter GCS_TIMESTAMP_FORMATTER =
@@ -489,8 +492,8 @@ public class DownloadDayImplV2 {
                 final BlockWork bw =
                         new BlockWork(blockNumber, blockHashFromMirrorNode, blockTime, orderedFilesToDownload);
                 for (ListingRecordFile lr : orderedFilesToDownload) {
-                    final String blobName = BUCKET_PATH_PREFIX + lr.path();
-                    bw.futures.add(downloadManager.downloadAsync(BUCKET_NAME, blobName));
+                    final String blobName = current().bucketPathPrefix() + lr.path();
+                    bw.futures.add(downloadManager.downloadAsync(current().gcsBucketName(), blobName));
                 }
                 try {
                     // block if queue is full to provide backpressure
@@ -548,8 +551,8 @@ public class DownloadDayImplV2 {
                                 boolean md5Valid = Md5Checker.checkMd5(lr.md5Hex(), downloadedFile.data());
                                 if (!md5Valid) {
                                     clearProgress();
-                                    System.err.println("MD5 mismatch for " + (BUCKET_PATH_PREFIX + lr.path())
-                                            + ", retrying download...");
+                                    System.err.println("MD5 mismatch for "
+                                            + (current().bucketPathPrefix() + lr.path()) + ", retrying download...");
                                     // Retry download with built-in retry logic
                                     downloadedFile = downloadFileWithRetry(downloadManager, lr);
                                     if (downloadedFile == null) {
@@ -619,10 +622,10 @@ public class DownloadDayImplV2 {
                                 System.err.println("Re-downloading most common record file and retrying...");
                                 if (!ready.orderedFiles.isEmpty()) {
                                     ListingRecordFile mostCommon = ready.orderedFiles.get(0);
-                                    String blobName = BUCKET_PATH_PREFIX + mostCommon.path();
+                                    String blobName = current().bucketPathPrefix() + mostCommon.path();
                                     try {
-                                        CompletableFuture<InMemoryFile> newFuture =
-                                                downloadManager.downloadAsync(BUCKET_NAME, blobName);
+                                        CompletableFuture<InMemoryFile> newFuture = downloadManager.downloadAsync(
+                                                current().gcsBucketName(), blobName);
                                         ready.futures.set(0, newFuture);
                                         newFuture.join();
                                     } catch (Exception redownloadEx) {
@@ -636,10 +639,10 @@ public class DownloadDayImplV2 {
                                     ListingRecordFile alternate = ready.orderedFiles.get(alternateIndex);
                                     System.err.println(
                                             "Trying alternate record file from different node: " + alternate.path());
-                                    String blobName = BUCKET_PATH_PREFIX + alternate.path();
+                                    String blobName = current().bucketPathPrefix() + alternate.path();
                                     try {
-                                        CompletableFuture<InMemoryFile> newFuture =
-                                                downloadManager.downloadAsync(BUCKET_NAME, blobName);
+                                        CompletableFuture<InMemoryFile> newFuture = downloadManager.downloadAsync(
+                                                current().gcsBucketName(), blobName);
                                         // Swap the alternate with position 0 so it becomes the "most common"
                                         // for this block's processing
                                         ready.futures.set(0, newFuture);
@@ -653,10 +656,10 @@ public class DownloadDayImplV2 {
                                     System.err.println("No alternate record files available, retrying same file...");
                                     if (!ready.orderedFiles.isEmpty()) {
                                         ListingRecordFile mostCommon = ready.orderedFiles.get(0);
-                                        String blobName = BUCKET_PATH_PREFIX + mostCommon.path();
+                                        String blobName = current().bucketPathPrefix() + mostCommon.path();
                                         try {
-                                            CompletableFuture<InMemoryFile> newFuture =
-                                                    downloadManager.downloadAsync(BUCKET_NAME, blobName);
+                                            CompletableFuture<InMemoryFile> newFuture = downloadManager.downloadAsync(
+                                                    current().gcsBucketName(), blobName);
                                             ready.futures.set(0, newFuture);
                                             newFuture.join();
                                         } catch (Exception redownloadEx) {
@@ -755,13 +758,14 @@ public class DownloadDayImplV2 {
      */
     private static InMemoryFile downloadFileWithRetry(
             final ConcurrentDownloadManager downloadManager, final ListingRecordFile lr) throws IOException {
-        final String blobName = BUCKET_PATH_PREFIX + lr.path();
+        final String blobName = current().bucketPathPrefix() + lr.path();
         final boolean isSignatureFile = lr.type() == ListingRecordFile.Type.RECORD_SIG;
         IOException lastException = null;
 
         for (int attempt = 1; attempt <= MAX_MD5_RETRIES; attempt++) {
             try {
-                final CompletableFuture<InMemoryFile> future = downloadManager.downloadAsync(BUCKET_NAME, blobName);
+                final CompletableFuture<InMemoryFile> future =
+                        downloadManager.downloadAsync(current().gcsBucketName(), blobName);
                 final InMemoryFile downloadedFile = future.join();
 
                 if (!Md5Checker.checkMd5(lr.md5Hex(), downloadedFile.data())) {
@@ -993,15 +997,16 @@ public class DownloadDayImplV2 {
         String timestamp = blockTime.format(GCS_TIMESTAMP_FORMATTER);
 
         // Try each node from MIN to MAX
-        for (int nodeId = MIN_NODE_ID; nodeId <= MAX_NODE_ID; nodeId++) {
+        for (int nodeId = minNodeId(); nodeId <= maxNodeId(); nodeId++) {
             // Try both .rcd.gz and .rcd formats
             String[] extensions = {".rcd.gz", ".rcd"};
             for (String ext : extensions) {
                 String relativePath = "record0.0." + nodeId + "/" + timestamp + ext;
-                String blobPath = BUCKET_PATH_PREFIX + relativePath;
+                String blobPath = current().bucketPathPrefix() + relativePath;
 
                 try {
-                    CompletableFuture<InMemoryFile> future = downloadManager.downloadAsync(BUCKET_NAME, blobPath);
+                    CompletableFuture<InMemoryFile> future =
+                            downloadManager.downloadAsync(current().gcsBucketName(), blobPath);
                     InMemoryFile file = future.get(10, TimeUnit.SECONDS);
 
                     if (file != null && file.data() != null && file.data().length > 0) {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/downloadlive/LiveDownloader.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/downloadlive/LiveDownloader.java
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.days.downloadlive;
 
-import static org.hiero.block.tools.days.download.DownloadConstants.BUCKET_NAME;
-import static org.hiero.block.tools.days.download.DownloadConstants.BUCKET_PATH_PREFIX;
+import static org.hiero.block.tools.config.NetworkConfig.current;
 import static org.hiero.block.tools.days.download.DownloadConstants.GCP_PROJECT_ID;
 import static org.hiero.block.tools.days.downloadlive.ValidateDownloadLive.fullBlockValidate;
 import static org.hiero.block.tools.days.listing.DayListingFileReader.loadRecordsFileForDay;
@@ -757,8 +756,8 @@ public class LiveDownloader {
                 final BlockWork bw =
                         new BlockWork(blockNumber, blockHashFromMirrorNode, blockTime, orderedFilesToDownload);
                 for (ListingRecordFile lr : orderedFilesToDownload) {
-                    final String blobName = BUCKET_PATH_PREFIX + lr.path();
-                    bw.futures.add(downloadManager.downloadAsync(BUCKET_NAME, blobName));
+                    final String blobName = current().bucketPathPrefix() + lr.path();
+                    bw.futures.add(downloadManager.downloadAsync(current().gcsBucketName(), blobName));
                 }
 
                 try {
@@ -929,13 +928,14 @@ public class LiveDownloader {
      * Downloads a file with retry logic for MD5 mismatch errors.
      */
     private InMemoryFile downloadFileWithRetry(ListingRecordFile lr) throws IOException {
-        final String blobName = BUCKET_PATH_PREFIX + lr.path();
+        final String blobName = current().bucketPathPrefix() + lr.path();
         final boolean isSignatureFile = lr.type() == ListingRecordFile.Type.RECORD_SIG;
         IOException lastException = null;
 
         for (int attempt = 1; attempt <= MAX_MD5_RETRIES; attempt++) {
             try {
-                final CompletableFuture<InMemoryFile> future = downloadManager.downloadAsync(BUCKET_NAME, blobName);
+                final CompletableFuture<InMemoryFile> future =
+                        downloadManager.downloadAsync(current().gcsBucketName(), blobName);
                 final InMemoryFile downloadedFile = future.join();
 
                 if (!Md5Checker.checkMd5(lr.md5Hex(), downloadedFile.data())) {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/AddressBookRegistry.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/AddressBookRegistry.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.days.model;
 
-import static org.hiero.block.tools.utils.TimeUtils.GENESIS_TIMESTAMP;
 import static org.hiero.block.tools.utils.TimeUtils.toTimestamp;
 
 import com.hedera.hapi.node.base.NodeAddress;
@@ -26,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.hiero.block.internal.AddressBookHistory;
 import org.hiero.block.internal.DatedNodeAddressBook;
+import org.hiero.block.tools.config.NetworkConfig;
 import picocli.CommandLine.Help.Ansi;
 
 /**
@@ -41,11 +41,15 @@ public class AddressBookRegistry {
     private ByteArrayOutputStream partialFileUpload = null;
 
     /**
-     * Create a new AddressBookRegistry instance and load the Genesis address book.
+     * Create a new AddressBookRegistry instance and load the Genesis address book for the current network.
      */
     public AddressBookRegistry() {
         try {
-            addressBooks.add(new DatedNodeAddressBook(GENESIS_TIMESTAMP, loadGenesisAddressBook()));
+            final String genesisTs = NetworkConfig.current().genesisTimestamp().replace('_', ':');
+            final Instant genesisInstant = Instant.parse(genesisTs);
+            addressBooks.add(new DatedNodeAddressBook(
+                    toTimestamp(genesisInstant),
+                    loadGenesisAddressBook(NetworkConfig.current().genesisAddressBookResource())));
         } catch (ParseException e) {
             throw new RuntimeException("Error loading Genesis Address Book", e);
         }
@@ -215,15 +219,25 @@ public class AddressBookRegistry {
     }
 
     /**
-     * Load the Genesis address book from the classpath resource "mainnet-genesis-address-book.proto.bin".
+     * Load the Genesis address book for the current network from the classpath.
      *
      * @return the Genesis NodeAddressBook
      * @throws ParseException if there is an error parsing the address book
      */
     public static NodeAddressBook loadGenesisAddressBook() throws ParseException {
-        try (var in = new ReadableStreamingData(Objects.requireNonNull(AddressBookRegistry.class
-                .getClassLoader()
-                .getResourceAsStream("mainnet-genesis-address-book.proto.bin")))) {
+        return loadGenesisAddressBook(NetworkConfig.current().genesisAddressBookResource());
+    }
+
+    /**
+     * Load a Genesis address book from the classpath resource with the given name.
+     *
+     * @param resourceName the classpath resource name (e.g. "mainnet-genesis-address-book.proto.bin")
+     * @return the Genesis NodeAddressBook
+     * @throws ParseException if there is an error parsing the address book
+     */
+    public static NodeAddressBook loadGenesisAddressBook(String resourceName) throws ParseException {
+        try (var in = new ReadableStreamingData(Objects.requireNonNull(
+                AddressBookRegistry.class.getClassLoader().getResourceAsStream(resourceName)))) {
             return NodeAddressBook.PROTOBUF.parse(in);
         }
     }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/DownloadDaysV3.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/DownloadDaysV3.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.Map;
+import org.hiero.block.tools.config.NetworkConfig;
 import org.hiero.block.tools.metadata.MetadataFiles;
 import org.hiero.block.tools.mirrornode.BlockTimeReader;
 import org.hiero.block.tools.mirrornode.DayBlockInfo;
@@ -42,13 +43,13 @@ public class DownloadDaysV3 implements Runnable {
     private int threads = 100; // Reduced from 1000 to avoid virtual thread pinning with gRPC
 
     @Parameters(index = "0", description = "From year to download")
-    private int fromYear = 2019;
+    private int fromYear = NetworkConfig.current().genesisDate().getYear();
 
     @Parameters(index = "1", description = "From month to download")
-    private int fromMonth = 9;
+    private int fromMonth = NetworkConfig.current().genesisDate().getMonthValue();
 
     @Parameters(index = "2", description = "From day to download")
-    private int fromDay = 13;
+    private int fromDay = NetworkConfig.current().genesisDate().getDayOfMonth();
 
     @Parameters(index = "3", description = "To year to download")
     private int toYear = LocalDate.now().getYear();

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/UpdateDayListingsCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/UpdateDayListingsCommand.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import org.hiero.block.tools.config.NetworkConfig;
 import org.hiero.block.tools.days.download.DownloadConstants;
 import org.hiero.block.tools.days.listing.DayListingFileWriter;
 import org.hiero.block.tools.days.listing.ListingRecordFile;
@@ -70,13 +71,13 @@ public class UpdateDayListingsCommand implements Runnable {
 
     @Option(
             names = {"--min-node"},
-            description = "Minimum node account ID (default: 3)")
-    private int minNodeAccountId = 3;
+            description = "Minimum node account ID (default: from network config)")
+    private int minNodeAccountId = NetworkConfig.current().minNodeAccountId();
 
     @Option(
             names = {"--max-node"},
-            description = "Maximum node account ID (default: 37)")
-    private int maxNodeAccountId = 37;
+            description = "Maximum node account ID (default: from network config)")
+    private int maxNodeAccountId = NetworkConfig.current().maxNodeAccountId();
 
     @Option(
             names = {"-p", "--user-project"},
@@ -92,8 +93,10 @@ public class UpdateDayListingsCommand implements Runnable {
         updateDayListings(listingDir, cacheDir.toPath(), cacheEnabled, minNodeAccountId, maxNodeAccountId, userProject);
     }
 
-    /** The first day of Hedera mainnet. */
-    private static final LocalDate HEDERA_START_DATE = LocalDate.of(2019, 9, 13);
+    /** The first day of the active Hedera network, from {@link NetworkConfig}. */
+    private static LocalDate networkStartDate() {
+        return NetworkConfig.current().genesisDate();
+    }
 
     /**
      * Update day listing files by fetching file metadata from Google Cloud Storage.
@@ -133,7 +136,7 @@ public class UpdateDayListingsCommand implements Runnable {
             final LocalDate yesterday = today.minusDays(1);
 
             // Find all missing days (including gaps) from Hedera start to yesterday
-            final List<LocalDate> missingDays = findMissingDaysStatic(listingDir, HEDERA_START_DATE, yesterday);
+            final List<LocalDate> missingDays = findMissingDaysStatic(listingDir, networkStartDate(), yesterday);
 
             // Check if there are any days to process
             if (missingDays.isEmpty()) {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/Validate.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/Validate.java
@@ -4,6 +4,7 @@ package org.hiero.block.tools.days.subcommands;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.time.ZoneOffset.UTC;
+import static org.hiero.block.tools.config.NetworkConfig.current;
 import static org.hiero.block.tools.days.model.TarZstdDayUtils.parseDayFromFileName;
 
 import com.google.gson.Gson;
@@ -213,7 +214,7 @@ public class Validate implements Runnable {
                     resumeStatus.recordFileTime, resumeStatus.endRunningHashHex.substring(0, 8));
         } else if (actualStartDate != null) {
             // Starting from explicit date - try to get prior day hash from mirror node
-            if (actualStartDate.equals(LocalDate.parse("2019-09-13"))) {
+            if (actualStartDate.equals(current().genesisDate())) {
                 carryOverHash.set(ZERO_HASH);
                 System.out.println("Starting at genesis with hash[" + Bytes.wrap(carryOverHash.get()) + "]");
             } else if (dayInfo != null) {
@@ -233,7 +234,10 @@ public class Validate implements Runnable {
             }
         } else {
             // Starting from beginning without resume
-            if (dayPaths.getFirst().getFileName().toString().startsWith("2019-09-13")) {
+            if (dayPaths.getFirst()
+                    .getFileName()
+                    .toString()
+                    .startsWith(current().genesisDate().toString())) {
                 carryOverHash.set(ZERO_HASH);
                 System.out.println("Starting at genesis with hash[" + Bytes.wrap(carryOverHash.get()) + "]");
             } else if (dayInfo != null) {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/ValidateWithStats.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/ValidateWithStats.java
@@ -5,6 +5,7 @@ import static java.nio.file.StandardOpenOption.*;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.time.ZoneOffset.UTC;
+import static org.hiero.block.tools.config.NetworkConfig.current;
 import static org.hiero.block.tools.days.model.TarZstdDayUtils.parseDayFromFileName;
 
 import com.google.gson.Gson;
@@ -566,7 +567,7 @@ public class ValidateWithStats implements Runnable {
                     "Resuming at %s with hash[%s]%n",
                     resumeStatus.recordFileTime, resumeStatus.endRunningHashHex.substring(0, 8));
         } else if (actualStartDate != null) {
-            if (actualStartDate.equals(LocalDate.parse("2019-09-13"))) {
+            if (actualStartDate.equals(current().genesisDate())) {
                 carryOverHash.set(ZERO_HASH);
                 System.out.println("Starting at genesis with hash[" + Bytes.wrap(carryOverHash.get()) + "]");
             } else if (dayInfo != null) {
@@ -585,7 +586,10 @@ public class ValidateWithStats implements Runnable {
                 }
             }
         } else {
-            if (dayPaths.getFirst().getFileName().toString().startsWith("2019-09-13")) {
+            if (dayPaths.getFirst()
+                    .getFileName()
+                    .toString()
+                    .startsWith(current().genesisDate().toString())) {
                 carryOverHash.set(ZERO_HASH);
                 System.out.println("Starting at genesis with hash[" + Bytes.wrap(carryOverHash.get()) + "]");
             } else if (dayInfo != null) {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/BlockTimeCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/BlockTimeCommand.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.mirrornode;
 
-import static org.hiero.block.tools.mirrornode.MirrorNodeUtils.MAINNET_MIRROR_NODE_API_URL;
+import static org.hiero.block.tools.config.NetworkConfig.current;
 
 import com.google.gson.JsonObject;
 import java.io.IOException;
@@ -154,7 +154,7 @@ public class BlockTimeCommand implements Runnable {
     private void printMirrorNodeData(long blockNumber) {
         System.out.println(Ansi.AUTO.string("  @|white Mirror Node Data:|@"));
 
-        String url = MAINNET_MIRROR_NODE_API_URL + "blocks/" + blockNumber;
+        String url = current().mirrorNodeApiUrl() + "blocks/" + blockNumber;
         System.out.println(Ansi.AUTO.string("    @|faint URL: " + url + "|@"));
         System.out.println();
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/ExtractDayBlocksFromApi.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/ExtractDayBlocksFromApi.java
@@ -13,6 +13,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.hiero.block.tools.config.NetworkConfig;
 import org.hiero.block.tools.metadata.MetadataFiles;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -42,8 +43,8 @@ public class ExtractDayBlocksFromApi implements Runnable {
 
     @Option(
             names = {"--start-date"},
-            description = "First day to fetch (inclusive), format YYYY-MM-DD. Default: 2019-09-13 (genesis).")
-    private String startDate = "2019-09-13";
+            description = "First day to fetch (inclusive), format YYYY-MM-DD. Default: network genesis date.")
+    private String startDate = NetworkConfig.current().genesisDate().toString();
 
     @Option(
             names = {"--end-date"},
@@ -64,7 +65,7 @@ public class ExtractDayBlocksFromApi implements Runnable {
     @Option(
             names = {"--mirror-node-url"},
             description = "Base URL for the mirror node API (must end with '/').")
-    private String mirrorNodeUrl = MirrorNodeUtils.MAINNET_MIRROR_NODE_API_URL;
+    private String mirrorNodeUrl = NetworkConfig.current().mirrorNodeApiUrl();
 
     @Override
     public void run() {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/FetchBlockQuery.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/FetchBlockQuery.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.mirrornode;
 
-import static org.hiero.block.tools.mirrornode.MirrorNodeUtils.MAINNET_MIRROR_NODE_API_URL;
+import static org.hiero.block.tools.config.NetworkConfig.current;
 
 import com.google.gson.JsonObject;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -24,7 +24,7 @@ public class FetchBlockQuery {
      * @return the record file name
      */
     public static String getRecordFileNameForBlock(long blockNumber) {
-        final String url = MAINNET_MIRROR_NODE_API_URL + "blocks/" + blockNumber;
+        final String url = current().mirrorNodeApiUrl() + "blocks/" + blockNumber;
         final JsonObject json = MirrorNodeUtils.readUrl(url);
         return json.get("name").getAsString();
     }
@@ -36,7 +36,7 @@ public class FetchBlockQuery {
      * @return the record file name
      */
     public static Bytes getPreviousHashForBlock(long blockNumber) {
-        final String url = MAINNET_MIRROR_NODE_API_URL + "blocks/" + blockNumber;
+        final String url = current().mirrorNodeApiUrl() + "blocks/" + blockNumber;
         final JsonObject json = MirrorNodeUtils.readUrl(url);
         final String hashStr = json.get("previous_hash").getAsString();
         return Bytes.wrap(HexFormat.of().parseHex(hashStr.substring(2))); // remove 0x prefix and parse
@@ -70,7 +70,7 @@ public class FetchBlockQuery {
      */
     public static List<BlockInfo> getLatestBlocks(
             int limit, MirrorNodeBlockQueryOrder order, List<String> timestampFilters) {
-        return getLatestBlocks(limit, order, timestampFilters, MAINNET_MIRROR_NODE_API_URL);
+        return getLatestBlocks(limit, order, timestampFilters, current().mirrorNodeApiUrl());
     }
 
     /**
@@ -100,7 +100,7 @@ public class FetchBlockQuery {
      */
     private static String buildBlocksQueryUrl(
             int limit, MirrorNodeBlockQueryOrder order, List<String> timestampFilters) {
-        return buildBlocksQueryUrl(limit, order, timestampFilters, MAINNET_MIRROR_NODE_API_URL);
+        return buildBlocksQueryUrl(limit, order, timestampFilters, current().mirrorNodeApiUrl());
     }
 
     /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/FixBlockTime.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/FixBlockTime.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.mirrornode;
 
-import static org.hiero.block.tools.mirrornode.MirrorNodeUtils.MAINNET_MIRROR_NODE_API_URL;
+import static org.hiero.block.tools.config.NetworkConfig.current;
 import static org.hiero.block.tools.records.RecordFileDates.extractRecordFileTime;
 import static org.hiero.block.tools.records.RecordFileDates.instantToBlockTimeLong;
 
@@ -136,7 +136,7 @@ public class FixBlockTime implements Runnable {
     private int processBlock(long blockNumber, RandomAccessFile raf, BlockTimeReader reader) throws IOException {
         Instant currentTime = reader.getBlockInstant(blockNumber);
 
-        String url = MAINNET_MIRROR_NODE_API_URL + "blocks/" + blockNumber;
+        String url = current().mirrorNodeApiUrl() + "blocks/" + blockNumber;
         JsonObject blockData = MirrorNodeUtils.readUrl(url);
 
         if (blockData == null || !blockData.has("name")) {
@@ -277,7 +277,7 @@ public class FixBlockTime implements Runnable {
     }
 
     private static int[] processBatch(long fromBlock, long toBlock, RandomAccessFile raf, BlockTimeReader reader) {
-        String url = MAINNET_MIRROR_NODE_API_URL + "blocks"
+        String url = current().mirrorNodeApiUrl() + "blocks"
                 + "?block.number=gte:" + fromBlock
                 + "&block.number=lte:" + toBlock
                 + "&limit=100&order=asc";

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/MirrorNodeAddressBook.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/MirrorNodeAddressBook.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.mirrornode;
 
-import static org.hiero.block.tools.mirrornode.MirrorNodeUtils.MAINNET_MIRROR_NODE_API_URL;
+import static org.hiero.block.tools.config.NetworkConfig.current;
 
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
@@ -30,7 +30,7 @@ public class MirrorNodeAddressBook {
      */
     public static NodeAddressBook getLatestAddressBook() {
         try {
-            return loadJsonAddressBook(URI.create(MAINNET_MIRROR_NODE_API_URL + "network/nodes?limit=40&order=asc")
+            return loadJsonAddressBook(URI.create(current().mirrorNodeApiUrl() + "network/nodes?limit=40&order=asc")
                     .toURL());
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/UpdateBlockData.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/UpdateBlockData.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.mirrornode;
 
-import static org.hiero.block.tools.mirrornode.MirrorNodeUtils.MAINNET_MIRROR_NODE_API_URL;
+import static org.hiero.block.tools.config.NetworkConfig.current;
 import static org.hiero.block.tools.records.RecordFileDates.extractRecordFileTime;
 import static org.hiero.block.tools.records.RecordFileDates.instantToBlockTimeLong;
 
@@ -283,7 +283,7 @@ public class UpdateBlockData implements Runnable {
      * @return the latest block number
      */
     private static long getLatestBlockNumber() {
-        String url = MAINNET_MIRROR_NODE_API_URL + "blocks?limit=1&order=desc";
+        String url = current().mirrorNodeApiUrl() + "blocks?limit=1&order=desc";
         JsonObject response = MirrorNodeUtils.readUrl(url);
         JsonArray blocks = response.getAsJsonArray("blocks");
         if (blocks.isEmpty()) {
@@ -301,7 +301,7 @@ public class UpdateBlockData implements Runnable {
      */
     @SuppressWarnings("SameParameterValue")
     private static JsonArray fetchBlockBatch(long startBlock, int limit) {
-        String url = MAINNET_MIRROR_NODE_API_URL + "blocks?block.number=gte%3A" + startBlock + "&limit=" + limit
+        String url = current().mirrorNodeApiUrl() + "blocks?block.number=gte%3A" + startBlock + "&limit=" + limit
                 + "&order=asc";
         JsonObject response = MirrorNodeUtils.readUrl(url);
         return response.getAsJsonArray("blocks");

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/utils/gcp/MainNetBucket.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/utils/gcp/MainNetBucket.java
@@ -29,6 +29,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import org.hiero.block.tools.config.NetworkConfig;
 import org.hiero.block.tools.records.ChainFile;
 import org.hiero.block.tools.records.RecordFileDates;
 
@@ -50,8 +51,6 @@ public class MainNetBucket {
     private static final Storage.BlobListOption NAME_FIELD_ONLY = BlobListOption.fields(BlobField.NAME);
     /** Glob filter to signature files only */
     private static final Storage.BlobListOption SIGNATURE_FILES_ONLY = BlobListOption.matchGlob("**.rcd_sig");
-    /** The mainnet bucket name*/
-    private static final String HEDERA_MAINNET_STREAMS_BUCKET = "hedera-mainnet-streams";
     /** The GCP Storage service instance - use Storage.list() directly to avoid needing bucket metadata access */
     private static final Storage STORAGE = StorageOptions.getDefaultInstance().getService();
 
@@ -73,6 +72,9 @@ public class MainNetBucket {
 
     /** The GCP project to bill for requester-pays bucket access. */
     private final String userProject;
+
+    /** The GCS bucket name to use for listing and downloading. */
+    private final String bucketName;
 
     /**
      * Create a new MainNetBucket instance with the given cache enabled switch and cache directory.
@@ -97,11 +99,38 @@ public class MainNetBucket {
      */
     public MainNetBucket(
             boolean cacheEnabled, Path cacheDir, int minNodeAccountId, int maxNodeAccountId, String userProject) {
+        this(
+                cacheEnabled,
+                cacheDir,
+                minNodeAccountId,
+                maxNodeAccountId,
+                userProject,
+                NetworkConfig.current().gcsBucketName());
+    }
+
+    /**
+     * Create a new MainNetBucket instance with all parameters including bucket name.
+     *
+     * @param cacheEnabled the cache enabled switch
+     * @param cacheDir the cache directory
+     * @param minNodeAccountId the minimum node account id in the network
+     * @param maxNodeAccountId the maximum node account id in the network
+     * @param userProject the GCP project to bill for requester-pays bucket access (can be null)
+     * @param bucketName the GCS bucket name to use
+     */
+    public MainNetBucket(
+            boolean cacheEnabled,
+            Path cacheDir,
+            int minNodeAccountId,
+            int maxNodeAccountId,
+            String userProject,
+            String bucketName) {
         this.cacheEnabled = cacheEnabled;
         this.cacheDir = cacheDir;
         this.minNodeAccountId = minNodeAccountId;
         this.maxNodeAccountId = maxNodeAccountId;
         this.userProject = userProject;
+        this.bucketName = bucketName;
     }
 
     /** Maximum number of retry attempts for GCP operations. */
@@ -155,8 +184,7 @@ public class MainNetBucket {
     private byte[] downloadWithRetry(String path) {
         long delay = INITIAL_RETRY_DELAY_MS;
         for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-            var blob =
-                    STORAGE.get(BlobId.of(HEDERA_MAINNET_STREAMS_BUCKET, path), BlobGetOption.userProject(userProject));
+            var blob = STORAGE.get(BlobId.of(bucketName, path), BlobGetOption.userProject(userProject));
             if (blob != null) {
                 return blob.getContent(BlobSourceOption.userProject(userProject));
             }
@@ -212,7 +240,7 @@ public class MainNetBucket {
     private byte[] downloadWithRetryNoUserProject(String path) {
         long delay = INITIAL_RETRY_DELAY_MS;
         for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-            var blob = STORAGE.get(BlobId.of(HEDERA_MAINNET_STREAMS_BUCKET, path));
+            var blob = STORAGE.get(BlobId.of(bucketName, path));
             if (blob != null) {
                 return blob.getContent();
             }
@@ -318,14 +346,14 @@ public class MainNetBucket {
                     .parallel()
                     .mapToObj(nodeAccountId -> Stream.concat(
                                     STORAGE.list(
-                                                    HEDERA_MAINNET_STREAMS_BUCKET,
+                                                    bucketName,
                                                     getBlobListOptions(
                                                             "recordstreams/record0.0." + nodeAccountId + "/"
                                                                     + filePrefix,
                                                             REQUIRED_FIELDS))
                                             .streamAll(),
                                     STORAGE.list(
-                                                    HEDERA_MAINNET_STREAMS_BUCKET,
+                                                    bucketName,
                                                     getBlobListOptions(
                                                             "recordstreams/record0.0." + nodeAccountId + "/sidecar/"
                                                                     + filePrefix,
@@ -376,7 +404,7 @@ public class MainNetBucket {
             List<String> fileNames = IntStream.range(minNodeAccountId, maxNodeAccountId + 1)
                     .parallel()
                     .mapToObj(nodeAccountId -> STORAGE.list(
-                                    HEDERA_MAINNET_STREAMS_BUCKET,
+                                    bucketName,
                                     getBlobListOptions(
                                             "recordstreams/record0.0." + nodeAccountId + "/" + filePrefix,
                                             NAME_FIELD_ONLY))
@@ -410,7 +438,7 @@ public class MainNetBucket {
      */
     public boolean signatureFileExists(String nodeAccountId, String blockTimestamp) {
         String path = "recordstreams/record" + nodeAccountId + "/" + blockTimestamp + ".rcd_sig";
-        BlobId blobId = BlobId.of(HEDERA_MAINNET_STREAMS_BUCKET, path);
+        BlobId blobId = BlobId.of(bucketName, path);
         try {
             var blob = STORAGE.get(blobId, Storage.BlobGetOption.fields(BlobField.NAME));
             return blob != null && blob.exists();
@@ -474,7 +502,7 @@ public class MainNetBucket {
 
                     Map<Instant, Set<String>> nodeSignatures = new HashMap<>();
                     try {
-                        STORAGE.list(HEDERA_MAINNET_STREAMS_BUCKET, new BlobListOption[] {
+                        STORAGE.list(bucketName, new BlobListOption[] {
                                     BlobListOption.prefix(prefix),
                                     NAME_FIELD_ONLY,
                                     SIGNATURE_FILES_ONLY,


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                              
  - Adds a `NetworkConfig` record with static `current()` singleton that holds all network-specific parameters (GCS bucket, mirror node URL, genesis date, node range, genesis address book, etc.)                                                            
  - Adds `--network` option (mainnet/testnet) to `BlockStreamTool` root command with `scope = ScopeType.INHERIT`, making it available on all subcommands                                                                                                      
  - Replaces hardcoded mainnet values across 16 files with `NetworkConfig.current()` references
  - `AddressBookRegistry` falls back to fetching the genesis address book from the mirror node API at runtime when a bundled resource isn't available (e.g. for testnet)

  ## Files Changed

  | Area | Files | Change |
  |------|-------|--------|
  | **New** | `NetworkConfig.java` | Central config record with `mainnet()` / `testnet()` factories |
  | **CLI root** | `BlockStreamTool.java` | `--network` option with inherited scope |
  | **GCS bucket** | `DownloadConstants.java`, `MainNetBucket.java`, `DownloadDayImplV2.java`, `LiveDownloader.java` | Bucket name + path prefix from `NetworkConfig` |
  | **Mirror node** | `FetchBlockQuery.java`, `FixBlockTime.java`, `BlockTimeCommand.java`, `UpdateBlockData.java`, `MirrorNodeAddressBook.java`, `ExtractDayBlocksFromApi.java` | Mirror node URL from `NetworkConfig` |
  | **Genesis date** | `DownloadDaysV3.java`, `UpdateDayListingsCommand.java`, `Validate.java`, `ValidateWithStats.java` | Genesis date + node range from `NetworkConfig` |
  | **Address book** | `AddressBookRegistry.java` | Genesis address book resource from `NetworkConfig` with mirror node fallback |

  ## Test plan

  - [x] `./gradlew :tools:compileJava` — compiles without errors
  - [x] `./gradlew :tools:test` — all 1075 existing tests pass
  - [x] `./gradlew spotlessApply` — formatting clean
  - [x] Default behavior unchanged: commands without `--network` still use mainnet
  - [x] Testnet: `--network testnet` commands hit testnet mirror node and GCS bucket

  Closes #2268