### PR TITLE
fix: update verification state after live-tail backfill (#2471)

### DIFF
--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
@@ -62,6 +62,9 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
     private Counter hashingBlockTimeNs;
     /** The previous block hash, used for verification of the current block. */
     private Bytes previousBlockHash;
+    /** The block number of the last successfully verified block (live-stream or sequential backfill). */
+    private long previousVerifiedBlockNumber = -1;
+
     /** Handler for root hash for all previous blocks hasher operations and lifecycle. */
     AllBlocksHasherHandler allBlocksHasherHandler;
     /**
@@ -212,13 +215,18 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                 } else {
                     headerValid = true;
                 }
+                // Only use our tracked previousBlockHash when this block is sequentially
+                // next after the last verified block. Otherwise pass null so the session
+                // falls back to the authoritative values in the block footer.
+                final Bytes previousHash =
+                        currentBlockNumber == previousVerifiedBlockNumber + 1 ? previousBlockHash : null;
                 SemanticVersion semanticVersion = blockHeader.hapiProtoVersionOrThrow();
                 // create a new verification session for the new block based on hapi version on block header.
                 currentSession = HapiVersionSessionFactory.createSession(
                         currentBlockNumber,
                         BlockSource.PUBLISHER,
                         semanticVersion,
-                        previousBlockHash,
+                        previousHash,
                         getRootOfAllPreviousBlocks(),
                         activeLedgerId);
                 LOGGER.log(TRACE, "Started new block verification session for block number {0}", currentBlockNumber);
@@ -250,8 +258,9 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                         // send the notification to the block messaging service
                         LOGGER.log(TRACE, "Sending verification notification for block={0}", currentBlockNumber);
                         context.blockMessaging().sendBlockVerification(notification);
-                        // Update previousBlockHash for next block verification
+                        // Update previousBlockHash and previousVerifiedBlockNumber for next block verification
                         this.previousBlockHash = notification.blockHash();
+                        this.previousVerifiedBlockNumber = currentBlockNumber;
                         // Update streamingHasherAllPreviousBlocks
                         allBlocksHasherHandler.appendLatestHashToAllPreviousBlocksStreamingHasher(
                                 this.previousBlockHash.toByteArray());
@@ -280,12 +289,12 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
 
     private Bytes getRootOfAllPreviousBlocks() {
         if (allBlocksHasherHandler != null && allBlocksHasherHandler.isAvailable()) {
-            // When earliestManagedBlock > 0 the node may not have a continuous chain from genesis.
             // Only use the hasher's computed root when its leaf count matches currentBlockNumber
             // exactly (i.e. it holds hashes for blocks 0 through currentBlockNumber-1). Any other
-            // count means continuity is absent, so defer to the block footer's authoritative value.
-            // When earliestManagedBlock == 0 full genesis continuity is expected; always use hasher.
-            if (earliestManagedBlock > 0 && allBlocksHasherHandler.getNumberOfBlocks() != currentBlockNumber) {
+            // count means the hasher is out of sync (e.g. backfill advanced it past the live-stream
+            // position, or the node doesn't have a continuous chain from genesis), so defer to the
+            // block footer's authoritative value.
+            if (allBlocksHasherHandler.getNumberOfBlocks() != currentBlockNumber) {
                 return null;
             }
             return Bytes.wrap(allBlocksHasherHandler.computeRootHash());
@@ -386,12 +395,14 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                         if (notification.blockNumber() == 0) {
                             persistTssParameters();
                         }
-                        // Update the allBlocksHasher only when this backfilled block is the next
-                        // sequential one (leafCount == blockNumber). Historical backfill can arrive
-                        // out of order, so we must not append blocks that would break the hasher's
-                        // contiguous chain from genesis.
+                        // Only update live-stream verification state when this backfilled block
+                        // is sequentially next after the last verified block (live-tail backfill).
+                        // Historical backfill can arrive out of order and must not alter state
+                        // used by the live-stream verification path.
                         if (backfillNotification.blockHash() != null
-                                && allBlocksHasherHandler.getNumberOfBlocks() == notification.blockNumber()) {
+                                && notification.blockNumber() == previousVerifiedBlockNumber + 1) {
+                            this.previousBlockHash = backfillNotification.blockHash();
+                            this.previousVerifiedBlockNumber = notification.blockNumber();
                             allBlocksHasherHandler.appendLatestHashToAllPreviousBlocksStreamingHasher(
                                     backfillNotification.blockHash().toByteArray());
                         }

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/VerifiableBlockFactory.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/VerifiableBlockFactory.java
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.verification;
+
+import static org.hiero.block.common.hasher.HashingUtilities.getBlockItemHash;
+import static org.hiero.block.common.hasher.HashingUtilities.noThrowSha384HashOf;
+
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.block.stream.BlockItem.ItemOneOfType;
+import com.hedera.hapi.block.stream.BlockProof;
+import com.hedera.hapi.block.stream.TssSignedBlockProof;
+import com.hedera.hapi.block.stream.input.RoundHeader;
+import com.hedera.hapi.block.stream.output.BlockFooter;
+import com.hedera.hapi.block.stream.output.BlockHeader;
+import com.hedera.hapi.node.base.BlockHashAlgorithm;
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.pbj.runtime.OneOf;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.List;
+import org.hiero.block.common.hasher.HashingUtilities;
+import org.hiero.block.common.hasher.NaiveStreamingTreeHasher;
+import org.hiero.block.internal.BlockItemUnparsed;
+
+/**
+ * Factory for creating synthetic blocks that pass {@code ExtendedMerkleTreeSession} verification.
+ *
+ * <p>Blocks use the hash-of-hash signature path: the proof signature is {@code SHA384(blockRootHash)}.
+ * HAPI version 1.2.3 routes to {@code ExtendedMerkleTreeSession} (>= 0.72.0).
+ */
+final class VerifiableBlockFactory {
+
+    private static final Timestamp BLOCK_TIMESTAMP = new Timestamp(123L, 456);
+    private static final SemanticVersion HAPI_VERSION = new SemanticVersion(1, 2, 3, "a", "b");
+    private static final SemanticVersion SOFTWARE_VERSION = new SemanticVersion(4, 5, 6, "c", "d");
+    private static final Bytes ZERO_HASH = Bytes.wrap(new byte[HashingUtilities.HASH_SIZE]);
+
+    private VerifiableBlockFactory() {}
+
+    /**
+     * Creates unparsed block items for a verifiable synthetic block.
+     *
+     * @param blockNumber the block number
+     * @param previousBlockHash the hash of the previous block, or null for genesis
+     * @return list of unparsed block items (header, round header, footer, proof)
+     */
+    static List<BlockItemUnparsed> createBlockItems(long blockNumber, @Nullable Bytes previousBlockHash) {
+        Bytes previousHash = previousBlockHash != null ? previousBlockHash : ZERO_HASH;
+
+        BlockItem header = new BlockItem(new OneOf<>(
+                ItemOneOfType.BLOCK_HEADER,
+                new BlockHeader(
+                        HAPI_VERSION, SOFTWARE_VERSION, blockNumber, BLOCK_TIMESTAMP, BlockHashAlgorithm.SHA2_384)));
+        BlockItem roundHeader =
+                new BlockItem(new OneOf<>(ItemOneOfType.ROUND_HEADER, new RoundHeader(blockNumber * 10L)));
+        BlockItem footer = new BlockItem(
+                new OneOf<>(ItemOneOfType.BLOCK_FOOTER, new BlockFooter(previousHash, ZERO_HASH, Bytes.EMPTY)));
+
+        Bytes blockHash = computeBlockHash(blockNumber, previousBlockHash);
+        Bytes signature = noThrowSha384HashOf(blockHash);
+        BlockItem proof = new BlockItem(new OneOf<>(
+                ItemOneOfType.BLOCK_PROOF,
+                BlockProof.newBuilder()
+                        .block(blockNumber)
+                        .signedBlockProof(TssSignedBlockProof.newBuilder()
+                                .blockSignature(signature)
+                                .build())
+                        .build()));
+
+        return List.of(header, roundHeader, footer, proof).stream()
+                .map(VerifiableBlockFactory::toUnparsed)
+                .toList();
+    }
+
+    /**
+     * Computes the block root hash for a synthetic block. Use the returned hash as
+     * the {@code previousBlockHash} argument when creating the next block in the chain.
+     *
+     * @param blockNumber the block number
+     * @param previousBlockHash the hash of the previous block, or null for genesis
+     * @return the computed block root hash
+     */
+    static Bytes computeBlockHash(long blockNumber, @Nullable Bytes previousBlockHash) {
+        Bytes previousHash = previousBlockHash != null ? previousBlockHash : ZERO_HASH;
+
+        BlockItemUnparsed headerUnparsed = BlockItemUnparsed.newBuilder()
+                .blockHeader(BlockHeader.PROTOBUF.toBytes(new BlockHeader(
+                        HAPI_VERSION, SOFTWARE_VERSION, blockNumber, BLOCK_TIMESTAMP, BlockHashAlgorithm.SHA2_384)))
+                .build();
+        BlockItemUnparsed roundHeaderUnparsed = BlockItemUnparsed.newBuilder()
+                .roundHeader(RoundHeader.PROTOBUF.toBytes(new RoundHeader(blockNumber * 10L)))
+                .build();
+
+        NaiveStreamingTreeHasher outputHasher = new NaiveStreamingTreeHasher();
+        outputHasher.addLeaf(getBlockItemHash(headerUnparsed));
+        NaiveStreamingTreeHasher consensusHasher = new NaiveStreamingTreeHasher();
+        consensusHasher.addLeaf(getBlockItemHash(roundHeaderUnparsed));
+
+        return HashingUtilities.computeFinalBlockHash(
+                BLOCK_TIMESTAMP,
+                previousHash,
+                ZERO_HASH,
+                Bytes.EMPTY,
+                new NaiveStreamingTreeHasher(),
+                outputHasher,
+                consensusHasher,
+                new NaiveStreamingTreeHasher(),
+                new NaiveStreamingTreeHasher());
+    }
+
+    private static BlockItemUnparsed toUnparsed(BlockItem item) {
+        try {
+            return BlockItemUnparsed.PROTOBUF.parse(BlockItem.PROTOBUF.toBytes(item));
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationRegressionTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationRegressionTest.java
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.verification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.node.app.fixtures.async.BlockingExecutor;
+import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
+import org.hiero.block.node.app.fixtures.blocks.BlockUtils;
+import org.hiero.block.node.app.fixtures.plugintest.NoBlocksHistoricalBlockFacility;
+import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
+import org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility;
+import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
+import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression tests for verification bugs found in production.
+ */
+class VerificationRegressionTest
+        extends PluginTestBase<VerificationServicePlugin, BlockingExecutor, ScheduledExecutorService> {
+
+    private final Map<String, String> defaultConfig;
+
+    public VerificationRegressionTest(@TempDir final Path tempDir) {
+        super(
+                new BlockingExecutor(new LinkedBlockingQueue<>()),
+                new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+        VerificationServicePlugin.activeLedgerId = null;
+        VerificationServicePlugin.activeTssPublication = null;
+        VerificationServicePlugin.tssParametersPersisted = false;
+        defaultConfig = VerificationConfigBuilder.newBuilder()
+                .allBlocksHasherFilePath(tempDir.resolve("verificationData.bin"))
+                .allBlocksHasherEnabled(true)
+                .tssParametersFilePath(tempDir.resolve("tss-parameters.bin"))
+                .toMap();
+        start(new VerificationServicePlugin(), new NoBlocksHistoricalBlockFacility(), defaultConfig);
+    }
+
+    /**
+     * When a block is backfilled and then the same block arrives via the live-stream, the
+     * live-stream verification fails with PUBLISHER source. This triggers BAD_BLOCK_PROOF,
+     * disconnects all publishers, and the node enters a NODE_BEHIND loop it cannot escape.
+     *
+     * <p>Backfill appends the block hash to the allBlocksHasher, so getRootOfAllPreviousBlocks()
+     * returns a root that already includes the block being verified — causing a hash mismatch.
+     */
+    @Test
+    @DisplayName("backfilled block via live-stream should not emit PUBLISHER failure (hasher enabled)")
+    void backfilledBlockWithHasherEnabledShouldNotCausePublisherFailure() throws IOException, ParseException {
+        BlockUtils.SampleBlockInfo block0 = BlockUtils.getSampleBlockInfo(BlockUtils.SAMPLE_BLOCKS.HAPI_0_72_0_BLOCK_0);
+        BlockUtils.SampleBlockInfo block1 = BlockUtils.getSampleBlockInfo(BlockUtils.SAMPLE_BLOCKS.HAPI_0_72_0_BLOCK_1);
+
+        // Block 0 via live stream — establishes verification state
+        blockMessaging.sendBlockItems(
+                new BlockItems(block0.blockUnparsed().blockItems(), block0.blockNumber(), true, true));
+
+        // Block 1 via backfill — succeeds, but pollutes allBlocksHasher
+        plugin.handleBackfilled(new BackfilledBlockNotification(block1.blockNumber(), block1.blockUnparsed()));
+
+        // Same block 1 via live stream — reconnecting publisher resends it
+        plugin.handleBlockItemsReceived(
+                new BlockItems(block1.blockUnparsed().blockItems(), block1.blockNumber(), true, true));
+
+        List<VerificationNotification> notifications = blockMessaging.getSentVerificationNotifications();
+        assertTrue(notifications.get(0).success(), "Block 0 live-stream should succeed");
+        assertTrue(notifications.get(1).success(), "Block 1 backfill should succeed");
+        assertEquals(BlockSource.BACKFILL, notifications.get(1).source());
+
+        // Block 1 via live-stream should be skipped (already verified via backfill),
+        // so no PUBLISHER failure notification should be emitted
+        for (VerificationNotification notification : notifications) {
+            assertTrue(
+                    notification.success() || notification.source() != BlockSource.PUBLISHER,
+                    "Must not emit PUBLISHER failure for a block already verified via backfill. "
+                            + "Actual: success=" + notification.success()
+                            + ", source=" + notification.source());
+        }
+    }
+
+    /**
+     * Backfilling multiple blocks does not update {@code previousBlockHash}. When the next
+     * expected block arrives via live stream, verification computes the wrong block hash
+     * because it still uses the pre-backfill previous hash — causing a PUBLISHER failure.
+     *
+     * <p>Uses synthetic blocks with hash-of-hash signatures so the test exercises real
+     * verification via {@code ExtendedMerkleTreeSession}.
+     */
+    @Test
+    @DisplayName("stale previousBlockHash after multi-block backfill causes PUBLISHER failure")
+    void stalePreviousBlockHashAfterMultiBlockBackfillShouldNotCausePublisherFailure() {
+        VerificationServicePlugin.activeLedgerId = null;
+        VerificationServicePlugin.activeTssPublication = null;
+        VerificationServicePlugin.tssParametersPersisted = false;
+        blockMessaging = new TestBlockMessagingFacility();
+        Map<String, String> config = new HashMap<>(defaultConfig);
+        config.put("verification.allBlocksHasherEnabled", "false");
+        start(new VerificationServicePlugin(), new NoBlocksHistoricalBlockFacility(), config);
+
+        Bytes hash0 = VerifiableBlockFactory.computeBlockHash(0, null);
+        Bytes hash1 = VerifiableBlockFactory.computeBlockHash(1, hash0);
+        Bytes hash2 = VerifiableBlockFactory.computeBlockHash(2, hash1);
+
+        List<BlockItemUnparsed> block0Items = VerifiableBlockFactory.createBlockItems(0, null);
+        List<BlockItemUnparsed> block1Items = VerifiableBlockFactory.createBlockItems(1, hash0);
+        List<BlockItemUnparsed> block2Items = VerifiableBlockFactory.createBlockItems(2, hash1);
+        List<BlockItemUnparsed> block3Items = VerifiableBlockFactory.createBlockItems(3, hash2);
+
+        // Block 0 via live stream — establishes verification state
+        blockMessaging.sendBlockItems(new BlockItems(block0Items, 0, true, true));
+
+        // Backfill blocks 1 and 2 — succeed, but do NOT update previousBlockHash
+        plugin.handleBackfilled(new BackfilledBlockNotification(1, new BlockUnparsed(block1Items)));
+        plugin.handleBackfilled(new BackfilledBlockNotification(2, new BlockUnparsed(block2Items)));
+
+        // Block 3 via live stream — should use hash(block2) as previousBlockHash,
+        // but plugin still holds hash(block0)
+        plugin.handleBlockItemsReceived(new BlockItems(block3Items, 3, true, true));
+
+        List<VerificationNotification> notifications = blockMessaging.getSentVerificationNotifications();
+        assertTrue(notifications.get(0).success(), "Block 0 live-stream should succeed");
+        assertTrue(notifications.get(1).success(), "Block 1 backfill should succeed");
+        assertTrue(notifications.get(2).success(), "Block 2 backfill should succeed");
+
+        VerificationNotification liveStreamBlock3 = notifications.get(3);
+        assertTrue(
+                liveStreamBlock3.success() || liveStreamBlock3.source() != BlockSource.PUBLISHER,
+                "Must not emit PUBLISHER failure for block after backfill gap. "
+                        + "Actual: success=" + liveStreamBlock3.success()
+                        + ", source=" + liveStreamBlock3.source());
+    }
+
+    private static class VerificationConfigBuilder {
+
+        private Path allBlocksHasherFilePath;
+        private boolean allBlocksHasherEnabled = true;
+        private Path tssParametersFilePath = Path.of("");
+
+        static VerificationConfigBuilder newBuilder() {
+            return new VerificationConfigBuilder();
+        }
+
+        VerificationConfigBuilder allBlocksHasherEnabled(boolean value) {
+            this.allBlocksHasherEnabled = value;
+            return this;
+        }
+
+        VerificationConfigBuilder allBlocksHasherFilePath(Path value) {
+            this.allBlocksHasherFilePath = value;
+            return this;
+        }
+
+        VerificationConfigBuilder tssParametersFilePath(Path value) {
+            this.tssParametersFilePath = value;
+            return this;
+        }
+
+        Map<String, String> toMap() {
+            Map<String, String> configMap = new HashMap<>();
+            configMap.put("verification.allBlocksHasherFilePath", allBlocksHasherFilePath.toString());
+            configMap.put("verification.allBlocksHasherEnabled", String.valueOf(allBlocksHasherEnabled));
+            configMap.put("verification.allBlocksHasherPersistenceInterval", "10");
+            configMap.put("verification.tssParametersFilePath", tssParametersFilePath.toString());
+            return configMap;
+        }
+    }
+}

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -109,7 +109,7 @@ plugins:
     - id: central
       url: https://repo1.maven.org/maven2
     - id: besu-maven
-      url: https://hyperledger.jfrog.io/artifactory/besu-maven
+      url: https://artifacts.hashgraph.io/artifactory/hyperledger-besu-maven-external/
     - id: consensys
       url: https://artifacts.consensys.net/public/maven/maven/
     - id: sonatype-snapshots


### PR DESCRIPTION
## Reviewer Notes
Cherry-pick of #2472 into release/0.30 for a hot-fix patch version `0.30.2` in order to unblock both perf and previewnet.
