### PR TITLE
fix: Correct the memory values

### DIFF
--- a/charts/block-node-server/values-overrides/nano.yaml
+++ b/charts/block-node-server/values-overrides/nano.yaml
@@ -7,10 +7,10 @@
 resources:
   requests:
     cpu: "500m"
-    memory: "128m"
+    memory: "128M"
   limits:
     cpu: "1"
-    memory: "128m"
+    memory: "128M"
 
 blockNode:
   config:


### PR DESCRIPTION
'M' is megabytes not 'm'

Change the memory value in the helm charts to 128M