### PR TITLE
fix: add --day option to updateDayListings and remove duplicate --network flag

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
@@ -43,6 +43,7 @@ import org.hiero.block.tools.blocks.model.PreVerifiedBlock;
 import org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHashRegistry;
 import org.hiero.block.tools.blocks.model.hashing.InMemoryTreeHasher;
 import org.hiero.block.tools.blocks.model.hashing.StreamingHasher;
+import org.hiero.block.tools.config.NetworkConfig;
 import org.hiero.block.tools.days.model.AddressBookRegistry;
 import org.hiero.block.tools.days.model.TarZstdDayReaderUsingExec;
 import org.hiero.block.tools.days.model.TarZstdDayUtils;
@@ -174,11 +175,6 @@ public class ToWrappedBlocksCommand implements Runnable {
     private Path outputBlocksDir = Path.of("wrappedBlocks");
 
     @Option(
-            names = {"-n", "--network"},
-            description = "Network name for applying amendments (mainnet, testnet, none). Default: mainnet")
-    private String network = "mainnet";
-
-    @Option(
             names = {"--parse-threads"},
             description = "Thread count for the parse + RSA-verify stage. Default: CPU count minus 1")
     private int parseThreads = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
@@ -244,8 +240,9 @@ public class ToWrappedBlocksCommand implements Runnable {
         // load day block info map
         final Map<LocalDate, DayBlockInfo> dayMap = loadDayBlockInfoMap(dayBlocksFile);
 
-        // Create an amendment provider based on network selection
-        final AmendmentProvider amendmentProvider = createAmendmentProvider(network);
+        // Create an amendment provider based on network selection (inherited from parent --network flag)
+        final AmendmentProvider amendmentProvider =
+                createAmendmentProvider(NetworkConfig.current().networkName());
 
         // ---- Pipeline executor services ----
         final int resolvedPrefetch = prefetchSize < 1 ? parseThreads : prefetchSize;

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/UpdateDayListingsCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/UpdateDayListingsCommand.java
@@ -84,13 +84,56 @@ public class UpdateDayListingsCommand implements Runnable {
             description = "GCP project to bill for requester-pays bucket access (default: from GCP_PROJECT_ID env var)")
     private String userProject = DownloadConstants.GCP_PROJECT_ID;
 
+    @Option(
+            names = {"--day"},
+            description = "Regenerate listing for a specific day (YYYY-MM-DD). Deletes existing listing first.")
+    private LocalDate targetDay;
+
     /**
      * Main entry point for the command. Discovers the last complete day on disk,
      * then updates listings for all subsequent days up to yesterday.
+     *
+     * <p>When {@code --day} is specified, only that single day's listing is regenerated
+     * (any existing listing file is deleted first).
      */
     @Override
     public void run() {
-        updateDayListings(listingDir, cacheDir.toPath(), cacheEnabled, minNodeAccountId, maxNodeAccountId, userProject);
+        if (targetDay != null) {
+            // Delete existing listing file so it gets regenerated fresh
+            deleteExistingListing(listingDir, targetDay);
+            updateListingsForSingleDay(
+                    listingDir,
+                    cacheDir.toPath(),
+                    cacheEnabled,
+                    minNodeAccountId,
+                    maxNodeAccountId,
+                    userProject,
+                    targetDay);
+        } else {
+            updateDayListings(
+                    listingDir, cacheDir.toPath(), cacheEnabled, minNodeAccountId, maxNodeAccountId, userProject);
+        }
+    }
+
+    /**
+     * Deletes the existing listing file for a given day, if it exists.
+     *
+     * @param listingDir the listing directory
+     * @param day the day whose listing file should be deleted
+     */
+    private static void deleteExistingListing(final Path listingDir, final LocalDate day) {
+        final Path dayFile = listingDir
+                .resolve(String.format("%04d", day.getYear()))
+                .resolve(String.format("%02d", day.getMonthValue()))
+                .resolve(String.format("%02d.bin", day.getDayOfMonth()));
+        if (Files.exists(dayFile)) {
+            try {
+                Files.delete(dayFile);
+                System.out.println("Deleted existing listing: " + dayFile);
+            } catch (IOException e) {
+                System.err.println("Warning: Could not delete existing listing " + dayFile + ": " + e.getMessage());
+            }
+        }
     }
 
     /** The first day of the active Hedera network, from {@link NetworkConfig}. */


### PR DESCRIPTION
## Summary
- Add `--day` option to `UpdateDayListingsCommand` to regenerate the listing for a specific day (e.g. `--day 2026-02-06`), deleting any existing stale listing first
- Remove duplicate `--network` option from `ToWrappedBlocksCommand` since it is now inherited from parent 
