### PR TITLE
feat: Files Historic Plugin Ensure Unchangeable Setting for Files per Zip

### DIFF
--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
@@ -166,6 +166,14 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
                                 .formatted(firstZippedBlock, latestZippedBlock));
             }
             if (firstZippedBlock >= 0) {
+                // Check whether, if there are archives stored from previous plugin runs, they follow the same
+                // powersOfTenPerZipFileContents config as the one with which the plugin is started.
+                Optional<Path> minArchive = zipBlockArchive.minStoredArchive();
+                if (minArchive.isPresent() && !checkZipBlockArchiveIntegrity(minArchive.get(), firstZippedBlock)) {
+                    // @todo(2235) At the moment we only log a warning, but maybe we should think about alerting
+                    LOGGER.log(WARNING, "Detected change in powersOfTenPerZipFileContents configuration.");
+                }
+
                 // add the blocks to the available blocks only if the range is a valid one (positive)
                 availableBlocks.add(firstZippedBlock, latestZippedBlock);
 
@@ -206,6 +214,20 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
         } catch (final IOException e) {
             LOGGER.log(WARNING, "Failed to rename old format archives", e);
         }
+    }
+
+    /**
+     * Checks if the archive path matches the expected path based on current configuration.
+     * Returns {@code false} if the configuration has changed since the archive was created.
+     *
+     * @param path the actual archive path
+     * @param firstZippedBlock the first block number in the archive
+     * @return {@code true} if the path matches the expected configuration, {@code false} otherwise
+     */
+    // Visible for Testing
+    boolean checkZipBlockArchiveIntegrity(Path path, long firstZippedBlock) {
+        final Path computedPath = computeBlockPath(config, firstZippedBlock).zipFilePath();
+        return path.equals(computedPath);
     }
 
     /**

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
@@ -1495,5 +1495,57 @@ class BlockFileHistoricPluginTest {
             assertThat(Files.exists(quarantinedZip)).isTrue();
             assertThat(pluginUnderTest.availableBlocks().size()).isZero();
         }
+
+        @Test
+        @DisplayName("check plugin is able to detect configuration mismatch")
+        void checkZipBlockArchiveIntegrityDetectsConfigMismatch() throws IOException {
+            final Path mismatchRoot = dataRoot.resolve("config-mismatch-root");
+
+            // Phase 1: Start with powersOfTenPerZipFileContents = 1, which creates archives like "00.zip" (2 chars)
+            FilesHistoricConfig initialConfig = new FilesHistoricConfig(mismatchRoot, CompressionType.NONE, 1, 10L, 3);
+            final BlockFileHistoricPlugin firstPlugin = new BlockFileHistoricPlugin();
+            start(firstPlugin, regressionHistoricalBlockFacility, buildConfigOverrides(initialConfig));
+
+            // Send 10 blocks to trigger archive creation (blocks 0-9)
+            for (int i = 0; i < 10; i++) {
+                final BlockUnparsed block =
+                        TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
+                blockMessaging.sendBlockVerification(new VerificationNotification(
+                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+            }
+
+            // Execute archival tasks to create the zip files
+            testThreadPoolManager.executor().executeSerially();
+
+            // Get the path to the created archive
+            final Path createdArchive =
+                    BlockPath.computeExistingBlockPath(initialConfig, 0).zipFilePath();
+            assertThat(createdArchive).exists().isRegularFile();
+
+            // Phase 2: Restart the plugin with the same powersOfTenPerZipFileContents to make sure the
+            // happy path works
+
+            testConfig = new FilesHistoricConfig(mismatchRoot, CompressionType.NONE, 1, 10L, 3);
+            final BlockFileHistoricPlugin secondPlugin = new BlockFileHistoricPlugin();
+            start(secondPlugin, regressionHistoricalBlockFacility, buildConfigOverrides(testConfig));
+
+            // Verify that checkZipBlockArchiveIntegrity returns true when the config is unchanged
+            final boolean firstIntegrityCheckResult = secondPlugin.checkZipBlockArchiveIntegrity(createdArchive, 0);
+            assertThat(firstIntegrityCheckResult).isTrue();
+
+            // Phase 3: Create plugin with different powersOfTenPerZipFileContents = 3
+            // This expects archives like "0000.zip" (4 chars) but will find "00.zip" (2 chars)
+            testConfig = new FilesHistoricConfig(mismatchRoot, CompressionType.NONE, 3, 10L, 3);
+            final BlockFileHistoricPlugin thirdPlugin = new BlockFileHistoricPlugin();
+            start(thirdPlugin, regressionHistoricalBlockFacility, buildConfigOverrides(testConfig));
+
+            // Verify that checkZipBlockArchiveIntegrity returns false for the mismatched archive
+            final boolean secondIntegrityCheckResult = thirdPlugin.checkZipBlockArchiveIntegrity(createdArchive, 0);
+            assertThat(secondIntegrityCheckResult).isFalse();
+
+            // Verify that the plugin continues running (no shutdown triggered)
+            final TestHealthFacility healthFacility = (TestHealthFacility) blockNodeContext.serverHealth();
+            assertThat(healthFacility.shutdownCalled.get()).isFalse();
+        }
     }
 }


### PR DESCRIPTION
## Reviewer Notes

Adds a configuration integrity check to `BlockFileHistoricPlugin` that detects when the `powersOfTenPerZipFileContents` setting has changed between plugin runs.

On startup, the plugin now compares the path of the oldest stored archive against the path it would compute using the current configuration. If they differ, it means the setting was changed after archives were created, which could lead to data access issues. A WARNING log is emitted in that case.

## Related Issue(s)

Closes #742 
