### PR TITLE
docs: add testnet support documentation and multi-network usage guide…

### DIFF
--- a/tools-and-tests/tools/README.md
+++ b/tools-and-tests/tools/README.md
@@ -13,12 +13,13 @@
    6. [The `networkCapacity` Subcommand](docs/network-capacity-commands.md)
    7. [The `states` Subcommand](docs/states-commands.md)
 4. [Running from Command Line](#running-from-command-line)
-5. [Help and Discovery](#help-and-discovery)
-6. [Requirements](#requirements)
-7. [Install & Build](#install--build)
-8. [Docker / Compose](#docker--compose)
-9. [Troubleshooting](#troubleshooting)
-10. [Development](#development)
+5. [Multi-Network Usage](#multi-network-usage)
+6. [Help and Discovery](#help-and-discovery)
+7. [Requirements](#requirements)
+8. [Install & Build](#install--build)
+9. [Docker / Compose](#docker--compose)
+10. [Troubleshooting](#troubleshooting)
+11. [Development](#development)
 
 ## Overview
 
@@ -49,7 +50,7 @@ Additional documentation for specific technical topics:
 - [Address Book Analysis](docs/address-book-analysis.md)
 - [Record Files Format Spec](docs/record-file-format.md)
 - [Record to Block Conversion](docs/record-to-block-conversion.md)
-  -
+- [Testnet Pipeline Guide](docs/testnet-guide.md)
 
 ## Command Reference
 
@@ -126,21 +127,36 @@ subcommands
 Typical invocation after building:
 
 ```bash
-java -jar tools-and-tests/tools/build/libs/tools-0.21.0-SNAPSHOT-all.jar <command> <subcommand> [options]
+java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar <command> <subcommand> [options]
 ```
 
 For example:
 
 ```bash
 # Convert block files to JSON
-java -jar tools-and-tests/tools/build/libs/tools-0.21.0-SNAPSHOT-all.jar blocks json path/to/blocks/
+java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar blocks json path/to/blocks/
 
 # List block file info
-java -jar tools-and-tests/tools/build/libs/tools-0.21.0-SNAPSHOT-all.jar blocks ls path/to/blocks/
+java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar blocks ls path/to/blocks/
 
 # Validate day archives
-java -jar tools-and-tests/tools/build/libs/tools-0.21.0-SNAPSHOT-all.jar days validate /path/to/compressedDays
+java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar days validate /path/to/compressedDays
 ```
+
+### Testnet Examples
+
+```bash
+# Update mirror metadata for testnet
+java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar --network testnet mirror update
+
+# Download testnet day archives
+java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar --network testnet days download-days-v3 2024 2 1 2024 3 1
+
+# Wrap testnet record files into blocks
+java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar --network testnet blocks wrap
+```
+
+> See the [Testnet Pipeline Guide](docs/testnet-guide.md) for a full end-to-end walkthrough.
 
 ### Running via Gradle (Development)
 
@@ -151,19 +167,48 @@ java -jar tools-and-tests/tools/build/libs/tools-0.21.0-SNAPSHOT-all.jar days va
 ./gradlew :tools:run --args="blocks ls path/to/blocks/"
 ```
 
+## Multi-Network Usage
+
+The tools support multiple Hedera networks via the `--network` flag:
+
+|  Network  |                            Description                             |
+|-----------|--------------------------------------------------------------------|
+| `mainnet` | Hedera mainnet (default). Genesis: 2019-09-13, nodes 3-37.         |
+| `testnet` | Hedera testnet (current instance). Genesis: 2024-02-01, nodes 3-9. |
+
+The `--network` flag is a **top-level option** that goes before the subcommand. It is inherited by all subcommands, so you only need to specify it once.
+
+```bash
+# Syntax: java -jar tools.jar --network <network> <command> <subcommand> [options]
+
+# Mainnet (default — --network can be omitted)
+java -jar tools.jar mirror update
+
+# Testnet
+java -jar tools.jar --network testnet mirror update
+```
+
+When `--network testnet` is specified, the tools automatically use:
+- **GCS bucket**: `hedera-testnet-streams`
+- **Mirror Node API**: `https://testnet.mirrornode.hedera.com/api/v1/`
+- **Node account IDs**: 0.0.3 through 0.0.9 (7 nodes)
+- **Genesis address book**: bundled as a classpath resource (no generation step needed)
+
+> For a complete end-to-end testnet walkthrough, see the [Testnet Pipeline Guide](docs/testnet-guide.md).
+
 ## Help and Discovery
 
 For full, authoritative usage and all options for any command, run the tool with `--help`:
 
 ```bash
 # Top-level help (lists all commands)
-java -jar tools-and-tests/tools/build/libs/tools-0.21.0-SNAPSHOT-all.jar --help
+java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar --help
 
 # Help for a specific command
-java -jar tools-and-tests/tools/build/libs/tools-0.21.0-SNAPSHOT-all.jar blocks --help
+java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar blocks --help
 
 # Help for a nested subcommand
-java -jar tools-and-tests/tools/build/libs/tools-0.21.0-SNAPSHOT-all.jar days download-days-v2 --help
+java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar days download-days-v2 --help
 ```
 
 ## Docker / Compose

--- a/tools-and-tests/tools/docs/blocks-commands.md
+++ b/tools-and-tests/tools/docs/blocks-commands.md
@@ -119,6 +119,18 @@ blocks validate -a /path/to/addressBookHistory.json /path/to/blocks/
 blocks validate --skip-signatures /path/to/blocks/
 ```
 
+#### Testnet Example
+
+```bash
+# Validate testnet blocks (uses testnet address book automatically)
+--network testnet blocks validate /path/to/testnetWrappedBlocks
+
+# Testnet without balance validation (balance checkpoints not yet available for testnet)
+--network testnet blocks validate --no-validate-balances /path/to/testnetWrappedBlocks
+```
+
+> **Note:** Balance checkpoint files are not yet available for testnet. Use `--no-validate-balances` to skip balance validation when running against testnet data.
+
 ---
 
 ### The `validate-wrapped` Subcommand
@@ -256,12 +268,21 @@ The command writes:
 #### Example
 
 ```bash
-# Basic conversion
+# Basic conversion (mainnet default)
 blocks wrap -i /path/to/compressedDays -o /path/to/wrappedBlocks
 
 # Output as individual unzipped files
 blocks wrap -u -i /path/to/compressedDays -o /path/to/wrappedBlocks
 ```
+
+#### Testnet Example
+
+```bash
+# Wrap testnet record files into blocks
+--network testnet blocks wrap -i /path/to/testnetCompressedDays -o /path/to/testnetWrappedBlocks
+```
+
+> **Testnet prerequisites:** The testnet genesis address book is bundled as a classpath resource and will be used automatically. You still need `block_times.bin` and `day_blocks.json` generated via `--network testnet mirror update`.
 
 ---
 

--- a/tools-and-tests/tools/docs/days-commands.md
+++ b/tools-and-tests/tools/docs/days-commands.md
@@ -207,6 +207,18 @@ days download-days-v3 [-l <listingDir>] [-d <downloadedDaysDir>] [-t <threads>] 
 
 Same as `download-days-v2`.
 
+#### Testnet Example
+
+```bash
+# Download testnet days for February 2024 (testnet genesis month)
+--network testnet days download-days-v3 2024 2 1 2024 2 28
+
+# Download all available testnet days
+--network testnet days download-days-v3 2024 2 1 2026 3 16
+```
+
+> **Testnet notes:** The testnet GCS bucket is `hedera-testnet-streams`. Testnet has 7 nodes (account IDs 0.0.3 through 0.0.9) compared to mainnet's 35 nodes (0.0.3 through 0.0.37). The `--network testnet` flag configures the bucket and node range automatically.
+
 ---
 
 ### `download-live`
@@ -242,6 +254,16 @@ days download-live [options]
 1. **Start + end date (finite historical range)**: Specify both `--start-day` and `--end-day` for bounded historical backfill.
 2. **Start date only (catch-up then follow live)**: Specify `--start-day` but omit `--end-day` to bootstrap from a date and then stay live.
 3. **No start/end date (pure live mode)**: If neither is supplied, the poller starts from "today" and tracks new blocks as they appear.
+
+#### Testnet Example
+
+```bash
+# Follow testnet live blocks
+--network testnet days download-live -o /path/to/testnetCompressedDays
+
+# Backfill testnet from genesis and then follow live
+--network testnet days download-live --start-day 2024-02-01 -o /path/to/testnetCompressedDays
+```
 
 ---
 
@@ -408,6 +430,16 @@ days updateDayListings [options]
 | `-l`, `--listing-dir <dir>` | Directory where listing files are stored. |
 | `--start-date <YYYY-MM-DD>` | Start date for updating listings.         |
 | `--end-date <YYYY-MM-DD>`   | End date for updating listings.           |
+
+#### Testnet Example
+
+```bash
+# Update testnet day listings
+--network testnet days updateDayListings
+
+# Update testnet listings for a specific date range
+--network testnet days updateDayListings --start-date 2024-02-01 --end-date 2024-03-01
+```
 
 ---
 

--- a/tools-and-tests/tools/docs/mirror-node-commands.md
+++ b/tools-and-tests/tools/docs/mirror-node-commands.md
@@ -3,15 +3,15 @@
 Top-level `mirror` command contains utilities for downloading Mirror Node CSV exports and producing the `block_times.bin` file used by the `record2block` pipeline.
 
 Available subcommands include:
-- `fetchRecordsCsv` - Download Mirror Node record table CSV dump from GCP bucket
+- `fetchRecordsCsv` - Download Mirror Node record table CSV dump from GCP bucket (**mainnet only**)
 - `extractBlockTimes` - Extract block times binary file from the Mirror Node record CSV
 - `validateBlockTimes` - Validate a `block_times.bin` file against the Mirror Node CSV
 - `addNewerBlockTimes` - Extend an existing `block_times.bin` with newer block times by listing GCP
 - `fixBlockTime` - Repair incorrect entries in `block_times.bin` by querying the Mirror Node
-- `fetchMissingTransactions` - Download and compile mainnet errata for missing transactions
+- `fetchMissingTransactions` - Download and compile mainnet errata for missing transactions (**mainnet only**)
 - `update` - Update `block_times.bin` and `day_blocks.json` with newer blocks from mirror node REST API
 - `extractDayBlocks` - (utility) Extract per-day block info from CSV/other sources
-- `generateAddressBook` - Generate address book history JSON from Mirror Node CSV export
+- `generateAddressBook` - Generate address book history JSON from Mirror Node CSV export (**mainnet only**)
 - `compareAddressBooks` - Compare two address book history JSON files
 
 > Important: many mirror commands download from public GCP buckets that are configured as Requester Pays. To access these you must have Google Cloud authentication configured locally. Typical steps:
@@ -27,6 +27,8 @@ Available subcommands include:
 ---
 
 ### `fetchRecordsCsv`
+
+> **Mainnet only.** There is no public CSV export bucket for testnet.
 
 Download Mirror Node record table CSV dump from the `mirrornode-db-export` GCP bucket. This bucket contains large gzipped CSVs (many GB) under a versioned directory.
 
@@ -121,7 +123,7 @@ Features:
 Example:
 
 ```bash
-# Update metadata files with all available blocks
+# Update metadata files with all available mainnet blocks (default)
 mirror update
 
 # Fetch only the first two days of mainnet (for testing)
@@ -131,10 +133,23 @@ mirror update --end-date 2019-09-14
 mirror update --block-times /path/to/block_times.bin --day-blocks /path/to/day_blocks.json
 ```
 
+#### Testnet Usage
+
+Use the top-level `--network testnet` flag to fetch from the testnet Mirror Node instead of mainnet:
+
+```bash
+# Update metadata with all available testnet blocks
+--network testnet mirror update
+
+# Fetch only the first week of testnet
+--network testnet mirror update --end-date 2024-02-07
+```
+
 Notes:
 - Does not require GCP credentials — uses the public Mirror Node REST API.
 - Progress is printed every 1000 blocks and for the first few blocks.
 - The `block_times.bin` file is flushed to disk after each batch.
+- When using `--network testnet`, queries `https://testnet.mirrornode.hedera.com/api/v1/` instead of the mainnet API.
 
 ---
 
@@ -145,6 +160,8 @@ Utility for extracting per-day block information (used by other tooling). See co
 ---
 
 ### `generateAddressBook`
+
+> **Mainnet only.** For testnet, the genesis address book is bundled as a classpath resource (`testnet-genesis-address-book.proto.bin`) and is used automatically when `--network testnet` is specified with the `wrap` or `validate` commands.
 
 Generate an address book history JSON file from the Mirror Node `address_book` CSV export. This command downloads the latest CSV from the `mirrornode-db-export` GCP bucket, parses it, filters duplicates, and produces a JSON file compatible with `AddressBookHistory`.
 
@@ -287,6 +304,8 @@ Notes:
 ---
 
 ### `fetchMissingTransactions`
+
+> **Mainnet only.** There are no known missing-transaction errata for testnet.
 
 Download and compile mainnet errata for missing transactions. This command fetches information about transactions that are known to be missing from the blockchain record.
 

--- a/tools-and-tests/tools/docs/testnet-guide.md
+++ b/tools-and-tests/tools/docs/testnet-guide.md
@@ -1,0 +1,122 @@
+# Testnet Pipeline Guide
+
+End-to-end guide for running the record-to-block conversion pipeline against the Hedera testnet.
+
+## Prerequisites
+
+- **Java JDK 25** or later
+- **`zstd`** command-line tool installed (used for day archive compression)
+
+  ```bash
+  # macOS
+  brew install zstd
+  # Ubuntu/Debian
+  sudo apt install zstd
+  ```
+- **GCP credentials** configured for requester-pays bucket access:
+
+  ```bash
+  gcloud auth application-default login
+  gcloud config set project YOUR_PROJECT_ID
+  ```
+
+## Testnet Details
+
+|       Property       |                        Value                         |
+|----------------------|------------------------------------------------------|
+| Network name         | `testnet`                                            |
+| Genesis date         | 2024-02-01                                           |
+| Consensus nodes      | 7 (account IDs 0.0.3 through 0.0.9)                  |
+| GCS bucket           | `hedera-testnet-streams`                             |
+| Mirror Node API      | `https://testnet.mirrornode.hedera.com/api/v1/`      |
+| Total HBAR supply    | 5 billion (5,000,000,000 HBAR)                       |
+| Genesis address book | Bundled as classpath resource (no generation needed) |
+
+## Step-by-Step Pipeline
+
+All commands use the `--network testnet` flag, which must appear **before** the subcommand. For brevity, the examples below use `TOOLS_JAR` as a shorthand:
+
+```bash
+export TOOLS_JAR="java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar"
+```
+
+### 1. Build the JAR
+
+```bash
+./gradlew :tools:shadowJar
+```
+
+### 2. Fetch Metadata from Mirror Node
+
+Generate `block_times.bin` and `day_blocks.json` from the testnet Mirror Node REST API. This does **not** require GCP credentials.
+
+```bash
+$TOOLS_JAR --network testnet mirror update
+```
+
+To limit the fetch to a specific date range:
+
+```bash
+$TOOLS_JAR --network testnet mirror update --end-date 2024-03-01
+```
+
+### 3. Generate Day Listings
+
+Download file listing metadata from the testnet GCS bucket. This tells the download commands which files exist for each day.
+
+```bash
+$TOOLS_JAR --network testnet days updateDayListings
+```
+
+### 4. Download Days
+
+Download compressed daily record file archives from the testnet GCS bucket.
+
+```bash
+# Download all available testnet days
+$TOOLS_JAR --network testnet days download-days-v3 2024 2 1 2026 3 16
+
+# Or download a smaller range to test
+$TOOLS_JAR --network testnet days download-days-v3 2024 2 1 2024 2 28
+```
+
+### 5. Wrap Record Files into Blocks
+
+Convert the downloaded record file day archives into wrapped Block Stream blocks.
+
+```bash
+$TOOLS_JAR --network testnet blocks wrap \
+  -i compressedDays \
+  -o testnetWrappedBlocks
+```
+
+The testnet genesis address book is bundled and will be loaded automatically.
+
+### 6. Validate Wrapped Blocks
+
+Validate the hash chain, signatures, and structure of the wrapped blocks.
+
+```bash
+$TOOLS_JAR --network testnet blocks validate testnetWrappedBlocks
+```
+
+To skip balance validation (balance checkpoints are not yet available for testnet):
+
+```bash
+$TOOLS_JAR --network testnet blocks validate \
+  --no-validate-balances \
+  testnetWrappedBlocks
+```
+
+> **Note:** Balance checkpoint files are not yet available for testnet. Use `--no-validate-balances` to skip balance validation.
+
+## Common Issues
+
+|                         Problem                          |                                                                 Solution                                                                  |
+|----------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `zstd: command not found`                                | Install zstd: `brew install zstd` (macOS) or `apt install zstd` (Linux).                                                                  |
+| GCP authentication errors                                | Run `gcloud auth application-default login` and ensure a billing-enabled project is set with `gcloud config set project YOUR_PROJECT_ID`. |
+| "Requester pays" access denied                           | Ensure your GCP project has billing enabled and is set as the active project.                                                             |
+| Edge-day sync problems (missing files at day boundaries) | Some days near the genesis boundary may have incomplete data. Use `days clean` to remove bad record sets, then re-download.               |
+| `IndexOutOfBoundsException` during download              | The `block_times.bin` may be out of date. Re-run `--network testnet mirror update` to refresh it.                                         |
+| Validation fails on first block                          | Ensure you are starting from block 0 for full validation, or use `--skip-signatures` for partial runs.                                    |


### PR DESCRIPTION
 - Add a Multi-Network Usage section to the tools README explaining the --network flag, supported networks, and what testnet configures automatically                                                           
  - Add testnet examples to blocks-commands.md (validate, wrap), days-commands.md (download-days-v3, download-live, updateDayListings), and mirror-node-commands.md (update)                                     
  - Mark fetchRecordsCsv, generateAddressBook, and fetchMissingTransactions as mainnet-only in mirror node docs                                                                                                  
  - Create a new docs/testnet-guide.md with end-to-end steps (build, metadata, listings, download, wrap, validate) and common issues       