### PR TITLE
test: Improved Persistence Handling in Publisher Manager

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/blocks/TestBlock.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/blocks/TestBlock.java
@@ -49,6 +49,14 @@ public final class TestBlock {
         return block;
     }
 
+    public BlockItem getHeader() {
+        return block.items().getFirst();
+    }
+
+    public BlockItemUnparsed getHeaderUnparsed() {
+        return blockUnparsed.blockItems().getFirst();
+    }
+
     public BlockUnparsed blockUnparsed() {
         return blockUnparsed;
     }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -646,7 +646,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 final long currentBlockNumber = determineCurrentBlockNumber();
                 final Deque<BlockItemSetUnparsed> queueToForward =
                         publisherManager.queueByBlockMap.get(currentBlockNumber);
-                if (queueToForward != null) {
+                if (queueToForward != null && !publisherManager.blockProofs.containsKey(currentBlockNumber)) {
                     boolean moreToSend = queueToForward.peek() != null;
                     while (moreToSend) {
                         // We MUST remove each batch from the queue before sending, otherwise we end
@@ -655,15 +655,8 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                         // runtime exception if the queue is empty.
                         final BlockItemSetUnparsed currentBatch = queueToForward.poll();
                         if (currentBatch != null) {
-                            // log the batch being forwarded to messaging facility from publisher plugin
-                            LOGGER.log(
-                                    TRACE,
-                                    "Forwarding batch for block={0} with blockItemSize={1}",
-                                    currentBlockNumber,
-                                    currentBatch.blockItems().size());
-                            // send the batch to the messaging facility
-                            // @todo(2200) when we add support for the end of block message we might change
-                            //    the way we send the block items
+                            // @todo(2347) as an improvement we can opt in to possibly change the
+                            //    way we send the last batch of BlockItems
                             final boolean hasBlockProof =
                                     currentBatch.blockItems().getLast().hasBlockProof();
                             final int itemsSent;
@@ -682,9 +675,6 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                                 } else {
                                     itemsSent = 0;
                                 }
-                                // If the last item in the batch is a block proof,
-                                // we need to remove the queue from the queueByBlockMap.
-                                publisherManager.queueByBlockMap.remove(currentBlockNumber);
                                 // exit this while loop so we do not accidentally
                                 // send a block out of order.
                                 moreToSend = false;
@@ -719,15 +709,20 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                             final BlockItemSetUnparsed itemSet = BlockItemSetUnparsed.newBuilder()
                                     .blockItems(proof)
                                     .build();
+                            // Remove the queue of the block, this will now mark the block as no longer active
+                            publisherManager.queueByBlockMap.remove(currentBlockNumber);
+                            // Send the last item set to internal messaging
                             sendBlockItems(itemSet, currentBlockNumber, true);
+                            // Now potentially increment  the current streaming block
+                            publisherManager.currentStreamingBlockNumber.compareAndSet(
+                                    currentBlockNumber, currentBlockNumber + 1);
+                            // Finally, update metrics
                             publisherManager
                                     .metrics
                                     .blockItemsMessaged()
                                     .add(itemSet.blockItems().size());
                             // Then potentially increment the current streaming
                             // block number.
-                            publisherManager.currentStreamingBlockNumber.compareAndSet(
-                                    currentBlockNumber, currentBlockNumber + 1);
                         } else {
                             // @todo(2200) if we have received the end of block message, but we do not have the proof,
                             //    should we take any action? In theory the end of block message should arrive after the

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -1149,16 +1149,21 @@ class LiveStreamPublisherManagerTest {
             /// [LiveStreamPublisherManager#handlePersisted(PersistedNotification)]
             /// will send acknowledgement to registered publisher handlers
             /// with the latest block number, i.e.
-            /// [PersistedNotification#blockNumber()].
-            @Test
-            @DisplayName("handlePersisted() sends acknowledgement with latest block number to all registered handlers")
-            void testHandlePersistedValidNotification() {
-                // As a precondition, assert that the responses pipeline is empty (nothing has been sent yet).
+            /// [PersistedNotification#blockNumber()]. This test is when we have no active blocks.
+            /// Active blocks are ones that are currently being published or awaiting,
+            /// or in the process of being streamed to the live items messaging pipeline.
+            @ParameterizedTest
+            @ValueSource(longs = {0L, 1L, 10L, 100L, 1000L})
+            @DisplayName(
+                    "handlePersisted() sends acknowledgement with latest block number to all registered handlers - no active block")
+            void testHandlePersistedValidNotificationNoActiveBlock(final long blockNumber) {
+                // As a precondition, assert that the responses pipeline is empty (nothing has been sent yet)
+                // Also as a precondition establish the last acknowledged block metric's value
                 assertThat(responsePipeline.getOnNextCalls()).isEmpty();
-                // Build the notification with end block number 10L.
-                final long expectedLatestBlockNumber = 10L;
+                assertThat(managerMetrics.latestBlockNumberAcknowledged().get()).isEqualTo(0L);
+                // Build the notification with end block number.
                 final PersistedNotification notification =
-                        new PersistedNotification(10L, true, 0, BlockSource.PUBLISHER);
+                        new PersistedNotification(blockNumber, true, 0, BlockSource.PUBLISHER);
                 // Call
                 toTest.handlePersisted(notification);
                 // Assert that the response pipeline has received a response with the expected latest block number.
@@ -1167,8 +1172,8 @@ class LiveStreamPublisherManagerTest {
                         .hasSize(1)
                         .first()
                         .returns(ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor)
-                        .returns(expectedLatestBlockNumber, acknowledgementBlockNumberExtractor);
-                assertThat(managerMetrics.latestBlockNumberAcknowledged().get()).isEqualTo(expectedLatestBlockNumber);
+                        .returns(blockNumber, acknowledgementBlockNumberExtractor);
+                assertThat(managerMetrics.latestBlockNumberAcknowledged().get()).isEqualTo(blockNumber);
                 // Assert no other responses sent
                 assertThat(responsePipeline.getOnErrorCalls()).isEmpty();
                 assertThat(responsePipeline.getOnSubscriptionCalls()).isEmpty();
@@ -1178,20 +1183,189 @@ class LiveStreamPublisherManagerTest {
 
             /// This test aims to assert that the
             /// [LiveStreamPublisherManager#handlePersisted(PersistedNotification)]
-            /// will set the latest known block number to the
-            /// [PersistedNotification#blockNumber()].
+            /// will send acknowledgement to registered publisher handlers
+            /// with the latest block number, i.e.
+            /// [PersistedNotification#blockNumber()]. This test is when we have active blocks.
+            /// Active blocks are ones that are currently being published or awaiting,
+            /// or in the process of being streamed to the live items messaging pipeline.
+            /// For this test, we will stream the next expected block, which is 0L, then we will
+            /// start streaming block 1L but will not finish it (will remain active) and we
+            /// expect that when we send the persisted notification for block 0L it will be
+            /// acknowledged.
             @Test
-            @DisplayName("handlePersisted() sets latest known block number to notification's endBlockNumber")
-            void testHandlePersistedSetsLatestKnownBlockNumber() {
+            @DisplayName(
+                    "handlePersisted() sends acknowledgement with latest block number to all registered handlers - with active block")
+            void testHandlePersistedValidNotificationWithActiveBlock() {
+                // As a precondition, assert that the responses pipeline is empty (nothing has been sent yet)
+                // Also as a precondition establish the last acknowledged block metric's value
+                assertThat(responsePipeline.getOnNextCalls()).isEmpty();
+                assertThat(managerMetrics.latestBlockNumberAcknowledged().get()).isEqualTo(0L);
+                // Then we need to stream the next expected block, which is 0L now, but do not end it.
+                // It must remain active when we send the notification.
+                final TestBlock block0 = TestBlockBuilder.generateBlockWithNumber(0L);
+                final PublishStreamRequestUnparsed request0 = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(block0.asItemSetUnparsed())
+                        .build();
+                publisherHandler.onNext(request0);
+                // Then end the block
+                endThisBlock(publisherHandler, block0.number());
+                // Now we need to actually stream the block to messaging
+                threadPoolManager.executor().executeAsync(1_000L, false);
+                // Now start streaming block 1L
+                final TestBlock block1 = TestBlockBuilder.generateBlockWithNumber(1L);
+                final PublishStreamRequestUnparsed request1 = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(block1.asItemSetUnparsed())
+                        .build();
+                publisherHandler.onNext(request1);
+                // Now send the notification for block 0
+                final PersistedNotification notification =
+                        new PersistedNotification(block0.number(), true, 0, BlockSource.PUBLISHER);
+                // Call
+                toTest.handlePersisted(notification);
+                // Assert that the response pipeline has received a response with the expected latest block number.
+                // We have one handler, so we expect one response.
+                assertThat(responsePipeline.getOnNextCalls())
+                        .hasSize(1)
+                        .first()
+                        .returns(ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor)
+                        .returns(block0.number(), acknowledgementBlockNumberExtractor);
+                assertThat(managerMetrics.latestBlockNumberAcknowledged().get()).isEqualTo(block0.number());
+                // Assert no other responses sent
+                assertThat(responsePipeline.getOnErrorCalls()).isEmpty();
+                assertThat(responsePipeline.getOnSubscriptionCalls()).isEmpty();
+                assertThat(responsePipeline.getOnCompleteCalls().get()).isEqualTo(0);
+                assertThat(responsePipeline.getClientEndStreamCalls().get()).isEqualTo(0);
+            }
+
+            /// This test aims to assert that the
+            /// [LiveStreamPublisherManager#handlePersisted(PersistedNotification)]
+            /// will not send any acknowledgements and update any metrics when the notification is
+            /// for a block that is higher than or equal to the current lowest active block.
+            /// The current lowest active block is the block that is currently being published or
+            /// awaiting, or in the process of being streamed to the live items messaging
+            /// pipeline.
+            @ParameterizedTest
+            @ValueSource(longs = {0L, 1L, 10L, 100L, 1000L})
+            @DisplayName(
+                    "handlePersisted() - no acknowledgement for future block before acknowledgement for lowest active block")
+            void testNoAcknowledgementForBlocksGreaterOrEqualToLowestActive(long blockNumber) {
+                // As a precondition, assert that the responses pipeline is empty (nothing has been sent yet)
+                // Also as a precondition establish the last acknowledged block metric's value
+                assertThat(responsePipeline.getOnNextCalls()).isEmpty();
+                assertThat(managerMetrics.latestBlockNumberAcknowledged().get()).isEqualTo(0L);
+                // Then we need to stream the next expected block, which is 0L now, but do not end it.
+                // It must remain active when we send the notification.
+                final TestBlock block0 = TestBlockBuilder.generateBlockWithNumber(0L);
+                final PublishStreamRequestUnparsed request = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(block0.asItemSetUnparsed())
+                        .build();
+                publisherHandler.onNext(request);
+                final PersistedNotification notification =
+                        new PersistedNotification(blockNumber, true, 0, BlockSource.PUBLISHER);
+                // Call
+                toTest.handlePersisted(notification);
+                // Assert no metrics for last acknowledged are updated
+                assertThat(managerMetrics.latestBlockNumberAcknowledged().get()).isEqualTo(0L);
+                // Assert no responses
+                assertThat(responsePipeline.getOnNextCalls()).isEmpty();
+                assertThat(responsePipeline.getOnErrorCalls()).isEmpty();
+                assertThat(responsePipeline.getOnSubscriptionCalls()).isEmpty();
+                assertThat(responsePipeline.getOnCompleteCalls().get()).isEqualTo(0);
+                assertThat(responsePipeline.getClientEndStreamCalls().get()).isEqualTo(0);
+            }
+
+            /// This test aims to assert that the
+            /// [LiveStreamPublisherManager#handlePersisted(PersistedNotification)]
+            /// will set the latest known block number to the
+            /// [PersistedNotification#blockNumber()] when there are no active blocks.
+            /// Active blocks are ones that are currently being published or awaiting,
+            /// or in the process of being streamed to the live items messaging pipeline.
+            @ParameterizedTest
+            @ValueSource(longs = {0L, 1L, 10L, 100L, 1000L})
+            @DisplayName(
+                    "handlePersisted() sets latest known block number to notification's blockNumber when acknowledged - no active block")
+            void testHandlePersistedSetsLatestKnownBlockNumberNoActiveBlock(final long blockNumber) {
                 // As a precondition, assert that the latest known block number is -1L (nothing has been persisted yet).
                 assertThat(toTest.getLatestBlockNumber()).isEqualTo(-1L);
                 // Build the notification with end block number 10L.
-                final long expectedLatestBlockNumber = 10L;
                 final PersistedNotification notification =
-                        new PersistedNotification(10L, true, 0, BlockSource.PUBLISHER);
+                        new PersistedNotification(blockNumber, true, 0, BlockSource.PUBLISHER);
                 // Call
                 toTest.handlePersisted(notification);
-                assertThat(managerMetrics.latestBlockNumberAcknowledged().get()).isEqualTo(expectedLatestBlockNumber);
+                // Assert that the latest known block number is now set to the notification's end block number.
+                assertThat(toTest.getLatestBlockNumber()).isEqualTo(blockNumber);
+            }
+
+            /// This test aims to assert that the
+            /// [LiveStreamPublisherManager#handlePersisted(PersistedNotification)]
+            /// will set the latest known block number to the
+            /// [PersistedNotification#blockNumber()] when there are active blocks.
+            /// Active blocks are ones that are currently being published or awaiting,
+            /// or in the process of being streamed to the live items messaging pipeline.
+            /// Here we stream block 0 in full, it is then sent to internal messaging.
+            /// Then we start streaming block 1, but we do not finish it, we must remain
+            /// in the middle of streaming it so it is active. We expect that when we
+            /// send successful persistence for block 0, it will be acknowledged and the
+            /// [LiveStreamPublisherManager#getLatestBlockNumber()] will be updated to
+            /// match the block we received successful persistence for.
+            @Test
+            @DisplayName(
+                    "handlePersisted() sets latest known block number to notification's blockNumber when acknowledged - with active block")
+            void testHandlePersistedSetsLatestKnownBlockNumberWithActiveBlock() {
+                // As a precondition, assert that the latest known block number is -1L (nothing has been persisted yet).
+                assertThat(toTest.getLatestBlockNumber()).isEqualTo(-1L);
+                // Then we need to stream the next expected block, which is 0L now, but do not end it.
+                // It must remain active when we send the notification.
+                final TestBlock block0 = TestBlockBuilder.generateBlockWithNumber(0L);
+                final PublishStreamRequestUnparsed request0 = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(block0.asItemSetUnparsed())
+                        .build();
+                publisherHandler.onNext(request0);
+                // Then end the block
+                endThisBlock(publisherHandler, block0.number());
+                // Now we need to actually stream the block to messaging
+                threadPoolManager.executor().executeAsync(1_000L, false);
+                // Now start streaming block 1L
+                final TestBlock block1 = TestBlockBuilder.generateBlockWithNumber(1L);
+                final PublishStreamRequestUnparsed request1 = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(block1.asItemSetUnparsed())
+                        .build();
+                publisherHandler.onNext(request1);
+                // Now send the notification for block 0
+                final PersistedNotification notification =
+                        new PersistedNotification(block0.number(), true, 0, BlockSource.PUBLISHER);
+                // Call
+                toTest.handlePersisted(notification);
+                // Assert that the latest known block number is now set to the notification's end block number.
+                assertThat(toTest.getLatestBlockNumber()).isEqualTo(block0.number());
+            }
+
+            /// This test aims to assert that the
+            /// [LiveStreamPublisherManager#handlePersisted(PersistedNotification)]
+            /// will not set the latest known block number to the
+            /// [PersistedNotification#blockNumber()] when that value is lower than the lowest active block.
+            /// Active blocks are ones that are currently being published or awaiting,
+            /// or in the process of being streamed to the live items messaging pipeline.
+            @ParameterizedTest
+            @ValueSource(longs = {0L, 1L, 10L, 100L, 1000L})
+            @DisplayName(
+                    "handlePersisted() does not change latest known block number to notification's blockNumber when it is lower that lowest active")
+            void testHandlePersistedDoesNotSetLatestKnownBlockNumberWhenLowerThanLowestActive(final long blockNumber) {
+                // As a precondition, assert that the latest known block number is -1L (nothing has been persisted yet).
+                final long expectedLatestBlockNumber = -1L;
+                assertThat(toTest.getLatestBlockNumber()).isEqualTo(expectedLatestBlockNumber);
+                // Then we need to stream the next expected block, which is 0L now, but do not end it.
+                // It must remain active when we send the notification.
+                final TestBlock block0 = TestBlockBuilder.generateBlockWithNumber(0L);
+                final PublishStreamRequestUnparsed request = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(block0.asItemSetUnparsed())
+                        .build();
+                publisherHandler.onNext(request);
+                // Build the notification.
+                final PersistedNotification notification =
+                        new PersistedNotification(blockNumber, true, 0, BlockSource.PUBLISHER);
+                // Call
+                toTest.handlePersisted(notification);
                 // Assert that the latest known block number is now set to the notification's end block number.
                 assertThat(toTest.getLatestBlockNumber()).isEqualTo(expectedLatestBlockNumber);
             }

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
@@ -197,7 +197,7 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
             endThisBlock(toPluginPipe, blockNumber);
             // Await to ensure async execution and assert response
-            parkNanos(500_000_000L);
+            awaitPluginResponses(1);
             assertThat(fromPluginBytes)
                     .hasSize(1)
                     .first()
@@ -221,7 +221,7 @@ class StreamPublisherPluginTest {
                     .build();
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(firstRequest));
             endThisBlock(toPluginPipe, block0.number());
-            parkNanos(500_000_000L);
+            awaitPluginResponses(1);
             assertThat(fromPluginBytes)
                     .hasSize(1)
                     .first()
@@ -278,7 +278,7 @@ class StreamPublisherPluginTest {
                     .build();
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(retryProofRequest));
             endThisBlock(toPluginPipe, block1.number());
-            parkNanos(500_000_000L);
+            awaitPluginResponses(1);
             assertThat(fromPluginBytes).isNotEmpty();
             final PublishStreamResponse response = bytesToPublishStreamResponseMapper.apply(fromPluginBytes.getLast());
             assertThat(response)


### PR DESCRIPTION
* Added tests for improvements to persisted blocks handling in #2354
* Additional small improvement in queue for block removal

## Related Issue(s)

Tests for #2354 that cover improved persistence handling
