### PR TITLE
fix: detect and fail on mirror node block gaps

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/UpdateBlockData.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/UpdateBlockData.java
@@ -266,7 +266,7 @@ public class UpdateBlockData implements Runnable {
                 sb.append(
                         "day_blocks.json was NOT updated to prevent corrupt metadata. block_times.bin may have partial writes but will be corrected on re-run.");
                 System.out.println(sb);
-                throw new RuntimeException(sb.toString());
+                throw new IllegalStateException(sb.toString());
             }
 
             // Write updated day_blocks.json only if no gaps

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/mirrornode/UpdateBlockDataTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/mirrornode/UpdateBlockDataTest.java
@@ -504,7 +504,7 @@ class UpdateBlockDataTest {
                 }
             };
 
-            RuntimeException ex = assertThrows(RuntimeException.class, () -> {
+            IllegalStateException ex = assertThrows(IllegalStateException.class, () -> {
                 UpdateBlockData.updateMirrorNodeData(timesFile, dayBlocksFile, null, 52, fetcher);
             });
 


### PR DESCRIPTION
## Summary
- Detects gaps in mirror node API responses by comparing the first returned block number against the expected block number
- Advances `currentBlock` based on the **last block actually returned** instead of the pre-computed `batchEndBlock`, preventing silent data corruption
- Collects all detected gaps and fails with a detailed summary, preventing `day_blocks.json` from being written with corrupt metadata
- Handles empty batch responses to avoid infinite loops

Resolves #2378
