### PR TITLE
feat: add live-sequential command for single-block download+wrap+validate pipeline

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/DaysCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/DaysCommand.java
@@ -9,9 +9,9 @@ import org.hiero.block.tools.days.subcommands.DownloadDaysV2;
 import org.hiero.block.tools.days.subcommands.DownloadDaysV3;
 import org.hiero.block.tools.days.subcommands.DownloadLive;
 import org.hiero.block.tools.days.subcommands.DownloadLive2;
-import org.hiero.block.tools.days.subcommands.DownloadSequential;
 import org.hiero.block.tools.days.subcommands.FixMissingSignatures;
 import org.hiero.block.tools.days.subcommands.FixSignatureFileNames;
+import org.hiero.block.tools.days.subcommands.LiveSequential;
 import org.hiero.block.tools.days.subcommands.Ls;
 import org.hiero.block.tools.days.subcommands.LsDayListing;
 import org.hiero.block.tools.days.subcommands.PrintListing;
@@ -44,7 +44,7 @@ import picocli.CommandLine.Spec;
             DownloadDays.class,
             DownloadLive.class,
             DownloadLive2.class,
-            DownloadSequential.class,
+            LiveSequential.class,
             PrintListing.class,
             LsDayListing.class,
             SplitJsonToDayFiles.class,

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/DaysCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/DaysCommand.java
@@ -9,6 +9,7 @@ import org.hiero.block.tools.days.subcommands.DownloadDaysV2;
 import org.hiero.block.tools.days.subcommands.DownloadDaysV3;
 import org.hiero.block.tools.days.subcommands.DownloadLive;
 import org.hiero.block.tools.days.subcommands.DownloadLive2;
+import org.hiero.block.tools.days.subcommands.DownloadSequential;
 import org.hiero.block.tools.days.subcommands.FixMissingSignatures;
 import org.hiero.block.tools.days.subcommands.FixSignatureFileNames;
 import org.hiero.block.tools.days.subcommands.Ls;
@@ -43,6 +44,7 @@ import picocli.CommandLine.Spec;
             DownloadDays.class,
             DownloadLive.class,
             DownloadLive2.class,
+            DownloadSequential.class,
             PrintListing.class,
             LsDayListing.class,
             SplitJsonToDayFiles.class,

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/downloadlive/ValidateDownloadLive.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/downloadlive/ValidateDownloadLive.java
@@ -112,6 +112,7 @@ public class ValidateDownloadLive {
      * @return a list of sidecar files matching the primary record's timestamp, or an empty list
      *         if primaryRecord is null or no sidecars are found
      */
+    @SuppressWarnings("java:S3776") // NPath complexity inherent to multi-criteria filtering
     public static List<InMemoryFile> findSidecars(
             final DownloadDayLiveImpl.BlockDownloadResult result, final InMemoryFile primaryRecord) {
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/downloadlive/ValidateDownloadLive.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/downloadlive/ValidateDownloadLive.java
@@ -44,7 +44,7 @@ public class ValidateDownloadLive {
      * @param result the block download result containing all downloaded files
      * @return the primary record file, or null if not found
      */
-    private static InMemoryFile findPrimaryRecord(final DownloadDayLiveImpl.BlockDownloadResult result) {
+    public static InMemoryFile findPrimaryRecord(final DownloadDayLiveImpl.BlockDownloadResult result) {
         return result.files.stream()
                 .filter(f -> {
                     final String name = f.path().getFileName().toString();
@@ -71,7 +71,7 @@ public class ValidateDownloadLive {
      * @param result the block download result containing all downloaded files
      * @return a list of all signature files found; may be empty if none exist
      */
-    private static List<InMemoryFile> findSignatures(final DownloadDayLiveImpl.BlockDownloadResult result) {
+    public static List<InMemoryFile> findSignatures(final DownloadDayLiveImpl.BlockDownloadResult result) {
         return result.files.stream()
                 .filter(f -> {
                     final String name = f.path().getFileName().toString();
@@ -112,7 +112,7 @@ public class ValidateDownloadLive {
      * @return a list of sidecar files matching the primary record's timestamp, or an empty list
      *         if primaryRecord is null or no sidecars are found
      */
-    private static List<InMemoryFile> findSidecars(
+    public static List<InMemoryFile> findSidecars(
             final DownloadDayLiveImpl.BlockDownloadResult result, final InMemoryFile primaryRecord) {
 
         if (primaryRecord == null) {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/downloadlive/ValidateDownloadLive.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/downloadlive/ValidateDownloadLive.java
@@ -112,7 +112,7 @@ public class ValidateDownloadLive {
      * @return a list of sidecar files matching the primary record's timestamp, or an empty list
      *         if primaryRecord is null or no sidecars are found
      */
-    @SuppressWarnings("java:S3776") // NPath complexity inherent to multi-criteria filtering
+    @SuppressWarnings("PMD.NPathComplexity") // NPath complexity inherent to multi-criteria filtering
     public static List<InMemoryFile> findSidecars(
             final DownloadDayLiveImpl.BlockDownloadResult result, final InMemoryFile primaryRecord) {
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/DownloadSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/DownloadSequential.java
@@ -1,0 +1,1100 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.days.subcommands;
+
+import static org.hiero.block.tools.blocks.AmendmentProvider.createAmendmentProvider;
+import static org.hiero.block.tools.blocks.HasherStateFiles.saveStateCheckpoint;
+import static org.hiero.block.tools.blocks.model.BlockWriter.DEFAULT_COMPRESSION;
+import static org.hiero.block.tools.blocks.model.BlockWriter.DEFAULT_POWERS_OF_TEN_PER_ZIP;
+import static org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHasher.hashBlock;
+import static org.hiero.block.tools.days.downloadlive.ValidateDownloadLive.findPrimaryRecord;
+import static org.hiero.block.tools.days.downloadlive.ValidateDownloadLive.findSidecars;
+import static org.hiero.block.tools.days.downloadlive.ValidateDownloadLive.findSignatures;
+import static org.hiero.block.tools.days.downloadlive.ValidateDownloadLive.fullBlockValidate;
+import static org.hiero.block.tools.utils.Md5Checker.checkMd5;
+
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.RecordFileSignature;
+import com.hedera.hapi.node.base.NodeAddressBook;
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.tools.blocks.AmendmentProvider;
+import org.hiero.block.tools.blocks.model.BlockArchiveType;
+import org.hiero.block.tools.blocks.model.BlockWriter;
+import org.hiero.block.tools.blocks.model.BlockWriter.BlockPath;
+import org.hiero.block.tools.blocks.model.BlockWriter.BlockZipAppender;
+import org.hiero.block.tools.blocks.model.PreVerifiedBlock;
+import org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHashRegistry;
+import org.hiero.block.tools.blocks.model.hashing.StreamingHasher;
+import org.hiero.block.tools.blocks.validation.AddressBookUpdateValidation;
+import org.hiero.block.tools.blocks.validation.BlockChainValidation;
+import org.hiero.block.tools.blocks.validation.BlockStructureValidation;
+import org.hiero.block.tools.blocks.validation.BlockValidation;
+import org.hiero.block.tools.blocks.validation.HashRegistryValidation;
+import org.hiero.block.tools.blocks.validation.HbarSupplyValidation;
+import org.hiero.block.tools.blocks.validation.HistoricalBlockTreeValidation;
+import org.hiero.block.tools.blocks.validation.JumpstartValidation;
+import org.hiero.block.tools.blocks.validation.RequiredItemsValidation;
+import org.hiero.block.tools.blocks.validation.SignatureValidation;
+import org.hiero.block.tools.blocks.validation.StreamingMerkleTreeValidation;
+import org.hiero.block.tools.config.NetworkConfig;
+import org.hiero.block.tools.days.download.DownloadConstants;
+import org.hiero.block.tools.days.download.DownloadDayLiveImpl;
+import org.hiero.block.tools.days.listing.DayListingFileReader;
+import org.hiero.block.tools.days.listing.ListingRecordFile;
+import org.hiero.block.tools.days.model.AddressBookRegistry;
+import org.hiero.block.tools.metadata.MetadataFiles;
+import org.hiero.block.tools.mirrornode.BlockInfo;
+import org.hiero.block.tools.mirrornode.BlockTimeReader;
+import org.hiero.block.tools.mirrornode.FetchBlockQuery;
+import org.hiero.block.tools.mirrornode.FixBlockTime;
+import org.hiero.block.tools.mirrornode.MirrorNodeBlockQueryOrder;
+import org.hiero.block.tools.mirrornode.UpdateBlockData;
+import org.hiero.block.tools.records.RecordFileUtils;
+import org.hiero.block.tools.records.model.parsed.ParsedRecordBlock;
+import org.hiero.block.tools.records.model.parsed.RecordBlockConverter;
+import org.hiero.block.tools.records.model.parsed.ValidationException;
+import org.hiero.block.tools.records.model.unparsed.InMemoryFile;
+import org.hiero.block.tools.records.model.unparsed.UnparsedRecordBlock;
+import org.hiero.block.tools.utils.ConcurrentTarZstdWriter;
+import org.hiero.block.tools.utils.Gzip;
+import org.hiero.block.tools.utils.gcp.ConcurrentDownloadManagerVirtualThreadsV3;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Sequential block download with inline wrapping and full validation.
+ *
+ * <p>Downloads blocks one at a time, strictly sequentially, failing hard on any gap. Each block is:
+ * <ol>
+ *   <li>Downloaded from GCS</li>
+ *   <li>Hash-chain validated and signature validated</li>
+ *   <li>Written to per-day {@code .tar.zstd} archives</li>
+ *   <li>Wrapped into block stream format (via {@link RecordBlockConverter})</li>
+ *   <li>Validated against all 11 {@link BlockValidation} checks</li>
+ *   <li>Written to hierarchical zip archives</li>
+ * </ol>
+ *
+ * <p>This combines the functionality of {@code download-live2}, {@code wrap}, and {@code validate}
+ * into a single pipeline optimized for correctness over throughput.
+ */
+@SuppressWarnings("FieldCanBeLocal")
+@Command(
+        name = "download-sequential",
+        description = "Sequential block download with inline validation and wrapping",
+        mixinStandardHelpOptions = true)
+public class DownloadSequential implements Runnable {
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final Duration LIVE_POLL_INTERVAL = Duration.ofSeconds(2);
+    private static final int PROGRESS_LOG_INTERVAL = 100;
+    private static final long MIN_BLOCK_TIME_REFRESH_INTERVAL_MS = 30_000;
+    private static final int WATERMARK_BATCH_SIZE = 256;
+
+    private static final File CACHE_DIR = new File("metadata/gcp-cache");
+
+    /** Poison pill to signal the wrap+validate thread to exit. */
+    private static final ValidatedBlock POISON_PILL = new ValidatedBlock(-1, null, List.of(), null);
+
+    @Option(
+            names = {"-l", "--listing-dir"},
+            description = "Directory where listing files are stored (default: listingsByDay)")
+    private File listingDir = new File("listingsByDay");
+
+    @Option(
+            names = {"-o", "--output-dir"},
+            description = "Directory where compressed day archives are written (default: compressedDays)")
+    private File outputDir = new File("compressedDays");
+
+    @Option(
+            names = {"--wrap-output-dir"},
+            description = "Directory to write wrapped block stream output (default: wrappedBlocks)")
+    private Path wrapOutputDir = Path.of("wrappedBlocks");
+
+    @Option(
+            names = {"--state-json"},
+            description = "Path to state JSON file for resume (default: outputDir/validateCmdStatus.json)")
+    private Path stateJsonPath;
+
+    @Option(
+            names = {"--address-book"},
+            description = "Path to address book file for signature validation")
+    private Path addressBookPath;
+
+    @Option(
+            names = {"--start-date"},
+            description = "Start date in YYYY-MM-DD format (default: auto-detect from mirror node)")
+    private String startDate;
+
+    @Option(
+            names = {"--stats-csv"},
+            description = "Path to signature statistics CSV file (default: outputDir/signature_statistics.csv)")
+    private Path statsCsvPath;
+
+    /** State persisted to JSON for resumability. Compatible with DownloadLive2 format. */
+    private static class State {
+        String dayDate;
+        String recordFileTime;
+        String endRunningHashHex;
+        long blockNumber;
+
+        State() {}
+
+        State(long blockNumber, byte[] hash, Instant recordFileTime, LocalDate dayDate) {
+            this.blockNumber = blockNumber;
+            this.dayDate = dayDate != null ? dayDate.toString() : null;
+            this.recordFileTime = recordFileTime != null ? recordFileTime.toString() : null;
+            this.endRunningHashHex = hash != null ? HexFormat.of().formatHex(hash) : null;
+        }
+
+        byte[] getHashBytes() {
+            return endRunningHashHex != null ? HexFormat.of().parseHex(endRunningHashHex) : null;
+        }
+
+        LocalDate getDayDate() {
+            return dayDate != null ? LocalDate.parse(dayDate) : null;
+        }
+    }
+
+    /** Block data passed from the download thread to the wrap+validate thread. */
+    private record ValidatedBlock(
+            long blockNumber, Instant recordFileTime, List<InMemoryFile> files, byte[] runningHash) {}
+
+    @Override
+    public void run() {
+        System.out.println(
+                "[download-sequential] Starting sequential block download with inline wrapping + validation");
+        System.out.println("Configuration:");
+        System.out.println("  listingDir=" + listingDir);
+        System.out.println("  outputDir=" + outputDir);
+        System.out.println("  wrapOutputDir=" + wrapOutputDir);
+        System.out.println("  stateJsonPath=" + stateJsonPath);
+        System.out.println("  addressBookPath=" + addressBookPath);
+        System.out.println("  startDate=" + (startDate != null ? startDate : "(auto-detect)"));
+
+        try {
+            // Create directories
+            Files.createDirectories(outputDir.toPath());
+            Files.createDirectories(wrapOutputDir);
+
+            // Set default state file path
+            if (stateJsonPath == null) {
+                stateJsonPath = outputDir.toPath().resolve("validateCmdStatus.json");
+            }
+            if (stateJsonPath.getParent() != null) {
+                Files.createDirectories(stateJsonPath.getParent());
+            }
+
+            // Initialize address book
+            final AddressBookRegistry addressBookRegistry =
+                    addressBookPath != null ? new AddressBookRegistry(addressBookPath) : new AddressBookRegistry();
+
+            // Use HTTP transport for stability
+            final Storage storage = StorageOptions.http()
+                    .setProjectId(DownloadConstants.GCP_PROJECT_ID)
+                    .build()
+                    .getService();
+
+            final ConcurrentDownloadManagerVirtualThreadsV3 downloadManager =
+                    ConcurrentDownloadManagerVirtualThreadsV3.newBuilder(storage)
+                            .setMaxConcurrency(16)
+                            .build();
+
+            final BlockTimeReader blockTimeReader = new BlockTimeReader();
+
+            // Stats CSV
+            if (statsCsvPath == null) {
+                statsCsvPath = outputDir.toPath().resolve("signature_statistics.csv");
+            }
+
+            // Determine starting point
+            final State initialState = determineStartingPoint(blockTimeReader);
+            System.out.println("[download-sequential] Starting from block " + initialState.blockNumber
+                    + " hash["
+                    + (initialState.endRunningHashHex != null
+                            ? initialState.endRunningHashHex.substring(
+                                    0, Math.min(8, initialState.endRunningHashHex.length()))
+                            : "null")
+                    + "]"
+                    + " day=" + initialState.dayDate);
+
+            // Create producer-consumer queue
+            final BlockingQueue<ValidatedBlock> queue = new LinkedBlockingQueue<>(32);
+            final AtomicReference<Throwable> wrapError = new AtomicReference<>(null);
+
+            // Start wrap+validate thread
+            final Thread wrapThread = new Thread(
+                    () -> {
+                        try {
+                            runWrapAndValidateThread(queue, addressBookRegistry);
+                        } catch (Throwable t) {
+                            wrapError.set(t);
+                            System.err.println("[WRAP] Fatal error in wrap+validate thread: " + t.getMessage());
+                            t.printStackTrace();
+                        }
+                    },
+                    "wrap-validate-thread");
+            wrapThread.setDaemon(true);
+            wrapThread.start();
+
+            // Add shutdown hook
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(
+                            () -> {
+                                System.out.println("[download-sequential] Shutdown requested...");
+                                downloadManager.close();
+                            },
+                            "download-sequential-shutdown"));
+
+            // Main download loop
+            processBlocksSequentially(
+                    initialState, addressBookRegistry, downloadManager, blockTimeReader, queue, wrapError);
+
+            // Signal wrap thread to exit and wait
+            queue.put(POISON_PILL);
+            wrapThread.join(60_000);
+
+            // Check for wrap errors
+            Throwable wrapErr = wrapError.get();
+            if (wrapErr != null) {
+                throw new RuntimeException("Wrap+validate thread failed", wrapErr);
+            }
+
+            System.out.println("[download-sequential] Complete.");
+        } catch (Exception e) {
+            System.err.println("[download-sequential] Fatal error: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Determines the starting point for block processing.
+     * Priority: 1) Resume from state file, 2) Use --start-date, 3) Auto-detect from mirror node
+     */
+    private State determineStartingPoint(BlockTimeReader blockTimeReader) {
+        // Priority 1: Resume from state file
+        if (Files.exists(stateJsonPath)) {
+            try {
+                String json = Files.readString(stateJsonPath, StandardCharsets.UTF_8);
+                State state = GSON.fromJson(json, State.class);
+                if (state != null && state.blockNumber > 0) {
+                    System.out.println("[download-sequential] Resuming from state file: block " + state.blockNumber);
+                    return state;
+                }
+            } catch (Exception e) {
+                System.err.println("[download-sequential] Warning: Failed to read state file: " + e.getMessage());
+            }
+        }
+
+        // Priority 2: Use --start-date
+        if (startDate != null && !startDate.isBlank()) {
+            LocalDate targetDay = LocalDate.parse(startDate);
+            System.out.println("[download-sequential] Using provided start date: " + targetDay);
+
+            LocalDateTime startOfDay = targetDay.atStartOfDay();
+            long firstBlockOfDay = blockTimeReader.getNearestBlockAfterTime(startOfDay);
+
+            System.out.println("[download-sequential] First block of " + targetDay + " is " + firstBlockOfDay);
+
+            State state = new State();
+            state.blockNumber = firstBlockOfDay - 1;
+            state.dayDate = targetDay.toString();
+            return state;
+        }
+
+        // Priority 3: Auto-detect from mirror node
+        System.out.println("[download-sequential] Querying mirror node for current day...");
+        List<BlockInfo> latestBlocks = FetchBlockQuery.getLatestBlocks(1, MirrorNodeBlockQueryOrder.DESC);
+
+        if (latestBlocks.isEmpty()) {
+            throw new RuntimeException("Failed to get latest block from mirror node");
+        }
+
+        BlockInfo latestBlock = latestBlocks.getFirst();
+        String timestamp = latestBlock.timestampFrom != null ? latestBlock.timestampFrom : latestBlock.timestampTo;
+
+        if (timestamp == null) {
+            throw new RuntimeException("Latest block has no timestamp");
+        }
+
+        String[] parts = timestamp.split("\\.");
+        long epochSeconds = Long.parseLong(parts[0]);
+        Instant blockInstant = Instant.ofEpochSecond(epochSeconds);
+        LocalDate today = blockInstant.atZone(ZoneOffset.UTC).toLocalDate();
+
+        System.out.println("[download-sequential] Detected current day: " + today);
+
+        LocalDateTime startOfDay = today.atStartOfDay();
+        long firstBlockOfDay = blockTimeReader.getNearestBlockAfterTime(startOfDay);
+
+        State state = new State();
+        state.blockNumber = firstBlockOfDay - 1;
+        state.dayDate = today.toString();
+        return state;
+    }
+
+    /**
+     * Main sequential download loop. Downloads one block at a time, validates, writes to tar.zstd,
+     * and queues for wrapping.
+     */
+    private void processBlocksSequentially(
+            State initialState,
+            AddressBookRegistry addressBookRegistry,
+            ConcurrentDownloadManagerVirtualThreadsV3 downloadManager,
+            BlockTimeReader initialBlockTimeReader,
+            BlockingQueue<ValidatedBlock> queue,
+            AtomicReference<Throwable> wrapError)
+            throws Exception {
+
+        long currentBlockNumber = initialState.blockNumber;
+        byte[] currentHash = initialState.getHashBytes();
+        LocalDate currentDay = initialState.getDayDate();
+        BlockTimeReader blockTimeReader = initialBlockTimeReader;
+
+        ConcurrentTarZstdWriter currentDayWriter = null;
+        long blocksProcessedTotal = 0;
+        long blocksProcessedToday = 0;
+        long dayStartTime = System.currentTimeMillis();
+        long lastBlockTimeRefreshMs = 0;
+
+        // Cache for listing files - reload only when day changes
+        List<ListingRecordFile> cachedListingFiles = null;
+        LocalDate cachedListingDay = null;
+
+        final NetworkConfig netConfig = NetworkConfig.current();
+
+        try {
+            while (true) {
+                // Check for wrap thread errors
+                Throwable wrapErr = wrapError.get();
+                if (wrapErr != null) {
+                    throw new RuntimeException("Wrap+validate thread failed, stopping download", wrapErr);
+                }
+
+                long nextBlockNumber = currentBlockNumber + 1;
+
+                // Step 1: Get block timestamp
+                LocalDateTime blockTime;
+                try {
+                    blockTime = blockTimeReader.getBlockLocalDateTime(nextBlockNumber);
+                } catch (Exception e) {
+                    long now = System.currentTimeMillis();
+                    if (now - lastBlockTimeRefreshMs >= MIN_BLOCK_TIME_REFRESH_INTERVAL_MS) {
+                        System.out.println(
+                                "[LIVE] Block " + nextBlockNumber + " not in BlockTimeReader, refreshing...");
+                        UpdateBlockData.updateMirrorNodeData(
+                                MetadataFiles.BLOCK_TIMES_FILE, MetadataFiles.DAY_BLOCKS_FILE);
+                        blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                        lastBlockTimeRefreshMs = now;
+                    }
+                    Thread.sleep(LIVE_POLL_INTERVAL.toMillis());
+                    continue;
+                }
+
+                LocalDate blockDay = blockTime.toLocalDate();
+
+                // Step 2: Handle day boundary
+                if (!blockDay.equals(currentDay)) {
+                    if (currentDayWriter != null) {
+                        currentDayWriter.close();
+                        System.out.println("[download-sequential] Day completed: " + currentDay + " ("
+                                + blocksProcessedToday + " blocks in "
+                                + formatDuration((System.currentTimeMillis() - dayStartTime) / 1000) + ")");
+                    }
+
+                    // Start new day
+                    currentDay = blockDay;
+                    Path dayArchive = outputDir.toPath().resolve(currentDay + ".tar.zstd");
+                    currentDayWriter = new ConcurrentTarZstdWriter(dayArchive);
+                    blocksProcessedToday = 0;
+                    dayStartTime = System.currentTimeMillis();
+                    cachedListingFiles = null;
+                    cachedListingDay = null;
+
+                    System.out.println("[download-sequential] Started new day: " + currentDay);
+                }
+
+                // Initialize writer if needed (first block)
+                if (currentDayWriter == null) {
+                    Path dayArchive = outputDir.toPath().resolve(currentDay + ".tar.zstd");
+                    currentDayWriter = new ConcurrentTarZstdWriter(dayArchive);
+                    dayStartTime = System.currentTimeMillis();
+                    System.out.println("[download-sequential] Started day: " + currentDay);
+                }
+
+                // Step 3: Load GCS listings if day changed
+                if (!blockDay.equals(cachedListingDay)) {
+                    int year = blockTime.getYear();
+                    int month = blockTime.getMonthValue();
+                    int day = blockTime.getDayOfMonth();
+
+                    int attempt = 0;
+                    while (true) {
+                        attempt++;
+                        refreshListingsForDay(blockDay, netConfig);
+                        try {
+                            cachedListingFiles =
+                                    DayListingFileReader.loadRecordsFileForDay(listingDir.toPath(), year, month, day);
+                            cachedListingDay = blockDay;
+                            System.out.println("[download-sequential] Loaded " + cachedListingFiles.size()
+                                    + " listing entries for " + blockDay);
+                            break;
+                        } catch (NoSuchFileException e) {
+                            System.out.println("[download-sequential] Listings not available yet for " + blockDay
+                                    + ", waiting 15 minutes... (attempt " + attempt + ")");
+                            Thread.sleep(15 * 60 * 1000);
+                        }
+                    }
+                }
+
+                // Step 4: Find files for this block
+                Map<LocalDateTime, List<ListingRecordFile>> filesByBlock =
+                        cachedListingFiles.stream().collect(Collectors.groupingBy(ListingRecordFile::timestamp));
+
+                List<ListingRecordFile> group = filesByBlock.get(blockTime);
+                if (group == null || group.isEmpty()) {
+                    // Refresh listings and retry
+                    refreshListingsForDay(blockDay, netConfig);
+                    cachedListingFiles = DayListingFileReader.loadRecordsFileForDay(
+                            listingDir.toPath(),
+                            blockTime.getYear(),
+                            blockTime.getMonthValue(),
+                            blockTime.getDayOfMonth());
+                    cachedListingDay = blockDay;
+                    filesByBlock =
+                            cachedListingFiles.stream().collect(Collectors.groupingBy(ListingRecordFile::timestamp));
+                    group = filesByBlock.get(blockTime);
+
+                    if (group == null || group.isEmpty()) {
+                        // Try fixing block time
+                        System.out.println("[download-sequential] No files found for block " + nextBlockNumber
+                                + " at time " + blockTime + ", fixing block times...");
+                        FixBlockTime.fixBlockTimeRange(
+                                MetadataFiles.BLOCK_TIMES_FILE, nextBlockNumber, nextBlockNumber + 100);
+                        blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                        continue;
+                    }
+                }
+
+                // If no hash yet, fetch from mirror node
+                if (currentHash == null && nextBlockNumber > 0) {
+                    System.out.println("[download-sequential] Fetching previous hash from mirror node for block "
+                            + nextBlockNumber);
+                    try {
+                        var prevHashBytes = FetchBlockQuery.getPreviousHashForBlock(nextBlockNumber);
+                        currentHash = prevHashBytes.toByteArray();
+                        System.out.println("[download-sequential] Got previous hash: "
+                                + HexFormat.of().formatHex(currentHash).substring(0, 16) + "...");
+                    } catch (Exception e) {
+                        System.err.println(
+                                "[download-sequential] Warning: Could not fetch previous hash: " + e.getMessage());
+                    }
+                }
+
+                // Step 5: Download one block
+                ListingRecordFile mostCommonRecord =
+                        RecordFileUtils.findMostCommonByType(group, ListingRecordFile.Type.RECORD);
+                ListingRecordFile[] mostCommonSidecars = RecordFileUtils.findMostCommonSidecars(group);
+                List<ListingRecordFile> orderedFiles =
+                        DownloadDayLiveImpl.computeFilesToDownload(mostCommonRecord, mostCommonSidecars, group);
+
+                Set<ListingRecordFile> mostCommonFilesSet = new HashSet<>();
+                if (mostCommonRecord != null) mostCommonFilesSet.add(mostCommonRecord);
+                ListingRecordFile mostCommonSidecarSingle =
+                        RecordFileUtils.findMostCommonByType(group, ListingRecordFile.Type.RECORD_SIDECAR);
+                if (mostCommonSidecarSingle != null) mostCommonFilesSet.add(mostCommonSidecarSingle);
+
+                List<InMemoryFile> inMemoryFiles = new ArrayList<>();
+                for (ListingRecordFile lr : orderedFiles) {
+                    String blobName = netConfig.bucketPathPrefix() + lr.path();
+                    try {
+                        InMemoryFile downloadedFile = downloadManager
+                                .downloadAsync(netConfig.gcsBucketName(), blobName)
+                                .join();
+
+                        String filename = lr.path().substring(lr.path().lastIndexOf('/') + 1);
+
+                        boolean md5Valid = checkMd5(lr.md5Hex(), downloadedFile.data());
+                        if (!md5Valid) {
+                            System.err.println("[download-sequential] MD5 mismatch for " + lr.path() + ", skipping");
+                            continue;
+                        }
+
+                        byte[] contentBytes = downloadedFile.data();
+                        if (filename.endsWith(".gz")) {
+                            contentBytes = Gzip.ungzipInMemory(contentBytes);
+                            filename = filename.replaceAll("\\.gz$", "");
+                        }
+
+                        Path newFilePath = DownloadDayLiveImpl.computeNewFilePath(lr, mostCommonFilesSet, filename);
+                        inMemoryFiles.add(new InMemoryFile(newFilePath, contentBytes));
+                    } catch (CompletionException ce) {
+                        System.err.println(
+                                "[download-sequential] Download failed for " + blobName + ": " + ce.getMessage());
+                        throw new IllegalStateException("Download failed for block " + nextBlockNumber, ce.getCause());
+                    }
+                }
+
+                // Step 6: Validate hash chain
+                byte[] newHash =
+                        DownloadDayLiveImpl.validateBlockHashes(nextBlockNumber, inMemoryFiles, currentHash, null);
+
+                // Validate signatures
+                DownloadDayLiveImpl.BlockDownloadResult result =
+                        new DownloadDayLiveImpl.BlockDownloadResult(nextBlockNumber, inMemoryFiles, newHash);
+                Instant recordFileTime = blockTime.atZone(ZoneOffset.UTC).toInstant();
+                boolean valid = fullBlockValidate(addressBookRegistry, currentHash, recordFileTime, result, null);
+                if (!valid) {
+                    throw new IllegalStateException(
+                            "Full block validation failed for block " + nextBlockNumber + " — aborting");
+                }
+
+                // Step 7: Assert sequential ordering
+                if (nextBlockNumber != currentBlockNumber + 1) {
+                    throw new IllegalStateException(
+                            "Block gap detected: expected " + (currentBlockNumber + 1) + " but got " + nextBlockNumber);
+                }
+
+                // Step 8: Write to tar.zstd archive
+                for (InMemoryFile file : inMemoryFiles) {
+                    currentDayWriter.putEntry(file);
+                }
+
+                // Step 9: Queue for wrapping
+                queue.put(new ValidatedBlock(nextBlockNumber, recordFileTime, inMemoryFiles, newHash));
+
+                // Step 10: Update state
+                currentBlockNumber = nextBlockNumber;
+                currentHash = newHash;
+                blocksProcessedTotal++;
+                blocksProcessedToday++;
+
+                // Save state every block
+                saveState(new State(currentBlockNumber, currentHash, recordFileTime, currentDay));
+
+                // Progress logging
+                if (blocksProcessedTotal % PROGRESS_LOG_INTERVAL == 0) {
+                    long elapsed = System.currentTimeMillis() - dayStartTime;
+                    double blocksPerSec = blocksProcessedToday / Math.max(1.0, elapsed / 1000.0);
+                    System.out.println("[download-sequential] Block " + currentBlockNumber + " (" + blocksProcessedToday
+                            + " today, " + String.format("%.1f", blocksPerSec) + " blocks/sec)");
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            System.out.println("[download-sequential] Interrupted, saving state...");
+        } finally {
+            if (currentHash != null) {
+                try {
+                    LocalDateTime finalBlockTime = blockTimeReader.getBlockLocalDateTime(currentBlockNumber);
+                    Instant finalRecordTime =
+                            finalBlockTime.atZone(ZoneOffset.UTC).toInstant();
+                    saveState(new State(currentBlockNumber, currentHash, finalRecordTime, currentDay));
+                    System.out.println("[download-sequential] Saved state at block " + currentBlockNumber);
+                } catch (Exception e) {
+                    System.err.println("[download-sequential] Error saving final state: " + e.getMessage());
+                }
+            }
+            if (currentDayWriter != null) {
+                try {
+                    currentDayWriter.close();
+                } catch (Exception e) {
+                    System.err.println("[download-sequential] Error closing writer: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Wrap+validate consumer thread. Takes downloaded blocks from the queue, wraps them into
+     * block stream format, and runs all 11 BlockValidation checks.
+     */
+    private void runWrapAndValidateThread(BlockingQueue<ValidatedBlock> queue, AddressBookRegistry addressBookRegistry)
+            throws Exception {
+
+        // Initialize wrapping state
+        final Path hashRegistryPath = wrapOutputDir.resolve("blockStreamBlockHashes.bin");
+        final Path streamingMerkleTreeFile = wrapOutputDir.resolve("streamingMerkleTree.bin");
+        final Path watermarkFile = wrapOutputDir.resolve("wrap-commit.bin");
+        final Path addressBookFile = wrapOutputDir.resolve("addressBookHistory.json");
+        final Path checkpointDir = wrapOutputDir.resolve("validateCheckpoint");
+
+        Files.createDirectories(wrapOutputDir);
+        Files.createDirectories(checkpointDir);
+
+        // Copy address book to wrap output if needed
+        if (!Files.exists(addressBookFile) && addressBookPath != null && Files.exists(addressBookPath)) {
+            Files.copy(addressBookPath, addressBookFile);
+        }
+
+        final AmendmentProvider amendmentProvider =
+                createAmendmentProvider(NetworkConfig.current().networkName());
+
+        try (BlockStreamBlockHashRegistry blockRegistry = new BlockStreamBlockHashRegistry(hashRegistryPath)) {
+
+            // Load watermark and reconcile
+            long watermark = loadWatermark(watermarkFile);
+            long registryHighest = blockRegistry.highestBlockNumberStored();
+
+            if (watermark >= 0 && registryHighest > watermark) {
+                System.out.println(
+                        "[WRAP] Registry at " + registryHighest + " but watermark at " + watermark + "; truncating.");
+                blockRegistry.truncateTo(watermark);
+            } else if (watermark < 0 && registryHighest >= 0) {
+                watermark = registryHighest;
+            }
+
+            long effectiveHighest = blockRegistry.highestBlockNumberStored();
+
+            // Mid-zip resume: back up to zip range start if needed
+            if (effectiveHighest >= 0) {
+                long zipRangeFirst = BlockWriter.zipRangeFirstBlock(effectiveHighest, DEFAULT_POWERS_OF_TEN_PER_ZIP);
+                long blocksPerZip = (long) Math.pow(10, DEFAULT_POWERS_OF_TEN_PER_ZIP);
+                long zipRangeLast = zipRangeFirst + blocksPerZip - 1;
+                if (effectiveHighest < zipRangeLast) {
+                    long truncateTo = zipRangeFirst - 1;
+                    System.out.println("[WRAP] Mid-zip resume: truncating to " + truncateTo);
+                    BlockPath partialZipPath = BlockWriter.computeBlockPath(
+                            wrapOutputDir, effectiveHighest, BlockArchiveType.UNCOMPRESSED_ZIP);
+                    Files.deleteIfExists(partialZipPath.zipFilePath());
+                    blockRegistry.truncateTo(truncateTo);
+                    saveWatermark(watermarkFile, truncateTo);
+                    effectiveHighest = blockRegistry.highestBlockNumberStored();
+                }
+            }
+
+            System.out.println("[WRAP] Starting from block: " + effectiveHighest);
+
+            // Create streaming hasher and replay from registry
+            final StreamingHasher streamingHasher = new StreamingHasher();
+            if (effectiveHighest >= 0) {
+                System.out.println("[WRAP] Replaying " + (effectiveHighest + 1) + " block hashes into hasher");
+                for (long bn = 0; bn <= effectiveHighest; bn++) {
+                    byte[] hash = blockRegistry.getBlockHash(bn);
+                    streamingHasher.addNodeByHash(hash);
+                }
+                System.out.println("[WRAP] Hasher replay complete. leafCount=" + streamingHasher.leafCount());
+            }
+
+            // Build validation list (same as ValidateBlocksCommand)
+            BlockChainValidation chainValidation = new BlockChainValidation();
+            HistoricalBlockTreeValidation treeValidation = new HistoricalBlockTreeValidation(chainValidation);
+            HbarSupplyValidation supplyValidation = new HbarSupplyValidation();
+
+            List<BlockValidation> parallelValidations = new ArrayList<>();
+            parallelValidations.add(new RequiredItemsValidation());
+            parallelValidations.add(new BlockStructureValidation());
+            SignatureValidation signatureValidation = new SignatureValidation(addressBookRegistry);
+            parallelValidations.add(signatureValidation);
+
+            List<BlockValidation> sequentialValidations = new ArrayList<>();
+            sequentialValidations.add(new AddressBookUpdateValidation(addressBookRegistry));
+            sequentialValidations.add(chainValidation);
+            sequentialValidations.add(treeValidation);
+            sequentialValidations.add(supplyValidation);
+            sequentialValidations.add(new HashRegistryValidation(blockRegistry, chainValidation));
+            sequentialValidations.add(new StreamingMerkleTreeValidation(streamingMerkleTreeFile, treeValidation));
+            Path jumpstartPath = wrapOutputDir.resolve("jumpstart.bin");
+            sequentialValidations.add(new JumpstartValidation(jumpstartPath, treeValidation, blockRegistry));
+
+            List<BlockValidation> allValidations = new ArrayList<>();
+            allValidations.addAll(parallelValidations);
+            allValidations.addAll(sequentialValidations);
+
+            // Filter out genesis-required validations when not starting from block 0
+            boolean startingFromGenesis = (effectiveHighest < 0);
+            if (!startingFromGenesis) {
+                // Try to load checkpoint state
+                boolean hasCheckpoint = false;
+                try {
+                    Path progressFile = checkpointDir.resolve("validateProgress.json");
+                    if (Files.exists(progressFile)) {
+                        for (BlockValidation v : allValidations) {
+                            try {
+                                v.load(checkpointDir);
+                            } catch (Exception e) {
+                                System.err.println(
+                                        "[WRAP] Warning: could not load " + v.name() + " state: " + e.getMessage());
+                            }
+                        }
+                        hasCheckpoint = true;
+                    }
+                } catch (Exception e) {
+                    System.err.println("[WRAP] Warning: could not load checkpoint: " + e.getMessage());
+                }
+
+                if (!hasCheckpoint) {
+                    List<BlockValidation> genesisSkipped = new ArrayList<>();
+                    sequentialValidations.removeIf(v -> {
+                        if (v.requiresGenesisStart()) {
+                            genesisSkipped.add(v);
+                            return true;
+                        }
+                        return false;
+                    });
+                    allValidations.removeIf(genesisSkipped::contains);
+                    for (BlockValidation skipped : genesisSkipped) {
+                        System.out.println("[WRAP] Skipping: " + skipped.name() + " (requires genesis start)");
+                    }
+                }
+            }
+
+            // Zip writing state
+            BlockZipAppender currentZip = null;
+            Path currentZipPath = null;
+            long durableWatermark = watermark;
+            long blocksSinceWatermarkFlush = 0;
+            long blocksValidated = 0;
+            long lastCheckpointSaveMs = System.currentTimeMillis();
+
+            try {
+                while (true) {
+                    ValidatedBlock vb = queue.take();
+                    if (vb == POISON_PILL) {
+                        break;
+                    }
+
+                    long blockNum = vb.blockNumber();
+
+                    // Skip if already wrapped
+                    if (blockNum <= effectiveHighest) {
+                        continue;
+                    }
+
+                    // Classify files and build UnparsedRecordBlock
+                    DownloadDayLiveImpl.BlockDownloadResult downloadResult =
+                            new DownloadDayLiveImpl.BlockDownloadResult(blockNum, vb.files(), vb.runningHash());
+                    InMemoryFile primaryRecord = findPrimaryRecord(downloadResult);
+                    List<InMemoryFile> signatures = findSignatures(downloadResult);
+                    List<InMemoryFile> sidecars = findSidecars(downloadResult, primaryRecord);
+
+                    if (primaryRecord == null) {
+                        throw new IllegalStateException("No primary record found for block " + blockNum);
+                    }
+
+                    UnparsedRecordBlock unparsedBlock = UnparsedRecordBlock.newInMemoryBlock(
+                            vb.recordFileTime(), primaryRecord, List.of(), signatures, sidecars, List.of());
+
+                    // Parse and verify signatures
+                    ParsedRecordBlock parsedBlock = unparsedBlock.parse();
+                    NodeAddressBook ab = addressBookRegistry.getAddressBookForBlock(parsedBlock.blockTime());
+                    byte[] signedHash = parsedBlock.recordFile().signedHash();
+                    List<RecordFileSignature> verifiedSigs = parsedBlock.signatureFiles().stream()
+                            .filter(psf -> psf.isValid(signedHash, ab))
+                            .map(psf -> psf.toRecordFileSignature(ab))
+                            .toList();
+
+                    PreVerifiedBlock preVerified = new PreVerifiedBlock(parsedBlock, ab, verifiedSigs);
+
+                    // Address book auto-update
+                    try {
+                        preVerified = updateAddressBookAndReverify(preVerified, blockNum, addressBookRegistry);
+                    } catch (Exception e) {
+                        System.err.printf(
+                                "[WRAP] Warning: address book auto-update failed at block %d: %s%n", blockNum, e);
+                    }
+
+                    // Convert to wrapped block
+                    Block wrapped = RecordBlockConverter.toBlock(
+                            preVerified,
+                            blockNum,
+                            blockRegistry.mostRecentBlockHash(),
+                            streamingHasher.computeRootHash(),
+                            amendmentProvider);
+
+                    // Hash and update chain state
+                    byte[] blockStreamBlockHash = hashBlock(wrapped);
+                    streamingHasher.addNodeByHash(blockStreamBlockHash);
+                    blockRegistry.addBlock(blockNum, blockStreamBlockHash);
+
+                    // Compute block path and write to zip
+                    BlockPath blockPath =
+                            BlockWriter.computeBlockPath(wrapOutputDir, blockNum, BlockArchiveType.UNCOMPRESSED_ZIP);
+                    Files.createDirectories(blockPath.dirPath());
+
+                    byte[] serializedBytes = BlockWriter.serializeBlockToBytes(wrapped, DEFAULT_COMPRESSION);
+
+                    // Switch zip file if needed
+                    if (!blockPath.zipFilePath().equals(currentZipPath)) {
+                        if (currentZip != null) {
+                            currentZip.close();
+                            saveWatermark(watermarkFile, durableWatermark);
+                            blocksSinceWatermarkFlush = 0;
+                        }
+                        currentZip = BlockWriter.openZipForAppend(blockPath.zipFilePath());
+                        currentZipPath = blockPath.zipFilePath();
+                    }
+                    BlockWriter.writeBlockEntry(currentZip, blockPath, serializedBytes);
+
+                    durableWatermark = blockNum;
+                    blocksSinceWatermarkFlush++;
+                    if (blocksSinceWatermarkFlush >= WATERMARK_BATCH_SIZE) {
+                        saveWatermark(watermarkFile, durableWatermark);
+                        blocksSinceWatermarkFlush = 0;
+                    }
+
+                    // Run BlockValidation checks
+                    // Convert Block to BlockUnparsed for validation
+                    Bytes wrappedBytes = Block.PROTOBUF.toBytes(wrapped);
+                    BlockUnparsed blockUnparsed = BlockUnparsed.PROTOBUF.parse(wrappedBytes);
+
+                    // Phase 1: Parallel validations
+                    for (BlockValidation v : parallelValidations) {
+                        try {
+                            v.validate(blockUnparsed, blockNum);
+                        } catch (ValidationException e) {
+                            throw new IllegalStateException(
+                                    "Validation '" + v.name() + "' failed at block " + blockNum + ": " + e.getMessage(),
+                                    e);
+                        }
+                    }
+
+                    // Phase 2: Sequential validations
+                    for (BlockValidation v : sequentialValidations) {
+                        try {
+                            v.validate(blockUnparsed, blockNum);
+                        } catch (ValidationException e) {
+                            // Save checkpoint before failing
+                            saveValidationCheckpoint(
+                                    checkpointDir, blocksValidated, blockNum - 1, chainValidation, allValidations);
+                            throw new IllegalStateException(
+                                    "Validation '" + v.name() + "' failed at block " + blockNum + ": " + e.getMessage(),
+                                    e);
+                        }
+                    }
+
+                    // Phase 3: Commit state for all validations
+                    for (BlockValidation v : allValidations) {
+                        v.commitState(blockUnparsed, blockNum);
+                    }
+
+                    blocksValidated++;
+
+                    // Periodic checkpoint save
+                    long nowMs = System.currentTimeMillis();
+                    if (nowMs - lastCheckpointSaveMs >= 60_000L) {
+                        saveValidationCheckpoint(
+                                checkpointDir, blocksValidated, blockNum, chainValidation, allValidations);
+                        lastCheckpointSaveMs = nowMs;
+                    }
+
+                    // Progress
+                    if (blocksValidated % PROGRESS_LOG_INTERVAL == 0) {
+                        System.out.println("[WRAP] Wrapped + validated block " + blockNum + " (" + blocksValidated
+                                + " total, sigs=" + verifiedSigs.size() + ")");
+                    }
+                }
+            } finally {
+                // Close zip and save state
+                if (currentZip != null) {
+                    try {
+                        currentZip.close();
+                    } catch (IOException e) {
+                        System.err.println("[WRAP] Error closing zip: " + e.getMessage());
+                    }
+                }
+                saveWatermark(watermarkFile, durableWatermark);
+                saveStateCheckpoint(streamingMerkleTreeFile, streamingHasher);
+                addressBookRegistry.saveAddressBookRegistryToJsonFile(addressBookFile);
+
+                // Save validation checkpoint
+                saveValidationCheckpoint(
+                        checkpointDir, blocksValidated, durableWatermark, chainValidation, allValidations);
+
+                // Close all validations
+                for (BlockValidation v : allValidations) {
+                    v.close();
+                }
+
+                System.out.println("[WRAP] Shutdown complete. Wrapped " + blocksValidated + " blocks.");
+            }
+        }
+    }
+
+    /**
+     * Saves validation checkpoint state.
+     */
+    private static void saveValidationCheckpoint(
+            Path checkpointDir,
+            long blocksValidated,
+            long lastValidatedBlockNumber,
+            BlockChainValidation chainValidation,
+            List<BlockValidation> validations) {
+        try {
+            Files.createDirectories(checkpointDir);
+            for (BlockValidation v : validations) {
+                try {
+                    v.save(checkpointDir);
+                } catch (Exception e) {
+                    System.err.println("[WRAP] Warning: could not save " + v.name() + " state: " + e.getMessage());
+                }
+            }
+        } catch (IOException e) {
+            System.err.println("[WRAP] Warning: could not create checkpoint directory: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Address book auto-update logic, copied from ToWrappedBlocksCommand.
+     */
+    private static PreVerifiedBlock updateAddressBookAndReverify(
+            PreVerifiedBlock preVerified, long blockNum, AddressBookRegistry addressBookRegistry) {
+        var streamItems =
+                preVerified.recordBlock().recordFile().recordStreamFile().recordStreamItems();
+        List<Transaction> transactions = new ArrayList<>();
+        for (var rsi : streamItems) {
+            if (rsi.hasTransaction()) {
+                transactions.add(rsi.transactionOrThrow());
+            }
+        }
+
+        if (!transactions.isEmpty()) {
+            try {
+                var addressBookTxns = AddressBookRegistry.filterToJustAddressBookTransactions(transactions);
+                if (!addressBookTxns.isEmpty()) {
+                    Instant blockInstant = preVerified.recordBlock().blockTime();
+                    String changes = addressBookRegistry.updateAddressBook(blockInstant.plusNanos(1), addressBookTxns);
+                    if (changes != null) {
+                        System.out.println("[WRAP] Address book updated at block " + blockNum + ": " + changes);
+                    }
+                }
+            } catch (Exception e) {
+                // Don't fail for address book parse errors
+            }
+        }
+
+        // Check if address book used in verification is stale
+        NodeAddressBook currentBook = addressBookRegistry.getAddressBookForBlock(
+                preVerified.recordBlock().blockTime());
+        if (!currentBook.equals(preVerified.addressBook())) {
+            byte[] signedHash = preVerified.recordBlock().recordFile().signedHash();
+            List<RecordFileSignature> reverifiedSigs = preVerified.recordBlock().signatureFiles().stream()
+                    .filter(psf -> psf.isValid(signedHash, currentBook))
+                    .map(psf -> psf.toRecordFileSignature(currentBook))
+                    .toList();
+            System.out.printf(
+                    "[WRAP] Block %d: re-verified signatures with updated address book: %d verified (was %d)%n",
+                    blockNum,
+                    reverifiedSigs.size(),
+                    preVerified.verifiedSignatures().size());
+            return new PreVerifiedBlock(preVerified.recordBlock(), currentBook, reverifiedSigs);
+        }
+
+        return preVerified;
+    }
+
+    /**
+     * Refreshes GCS listings for a specific day.
+     */
+    private void refreshListingsForDay(LocalDate day, NetworkConfig netConfig) {
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        boolean isToday = day.equals(today);
+
+        UpdateDayListingsCommand.updateDayListings(
+                listingDir.toPath(),
+                CACHE_DIR.toPath(),
+                true,
+                netConfig.minNodeAccountId(),
+                netConfig.maxNodeAccountId(),
+                DownloadConstants.GCP_PROJECT_ID);
+
+        UpdateDayListingsCommand.updateListingsForSingleDay(
+                listingDir.toPath(),
+                CACHE_DIR.toPath(),
+                !isToday,
+                netConfig.minNodeAccountId(),
+                netConfig.maxNodeAccountId(),
+                DownloadConstants.GCP_PROJECT_ID,
+                day);
+    }
+
+    /**
+     * Saves state to JSON file.
+     */
+    private void saveState(State state) {
+        try {
+            Path parentDir = stateJsonPath.getParent();
+            if (parentDir != null && !Files.exists(parentDir)) {
+                Files.createDirectories(parentDir);
+            }
+            String json = GSON.toJson(state);
+            Files.writeString(stateJsonPath, json, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            System.err.println("[download-sequential] Warning: Failed to save state: " + e.getMessage());
+        }
+    }
+
+    /** Load the durable commit watermark from the given file. */
+    private static long loadWatermark(Path watermarkFile) {
+        if (!Files.exists(watermarkFile)) {
+            return -1;
+        }
+        try {
+            byte[] bytes = Files.readAllBytes(watermarkFile);
+            if (bytes.length < Long.BYTES) {
+                return -1;
+            }
+            return ByteBuffer.wrap(bytes).getLong();
+        } catch (IOException e) {
+            System.err.println("Warning: could not read watermark file: " + e.getMessage());
+            return -1;
+        }
+    }
+
+    /** Save the durable commit watermark atomically (write to .tmp, then rename). */
+    private static void saveWatermark(Path watermarkFile, long blockNumber) {
+        if (blockNumber < 0) {
+            return;
+        }
+        Path tmpFile = watermarkFile.resolveSibling(watermarkFile.getFileName() + ".tmp");
+        try {
+            byte[] bytes = ByteBuffer.allocate(Long.BYTES).putLong(blockNumber).array();
+            Files.write(tmpFile, bytes, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            Files.move(tmpFile, watermarkFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            System.err.println("Warning: could not save watermark: " + e.getMessage());
+        }
+    }
+
+    private static String formatDuration(long seconds) {
+        if (seconds < 60) {
+            return seconds + "s";
+        } else if (seconds < 3600) {
+            return String.format("%dm %ds", seconds / 60, seconds % 60);
+        } else if (seconds < 86400) {
+            return String.format("%dh %dm", seconds / 3600, (seconds % 3600) / 60);
+        } else {
+            return String.format("%dd %dh", seconds / 86400, (seconds % 86400) / 3600);
+        }
+    }
+}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -190,8 +190,47 @@ public class LiveSequential implements Runnable {
             long blockNumber, Instant recordFileTime, List<InMemoryFile> files, byte[] runningHash) {}
 
     @Override
-    @SuppressWarnings({"PMD.NPathComplexity", "PMD.ExcessiveMethodLength"})
     public void run() {
+        logConfiguration();
+        try {
+            initializeDirectoriesAndDefaults();
+            final AddressBookRegistry addressBookRegistry =
+                    addressBookPath != null ? new AddressBookRegistry(addressBookPath) : new AddressBookRegistry();
+            final Storage storage = StorageOptions.http()
+                    .setProjectId(DownloadConstants.GCP_PROJECT_ID)
+                    .build()
+                    .getService();
+            final ConcurrentDownloadManagerVirtualThreadsV3 downloadManager =
+                    ConcurrentDownloadManagerVirtualThreadsV3.newBuilder(storage)
+                            .setMaxConcurrency(16)
+                            .build();
+            final BlockTimeReader blockTimeReader = new BlockTimeReader();
+            final State initialState = determineStartingPoint(blockTimeReader);
+            logStartingPoint(initialState);
+
+            final BlockingQueue<ValidatedBlock> queue = new LinkedBlockingQueue<>(32);
+            final AtomicReference<Throwable> wrapError = new AtomicReference<>(null);
+            final Thread wrapThread = startWrapThread(queue, addressBookRegistry, wrapError);
+            addShutdownHook(downloadManager);
+
+            processBlocksSequentially(
+                    initialState, addressBookRegistry, downloadManager, blockTimeReader, queue, wrapError);
+
+            queue.put(POISON_PILL);
+            wrapThread.join(60_000);
+            Throwable wrapErr = wrapError.get();
+            if (wrapErr != null) {
+                throw new IllegalStateException("Wrap+validate thread failed", wrapErr);
+            }
+            System.out.println("[live-sequential] Complete.");
+        } catch (Exception e) {
+            System.err.println("[live-sequential] Fatal error: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    private void logConfiguration() {
         System.out.println("[live-sequential] Starting sequential block download with inline wrapping + validation");
         System.out.println("Configuration:");
         System.out.println("  listingDir=" + listingDir);
@@ -200,101 +239,61 @@ public class LiveSequential implements Runnable {
         System.out.println("  stateJsonPath=" + stateJsonPath);
         System.out.println("  addressBookPath=" + addressBookPath);
         System.out.println("  startDate=" + (startDate != null ? startDate : "(auto-detect)"));
+    }
 
-        try {
-            // Create directories
-            Files.createDirectories(outputDir.toPath());
-            Files.createDirectories(wrapOutputDir);
-
-            // Set default state file path
-            if (stateJsonPath == null) {
-                stateJsonPath = outputDir.toPath().resolve("validateCmdStatus.json");
-            }
-            if (stateJsonPath.getParent() != null) {
-                Files.createDirectories(stateJsonPath.getParent());
-            }
-
-            // Initialize address book
-            final AddressBookRegistry addressBookRegistry =
-                    addressBookPath != null ? new AddressBookRegistry(addressBookPath) : new AddressBookRegistry();
-
-            // Use HTTP transport for stability
-            final Storage storage = StorageOptions.http()
-                    .setProjectId(DownloadConstants.GCP_PROJECT_ID)
-                    .build()
-                    .getService();
-
-            final ConcurrentDownloadManagerVirtualThreadsV3 downloadManager =
-                    ConcurrentDownloadManagerVirtualThreadsV3.newBuilder(storage)
-                            .setMaxConcurrency(16)
-                            .build();
-
-            final BlockTimeReader blockTimeReader = new BlockTimeReader();
-
-            // Stats CSV
-            if (statsCsvPath == null) {
-                statsCsvPath = outputDir.toPath().resolve("signature_statistics.csv");
-            }
-
-            // Determine starting point
-            final State initialState = determineStartingPoint(blockTimeReader);
-            System.out.println("[live-sequential] Starting from block " + initialState.blockNumber
-                    + " hash["
-                    + (initialState.endRunningHashHex != null
-                            ? initialState.endRunningHashHex.substring(
-                                    0, Math.min(8, initialState.endRunningHashHex.length()))
-                            : "null")
-                    + "]"
-                    + " day=" + initialState.dayDate);
-
-            // Create producer-consumer queue
-            final BlockingQueue<ValidatedBlock> queue = new LinkedBlockingQueue<>(32);
-            final AtomicReference<Throwable> wrapError = new AtomicReference<>(null);
-
-            // Start wrap+validate thread
-            final Thread wrapThread = new Thread(
-                    () -> {
-                        try {
-                            runWrapAndValidateThread(queue, addressBookRegistry);
-                        } catch (Throwable t) {
-                            wrapError.set(t);
-                            System.err.println("[WRAP] Fatal error in wrap+validate thread: " + t.getMessage());
-                            t.printStackTrace();
-                        }
-                    },
-                    "wrap-validate-thread");
-            wrapThread.setDaemon(true);
-            wrapThread.start();
-
-            // Add shutdown hook
-            Runtime.getRuntime()
-                    .addShutdownHook(new Thread(
-                            () -> {
-                                System.out.println("[live-sequential] Shutdown requested...");
-                                downloadManager.close();
-                            },
-                            "live-sequential-shutdown"));
-
-            // Main download loop
-            processBlocksSequentially(
-                    initialState, addressBookRegistry, downloadManager, blockTimeReader, queue, wrapError);
-
-            // Signal wrap thread to exit and wait
-            queue.put(POISON_PILL);
-            wrapThread.join(60_000);
-
-            // Check for wrap errors
-            Throwable wrapErr = wrapError.get();
-            if (wrapErr != null) {
-                throw new IllegalStateException("Wrap+validate thread failed", wrapErr);
-            }
-
-            System.out.println("[live-sequential] Complete.");
-        } catch (Exception e) {
-            System.err.println("[live-sequential] Fatal error: " + e.getMessage());
-            e.printStackTrace();
-            System.exit(1);
+    private void initializeDirectoriesAndDefaults() throws IOException {
+        Files.createDirectories(outputDir.toPath());
+        Files.createDirectories(wrapOutputDir);
+        if (stateJsonPath == null) {
+            stateJsonPath = outputDir.toPath().resolve("validateCmdStatus.json");
         }
+        if (stateJsonPath.getParent() != null) {
+            Files.createDirectories(stateJsonPath.getParent());
+        }
+        if (statsCsvPath == null) {
+            statsCsvPath = outputDir.toPath().resolve("signature_statistics.csv");
+        }
+    }
+
+    private static void logStartingPoint(State initialState) {
+        System.out.println("[live-sequential] Starting from block " + initialState.blockNumber
+                + " hash["
+                + (initialState.endRunningHashHex != null
+                        ? initialState.endRunningHashHex.substring(
+                                0, Math.min(8, initialState.endRunningHashHex.length()))
+                        : "null")
+                + "]"
+                + " day=" + initialState.dayDate);
+    }
+
+    private Thread startWrapThread(
+            BlockingQueue<ValidatedBlock> queue,
+            AddressBookRegistry addressBookRegistry,
+            AtomicReference<Throwable> wrapError) {
+        final Thread wrapThread = new Thread(
+                () -> {
+                    try {
+                        runWrapAndValidateThread(queue, addressBookRegistry);
+                    } catch (Throwable t) {
+                        wrapError.set(t);
+                        System.err.println("[WRAP] Fatal error in wrap+validate thread: " + t.getMessage());
+                        t.printStackTrace();
+                    }
+                },
+                "wrap-validate-thread");
+        wrapThread.setDaemon(true);
+        wrapThread.start();
+        return wrapThread;
+    }
+
+    private static void addShutdownHook(ConcurrentDownloadManagerVirtualThreadsV3 downloadManager) {
+        Runtime.getRuntime()
+                .addShutdownHook(new Thread(
+                        () -> {
+                            System.out.println("[live-sequential] Shutdown requested...");
+                            downloadManager.close();
+                        },
+                        "live-sequential-shutdown"));
     }
 
     /**
@@ -420,8 +419,7 @@ public class LiveSequential implements Runnable {
      * Main sequential download loop. Downloads one block at a time, validates, writes to tar.zstd,
      * and queues for wrapping.
      */
-    @SuppressWarnings({"PMD.NPathComplexity", "PMD.CyclomaticComplexity", "PMD.ExcessiveMethodLength"
-    }) // Pipeline orchestration — splitting would scatter sequential logic
+    @SuppressWarnings("PMD.NPathComplexity")
     private void processBlocksSequentially(
             State initialState,
             AddressBookRegistry addressBookRegistry,
@@ -435,27 +433,21 @@ public class LiveSequential implements Runnable {
         byte[] currentHash = initialState.getHashBytes();
         LocalDate currentDay = initialState.getDayDate();
         BlockTimeReader blockTimeReader = initialBlockTimeReader;
-
         ConcurrentTarZstdWriter currentDayWriter = null;
         long blocksProcessedTotal = 0;
         long blocksProcessedToday = 0;
         long dayStartTime = System.currentTimeMillis();
         long lastBlockTimeRefreshMs = 0;
-
-        // Cache for listing files - reload only when day changes
         List<ListingRecordFile> cachedListingFiles = null;
         LocalDate cachedListingDay = null;
-
         final NetworkConfig netConfig = NetworkConfig.current();
 
         try {
             while (true) {
-                // Check for wrap thread errors
                 Throwable wrapErr = wrapError.get();
                 if (wrapErr != null) {
                     throw new IllegalStateException("Wrap+validate thread failed, stopping download", wrapErr);
                 }
-
                 long nextBlockNumber = currentBlockNumber + 1;
 
                 // Step 1: Get block timestamp
@@ -475,43 +467,22 @@ public class LiveSequential implements Runnable {
                     Thread.sleep(LIVE_POLL_INTERVAL.toMillis());
                     continue;
                 }
-
                 LocalDate blockDay = blockTime.toLocalDate();
 
                 // Step 2: Handle day boundary
                 if (!blockDay.equals(currentDay)) {
-                    if (currentDayWriter != null) {
-                        currentDayWriter.close();
-                        currentDayWriter = null;
-                        System.out.println("[live-sequential] Day completed: " + currentDay + " ("
-                                + blocksProcessedToday + " blocks in "
-                                + formatDuration((System.currentTimeMillis() - dayStartTime) / 1000) + ")");
-                    }
-
-                    // Start new day
+                    closeDayWriter(currentDayWriter, currentDay, blocksProcessedToday, dayStartTime);
+                    currentDayWriter = openDayWriterIfNeeded(blockDay);
                     currentDay = blockDay;
                     blocksProcessedToday = 0;
                     dayStartTime = System.currentTimeMillis();
                     cachedListingFiles = null;
                     cachedListingDay = null;
-
-                    // Only create tar writer if archive doesn't already exist
-                    Path dayArchive = outputDir.toPath().resolve(currentDay + ".tar.zstd");
-                    if (Files.exists(dayArchive)) {
-                        System.out.println(
-                                "[live-sequential] Day archive already exists, skipping tar writes: " + currentDay);
-                    } else {
-                        currentDayWriter = new ConcurrentTarZstdWriter(dayArchive);
-                    }
-
                     System.out.println("[live-sequential] Started new day: " + currentDay);
                 }
-
-                // Initialize writer if needed (first block, no day boundary crossed yet)
                 if (currentDayWriter == null && currentDay != null) {
-                    Path dayArchive = outputDir.toPath().resolve(currentDay + ".tar.zstd");
-                    if (!Files.exists(dayArchive)) {
-                        currentDayWriter = new ConcurrentTarZstdWriter(dayArchive);
+                    currentDayWriter = openDayWriterIfNeeded(currentDay);
+                    if (currentDayWriter != null) {
                         dayStartTime = System.currentTimeMillis();
                         System.out.println("[live-sequential] Started day: " + currentDay);
                     }
@@ -519,49 +490,18 @@ public class LiveSequential implements Runnable {
 
                 // Step 3: Load GCS listings if day changed
                 if (!blockDay.equals(cachedListingDay)) {
-                    int year = blockTime.getYear();
-                    int month = blockTime.getMonthValue();
-                    int day = blockTime.getDayOfMonth();
-
-                    int attempt = 0;
-                    while (true) {
-                        attempt++;
-                        refreshListingsForDay(blockDay, netConfig);
-                        try {
-                            cachedListingFiles =
-                                    DayListingFileReader.loadRecordsFileForDay(listingDir.toPath(), year, month, day);
-                            cachedListingDay = blockDay;
-                            System.out.println("[live-sequential] Loaded " + cachedListingFiles.size()
-                                    + " listing entries for " + blockDay);
-                            break;
-                        } catch (NoSuchFileException e) {
-                            System.out.println("[live-sequential] Listings not available yet for " + blockDay
-                                    + ", waiting 15 minutes... (attempt " + attempt + ")");
-                            Thread.sleep(15 * 60 * 1000);
-                        }
-                    }
+                    cachedListingFiles = loadListingsWithRetry(blockDay, blockTime, netConfig);
+                    cachedListingDay = blockDay;
                 }
 
-                // Step 4: Find files for this block
-                Map<LocalDateTime, List<ListingRecordFile>> filesByBlock =
-                        cachedListingFiles.stream().collect(Collectors.groupingBy(ListingRecordFile::timestamp));
-
-                List<ListingRecordFile> group = filesByBlock.get(blockTime);
-                if (group == null || group.isEmpty()) {
-                    // Refresh listings and retry
+                // Step 4: Find files for this block (refresh if not found)
+                List<ListingRecordFile> group = findBlockGroup(blockTime, cachedListingFiles);
+                if (group == null) {
                     refreshListingsForDay(blockDay, netConfig);
-                    cachedListingFiles = DayListingFileReader.loadRecordsFileForDay(
-                            listingDir.toPath(),
-                            blockTime.getYear(),
-                            blockTime.getMonthValue(),
-                            blockTime.getDayOfMonth());
+                    cachedListingFiles = reloadListings(blockTime);
                     cachedListingDay = blockDay;
-                    filesByBlock =
-                            cachedListingFiles.stream().collect(Collectors.groupingBy(ListingRecordFile::timestamp));
-                    group = filesByBlock.get(blockTime);
-
-                    if (group == null || group.isEmpty()) {
-                        // Try fixing block time
+                    group = findBlockGroup(blockTime, cachedListingFiles);
+                    if (group == null) {
                         System.out.println("[live-sequential] No files found for block " + nextBlockNumber + " at time "
                                 + blockTime + ", fixing block times...");
                         FixBlockTime.fixBlockTimeRange(
@@ -571,133 +511,203 @@ public class LiveSequential implements Runnable {
                     }
                 }
 
-                // If no hash yet, fetch from mirror node
-                if (currentHash == null && nextBlockNumber > 0) {
-                    System.out.println(
-                            "[live-sequential] Fetching previous hash from mirror node for block " + nextBlockNumber);
-                    try {
-                        var prevHashBytes = FetchBlockQuery.getPreviousHashForBlock(nextBlockNumber);
-                        currentHash = prevHashBytes.toByteArray();
-                        System.out.println("[live-sequential] Got previous hash: "
-                                + HexFormat.of().formatHex(currentHash).substring(0, 16) + "...");
-                    } catch (Exception e) {
-                        System.err.println(
-                                "[live-sequential] Warning: Could not fetch previous hash: " + e.getMessage());
-                    }
-                }
-
-                // Step 5: Download one block
-                ListingRecordFile mostCommonRecord =
-                        RecordFileUtils.findMostCommonByType(group, ListingRecordFile.Type.RECORD);
-                ListingRecordFile[] mostCommonSidecars = RecordFileUtils.findMostCommonSidecars(group);
-                List<ListingRecordFile> orderedFiles =
-                        DownloadDayLiveImpl.computeFilesToDownload(mostCommonRecord, mostCommonSidecars, group);
-
-                Set<ListingRecordFile> mostCommonFilesSet = new HashSet<>();
-                if (mostCommonRecord != null) mostCommonFilesSet.add(mostCommonRecord);
-                ListingRecordFile mostCommonSidecarSingle =
-                        RecordFileUtils.findMostCommonByType(group, ListingRecordFile.Type.RECORD_SIDECAR);
-                if (mostCommonSidecarSingle != null) mostCommonFilesSet.add(mostCommonSidecarSingle);
-
-                List<InMemoryFile> inMemoryFiles = new ArrayList<>();
-                for (ListingRecordFile lr : orderedFiles) {
-                    String blobName = netConfig.bucketPathPrefix() + lr.path();
-                    try {
-                        InMemoryFile downloadedFile = downloadManager
-                                .downloadAsync(netConfig.gcsBucketName(), blobName)
-                                .join();
-
-                        String filename = lr.path().substring(lr.path().lastIndexOf('/') + 1);
-
-                        boolean md5Valid = checkMd5(lr.md5Hex(), downloadedFile.data());
-                        if (!md5Valid) {
-                            System.err.println("[live-sequential] MD5 mismatch for " + lr.path() + ", skipping");
-                            continue;
-                        }
-
-                        byte[] contentBytes = downloadedFile.data();
-                        if (filename.endsWith(".gz")) {
-                            contentBytes = Gzip.ungzipInMemory(contentBytes);
-                            filename = filename.replaceAll("\\.gz$", "");
-                        }
-
-                        Path newFilePath = DownloadDayLiveImpl.computeNewFilePath(lr, mostCommonFilesSet, filename);
-                        inMemoryFiles.add(new InMemoryFile(newFilePath, contentBytes));
-                    } catch (CompletionException ce) {
-                        System.err.println(
-                                "[live-sequential] Download failed for " + blobName + ": " + ce.getMessage());
-                        throw new IllegalStateException("Download failed for block " + nextBlockNumber, ce.getCause());
-                    }
-                }
-
-                // Step 6: Validate hash chain
+                // Step 5: Download, validate, write, and queue
+                currentHash = fetchPreviousHashIfNeeded(currentHash, nextBlockNumber);
+                List<InMemoryFile> inMemoryFiles =
+                        downloadBlockFiles(group, netConfig, downloadManager, nextBlockNumber);
                 byte[] newHash =
                         DownloadDayLiveImpl.validateBlockHashes(nextBlockNumber, inMemoryFiles, currentHash, null);
-
-                // Validate signatures
-                DownloadDayLiveImpl.BlockDownloadResult result =
-                        new DownloadDayLiveImpl.BlockDownloadResult(nextBlockNumber, inMemoryFiles, newHash);
+                validateBlock(addressBookRegistry, currentHash, blockTime, nextBlockNumber, inMemoryFiles, newHash);
+                assertSequentialOrdering(nextBlockNumber, currentBlockNumber);
+                writeToDayArchive(currentDayWriter, inMemoryFiles);
                 Instant recordFileTime = blockTime.atZone(ZoneOffset.UTC).toInstant();
-                boolean valid = fullBlockValidate(addressBookRegistry, currentHash, recordFileTime, result, null);
-                if (!valid) {
-                    throw new IllegalStateException(
-                            "Full block validation failed for block " + nextBlockNumber + " — aborting");
-                }
-
-                // Step 7: Assert sequential ordering
-                if (nextBlockNumber != currentBlockNumber + 1) {
-                    throw new IllegalStateException(
-                            "Block gap detected: expected " + (currentBlockNumber + 1) + " but got " + nextBlockNumber);
-                }
-
-                // Step 8: Write to tar.zstd archive (skip if archive already exists)
-                if (currentDayWriter != null) {
-                    for (InMemoryFile file : inMemoryFiles) {
-                        currentDayWriter.putEntry(file);
-                    }
-                }
-
-                // Step 9: Queue for wrapping
                 queue.put(new ValidatedBlock(nextBlockNumber, recordFileTime, inMemoryFiles, newHash));
 
-                // Step 10: Update state
+                // Step 6: Update state and log progress
                 currentBlockNumber = nextBlockNumber;
                 currentHash = newHash;
                 blocksProcessedTotal++;
                 blocksProcessedToday++;
-
-                // Save state every block
                 saveState(new State(currentBlockNumber, currentHash, recordFileTime, currentDay));
-
-                // Progress logging
-                if (blocksProcessedTotal % PROGRESS_LOG_INTERVAL == 0) {
-                    long elapsed = System.currentTimeMillis() - dayStartTime;
-                    double blocksPerSec = blocksProcessedToday / Math.max(1.0, elapsed / 1000.0);
-                    System.out.println("[live-sequential] Block " + currentBlockNumber + " (" + blocksProcessedToday
-                            + " today, " + String.format("%.1f", blocksPerSec) + " blocks/sec)");
-                }
+                logProgress(blocksProcessedTotal, blocksProcessedToday, currentBlockNumber, dayStartTime);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             System.out.println("[live-sequential] Interrupted, saving state...");
         } finally {
-            if (currentHash != null) {
-                try {
-                    LocalDateTime finalBlockTime = blockTimeReader.getBlockLocalDateTime(currentBlockNumber);
-                    Instant finalRecordTime =
-                            finalBlockTime.atZone(ZoneOffset.UTC).toInstant();
-                    saveState(new State(currentBlockNumber, currentHash, finalRecordTime, currentDay));
-                    System.out.println("[live-sequential] Saved state at block " + currentBlockNumber);
-                } catch (Exception e) {
-                    System.err.println("[live-sequential] Error saving final state: " + e.getMessage());
-                }
+            saveFinalState(currentBlockNumber, currentHash, currentDay, blockTimeReader);
+            closeQuietly(currentDayWriter);
+        }
+    }
+
+    private static void closeDayWriter(
+            ConcurrentTarZstdWriter writer, LocalDate day, long blocksToday, long dayStartTime) throws Exception {
+        if (writer != null) {
+            writer.close();
+            System.out.println("[live-sequential] Day completed: " + day + " (" + blocksToday + " blocks in "
+                    + formatDuration((System.currentTimeMillis() - dayStartTime) / 1000) + ")");
+        }
+    }
+
+    private ConcurrentTarZstdWriter openDayWriterIfNeeded(LocalDate day) throws Exception {
+        Path dayArchive = outputDir.toPath().resolve(day + ".tar.zstd");
+        if (Files.exists(dayArchive)) {
+            System.out.println("[live-sequential] Day archive already exists, skipping tar writes: " + day);
+            return null;
+        }
+        return new ConcurrentTarZstdWriter(dayArchive);
+    }
+
+    private List<ListingRecordFile> loadListingsWithRetry(
+            LocalDate blockDay, LocalDateTime blockTime, NetworkConfig netConfig) throws Exception {
+        int attempt = 0;
+        while (true) {
+            attempt++;
+            refreshListingsForDay(blockDay, netConfig);
+            try {
+                List<ListingRecordFile> listings = DayListingFileReader.loadRecordsFileForDay(
+                        listingDir.toPath(), blockTime.getYear(), blockTime.getMonthValue(), blockTime.getDayOfMonth());
+                System.out.println("[live-sequential] Loaded " + listings.size() + " listing entries for " + blockDay);
+                return listings;
+            } catch (NoSuchFileException e) {
+                System.out.println("[live-sequential] Listings not available yet for " + blockDay
+                        + ", waiting 15 minutes... (attempt " + attempt + ")");
+                Thread.sleep(15 * 60 * 1000);
             }
-            if (currentDayWriter != null) {
-                try {
-                    currentDayWriter.close();
-                } catch (Exception e) {
-                    System.err.println("[live-sequential] Error closing writer: " + e.getMessage());
+        }
+    }
+
+    private List<ListingRecordFile> reloadListings(LocalDateTime blockTime) throws Exception {
+        return DayListingFileReader.loadRecordsFileForDay(
+                listingDir.toPath(), blockTime.getYear(), blockTime.getMonthValue(), blockTime.getDayOfMonth());
+    }
+
+    private static List<ListingRecordFile> findBlockGroup(LocalDateTime blockTime, List<ListingRecordFile> listings) {
+        Map<LocalDateTime, List<ListingRecordFile>> filesByBlock =
+                listings.stream().collect(Collectors.groupingBy(ListingRecordFile::timestamp));
+        List<ListingRecordFile> group = filesByBlock.get(blockTime);
+        return (group == null || group.isEmpty()) ? null : group;
+    }
+
+    private static byte[] fetchPreviousHashIfNeeded(byte[] currentHash, long nextBlockNumber) {
+        if (currentHash == null && nextBlockNumber > 0) {
+            System.out.println(
+                    "[live-sequential] Fetching previous hash from mirror node for block " + nextBlockNumber);
+            try {
+                var prevHashBytes = FetchBlockQuery.getPreviousHashForBlock(nextBlockNumber);
+                byte[] hash = prevHashBytes.toByteArray();
+                System.out.println("[live-sequential] Got previous hash: "
+                        + HexFormat.of().formatHex(hash).substring(0, 16) + "...");
+                return hash;
+            } catch (Exception e) {
+                System.err.println("[live-sequential] Warning: Could not fetch previous hash: " + e.getMessage());
+            }
+        }
+        return currentHash;
+    }
+
+    private List<InMemoryFile> downloadBlockFiles(
+            List<ListingRecordFile> group,
+            NetworkConfig netConfig,
+            ConcurrentDownloadManagerVirtualThreadsV3 downloadManager,
+            long blockNumber)
+            throws Exception {
+        ListingRecordFile mostCommonRecord = RecordFileUtils.findMostCommonByType(group, ListingRecordFile.Type.RECORD);
+        ListingRecordFile[] mostCommonSidecars = RecordFileUtils.findMostCommonSidecars(group);
+        List<ListingRecordFile> orderedFiles =
+                DownloadDayLiveImpl.computeFilesToDownload(mostCommonRecord, mostCommonSidecars, group);
+        Set<ListingRecordFile> mostCommonFilesSet = new HashSet<>();
+        if (mostCommonRecord != null) mostCommonFilesSet.add(mostCommonRecord);
+        ListingRecordFile mostCommonSidecarSingle =
+                RecordFileUtils.findMostCommonByType(group, ListingRecordFile.Type.RECORD_SIDECAR);
+        if (mostCommonSidecarSingle != null) mostCommonFilesSet.add(mostCommonSidecarSingle);
+
+        List<InMemoryFile> inMemoryFiles = new ArrayList<>();
+        for (ListingRecordFile lr : orderedFiles) {
+            String blobName = netConfig.bucketPathPrefix() + lr.path();
+            try {
+                InMemoryFile downloadedFile = downloadManager
+                        .downloadAsync(netConfig.gcsBucketName(), blobName)
+                        .join();
+                String filename = lr.path().substring(lr.path().lastIndexOf('/') + 1);
+                if (!checkMd5(lr.md5Hex(), downloadedFile.data())) {
+                    System.err.println("[live-sequential] MD5 mismatch for " + lr.path() + ", skipping");
+                    continue;
                 }
+                byte[] contentBytes = downloadedFile.data();
+                if (filename.endsWith(".gz")) {
+                    contentBytes = Gzip.ungzipInMemory(contentBytes);
+                    filename = filename.replaceAll("\\.gz$", "");
+                }
+                Path newFilePath = DownloadDayLiveImpl.computeNewFilePath(lr, mostCommonFilesSet, filename);
+                inMemoryFiles.add(new InMemoryFile(newFilePath, contentBytes));
+            } catch (CompletionException ce) {
+                System.err.println("[live-sequential] Download failed for " + blobName + ": " + ce.getMessage());
+                throw new IllegalStateException("Download failed for block " + blockNumber, ce.getCause());
+            }
+        }
+        return inMemoryFiles;
+    }
+
+    private static void validateBlock(
+            AddressBookRegistry addressBookRegistry,
+            byte[] currentHash,
+            LocalDateTime blockTime,
+            long blockNumber,
+            List<InMemoryFile> files,
+            byte[] newHash)
+            throws Exception {
+        DownloadDayLiveImpl.BlockDownloadResult result =
+                new DownloadDayLiveImpl.BlockDownloadResult(blockNumber, files, newHash);
+        Instant recordFileTime = blockTime.atZone(ZoneOffset.UTC).toInstant();
+        if (!fullBlockValidate(addressBookRegistry, currentHash, recordFileTime, result, null)) {
+            throw new IllegalStateException("Full block validation failed for block " + blockNumber + " — aborting");
+        }
+    }
+
+    private static void assertSequentialOrdering(long nextBlockNumber, long currentBlockNumber) {
+        if (nextBlockNumber != currentBlockNumber + 1) {
+            throw new IllegalStateException(
+                    "Block gap detected: expected " + (currentBlockNumber + 1) + " but got " + nextBlockNumber);
+        }
+    }
+
+    private static void writeToDayArchive(ConcurrentTarZstdWriter writer, List<InMemoryFile> files) throws IOException {
+        if (writer != null) {
+            for (InMemoryFile file : files) {
+                writer.putEntry(file);
+            }
+        }
+    }
+
+    private static void logProgress(long total, long today, long blockNumber, long dayStartTime) {
+        if (total % PROGRESS_LOG_INTERVAL == 0) {
+            long elapsed = System.currentTimeMillis() - dayStartTime;
+            double blocksPerSec = today / Math.max(1.0, elapsed / 1000.0);
+            System.out.println("[live-sequential] Block " + blockNumber + " (" + today + " today, "
+                    + String.format("%.1f", blocksPerSec) + " blocks/sec)");
+        }
+    }
+
+    private void saveFinalState(long blockNumber, byte[] hash, LocalDate day, BlockTimeReader blockTimeReader) {
+        if (hash != null) {
+            try {
+                LocalDateTime finalBlockTime = blockTimeReader.getBlockLocalDateTime(blockNumber);
+                Instant finalRecordTime = finalBlockTime.atZone(ZoneOffset.UTC).toInstant();
+                saveState(new State(blockNumber, hash, finalRecordTime, day));
+                System.out.println("[live-sequential] Saved state at block " + blockNumber);
+            } catch (Exception e) {
+                System.err.println("[live-sequential] Error saving final state: " + e.getMessage());
+            }
+        }
+    }
+
+    private static void closeQuietly(ConcurrentTarZstdWriter writer) {
+        if (writer != null) {
+            try {
+                writer.close();
+            } catch (Exception e) {
+                System.err.println("[live-sequential] Error closing writer: " + e.getMessage());
             }
         }
     }
@@ -706,12 +716,10 @@ public class LiveSequential implements Runnable {
      * Wrap+validate consumer thread. Takes downloaded blocks from the queue, wraps them into
      * block stream format, and runs all 11 BlockValidation checks.
      */
-    @SuppressWarnings({"PMD.NPathComplexity", "PMD.CyclomaticComplexity", "PMD.ExcessiveMethodLength"
-    }) // Pipeline orchestration — splitting would scatter sequential logic
+    @SuppressWarnings("PMD.NPathComplexity")
     private void runWrapAndValidateThread(BlockingQueue<ValidatedBlock> queue, AddressBookRegistry addressBookRegistry)
             throws Exception {
 
-        // Initialize wrapping state
         final Path hashRegistryPath = wrapOutputDir.resolve("blockStreamBlockHashes.bin");
         final Path streamingMerkleTreeFile = wrapOutputDir.resolve("streamingMerkleTree.bin");
         final Path watermarkFile = wrapOutputDir.resolve("wrap-commit.bin");
@@ -720,8 +728,6 @@ public class LiveSequential implements Runnable {
 
         Files.createDirectories(wrapOutputDir);
         Files.createDirectories(checkpointDir);
-
-        // Copy address book to wrap output if needed
         if (!Files.exists(addressBookFile) && addressBookPath != null && Files.exists(addressBookPath)) {
             Files.copy(addressBookPath, addressBookFile);
         }
@@ -730,136 +736,29 @@ public class LiveSequential implements Runnable {
                 createAmendmentProvider(NetworkConfig.current().networkName());
 
         try (BlockStreamBlockHashRegistry blockRegistry = new BlockStreamBlockHashRegistry(hashRegistryPath)) {
-
-            // Load watermark and reconcile
-            long watermark = loadWatermark(watermarkFile);
-            long registryHighest = blockRegistry.highestBlockNumberStored();
-
-            if (watermark >= 0 && registryHighest > watermark) {
-                System.out.println(
-                        "[WRAP] Registry at " + registryHighest + " but watermark at " + watermark + "; truncating.");
-                blockRegistry.truncateTo(watermark);
-            } else if (watermark < 0 && registryHighest >= 0) {
-                watermark = registryHighest;
-            }
-
-            long effectiveHighest = blockRegistry.highestBlockNumberStored();
-
-            // Mid-zip resume: back up to zip range start if needed
-            if (effectiveHighest >= 0) {
-                long zipRangeFirst = BlockWriter.zipRangeFirstBlock(effectiveHighest, DEFAULT_POWERS_OF_TEN_PER_ZIP);
-                long blocksPerZip = (long) Math.pow(10, DEFAULT_POWERS_OF_TEN_PER_ZIP);
-                long zipRangeLast = zipRangeFirst + blocksPerZip - 1;
-                if (effectiveHighest < zipRangeLast) {
-                    long truncateTo = zipRangeFirst - 1;
-                    System.out.println("[WRAP] Mid-zip resume: truncating to " + truncateTo);
-                    BlockPath partialZipPath = BlockWriter.computeBlockPath(
-                            wrapOutputDir, effectiveHighest, BlockArchiveType.UNCOMPRESSED_ZIP);
-                    Files.deleteIfExists(partialZipPath.zipFilePath());
-                    blockRegistry.truncateTo(truncateTo);
-                    saveWatermark(watermarkFile, truncateTo);
-                    effectiveHighest = blockRegistry.highestBlockNumberStored();
-                }
-            }
+            long[] state = reconcileWrapState(blockRegistry, watermarkFile);
+            long effectiveHighest = state[0];
+            long watermark = state[1];
 
             System.out.println("[WRAP] Starting from block: " + effectiveHighest);
+            final StreamingHasher streamingHasher = replayHasher(blockRegistry, effectiveHighest);
 
-            // Create streaming hasher and replay from registry
-            final StreamingHasher streamingHasher = new StreamingHasher();
-            if (effectiveHighest >= 0) {
-                System.out.println("[WRAP] Replaying " + (effectiveHighest + 1) + " block hashes into hasher");
-                for (long bn = 0; bn <= effectiveHighest; bn++) {
-                    byte[] hash = blockRegistry.getBlockHash(bn);
-                    streamingHasher.addNodeByHash(hash);
-                }
-                System.out.println("[WRAP] Hasher replay complete. leafCount=" + streamingHasher.leafCount());
-            }
-
-            // Build validation list (same as ValidateBlocksCommand)
             BlockChainValidation chainValidation = new BlockChainValidation();
-            HistoricalBlockTreeValidation treeValidation = new HistoricalBlockTreeValidation(chainValidation);
-            HbarSupplyValidation supplyValidation = new HbarSupplyValidation();
-
-            List<BlockValidation> parallelValidations = new ArrayList<>();
-            parallelValidations.add(new RequiredItemsValidation());
-            parallelValidations.add(new BlockStructureValidation());
-            SignatureValidation signatureValidation = new SignatureValidation(addressBookRegistry);
-            parallelValidations.add(signatureValidation);
-
-            List<BlockValidation> sequentialValidations = new ArrayList<>();
-            sequentialValidations.add(new AddressBookUpdateValidation(addressBookRegistry));
-            sequentialValidations.add(chainValidation);
-            sequentialValidations.add(treeValidation);
-            sequentialValidations.add(supplyValidation);
-            sequentialValidations.add(new HashRegistryValidation(blockRegistry, chainValidation));
-            sequentialValidations.add(new StreamingMerkleTreeValidation(streamingMerkleTreeFile, treeValidation));
-            Path jumpstartPath = wrapOutputDir.resolve("jumpstart.bin");
-            sequentialValidations.add(new JumpstartValidation(jumpstartPath, treeValidation, blockRegistry));
-
+            List<BlockValidation> parallelValidations = buildParallelValidations(addressBookRegistry);
+            List<BlockValidation> sequentialValidations = buildSequentialValidations(
+                    addressBookRegistry, blockRegistry, chainValidation, streamingMerkleTreeFile);
             List<BlockValidation> allValidations = new ArrayList<>();
             allValidations.addAll(parallelValidations);
             allValidations.addAll(sequentialValidations);
 
-            // Filter out genesis-required validations when not starting from block 0
-            boolean startingFromGenesis = (effectiveHighest < 0);
-            if (!startingFromGenesis) {
-                // Try to load checkpoint state, but only if it's not ahead of the wrap state.
-                // Mid-zip truncation can push effectiveHighest behind the checkpoint — loading
-                // a checkpoint that is ahead would cause hash mismatches.
-                boolean hasCheckpoint = false;
-                try {
-                    Path progressFile = checkpointDir.resolve("validateProgress.json");
-                    if (Files.exists(progressFile)) {
-                        String cpJson = Files.readString(progressFile, StandardCharsets.UTF_8);
-                        com.google.gson.JsonObject cpRoot =
-                                com.google.gson.JsonParser.parseString(cpJson).getAsJsonObject();
-                        long cpBlock = cpRoot.get("lastValidatedBlockNumber").getAsLong();
+            initializeCheckpointState(
+                    effectiveHighest,
+                    checkpointDir,
+                    blockRegistry,
+                    chainValidation,
+                    sequentialValidations,
+                    allValidations);
 
-                        if (cpBlock <= effectiveHighest) {
-                            for (BlockValidation v : allValidations) {
-                                try {
-                                    v.load(checkpointDir);
-                                } catch (Exception e) {
-                                    System.err.println(
-                                            "[WRAP] Warning: could not load " + v.name() + " state: " + e.getMessage());
-                                }
-                            }
-                            hasCheckpoint = true;
-                        } else {
-                            System.out.println("[WRAP] Validate checkpoint (block " + cpBlock
-                                    + ") is ahead of wrap effective highest (" + effectiveHighest
-                                    + "); skipping checkpoint load");
-                            // Initialize chain validation from block hash registry so it
-                            // doesn't treat the first block as genesis
-                            byte[] lastHash = blockRegistry.getBlockHash(effectiveHighest);
-                            if (lastHash != null) {
-                                chainValidation.setPreviousBlockHash(lastHash);
-                                System.out.println("[WRAP] Initialized chain validation from registry at block "
-                                        + effectiveHighest);
-                            }
-                        }
-                    }
-                } catch (Exception e) {
-                    System.err.println("[WRAP] Warning: could not load checkpoint: " + e.getMessage());
-                }
-
-                if (!hasCheckpoint) {
-                    List<BlockValidation> genesisSkipped = new ArrayList<>();
-                    sequentialValidations.removeIf(v -> {
-                        if (v.requiresGenesisStart()) {
-                            genesisSkipped.add(v);
-                            return true;
-                        }
-                        return false;
-                    });
-                    allValidations.removeIf(genesisSkipped::contains);
-                    for (BlockValidation skipped : genesisSkipped) {
-                        System.out.println("[WRAP] Skipping: " + skipped.name() + " (requires genesis start)");
-                    }
-                }
-            }
-
-            // Zip writing state
             BlockZipAppender currentZip = null;
             Path currentZipPath = null;
             long durableWatermark = watermark;
@@ -870,51 +769,11 @@ public class LiveSequential implements Runnable {
             try {
                 while (true) {
                     ValidatedBlock vb = queue.take();
-                    if (vb == POISON_PILL) {
-                        break;
-                    }
-
+                    if (vb == POISON_PILL) break;
                     long blockNum = vb.blockNumber();
+                    if (blockNum <= effectiveHighest) continue;
 
-                    // Skip if already wrapped
-                    if (blockNum <= effectiveHighest) {
-                        continue;
-                    }
-
-                    // Classify files and build UnparsedRecordBlock
-                    DownloadDayLiveImpl.BlockDownloadResult downloadResult =
-                            new DownloadDayLiveImpl.BlockDownloadResult(blockNum, vb.files(), vb.runningHash());
-                    InMemoryFile primaryRecord = findPrimaryRecord(downloadResult);
-                    List<InMemoryFile> signatures = findSignatures(downloadResult);
-                    List<InMemoryFile> sidecars = findSidecars(downloadResult, primaryRecord);
-
-                    if (primaryRecord == null) {
-                        throw new IllegalStateException("No primary record found for block " + blockNum);
-                    }
-
-                    UnparsedRecordBlock unparsedBlock = UnparsedRecordBlock.newInMemoryBlock(
-                            vb.recordFileTime(), primaryRecord, List.of(), signatures, sidecars, List.of());
-
-                    // Parse and verify signatures
-                    ParsedRecordBlock parsedBlock = unparsedBlock.parse();
-                    NodeAddressBook ab = addressBookRegistry.getAddressBookForBlock(parsedBlock.blockTime());
-                    byte[] signedHash = parsedBlock.recordFile().signedHash();
-                    List<RecordFileSignature> verifiedSigs = parsedBlock.signatureFiles().stream()
-                            .filter(psf -> psf.isValid(signedHash, ab))
-                            .map(psf -> psf.toRecordFileSignature(ab))
-                            .toList();
-
-                    PreVerifiedBlock preVerified = new PreVerifiedBlock(parsedBlock, ab, verifiedSigs);
-
-                    // Address book auto-update
-                    try {
-                        preVerified = updateAddressBookAndReverify(preVerified, blockNum, addressBookRegistry);
-                    } catch (Exception e) {
-                        System.err.printf(
-                                "[WRAP] Warning: address book auto-update failed at block %d: %s%n", blockNum, e);
-                    }
-
-                    // Convert to wrapped block
+                    PreVerifiedBlock preVerified = parseAndVerifyBlock(vb, addressBookRegistry, blockNum);
                     Block wrapped = RecordBlockConverter.toBlock(
                             preVerified,
                             blockNum,
@@ -922,19 +781,15 @@ public class LiveSequential implements Runnable {
                             streamingHasher.computeRootHash(),
                             amendmentProvider);
 
-                    // Hash and update chain state
                     byte[] blockStreamBlockHash = hashBlock(wrapped);
                     streamingHasher.addNodeByHash(blockStreamBlockHash);
                     blockRegistry.addBlock(blockNum, blockStreamBlockHash);
 
-                    // Compute block path and write to zip
+                    // Write to zip archive
                     BlockPath blockPath =
                             BlockWriter.computeBlockPath(wrapOutputDir, blockNum, BlockArchiveType.UNCOMPRESSED_ZIP);
                     Files.createDirectories(blockPath.dirPath());
-
                     byte[] serializedBytes = BlockWriter.serializeBlockToBytes(wrapped, DEFAULT_COMPRESSION);
-
-                    // Switch zip file if needed
                     if (!blockPath.zipFilePath().equals(currentZipPath)) {
                         if (currentZip != null) {
                             currentZip.close();
@@ -945,7 +800,6 @@ public class LiveSequential implements Runnable {
                         currentZipPath = blockPath.zipFilePath();
                     }
                     BlockWriter.writeBlockEntry(currentZip, blockPath, serializedBytes);
-
                     durableWatermark = blockNum;
                     blocksSinceWatermarkFlush++;
                     if (blocksSinceWatermarkFlush >= WATERMARK_BATCH_SIZE) {
@@ -953,57 +807,27 @@ public class LiveSequential implements Runnable {
                         blocksSinceWatermarkFlush = 0;
                     }
 
-                    // Run BlockValidation checks
-                    // Convert Block to BlockUnparsed for validation
-                    Bytes wrappedBytes = Block.PROTOBUF.toBytes(wrapped);
-                    BlockUnparsed blockUnparsed = BlockUnparsed.PROTOBUF.parse(wrappedBytes);
-
-                    // Phase 1: Parallel validations
-                    for (BlockValidation v : parallelValidations) {
-                        try {
-                            v.validate(blockUnparsed, blockNum);
-                        } catch (ValidationException e) {
-                            throw new IllegalStateException(
-                                    "Validation '" + v.name() + "' failed at block " + blockNum + ": " + e.getMessage(),
-                                    e);
-                        }
-                    }
-
-                    // Phase 2: Sequential validations
-                    for (BlockValidation v : sequentialValidations) {
-                        try {
-                            v.validate(blockUnparsed, blockNum);
-                        } catch (ValidationException e) {
-                            // Save checkpoint before failing
-                            saveValidationCheckpoint(checkpointDir, blockNum - 1, allValidations);
-                            throw new IllegalStateException(
-                                    "Validation '" + v.name() + "' failed at block " + blockNum + ": " + e.getMessage(),
-                                    e);
-                        }
-                    }
-
-                    // Phase 3: Commit state for all validations
-                    for (BlockValidation v : allValidations) {
-                        v.commitState(blockUnparsed, blockNum);
-                    }
-
+                    // Validate wrapped block
+                    runBlockValidations(
+                            wrapped,
+                            blockNum,
+                            parallelValidations,
+                            sequentialValidations,
+                            allValidations,
+                            checkpointDir);
                     blocksValidated++;
 
-                    // Periodic checkpoint save
-                    long nowMs = System.currentTimeMillis();
-                    if (nowMs - lastCheckpointSaveMs >= 60_000L) {
+                    if (System.currentTimeMillis() - lastCheckpointSaveMs >= 60_000L) {
                         saveValidationCheckpoint(checkpointDir, blockNum, allValidations);
-                        lastCheckpointSaveMs = nowMs;
+                        lastCheckpointSaveMs = System.currentTimeMillis();
                     }
-
-                    // Progress
                     if (blocksValidated % PROGRESS_LOG_INTERVAL == 0) {
-                        System.out.println("[WRAP] Wrapped + validated block " + blockNum + " (" + blocksValidated
-                                + " total, sigs=" + verifiedSigs.size() + ")");
+                        System.out.println("[WRAP] Wrapped + validated block " + blockNum + " ("
+                                + blocksValidated + " total, sigs="
+                                + preVerified.verifiedSignatures().size() + ")");
                     }
                 }
             } finally {
-                // Close zip and save state
                 if (currentZip != null) {
                     try {
                         currentZip.close();
@@ -1014,17 +838,205 @@ public class LiveSequential implements Runnable {
                 saveWatermark(watermarkFile, durableWatermark);
                 saveStateCheckpoint(streamingMerkleTreeFile, streamingHasher);
                 addressBookRegistry.saveAddressBookRegistryToJsonFile(addressBookFile);
-
-                // Save validation checkpoint
                 saveValidationCheckpoint(checkpointDir, durableWatermark, allValidations);
-
-                // Close all validations
-                for (BlockValidation v : allValidations) {
-                    v.close();
-                }
-
+                for (BlockValidation v : allValidations) v.close();
                 System.out.println("[WRAP] Shutdown complete. Wrapped " + blocksValidated + " blocks.");
             }
+        }
+    }
+
+    private long[] reconcileWrapState(BlockStreamBlockHashRegistry blockRegistry, Path watermarkFile)
+            throws IOException {
+        long watermark = loadWatermark(watermarkFile);
+        long registryHighest = blockRegistry.highestBlockNumberStored();
+
+        if (watermark >= 0 && registryHighest > watermark) {
+            System.out.println(
+                    "[WRAP] Registry at " + registryHighest + " but watermark at " + watermark + "; truncating.");
+            blockRegistry.truncateTo(watermark);
+        } else if (watermark < 0 && registryHighest >= 0) {
+            watermark = registryHighest;
+        }
+
+        long effectiveHighest = blockRegistry.highestBlockNumberStored();
+        if (effectiveHighest >= 0) {
+            long zipRangeFirst = BlockWriter.zipRangeFirstBlock(effectiveHighest, DEFAULT_POWERS_OF_TEN_PER_ZIP);
+            long blocksPerZip = (long) Math.pow(10, DEFAULT_POWERS_OF_TEN_PER_ZIP);
+            long zipRangeLast = zipRangeFirst + blocksPerZip - 1;
+            if (effectiveHighest < zipRangeLast) {
+                long truncateTo = zipRangeFirst - 1;
+                System.out.println("[WRAP] Mid-zip resume: truncating to " + truncateTo);
+                BlockPath partialZipPath = BlockWriter.computeBlockPath(
+                        wrapOutputDir, effectiveHighest, BlockArchiveType.UNCOMPRESSED_ZIP);
+                Files.deleteIfExists(partialZipPath.zipFilePath());
+                blockRegistry.truncateTo(truncateTo);
+                saveWatermark(watermarkFile, truncateTo);
+                effectiveHighest = blockRegistry.highestBlockNumberStored();
+            }
+        }
+        return new long[] {effectiveHighest, watermark};
+    }
+
+    private static StreamingHasher replayHasher(BlockStreamBlockHashRegistry blockRegistry, long effectiveHighest) {
+        StreamingHasher streamingHasher = new StreamingHasher();
+        if (effectiveHighest >= 0) {
+            System.out.println("[WRAP] Replaying " + (effectiveHighest + 1) + " block hashes into hasher");
+            for (long bn = 0; bn <= effectiveHighest; bn++) {
+                streamingHasher.addNodeByHash(blockRegistry.getBlockHash(bn));
+            }
+            System.out.println("[WRAP] Hasher replay complete. leafCount=" + streamingHasher.leafCount());
+        }
+        return streamingHasher;
+    }
+
+    private static List<BlockValidation> buildParallelValidations(AddressBookRegistry addressBookRegistry) {
+        List<BlockValidation> validations = new ArrayList<>();
+        validations.add(new RequiredItemsValidation());
+        validations.add(new BlockStructureValidation());
+        validations.add(new SignatureValidation(addressBookRegistry));
+        return validations;
+    }
+
+    private List<BlockValidation> buildSequentialValidations(
+            AddressBookRegistry addressBookRegistry,
+            BlockStreamBlockHashRegistry blockRegistry,
+            BlockChainValidation chainValidation,
+            Path streamingMerkleTreeFile) {
+        HistoricalBlockTreeValidation treeValidation = new HistoricalBlockTreeValidation(chainValidation);
+        List<BlockValidation> validations = new ArrayList<>();
+        validations.add(new AddressBookUpdateValidation(addressBookRegistry));
+        validations.add(chainValidation);
+        validations.add(treeValidation);
+        validations.add(new HbarSupplyValidation());
+        validations.add(new HashRegistryValidation(blockRegistry, chainValidation));
+        validations.add(new StreamingMerkleTreeValidation(streamingMerkleTreeFile, treeValidation));
+        Path jumpstartPath = wrapOutputDir.resolve("jumpstart.bin");
+        validations.add(new JumpstartValidation(jumpstartPath, treeValidation, blockRegistry));
+        return validations;
+    }
+
+    @SuppressWarnings("PMD.NPathComplexity")
+    private static void initializeCheckpointState(
+            long effectiveHighest,
+            Path checkpointDir,
+            BlockStreamBlockHashRegistry blockRegistry,
+            BlockChainValidation chainValidation,
+            List<BlockValidation> sequentialValidations,
+            List<BlockValidation> allValidations) {
+        if (effectiveHighest < 0) return; // starting from genesis
+
+        boolean hasCheckpoint = false;
+        try {
+            Path progressFile = checkpointDir.resolve("validateProgress.json");
+            if (Files.exists(progressFile)) {
+                String cpJson = Files.readString(progressFile, StandardCharsets.UTF_8);
+                com.google.gson.JsonObject cpRoot =
+                        com.google.gson.JsonParser.parseString(cpJson).getAsJsonObject();
+                long cpBlock = cpRoot.get("lastValidatedBlockNumber").getAsLong();
+
+                if (cpBlock <= effectiveHighest) {
+                    for (BlockValidation v : allValidations) {
+                        try {
+                            v.load(checkpointDir);
+                        } catch (Exception e) {
+                            System.err.println(
+                                    "[WRAP] Warning: could not load " + v.name() + " state: " + e.getMessage());
+                        }
+                    }
+                    hasCheckpoint = true;
+                } else {
+                    System.out.println("[WRAP] Validate checkpoint (block " + cpBlock
+                            + ") is ahead of wrap effective highest (" + effectiveHighest
+                            + "); skipping checkpoint load");
+                    byte[] lastHash = blockRegistry.getBlockHash(effectiveHighest);
+                    if (lastHash != null) {
+                        chainValidation.setPreviousBlockHash(lastHash);
+                        System.out.println(
+                                "[WRAP] Initialized chain validation from registry at block " + effectiveHighest);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("[WRAP] Warning: could not load checkpoint: " + e.getMessage());
+        }
+
+        if (!hasCheckpoint) {
+            List<BlockValidation> genesisSkipped = new ArrayList<>();
+            sequentialValidations.removeIf(v -> {
+                if (v.requiresGenesisStart()) {
+                    genesisSkipped.add(v);
+                    return true;
+                }
+                return false;
+            });
+            allValidations.removeIf(genesisSkipped::contains);
+            for (BlockValidation skipped : genesisSkipped) {
+                System.out.println("[WRAP] Skipping: " + skipped.name() + " (requires genesis start)");
+            }
+        }
+    }
+
+    private PreVerifiedBlock parseAndVerifyBlock(
+            ValidatedBlock vb, AddressBookRegistry addressBookRegistry, long blockNum) throws Exception {
+        DownloadDayLiveImpl.BlockDownloadResult downloadResult =
+                new DownloadDayLiveImpl.BlockDownloadResult(blockNum, vb.files(), vb.runningHash());
+        InMemoryFile primaryRecord = findPrimaryRecord(downloadResult);
+        List<InMemoryFile> signatures = findSignatures(downloadResult);
+        List<InMemoryFile> sidecars = findSidecars(downloadResult, primaryRecord);
+
+        if (primaryRecord == null) {
+            throw new IllegalStateException("No primary record found for block " + blockNum);
+        }
+
+        UnparsedRecordBlock unparsedBlock = UnparsedRecordBlock.newInMemoryBlock(
+                vb.recordFileTime(), primaryRecord, List.of(), signatures, sidecars, List.of());
+        ParsedRecordBlock parsedBlock = unparsedBlock.parse();
+        NodeAddressBook ab = addressBookRegistry.getAddressBookForBlock(parsedBlock.blockTime());
+        byte[] signedHash = parsedBlock.recordFile().signedHash();
+        List<RecordFileSignature> verifiedSigs = parsedBlock.signatureFiles().stream()
+                .filter(psf -> psf.isValid(signedHash, ab))
+                .map(psf -> psf.toRecordFileSignature(ab))
+                .toList();
+
+        PreVerifiedBlock preVerified = new PreVerifiedBlock(parsedBlock, ab, verifiedSigs);
+        try {
+            preVerified = updateAddressBookAndReverify(preVerified, blockNum, addressBookRegistry);
+        } catch (Exception e) {
+            System.err.printf("[WRAP] Warning: address book auto-update failed at block %d: %s%n", blockNum, e);
+        }
+        return preVerified;
+    }
+
+    private static void runBlockValidations(
+            Block wrapped,
+            long blockNum,
+            List<BlockValidation> parallelValidations,
+            List<BlockValidation> sequentialValidations,
+            List<BlockValidation> allValidations,
+            Path checkpointDir)
+            throws Exception {
+        Bytes wrappedBytes = Block.PROTOBUF.toBytes(wrapped);
+        BlockUnparsed blockUnparsed = BlockUnparsed.PROTOBUF.parse(wrappedBytes);
+
+        for (BlockValidation v : parallelValidations) {
+            try {
+                v.validate(blockUnparsed, blockNum);
+            } catch (ValidationException e) {
+                throw new IllegalStateException(
+                        "Validation '" + v.name() + "' failed at block " + blockNum + ": " + e.getMessage(), e);
+            }
+        }
+        for (BlockValidation v : sequentialValidations) {
+            try {
+                v.validate(blockUnparsed, blockNum);
+            } catch (ValidationException e) {
+                saveValidationCheckpoint(checkpointDir, blockNum - 1, allValidations);
+                throw new IllegalStateException(
+                        "Validation '" + v.name() + "' failed at block " + blockNum + ": " + e.getMessage(), e);
+            }
+        }
+        for (BlockValidation v : allValidations) {
+            v.commitState(blockUnparsed, blockNum);
         }
     }
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -515,18 +515,14 @@ public class LiveSequential implements Runnable {
         }
         state.cachedListingFiles = reloadListings(blockTime);
         state.cachedListingDay = blockDay;
-        byte[] newHash = downloadValidateAndEnqueue(
-                addressBookRegistry,
-                downloadManager,
-                state.netConfig,
-                group,
-                nextBlockNumber,
-                state.currentBlockNumber,
-                state.currentHash,
-                blockTime,
-                state.dayWriter,
-                queue);
+        byte[] resolvedHash = fetchPreviousHashIfNeeded(state.currentHash, nextBlockNumber);
+        List<InMemoryFile> inMemoryFiles = downloadBlockFiles(group, state.netConfig, downloadManager, nextBlockNumber);
+        byte[] newHash = DownloadDayLiveImpl.validateBlockHashes(nextBlockNumber, inMemoryFiles, resolvedHash, null);
+        validateBlock(addressBookRegistry, resolvedHash, blockTime, nextBlockNumber, inMemoryFiles, newHash);
+        assertSequentialOrdering(nextBlockNumber, state.currentBlockNumber);
+        writeToDayArchive(state.dayWriter, inMemoryFiles);
         Instant recordFileTime = blockTime.atZone(ZoneOffset.UTC).toInstant();
+        queue.put(new ValidatedBlock(nextBlockNumber, recordFileTime, inMemoryFiles, newHash));
         state.currentBlockNumber = nextBlockNumber;
         state.currentHash = newHash;
         state.blocksProcessedTotal++;
@@ -534,29 +530,6 @@ public class LiveSequential implements Runnable {
         saveState(new State(state.currentBlockNumber, state.currentHash, recordFileTime, state.currentDay));
         logProgress(
                 state.blocksProcessedTotal, state.blocksProcessedToday, state.currentBlockNumber, state.dayStartTime);
-    }
-
-    private byte[] downloadValidateAndEnqueue(
-            AddressBookRegistry addressBookRegistry,
-            ConcurrentDownloadManagerVirtualThreadsV3 downloadManager,
-            NetworkConfig netConfig,
-            List<ListingRecordFile> group,
-            long nextBlockNumber,
-            long currentBlockNumber,
-            byte[] currentHash,
-            LocalDateTime blockTime,
-            ConcurrentTarZstdWriter dayWriter,
-            BlockingQueue<ValidatedBlock> queue)
-            throws Exception {
-        currentHash = fetchPreviousHashIfNeeded(currentHash, nextBlockNumber);
-        List<InMemoryFile> inMemoryFiles = downloadBlockFiles(group, netConfig, downloadManager, nextBlockNumber);
-        byte[] newHash = DownloadDayLiveImpl.validateBlockHashes(nextBlockNumber, inMemoryFiles, currentHash, null);
-        validateBlock(addressBookRegistry, currentHash, blockTime, nextBlockNumber, inMemoryFiles, newHash);
-        assertSequentialOrdering(nextBlockNumber, currentBlockNumber);
-        writeToDayArchive(dayWriter, inMemoryFiles);
-        Instant recordFileTime = blockTime.atZone(ZoneOffset.UTC).toInstant();
-        queue.put(new ValidatedBlock(nextBlockNumber, recordFileTime, inMemoryFiles, newHash));
-        return newHash;
     }
 
     private static BlockTimeReader refreshBlockTimeIfNeeded(
@@ -845,8 +818,8 @@ public class LiveSequential implements Runnable {
                         addressBookRegistry,
                         addressBookFile,
                         checkpointDir,
-                        wv.all(),
-                        blocksValidated);
+                        wv.all());
+                System.out.println("[WRAP] Shutdown complete. Wrapped " + blocksValidated + " blocks.");
             }
         }
     }
@@ -884,8 +857,7 @@ public class LiveSequential implements Runnable {
             AddressBookRegistry addressBookRegistry,
             Path addressBookFile,
             Path checkpointDir,
-            List<BlockValidation> allValidations,
-            long blocksValidated) {
+            List<BlockValidation> allValidations) {
         if (currentZip != null) {
             try {
                 currentZip.close();
@@ -898,7 +870,6 @@ public class LiveSequential implements Runnable {
         addressBookRegistry.saveAddressBookRegistryToJsonFile(addressBookFile);
         saveValidationCheckpoint(checkpointDir, durableWatermark, allValidations);
         for (BlockValidation v : allValidations) v.close();
-        System.out.println("[WRAP] Shutdown complete. Wrapped " + blocksValidated + " blocks.");
     }
 
     private void writeToZipArchive(

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -332,12 +332,18 @@ public class LiveSequential implements Runnable {
      */
     @SuppressWarnings("PMD.NPathComplexity") // Multiple priority levels require branching
     private State determineStartingPoint(BlockTimeReader blockTimeReader) {
-        // Priority 1: Resume from wrap state (the authoritative source, accounts for mid-zip truncation)
+        // Priority 1: Resume from wrap state — start download from beginning of the day
+        // so the day archive is complete; the wrap thread skips already-wrapped blocks
         long wrapEffective = computeWrapEffectiveHighest();
         if (wrapEffective >= 0) {
-            System.out.println("[live-sequential] Resuming from wrap effective highest: block " + wrapEffective);
+            LocalDateTime wrapBlockTime = blockTimeReader.getBlockLocalDateTime(wrapEffective);
+            LocalDate wrapDay = wrapBlockTime.toLocalDate();
+            long firstBlockOfDay = blockTimeReader.getNearestBlockAfterTime(wrapDay.atStartOfDay());
+            System.out.println("[live-sequential] Wrap state at block " + wrapEffective
+                    + "; starting download from beginning of day " + wrapDay + " (block " + firstBlockOfDay + ")");
             State state = new State();
-            state.blockNumber = wrapEffective;
+            state.blockNumber = firstBlockOfDay - 1;
+            state.dayDate = wrapDay.toString();
             return state;
         }
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -513,14 +513,11 @@ public class LiveSequential implements Runnable {
             state.cachedListingFiles = loadListingsWithRetry(blockDay, blockTime, state.netConfig);
             state.cachedListingDay = blockDay;
         }
-        List<ListingRecordFile> group = findBlockGroupWithRefresh(
-                blockTime, blockDay, nextBlockNumber, state.cachedListingFiles, state.netConfig);
+        List<ListingRecordFile> group = findBlockGroupWithRefresh(state, blockTime, blockDay, nextBlockNumber);
         if (group == null) {
             state.blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
             return;
         }
-        state.cachedListingFiles = reloadListings(blockTime);
-        state.cachedListingDay = blockDay;
         byte[] resolvedHash = fetchPreviousHashIfNeeded(state.currentHash, nextBlockNumber);
         List<InMemoryFile> inMemoryFiles = downloadBlockFiles(group, state.netConfig, downloadManager, nextBlockNumber);
         byte[] newHash = DownloadDayLiveImpl.validateBlockHashes(nextBlockNumber, inMemoryFiles, resolvedHash, null);
@@ -558,18 +555,14 @@ public class LiveSequential implements Runnable {
     }
 
     private List<ListingRecordFile> findBlockGroupWithRefresh(
-            LocalDateTime blockTime,
-            LocalDate blockDay,
-            long blockNumber,
-            List<ListingRecordFile> cachedListingFiles,
-            NetworkConfig netConfig)
-            throws Exception {
-        List<ListingRecordFile> group = findBlockGroup(blockTime, cachedListingFiles);
+            DownloadLoopState state, LocalDateTime blockTime, LocalDate blockDay, long blockNumber) throws Exception {
+        List<ListingRecordFile> group = findBlockGroup(blockTime, state.cachedListingFiles);
         if (group != null) return group;
 
-        refreshListingsForDay(blockDay, netConfig);
-        List<ListingRecordFile> refreshed = reloadListings(blockTime);
-        group = findBlockGroup(blockTime, refreshed);
+        refreshListingsForDay(blockDay, state.netConfig);
+        state.cachedListingFiles = reloadListings(blockTime);
+        state.cachedListingDay = blockDay;
+        group = findBlockGroup(blockTime, state.cachedListingFiles);
         if (group != null) return group;
 
         System.out.println("[live-sequential] No files found for block " + blockNumber + " at time " + blockTime

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -190,7 +190,7 @@ public class LiveSequential implements Runnable {
             long blockNumber, Instant recordFileTime, List<InMemoryFile> files, byte[] runningHash) {}
 
     @Override
-    @SuppressWarnings("java:S3776") // Orchestration method — splitting would hurt readability
+    @SuppressWarnings({"PMD.NPathComplexity", "PMD.ExcessiveMethodLength"})
     public void run() {
         System.out.println("[live-sequential] Starting sequential block download with inline wrapping + validation");
         System.out.println("Configuration:");
@@ -302,7 +302,7 @@ public class LiveSequential implements Runnable {
      * Priority: 1) Wrap effective highest (accounts for mid-zip truncation), 2) Resume from state file,
      * 3) Use --start-date, 4) Auto-detect from mirror node
      */
-    @SuppressWarnings("java:S3776") // Multiple priority levels require branching
+    @SuppressWarnings("PMD.NPathComplexity") // Multiple priority levels require branching
     private State determineStartingPoint(BlockTimeReader blockTimeReader) {
         // Priority 1: Resume from wrap state (the authoritative source, accounts for mid-zip truncation)
         long wrapEffective = computeWrapEffectiveHighest();
@@ -420,7 +420,8 @@ public class LiveSequential implements Runnable {
      * Main sequential download loop. Downloads one block at a time, validates, writes to tar.zstd,
      * and queues for wrapping.
      */
-    @SuppressWarnings("java:S3776") // Pipeline orchestration — splitting would scatter sequential logic
+    @SuppressWarnings({"PMD.NPathComplexity", "PMD.CyclomaticComplexity", "PMD.ExcessiveMethodLength"
+    }) // Pipeline orchestration — splitting would scatter sequential logic
     private void processBlocksSequentially(
             State initialState,
             AddressBookRegistry addressBookRegistry,
@@ -705,7 +706,8 @@ public class LiveSequential implements Runnable {
      * Wrap+validate consumer thread. Takes downloaded blocks from the queue, wraps them into
      * block stream format, and runs all 11 BlockValidation checks.
      */
-    @SuppressWarnings("java:S3776") // Pipeline orchestration — splitting would scatter sequential logic
+    @SuppressWarnings({"PMD.NPathComplexity", "PMD.CyclomaticComplexity", "PMD.ExcessiveMethodLength"
+    }) // Pipeline orchestration — splitting would scatter sequential logic
     private void runWrapAndValidateThread(BlockingQueue<ValidatedBlock> queue, AddressBookRegistry addressBookRegistry)
             throws Exception {
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -190,6 +190,7 @@ public class LiveSequential implements Runnable {
             long blockNumber, Instant recordFileTime, List<InMemoryFile> files, byte[] runningHash) {}
 
     @Override
+    @SuppressWarnings("java:S3776") // Orchestration method — splitting would hurt readability
     public void run() {
         System.out.println("[live-sequential] Starting sequential block download with inline wrapping + validation");
         System.out.println("Configuration:");
@@ -301,6 +302,7 @@ public class LiveSequential implements Runnable {
      * Priority: 1) Wrap effective highest (accounts for mid-zip truncation), 2) Resume from state file,
      * 3) Use --start-date, 4) Auto-detect from mirror node
      */
+    @SuppressWarnings("java:S3776") // Multiple priority levels require branching
     private State determineStartingPoint(BlockTimeReader blockTimeReader) {
         // Priority 1: Resume from wrap state (the authoritative source, accounts for mid-zip truncation)
         long wrapEffective = computeWrapEffectiveHighest();
@@ -418,6 +420,7 @@ public class LiveSequential implements Runnable {
      * Main sequential download loop. Downloads one block at a time, validates, writes to tar.zstd,
      * and queues for wrapping.
      */
+    @SuppressWarnings("java:S3776") // Pipeline orchestration — splitting would scatter sequential logic
     private void processBlocksSequentially(
             State initialState,
             AddressBookRegistry addressBookRegistry,
@@ -702,6 +705,7 @@ public class LiveSequential implements Runnable {
      * Wrap+validate consumer thread. Takes downloaded blocks from the queue, wraps them into
      * block stream format, and runs all 11 BlockValidation checks.
      */
+    @SuppressWarnings("java:S3776") // Pipeline orchestration — splitting would scatter sequential logic
     private void runWrapAndValidateThread(BlockingQueue<ValidatedBlock> queue, AddressBookRegistry addressBookRegistry)
             throws Exception {
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -131,6 +131,9 @@ public class LiveSequential implements Runnable {
     /** Maximum time to wait for all signatures at the live edge before proceeding with what we have. */
     private static final Duration MAX_SIG_WAIT = Duration.ofMinutes(2);
 
+    /** Maximum number of 15-minute retries when waiting for GCS listings for a new day. */
+    private static final int MAX_LISTING_WAIT_ATTEMPTS = 10;
+
     private static final File CACHE_DIR = new File("metadata/gcp-cache");
 
     /** Poison pill to signal the wrap+validate thread to exit. */
@@ -554,8 +557,13 @@ public class LiveSequential implements Runnable {
                                     + " listing entries for " + blockDay);
                             break;
                         } catch (NoSuchFileException e) {
+                            if (attempt >= MAX_LISTING_WAIT_ATTEMPTS) {
+                                throw new IllegalStateException("Listings not available for " + blockDay + " after "
+                                        + attempt + " attempts (waited " + (attempt * 15) + " minutes)");
+                            }
                             System.out.println("[live-sequential] Listings not available yet for " + blockDay
-                                    + ", waiting 15 minutes... (attempt " + attempt + ")");
+                                    + ", waiting 15 minutes... (attempt " + attempt + "/"
+                                    + MAX_LISTING_WAIT_ATTEMPTS + ")");
                             Thread.sleep(15 * 60 * 1000);
                         }
                     }
@@ -811,6 +819,9 @@ public class LiveSequential implements Runnable {
                 }
 
                 // Step 7: Validate hash chain (lightweight, keeps sequential integrity)
+                // TODO: download-live2 also calls UnparsedRecordBlockV6.validate() which verifies sidecar
+                // SHA-384 hashes against the record file metadata. This pipeline only does MD5 at download
+                // time + RSA verification in the wrap thread. Consider adding sidecar hash verification.
                 byte[] newHash =
                         DownloadDayLiveImpl.validateBlockHashes(nextBlockNumber, inMemoryFiles, currentHash, null);
                 Instant recordFileTime = blockTime.atZone(ZoneOffset.UTC).toInstant();

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -92,7 +92,7 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 /**
- * Sequential block download with inline wrapping and full validation.
+ * Live sequential block download with inline wrapping and full validation.
  *
  * <p>Downloads blocks one at a time, strictly sequentially, failing hard on any gap. Each block is:
  * <ol>
@@ -109,10 +109,10 @@ import picocli.CommandLine.Option;
  */
 @SuppressWarnings("FieldCanBeLocal")
 @Command(
-        name = "download-sequential",
-        description = "Sequential block download with inline validation and wrapping",
+        name = "live-sequential",
+        description = "Live sequential block download with inline validation and wrapping",
         mixinStandardHelpOptions = true)
-public class DownloadSequential implements Runnable {
+public class LiveSequential implements Runnable {
 
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static final Duration LIVE_POLL_INTERVAL = Duration.ofSeconds(2);
@@ -191,8 +191,7 @@ public class DownloadSequential implements Runnable {
 
     @Override
     public void run() {
-        System.out.println(
-                "[download-sequential] Starting sequential block download with inline wrapping + validation");
+        System.out.println("[live-sequential] Starting sequential block download with inline wrapping + validation");
         System.out.println("Configuration:");
         System.out.println("  listingDir=" + listingDir);
         System.out.println("  outputDir=" + outputDir);
@@ -238,7 +237,7 @@ public class DownloadSequential implements Runnable {
 
             // Determine starting point
             final State initialState = determineStartingPoint(blockTimeReader);
-            System.out.println("[download-sequential] Starting from block " + initialState.blockNumber
+            System.out.println("[live-sequential] Starting from block " + initialState.blockNumber
                     + " hash["
                     + (initialState.endRunningHashHex != null
                             ? initialState.endRunningHashHex.substring(
@@ -270,10 +269,10 @@ public class DownloadSequential implements Runnable {
             Runtime.getRuntime()
                     .addShutdownHook(new Thread(
                             () -> {
-                                System.out.println("[download-sequential] Shutdown requested...");
+                                System.out.println("[live-sequential] Shutdown requested...");
                                 downloadManager.close();
                             },
-                            "download-sequential-shutdown"));
+                            "live-sequential-shutdown"));
 
             // Main download loop
             processBlocksSequentially(
@@ -289,9 +288,9 @@ public class DownloadSequential implements Runnable {
                 throw new RuntimeException("Wrap+validate thread failed", wrapErr);
             }
 
-            System.out.println("[download-sequential] Complete.");
+            System.out.println("[live-sequential] Complete.");
         } catch (Exception e) {
-            System.err.println("[download-sequential] Fatal error: " + e.getMessage());
+            System.err.println("[live-sequential] Fatal error: " + e.getMessage());
             e.printStackTrace();
             System.exit(1);
         }
@@ -308,23 +307,23 @@ public class DownloadSequential implements Runnable {
                 String json = Files.readString(stateJsonPath, StandardCharsets.UTF_8);
                 State state = GSON.fromJson(json, State.class);
                 if (state != null && state.blockNumber > 0) {
-                    System.out.println("[download-sequential] Resuming from state file: block " + state.blockNumber);
+                    System.out.println("[live-sequential] Resuming from state file: block " + state.blockNumber);
                     return state;
                 }
             } catch (Exception e) {
-                System.err.println("[download-sequential] Warning: Failed to read state file: " + e.getMessage());
+                System.err.println("[live-sequential] Warning: Failed to read state file: " + e.getMessage());
             }
         }
 
         // Priority 2: Use --start-date
         if (startDate != null && !startDate.isBlank()) {
             LocalDate targetDay = LocalDate.parse(startDate);
-            System.out.println("[download-sequential] Using provided start date: " + targetDay);
+            System.out.println("[live-sequential] Using provided start date: " + targetDay);
 
             LocalDateTime startOfDay = targetDay.atStartOfDay();
             long firstBlockOfDay = blockTimeReader.getNearestBlockAfterTime(startOfDay);
 
-            System.out.println("[download-sequential] First block of " + targetDay + " is " + firstBlockOfDay);
+            System.out.println("[live-sequential] First block of " + targetDay + " is " + firstBlockOfDay);
 
             State state = new State();
             state.blockNumber = firstBlockOfDay - 1;
@@ -333,7 +332,7 @@ public class DownloadSequential implements Runnable {
         }
 
         // Priority 3: Auto-detect from mirror node
-        System.out.println("[download-sequential] Querying mirror node for current day...");
+        System.out.println("[live-sequential] Querying mirror node for current day...");
         List<BlockInfo> latestBlocks = FetchBlockQuery.getLatestBlocks(1, MirrorNodeBlockQueryOrder.DESC);
 
         if (latestBlocks.isEmpty()) {
@@ -352,7 +351,7 @@ public class DownloadSequential implements Runnable {
         Instant blockInstant = Instant.ofEpochSecond(epochSeconds);
         LocalDate today = blockInstant.atZone(ZoneOffset.UTC).toLocalDate();
 
-        System.out.println("[download-sequential] Detected current day: " + today);
+        System.out.println("[live-sequential] Detected current day: " + today);
 
         LocalDateTime startOfDay = today.atStartOfDay();
         long firstBlockOfDay = blockTimeReader.getNearestBlockAfterTime(startOfDay);
@@ -427,7 +426,7 @@ public class DownloadSequential implements Runnable {
                 if (!blockDay.equals(currentDay)) {
                     if (currentDayWriter != null) {
                         currentDayWriter.close();
-                        System.out.println("[download-sequential] Day completed: " + currentDay + " ("
+                        System.out.println("[live-sequential] Day completed: " + currentDay + " ("
                                 + blocksProcessedToday + " blocks in "
                                 + formatDuration((System.currentTimeMillis() - dayStartTime) / 1000) + ")");
                     }
@@ -441,7 +440,7 @@ public class DownloadSequential implements Runnable {
                     cachedListingFiles = null;
                     cachedListingDay = null;
 
-                    System.out.println("[download-sequential] Started new day: " + currentDay);
+                    System.out.println("[live-sequential] Started new day: " + currentDay);
                 }
 
                 // Initialize writer if needed (first block)
@@ -449,7 +448,7 @@ public class DownloadSequential implements Runnable {
                     Path dayArchive = outputDir.toPath().resolve(currentDay + ".tar.zstd");
                     currentDayWriter = new ConcurrentTarZstdWriter(dayArchive);
                     dayStartTime = System.currentTimeMillis();
-                    System.out.println("[download-sequential] Started day: " + currentDay);
+                    System.out.println("[live-sequential] Started day: " + currentDay);
                 }
 
                 // Step 3: Load GCS listings if day changed
@@ -466,11 +465,11 @@ public class DownloadSequential implements Runnable {
                             cachedListingFiles =
                                     DayListingFileReader.loadRecordsFileForDay(listingDir.toPath(), year, month, day);
                             cachedListingDay = blockDay;
-                            System.out.println("[download-sequential] Loaded " + cachedListingFiles.size()
+                            System.out.println("[live-sequential] Loaded " + cachedListingFiles.size()
                                     + " listing entries for " + blockDay);
                             break;
                         } catch (NoSuchFileException e) {
-                            System.out.println("[download-sequential] Listings not available yet for " + blockDay
+                            System.out.println("[live-sequential] Listings not available yet for " + blockDay
                                     + ", waiting 15 minutes... (attempt " + attempt + ")");
                             Thread.sleep(15 * 60 * 1000);
                         }
@@ -497,8 +496,8 @@ public class DownloadSequential implements Runnable {
 
                     if (group == null || group.isEmpty()) {
                         // Try fixing block time
-                        System.out.println("[download-sequential] No files found for block " + nextBlockNumber
-                                + " at time " + blockTime + ", fixing block times...");
+                        System.out.println("[live-sequential] No files found for block " + nextBlockNumber + " at time "
+                                + blockTime + ", fixing block times...");
                         FixBlockTime.fixBlockTimeRange(
                                 MetadataFiles.BLOCK_TIMES_FILE, nextBlockNumber, nextBlockNumber + 100);
                         blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
@@ -508,16 +507,16 @@ public class DownloadSequential implements Runnable {
 
                 // If no hash yet, fetch from mirror node
                 if (currentHash == null && nextBlockNumber > 0) {
-                    System.out.println("[download-sequential] Fetching previous hash from mirror node for block "
-                            + nextBlockNumber);
+                    System.out.println(
+                            "[live-sequential] Fetching previous hash from mirror node for block " + nextBlockNumber);
                     try {
                         var prevHashBytes = FetchBlockQuery.getPreviousHashForBlock(nextBlockNumber);
                         currentHash = prevHashBytes.toByteArray();
-                        System.out.println("[download-sequential] Got previous hash: "
+                        System.out.println("[live-sequential] Got previous hash: "
                                 + HexFormat.of().formatHex(currentHash).substring(0, 16) + "...");
                     } catch (Exception e) {
                         System.err.println(
-                                "[download-sequential] Warning: Could not fetch previous hash: " + e.getMessage());
+                                "[live-sequential] Warning: Could not fetch previous hash: " + e.getMessage());
                     }
                 }
 
@@ -546,7 +545,7 @@ public class DownloadSequential implements Runnable {
 
                         boolean md5Valid = checkMd5(lr.md5Hex(), downloadedFile.data());
                         if (!md5Valid) {
-                            System.err.println("[download-sequential] MD5 mismatch for " + lr.path() + ", skipping");
+                            System.err.println("[live-sequential] MD5 mismatch for " + lr.path() + ", skipping");
                             continue;
                         }
 
@@ -560,7 +559,7 @@ public class DownloadSequential implements Runnable {
                         inMemoryFiles.add(new InMemoryFile(newFilePath, contentBytes));
                     } catch (CompletionException ce) {
                         System.err.println(
-                                "[download-sequential] Download failed for " + blobName + ": " + ce.getMessage());
+                                "[live-sequential] Download failed for " + blobName + ": " + ce.getMessage());
                         throw new IllegalStateException("Download failed for block " + nextBlockNumber, ce.getCause());
                     }
                 }
@@ -606,13 +605,13 @@ public class DownloadSequential implements Runnable {
                 if (blocksProcessedTotal % PROGRESS_LOG_INTERVAL == 0) {
                     long elapsed = System.currentTimeMillis() - dayStartTime;
                     double blocksPerSec = blocksProcessedToday / Math.max(1.0, elapsed / 1000.0);
-                    System.out.println("[download-sequential] Block " + currentBlockNumber + " (" + blocksProcessedToday
+                    System.out.println("[live-sequential] Block " + currentBlockNumber + " (" + blocksProcessedToday
                             + " today, " + String.format("%.1f", blocksPerSec) + " blocks/sec)");
                 }
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            System.out.println("[download-sequential] Interrupted, saving state...");
+            System.out.println("[live-sequential] Interrupted, saving state...");
         } finally {
             if (currentHash != null) {
                 try {
@@ -620,16 +619,16 @@ public class DownloadSequential implements Runnable {
                     Instant finalRecordTime =
                             finalBlockTime.atZone(ZoneOffset.UTC).toInstant();
                     saveState(new State(currentBlockNumber, currentHash, finalRecordTime, currentDay));
-                    System.out.println("[download-sequential] Saved state at block " + currentBlockNumber);
+                    System.out.println("[live-sequential] Saved state at block " + currentBlockNumber);
                 } catch (Exception e) {
-                    System.err.println("[download-sequential] Error saving final state: " + e.getMessage());
+                    System.err.println("[live-sequential] Error saving final state: " + e.getMessage());
                 }
             }
             if (currentDayWriter != null) {
                 try {
                     currentDayWriter.close();
                 } catch (Exception e) {
-                    System.err.println("[download-sequential] Error closing writer: " + e.getMessage());
+                    System.err.println("[live-sequential] Error closing writer: " + e.getMessage());
                 }
             }
         }
@@ -1050,7 +1049,7 @@ public class DownloadSequential implements Runnable {
             String json = GSON.toJson(state);
             Files.writeString(stateJsonPath, json, StandardCharsets.UTF_8);
         } catch (IOException e) {
-            System.err.println("[download-sequential] Warning: Failed to save state: " + e.getMessage());
+            System.err.println("[live-sequential] Warning: Failed to save state: " + e.getMessage());
         }
     }
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -285,7 +285,7 @@ public class LiveSequential implements Runnable {
             // Check for wrap errors
             Throwable wrapErr = wrapError.get();
             if (wrapErr != null) {
-                throw new RuntimeException("Wrap+validate thread failed", wrapErr);
+                throw new IllegalStateException("Wrap+validate thread failed", wrapErr);
             }
 
             System.out.println("[live-sequential] Complete.");
@@ -346,14 +346,14 @@ public class LiveSequential implements Runnable {
         List<BlockInfo> latestBlocks = FetchBlockQuery.getLatestBlocks(1, MirrorNodeBlockQueryOrder.DESC);
 
         if (latestBlocks.isEmpty()) {
-            throw new RuntimeException("Failed to get latest block from mirror node");
+            throw new IllegalStateException("Failed to get latest block from mirror node");
         }
 
         BlockInfo latestBlock = latestBlocks.getFirst();
         String timestamp = latestBlock.timestampFrom != null ? latestBlock.timestampFrom : latestBlock.timestampTo;
 
         if (timestamp == null) {
-            throw new RuntimeException("Latest block has no timestamp");
+            throw new IllegalStateException("Latest block has no timestamp");
         }
 
         String[] parts = timestamp.split("\\.");
@@ -449,7 +449,7 @@ public class LiveSequential implements Runnable {
                 // Check for wrap thread errors
                 Throwable wrapErr = wrapError.get();
                 if (wrapErr != null) {
-                    throw new RuntimeException("Wrap+validate thread failed, stopping download", wrapErr);
+                    throw new IllegalStateException("Wrap+validate thread failed, stopping download", wrapErr);
                 }
 
                 long nextBlockNumber = currentBlockNumber + 1;
@@ -969,8 +969,7 @@ public class LiveSequential implements Runnable {
                             v.validate(blockUnparsed, blockNum);
                         } catch (ValidationException e) {
                             // Save checkpoint before failing
-                            saveValidationCheckpoint(
-                                    checkpointDir, blocksValidated, blockNum - 1, chainValidation, allValidations);
+                            saveValidationCheckpoint(checkpointDir, blockNum - 1, allValidations);
                             throw new IllegalStateException(
                                     "Validation '" + v.name() + "' failed at block " + blockNum + ": " + e.getMessage(),
                                     e);
@@ -987,8 +986,7 @@ public class LiveSequential implements Runnable {
                     // Periodic checkpoint save
                     long nowMs = System.currentTimeMillis();
                     if (nowMs - lastCheckpointSaveMs >= 60_000L) {
-                        saveValidationCheckpoint(
-                                checkpointDir, blocksValidated, blockNum, chainValidation, allValidations);
+                        saveValidationCheckpoint(checkpointDir, blockNum, allValidations);
                         lastCheckpointSaveMs = nowMs;
                     }
 
@@ -1012,8 +1010,7 @@ public class LiveSequential implements Runnable {
                 addressBookRegistry.saveAddressBookRegistryToJsonFile(addressBookFile);
 
                 // Save validation checkpoint
-                saveValidationCheckpoint(
-                        checkpointDir, blocksValidated, durableWatermark, chainValidation, allValidations);
+                saveValidationCheckpoint(checkpointDir, durableWatermark, allValidations);
 
                 // Close all validations
                 for (BlockValidation v : allValidations) {
@@ -1029,13 +1026,13 @@ public class LiveSequential implements Runnable {
      * Saves validation checkpoint state.
      */
     private static void saveValidationCheckpoint(
-            Path checkpointDir,
-            long blocksValidated,
-            long lastValidatedBlockNumber,
-            BlockChainValidation chainValidation,
-            List<BlockValidation> validations) {
+            Path checkpointDir, long lastValidatedBlockNumber, List<BlockValidation> validations) {
         try {
             Files.createDirectories(checkpointDir);
+            // Save progress file so resume can detect checkpoint position
+            Path progressFile = checkpointDir.resolve("validateProgress.json");
+            String progressJson = "{\"lastValidatedBlockNumber\":" + lastValidatedBlockNumber + "}";
+            Files.writeString(progressFile, progressJson, StandardCharsets.UTF_8);
             for (BlockValidation v : validations) {
                 try {
                     v.save(checkpointDir);

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -185,6 +185,35 @@ public class LiveSequential implements Runnable {
         }
     }
 
+    /** Mutable state for the download loop, enabling extraction of the loop body into a helper method. */
+    private static class DownloadLoopState {
+        long currentBlockNumber;
+        byte[] currentHash;
+        LocalDate currentDay;
+        BlockTimeReader blockTimeReader;
+        ConcurrentTarZstdWriter dayWriter;
+        long blocksProcessedTotal;
+        long blocksProcessedToday;
+        long dayStartTime;
+        long lastBlockTimeRefreshMs;
+        List<ListingRecordFile> cachedListingFiles;
+        LocalDate cachedListingDay;
+        final NetworkConfig netConfig;
+
+        DownloadLoopState(State initialState, BlockTimeReader reader) {
+            this.currentBlockNumber = initialState.blockNumber;
+            this.currentHash = initialState.getHashBytes();
+            this.currentDay = initialState.getDayDate();
+            this.blockTimeReader = reader;
+            this.dayStartTime = System.currentTimeMillis();
+            this.netConfig = NetworkConfig.current();
+        }
+    }
+
+    /** Immutable container for the three validation lists used by the wrap+validate thread. */
+    private record WrapValidations(
+            List<BlockValidation> parallel, List<BlockValidation> sequential, List<BlockValidation> all) {}
+
     /** Block data passed from the download thread to the wrap+validate thread. */
     private record ValidatedBlock(
             long blockNumber, Instant recordFileTime, List<InMemoryFile> files, byte[] runningHash) {}
@@ -428,104 +457,117 @@ public class LiveSequential implements Runnable {
             BlockingQueue<ValidatedBlock> queue,
             AtomicReference<Throwable> wrapError)
             throws Exception {
-
-        long currentBlockNumber = initialState.blockNumber;
-        byte[] currentHash = initialState.getHashBytes();
-        LocalDate currentDay = initialState.getDayDate();
-        BlockTimeReader blockTimeReader = initialBlockTimeReader;
-        ConcurrentTarZstdWriter currentDayWriter = null;
-        long blocksProcessedTotal = 0;
-        long blocksProcessedToday = 0;
-        long dayStartTime = System.currentTimeMillis();
-        long lastBlockTimeRefreshMs = 0;
-        List<ListingRecordFile> cachedListingFiles = null;
-        LocalDate cachedListingDay = null;
-        final NetworkConfig netConfig = NetworkConfig.current();
-
+        final DownloadLoopState state = new DownloadLoopState(initialState, initialBlockTimeReader);
         try {
             while (true) {
                 Throwable wrapErr = wrapError.get();
                 if (wrapErr != null) {
                     throw new IllegalStateException("Wrap+validate thread failed, stopping download", wrapErr);
                 }
-                long nextBlockNumber = currentBlockNumber + 1;
-
-                // Step 1: Get block timestamp (poll if not yet available)
-                LocalDateTime blockTime = resolveBlockTime(blockTimeReader, nextBlockNumber);
-                if (blockTime == null) {
-                    long now = System.currentTimeMillis();
-                    if (now - lastBlockTimeRefreshMs >= MIN_BLOCK_TIME_REFRESH_INTERVAL_MS) {
-                        System.out.println(
-                                "[LIVE] Block " + nextBlockNumber + " not in BlockTimeReader, refreshing...");
-                        UpdateBlockData.updateMirrorNodeData(
-                                MetadataFiles.BLOCK_TIMES_FILE, MetadataFiles.DAY_BLOCKS_FILE);
-                        blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
-                        lastBlockTimeRefreshMs = now;
-                    }
-                    Thread.sleep(LIVE_POLL_INTERVAL.toMillis());
-                    continue;
-                }
-                LocalDate blockDay = blockTime.toLocalDate();
-
-                // Step 2: Handle day boundary and initialize writer
-                if (!blockDay.equals(currentDay)) {
-                    closeDayWriter(currentDayWriter, currentDay, blocksProcessedToday, dayStartTime);
-                    currentDayWriter = openDayWriterIfNeeded(blockDay);
-                    currentDay = blockDay;
-                    blocksProcessedToday = 0;
-                    dayStartTime = System.currentTimeMillis();
-                    cachedListingFiles = null;
-                    cachedListingDay = null;
-                    System.out.println("[live-sequential] Started new day: " + currentDay);
-                } else if (currentDayWriter == null && currentDay != null) {
-                    currentDayWriter = openDayWriterIfNeeded(currentDay);
-                    if (currentDayWriter != null) {
-                        dayStartTime = System.currentTimeMillis();
-                        System.out.println("[live-sequential] Started day: " + currentDay);
-                    }
-                }
-
-                // Step 3: Load/refresh GCS listings and find files for this block
-                if (!blockDay.equals(cachedListingDay)) {
-                    cachedListingFiles = loadListingsWithRetry(blockDay, blockTime, netConfig);
-                    cachedListingDay = blockDay;
-                }
-                List<ListingRecordFile> group =
-                        findBlockGroupWithRefresh(blockTime, blockDay, nextBlockNumber, cachedListingFiles, netConfig);
-                if (group == null) {
-                    blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
-                    continue;
-                }
-                cachedListingFiles = reloadListings(blockTime); // keep cache in sync after refresh
-                cachedListingDay = blockDay;
-
-                // Step 4: Download, validate, write, and queue
-                currentHash = fetchPreviousHashIfNeeded(currentHash, nextBlockNumber);
-                List<InMemoryFile> inMemoryFiles =
-                        downloadBlockFiles(group, netConfig, downloadManager, nextBlockNumber);
-                byte[] newHash =
-                        DownloadDayLiveImpl.validateBlockHashes(nextBlockNumber, inMemoryFiles, currentHash, null);
-                validateBlock(addressBookRegistry, currentHash, blockTime, nextBlockNumber, inMemoryFiles, newHash);
-                assertSequentialOrdering(nextBlockNumber, currentBlockNumber);
-                writeToDayArchive(currentDayWriter, inMemoryFiles);
-                Instant recordFileTime = blockTime.atZone(ZoneOffset.UTC).toInstant();
-                queue.put(new ValidatedBlock(nextBlockNumber, recordFileTime, inMemoryFiles, newHash));
-
-                // Step 5: Update state and log progress
-                currentBlockNumber = nextBlockNumber;
-                currentHash = newHash;
-                blocksProcessedTotal++;
-                blocksProcessedToday++;
-                saveState(new State(currentBlockNumber, currentHash, recordFileTime, currentDay));
-                logProgress(blocksProcessedTotal, blocksProcessedToday, currentBlockNumber, dayStartTime);
+                processOneBlock(state, addressBookRegistry, downloadManager, queue);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             System.out.println("[live-sequential] Interrupted, saving state...");
         } finally {
-            saveFinalState(currentBlockNumber, currentHash, currentDay, blockTimeReader);
-            closeQuietly(currentDayWriter);
+            saveFinalState(state.currentBlockNumber, state.currentHash, state.currentDay, state.blockTimeReader);
+            closeQuietly(state.dayWriter);
         }
+    }
+
+    private void processOneBlock(
+            DownloadLoopState state,
+            AddressBookRegistry addressBookRegistry,
+            ConcurrentDownloadManagerVirtualThreadsV3 downloadManager,
+            BlockingQueue<ValidatedBlock> queue)
+            throws Exception {
+        long nextBlockNumber = state.currentBlockNumber + 1;
+        LocalDateTime blockTime = resolveBlockTime(state.blockTimeReader, nextBlockNumber);
+        if (blockTime == null) {
+            state.blockTimeReader =
+                    refreshBlockTimeIfNeeded(state.blockTimeReader, nextBlockNumber, state.lastBlockTimeRefreshMs);
+            state.lastBlockTimeRefreshMs = System.currentTimeMillis();
+            Thread.sleep(LIVE_POLL_INTERVAL.toMillis());
+            return;
+        }
+        LocalDate blockDay = blockTime.toLocalDate();
+        if (!blockDay.equals(state.currentDay)) {
+            closeDayWriter(state.dayWriter, state.currentDay, state.blocksProcessedToday, state.dayStartTime);
+            state.dayWriter = openDayWriterIfNeeded(blockDay);
+            state.currentDay = blockDay;
+            state.blocksProcessedToday = 0;
+            state.dayStartTime = System.currentTimeMillis();
+            state.cachedListingFiles = null;
+            state.cachedListingDay = null;
+        } else if (state.dayWriter == null && state.currentDay != null) {
+            state.dayWriter = openDayWriterIfNeeded(state.currentDay);
+            if (state.dayWriter != null) state.dayStartTime = System.currentTimeMillis();
+        }
+        if (!blockDay.equals(state.cachedListingDay)) {
+            state.cachedListingFiles = loadListingsWithRetry(blockDay, blockTime, state.netConfig);
+            state.cachedListingDay = blockDay;
+        }
+        List<ListingRecordFile> group = findBlockGroupWithRefresh(
+                blockTime, blockDay, nextBlockNumber, state.cachedListingFiles, state.netConfig);
+        if (group == null) {
+            state.blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+            return;
+        }
+        state.cachedListingFiles = reloadListings(blockTime);
+        state.cachedListingDay = blockDay;
+        byte[] newHash = downloadValidateAndEnqueue(
+                addressBookRegistry,
+                downloadManager,
+                state.netConfig,
+                group,
+                nextBlockNumber,
+                state.currentBlockNumber,
+                state.currentHash,
+                blockTime,
+                state.dayWriter,
+                queue);
+        Instant recordFileTime = blockTime.atZone(ZoneOffset.UTC).toInstant();
+        state.currentBlockNumber = nextBlockNumber;
+        state.currentHash = newHash;
+        state.blocksProcessedTotal++;
+        state.blocksProcessedToday++;
+        saveState(new State(state.currentBlockNumber, state.currentHash, recordFileTime, state.currentDay));
+        logProgress(
+                state.blocksProcessedTotal, state.blocksProcessedToday, state.currentBlockNumber, state.dayStartTime);
+    }
+
+    private byte[] downloadValidateAndEnqueue(
+            AddressBookRegistry addressBookRegistry,
+            ConcurrentDownloadManagerVirtualThreadsV3 downloadManager,
+            NetworkConfig netConfig,
+            List<ListingRecordFile> group,
+            long nextBlockNumber,
+            long currentBlockNumber,
+            byte[] currentHash,
+            LocalDateTime blockTime,
+            ConcurrentTarZstdWriter dayWriter,
+            BlockingQueue<ValidatedBlock> queue)
+            throws Exception {
+        currentHash = fetchPreviousHashIfNeeded(currentHash, nextBlockNumber);
+        List<InMemoryFile> inMemoryFiles = downloadBlockFiles(group, netConfig, downloadManager, nextBlockNumber);
+        byte[] newHash = DownloadDayLiveImpl.validateBlockHashes(nextBlockNumber, inMemoryFiles, currentHash, null);
+        validateBlock(addressBookRegistry, currentHash, blockTime, nextBlockNumber, inMemoryFiles, newHash);
+        assertSequentialOrdering(nextBlockNumber, currentBlockNumber);
+        writeToDayArchive(dayWriter, inMemoryFiles);
+        Instant recordFileTime = blockTime.atZone(ZoneOffset.UTC).toInstant();
+        queue.put(new ValidatedBlock(nextBlockNumber, recordFileTime, inMemoryFiles, newHash));
+        return newHash;
+    }
+
+    private static BlockTimeReader refreshBlockTimeIfNeeded(
+            BlockTimeReader reader, long blockNumber, long lastRefreshMs) throws IOException {
+        long now = System.currentTimeMillis();
+        if (now - lastRefreshMs >= MIN_BLOCK_TIME_REFRESH_INTERVAL_MS) {
+            System.out.println("[LIVE] Block " + blockNumber + " not in BlockTimeReader, refreshing...");
+            UpdateBlockData.updateMirrorNodeData(MetadataFiles.BLOCK_TIMES_FILE, MetadataFiles.DAY_BLOCKS_FILE);
+            return new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+        }
+        return reader;
     }
 
     private static LocalDateTime resolveBlockTime(BlockTimeReader reader, long blockNumber) {
@@ -736,47 +778,26 @@ public class LiveSequential implements Runnable {
     @SuppressWarnings("PMD.NPathComplexity")
     private void runWrapAndValidateThread(BlockingQueue<ValidatedBlock> queue, AddressBookRegistry addressBookRegistry)
             throws Exception {
-
-        final Path hashRegistryPath = wrapOutputDir.resolve("blockStreamBlockHashes.bin");
         final Path streamingMerkleTreeFile = wrapOutputDir.resolve("streamingMerkleTree.bin");
         final Path watermarkFile = wrapOutputDir.resolve("wrap-commit.bin");
         final Path addressBookFile = wrapOutputDir.resolve("addressBookHistory.json");
         final Path checkpointDir = wrapOutputDir.resolve("validateCheckpoint");
 
-        Files.createDirectories(wrapOutputDir);
-        Files.createDirectories(checkpointDir);
-        if (!Files.exists(addressBookFile) && addressBookPath != null && Files.exists(addressBookPath)) {
-            Files.copy(addressBookPath, addressBookFile);
-        }
-
+        initializeWrapDirectories(addressBookFile, checkpointDir);
         final AmendmentProvider amendmentProvider =
                 createAmendmentProvider(NetworkConfig.current().networkName());
-
-        try (BlockStreamBlockHashRegistry blockRegistry = new BlockStreamBlockHashRegistry(hashRegistryPath)) {
+        try (BlockStreamBlockHashRegistry blockRegistry =
+                new BlockStreamBlockHashRegistry(wrapOutputDir.resolve("blockStreamBlockHashes.bin"))) {
             long[] state = reconcileWrapState(blockRegistry, watermarkFile);
             long effectiveHighest = state[0];
-            long watermark = state[1];
 
             System.out.println("[WRAP] Starting from block: " + effectiveHighest);
             final StreamingHasher streamingHasher = replayHasher(blockRegistry, effectiveHighest);
 
-            BlockChainValidation chainValidation = new BlockChainValidation();
-            List<BlockValidation> parallelValidations = buildParallelValidations(addressBookRegistry);
-            List<BlockValidation> sequentialValidations = buildSequentialValidations(
-                    addressBookRegistry, blockRegistry, chainValidation, streamingMerkleTreeFile);
-            List<BlockValidation> allValidations = new ArrayList<>();
-            allValidations.addAll(parallelValidations);
-            allValidations.addAll(sequentialValidations);
+            WrapValidations wv = setupValidations(
+                    addressBookRegistry, blockRegistry, streamingMerkleTreeFile, effectiveHighest, checkpointDir);
 
-            initializeCheckpointState(
-                    effectiveHighest,
-                    checkpointDir,
-                    blockRegistry,
-                    chainValidation,
-                    sequentialValidations,
-                    allValidations);
-
-            long[] zipState = {watermark, 0}; // [durableWatermark, blocksSinceFlush]
+            long[] zipState = {state[1], 0};
             BlockZipAppender[] zipHolder = {null};
             Path[] zipPathHolder = {null};
             long blocksValidated = 0;
@@ -797,23 +818,15 @@ public class LiveSequential implements Runnable {
                             streamingHasher.computeRootHash(),
                             amendmentProvider);
 
-                    byte[] blockStreamBlockHash = hashBlock(wrapped);
-                    streamingHasher.addNodeByHash(blockStreamBlockHash);
-                    blockRegistry.addBlock(blockNum, blockStreamBlockHash);
-
+                    byte[] blockHash = hashBlock(wrapped);
+                    streamingHasher.addNodeByHash(blockHash);
+                    blockRegistry.addBlock(blockNum, blockHash);
                     writeToZipArchive(blockNum, wrapped, watermarkFile, zipHolder, zipPathHolder, zipState);
-
-                    runBlockValidations(
-                            wrapped,
-                            blockNum,
-                            parallelValidations,
-                            sequentialValidations,
-                            allValidations,
-                            checkpointDir);
+                    runBlockValidations(wrapped, blockNum, wv.parallel(), wv.sequential(), wv.all(), checkpointDir);
                     blocksValidated++;
 
                     if (System.currentTimeMillis() - lastCheckpointSaveMs >= 60_000L) {
-                        saveValidationCheckpoint(checkpointDir, blockNum, allValidations);
+                        saveValidationCheckpoint(checkpointDir, blockNum, wv.all());
                         lastCheckpointSaveMs = System.currentTimeMillis();
                     }
                     if (blocksValidated % PROGRESS_LOG_INTERVAL == 0) {
@@ -823,21 +836,69 @@ public class LiveSequential implements Runnable {
                     }
                 }
             } finally {
-                if (zipHolder[0] != null) {
-                    try {
-                        zipHolder[0].close();
-                    } catch (IOException e) {
-                        System.err.println("[WRAP] Error closing zip: " + e.getMessage());
-                    }
-                }
-                saveWatermark(watermarkFile, zipState[0]);
-                saveStateCheckpoint(streamingMerkleTreeFile, streamingHasher);
-                addressBookRegistry.saveAddressBookRegistryToJsonFile(addressBookFile);
-                saveValidationCheckpoint(checkpointDir, zipState[0], allValidations);
-                for (BlockValidation v : allValidations) v.close();
-                System.out.println("[WRAP] Shutdown complete. Wrapped " + blocksValidated + " blocks.");
+                finalizeWrapState(
+                        zipHolder[0],
+                        zipState[0],
+                        watermarkFile,
+                        streamingMerkleTreeFile,
+                        streamingHasher,
+                        addressBookRegistry,
+                        addressBookFile,
+                        checkpointDir,
+                        wv.all(),
+                        blocksValidated);
             }
         }
+    }
+
+    private WrapValidations setupValidations(
+            AddressBookRegistry addressBookRegistry,
+            BlockStreamBlockHashRegistry blockRegistry,
+            Path streamingMerkleTreeFile,
+            long effectiveHighest,
+            Path checkpointDir) {
+        BlockChainValidation chainValidation = new BlockChainValidation();
+        List<BlockValidation> parallel = buildParallelValidations(addressBookRegistry);
+        List<BlockValidation> sequential = buildSequentialValidations(
+                addressBookRegistry, blockRegistry, chainValidation, streamingMerkleTreeFile);
+        List<BlockValidation> all = new ArrayList<>(parallel);
+        all.addAll(sequential);
+        initializeCheckpointState(effectiveHighest, checkpointDir, blockRegistry, chainValidation, sequential, all);
+        return new WrapValidations(parallel, sequential, all);
+    }
+
+    private void initializeWrapDirectories(Path addressBookFile, Path checkpointDir) throws IOException {
+        Files.createDirectories(wrapOutputDir);
+        Files.createDirectories(checkpointDir);
+        if (!Files.exists(addressBookFile) && addressBookPath != null && Files.exists(addressBookPath)) {
+            Files.copy(addressBookPath, addressBookFile);
+        }
+    }
+
+    private static void finalizeWrapState(
+            BlockZipAppender currentZip,
+            long durableWatermark,
+            Path watermarkFile,
+            Path streamingMerkleTreeFile,
+            StreamingHasher streamingHasher,
+            AddressBookRegistry addressBookRegistry,
+            Path addressBookFile,
+            Path checkpointDir,
+            List<BlockValidation> allValidations,
+            long blocksValidated) {
+        if (currentZip != null) {
+            try {
+                currentZip.close();
+            } catch (IOException e) {
+                System.err.println("[WRAP] Error closing zip: " + e.getMessage());
+            }
+        }
+        saveWatermark(watermarkFile, durableWatermark);
+        saveStateCheckpoint(streamingMerkleTreeFile, streamingHasher);
+        addressBookRegistry.saveAddressBookRegistryToJsonFile(addressBookFile);
+        saveValidationCheckpoint(checkpointDir, durableWatermark, allValidations);
+        for (BlockValidation v : allValidations) v.close();
+        System.out.println("[WRAP] Shutdown complete. Wrapped " + blocksValidated + " blocks.");
     }
 
     private void writeToZipArchive(

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -450,11 +450,9 @@ public class LiveSequential implements Runnable {
                 }
                 long nextBlockNumber = currentBlockNumber + 1;
 
-                // Step 1: Get block timestamp
-                LocalDateTime blockTime;
-                try {
-                    blockTime = blockTimeReader.getBlockLocalDateTime(nextBlockNumber);
-                } catch (Exception e) {
+                // Step 1: Get block timestamp (poll if not yet available)
+                LocalDateTime blockTime = resolveBlockTime(blockTimeReader, nextBlockNumber);
+                if (blockTime == null) {
                     long now = System.currentTimeMillis();
                     if (now - lastBlockTimeRefreshMs >= MIN_BLOCK_TIME_REFRESH_INTERVAL_MS) {
                         System.out.println(
@@ -469,7 +467,7 @@ public class LiveSequential implements Runnable {
                 }
                 LocalDate blockDay = blockTime.toLocalDate();
 
-                // Step 2: Handle day boundary
+                // Step 2: Handle day boundary and initialize writer
                 if (!blockDay.equals(currentDay)) {
                     closeDayWriter(currentDayWriter, currentDay, blocksProcessedToday, dayStartTime);
                     currentDayWriter = openDayWriterIfNeeded(blockDay);
@@ -479,8 +477,7 @@ public class LiveSequential implements Runnable {
                     cachedListingFiles = null;
                     cachedListingDay = null;
                     System.out.println("[live-sequential] Started new day: " + currentDay);
-                }
-                if (currentDayWriter == null && currentDay != null) {
+                } else if (currentDayWriter == null && currentDay != null) {
                     currentDayWriter = openDayWriterIfNeeded(currentDay);
                     if (currentDayWriter != null) {
                         dayStartTime = System.currentTimeMillis();
@@ -488,30 +485,21 @@ public class LiveSequential implements Runnable {
                     }
                 }
 
-                // Step 3: Load GCS listings if day changed
+                // Step 3: Load/refresh GCS listings and find files for this block
                 if (!blockDay.equals(cachedListingDay)) {
                     cachedListingFiles = loadListingsWithRetry(blockDay, blockTime, netConfig);
                     cachedListingDay = blockDay;
                 }
-
-                // Step 4: Find files for this block (refresh if not found)
-                List<ListingRecordFile> group = findBlockGroup(blockTime, cachedListingFiles);
+                List<ListingRecordFile> group =
+                        findBlockGroupWithRefresh(blockTime, blockDay, nextBlockNumber, cachedListingFiles, netConfig);
                 if (group == null) {
-                    refreshListingsForDay(blockDay, netConfig);
-                    cachedListingFiles = reloadListings(blockTime);
-                    cachedListingDay = blockDay;
-                    group = findBlockGroup(blockTime, cachedListingFiles);
-                    if (group == null) {
-                        System.out.println("[live-sequential] No files found for block " + nextBlockNumber + " at time "
-                                + blockTime + ", fixing block times...");
-                        FixBlockTime.fixBlockTimeRange(
-                                MetadataFiles.BLOCK_TIMES_FILE, nextBlockNumber, nextBlockNumber + 100);
-                        blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
-                        continue;
-                    }
+                    blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                    continue;
                 }
+                cachedListingFiles = reloadListings(blockTime); // keep cache in sync after refresh
+                cachedListingDay = blockDay;
 
-                // Step 5: Download, validate, write, and queue
+                // Step 4: Download, validate, write, and queue
                 currentHash = fetchPreviousHashIfNeeded(currentHash, nextBlockNumber);
                 List<InMemoryFile> inMemoryFiles =
                         downloadBlockFiles(group, netConfig, downloadManager, nextBlockNumber);
@@ -523,7 +511,7 @@ public class LiveSequential implements Runnable {
                 Instant recordFileTime = blockTime.atZone(ZoneOffset.UTC).toInstant();
                 queue.put(new ValidatedBlock(nextBlockNumber, recordFileTime, inMemoryFiles, newHash));
 
-                // Step 6: Update state and log progress
+                // Step 5: Update state and log progress
                 currentBlockNumber = nextBlockNumber;
                 currentHash = newHash;
                 blocksProcessedTotal++;
@@ -538,6 +526,35 @@ public class LiveSequential implements Runnable {
             saveFinalState(currentBlockNumber, currentHash, currentDay, blockTimeReader);
             closeQuietly(currentDayWriter);
         }
+    }
+
+    private static LocalDateTime resolveBlockTime(BlockTimeReader reader, long blockNumber) {
+        try {
+            return reader.getBlockLocalDateTime(blockNumber);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private List<ListingRecordFile> findBlockGroupWithRefresh(
+            LocalDateTime blockTime,
+            LocalDate blockDay,
+            long blockNumber,
+            List<ListingRecordFile> cachedListingFiles,
+            NetworkConfig netConfig)
+            throws Exception {
+        List<ListingRecordFile> group = findBlockGroup(blockTime, cachedListingFiles);
+        if (group != null) return group;
+
+        refreshListingsForDay(blockDay, netConfig);
+        List<ListingRecordFile> refreshed = reloadListings(blockTime);
+        group = findBlockGroup(blockTime, refreshed);
+        if (group != null) return group;
+
+        System.out.println("[live-sequential] No files found for block " + blockNumber + " at time " + blockTime
+                + ", fixing block times...");
+        FixBlockTime.fixBlockTimeRange(MetadataFiles.BLOCK_TIMES_FILE, blockNumber, blockNumber + 100);
+        return null;
     }
 
     private static void closeDayWriter(
@@ -759,10 +776,9 @@ public class LiveSequential implements Runnable {
                     sequentialValidations,
                     allValidations);
 
-            BlockZipAppender currentZip = null;
-            Path currentZipPath = null;
-            long durableWatermark = watermark;
-            long blocksSinceWatermarkFlush = 0;
+            long[] zipState = {watermark, 0}; // [durableWatermark, blocksSinceFlush]
+            BlockZipAppender[] zipHolder = {null};
+            Path[] zipPathHolder = {null};
             long blocksValidated = 0;
             long lastCheckpointSaveMs = System.currentTimeMillis();
 
@@ -785,29 +801,8 @@ public class LiveSequential implements Runnable {
                     streamingHasher.addNodeByHash(blockStreamBlockHash);
                     blockRegistry.addBlock(blockNum, blockStreamBlockHash);
 
-                    // Write to zip archive
-                    BlockPath blockPath =
-                            BlockWriter.computeBlockPath(wrapOutputDir, blockNum, BlockArchiveType.UNCOMPRESSED_ZIP);
-                    Files.createDirectories(blockPath.dirPath());
-                    byte[] serializedBytes = BlockWriter.serializeBlockToBytes(wrapped, DEFAULT_COMPRESSION);
-                    if (!blockPath.zipFilePath().equals(currentZipPath)) {
-                        if (currentZip != null) {
-                            currentZip.close();
-                            saveWatermark(watermarkFile, durableWatermark);
-                            blocksSinceWatermarkFlush = 0;
-                        }
-                        currentZip = BlockWriter.openZipForAppend(blockPath.zipFilePath());
-                        currentZipPath = blockPath.zipFilePath();
-                    }
-                    BlockWriter.writeBlockEntry(currentZip, blockPath, serializedBytes);
-                    durableWatermark = blockNum;
-                    blocksSinceWatermarkFlush++;
-                    if (blocksSinceWatermarkFlush >= WATERMARK_BATCH_SIZE) {
-                        saveWatermark(watermarkFile, durableWatermark);
-                        blocksSinceWatermarkFlush = 0;
-                    }
+                    writeToZipArchive(blockNum, wrapped, watermarkFile, zipHolder, zipPathHolder, zipState);
 
-                    // Validate wrapped block
                     runBlockValidations(
                             wrapped,
                             blockNum,
@@ -828,20 +823,49 @@ public class LiveSequential implements Runnable {
                     }
                 }
             } finally {
-                if (currentZip != null) {
+                if (zipHolder[0] != null) {
                     try {
-                        currentZip.close();
+                        zipHolder[0].close();
                     } catch (IOException e) {
                         System.err.println("[WRAP] Error closing zip: " + e.getMessage());
                     }
                 }
-                saveWatermark(watermarkFile, durableWatermark);
+                saveWatermark(watermarkFile, zipState[0]);
                 saveStateCheckpoint(streamingMerkleTreeFile, streamingHasher);
                 addressBookRegistry.saveAddressBookRegistryToJsonFile(addressBookFile);
-                saveValidationCheckpoint(checkpointDir, durableWatermark, allValidations);
+                saveValidationCheckpoint(checkpointDir, zipState[0], allValidations);
                 for (BlockValidation v : allValidations) v.close();
                 System.out.println("[WRAP] Shutdown complete. Wrapped " + blocksValidated + " blocks.");
             }
+        }
+    }
+
+    private void writeToZipArchive(
+            long blockNum,
+            Block wrapped,
+            Path watermarkFile,
+            BlockZipAppender[] zipHolder,
+            Path[] zipPathHolder,
+            long[] zipState)
+            throws Exception {
+        BlockPath blockPath = BlockWriter.computeBlockPath(wrapOutputDir, blockNum, BlockArchiveType.UNCOMPRESSED_ZIP);
+        Files.createDirectories(blockPath.dirPath());
+        byte[] serializedBytes = BlockWriter.serializeBlockToBytes(wrapped, DEFAULT_COMPRESSION);
+        if (!blockPath.zipFilePath().equals(zipPathHolder[0])) {
+            if (zipHolder[0] != null) {
+                zipHolder[0].close();
+                saveWatermark(watermarkFile, zipState[0]);
+                zipState[1] = 0;
+            }
+            zipHolder[0] = BlockWriter.openZipForAppend(blockPath.zipFilePath());
+            zipPathHolder[0] = blockPath.zipFilePath();
+        }
+        BlockWriter.writeBlockEntry(zipHolder[0], blockPath, serializedBytes);
+        zipState[0] = blockNum;
+        zipState[1]++;
+        if (zipState[1] >= WATERMARK_BATCH_SIZE) {
+            saveWatermark(watermarkFile, zipState[0]);
+            zipState[1] = 0;
         }
     }
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -166,11 +166,6 @@ public class LiveSequential implements Runnable {
             description = "Start date in YYYY-MM-DD format (default: auto-detect from mirror node)")
     private String startDate;
 
-    @Option(
-            names = {"--stats-csv"},
-            description = "Path to signature statistics CSV file (default: outputDir/signature_statistics.csv)")
-    private Path statsCsvPath;
-
     /** State persisted to JSON for resumability. Compatible with DownloadLive2 format. */
     private static class State {
         String dayDate;
@@ -253,11 +248,6 @@ public class LiveSequential implements Runnable {
                             .build();
 
             final BlockTimeReader blockTimeReader = new BlockTimeReader();
-
-            // Stats CSV
-            if (statsCsvPath == null) {
-                statsCsvPath = outputDir.toPath().resolve("signature_statistics.csv");
-            }
 
             // Determine starting point
             final State initialState = determineStartingPoint(blockTimeReader);
@@ -437,8 +427,6 @@ public class LiveSequential implements Runnable {
 
             if (watermark >= 0 && registryHighest > watermark) {
                 registryHighest = watermark;
-            } else if (watermark < 0 && registryHighest >= 0) {
-                // trust registry
             }
 
             // Mid-zip truncation (same logic as runWrapAndValidateThread)
@@ -741,13 +729,17 @@ public class LiveSequential implements Runnable {
                     continue;
                 }
 
-                // Verify sufficient signature files (need at least 3/7 for consensus)
+                // Verify sufficient signature files (need at least 3/N for consensus)
                 long sigCount = inMemoryFiles.stream()
                         .filter(f -> f.path().getFileName().toString().contains("_sig"))
                         .count();
+                long maxExpectedSigs = addressBookRegistry
+                        .getCurrentAddressBook()
+                        .nodeAddress()
+                        .size();
                 if (sigCount < 3) {
                     System.out.println("[live-sequential] Insufficient signatures for block " + nextBlockNumber + " ("
-                            + sigCount + "/7), waiting for GCS uploads...");
+                            + sigCount + "/" + maxExpectedSigs + "), waiting for GCS uploads...");
                     refreshListingsForSingleDay(blockDay, netConfig);
                     cachedListingFiles = DayListingFileReader.loadRecordsFileForDay(
                             listingDir.toPath(),
@@ -786,10 +778,8 @@ public class LiveSequential implements Runnable {
                         continue;
                     }
                     // Check if more sigs might still be uploading to GCS
-                    long maxExpectedSigs = addressBookRegistry
-                            .getCurrentAddressBook()
-                            .nodeAddress()
-                            .size();
+                    // (reuse maxExpectedSigs computed above)
+
                     if (expectedSigs < maxExpectedSigs) {
                         long waitedMs =
                                 Duration.between(blockInstantUtc, Instant.now()).toMillis();
@@ -963,6 +953,9 @@ public class LiveSequential implements Runnable {
             sequentialValidations.add(new StreamingMerkleTreeValidation(streamingMerkleTreeFile, treeValidation));
             Path jumpstartPath = wrapOutputDir.resolve("jumpstart.bin");
             sequentialValidations.add(new JumpstartValidation(jumpstartPath, treeValidation, blockRegistry));
+            // TODO: BalanceCheckpointValidation is intentionally excluded. It requires genesis start and
+            // sourcing monthly balance checkpoint files, which adds significant complexity in live mode.
+            // See ValidateBlocksCommand for the full pattern if this is needed in the future.
 
             List<BlockValidation> allValidations = new ArrayList<>();
             allValidations.addAll(parallelValidations);
@@ -1384,14 +1377,15 @@ public class LiveSequential implements Runnable {
         return DownloadDayLiveImpl.computeFilesToDownload(mostCommonRecord, mostCommonSidecars, group);
     }
 
-    /** Resolve the set of most-common files (record + sidecar) for path deduplication. */
+    /** Resolve the set of most-common files (record + sidecars) for path deduplication. */
     private static Set<ListingRecordFile> resolveMostCommonFilesSet(List<ListingRecordFile> group) {
         Set<ListingRecordFile> set = new HashSet<>();
         ListingRecordFile mostCommonRecord = RecordFileUtils.findMostCommonByType(group, ListingRecordFile.Type.RECORD);
         if (mostCommonRecord != null) set.add(mostCommonRecord);
-        ListingRecordFile mostCommonSidecar =
-                RecordFileUtils.findMostCommonByType(group, ListingRecordFile.Type.RECORD_SIDECAR);
-        if (mostCommonSidecar != null) set.add(mostCommonSidecar);
+        ListingRecordFile[] mostCommonSidecars = RecordFileUtils.findMostCommonSidecars(group);
+        for (ListingRecordFile sidecar : mostCommonSidecars) {
+            if (sidecar != null) set.add(sidecar);
+        }
         return set;
     }
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -9,18 +9,21 @@ import static org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHasher.
 import static org.hiero.block.tools.days.downloadlive.ValidateDownloadLive.findPrimaryRecord;
 import static org.hiero.block.tools.days.downloadlive.ValidateDownloadLive.findSidecars;
 import static org.hiero.block.tools.days.downloadlive.ValidateDownloadLive.findSignatures;
-import static org.hiero.block.tools.days.downloadlive.ValidateDownloadLive.fullBlockValidate;
 import static org.hiero.block.tools.utils.Md5Checker.checkMd5;
 
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.RecordFileSignature;
 import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.hapi.node.base.Transaction;
+import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -35,6 +38,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.HexFormat;
@@ -42,12 +46,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.tools.blocks.AmendmentProvider;
+import org.hiero.block.tools.blocks.HasherStateFiles;
 import org.hiero.block.tools.blocks.model.BlockArchiveType;
 import org.hiero.block.tools.blocks.model.BlockWriter;
 import org.hiero.block.tools.blocks.model.BlockWriter.BlockPath;
@@ -117,13 +123,18 @@ public class LiveSequential implements Runnable {
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static final Duration LIVE_POLL_INTERVAL = Duration.ofSeconds(2);
     private static final int PROGRESS_LOG_INTERVAL = 100;
-    private static final long MIN_BLOCK_TIME_REFRESH_INTERVAL_MS = 30_000;
+    private static final long MIN_BLOCK_TIME_REFRESH_INTERVAL_MS = 60_000;
     private static final int WATERMARK_BATCH_SIZE = 256;
+
+    /** How close to wall-clock time a block must be to count as "live edge". */
+    private static final Duration LIVE_EDGE_THRESHOLD = Duration.ofMinutes(5);
+    /** Maximum time to wait for all signatures at the live edge before proceeding with what we have. */
+    private static final Duration MAX_SIG_WAIT = Duration.ofMinutes(2);
 
     private static final File CACHE_DIR = new File("metadata/gcp-cache");
 
     /** Poison pill to signal the wrap+validate thread to exit. */
-    private static final ValidatedBlock POISON_PILL = new ValidatedBlock(-1, null, List.of(), null);
+    private static final ValidatedBlock POISON_PILL = new ValidatedBlock(-1, null, List.of(), null, null);
 
     @Option(
             names = {"-l", "--listing-dir"},
@@ -185,81 +196,25 @@ public class LiveSequential implements Runnable {
         }
     }
 
-    /** Mutable state for the download loop, enabling extraction of the loop body into a helper method. */
-    private static class DownloadLoopState {
-        long currentBlockNumber;
-        byte[] currentHash;
-        LocalDate currentDay;
-        BlockTimeReader blockTimeReader;
-        ConcurrentTarZstdWriter dayWriter;
-        long blocksProcessedTotal;
-        long blocksProcessedToday;
-        long dayStartTime;
-        long lastBlockTimeRefreshMs;
-        List<ListingRecordFile> cachedListingFiles;
-        LocalDate cachedListingDay;
-        final NetworkConfig netConfig;
-
-        DownloadLoopState(State initialState, BlockTimeReader reader) {
-            this.currentBlockNumber = initialState.blockNumber;
-            this.currentHash = initialState.getHashBytes();
-            this.currentDay = initialState.getDayDate();
-            this.blockTimeReader = reader;
-            this.dayStartTime = System.currentTimeMillis();
-            this.netConfig = NetworkConfig.current();
-        }
-    }
-
-    /** Immutable container for the three validation lists used by the wrap+validate thread. */
-    private record WrapValidations(
-            List<BlockValidation> parallel, List<BlockValidation> sequential, List<BlockValidation> all) {}
-
     /** Block data passed from the download thread to the wrap+validate thread. */
     private record ValidatedBlock(
-            long blockNumber, Instant recordFileTime, List<InMemoryFile> files, byte[] runningHash) {}
+            long blockNumber,
+            Instant recordFileTime,
+            List<InMemoryFile> files,
+            byte[] runningHash,
+            LocalDate blockDay) {}
+
+    /** A block whose file downloads have been fired but not yet joined. */
+    private record PrefetchedBlock(
+            long blockNumber,
+            LocalDateTime blockTime,
+            LocalDate blockDay,
+            List<ListingRecordFile> orderedFiles,
+            Set<ListingRecordFile> mostCommonFilesSet,
+            List<CompletableFuture<InMemoryFile>> futures) {}
 
     @Override
     public void run() {
-        logConfiguration();
-        try {
-            initializeDirectoriesAndDefaults();
-            final AddressBookRegistry addressBookRegistry =
-                    addressBookPath != null ? new AddressBookRegistry(addressBookPath) : new AddressBookRegistry();
-            final Storage storage = StorageOptions.http()
-                    .setProjectId(DownloadConstants.GCP_PROJECT_ID)
-                    .build()
-                    .getService();
-            final ConcurrentDownloadManagerVirtualThreadsV3 downloadManager =
-                    ConcurrentDownloadManagerVirtualThreadsV3.newBuilder(storage)
-                            .setMaxConcurrency(16)
-                            .build();
-            final BlockTimeReader blockTimeReader = new BlockTimeReader();
-            final State initialState = determineStartingPoint(blockTimeReader);
-            logStartingPoint(initialState);
-
-            final BlockingQueue<ValidatedBlock> queue = new LinkedBlockingQueue<>(32);
-            final AtomicReference<Throwable> wrapError = new AtomicReference<>(null);
-            final Thread wrapThread = startWrapThread(queue, addressBookRegistry, wrapError);
-            addShutdownHook(downloadManager);
-
-            processBlocksSequentially(
-                    initialState, addressBookRegistry, downloadManager, blockTimeReader, queue, wrapError);
-
-            queue.put(POISON_PILL);
-            wrapThread.join(60_000);
-            Throwable wrapErr = wrapError.get();
-            if (wrapErr != null) {
-                throw new IllegalStateException("Wrap+validate thread failed", wrapErr);
-            }
-            System.out.println("[live-sequential] Complete.");
-        } catch (Exception e) {
-            System.err.println("[live-sequential] Fatal error: " + e.getMessage());
-            e.printStackTrace();
-            System.exit(1);
-        }
-    }
-
-    private void logConfiguration() {
         System.out.println("[live-sequential] Starting sequential block download with inline wrapping + validation");
         System.out.println("Configuration:");
         System.out.println("  listingDir=" + listingDir);
@@ -268,61 +223,101 @@ public class LiveSequential implements Runnable {
         System.out.println("  stateJsonPath=" + stateJsonPath);
         System.out.println("  addressBookPath=" + addressBookPath);
         System.out.println("  startDate=" + (startDate != null ? startDate : "(auto-detect)"));
-    }
 
-    private void initializeDirectoriesAndDefaults() throws IOException {
-        Files.createDirectories(outputDir.toPath());
-        Files.createDirectories(wrapOutputDir);
-        if (stateJsonPath == null) {
-            stateJsonPath = outputDir.toPath().resolve("validateCmdStatus.json");
+        try {
+            // Create directories
+            Files.createDirectories(outputDir.toPath());
+            Files.createDirectories(wrapOutputDir);
+
+            // Set default state file path
+            if (stateJsonPath == null) {
+                stateJsonPath = outputDir.toPath().resolve("validateCmdStatus.json");
+            }
+            if (stateJsonPath.getParent() != null) {
+                Files.createDirectories(stateJsonPath.getParent());
+            }
+
+            // Initialize address book
+            final AddressBookRegistry addressBookRegistry =
+                    addressBookPath != null ? new AddressBookRegistry(addressBookPath) : new AddressBookRegistry();
+
+            // Use HTTP transport for stability
+            final Storage storage = StorageOptions.http()
+                    .setProjectId(DownloadConstants.GCP_PROJECT_ID)
+                    .build()
+                    .getService();
+
+            final ConcurrentDownloadManagerVirtualThreadsV3 downloadManager =
+                    ConcurrentDownloadManagerVirtualThreadsV3.newBuilder(storage)
+                            .setMaxConcurrency(64)
+                            .build();
+
+            final BlockTimeReader blockTimeReader = new BlockTimeReader();
+
+            // Stats CSV
+            if (statsCsvPath == null) {
+                statsCsvPath = outputDir.toPath().resolve("signature_statistics.csv");
+            }
+
+            // Determine starting point
+            final State initialState = determineStartingPoint(blockTimeReader);
+            System.out.println("[live-sequential] Starting from block " + initialState.blockNumber
+                    + " hash["
+                    + (initialState.endRunningHashHex != null
+                            ? initialState.endRunningHashHex.substring(
+                                    0, Math.min(8, initialState.endRunningHashHex.length()))
+                            : "null")
+                    + "]"
+                    + " day=" + initialState.dayDate);
+
+            // Create producer-consumer queue
+            final BlockingQueue<ValidatedBlock> queue = new LinkedBlockingQueue<>(32);
+            final AtomicReference<Throwable> wrapError = new AtomicReference<>(null);
+
+            // Start wrap+validate thread
+            final Thread wrapThread = new Thread(
+                    () -> {
+                        try {
+                            runWrapAndValidateThread(queue, addressBookRegistry);
+                        } catch (Throwable t) {
+                            wrapError.set(t);
+                            System.err.println("[WRAP] Fatal error in wrap+validate thread: " + t.getMessage());
+                            t.printStackTrace();
+                        }
+                    },
+                    "wrap-validate-thread");
+            wrapThread.setDaemon(true);
+            wrapThread.start();
+
+            // Add shutdown hook
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(
+                            () -> {
+                                System.out.println("[live-sequential] Shutdown requested...");
+                                downloadManager.close();
+                            },
+                            "live-sequential-shutdown"));
+
+            // Main download loop
+            processBlocksSequentially(
+                    initialState, downloadManager, blockTimeReader, queue, wrapError, addressBookRegistry);
+
+            // Signal wrap thread to exit and wait
+            queue.put(POISON_PILL);
+            wrapThread.join(60_000);
+
+            // Check for wrap errors
+            Throwable wrapErr = wrapError.get();
+            if (wrapErr != null) {
+                throw new RuntimeException("Wrap+validate thread failed", wrapErr);
+            }
+
+            System.out.println("[live-sequential] Complete.");
+        } catch (Exception e) {
+            System.err.println("[live-sequential] Fatal error: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
         }
-        if (stateJsonPath.getParent() != null) {
-            Files.createDirectories(stateJsonPath.getParent());
-        }
-        if (statsCsvPath == null) {
-            statsCsvPath = outputDir.toPath().resolve("signature_statistics.csv");
-        }
-    }
-
-    private static void logStartingPoint(State initialState) {
-        System.out.println("[live-sequential] Starting from block " + initialState.blockNumber
-                + " hash["
-                + (initialState.endRunningHashHex != null
-                        ? initialState.endRunningHashHex.substring(
-                                0, Math.min(8, initialState.endRunningHashHex.length()))
-                        : "null")
-                + "]"
-                + " day=" + initialState.dayDate);
-    }
-
-    private Thread startWrapThread(
-            BlockingQueue<ValidatedBlock> queue,
-            AddressBookRegistry addressBookRegistry,
-            AtomicReference<Throwable> wrapError) {
-        final Thread wrapThread = new Thread(
-                () -> {
-                    try {
-                        runWrapAndValidateThread(queue, addressBookRegistry);
-                    } catch (Throwable t) {
-                        wrapError.set(t);
-                        System.err.println("[WRAP] Fatal error in wrap+validate thread: " + t.getMessage());
-                        t.printStackTrace();
-                    }
-                },
-                "wrap-validate-thread");
-        wrapThread.setDaemon(true);
-        wrapThread.start();
-        return wrapThread;
-    }
-
-    private static void addShutdownHook(ConcurrentDownloadManagerVirtualThreadsV3 downloadManager) {
-        Runtime.getRuntime()
-                .addShutdownHook(new Thread(
-                        () -> {
-                            System.out.println("[live-sequential] Shutdown requested...");
-                            downloadManager.close();
-                        },
-                        "live-sequential-shutdown"));
     }
 
     /**
@@ -330,20 +325,33 @@ public class LiveSequential implements Runnable {
      * Priority: 1) Wrap effective highest (accounts for mid-zip truncation), 2) Resume from state file,
      * 3) Use --start-date, 4) Auto-detect from mirror node
      */
-    @SuppressWarnings("PMD.NPathComplexity") // Multiple priority levels require branching
     private State determineStartingPoint(BlockTimeReader blockTimeReader) {
-        // Priority 1: Resume from wrap state — start download from beginning of the day
-        // so the day archive is complete; the wrap thread skips already-wrapped blocks
+        // Priority 1: Resume from wrap state (the authoritative source, accounts for mid-zip truncation)
         long wrapEffective = computeWrapEffectiveHighest();
         if (wrapEffective >= 0) {
-            LocalDateTime wrapBlockTime = blockTimeReader.getBlockLocalDateTime(wrapEffective);
-            LocalDate wrapDay = wrapBlockTime.toLocalDate();
-            long firstBlockOfDay = blockTimeReader.getNearestBlockAfterTime(wrapDay.atStartOfDay());
-            System.out.println("[live-sequential] Wrap state at block " + wrapEffective
-                    + "; starting download from beginning of day " + wrapDay + " (block " + firstBlockOfDay + ")");
+            System.out.println("[live-sequential] Resuming from wrap effective highest: block " + wrapEffective);
+            // If the day's tar archive doesn't exist, back up to the start of that day
+            // so the tar gets all blocks for the day (wrap thread skips already-wrapped blocks)
+            try {
+                LocalDateTime blockTime = blockTimeReader.getBlockLocalDateTime(wrapEffective);
+                LocalDate day = blockTime.toLocalDate();
+                Path dayArchive = outputDir.toPath().resolve(day + ".tar.zstd");
+                if (!Files.exists(dayArchive)) {
+                    LocalDateTime startOfDay = day.atStartOfDay();
+                    long firstBlockOfDay = blockTimeReader.getNearestBlockAfterTime(startOfDay);
+                    long dlStart = firstBlockOfDay - 1;
+                    System.out.println("[live-sequential] No tar archive for " + day
+                            + ", backing up download start to block " + dlStart
+                            + " (start of day) for complete tar");
+                    State state = new State();
+                    state.blockNumber = dlStart;
+                    return state;
+                }
+            } catch (Exception e) {
+                System.err.println("[live-sequential] Warning: could not check day archive: " + e.getMessage());
+            }
             State state = new State();
-            state.blockNumber = firstBlockOfDay - 1;
-            state.dayDate = wrapDay.toString();
+            state.blockNumber = wrapEffective;
             return state;
         }
 
@@ -382,14 +390,14 @@ public class LiveSequential implements Runnable {
         List<BlockInfo> latestBlocks = FetchBlockQuery.getLatestBlocks(1, MirrorNodeBlockQueryOrder.DESC);
 
         if (latestBlocks.isEmpty()) {
-            throw new IllegalStateException("Failed to get latest block from mirror node");
+            throw new RuntimeException("Failed to get latest block from mirror node");
         }
 
         BlockInfo latestBlock = latestBlocks.getFirst();
         String timestamp = latestBlock.timestampFrom != null ? latestBlock.timestampFrom : latestBlock.timestampTo;
 
         if (timestamp == null) {
-            throw new IllegalStateException("Latest block has no timestamp");
+            throw new RuntimeException("Latest block has no timestamp");
         }
 
         String[] parts = timestamp.split("\\.");
@@ -454,291 +462,412 @@ public class LiveSequential implements Runnable {
      * Main sequential download loop. Downloads one block at a time, validates, writes to tar.zstd,
      * and queues for wrapping.
      */
-    @SuppressWarnings("PMD.NPathComplexity")
     private void processBlocksSequentially(
             State initialState,
-            AddressBookRegistry addressBookRegistry,
             ConcurrentDownloadManagerVirtualThreadsV3 downloadManager,
             BlockTimeReader initialBlockTimeReader,
             BlockingQueue<ValidatedBlock> queue,
-            AtomicReference<Throwable> wrapError)
+            AtomicReference<Throwable> wrapError,
+            AddressBookRegistry addressBookRegistry)
             throws Exception {
-        final DownloadLoopState state = new DownloadLoopState(initialState, initialBlockTimeReader);
+
+        long currentBlockNumber = initialState.blockNumber;
+        byte[] currentHash = initialState.getHashBytes();
+        LocalDate currentDay = initialState.getDayDate();
+        BlockTimeReader blockTimeReader = initialBlockTimeReader;
+
+        long blocksProcessedTotal = 0;
+        long blocksProcessedToday = 0;
+        long dayStartTime = System.currentTimeMillis();
+        long lastBlockTimeRefreshMs = 0;
+
+        // Cache for listing files and grouped map - reload only when day changes
+        List<ListingRecordFile> cachedListingFiles = null;
+        Map<LocalDateTime, List<ListingRecordFile>> cachedFilesByBlock = null;
+        LocalDate cachedListingDay = null;
+
+        // Sliding window: prefetch up to PREFETCH_WINDOW blocks ahead
+        final int PREFETCH_WINDOW = 8;
+        final ArrayDeque<PrefetchedBlock> prefetchWindow = new ArrayDeque<>();
+        long nextPrefetchBlock = currentBlockNumber + 1; // next block number to fire downloads for
+
+        final NetworkConfig netConfig = NetworkConfig.current();
+
         try {
             while (true) {
+                // Check for wrap thread errors
                 Throwable wrapErr = wrapError.get();
                 if (wrapErr != null) {
-                    throw new IllegalStateException("Wrap+validate thread failed, stopping download", wrapErr);
+                    throw new RuntimeException("Wrap+validate thread failed, stopping download", wrapErr);
                 }
-                processOneBlock(state, addressBookRegistry, downloadManager, queue);
+
+                long nextBlockNumber = currentBlockNumber + 1;
+
+                // Step 1: Get block timestamp
+                LocalDateTime blockTime;
+                try {
+                    blockTime = blockTimeReader.getBlockLocalDateTime(nextBlockNumber);
+                } catch (Exception e) {
+                    long now = System.currentTimeMillis();
+                    if (now - lastBlockTimeRefreshMs >= MIN_BLOCK_TIME_REFRESH_INTERVAL_MS) {
+                        System.out.println(
+                                "[LIVE] Block " + nextBlockNumber + " not in BlockTimeReader, refreshing...");
+                        UpdateBlockData.updateBlockTimesOnly(MetadataFiles.BLOCK_TIMES_FILE);
+                        blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                        lastBlockTimeRefreshMs = now;
+                    }
+                    // Drain the prefetch window — we can't resolve more blocks yet
+                    prefetchWindow.clear();
+                    nextPrefetchBlock = nextBlockNumber;
+                    Thread.sleep(LIVE_POLL_INTERVAL.toMillis());
+                    continue;
+                }
+
+                LocalDate blockDay = blockTime.toLocalDate();
+
+                // Step 2: Handle day boundary
+                if (!blockDay.equals(currentDay)) {
+                    if (currentDay != null) {
+                        System.out.println("[live-sequential] Day completed: " + currentDay + " ("
+                                + blocksProcessedToday + " blocks in "
+                                + formatDuration((System.currentTimeMillis() - dayStartTime) / 1000) + ")");
+                    }
+
+                    // Start new day — clear prefetch since listings change
+                    currentDay = blockDay;
+                    blocksProcessedToday = 0;
+                    dayStartTime = System.currentTimeMillis();
+                    cachedListingFiles = null;
+                    cachedFilesByBlock = null;
+                    cachedListingDay = null;
+                    prefetchWindow.clear();
+                    nextPrefetchBlock = nextBlockNumber;
+
+                    System.out.println("[live-sequential] Started new day: " + currentDay);
+                }
+
+                // Step 3: Load GCS listings if day changed
+                if (!blockDay.equals(cachedListingDay)) {
+                    int year = blockTime.getYear();
+                    int month = blockTime.getMonthValue();
+                    int day = blockTime.getDayOfMonth();
+
+                    int attempt = 0;
+                    while (true) {
+                        attempt++;
+                        refreshListingsForDay(blockDay, netConfig);
+                        try {
+                            cachedListingFiles =
+                                    DayListingFileReader.loadRecordsFileForDay(listingDir.toPath(), year, month, day);
+                            cachedFilesByBlock = cachedListingFiles.stream()
+                                    .collect(Collectors.groupingBy(ListingRecordFile::timestamp));
+                            cachedListingDay = blockDay;
+                            System.out.println("[live-sequential] Loaded " + cachedListingFiles.size()
+                                    + " listing entries for " + blockDay);
+                            break;
+                        } catch (NoSuchFileException e) {
+                            System.out.println("[live-sequential] Listings not available yet for " + blockDay
+                                    + ", waiting 15 minutes... (attempt " + attempt + ")");
+                            Thread.sleep(15 * 60 * 1000);
+                        }
+                    }
+                }
+
+                // Step 4: Fill the prefetch window — fire downloads for blocks ahead
+                while (prefetchWindow.size() < PREFETCH_WINDOW) {
+                    long target = nextPrefetchBlock;
+                    if (target < nextBlockNumber) {
+                        target = nextBlockNumber;
+                        nextPrefetchBlock = nextBlockNumber;
+                    }
+                    try {
+                        LocalDateTime targetTime = blockTimeReader.getBlockLocalDateTime(target);
+                        LocalDate targetDay = targetTime.toLocalDate();
+                        // Stop prefetching across day boundary (listings may differ)
+                        if (!targetDay.equals(cachedListingDay)) {
+                            break;
+                        }
+                        List<ListingRecordFile> group = cachedFilesByBlock.get(targetTime);
+                        if (group == null || group.isEmpty()) {
+                            break; // block not in listings yet
+                        }
+                        // Don't prefetch if no primary record file in listings (incomplete upload)
+                        boolean hasRecord = group.stream().anyMatch(f -> f.type() == ListingRecordFile.Type.RECORD);
+                        long sigFiles = group.stream()
+                                .filter(f -> f.type() == ListingRecordFile.Type.RECORD_SIG)
+                                .count();
+                        if (!hasRecord || sigFiles < 3) {
+                            break; // incomplete upload — stop prefetching
+                        }
+                        List<ListingRecordFile> ordered = resolveOrderedFiles(group);
+                        Set<ListingRecordFile> common = resolveMostCommonFilesSet(group);
+                        List<CompletableFuture<InMemoryFile>> futures =
+                                fireDownloads(ordered, netConfig, downloadManager);
+                        prefetchWindow.addLast(
+                                new PrefetchedBlock(target, targetTime, targetDay, ordered, common, futures));
+                        nextPrefetchBlock = target + 1;
+                    } catch (Exception e) {
+                        break; // block time not available — stop filling
+                    }
+                }
+
+                // Step 5: Get downloads for current block (from window or fresh)
+                List<CompletableFuture<InMemoryFile>> downloadFutures;
+                List<ListingRecordFile> orderedFiles;
+                Set<ListingRecordFile> mostCommonFilesSet;
+
+                PrefetchedBlock head = prefetchWindow.peekFirst();
+                if (head != null && head.blockNumber == nextBlockNumber) {
+                    // Use prefetched downloads
+                    prefetchWindow.pollFirst();
+                    downloadFutures = head.futures;
+                    orderedFiles = head.orderedFiles;
+                    mostCommonFilesSet = head.mostCommonFilesSet;
+                } else {
+                    // Prefetch miss — resolve and download normally
+                    // Clear stale window entries
+                    prefetchWindow.clear();
+                    nextPrefetchBlock = nextBlockNumber + 1;
+
+                    List<ListingRecordFile> group = cachedFilesByBlock.get(blockTime);
+                    if (group == null || group.isEmpty()) {
+                        refreshListingsForSingleDay(blockDay, netConfig);
+                        cachedListingFiles = DayListingFileReader.loadRecordsFileForDay(
+                                listingDir.toPath(),
+                                blockTime.getYear(),
+                                blockTime.getMonthValue(),
+                                blockTime.getDayOfMonth());
+                        cachedFilesByBlock = cachedListingFiles.stream()
+                                .collect(Collectors.groupingBy(ListingRecordFile::timestamp));
+                        cachedListingDay = blockDay;
+                        group = cachedFilesByBlock.get(blockTime);
+
+                        if (group == null || group.isEmpty()) {
+                            System.out.println("[live-sequential] No files found for block " + nextBlockNumber
+                                    + " at time " + blockTime + ", fixing block times...");
+                            FixBlockTime.fixBlockTimeRange(
+                                    MetadataFiles.BLOCK_TIMES_FILE, nextBlockNumber, nextBlockNumber + 100);
+                            blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                            continue;
+                        }
+                    }
+
+                    orderedFiles = resolveOrderedFiles(group);
+                    mostCommonFilesSet = resolveMostCommonFilesSet(group);
+                    downloadFutures = fireDownloads(orderedFiles, netConfig, downloadManager);
+                }
+
+                // If no hash yet, fetch from mirror node
+                if (currentHash == null && nextBlockNumber > 0) {
+                    System.out.println(
+                            "[live-sequential] Fetching previous hash from mirror node for block " + nextBlockNumber);
+                    try {
+                        var prevHashBytes = FetchBlockQuery.getPreviousHashForBlock(nextBlockNumber);
+                        currentHash = prevHashBytes.toByteArray();
+                        System.out.println("[live-sequential] Got previous hash: "
+                                + HexFormat.of().formatHex(currentHash).substring(0, 16) + "...");
+                    } catch (Exception e) {
+                        System.err.println(
+                                "[live-sequential] Warning: Could not fetch previous hash: " + e.getMessage());
+                    }
+                }
+
+                // Step 6: Process download results
+                List<InMemoryFile> inMemoryFiles = new ArrayList<>();
+                for (int fi = 0; fi < orderedFiles.size(); fi++) {
+                    ListingRecordFile lr = orderedFiles.get(fi);
+                    String blobName = netConfig.bucketPathPrefix() + lr.path();
+                    try {
+                        InMemoryFile downloadedFile = downloadFutures.get(fi).join();
+
+                        String filename = lr.path().substring(lr.path().lastIndexOf('/') + 1);
+
+                        boolean md5Valid = checkMd5(lr.md5Hex(), downloadedFile.data());
+                        if (!md5Valid) {
+                            System.err.println("[live-sequential] MD5 mismatch for " + lr.path() + ", skipping");
+                            continue;
+                        }
+
+                        byte[] contentBytes = downloadedFile.data();
+                        if (filename.endsWith(".gz")) {
+                            contentBytes = Gzip.ungzipInMemory(contentBytes);
+                            filename = filename.replaceAll("\\.gz$", "");
+                        }
+
+                        Path newFilePath = DownloadDayLiveImpl.computeNewFilePath(lr, mostCommonFilesSet, filename);
+                        inMemoryFiles.add(new InMemoryFile(newFilePath, contentBytes));
+                    } catch (CompletionException ce) {
+                        System.err.println(
+                                "[live-sequential] Download failed for " + blobName + ": " + ce.getMessage());
+                        throw new IllegalStateException("Download failed for block " + nextBlockNumber, ce.getCause());
+                    }
+                }
+
+                // Ensure primary record file is first (validateBlockHashes assumes getFirst() is the record)
+                inMemoryFiles.sort((a, b) -> {
+                    String aName = a.path().getFileName().toString();
+                    String bName = b.path().getFileName().toString();
+                    boolean aIsRecord = aName.endsWith(".rcd") && !aName.contains("_sig") && !aName.contains("_node_");
+                    boolean bIsRecord = bName.endsWith(".rcd") && !bName.contains("_sig") && !bName.contains("_node_");
+                    return Boolean.compare(bIsRecord, aIsRecord);
+                });
+
+                // Verify primary record file exists — if not, listings may be incomplete (near live tip)
+                if (inMemoryFiles.isEmpty()) {
+                    System.out.println("[live-sequential] No files downloaded for block " + nextBlockNumber
+                            + ", waiting for GCS uploads...");
+                    prefetchWindow.clear();
+                    nextPrefetchBlock = nextBlockNumber;
+                    Thread.sleep(LIVE_POLL_INTERVAL.toMillis());
+                    continue;
+                }
+                String firstFileName =
+                        inMemoryFiles.getFirst().path().getFileName().toString();
+                if (!firstFileName.endsWith(".rcd") || firstFileName.contains("_sig")) {
+                    System.out.println("[live-sequential] No primary record file for block " + nextBlockNumber
+                            + " (first file: " + firstFileName + "), refreshing listings...");
+                    refreshListingsForSingleDay(blockDay, netConfig);
+                    cachedListingFiles = DayListingFileReader.loadRecordsFileForDay(
+                            listingDir.toPath(),
+                            blockTime.getYear(),
+                            blockTime.getMonthValue(),
+                            blockTime.getDayOfMonth());
+                    cachedFilesByBlock =
+                            cachedListingFiles.stream().collect(Collectors.groupingBy(ListingRecordFile::timestamp));
+                    cachedListingDay = blockDay;
+                    prefetchWindow.clear();
+                    nextPrefetchBlock = nextBlockNumber;
+                    Thread.sleep(LIVE_POLL_INTERVAL.toMillis());
+                    continue;
+                }
+
+                // Verify sufficient signature files (need at least 3/7 for consensus)
+                long sigCount = inMemoryFiles.stream()
+                        .filter(f -> f.path().getFileName().toString().contains("_sig"))
+                        .count();
+                if (sigCount < 3) {
+                    System.out.println("[live-sequential] Insufficient signatures for block " + nextBlockNumber + " ("
+                            + sigCount + "/7), waiting for GCS uploads...");
+                    refreshListingsForSingleDay(blockDay, netConfig);
+                    cachedListingFiles = DayListingFileReader.loadRecordsFileForDay(
+                            listingDir.toPath(),
+                            blockTime.getYear(),
+                            blockTime.getMonthValue(),
+                            blockTime.getDayOfMonth());
+                    cachedFilesByBlock =
+                            cachedListingFiles.stream().collect(Collectors.groupingBy(ListingRecordFile::timestamp));
+                    cachedListingDay = blockDay;
+                    prefetchWindow.clear();
+                    nextPrefetchBlock = nextBlockNumber;
+                    Thread.sleep(LIVE_POLL_INTERVAL.toMillis());
+                    continue;
+                }
+
+                // At the live edge, wait for all signatures before proceeding.
+                // This ensures the tar archive has complete signature coverage.
+                Instant blockInstantUtc = blockTime.atZone(ZoneOffset.UTC).toInstant();
+                boolean isLiveEdge =
+                        Duration.between(blockInstantUtc, Instant.now()).compareTo(LIVE_EDGE_THRESHOLD) < 0;
+                if (isLiveEdge) {
+                    // Count expected signatures from GCS listing
+                    List<ListingRecordFile> currentGroup = cachedFilesByBlock.get(blockTime);
+                    long expectedSigs = currentGroup != null
+                            ? currentGroup.stream()
+                                    .filter(f -> f.type() == ListingRecordFile.Type.RECORD_SIG)
+                                    .count()
+                            : 0;
+                    if (sigCount < expectedSigs) {
+                        // Some listed sigs failed MD5 — re-download; treat like insufficient
+                        System.out.println("[live-sequential] Block " + nextBlockNumber + " has " + sigCount + "/"
+                                + expectedSigs + " sigs (some failed MD5), retrying...");
+                        prefetchWindow.clear();
+                        nextPrefetchBlock = nextBlockNumber;
+                        Thread.sleep(LIVE_POLL_INTERVAL.toMillis());
+                        continue;
+                    }
+                    // Check if more sigs might still be uploading to GCS
+                    long maxExpectedSigs = addressBookRegistry
+                            .getCurrentAddressBook()
+                            .nodeAddress()
+                            .size();
+                    if (expectedSigs < maxExpectedSigs) {
+                        long waitedMs =
+                                Duration.between(blockInstantUtc, Instant.now()).toMillis();
+                        if (waitedMs < MAX_SIG_WAIT.toMillis()) {
+                            System.out.println("[live-sequential] Block " + nextBlockNumber + " has " + sigCount + "/"
+                                    + maxExpectedSigs + " sigs, waiting for remaining ("
+                                    + (MAX_SIG_WAIT.toMillis() - waitedMs) / 1000 + "s left)...");
+                            refreshListingsForSingleDay(blockDay, netConfig);
+                            cachedListingFiles = DayListingFileReader.loadRecordsFileForDay(
+                                    listingDir.toPath(),
+                                    blockTime.getYear(),
+                                    blockTime.getMonthValue(),
+                                    blockTime.getDayOfMonth());
+                            cachedFilesByBlock = cachedListingFiles.stream()
+                                    .collect(Collectors.groupingBy(ListingRecordFile::timestamp));
+                            cachedListingDay = blockDay;
+                            prefetchWindow.clear();
+                            nextPrefetchBlock = nextBlockNumber;
+                            Thread.sleep(LIVE_POLL_INTERVAL.toMillis());
+                            continue;
+                        }
+                        System.out.println("[live-sequential] Block " + nextBlockNumber
+                                + " timed out waiting for all sigs, proceeding with " + sigCount + "/"
+                                + maxExpectedSigs);
+                    } else {
+                        System.out.println("[live-sequential] Block " + nextBlockNumber + " has all signatures ("
+                                + sigCount + "/" + maxExpectedSigs + ")");
+                    }
+                }
+
+                // Step 7: Validate hash chain (lightweight, keeps sequential integrity)
+                byte[] newHash =
+                        DownloadDayLiveImpl.validateBlockHashes(nextBlockNumber, inMemoryFiles, currentHash, null);
+                Instant recordFileTime = blockTime.atZone(ZoneOffset.UTC).toInstant();
+
+                // Step 8: Assert sequential ordering
+                if (nextBlockNumber != currentBlockNumber + 1) {
+                    throw new IllegalStateException(
+                            "Block gap detected: expected " + (currentBlockNumber + 1) + " but got " + nextBlockNumber);
+                }
+
+                // Step 9: Queue for wrapping (tar writing moved to wrap thread)
+                queue.put(new ValidatedBlock(nextBlockNumber, recordFileTime, inMemoryFiles, newHash, blockDay));
+
+                // Step 10: Update state
+                currentBlockNumber = nextBlockNumber;
+                currentHash = newHash;
+                blocksProcessedTotal++;
+                blocksProcessedToday++;
+
+                // Save state periodically (every 10 blocks) to reduce disk I/O
+                if (blocksProcessedTotal % 10 == 0) {
+                    saveState(new State(currentBlockNumber, currentHash, recordFileTime, currentDay));
+                }
+
+                // Progress logging
+                if (blocksProcessedTotal % PROGRESS_LOG_INTERVAL == 0) {
+                    long elapsed = System.currentTimeMillis() - dayStartTime;
+                    double blocksPerSec = blocksProcessedToday / Math.max(1.0, elapsed / 1000.0);
+                    System.out.println("[live-sequential] Block " + currentBlockNumber + " (" + blocksProcessedToday
+                            + " today, " + String.format("%.1f", blocksPerSec) + " blocks/sec, queue="
+                            + queue.size() + "/" + 32 + ")");
+                }
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             System.out.println("[live-sequential] Interrupted, saving state...");
         } finally {
-            saveFinalState(state.currentBlockNumber, state.currentHash, state.currentDay, state.blockTimeReader);
-            closeQuietly(state.dayWriter);
-        }
-    }
-
-    private void processOneBlock(
-            DownloadLoopState state,
-            AddressBookRegistry addressBookRegistry,
-            ConcurrentDownloadManagerVirtualThreadsV3 downloadManager,
-            BlockingQueue<ValidatedBlock> queue)
-            throws Exception {
-        long nextBlockNumber = state.currentBlockNumber + 1;
-        LocalDateTime blockTime = resolveBlockTime(state.blockTimeReader, nextBlockNumber);
-        if (blockTime == null) {
-            state.blockTimeReader =
-                    refreshBlockTimeIfNeeded(state.blockTimeReader, nextBlockNumber, state.lastBlockTimeRefreshMs);
-            state.lastBlockTimeRefreshMs = System.currentTimeMillis();
-            Thread.sleep(LIVE_POLL_INTERVAL.toMillis());
-            return;
-        }
-        LocalDate blockDay = blockTime.toLocalDate();
-        if (!blockDay.equals(state.currentDay)) {
-            closeDayWriter(state.dayWriter, state.currentDay, state.blocksProcessedToday, state.dayStartTime);
-            state.dayWriter = openDayWriterIfNeeded(blockDay);
-            state.currentDay = blockDay;
-            state.blocksProcessedToday = 0;
-            state.dayStartTime = System.currentTimeMillis();
-            state.cachedListingFiles = null;
-            state.cachedListingDay = null;
-        } else if (state.dayWriter == null && state.currentDay != null) {
-            state.dayWriter = openDayWriterIfNeeded(state.currentDay);
-            if (state.dayWriter != null) state.dayStartTime = System.currentTimeMillis();
-        }
-        if (!blockDay.equals(state.cachedListingDay)) {
-            state.cachedListingFiles = loadListingsWithRetry(blockDay, blockTime, state.netConfig);
-            state.cachedListingDay = blockDay;
-        }
-        List<ListingRecordFile> group = findBlockGroupWithRefresh(state, blockTime, blockDay, nextBlockNumber);
-        if (group == null) {
-            state.blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
-            return;
-        }
-        byte[] resolvedHash = fetchPreviousHashIfNeeded(state.currentHash, nextBlockNumber);
-        List<InMemoryFile> inMemoryFiles = downloadBlockFiles(group, state.netConfig, downloadManager, nextBlockNumber);
-        byte[] newHash = DownloadDayLiveImpl.validateBlockHashes(nextBlockNumber, inMemoryFiles, resolvedHash, null);
-        validateBlock(addressBookRegistry, resolvedHash, blockTime, nextBlockNumber, inMemoryFiles, newHash);
-        assertSequentialOrdering(nextBlockNumber, state.currentBlockNumber);
-        writeToDayArchive(state.dayWriter, inMemoryFiles);
-        Instant recordFileTime = blockTime.atZone(ZoneOffset.UTC).toInstant();
-        queue.put(new ValidatedBlock(nextBlockNumber, recordFileTime, inMemoryFiles, newHash));
-        state.currentBlockNumber = nextBlockNumber;
-        state.currentHash = newHash;
-        state.blocksProcessedTotal++;
-        state.blocksProcessedToday++;
-        saveState(new State(state.currentBlockNumber, state.currentHash, recordFileTime, state.currentDay));
-        logProgress(
-                state.blocksProcessedTotal, state.blocksProcessedToday, state.currentBlockNumber, state.dayStartTime);
-    }
-
-    private static BlockTimeReader refreshBlockTimeIfNeeded(
-            BlockTimeReader reader, long blockNumber, long lastRefreshMs) throws IOException {
-        long now = System.currentTimeMillis();
-        if (now - lastRefreshMs >= MIN_BLOCK_TIME_REFRESH_INTERVAL_MS) {
-            System.out.println("[LIVE] Block " + blockNumber + " not in BlockTimeReader, refreshing...");
-            UpdateBlockData.updateMirrorNodeData(MetadataFiles.BLOCK_TIMES_FILE, MetadataFiles.DAY_BLOCKS_FILE);
-            return new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
-        }
-        return reader;
-    }
-
-    private static LocalDateTime resolveBlockTime(BlockTimeReader reader, long blockNumber) {
-        try {
-            return reader.getBlockLocalDateTime(blockNumber);
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    private List<ListingRecordFile> findBlockGroupWithRefresh(
-            DownloadLoopState state, LocalDateTime blockTime, LocalDate blockDay, long blockNumber) throws Exception {
-        List<ListingRecordFile> group = findBlockGroup(blockTime, state.cachedListingFiles);
-        if (group != null) return group;
-
-        refreshListingsForDay(blockDay, state.netConfig);
-        state.cachedListingFiles = reloadListings(blockTime);
-        state.cachedListingDay = blockDay;
-        group = findBlockGroup(blockTime, state.cachedListingFiles);
-        if (group != null) return group;
-
-        System.out.println("[live-sequential] No files found for block " + blockNumber + " at time " + blockTime
-                + ", fixing block times...");
-        FixBlockTime.fixBlockTimeRange(MetadataFiles.BLOCK_TIMES_FILE, blockNumber, blockNumber + 100);
-        return null;
-    }
-
-    private static void closeDayWriter(
-            ConcurrentTarZstdWriter writer, LocalDate day, long blocksToday, long dayStartTime) throws Exception {
-        if (writer != null) {
-            writer.close();
-            System.out.println("[live-sequential] Day completed: " + day + " (" + blocksToday + " blocks in "
-                    + formatDuration((System.currentTimeMillis() - dayStartTime) / 1000) + ")");
-        }
-    }
-
-    private ConcurrentTarZstdWriter openDayWriterIfNeeded(LocalDate day) throws Exception {
-        Path dayArchive = outputDir.toPath().resolve(day + ".tar.zstd");
-        if (Files.exists(dayArchive)) {
-            System.out.println("[live-sequential] Day archive already exists, skipping tar writes: " + day);
-            return null;
-        }
-        return new ConcurrentTarZstdWriter(dayArchive);
-    }
-
-    private List<ListingRecordFile> loadListingsWithRetry(
-            LocalDate blockDay, LocalDateTime blockTime, NetworkConfig netConfig) throws Exception {
-        int attempt = 0;
-        while (true) {
-            attempt++;
-            refreshListingsForDay(blockDay, netConfig);
-            try {
-                List<ListingRecordFile> listings = DayListingFileReader.loadRecordsFileForDay(
-                        listingDir.toPath(), blockTime.getYear(), blockTime.getMonthValue(), blockTime.getDayOfMonth());
-                System.out.println("[live-sequential] Loaded " + listings.size() + " listing entries for " + blockDay);
-                return listings;
-            } catch (NoSuchFileException e) {
-                System.out.println("[live-sequential] Listings not available yet for " + blockDay
-                        + ", waiting 15 minutes... (attempt " + attempt + ")");
-                Thread.sleep(15 * 60 * 1000);
-            }
-        }
-    }
-
-    private List<ListingRecordFile> reloadListings(LocalDateTime blockTime) throws Exception {
-        return DayListingFileReader.loadRecordsFileForDay(
-                listingDir.toPath(), blockTime.getYear(), blockTime.getMonthValue(), blockTime.getDayOfMonth());
-    }
-
-    private static List<ListingRecordFile> findBlockGroup(LocalDateTime blockTime, List<ListingRecordFile> listings) {
-        Map<LocalDateTime, List<ListingRecordFile>> filesByBlock =
-                listings.stream().collect(Collectors.groupingBy(ListingRecordFile::timestamp));
-        List<ListingRecordFile> group = filesByBlock.get(blockTime);
-        return (group == null || group.isEmpty()) ? null : group;
-    }
-
-    private static byte[] fetchPreviousHashIfNeeded(byte[] currentHash, long nextBlockNumber) {
-        if (currentHash == null && nextBlockNumber > 0) {
-            System.out.println(
-                    "[live-sequential] Fetching previous hash from mirror node for block " + nextBlockNumber);
-            try {
-                var prevHashBytes = FetchBlockQuery.getPreviousHashForBlock(nextBlockNumber);
-                byte[] hash = prevHashBytes.toByteArray();
-                System.out.println("[live-sequential] Got previous hash: "
-                        + HexFormat.of().formatHex(hash).substring(0, 16) + "...");
-                return hash;
-            } catch (Exception e) {
-                System.err.println("[live-sequential] Warning: Could not fetch previous hash: " + e.getMessage());
-            }
-        }
-        return currentHash;
-    }
-
-    private List<InMemoryFile> downloadBlockFiles(
-            List<ListingRecordFile> group,
-            NetworkConfig netConfig,
-            ConcurrentDownloadManagerVirtualThreadsV3 downloadManager,
-            long blockNumber)
-            throws Exception {
-        ListingRecordFile mostCommonRecord = RecordFileUtils.findMostCommonByType(group, ListingRecordFile.Type.RECORD);
-        ListingRecordFile[] mostCommonSidecars = RecordFileUtils.findMostCommonSidecars(group);
-        List<ListingRecordFile> orderedFiles =
-                DownloadDayLiveImpl.computeFilesToDownload(mostCommonRecord, mostCommonSidecars, group);
-        Set<ListingRecordFile> mostCommonFilesSet = new HashSet<>();
-        if (mostCommonRecord != null) mostCommonFilesSet.add(mostCommonRecord);
-        ListingRecordFile mostCommonSidecarSingle =
-                RecordFileUtils.findMostCommonByType(group, ListingRecordFile.Type.RECORD_SIDECAR);
-        if (mostCommonSidecarSingle != null) mostCommonFilesSet.add(mostCommonSidecarSingle);
-
-        List<InMemoryFile> inMemoryFiles = new ArrayList<>();
-        for (ListingRecordFile lr : orderedFiles) {
-            String blobName = netConfig.bucketPathPrefix() + lr.path();
-            try {
-                InMemoryFile downloadedFile = downloadManager
-                        .downloadAsync(netConfig.gcsBucketName(), blobName)
-                        .join();
-                String filename = lr.path().substring(lr.path().lastIndexOf('/') + 1);
-                if (!checkMd5(lr.md5Hex(), downloadedFile.data())) {
-                    System.err.println("[live-sequential] MD5 mismatch for " + lr.path() + ", skipping");
-                    continue;
+            if (currentHash != null) {
+                try {
+                    LocalDateTime finalBlockTime = blockTimeReader.getBlockLocalDateTime(currentBlockNumber);
+                    Instant finalRecordTime =
+                            finalBlockTime.atZone(ZoneOffset.UTC).toInstant();
+                    saveState(new State(currentBlockNumber, currentHash, finalRecordTime, currentDay));
+                    System.out.println("[live-sequential] Saved state at block " + currentBlockNumber);
+                } catch (Exception e) {
+                    System.err.println("[live-sequential] Error saving final state: " + e.getMessage());
                 }
-                byte[] contentBytes = downloadedFile.data();
-                if (filename.endsWith(".gz")) {
-                    contentBytes = Gzip.ungzipInMemory(contentBytes);
-                    filename = filename.replaceAll("\\.gz$", "");
-                }
-                Path newFilePath = DownloadDayLiveImpl.computeNewFilePath(lr, mostCommonFilesSet, filename);
-                inMemoryFiles.add(new InMemoryFile(newFilePath, contentBytes));
-            } catch (CompletionException ce) {
-                System.err.println("[live-sequential] Download failed for " + blobName + ": " + ce.getMessage());
-                throw new IllegalStateException("Download failed for block " + blockNumber, ce.getCause());
-            }
-        }
-        return inMemoryFiles;
-    }
-
-    private static void validateBlock(
-            AddressBookRegistry addressBookRegistry,
-            byte[] currentHash,
-            LocalDateTime blockTime,
-            long blockNumber,
-            List<InMemoryFile> files,
-            byte[] newHash)
-            throws Exception {
-        DownloadDayLiveImpl.BlockDownloadResult result =
-                new DownloadDayLiveImpl.BlockDownloadResult(blockNumber, files, newHash);
-        Instant recordFileTime = blockTime.atZone(ZoneOffset.UTC).toInstant();
-        if (!fullBlockValidate(addressBookRegistry, currentHash, recordFileTime, result, null)) {
-            throw new IllegalStateException("Full block validation failed for block " + blockNumber + " — aborting");
-        }
-    }
-
-    private static void assertSequentialOrdering(long nextBlockNumber, long currentBlockNumber) {
-        if (nextBlockNumber != currentBlockNumber + 1) {
-            throw new IllegalStateException(
-                    "Block gap detected: expected " + (currentBlockNumber + 1) + " but got " + nextBlockNumber);
-        }
-    }
-
-    private static void writeToDayArchive(ConcurrentTarZstdWriter writer, List<InMemoryFile> files) throws IOException {
-        if (writer != null) {
-            for (InMemoryFile file : files) {
-                writer.putEntry(file);
-            }
-        }
-    }
-
-    private static void logProgress(long total, long today, long blockNumber, long dayStartTime) {
-        if (total % PROGRESS_LOG_INTERVAL == 0) {
-            long elapsed = System.currentTimeMillis() - dayStartTime;
-            double blocksPerSec = today / Math.max(1.0, elapsed / 1000.0);
-            System.out.println("[live-sequential] Block " + blockNumber + " (" + today + " today, "
-                    + String.format("%.1f", blocksPerSec) + " blocks/sec)");
-        }
-    }
-
-    private void saveFinalState(long blockNumber, byte[] hash, LocalDate day, BlockTimeReader blockTimeReader) {
-        if (hash != null) {
-            try {
-                LocalDateTime finalBlockTime = blockTimeReader.getBlockLocalDateTime(blockNumber);
-                Instant finalRecordTime = finalBlockTime.atZone(ZoneOffset.UTC).toInstant();
-                saveState(new State(blockNumber, hash, finalRecordTime, day));
-                System.out.println("[live-sequential] Saved state at block " + blockNumber);
-            } catch (Exception e) {
-                System.err.println("[live-sequential] Error saving final state: " + e.getMessage());
-            }
-        }
-    }
-
-    private static void closeQuietly(ConcurrentTarZstdWriter writer) {
-        if (writer != null) {
-            try {
-                writer.close();
-            } catch (Exception e) {
-                System.err.println("[live-sequential] Error closing writer: " + e.getMessage());
             }
         }
     }
@@ -747,42 +876,236 @@ public class LiveSequential implements Runnable {
      * Wrap+validate consumer thread. Takes downloaded blocks from the queue, wraps them into
      * block stream format, and runs all 11 BlockValidation checks.
      */
-    @SuppressWarnings("PMD.NPathComplexity")
     private void runWrapAndValidateThread(BlockingQueue<ValidatedBlock> queue, AddressBookRegistry addressBookRegistry)
             throws Exception {
+
+        // Initialize wrapping state
+        final Path hashRegistryPath = wrapOutputDir.resolve("blockStreamBlockHashes.bin");
         final Path streamingMerkleTreeFile = wrapOutputDir.resolve("streamingMerkleTree.bin");
         final Path watermarkFile = wrapOutputDir.resolve("wrap-commit.bin");
         final Path addressBookFile = wrapOutputDir.resolve("addressBookHistory.json");
         final Path checkpointDir = wrapOutputDir.resolve("validateCheckpoint");
 
-        initializeWrapDirectories(addressBookFile, checkpointDir);
+        Files.createDirectories(wrapOutputDir);
+        Files.createDirectories(checkpointDir);
+
+        // Copy address book to wrap output if needed
+        if (!Files.exists(addressBookFile) && addressBookPath != null && Files.exists(addressBookPath)) {
+            Files.copy(addressBookPath, addressBookFile);
+        }
+
         final AmendmentProvider amendmentProvider =
                 createAmendmentProvider(NetworkConfig.current().networkName());
-        try (BlockStreamBlockHashRegistry blockRegistry =
-                new BlockStreamBlockHashRegistry(wrapOutputDir.resolve("blockStreamBlockHashes.bin"))) {
-            long[] state = reconcileWrapState(blockRegistry, watermarkFile);
-            long effectiveHighest = state[0];
+
+        try (BlockStreamBlockHashRegistry blockRegistry = new BlockStreamBlockHashRegistry(hashRegistryPath)) {
+
+            // Load watermark and reconcile
+            long watermark = loadWatermark(watermarkFile);
+            long registryHighest = blockRegistry.highestBlockNumberStored();
+
+            if (watermark >= 0 && registryHighest > watermark) {
+                System.out.println(
+                        "[WRAP] Registry at " + registryHighest + " but watermark at " + watermark + "; truncating.");
+                blockRegistry.truncateTo(watermark);
+            } else if (watermark < 0 && registryHighest >= 0) {
+                watermark = registryHighest;
+            }
+
+            long effectiveHighest = blockRegistry.highestBlockNumberStored();
+
+            // Mid-zip resume: back up to zip range start if needed
+            if (effectiveHighest >= 0) {
+                long zipRangeFirst = BlockWriter.zipRangeFirstBlock(effectiveHighest, DEFAULT_POWERS_OF_TEN_PER_ZIP);
+                long blocksPerZip = (long) Math.pow(10, DEFAULT_POWERS_OF_TEN_PER_ZIP);
+                long zipRangeLast = zipRangeFirst + blocksPerZip - 1;
+                if (effectiveHighest < zipRangeLast) {
+                    long truncateTo = zipRangeFirst - 1;
+                    System.out.println("[WRAP] Mid-zip resume: truncating to " + truncateTo);
+                    BlockPath partialZipPath = BlockWriter.computeBlockPath(
+                            wrapOutputDir, effectiveHighest, BlockArchiveType.UNCOMPRESSED_ZIP);
+                    Files.deleteIfExists(partialZipPath.zipFilePath());
+                    blockRegistry.truncateTo(truncateTo);
+                    saveWatermark(watermarkFile, truncateTo);
+                    effectiveHighest = blockRegistry.highestBlockNumberStored();
+                }
+            }
 
             System.out.println("[WRAP] Starting from block: " + effectiveHighest);
-            final StreamingHasher streamingHasher = replayHasher(blockRegistry, effectiveHighest);
 
-            WrapValidations wv = setupValidations(
-                    addressBookRegistry, blockRegistry, streamingMerkleTreeFile, effectiveHighest, checkpointDir);
+            // Create streaming hasher and replay from registry
+            final StreamingHasher streamingHasher = new StreamingHasher();
+            if (effectiveHighest >= 0) {
+                System.out.println("[WRAP] Replaying " + (effectiveHighest + 1) + " block hashes into hasher");
+                for (long bn = 0; bn <= effectiveHighest; bn++) {
+                    byte[] hash = blockRegistry.getBlockHash(bn);
+                    streamingHasher.addNodeByHash(hash);
+                }
+                System.out.println("[WRAP] Hasher replay complete. leafCount=" + streamingHasher.leafCount());
+            }
 
-            long[] zipState = {state[1], 0};
-            BlockZipAppender[] zipHolder = {null};
-            Path[] zipPathHolder = {null};
+            // Build validation list (same as ValidateBlocksCommand)
+            BlockChainValidation chainValidation = new BlockChainValidation();
+            HistoricalBlockTreeValidation treeValidation = new HistoricalBlockTreeValidation(chainValidation);
+            HbarSupplyValidation supplyValidation = new HbarSupplyValidation();
+
+            List<BlockValidation> parallelValidations = new ArrayList<>();
+            parallelValidations.add(new RequiredItemsValidation());
+            parallelValidations.add(new BlockStructureValidation());
+            SignatureValidation signatureValidation = new SignatureValidation(addressBookRegistry);
+            parallelValidations.add(signatureValidation);
+
+            List<BlockValidation> sequentialValidations = new ArrayList<>();
+            sequentialValidations.add(new AddressBookUpdateValidation(addressBookRegistry));
+            sequentialValidations.add(chainValidation);
+            sequentialValidations.add(treeValidation);
+            sequentialValidations.add(supplyValidation);
+            sequentialValidations.add(new HashRegistryValidation(blockRegistry, chainValidation));
+            sequentialValidations.add(new StreamingMerkleTreeValidation(streamingMerkleTreeFile, treeValidation));
+            Path jumpstartPath = wrapOutputDir.resolve("jumpstart.bin");
+            sequentialValidations.add(new JumpstartValidation(jumpstartPath, treeValidation, blockRegistry));
+
+            List<BlockValidation> allValidations = new ArrayList<>();
+            allValidations.addAll(parallelValidations);
+            allValidations.addAll(sequentialValidations);
+
+            // Filter out genesis-required validations when not starting from block 0
+            boolean startingFromGenesis = (effectiveHighest < 0);
+            if (!startingFromGenesis) {
+                // Try to load checkpoint state, but only if it's not ahead of the wrap state.
+                // Mid-zip truncation can push effectiveHighest behind the checkpoint — loading
+                // a checkpoint that is ahead would cause hash mismatches.
+                boolean hasCheckpoint = false;
+                try {
+                    Path progressFile = checkpointDir.resolve("validateProgress.json");
+                    if (Files.exists(progressFile)) {
+                        String cpJson = Files.readString(progressFile, StandardCharsets.UTF_8);
+                        com.google.gson.JsonObject cpRoot =
+                                com.google.gson.JsonParser.parseString(cpJson).getAsJsonObject();
+                        long cpBlock = cpRoot.get("lastValidatedBlockNumber").getAsLong();
+
+                        if (cpBlock <= effectiveHighest) {
+                            for (BlockValidation v : allValidations) {
+                                try {
+                                    v.load(checkpointDir);
+                                } catch (Exception e) {
+                                    System.err.println(
+                                            "[WRAP] Warning: could not load " + v.name() + " state: " + e.getMessage());
+                                }
+                            }
+                            hasCheckpoint = true;
+                        } else {
+                            System.out.println("[WRAP] Validate checkpoint (block " + cpBlock
+                                    + ") is ahead of wrap effective highest (" + effectiveHighest
+                                    + "); skipping checkpoint load");
+                            // Initialize chain validation from block hash registry so it
+                            // doesn't treat the first block as genesis
+                            byte[] lastHash = blockRegistry.getBlockHash(effectiveHighest);
+                            if (lastHash != null) {
+                                chainValidation.setPreviousBlockHash(lastHash);
+                                System.out.println("[WRAP] Initialized chain validation from registry at block "
+                                        + effectiveHighest);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    System.err.println("[WRAP] Warning: could not load checkpoint: " + e.getMessage());
+                }
+
+                if (!hasCheckpoint) {
+                    List<BlockValidation> genesisSkipped = new ArrayList<>();
+                    sequentialValidations.removeIf(v -> {
+                        if (v.requiresGenesisStart()) {
+                            genesisSkipped.add(v);
+                            return true;
+                        }
+                        return false;
+                    });
+                    allValidations.removeIf(genesisSkipped::contains);
+                    for (BlockValidation skipped : genesisSkipped) {
+                        System.out.println("[WRAP] Skipping: " + skipped.name() + " (requires genesis start)");
+                    }
+                }
+            }
+
+            // Zip writing state
+            BlockZipAppender currentZip = null;
+            Path currentZipPath = null;
+            long durableWatermark = watermark;
+            long blocksSinceWatermarkFlush = 0;
             long blocksValidated = 0;
             long lastCheckpointSaveMs = System.currentTimeMillis();
+
+            // Tar archive state (moved from download thread to free it for faster downloading)
+            ConcurrentTarZstdWriter currentDayWriter = null;
+            LocalDate currentTarDay = null;
 
             try {
                 while (true) {
                     ValidatedBlock vb = queue.take();
-                    if (vb == POISON_PILL) break;
-                    long blockNum = vb.blockNumber();
-                    if (blockNum <= effectiveHighest) continue;
+                    if (vb == POISON_PILL) {
+                        break;
+                    }
 
-                    PreVerifiedBlock preVerified = parseAndVerifyBlock(vb, addressBookRegistry, blockNum);
+                    long blockNum = vb.blockNumber();
+
+                    // Write to tar.zstd archive (handles day boundaries)
+                    LocalDate blockDay = vb.blockDay();
+                    if (blockDay != null && !blockDay.equals(currentTarDay)) {
+                        if (currentDayWriter != null) {
+                            currentDayWriter.close();
+                            currentDayWriter = null;
+                        }
+                        currentTarDay = blockDay;
+                        Path dayArchive = outputDir.toPath().resolve(currentTarDay + ".tar.zstd");
+                        if (!Files.exists(dayArchive)) {
+                            currentDayWriter = new ConcurrentTarZstdWriter(dayArchive);
+                        }
+                    }
+                    if (currentDayWriter != null) {
+                        for (InMemoryFile file : vb.files()) {
+                            currentDayWriter.putEntry(file);
+                        }
+                    }
+
+                    // Skip if already wrapped
+                    if (blockNum <= effectiveHighest) {
+                        continue;
+                    }
+
+                    // Classify files and build UnparsedRecordBlock
+                    DownloadDayLiveImpl.BlockDownloadResult downloadResult =
+                            new DownloadDayLiveImpl.BlockDownloadResult(blockNum, vb.files(), vb.runningHash());
+                    InMemoryFile primaryRecord = findPrimaryRecord(downloadResult);
+                    List<InMemoryFile> signatures = findSignatures(downloadResult);
+                    List<InMemoryFile> sidecars = findSidecars(downloadResult, primaryRecord);
+
+                    if (primaryRecord == null) {
+                        throw new IllegalStateException("No primary record found for block " + blockNum);
+                    }
+
+                    UnparsedRecordBlock unparsedBlock = UnparsedRecordBlock.newInMemoryBlock(
+                            vb.recordFileTime(), primaryRecord, List.of(), signatures, sidecars, List.of());
+
+                    // Parse and verify signatures
+                    ParsedRecordBlock parsedBlock = unparsedBlock.parse();
+                    NodeAddressBook ab = addressBookRegistry.getAddressBookForBlock(parsedBlock.blockTime());
+                    byte[] signedHash = parsedBlock.recordFile().signedHash();
+                    List<RecordFileSignature> verifiedSigs = parsedBlock.signatureFiles().stream()
+                            .filter(psf -> psf.isValid(signedHash, ab))
+                            .map(psf -> psf.toRecordFileSignature(ab))
+                            .toList();
+
+                    PreVerifiedBlock preVerified = new PreVerifiedBlock(parsedBlock, ab, verifiedSigs);
+
+                    // Address book auto-update
+                    try {
+                        preVerified = updateAddressBookAndReverify(preVerified, blockNum, addressBookRegistry);
+                    } catch (Exception e) {
+                        System.err.printf(
+                                "[WRAP] Warning: address book auto-update failed at block %d: %s%n", blockNum, e);
+                    }
+
+                    // Convert to wrapped block
                     Block wrapped = RecordBlockConverter.toBlock(
                             preVerified,
                             blockNum,
@@ -790,308 +1113,126 @@ public class LiveSequential implements Runnable {
                             streamingHasher.computeRootHash(),
                             amendmentProvider);
 
-                    byte[] blockHash = hashBlock(wrapped);
-                    streamingHasher.addNodeByHash(blockHash);
-                    blockRegistry.addBlock(blockNum, blockHash);
-                    writeToZipArchive(blockNum, wrapped, watermarkFile, zipHolder, zipPathHolder, zipState);
-                    runBlockValidations(wrapped, blockNum, wv.parallel(), wv.sequential(), wv.all(), checkpointDir);
+                    // Hash and update chain state
+                    byte[] blockStreamBlockHash = hashBlock(wrapped);
+                    streamingHasher.addNodeByHash(blockStreamBlockHash);
+                    blockRegistry.addBlock(blockNum, blockStreamBlockHash);
+
+                    // Compute block path and write to zip
+                    BlockPath blockPath =
+                            BlockWriter.computeBlockPath(wrapOutputDir, blockNum, BlockArchiveType.UNCOMPRESSED_ZIP);
+                    Files.createDirectories(blockPath.dirPath());
+
+                    Bytes wrappedBytes = Block.PROTOBUF.toBytes(wrapped);
+                    byte[] serializedBytes = BlockWriter.serializeBlockToBytes(wrapped, DEFAULT_COMPRESSION);
+
+                    // Switch zip file if needed
+                    if (!blockPath.zipFilePath().equals(currentZipPath)) {
+                        if (currentZip != null) {
+                            currentZip.close();
+                            saveWatermark(watermarkFile, durableWatermark);
+                            blocksSinceWatermarkFlush = 0;
+                        }
+                        currentZip = BlockWriter.openZipForAppend(blockPath.zipFilePath());
+                        currentZipPath = blockPath.zipFilePath();
+                    }
+                    BlockWriter.writeBlockEntry(currentZip, blockPath, serializedBytes);
+
+                    durableWatermark = blockNum;
+                    blocksSinceWatermarkFlush++;
+                    if (blocksSinceWatermarkFlush >= WATERMARK_BATCH_SIZE) {
+                        saveWatermark(watermarkFile, durableWatermark);
+                        blocksSinceWatermarkFlush = 0;
+                    }
+
+                    // Run BlockValidation checks (reuse raw protobuf bytes, skip re-serialization)
+                    BlockUnparsed blockUnparsed = BlockUnparsed.PROTOBUF.parse(
+                            wrappedBytes.toReadableSequentialData(), false, false, Codec.DEFAULT_MAX_DEPTH, 37_748_736);
+
+                    // Phase 1: Parallel validations
+                    for (BlockValidation v : parallelValidations) {
+                        try {
+                            v.validate(blockUnparsed, blockNum);
+                        } catch (ValidationException e) {
+                            throw new IllegalStateException(
+                                    "Validation '" + v.name() + "' failed at block " + blockNum + ": " + e.getMessage(),
+                                    e);
+                        }
+                    }
+
+                    // Phase 2: Sequential validations
+                    for (BlockValidation v : sequentialValidations) {
+                        try {
+                            v.validate(blockUnparsed, blockNum);
+                        } catch (ValidationException e) {
+                            // Save checkpoint before failing
+                            saveValidationCheckpoint(
+                                    checkpointDir, blocksValidated, blockNum - 1, chainValidation, allValidations);
+                            throw new IllegalStateException(
+                                    "Validation '" + v.name() + "' failed at block " + blockNum + ": " + e.getMessage(),
+                                    e);
+                        }
+                    }
+
+                    // Phase 3: Commit state for all validations
+                    for (BlockValidation v : allValidations) {
+                        v.commitState(blockUnparsed, blockNum);
+                    }
+
                     blocksValidated++;
 
-                    if (System.currentTimeMillis() - lastCheckpointSaveMs >= 60_000L) {
-                        saveValidationCheckpoint(checkpointDir, blockNum, wv.all());
-                        lastCheckpointSaveMs = System.currentTimeMillis();
+                    // Save jumpstart.bin every block (tiny ~1KB write)
+                    saveJumpstart(jumpstartPath, blockNum, blockStreamBlockHash, streamingHasher);
+
+                    // Periodic checkpoint save
+                    long nowMs = System.currentTimeMillis();
+                    if (nowMs - lastCheckpointSaveMs >= 60_000L) {
+                        saveValidationCheckpoint(
+                                checkpointDir, blocksValidated, blockNum, chainValidation, allValidations);
+                        lastCheckpointSaveMs = nowMs;
                     }
+
+                    // Progress
                     if (blocksValidated % PROGRESS_LOG_INTERVAL == 0) {
-                        System.out.println("[WRAP] Wrapped + validated block " + blockNum + " ("
-                                + blocksValidated + " total, sigs="
-                                + preVerified.verifiedSignatures().size() + ")");
+                        System.out.println("[WRAP] Wrapped + validated block " + blockNum + " (" + blocksValidated
+                                + " total, sigs=" + verifiedSigs.size() + ")");
                     }
                 }
             } finally {
-                finalizeWrapState(
-                        zipHolder[0],
-                        zipState[0],
-                        watermarkFile,
-                        streamingMerkleTreeFile,
-                        streamingHasher,
-                        addressBookRegistry,
-                        addressBookFile,
-                        checkpointDir,
-                        wv.all());
+                // Close zip and save state
+                if (currentZip != null) {
+                    try {
+                        currentZip.close();
+                    } catch (IOException e) {
+                        System.err.println("[WRAP] Error closing zip: " + e.getMessage());
+                    }
+                }
+                if (currentDayWriter != null) {
+                    try {
+                        currentDayWriter.close();
+                    } catch (Exception e) {
+                        System.err.println("[WRAP] Error closing tar writer: " + e.getMessage());
+                    }
+                }
+                saveWatermark(watermarkFile, durableWatermark);
+                saveStateCheckpoint(streamingMerkleTreeFile, streamingHasher);
+                byte[] lastBlockHash = blockRegistry.getBlockHash(durableWatermark);
+                if (lastBlockHash != null) {
+                    saveJumpstart(jumpstartPath, durableWatermark, lastBlockHash, streamingHasher);
+                }
+                addressBookRegistry.saveAddressBookRegistryToJsonFile(addressBookFile);
+
+                // Save validation checkpoint
+                saveValidationCheckpoint(
+                        checkpointDir, blocksValidated, durableWatermark, chainValidation, allValidations);
+
+                // Close all validations
+                for (BlockValidation v : allValidations) {
+                    v.close();
+                }
+
                 System.out.println("[WRAP] Shutdown complete. Wrapped " + blocksValidated + " blocks.");
             }
-        }
-    }
-
-    private WrapValidations setupValidations(
-            AddressBookRegistry addressBookRegistry,
-            BlockStreamBlockHashRegistry blockRegistry,
-            Path streamingMerkleTreeFile,
-            long effectiveHighest,
-            Path checkpointDir) {
-        BlockChainValidation chainValidation = new BlockChainValidation();
-        List<BlockValidation> parallel = buildParallelValidations(addressBookRegistry);
-        List<BlockValidation> sequential = buildSequentialValidations(
-                addressBookRegistry, blockRegistry, chainValidation, streamingMerkleTreeFile);
-        List<BlockValidation> all = new ArrayList<>(parallel);
-        all.addAll(sequential);
-        initializeCheckpointState(effectiveHighest, checkpointDir, blockRegistry, chainValidation, sequential, all);
-        return new WrapValidations(parallel, sequential, all);
-    }
-
-    private void initializeWrapDirectories(Path addressBookFile, Path checkpointDir) throws IOException {
-        Files.createDirectories(wrapOutputDir);
-        Files.createDirectories(checkpointDir);
-        if (!Files.exists(addressBookFile) && addressBookPath != null && Files.exists(addressBookPath)) {
-            Files.copy(addressBookPath, addressBookFile);
-        }
-    }
-
-    private static void finalizeWrapState(
-            BlockZipAppender currentZip,
-            long durableWatermark,
-            Path watermarkFile,
-            Path streamingMerkleTreeFile,
-            StreamingHasher streamingHasher,
-            AddressBookRegistry addressBookRegistry,
-            Path addressBookFile,
-            Path checkpointDir,
-            List<BlockValidation> allValidations) {
-        if (currentZip != null) {
-            try {
-                currentZip.close();
-            } catch (IOException e) {
-                System.err.println("[WRAP] Error closing zip: " + e.getMessage());
-            }
-        }
-        saveWatermark(watermarkFile, durableWatermark);
-        saveStateCheckpoint(streamingMerkleTreeFile, streamingHasher);
-        addressBookRegistry.saveAddressBookRegistryToJsonFile(addressBookFile);
-        saveValidationCheckpoint(checkpointDir, durableWatermark, allValidations);
-        for (BlockValidation v : allValidations) v.close();
-    }
-
-    private void writeToZipArchive(
-            long blockNum,
-            Block wrapped,
-            Path watermarkFile,
-            BlockZipAppender[] zipHolder,
-            Path[] zipPathHolder,
-            long[] zipState)
-            throws Exception {
-        BlockPath blockPath = BlockWriter.computeBlockPath(wrapOutputDir, blockNum, BlockArchiveType.UNCOMPRESSED_ZIP);
-        Files.createDirectories(blockPath.dirPath());
-        byte[] serializedBytes = BlockWriter.serializeBlockToBytes(wrapped, DEFAULT_COMPRESSION);
-        if (!blockPath.zipFilePath().equals(zipPathHolder[0])) {
-            if (zipHolder[0] != null) {
-                zipHolder[0].close();
-                saveWatermark(watermarkFile, zipState[0]);
-                zipState[1] = 0;
-            }
-            zipHolder[0] = BlockWriter.openZipForAppend(blockPath.zipFilePath());
-            zipPathHolder[0] = blockPath.zipFilePath();
-        }
-        BlockWriter.writeBlockEntry(zipHolder[0], blockPath, serializedBytes);
-        zipState[0] = blockNum;
-        zipState[1]++;
-        if (zipState[1] >= WATERMARK_BATCH_SIZE) {
-            saveWatermark(watermarkFile, zipState[0]);
-            zipState[1] = 0;
-        }
-    }
-
-    private long[] reconcileWrapState(BlockStreamBlockHashRegistry blockRegistry, Path watermarkFile)
-            throws IOException {
-        long watermark = loadWatermark(watermarkFile);
-        long registryHighest = blockRegistry.highestBlockNumberStored();
-
-        if (watermark >= 0 && registryHighest > watermark) {
-            System.out.println(
-                    "[WRAP] Registry at " + registryHighest + " but watermark at " + watermark + "; truncating.");
-            blockRegistry.truncateTo(watermark);
-        } else if (watermark < 0 && registryHighest >= 0) {
-            watermark = registryHighest;
-        }
-
-        long effectiveHighest = blockRegistry.highestBlockNumberStored();
-        if (effectiveHighest >= 0) {
-            long zipRangeFirst = BlockWriter.zipRangeFirstBlock(effectiveHighest, DEFAULT_POWERS_OF_TEN_PER_ZIP);
-            long blocksPerZip = (long) Math.pow(10, DEFAULT_POWERS_OF_TEN_PER_ZIP);
-            long zipRangeLast = zipRangeFirst + blocksPerZip - 1;
-            if (effectiveHighest < zipRangeLast) {
-                long truncateTo = zipRangeFirst - 1;
-                System.out.println("[WRAP] Mid-zip resume: truncating to " + truncateTo);
-                BlockPath partialZipPath = BlockWriter.computeBlockPath(
-                        wrapOutputDir, effectiveHighest, BlockArchiveType.UNCOMPRESSED_ZIP);
-                Files.deleteIfExists(partialZipPath.zipFilePath());
-                blockRegistry.truncateTo(truncateTo);
-                saveWatermark(watermarkFile, truncateTo);
-                effectiveHighest = blockRegistry.highestBlockNumberStored();
-            }
-        }
-        return new long[] {effectiveHighest, watermark};
-    }
-
-    private static StreamingHasher replayHasher(BlockStreamBlockHashRegistry blockRegistry, long effectiveHighest) {
-        StreamingHasher streamingHasher = new StreamingHasher();
-        if (effectiveHighest >= 0) {
-            System.out.println("[WRAP] Replaying " + (effectiveHighest + 1) + " block hashes into hasher");
-            for (long bn = 0; bn <= effectiveHighest; bn++) {
-                streamingHasher.addNodeByHash(blockRegistry.getBlockHash(bn));
-            }
-            System.out.println("[WRAP] Hasher replay complete. leafCount=" + streamingHasher.leafCount());
-        }
-        return streamingHasher;
-    }
-
-    private static List<BlockValidation> buildParallelValidations(AddressBookRegistry addressBookRegistry) {
-        List<BlockValidation> validations = new ArrayList<>();
-        validations.add(new RequiredItemsValidation());
-        validations.add(new BlockStructureValidation());
-        validations.add(new SignatureValidation(addressBookRegistry));
-        return validations;
-    }
-
-    private List<BlockValidation> buildSequentialValidations(
-            AddressBookRegistry addressBookRegistry,
-            BlockStreamBlockHashRegistry blockRegistry,
-            BlockChainValidation chainValidation,
-            Path streamingMerkleTreeFile) {
-        HistoricalBlockTreeValidation treeValidation = new HistoricalBlockTreeValidation(chainValidation);
-        List<BlockValidation> validations = new ArrayList<>();
-        validations.add(new AddressBookUpdateValidation(addressBookRegistry));
-        validations.add(chainValidation);
-        validations.add(treeValidation);
-        validations.add(new HbarSupplyValidation());
-        validations.add(new HashRegistryValidation(blockRegistry, chainValidation));
-        validations.add(new StreamingMerkleTreeValidation(streamingMerkleTreeFile, treeValidation));
-        Path jumpstartPath = wrapOutputDir.resolve("jumpstart.bin");
-        validations.add(new JumpstartValidation(jumpstartPath, treeValidation, blockRegistry));
-        return validations;
-    }
-
-    @SuppressWarnings("PMD.NPathComplexity")
-    private static void initializeCheckpointState(
-            long effectiveHighest,
-            Path checkpointDir,
-            BlockStreamBlockHashRegistry blockRegistry,
-            BlockChainValidation chainValidation,
-            List<BlockValidation> sequentialValidations,
-            List<BlockValidation> allValidations) {
-        if (effectiveHighest < 0) return; // starting from genesis
-
-        boolean hasCheckpoint = false;
-        try {
-            Path progressFile = checkpointDir.resolve("validateProgress.json");
-            if (Files.exists(progressFile)) {
-                String cpJson = Files.readString(progressFile, StandardCharsets.UTF_8);
-                com.google.gson.JsonObject cpRoot =
-                        com.google.gson.JsonParser.parseString(cpJson).getAsJsonObject();
-                long cpBlock = cpRoot.get("lastValidatedBlockNumber").getAsLong();
-
-                if (cpBlock <= effectiveHighest) {
-                    for (BlockValidation v : allValidations) {
-                        try {
-                            v.load(checkpointDir);
-                        } catch (Exception e) {
-                            System.err.println(
-                                    "[WRAP] Warning: could not load " + v.name() + " state: " + e.getMessage());
-                        }
-                    }
-                    hasCheckpoint = true;
-                } else {
-                    System.out.println("[WRAP] Validate checkpoint (block " + cpBlock
-                            + ") is ahead of wrap effective highest (" + effectiveHighest
-                            + "); skipping checkpoint load");
-                    byte[] lastHash = blockRegistry.getBlockHash(effectiveHighest);
-                    if (lastHash != null) {
-                        chainValidation.setPreviousBlockHash(lastHash);
-                        System.out.println(
-                                "[WRAP] Initialized chain validation from registry at block " + effectiveHighest);
-                    }
-                }
-            }
-        } catch (Exception e) {
-            System.err.println("[WRAP] Warning: could not load checkpoint: " + e.getMessage());
-        }
-
-        if (!hasCheckpoint) {
-            List<BlockValidation> genesisSkipped = new ArrayList<>();
-            sequentialValidations.removeIf(v -> {
-                if (v.requiresGenesisStart()) {
-                    genesisSkipped.add(v);
-                    return true;
-                }
-                return false;
-            });
-            allValidations.removeIf(genesisSkipped::contains);
-            for (BlockValidation skipped : genesisSkipped) {
-                System.out.println("[WRAP] Skipping: " + skipped.name() + " (requires genesis start)");
-            }
-        }
-    }
-
-    private PreVerifiedBlock parseAndVerifyBlock(
-            ValidatedBlock vb, AddressBookRegistry addressBookRegistry, long blockNum) throws Exception {
-        DownloadDayLiveImpl.BlockDownloadResult downloadResult =
-                new DownloadDayLiveImpl.BlockDownloadResult(blockNum, vb.files(), vb.runningHash());
-        InMemoryFile primaryRecord = findPrimaryRecord(downloadResult);
-        List<InMemoryFile> signatures = findSignatures(downloadResult);
-        List<InMemoryFile> sidecars = findSidecars(downloadResult, primaryRecord);
-
-        if (primaryRecord == null) {
-            throw new IllegalStateException("No primary record found for block " + blockNum);
-        }
-
-        UnparsedRecordBlock unparsedBlock = UnparsedRecordBlock.newInMemoryBlock(
-                vb.recordFileTime(), primaryRecord, List.of(), signatures, sidecars, List.of());
-        ParsedRecordBlock parsedBlock = unparsedBlock.parse();
-        NodeAddressBook ab = addressBookRegistry.getAddressBookForBlock(parsedBlock.blockTime());
-        byte[] signedHash = parsedBlock.recordFile().signedHash();
-        List<RecordFileSignature> verifiedSigs = parsedBlock.signatureFiles().stream()
-                .filter(psf -> psf.isValid(signedHash, ab))
-                .map(psf -> psf.toRecordFileSignature(ab))
-                .toList();
-
-        PreVerifiedBlock preVerified = new PreVerifiedBlock(parsedBlock, ab, verifiedSigs);
-        try {
-            preVerified = updateAddressBookAndReverify(preVerified, blockNum, addressBookRegistry);
-        } catch (Exception e) {
-            System.err.printf("[WRAP] Warning: address book auto-update failed at block %d: %s%n", blockNum, e);
-        }
-        return preVerified;
-    }
-
-    private static void runBlockValidations(
-            Block wrapped,
-            long blockNum,
-            List<BlockValidation> parallelValidations,
-            List<BlockValidation> sequentialValidations,
-            List<BlockValidation> allValidations,
-            Path checkpointDir)
-            throws Exception {
-        Bytes wrappedBytes = Block.PROTOBUF.toBytes(wrapped);
-        BlockUnparsed blockUnparsed = BlockUnparsed.PROTOBUF.parse(wrappedBytes);
-
-        for (BlockValidation v : parallelValidations) {
-            try {
-                v.validate(blockUnparsed, blockNum);
-            } catch (ValidationException e) {
-                throw new IllegalStateException(
-                        "Validation '" + v.name() + "' failed at block " + blockNum + ": " + e.getMessage(), e);
-            }
-        }
-        for (BlockValidation v : sequentialValidations) {
-            try {
-                v.validate(blockUnparsed, blockNum);
-            } catch (ValidationException e) {
-                saveValidationCheckpoint(checkpointDir, blockNum - 1, allValidations);
-                throw new IllegalStateException(
-                        "Validation '" + v.name() + "' failed at block " + blockNum + ": " + e.getMessage(), e);
-            }
-        }
-        for (BlockValidation v : allValidations) {
-            v.commitState(blockUnparsed, blockNum);
         }
     }
 
@@ -1099,13 +1240,14 @@ public class LiveSequential implements Runnable {
      * Saves validation checkpoint state.
      */
     private static void saveValidationCheckpoint(
-            Path checkpointDir, long lastValidatedBlockNumber, List<BlockValidation> validations) {
+            Path checkpointDir,
+            long blocksValidated,
+            long lastValidatedBlockNumber,
+            BlockChainValidation chainValidation,
+            List<BlockValidation> validations) {
         try {
             Files.createDirectories(checkpointDir);
-            // Save progress file so resume can detect checkpoint position
-            Path progressFile = checkpointDir.resolve("validateProgress.json");
-            String progressJson = "{\"lastValidatedBlockNumber\":" + lastValidatedBlockNumber + "}";
-            Files.writeString(progressFile, progressJson, StandardCharsets.UTF_8);
+            // Save each validation's state
             for (BlockValidation v : validations) {
                 try {
                     v.save(checkpointDir);
@@ -1113,8 +1255,23 @@ public class LiveSequential implements Runnable {
                     System.err.println("[WRAP] Warning: could not save " + v.name() + " state: " + e.getMessage());
                 }
             }
-        } catch (IOException e) {
-            System.err.println("[WRAP] Warning: could not create checkpoint directory: " + e.getMessage());
+            // Save validateProgress.json
+            byte[] previousBlockHash = chainValidation.getPreviousBlockHash();
+            JsonObject root = new JsonObject();
+            root.addProperty("schemaVersion", 3);
+            root.addProperty("lastValidatedBlockNumber", lastValidatedBlockNumber);
+            root.addProperty("blocksValidated", blocksValidated);
+            root.addProperty(
+                    "previousBlockHashHex",
+                    previousBlockHash != null ? Bytes.wrap(previousBlockHash).toHex() : "");
+            final String json = new GsonBuilder().setPrettyPrinting().create().toJson(root);
+            HasherStateFiles.saveAtomically(checkpointDir.resolve("validateProgress.json"), path -> {
+                try (var writer = Files.newBufferedWriter(path)) {
+                    writer.write(json);
+                }
+            });
+        } catch (Exception e) {
+            System.err.println("[WRAP] Warning: could not save checkpoint: " + e.getMessage());
         }
     }
 
@@ -1168,7 +1325,7 @@ public class LiveSequential implements Runnable {
     }
 
     /**
-     * Refreshes GCS listings for a specific day.
+     * Refreshes GCS listings for all days plus a specific day.
      */
     private void refreshListingsForDay(LocalDate day, NetworkConfig netConfig) {
         LocalDate today = LocalDate.now(ZoneOffset.UTC);
@@ -1190,6 +1347,54 @@ public class LiveSequential implements Runnable {
                 netConfig.maxNodeAccountId(),
                 DownloadConstants.GCP_PROJECT_ID,
                 day);
+    }
+
+    /**
+     * Refreshes GCS listings for only the given day (skips the global all-days refresh).
+     */
+    private void refreshListingsForSingleDay(LocalDate day, NetworkConfig netConfig) {
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        boolean isToday = day.equals(today);
+
+        UpdateDayListingsCommand.updateListingsForSingleDay(
+                listingDir.toPath(),
+                CACHE_DIR.toPath(),
+                !isToday,
+                netConfig.minNodeAccountId(),
+                netConfig.maxNodeAccountId(),
+                DownloadConstants.GCP_PROJECT_ID,
+                day);
+    }
+
+    /** Resolve the ordered download file list from a group of listing files. */
+    private static List<ListingRecordFile> resolveOrderedFiles(List<ListingRecordFile> group) {
+        ListingRecordFile mostCommonRecord = RecordFileUtils.findMostCommonByType(group, ListingRecordFile.Type.RECORD);
+        ListingRecordFile[] mostCommonSidecars = RecordFileUtils.findMostCommonSidecars(group);
+        return DownloadDayLiveImpl.computeFilesToDownload(mostCommonRecord, mostCommonSidecars, group);
+    }
+
+    /** Resolve the set of most-common files (record + sidecar) for path deduplication. */
+    private static Set<ListingRecordFile> resolveMostCommonFilesSet(List<ListingRecordFile> group) {
+        Set<ListingRecordFile> set = new HashSet<>();
+        ListingRecordFile mostCommonRecord = RecordFileUtils.findMostCommonByType(group, ListingRecordFile.Type.RECORD);
+        if (mostCommonRecord != null) set.add(mostCommonRecord);
+        ListingRecordFile mostCommonSidecar =
+                RecordFileUtils.findMostCommonByType(group, ListingRecordFile.Type.RECORD_SIDECAR);
+        if (mostCommonSidecar != null) set.add(mostCommonSidecar);
+        return set;
+    }
+
+    /** Fire parallel downloads for all files in the ordered list. */
+    private static List<CompletableFuture<InMemoryFile>> fireDownloads(
+            List<ListingRecordFile> orderedFiles,
+            NetworkConfig netConfig,
+            ConcurrentDownloadManagerVirtualThreadsV3 downloadManager) {
+        List<CompletableFuture<InMemoryFile>> futures = new ArrayList<>(orderedFiles.size());
+        for (ListingRecordFile lr : orderedFiles) {
+            String blobName = netConfig.bucketPathPrefix() + lr.path();
+            futures.add(downloadManager.downloadAsync(netConfig.gcsBucketName(), blobName));
+        }
+        return futures;
     }
 
     /**
@@ -1237,6 +1442,31 @@ public class LiveSequential implements Runnable {
             Files.move(tmpFile, watermarkFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
         } catch (IOException e) {
             System.err.println("Warning: could not save watermark: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Save jumpstart.bin atomically. Format matches what {@link JumpstartValidation} reads:
+     * block number (long), block hash (48 bytes), leaf count (long), hash count (int),
+     * followed by hash count × 48-byte hashes (streaming hasher intermediate state).
+     */
+    private static void saveJumpstart(
+            Path jumpstartPath, long blockNumber, byte[] blockHash, StreamingHasher streamingHasher) {
+        try {
+            HasherStateFiles.saveAtomically(jumpstartPath, path -> {
+                try (var out = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(path), 8192))) {
+                    out.writeLong(blockNumber);
+                    out.write(blockHash);
+                    out.writeLong(streamingHasher.leafCount());
+                    List<byte[]> hashes = streamingHasher.intermediateHashingState();
+                    out.writeInt(hashes.size());
+                    for (byte[] h : hashes) {
+                        out.write(h);
+                    }
+                }
+            });
+        } catch (Exception e) {
+            System.err.println("[WRAP] Warning: could not save jumpstart.bin: " + e.getMessage());
         }
     }
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -298,10 +298,20 @@ public class LiveSequential implements Runnable {
 
     /**
      * Determines the starting point for block processing.
-     * Priority: 1) Resume from state file, 2) Use --start-date, 3) Auto-detect from mirror node
+     * Priority: 1) Wrap effective highest (accounts for mid-zip truncation), 2) Resume from state file,
+     * 3) Use --start-date, 4) Auto-detect from mirror node
      */
     private State determineStartingPoint(BlockTimeReader blockTimeReader) {
-        // Priority 1: Resume from state file
+        // Priority 1: Resume from wrap state (the authoritative source, accounts for mid-zip truncation)
+        long wrapEffective = computeWrapEffectiveHighest();
+        if (wrapEffective >= 0) {
+            System.out.println("[live-sequential] Resuming from wrap effective highest: block " + wrapEffective);
+            State state = new State();
+            state.blockNumber = wrapEffective;
+            return state;
+        }
+
+        // Priority 2: Resume from state file
         if (Files.exists(stateJsonPath)) {
             try {
                 String json = Files.readString(stateJsonPath, StandardCharsets.UTF_8);
@@ -315,7 +325,7 @@ public class LiveSequential implements Runnable {
             }
         }
 
-        // Priority 2: Use --start-date
+        // Priority 3: Use --start-date
         if (startDate != null && !startDate.isBlank()) {
             LocalDate targetDay = LocalDate.parse(startDate);
             System.out.println("[live-sequential] Using provided start date: " + targetDay);
@@ -331,7 +341,7 @@ public class LiveSequential implements Runnable {
             return state;
         }
 
-        // Priority 3: Auto-detect from mirror node
+        // Priority 4: Auto-detect from mirror node
         System.out.println("[live-sequential] Querying mirror node for current day...");
         List<BlockInfo> latestBlocks = FetchBlockQuery.getLatestBlocks(1, MirrorNodeBlockQueryOrder.DESC);
 
@@ -360,6 +370,48 @@ public class LiveSequential implements Runnable {
         state.blockNumber = firstBlockOfDay - 1;
         state.dayDate = today.toString();
         return state;
+    }
+
+    /**
+     * Computes the wrap thread's effective highest block, including mid-zip truncation.
+     * This mirrors the logic in {@link #runWrapAndValidateThread} so the download thread
+     * starts from the same block the wrap thread expects.
+     *
+     * @return the effective highest block, or -1 if no wrap state exists
+     */
+    private long computeWrapEffectiveHighest() {
+        final Path hashRegistryPath = wrapOutputDir.resolve("blockStreamBlockHashes.bin");
+        final Path watermarkFile = wrapOutputDir.resolve("wrap-commit.bin");
+
+        if (!Files.exists(hashRegistryPath)) {
+            return -1;
+        }
+
+        try (BlockStreamBlockHashRegistry blockRegistry = new BlockStreamBlockHashRegistry(hashRegistryPath)) {
+            long watermark = loadWatermark(watermarkFile);
+            long registryHighest = blockRegistry.highestBlockNumberStored();
+
+            if (watermark >= 0 && registryHighest > watermark) {
+                registryHighest = watermark;
+            } else if (watermark < 0 && registryHighest >= 0) {
+                // trust registry
+            }
+
+            // Mid-zip truncation (same logic as runWrapAndValidateThread)
+            if (registryHighest >= 0) {
+                long zipRangeFirst = BlockWriter.zipRangeFirstBlock(registryHighest, DEFAULT_POWERS_OF_TEN_PER_ZIP);
+                long blocksPerZip = (long) Math.pow(10, DEFAULT_POWERS_OF_TEN_PER_ZIP);
+                long zipRangeLast = zipRangeFirst + blocksPerZip - 1;
+                if (registryHighest < zipRangeLast) {
+                    registryHighest = zipRangeFirst - 1;
+                }
+            }
+
+            return registryHighest;
+        } catch (Exception e) {
+            System.err.println("[live-sequential] Warning: Failed to read wrap state: " + e.getMessage());
+            return -1;
+        }
     }
 
     /**
@@ -426,6 +478,7 @@ public class LiveSequential implements Runnable {
                 if (!blockDay.equals(currentDay)) {
                     if (currentDayWriter != null) {
                         currentDayWriter.close();
+                        currentDayWriter = null;
                         System.out.println("[live-sequential] Day completed: " + currentDay + " ("
                                 + blocksProcessedToday + " blocks in "
                                 + formatDuration((System.currentTimeMillis() - dayStartTime) / 1000) + ")");
@@ -433,22 +486,31 @@ public class LiveSequential implements Runnable {
 
                     // Start new day
                     currentDay = blockDay;
-                    Path dayArchive = outputDir.toPath().resolve(currentDay + ".tar.zstd");
-                    currentDayWriter = new ConcurrentTarZstdWriter(dayArchive);
                     blocksProcessedToday = 0;
                     dayStartTime = System.currentTimeMillis();
                     cachedListingFiles = null;
                     cachedListingDay = null;
 
+                    // Only create tar writer if archive doesn't already exist
+                    Path dayArchive = outputDir.toPath().resolve(currentDay + ".tar.zstd");
+                    if (Files.exists(dayArchive)) {
+                        System.out.println(
+                                "[live-sequential] Day archive already exists, skipping tar writes: " + currentDay);
+                    } else {
+                        currentDayWriter = new ConcurrentTarZstdWriter(dayArchive);
+                    }
+
                     System.out.println("[live-sequential] Started new day: " + currentDay);
                 }
 
-                // Initialize writer if needed (first block)
-                if (currentDayWriter == null) {
+                // Initialize writer if needed (first block, no day boundary crossed yet)
+                if (currentDayWriter == null && currentDay != null) {
                     Path dayArchive = outputDir.toPath().resolve(currentDay + ".tar.zstd");
-                    currentDayWriter = new ConcurrentTarZstdWriter(dayArchive);
-                    dayStartTime = System.currentTimeMillis();
-                    System.out.println("[live-sequential] Started day: " + currentDay);
+                    if (!Files.exists(dayArchive)) {
+                        currentDayWriter = new ConcurrentTarZstdWriter(dayArchive);
+                        dayStartTime = System.currentTimeMillis();
+                        System.out.println("[live-sequential] Started day: " + currentDay);
+                    }
                 }
 
                 // Step 3: Load GCS listings if day changed
@@ -584,9 +646,11 @@ public class LiveSequential implements Runnable {
                             "Block gap detected: expected " + (currentBlockNumber + 1) + " but got " + nextBlockNumber);
                 }
 
-                // Step 8: Write to tar.zstd archive
-                for (InMemoryFile file : inMemoryFiles) {
-                    currentDayWriter.putEntry(file);
+                // Step 8: Write to tar.zstd archive (skip if archive already exists)
+                if (currentDayWriter != null) {
+                    for (InMemoryFile file : inMemoryFiles) {
+                        currentDayWriter.putEntry(file);
+                    }
                 }
 
                 // Step 9: Queue for wrapping
@@ -733,20 +797,41 @@ public class LiveSequential implements Runnable {
             // Filter out genesis-required validations when not starting from block 0
             boolean startingFromGenesis = (effectiveHighest < 0);
             if (!startingFromGenesis) {
-                // Try to load checkpoint state
+                // Try to load checkpoint state, but only if it's not ahead of the wrap state.
+                // Mid-zip truncation can push effectiveHighest behind the checkpoint — loading
+                // a checkpoint that is ahead would cause hash mismatches.
                 boolean hasCheckpoint = false;
                 try {
                     Path progressFile = checkpointDir.resolve("validateProgress.json");
                     if (Files.exists(progressFile)) {
-                        for (BlockValidation v : allValidations) {
-                            try {
-                                v.load(checkpointDir);
-                            } catch (Exception e) {
-                                System.err.println(
-                                        "[WRAP] Warning: could not load " + v.name() + " state: " + e.getMessage());
+                        String cpJson = Files.readString(progressFile, StandardCharsets.UTF_8);
+                        com.google.gson.JsonObject cpRoot =
+                                com.google.gson.JsonParser.parseString(cpJson).getAsJsonObject();
+                        long cpBlock = cpRoot.get("lastValidatedBlockNumber").getAsLong();
+
+                        if (cpBlock <= effectiveHighest) {
+                            for (BlockValidation v : allValidations) {
+                                try {
+                                    v.load(checkpointDir);
+                                } catch (Exception e) {
+                                    System.err.println(
+                                            "[WRAP] Warning: could not load " + v.name() + " state: " + e.getMessage());
+                                }
+                            }
+                            hasCheckpoint = true;
+                        } else {
+                            System.out.println("[WRAP] Validate checkpoint (block " + cpBlock
+                                    + ") is ahead of wrap effective highest (" + effectiveHighest
+                                    + "); skipping checkpoint load");
+                            // Initialize chain validation from block hash registry so it
+                            // doesn't treat the first block as genesis
+                            byte[] lastHash = blockRegistry.getBlockHash(effectiveHighest);
+                            if (lastHash != null) {
+                                chainValidation.setPreviousBlockHash(lastHash);
+                                System.out.println("[WRAP] Initialized chain validation from registry at block "
+                                        + effectiveHighest);
                             }
                         }
-                        hasCheckpoint = true;
                     }
                 } catch (Exception e) {
                     System.err.println("[WRAP] Warning: could not load checkpoint: " + e.getMessage());

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -1149,18 +1149,8 @@ public class LiveSequential implements Runnable {
                     BlockUnparsed blockUnparsed = BlockUnparsed.PROTOBUF.parse(
                             wrappedBytes.toReadableSequentialData(), false, false, Codec.DEFAULT_MAX_DEPTH, 37_748_736);
 
-                    // Phase 1: Parallel validations
-                    for (BlockValidation v : parallelValidations) {
-                        try {
-                            v.validate(blockUnparsed, blockNum);
-                        } catch (ValidationException e) {
-                            throw new IllegalStateException(
-                                    "Validation '" + v.name() + "' failed at block " + blockNum + ": " + e.getMessage(),
-                                    e);
-                        }
-                    }
-
-                    // Phase 2: Sequential validations
+                    // Phase 1: Sequential validations (run first so AddressBookUpdateValidation
+                    // updates the address book before SignatureValidation uses it)
                     for (BlockValidation v : sequentialValidations) {
                         try {
                             v.validate(blockUnparsed, blockNum);
@@ -1168,6 +1158,18 @@ public class LiveSequential implements Runnable {
                             // Save checkpoint before failing
                             saveValidationCheckpoint(
                                     checkpointDir, blocksValidated, blockNum - 1, chainValidation, allValidations);
+                            throw new IllegalStateException(
+                                    "Validation '" + v.name() + "' failed at block " + blockNum + ": " + e.getMessage(),
+                                    e);
+                        }
+                    }
+
+                    // Phase 2: Parallel validations (including SignatureValidation, which now
+                    // sees the up-to-date address book)
+                    for (BlockValidation v : parallelValidations) {
+                        try {
+                            v.validate(blockUnparsed, blockNum);
+                        } catch (ValidationException e) {
                             throw new IllegalStateException(
                                     "Validation '" + v.name() + "' failed at block " + blockNum + ": " + e.getMessage(),
                                     e);
@@ -1225,6 +1227,15 @@ public class LiveSequential implements Runnable {
                 // Save validation checkpoint
                 saveValidationCheckpoint(
                         checkpointDir, blocksValidated, durableWatermark, chainValidation, allValidations);
+
+                // Finalize all validations (end-of-stream checks)
+                for (BlockValidation v : allValidations) {
+                    try {
+                        v.finalize(blocksValidated, durableWatermark);
+                    } catch (ValidationException e) {
+                        System.err.println("[WRAP] Warning: finalize failed for " + v.name() + ": " + e.getMessage());
+                    }
+                }
 
                 // Close all validations
                 for (BlockValidation v : allValidations) {
@@ -1407,8 +1418,9 @@ public class LiveSequential implements Runnable {
                 Files.createDirectories(parentDir);
             }
             String json = GSON.toJson(state);
-            Files.writeString(stateJsonPath, json, StandardCharsets.UTF_8);
-        } catch (IOException e) {
+            HasherStateFiles.saveAtomically(
+                    stateJsonPath, path -> Files.writeString(path, json, StandardCharsets.UTF_8));
+        } catch (Exception e) {
             System.err.println("[live-sequential] Warning: Failed to save state: " + e.getMessage());
         }
     }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/UpdateBlockData.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/UpdateBlockData.java
@@ -77,6 +77,52 @@ public class UpdateBlockData implements Runnable {
     }
 
     /**
+     * Lightweight update that only writes to block_times.bin, starting from its highest block.
+     * Unlike {@link #updateMirrorNodeData}, this does not touch day_blocks.json, making it
+     * suitable for live polling where only block times are needed. It extends the file for
+     * new blocks beyond the current file size.
+     *
+     * @param blockTimesFile the path to the block times file
+     */
+    public static void updateBlockTimesOnly(Path blockTimesFile) {
+        try {
+            long highestBlock = readHighestBlockFromTimesFile(blockTimesFile);
+            long startBlock = highestBlock + 1;
+            long latestBlock = getLatestBlockNumber();
+            if (startBlock > latestBlock) {
+                return; // already up to date
+            }
+            if (blockTimesFile.getParent() != null) {
+                Files.createDirectories(blockTimesFile.getParent());
+            }
+            try (RandomAccessFile raf = new RandomAccessFile(blockTimesFile.toFile(), "rw")) {
+                long currentBlock = startBlock;
+                while (currentBlock <= latestBlock) {
+                    JsonArray blocks = fetchBlockBatch(currentBlock, BATCH_SIZE);
+                    if (blocks.isEmpty()) {
+                        break;
+                    }
+                    long lastProcessed = currentBlock - 1;
+                    for (int i = 0; i < blocks.size(); i++) {
+                        JsonObject block = blocks.get(i).getAsJsonObject();
+                        long blockNumber = block.get("number").getAsLong();
+                        String recordFileName = block.get("name").getAsString();
+                        Instant blockInstant = extractRecordFileTime(recordFileName);
+                        long blockTimeLong = instantToBlockTimeLong(blockInstant);
+                        raf.seek(blockNumber * Long.BYTES);
+                        raf.writeLong(blockTimeLong);
+                        lastProcessed = blockNumber;
+                    }
+                    raf.getChannel().force(false);
+                    currentBlock = lastProcessed + 1;
+                }
+            }
+        } catch (IOException e) {
+            System.err.println("[UpdateBlockData] Warning: could not update block times: " + e.getMessage());
+        }
+    }
+
+    /**
      * Update block data files (block_times.bin and day_blocks.json) with newer blocks from the mirror node.
      *
      * @param blockTimesFile the path to the block times file


### PR DESCRIPTION
## Summary

Adds a new `live-sequential` command that combines downloading, wrapping, and validating blocks into a single streaming pipeline. This replaces the previous three-step workflow (`download-live2` → `wrap` → `validate`) with a simpler, more reliable approach.

- Downloads blocks from GCS, wraps them into block stream format, and runs full validation inline
- Writes wrapped blocks to per-day `tar.zstd` archives with `jumpstart.bin` checkpoints for resumability
- At the live edge, waits for all node signatures (7/7) before processing, using the address book to determine expected node count

## Performance

**~44x throughput improvement** across iterations:
- v1: ~1.2 blocks/sec → v2: ~10.9 blocks/sec → v3: **~52.5 blocks/sec**
- A full day of mainnet (~43,200 blocks) processes in **~14 minutes**

### Steady-state historical processing (~52 blocks/sec)
```
[WRAP] Wrapped + validated block 33401499 (1500 total, sigs=7)
[live-sequential] Block 33401571 (11000 today, 52.5 blocks/sec, queue=5/32)
[WRAP] Wrapped + validated block 33401599 (1600 total, sigs=7)
[live-sequential] Block 33401671 (11100 today, 52.4 blocks/sec, queue=3/32)
[WRAP] Wrapped + validated block 33401799 (1800 total, sigs=7)
[live-sequential] Block 33401871 (11300 today, 52.5 blocks/sec, queue=5/32)
[WRAP] Wrapped + validated block 33401999 (2000 total, sigs=7)
[live-sequential] Block 33402071 (11500 today, 52.6 blocks/sec, queue=2/32)
```

### GCS listing cache refresh (auto-refreshes when blocks exhaust local cache)
```
[LIVE] Block 33417710 not in BlockTimeReader, refreshing...
UpdateBlockData - reading existing block data files
Highest block in block_times.bin: 33417709
Highest block in day_blocks.json: 33390571
Starting from block number: 33390572
Latest block number: 33435536
```

### Day boundary transition (seamless rollover)
```
[live-sequential] Day completed: 2026-03-30 (43200 blocks in 15m 24s)
[live-sequential] Started new day: 2026-03-31
Updated listings for 2026-03-31
[live-sequential] Loaded 35042 listing entries for 2026-03-31
[live-sequential] Block 33433871 (100 today, 41.4 blocks/sec, queue=4/32)
[live-sequential] Block 33434471 (700 today, 53.4 blocks/sec, queue=5/32)
```

### Insufficient signatures — waits and retries at live edge
```
[live-sequential] Insufficient signatures for block 33471947 (1/7), waiting for GCS uploads...

Updated listings for 2026-03-31
[live-sequential] Block 33471947 has all signatures (7/7)
```
When a block at the live tip doesn't yet have all signatures uploaded to GCS, the command detects the insufficient count, refreshes the GCS listings, and retries until all signatures are available.

### Live edge — waits for all signatures before processing
```
[LIVE] Block 33472248 not in BlockTimeReader, refreshing...
[live-sequential] Block 33472248 has all signatures (7/7)
[live-sequential] Block 33472249 has all signatures (7/7)
[live-sequential] Block 33472250 has all signatures (7/7)
...
[live-sequential] Block 33472271 (38500 today, 1.9 blocks/sec, queue=0/32)
```
At the live tip, throughput naturally drops to ~1.9 blocks/sec (matching the ~2 sec block production rate) as the command waits for each block's signatures to appear in GCS.

## Closes #2379

## Test plan
- [x] Tested on testnet — processed 43,200+ blocks per day at ~52 blocks/sec
- [x] Verified day boundary transitions
- [x] Verified GCS listing cache refresh
- [x] Verified live edge signature waiting (7/7)
- [x] Verified insufficient signature retry (1/7 → 7/7)
- [x] Verified resume from `jumpstart.bin` checkpoint
- [x] All wrapped blocks pass full validation (signatures, hashes, chain continuity)