### PR TITLE
fix: Verification all blocks hasher NPE reading historical block data.

### DIFF
--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockStagingFileAccessor.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockStagingFileAccessor.java
@@ -67,7 +67,7 @@ final class BlockStagingFileAccessor implements BlockAccessor {
         Objects.requireNonNull(format);
         try {
             return getBytesFromPath(format, blockFilePath, compressionType);
-        } catch (final UncheckedIOException | IOException e) {
+        } catch (final RuntimeException e) {
             LOGGER.log(WARNING, FAILED_TO_READ_MESSAGE.formatted(blockFilePath), e);
             return null;
         }
@@ -96,11 +96,9 @@ final class BlockStagingFileAccessor implements BlockAccessor {
      * @param sourcePath the path to the source file
      * @param sourceCompression the compression type of the source data
      * @return the bytes of the block in the desired format, or null if the block cannot be read
-     * @throws IOException if unable to read or decompress the data.
      */
     private Bytes getBytesFromPath(
-            final Format responseFormat, final Path sourcePath, final CompressionType sourceCompression)
-            throws IOException {
+            final Format responseFormat, final Path sourcePath, final CompressionType sourceCompression) {
         try (final InputStream in = Files.newInputStream(sourcePath);
                 final InputStream wrapped = sourceCompression.wrapStream(in)) {
             Bytes sourceData =
@@ -119,6 +117,9 @@ final class BlockStagingFileAccessor implements BlockAccessor {
             } else {
                 return sourceData;
             }
+        } catch (final RuntimeException | IOException e) {
+            LOGGER.log(WARNING, FAILED_TO_READ_MESSAGE.formatted(blockFilePath), e);
+            return null;
         }
     }
 

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessor.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessor.java
@@ -11,7 +11,6 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.lang.System.Logger;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -95,7 +94,7 @@ final class ZipBlockAccessor implements BlockAccessor {
         try (final FileSystem zipFileSystem = FileSystems.newFileSystem(zipFileLink)) {
             final Path entry = zipFileSystem.getPath(blockPathData.blockFileName());
             return getBytesFromPath(format, entry, blockPathData.compressionType());
-        } catch (final UncheckedIOException | IOException e) {
+        } catch (final RuntimeException | IOException e) {
             final String message = FAILED_TO_READ_MESSAGE.formatted(blockNumber, absoluteZipFilePath, entryName);
             LOGGER.log(WARNING, message, e);
             return null;
@@ -153,7 +152,7 @@ final class ZipBlockAccessor implements BlockAccessor {
                         false,
                         Codec.DEFAULT_MAX_DEPTH,
                         BlockAccessor.MAX_BLOCK_SIZE_BYTES));
-            } catch (final UncheckedIOException | ParseException e) {
+            } catch (final RuntimeException | ParseException e) {
                 String entryName = blockPathData.blockFileName();
                 final String message = FAILED_TO_PARSE_MESSAGE.formatted(blockNumber, absoluteZipFilePath, entryName);
                 LOGGER.log(WARNING, message, e);
@@ -168,7 +167,7 @@ final class ZipBlockAccessor implements BlockAccessor {
     public void close() {
         try {
             Files.delete(zipFileLink);
-        } catch (final IOException e) {
+        } catch (final RuntimeException | IOException e) {
             final String message = FAILED_TO_DELETE_LINK_MESSAGE.formatted(
                     blockNumber, absoluteZipFilePath, blockPathData.blockFileName());
             LOGGER.log(INFO, message, e);

--- a/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileBlockAccessor.java
+++ b/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileBlockAccessor.java
@@ -11,10 +11,8 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Objects;
 import java.util.UUID;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.base.CompressionType;
@@ -90,7 +88,7 @@ final class BlockFileBlockAccessor implements BlockAccessor {
                             false,
                             Codec.DEFAULT_MAX_DEPTH,
                             BlockAccessor.MAX_BLOCK_SIZE_BYTES);
-        } catch (final UncheckedIOException | ParseException e) {
+        } catch (final RuntimeException | ParseException e) {
             LOGGER.log(WARNING, FAILED_TO_PARSE_MESSAGE.formatted(absolutePathToBlock), e);
             return null;
         }
@@ -98,13 +96,15 @@ final class BlockFileBlockAccessor implements BlockAccessor {
 
     /**
      * {@inheritDoc}
+     *
+     * This method _will not throw_, but will return null if there is any failure
+     * while reading the block data from the provided path.
      */
     @Override
     public Bytes blockBytes(@NonNull final Format format) {
-        Objects.requireNonNull(format);
         try {
             return getBytesFromPath(format, blockFileLink, compressionType);
-        } catch (final UncheckedIOException | IOException e) {
+        } catch (final RuntimeException e) {
             LOGGER.log(WARNING, FAILED_TO_READ_MESSAGE.formatted(absolutePathToBlock), e);
             return null;
         }
@@ -113,17 +113,19 @@ final class BlockFileBlockAccessor implements BlockAccessor {
     /**
      * Get the bytes from the specified path, converting to the desired format if necessary.
      *
+     * This method _will not throw_, but will return null if there is any failure
+     * while reading the block data from the provided path.
+     *
      * @param responseFormat the desired format of the data
      * @param sourcePath the path to the source file
      * @param sourceCompression the compression type of the source data
      * @return the bytes of the block in the desired format, or null if the block cannot be read
-     * @throws IOException if unable to read or decompress the data.
      */
     private Bytes getBytesFromPath(
-            final Format responseFormat, final Path sourcePath, final CompressionType sourceCompression)
-            throws IOException {
+            final Format responseFormat, final Path sourcePath, final CompressionType sourceCompression) {
         try (final InputStream in = Files.newInputStream(sourcePath);
                 final InputStream wrapped = sourceCompression.wrapStream(in)) {
+            final Bytes result;
             Bytes sourceData =
                     switch (responseFormat) {
                         case JSON, PROTOBUF -> Bytes.wrap(wrapped.readAllBytes());
@@ -136,10 +138,14 @@ final class BlockFileBlockAccessor implements BlockAccessor {
                         }
                     };
             if (Format.JSON == responseFormat) {
-                return getJsonBytesFromProtobufBytes(sourceData);
+                result = getJsonBytesFromProtobufBytes(sourceData);
             } else {
-                return sourceData;
+                result = sourceData;
             }
+            return result;
+        } catch (final IOException | RuntimeException e) {
+            LOGGER.log(WARNING, FAILED_TO_READ_MESSAGE.formatted(absolutePathToBlock), e);
+            return null;
         }
     }
 
@@ -161,7 +167,7 @@ final class BlockFileBlockAccessor implements BlockAccessor {
                         false,
                         Codec.DEFAULT_MAX_DEPTH,
                         BlockAccessor.MAX_BLOCK_SIZE_BYTES));
-            } catch (final UncheckedIOException | ParseException e) {
+            } catch (final RuntimeException | ParseException e) {
                 final String message = FAILED_TO_PARSE_MESSAGE.formatted(absolutePathToBlock);
                 LOGGER.log(WARNING, message, e);
                 return null;
@@ -178,7 +184,7 @@ final class BlockFileBlockAccessor implements BlockAccessor {
     public void close() {
         try {
             Files.delete(blockFileLink);
-        } catch (final IOException e) {
+        } catch (final RuntimeException | IOException e) {
             final String message = "Failed to delete accessor link for block: %d, path: %s"
                     .formatted(blockNumber, absolutePathToBlock);
             LOGGER.log(INFO, message, e);

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/AllBlocksHasherHandler.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/AllBlocksHasherHandler.java
@@ -28,7 +28,9 @@ import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 import org.hiero.block.node.spi.historicalblocks.BlockRangeSet;
+import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
 import org.hiero.block.node.verification.session.HapiVersionSessionFactory;
 import org.hiero.block.node.verification.session.VerificationSession;
 
@@ -151,6 +153,8 @@ public class AllBlocksHasherHandler {
                     loadFromFile();
                     syncBlockHashesFromStore(getNumberOfBlocks(), available.max());
                 } else {
+                    // @todo(TBD) This is excessively expensive. We should have a config
+                    //    flag to enable this.
                     fullyRebuildFromStore();
                 }
                 // 3. Validate hasher state matches available blocks
@@ -291,26 +295,35 @@ public class AllBlocksHasherHandler {
     /**
      * Calculate the block hash for a given block number, using block footer values as authoritative source.
      *
+     * If the block cannot be read (historical storage is _not_ guaranteed), then
+     * this method will return an empty byte array.
+     *
      * @param blockNumber the block number to calculate the hash for
      * @return the calculated block hash
      * @throws ParseException if there is an error parsing the block or its items.
      */
     private byte[] calculateBlockHashFromBlockNumber(long blockNumber) throws ParseException {
-        final BlockUnparsed block =
-                context.historicalBlockProvider().block(blockNumber).blockUnparsed();
-        // is safe to assume first item is always block header
-        final BlockHeader blockHeader =
-                BlockHeader.PROTOBUF.parse(block.blockItems().getFirst().blockHeader());
+        final HistoricalBlockFacility blockProvider = context.historicalBlockProvider();
+        if (blockProvider != null) {
+            final BlockAccessor blockReader = blockProvider.block(blockNumber);
+            if (blockReader != null) {
+                final BlockUnparsed block = blockReader.blockUnparsed();
+                // is safe to assume first item is always block header
+                final BlockHeader blockHeader =
+                        BlockHeader.PROTOBUF.parse(block.blockItems().getFirst().blockHeader());
+                BlockItems blockItemsMessage = new BlockItems(block.blockItems(), blockNumber, true, true);
 
-        BlockItems blockItemsMessage = new BlockItems(block.blockItems(), blockNumber, true, true);
-
-        // Pass null, null so the session uses the block footer's authoritative values
-        final VerificationSession session = HapiVersionSessionFactory.createSession(
-                blockNumber, BlockSource.HISTORY, blockHeader.hapiProtoVersion(), null, null, null);
-
-        final VerificationNotification result = session.processBlockItems(blockItemsMessage);
-
-        return result.blockHash().toByteArray();
+                // Pass null, null so the session uses the block footer's authoritative values
+                final VerificationSession session = HapiVersionSessionFactory.createSession(
+                        blockNumber, BlockSource.HISTORY, blockHeader.hapiProtoVersion(), null, null, null);
+                final VerificationNotification result = session.processBlockItems(blockItemsMessage);
+                return result.blockHash().toByteArray();
+            } else {
+                return new byte[0];
+            }
+        } else {
+            return new byte[0];
+        }
     }
 
     /***


### PR DESCRIPTION
## Reviewer Notes

* Adjusted BlockAccessor catch clauses to be more comprehensive
* Added check for null block provider and block accessor in the all blocks hasher
   * Ensured the code returns a sane value rather than throwing a runtime exception.

## Related Issue(s)
 Fix: #2438 