### PR TITLE
fix: use picocli output capture in StateToJsonCommandTest to fix flaky test

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/states/StateToJsonCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/states/StateToJsonCommand.java
@@ -4,6 +4,7 @@ package org.hiero.block.tools.states;
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
 import java.io.File;
+import java.io.PrintWriter;
 import java.util.List;
 import org.hiero.block.tools.states.model.CompleteSavedState;
 import picocli.CommandLine.Command;
@@ -30,10 +31,12 @@ public class StateToJsonCommand implements Runnable {
             spec.commandLine().usage(spec.commandLine().getOut());
             return;
         }
+        final PrintWriter out = spec.commandLine().getOut();
         for (File savedStateDir : savedStateDirectories) {
             final CompleteSavedState completeSavedState = SavedStateConverter.loadState(savedStateDir.toPath());
             final List<BlockItem> blockItems = SavedStateConverter.signedStateToStateChanges(completeSavedState);
-            System.out.println(Block.JSON.toJSON(new Block(blockItems)));
+            out.println(Block.JSON.toJSON(new Block(blockItems)));
         }
+        out.flush();
     }
 }

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/states/StateToJsonCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/states/StateToJsonCommandTest.java
@@ -9,9 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.List;
 import org.hiero.block.tools.states.model.CompleteSavedState;
 import org.junit.jupiter.api.Test;
@@ -46,22 +45,16 @@ class StateToJsonCommandTest {
         String resourcePath = System.getProperty("user.dir") + "/src/main/resources/saved-state-33485415";
         assertTrue(new java.io.File(resourcePath).exists(), "saved-state-33485415 directory should exist");
 
-        // Capture stdout to validate the JSON output
-        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
-        PrintStream originalOut = System.out;
-        try {
-            System.setOut(new PrintStream(stdout, true, StandardCharsets.UTF_8));
-            int exitCode = new CommandLine(new StateToJsonCommand()).execute(resourcePath);
-            assertEquals(0, exitCode, "StateToJsonCommand should exit with code 0");
-        } finally {
-            System.setOut(originalOut);
-        }
+        // Use picocli's setOut() to capture output (thread-safe, unlike System.setOut)
+        StringWriter sw = new StringWriter();
+        CommandLine cmd = new CommandLine(new StateToJsonCommand());
+        cmd.setOut(new PrintWriter(sw));
+        int exitCode = cmd.execute(resourcePath);
+        assertEquals(0, exitCode, "StateToJsonCommand should exit with code 0");
 
-        // The command prints JSON via System.out.println(Block.JSON.toJSON(...))
         // Validate that the captured output contains valid JSON with block items
-        String output = stdout.toString(StandardCharsets.UTF_8);
+        String output = sw.toString();
         assertFalse(output.isBlank(), "Command should produce JSON output");
-        // The JSON output from Block.JSON.toJSON contains the block data
         assertTrue(output.contains("{") && output.contains("}"), "Output should contain JSON");
     }
 


### PR DESCRIPTION
## Summary
- `StateToJsonCommandTest.runWithDir()` was flaky because it used `System.setOut()` to capture stdout, which is not thread-safe when tests run with `maxParallelForks = availableProcessors()`
- Changed `StateToJsonCommand` to use picocli's `spec.commandLine().getOut()` instead of `System.out.println()`
- Changed the test to use `CommandLine.setOut(new PrintWriter(sw))` for thread-safe output capture


Fixes #2474