### PR TITLE
docs: clarify --network flag can be placed anywhere on the command line

### DIFF
--- a/tools-and-tests/tools/README.md
+++ b/tools-and-tests/tools/README.md
@@ -147,13 +147,13 @@ java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar days
 
 ```bash
 # Update mirror metadata for testnet
-java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar --network testnet mirror update
+java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar mirror update --network testnet
 
 # Download testnet day archives
-java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar --network testnet days download-days-v3 2024 2 1 2024 3 1
+java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar days download-days-v3 2024 2 1 2024 3 1 --network testnet
 
 # Wrap testnet record files into blocks
-java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar --network testnet blocks wrap
+java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar blocks wrap --network testnet
 ```
 
 > See the [Testnet Pipeline Guide](docs/testnet-guide.md) for a full end-to-end walkthrough.
@@ -176,16 +176,16 @@ The tools support multiple Hedera networks via the `--network` flag:
 | `mainnet` | Hedera mainnet (default). Genesis: 2019-09-13, nodes 3-37.         |
 | `testnet` | Hedera testnet (current instance). Genesis: 2024-02-01, nodes 3-9. |
 
-The `--network` flag is a **top-level option** that goes before the subcommand. It is inherited by all subcommands, so you only need to specify it once.
+The `--network` flag is a **top-level inherited option** — it can be placed anywhere on the command line (before, between, or after subcommands). You only need to specify it once.
 
 ```bash
-# Syntax: java -jar tools.jar --network <network> <command> <subcommand> [options]
-
 # Mainnet (default — --network can be omitted)
 java -jar tools.jar mirror update
 
-# Testnet
+# Testnet — all of these are equivalent:
+java -jar tools.jar mirror update --network testnet
 java -jar tools.jar --network testnet mirror update
+java -jar tools.jar mirror --network testnet update
 ```
 
 When `--network testnet` is specified, the tools automatically use:

--- a/tools-and-tests/tools/docs/blocks-commands.md
+++ b/tools-and-tests/tools/docs/blocks-commands.md
@@ -123,10 +123,10 @@ blocks validate --skip-signatures /path/to/blocks/
 
 ```bash
 # Validate testnet blocks (uses testnet address book automatically)
---network testnet blocks validate /path/to/testnetWrappedBlocks
+blocks validate /path/to/testnetWrappedBlocks --network testnet
 
 # Testnet without balance validation (balance checkpoints not yet available for testnet)
---network testnet blocks validate --no-validate-balances /path/to/testnetWrappedBlocks
+blocks validate --no-validate-balances /path/to/testnetWrappedBlocks --network testnet
 ```
 
 > **Note:** Balance checkpoint files are not yet available for testnet. Use `--no-validate-balances` to skip balance validation when running against testnet data.
@@ -279,10 +279,10 @@ blocks wrap -u -i /path/to/compressedDays -o /path/to/wrappedBlocks
 
 ```bash
 # Wrap testnet record files into blocks
---network testnet blocks wrap -i /path/to/testnetCompressedDays -o /path/to/testnetWrappedBlocks
+blocks wrap -i /path/to/testnetCompressedDays -o /path/to/testnetWrappedBlocks --network testnet
 ```
 
-> **Testnet prerequisites:** The testnet genesis address book is bundled as a classpath resource and will be used automatically. You still need `block_times.bin` and `day_blocks.json` generated via `--network testnet mirror update`.
+> **Testnet prerequisites:** The testnet genesis address book is bundled as a classpath resource and will be used automatically. You still need `block_times.bin` and `day_blocks.json` generated via `mirror update --network testnet`.
 
 ---
 

--- a/tools-and-tests/tools/docs/days-commands.md
+++ b/tools-and-tests/tools/docs/days-commands.md
@@ -211,10 +211,10 @@ Same as `download-days-v2`.
 
 ```bash
 # Download testnet days for February 2024 (testnet genesis month)
---network testnet days download-days-v3 2024 2 1 2024 2 28
+days download-days-v3 2024 2 1 2024 2 28 --network testnet
 
 # Download all available testnet days
---network testnet days download-days-v3 2024 2 1 2026 3 16
+days download-days-v3 2024 2 1 2026 3 16 --network testnet
 ```
 
 > **Testnet notes:** The testnet GCS bucket is `hedera-testnet-streams`. Testnet has 7 nodes (account IDs 0.0.3 through 0.0.9) compared to mainnet's 35 nodes (0.0.3 through 0.0.37). The `--network testnet` flag configures the bucket and node range automatically.
@@ -259,10 +259,10 @@ days download-live [options]
 
 ```bash
 # Follow testnet live blocks
---network testnet days download-live -o /path/to/testnetCompressedDays
+days download-live -o /path/to/testnetCompressedDays --network testnet
 
 # Backfill testnet from genesis and then follow live
---network testnet days download-live --start-day 2024-02-01 -o /path/to/testnetCompressedDays
+days download-live --start-day 2024-02-01 -o /path/to/testnetCompressedDays --network testnet
 ```
 
 ---
@@ -435,10 +435,10 @@ days updateDayListings [options]
 
 ```bash
 # Update testnet day listings
---network testnet days updateDayListings
+days updateDayListings --network testnet
 
 # Update testnet listings for a specific date range
---network testnet days updateDayListings --start-date 2024-02-01 --end-date 2024-03-01
+days updateDayListings --start-date 2024-02-01 --end-date 2024-03-01 --network testnet
 ```
 
 ---

--- a/tools-and-tests/tools/docs/mirror-node-commands.md
+++ b/tools-and-tests/tools/docs/mirror-node-commands.md
@@ -135,14 +135,14 @@ mirror update --block-times /path/to/block_times.bin --day-blocks /path/to/day_b
 
 #### Testnet Usage
 
-Use the top-level `--network testnet` flag to fetch from the testnet Mirror Node instead of mainnet:
+Use the `--network testnet` flag to fetch from the testnet Mirror Node instead of mainnet:
 
 ```bash
 # Update metadata with all available testnet blocks
---network testnet mirror update
+mirror update --network testnet
 
 # Fetch only the first week of testnet
---network testnet mirror update --end-date 2024-02-07
+mirror update --network testnet --end-date 2024-02-07
 ```
 
 Notes:

--- a/tools-and-tests/tools/docs/testnet-guide.md
+++ b/tools-and-tests/tools/docs/testnet-guide.md
@@ -34,7 +34,7 @@ End-to-end guide for running the record-to-block conversion pipeline against the
 
 ## Step-by-Step Pipeline
 
-All commands use the `--network testnet` flag, which must appear **before** the subcommand. For brevity, the examples below use `TOOLS_JAR` as a shorthand:
+All commands use the `--network testnet` flag, which can be placed anywhere on the command line. For brevity, the examples below use `TOOLS_JAR` as a shorthand:
 
 ```bash
 export TOOLS_JAR="java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNAPSHOT-all.jar"
@@ -51,13 +51,13 @@ export TOOLS_JAR="java -jar tools-and-tests/tools/build/libs/tools-<VERSION>-SNA
 Generate `block_times.bin` and `day_blocks.json` from the testnet Mirror Node REST API. This does **not** require GCP credentials.
 
 ```bash
-$TOOLS_JAR --network testnet mirror update
+$TOOLS_JAR mirror update --network testnet
 ```
 
 To limit the fetch to a specific date range:
 
 ```bash
-$TOOLS_JAR --network testnet mirror update --end-date 2024-03-01
+$TOOLS_JAR mirror update --network testnet --end-date 2024-03-01
 ```
 
 ### 3. Generate Day Listings
@@ -65,7 +65,7 @@ $TOOLS_JAR --network testnet mirror update --end-date 2024-03-01
 Download file listing metadata from the testnet GCS bucket. This tells the download commands which files exist for each day.
 
 ```bash
-$TOOLS_JAR --network testnet days updateDayListings
+$TOOLS_JAR days updateDayListings --network testnet
 ```
 
 ### 4. Download Days
@@ -74,10 +74,10 @@ Download compressed daily record file archives from the testnet GCS bucket.
 
 ```bash
 # Download all available testnet days
-$TOOLS_JAR --network testnet days download-days-v3 2024 2 1 2026 3 16
+$TOOLS_JAR days download-days-v3 2024 2 1 2026 3 16 --network testnet
 
 # Or download a smaller range to test
-$TOOLS_JAR --network testnet days download-days-v3 2024 2 1 2024 2 28
+$TOOLS_JAR days download-days-v3 2024 2 1 2024 2 28 --network testnet
 ```
 
 ### 5. Wrap Record Files into Blocks
@@ -85,9 +85,10 @@ $TOOLS_JAR --network testnet days download-days-v3 2024 2 1 2024 2 28
 Convert the downloaded record file day archives into wrapped Block Stream blocks.
 
 ```bash
-$TOOLS_JAR --network testnet blocks wrap \
+$TOOLS_JAR blocks wrap \
   -i compressedDays \
-  -o testnetWrappedBlocks
+  -o testnetWrappedBlocks \
+  --network testnet
 ```
 
 The testnet genesis address book is bundled and will be loaded automatically.
@@ -97,15 +98,16 @@ The testnet genesis address book is bundled and will be loaded automatically.
 Validate the hash chain, signatures, and structure of the wrapped blocks.
 
 ```bash
-$TOOLS_JAR --network testnet blocks validate testnetWrappedBlocks
+$TOOLS_JAR blocks validate testnetWrappedBlocks --network testnet
 ```
 
 To skip balance validation (balance checkpoints are not yet available for testnet):
 
 ```bash
-$TOOLS_JAR --network testnet blocks validate \
+$TOOLS_JAR blocks validate \
   --no-validate-balances \
-  testnetWrappedBlocks
+  testnetWrappedBlocks \
+  --network testnet
 ```
 
 > **Note:** Balance checkpoint files are not yet available for testnet. Use `--no-validate-balances` to skip balance validation.
@@ -118,5 +120,5 @@ $TOOLS_JAR --network testnet blocks validate \
 | GCP authentication errors                                | Run `gcloud auth application-default login` and ensure a billing-enabled project is set with `gcloud config set project YOUR_PROJECT_ID`. |
 | "Requester pays" access denied                           | Ensure your GCP project has billing enabled and is set as the active project.                                                             |
 | Edge-day sync problems (missing files at day boundaries) | Some days near the genesis boundary may have incomplete data. Use `days clean` to remove bad record sets, then re-download.               |
-| `IndexOutOfBoundsException` during download              | The `block_times.bin` may be out of date. Re-run `--network testnet mirror update` to refresh it.                                         |
+| `IndexOutOfBoundsException` during download              | The `block_times.bin` may be out of date. Re-run `mirror update --network testnet` to refresh it.                                         |
 | Validation fails on first block                          | Ensure you are starting from block 0 for full validation, or use `--skip-signatures` for partial runs.                                    |


### PR DESCRIPTION
## Summary
- Clarify in the Multi-Network Usage section that `--network` uses picocli `ScopeType.INHERIT` and can be placed before, between, or after subcommands
- Update all testnet examples across docs to use the more natural trailing position (e.g., `blocks validate /path --network testnet` instead of `--network testnet blocks validate /path`)
- Improves DevEx by matching the conventional command-then-flags ordering operators expect
