### PR TITLE
feat: increase maxMessageSizeBytes default and max to 36MB to support TSS Wraps Block Item (#2356)

### DIFF
--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ServerConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ServerConfig.java
@@ -24,9 +24,10 @@ import org.hiero.block.node.base.Loggable;
  * @param backlogSize the maximum length of the queue of incoming connections on the server socket.
  * @param writeQueueLength the number of buffers queued for write operations
  */
+// spotless:off
 @ConfigData("server")
 public record ServerConfig(
-        @Loggable @ConfigProperty(defaultValue = "4_194_304") @Min(262_144) @Max(16_777_215) int maxMessageSizeBytes,
+        @Loggable @ConfigProperty(defaultValue = "37_748_736") @Min(262_144) @Max(37_748_736) int maxMessageSizeBytes,
         @Loggable @ConfigProperty(defaultValue = "131_072") @Min(32768) @Max(Integer.MAX_VALUE)
                 int socketSendBufferSizeBytes,
         @Loggable @ConfigProperty(defaultValue = "131_072") @Min(32768) @Max(Integer.MAX_VALUE)
@@ -39,3 +40,4 @@ public record ServerConfig(
         @Loggable @ConfigProperty(defaultValue = "true") boolean tcpNoDelay,
         @Loggable @ConfigProperty(defaultValue = "8_192") int backlogSize,
         @Loggable @ConfigProperty(defaultValue = "8_192") int writeQueueLength) {}
+// spotless:on

--- a/block-node/app/src/test/java/org/hiero/block/node/app/ServerConfigTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/ServerConfigTest.java
@@ -106,13 +106,13 @@ class ServerConfigTest {
         return Stream.of(
                 Arguments.of(
                         10_238,
-                        String.format(RANGE_ERROR_TEMPLATE, "server.maxMessageSizeBytes", 10_238, 10_240, 16_777_215)),
+                        String.format(RANGE_ERROR_TEMPLATE, "server.maxMessageSizeBytes", 10_238, 10_240, 37_748_736)),
                 Arguments.of(
                         10_239,
-                        String.format(RANGE_ERROR_TEMPLATE, "server.maxMessageSizeBytes", 10_239, 10_240, 16_777_215)),
+                        String.format(RANGE_ERROR_TEMPLATE, "server.maxMessageSizeBytes", 10_239, 10_240, 37_748_736)),
                 Arguments.of(
-                        16_777_216,
+                        37_748_737,
                         String.format(
-                                RANGE_ERROR_TEMPLATE, "server.maxMessageSizeBytes", 16_777_216, 10_240, 16_777_215)));
+                                RANGE_ERROR_TEMPLATE, "server.maxMessageSizeBytes", 37_748_737, 10_240, 37_748_736)));
     }
 }

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -33,16 +33,16 @@ Each plugin has its own properties, but this focuses on core options and core pl
 
 ### Server Configuration
 
-| ENV Variable                            | Description                                  |   Default |
-|:----------------------------------------|:---------------------------------------------|----------:|
-| SERVER_MAX_MESSAGE_SIZE_BYTES           | Max message size (bytes) for HTTP/2.         | 4,194,304 |
-| SERVER_SOCKET_SEND_BUFFER_SIZE_BYTES    | Send buffer size (bytes).                    |     32768 |
-| SERVER_SOCKET_RECEIVE_BUFFER_SIZE_BYTES | Receive buffer size (bytes).                 |     32768 |
-| SERVER_PORT                             | Server listening port.                       |     40840 |
-| SERVER_SHUTDOWN_DELAY_MILLIS            | Delay before shutdown (ms).                  |       500 |
-| SERVER_MAX_TCP_CONNECTIONS              | Max TCP connections allowed.                 |      1000 |
-| SERVER_IDLE_CONNECTION_PERIOD_MINUTES   | Period for idle connections check (minutes). |         5 |
-| SERVER_IDLE_CONNECTION_TIMEOUT_MINUTES  | Timeout for idle connections (minutes).      |        30 |
+| ENV Variable                            | Description                                  |    Default |
+|:----------------------------------------|:---------------------------------------------|-----------:|
+| SERVER_MAX_MESSAGE_SIZE_BYTES           | Max message size (bytes) for HTTP/2.         | 37,748,736 |
+| SERVER_SOCKET_SEND_BUFFER_SIZE_BYTES    | Send buffer size (bytes).                    |      32768 |
+| SERVER_SOCKET_RECEIVE_BUFFER_SIZE_BYTES | Receive buffer size (bytes).                 |      32768 |
+| SERVER_PORT                             | Server listening port.                       |      40840 |
+| SERVER_SHUTDOWN_DELAY_MILLIS            | Delay before shutdown (ms).                  |        500 |
+| SERVER_MAX_TCP_CONNECTIONS              | Max TCP connections allowed.                 |       1000 |
+| SERVER_IDLE_CONNECTION_PERIOD_MINUTES   | Period for idle connections check (minutes). |          5 |
+| SERVER_IDLE_CONNECTION_TIMEOUT_MINUTES  | Timeout for idle connections (minutes).      |         30 |
 
 ### WebServerHttp2 Configuration
 


### PR DESCRIPTION
Cherry-picks TSS Wraps Block Item MaxMessageSize Change (#2356)
into 0.29 release branch.