### PR TITLE
fix: Remove testnet genesis amendments and add --skip-supply flag

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/TestnetAmendmentProvider.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/TestnetAmendmentProvider.java
@@ -3,22 +3,21 @@ package org.hiero.block.tools.blocks;
 
 import com.hedera.hapi.block.stream.BlockItem;
 import java.util.List;
-import org.hiero.block.tools.states.TestnetBlockZeroState;
 
 /**
  * Amendment provider for Hedera testnet.
  *
- * <p>Provides genesis amendments for block 0 representing the initial network state at
- * testnet genesis (2024-02-01). The genesis state is fetched from the testnet mirror node
- * API, which returns account balances at the genesis timestamp.
+ * <p>Unlike mainnet (where record streams began after the network was already running and
+ * a genesis state snapshot is needed), testnet was freshly reset in February 2024 and its
+ * record streams are complete from the very first genesis round. Block 0's record file
+ * already contains the genesis minting transactions, so no genesis amendments are needed.
+ * Injecting mirror-node-sourced genesis state would double-count the initial HBAR supply
+ * (once from the amendments' STATE_CHANGES and once from block 0's transfer lists).
  *
- * <p>Unlike mainnet, testnet does not have missing transaction amendments since the testnet
- * was freshly reset and record streams are complete from genesis.
+ * <p>Testnet also does not have missing transaction amendments since the record streams
+ * are complete from genesis.
  */
 public class TestnetAmendmentProvider implements AmendmentProvider {
-
-    /** Genesis is always block 0 */
-    private static final long GENESIS_BLOCK = 0L;
 
     /**
      * Creates a TestnetAmendmentProvider.
@@ -34,14 +33,11 @@ public class TestnetAmendmentProvider implements AmendmentProvider {
 
     @Override
     public boolean hasGenesisAmendments(long blockNumber) {
-        return blockNumber == GENESIS_BLOCK;
+        return false;
     }
 
     @Override
     public List<BlockItem> getGenesisAmendments(long blockNumber) {
-        if (blockNumber == GENESIS_BLOCK) {
-            return TestnetBlockZeroState.loadStartBlockZeroStateChanges();
-        }
         return List.of();
     }
 }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
@@ -124,6 +124,11 @@ public class ValidateBlocksCommand implements Runnable {
     private boolean skipSignatures = false;
 
     @Option(
+            names = {"--skip-supply"},
+            description = "Skip HBAR supply validation (useful for networks with known transfer list imbalances)")
+    private boolean skipSupply = false;
+
+    @Option(
             names = {"--validate-balances"},
             description = "Enable validation of account balances (enabled by default)",
             defaultValue = "true",
@@ -367,7 +372,7 @@ public class ValidateBlocksCommand implements Runnable {
 
         BlockChainValidation chainValidation = new BlockChainValidation();
         HistoricalBlockTreeValidation treeValidation = new HistoricalBlockTreeValidation(chainValidation);
-        HbarSupplyValidation supplyValidation = new HbarSupplyValidation();
+        HbarSupplyValidation supplyValidation = skipSupply ? null : new HbarSupplyValidation();
         // Parallel validations (stateless, run in decompPool threads)
         final AddressBookRegistry abRegistry = addressBookRegistry;
         List<BlockValidation> parallelValidations = new ArrayList<>();
@@ -378,12 +383,17 @@ public class ValidateBlocksCommand implements Runnable {
         } else {
             System.out.println(Ansi.AUTO.string("@|yellow Skipping:|@ Signature validation (--skip-signatures)"));
         }
+        if (skipSupply) {
+            System.out.println(Ansi.AUTO.string("@|yellow Skipping:|@ HBAR supply validation (--skip-supply)"));
+        }
 
         // Sequential validations (stateful, run on main thread)
         List<BlockValidation> sequentialValidations = new ArrayList<>();
         sequentialValidations.add(chainValidation);
         sequentialValidations.add(treeValidation);
-        sequentialValidations.add(supplyValidation);
+        if (supplyValidation != null) {
+            sequentialValidations.add(supplyValidation);
+        }
         if (registry != null) {
             sequentialValidations.add(new HashRegistryValidation(registry, chainValidation));
         }
@@ -392,8 +402,8 @@ public class ValidateBlocksCommand implements Runnable {
             sequentialValidations.add(new JumpstartValidation(jumpstartPath, treeValidation, registry));
         }
 
-        // Balance checkpoint validation (genesis-requiring, optional)
-        if (firstDisplayBlock == 0 && validateBalances) {
+        // Balance checkpoint validation (genesis-requiring, optional; requires supply validation)
+        if (firstDisplayBlock == 0 && validateBalances && supplyValidation != null) {
             try {
                 final BalanceCheckpointValidator checkpointValidator = new BalanceCheckpointValidator();
                 checkpointValidator.setCheckIntervalDays(balanceCheckIntervalDays);

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/AmendmentProviderTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/AmendmentProviderTest.java
@@ -83,22 +83,21 @@ class AmendmentProviderTest {
         }
 
         @Test
-        @DisplayName("hasGenesisAmendments returns true only for block 0")
+        @DisplayName("hasGenesisAmendments always returns false (record streams are complete from genesis)")
         void testHasGenesisAmendments() {
             TestnetAmendmentProvider provider = new TestnetAmendmentProvider();
-            assertTrue(provider.hasGenesisAmendments(0), "Block 0 should have genesis amendments");
+            assertFalse(provider.hasGenesisAmendments(0), "Block 0 should not have genesis amendments");
             assertFalse(provider.hasGenesisAmendments(1), "Block 1 should not have genesis amendments");
             assertFalse(provider.hasGenesisAmendments(-1), "Block -1 should not have genesis amendments");
             assertFalse(provider.hasGenesisAmendments(100), "Block 100 should not have genesis amendments");
         }
 
         @Test
-        @DisplayName("getGenesisAmendments returns empty list for non-genesis blocks")
+        @DisplayName("getGenesisAmendments always returns empty list")
         void testGetGenesisAmendmentsNonGenesis() {
             TestnetAmendmentProvider provider = new TestnetAmendmentProvider();
-            List<BlockItem> amendments = provider.getGenesisAmendments(1);
-            assertNotNull(amendments, "Amendments should not be null");
-            assertTrue(amendments.isEmpty(), "Amendments should be empty for non-genesis blocks");
+            assertTrue(provider.getGenesisAmendments(0).isEmpty(), "Block 0 should have no genesis amendments");
+            assertTrue(provider.getGenesisAmendments(1).isEmpty(), "Block 1 should have no genesis amendments");
         }
 
         @Test


### PR DESCRIPTION
## Summary
- **Remove testnet genesis amendments** — Testnet was freshly reset in Feb 2024 and its record streams are complete from genesis. Injecting mirror-node-sourced genesis state was double-counting the initial HBAR supply.
- **Add `--skip-supply` CLI flag** to `ValidateBlocksCommand` for networks with known transfer list imbalances (e.g., testnet block 7,557,270).
- **Update tests** to reflect the simplified `TestnetAmendmentProvider` behavior.


Closes #2271
