### PR TITLE
feat: add explicit testnet case to AmendmentProvider

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/AmendmentProvider.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/AmendmentProvider.java
@@ -75,6 +75,7 @@ public interface AmendmentProvider {
     static AmendmentProvider createAmendmentProvider(String network) {
         return switch (network.toLowerCase()) {
             case "mainnet" -> new MainnetAmendmentProvider();
+            case "testnet" -> new NoOpAmendmentProvider("testnet");
             case "none", "disabled" -> new NoOpAmendmentProvider();
             default -> {
                 System.out.println("No specific amendments for network: " + network + ", using no-op provider");

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/AmendmentProviderTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/AmendmentProviderTest.java
@@ -119,6 +119,56 @@ class AmendmentProviderTest {
     }
 
     @Nested
+    @DisplayName("createAmendmentProvider factory method tests")
+    class CreateAmendmentProviderTests {
+
+        @Test
+        @DisplayName("Testnet creates NoOpAmendmentProvider with 'testnet' network name")
+        void testTestnetCreatesNoOpProvider() {
+            AmendmentProvider provider = AmendmentProvider.createAmendmentProvider("testnet");
+            assertInstanceOf(NoOpAmendmentProvider.class, provider);
+            assertEquals("testnet", provider.getNetworkName());
+        }
+
+        @Test
+        @DisplayName("Testnet provider has no genesis amendments")
+        void testTestnetNoGenesisAmendments() {
+            AmendmentProvider provider = AmendmentProvider.createAmendmentProvider("testnet");
+            assertFalse(provider.hasGenesisAmendments(0));
+            assertTrue(provider.getGenesisAmendments(0).isEmpty());
+        }
+
+        @Test
+        @DisplayName("Testnet provider has no missing record stream items")
+        void testTestnetNoMissingItems() {
+            AmendmentProvider provider = AmendmentProvider.createAmendmentProvider("testnet");
+            assertTrue(provider.getMissingRecordStreamItems(0).isEmpty());
+        }
+
+        @Test
+        @DisplayName("Mainnet creates MainnetAmendmentProvider")
+        void testMainnetCreatesMainnetProvider() {
+            AmendmentProvider provider = AmendmentProvider.createAmendmentProvider("mainnet");
+            assertInstanceOf(MainnetAmendmentProvider.class, provider);
+        }
+
+        @Test
+        @DisplayName("None creates NoOpAmendmentProvider")
+        void testNoneCreatesNoOpProvider() {
+            AmendmentProvider provider = AmendmentProvider.createAmendmentProvider("none");
+            assertInstanceOf(NoOpAmendmentProvider.class, provider);
+        }
+
+        @Test
+        @DisplayName("Unknown network falls through to default NoOpAmendmentProvider")
+        void testUnknownNetworkFallsThrough() {
+            AmendmentProvider provider = AmendmentProvider.createAmendmentProvider("unknown");
+            assertInstanceOf(NoOpAmendmentProvider.class, provider);
+            assertEquals("unknown", provider.getNetworkName());
+        }
+    }
+
+    @Nested
     @DisplayName("AmendmentProvider interface default methods")
     class InterfaceDefaultMethodTests {
 


### PR DESCRIPTION
   - Add an explicit `"testnet"` case to `AmendmentProvider.createAmendmentProvider()` so testnet no longer falls through to the default branch with a warning log                                                                                            
   - Testnet had a clean start in Feb 2024 and requires no amendments, so it uses a `NoOpAmendmentProvider`                                                                                                                                                   
   - Add unit tests for the `createAmendmentProvider` factory method covering testnet, mainnet, none, and unknown network cases.

   Closes #2270