### PR TITLE
fix: Preserve validate checkpoint on successful completion

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
@@ -932,28 +931,9 @@ public class ValidateBlocksCommand implements Runnable {
                 (blocksValidated >= estimatedTotalBlocks - BlockZipsUtilities.DEFAULT_BLOCKS_PER_ZIP
                         || blocksValidated == estimatedTotalBlocks);
 
-        // On full success: remove checkpoint (validation is complete).
-        // On partial/error: save a final checkpoint for next resume.
-        if (!validationFailed && allBlocksValidated) {
-            try {
-                // Delete all checkpoint files
-                if (Files.isDirectory(checkpointDir)) {
-                    try (Stream<Path> cpFiles = Files.list(checkpointDir)) {
-                        cpFiles.forEach(p -> {
-                            try {
-                                Files.deleteIfExists(p);
-                            } catch (IOException ignored) {
-                            }
-                        });
-                    }
-                    Files.deleteIfExists(checkpointDir);
-                }
-                System.out.println(Ansi.AUTO.string("@|yellow Checkpoint deleted|@ (validation complete)"));
-            } catch (IOException e) {
-                System.err.println("Warning: could not delete checkpoint: " + e.getMessage());
-            }
-        } else if (!validationFailed && lastValidatedRef[0] >= 0 && chainValidation.getPreviousBlockHash() != null) {
-            // Partial completion (state file errors only) — save checkpoint
+        // Save checkpoint on both full success and partial completion so the next run
+        // can resume from where this one left off (instead of re-validating from block 0).
+        if (!validationFailed && lastValidatedRef[0] >= 0 && chainValidation.getPreviousBlockHash() != null) {
             try {
                 Files.createDirectories(checkpointDir);
             } catch (IOException ignored) {

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ValidateBlocksCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ValidateBlocksCommandTest.java
@@ -409,23 +409,27 @@ class ValidateBlocksCommandTest {
     }
 
     @Test
-    void checkpointDeletedOnFullSuccess() throws Exception {
+    void checkpointPreservedOnFullSuccess() throws Exception {
         List<Block> blocks = TestBlockFactory.createValidChain(5);
         writeBlocks(blocks);
         writeAddressBook();
-
-        // Create a fake checkpoint first so we can verify it gets cleaned up
-        Path checkpointDir = tempDir.resolve("validateCheckpoint");
-        Files.createDirectories(checkpointDir);
-        Files.writeString(checkpointDir.resolve("validateProgress.json"), "{}");
 
         Object[] result = runValidate();
         String output = (String) result[1];
 
         assertTrue(output.contains("VALIDATION PASSED"), "Should pass validation. Output:\n" + output);
-        assertFalse(
+
+        // Checkpoint should be preserved on success so that future runs can resume
+        Path checkpointDir = tempDir.resolve("validateCheckpoint");
+        assertTrue(
                 Files.exists(checkpointDir.resolve("validateProgress.json")),
-                "Checkpoint JSON should be deleted after full success");
+                "Checkpoint JSON should be preserved after full success");
+
+        // Verify checkpoint contents reflect all blocks validated
+        String json = Files.readString(checkpointDir.resolve("validateProgress.json"));
+        JsonObject root = JsonParser.parseString(json).getAsJsonObject();
+        assertEquals(4, root.get("lastValidatedBlockNumber").getAsLong(), "Last validated should be block 4");
+        assertEquals(5, root.get("blocksValidated").getAsLong(), "Should have validated 5 blocks (0-4)");
     }
 
     // ── CLI validation ──


### PR DESCRIPTION
**Fixes #2430**

## Summary
- **Preserve checkpoint on success**: The `validate` command now saves its checkpoint after successful completion instead of deleting it, allowing future runs to resume from the last validated block
- **Update test**: Changed `checkpointDeletedOnFullSuccess` → `checkpointPreservedOnFullSuccess` to verify the new behavior and assert correct checkpoint contents

## Context
In a continuous pipeline where `download-live2` keeps wrapping new day archives, deleting the checkpoint on success forced every `validate` run to start from block 0. Preserving the checkpoint enables incremental validation as new blocks are wrapped.

