### PR TITLE
feat: add stake-weighted signature validation

### DIFF
--- a/protobuf-sources/src/main/proto/internal/node_stake_history.proto
+++ b/protobuf-sources/src/main/proto/internal/node_stake_history.proto
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+syntax = "proto3";
+
+package org.hiero.block.internal;
+
+option java_package = "org.hiero.block.internal.protoc";
+// <<<pbj.java_package = "org.hiero.block.internal">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "services/timestamp.proto";
+
+/**
+ * A registry of node stake snapshots. This allows storing an ordered history
+ * of node stakes for a network, as discovered from NodeStakeUpdate
+ * transactions in the block stream.
+ */
+message NodeStakeHistory {
+    /**
+     * An ordered list of node stake snapshots, from oldest to newest.
+     */
+    repeated DatedNodeStake stake_snapshots = 1;
+}
+
+/**
+ * A node stake snapshot at a specific block timestamp. The block is the block
+ * that contained the NodeStakeUpdate transaction. The stake data is valid for
+ * all blocks with timestamps greater than the block timestamp, until the next
+ * NodeStakeUpdate.
+ */
+message DatedNodeStake {
+    /**
+     * The block timestamp at which this stake snapshot was set, it is valid
+     * for all blocks after, until the next update.
+     */
+    proto.Timestamp block_timestamp = 1;
+    /**
+     * The node stake entries valid after the given block.
+     */
+    repeated NodeStakeEntry entries = 2;
+}
+
+/**
+ * A single node's consensus stake weight.
+ */
+message NodeStakeEntry {
+    /**
+     * The node ID.
+     */
+    int64 node_id = 1;
+    /**
+     * The consensus stake weight for this node.
+     */
+    int64 stake = 2;
+}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
@@ -13,6 +13,7 @@ import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.RecordFileSignature;
 import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.transaction.SignedTransaction;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.streams.RecordStreamItem;
 import java.io.DataOutputStream;
@@ -51,6 +52,7 @@ import org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHashRegistry;
 import org.hiero.block.tools.blocks.model.hashing.StreamingHasher;
 import org.hiero.block.tools.config.NetworkConfig;
 import org.hiero.block.tools.days.model.AddressBookRegistry;
+import org.hiero.block.tools.days.model.NodeStakeRegistry;
 import org.hiero.block.tools.days.model.TarZstdDayReaderUsingExec;
 import org.hiero.block.tools.days.model.TarZstdDayUtils;
 import org.hiero.block.tools.metadata.MetadataFiles;
@@ -255,6 +257,24 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
                 Files.exists(addressBookFile) ? new AddressBookRegistry(addressBookFile) : new AddressBookRegistry();
         System.out.println(
                 Ansi.AUTO.string("@|yellow Loaded address book registry:|@ \n" + addressBookRegistry.toPrettyString()));
+        // load or create a new NodeStakeRegistry for stake-weighted consensus
+        final Path nodeStakeFile = outputBlocksDir.resolve("nodeStakeHistory.json");
+        if (!Files.exists(nodeStakeFile)) {
+            final Path inputNodeStakeFile = compressedDaysDir.resolve("nodeStakeHistory.json");
+            if (Files.exists(inputNodeStakeFile)) {
+                try {
+                    Files.copy(inputNodeStakeFile, nodeStakeFile);
+                    System.out.println(Ansi.AUTO.string("@|yellow Copied existing node stake history to output:|@ "
+                            + nodeStakeFile.toAbsolutePath()));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        }
+        final NodeStakeRegistry nodeStakeRegistry =
+                Files.exists(nodeStakeFile) ? new NodeStakeRegistry(nodeStakeFile) : new NodeStakeRegistry();
+        System.out.println(
+                Ansi.AUTO.string("@|yellow Loaded node stake registry:|@ \n" + nodeStakeRegistry.toPrettyString()));
         // get Archive type
         final BlockArchiveType archiveType =
                 unzipped ? BlockArchiveType.INDIVIDUAL_FILES : BlockArchiveType.UNCOMPRESSED_ZIP;
@@ -487,6 +507,12 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
                         } catch (Exception e) {
                             System.err.println("Shutdown: could not save address book: " + e.getMessage());
                         }
+                        try {
+                            System.err.println("Shutdown: saving node stake registry to " + nodeStakeFile);
+                            nodeStakeRegistry.saveToJsonFile(nodeStakeFile);
+                        } catch (Exception e) {
+                            System.err.println("Shutdown: could not save node stake registry: " + e.getMessage());
+                        }
                         synchronized (chainStateLock) {
                             saveStateCheckpoint(streamingMerkleTreeFile, streamingHasher);
                             System.err.println("Shutdown: saved merkle tree state to " + streamingMerkleTreeFile);
@@ -612,6 +638,16 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
                             // Don't fail wrapping for address book parse errors
                             System.err.printf(
                                     "Warning: address book auto-update failed at block %d: %s%n", blockNum, e);
+                        }
+
+                        // ---- Node stake auto-update from block transactions ----
+                        // Discover NodeStakeUpdate transactions (issued daily at midnight UTC)
+                        // so stake-weighted signature validation uses the correct weights.
+                        try {
+                            updateNodeStakeRegistry(effectiveBlock, blockNum, nodeStakeRegistry);
+                        } catch (Exception e) {
+                            // Don't fail wrapping for stake parse errors
+                            System.err.printf("Warning: node stake auto-update failed at block %d: %s%n", blockNum, e);
                         }
 
                         // Monthly checkpoint: save state once per calendar month of blockchain data.
@@ -796,6 +832,7 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
             }
 
             addressBookRegistry.saveAddressBookRegistryToJsonFile(addressBookFile);
+            nodeStakeRegistry.saveToJsonFile(nodeStakeFile);
 
             // If we stopped due to a parse failure, throw after saving state
             if (parseFailureMessage != null) {
@@ -1055,5 +1092,63 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
         }
 
         return preVerified;
+    }
+
+    /**
+     * Discovers {@code NodeStakeUpdate} transactions from the block's record stream and updates
+     * the node stake registry. Stake changes are stored with a +1ns timestamp offset so they
+     * apply to blocks AFTER the current one.
+     *
+     * @param preVerified the pre-verified block from Stage 1/2
+     * @param blockNum the block number
+     * @param nodeStakeRegistry the shared node stake registry
+     */
+    private static void updateNodeStakeRegistry(
+            final PreVerifiedBlock preVerified, final long blockNum, final NodeStakeRegistry nodeStakeRegistry) {
+        final List<RecordStreamItem> streamItems =
+                preVerified.recordBlock().recordFile().recordStreamFile().recordStreamItems();
+        final Instant blockInstant = preVerified.recordBlock().blockTime();
+
+        for (final RecordStreamItem rsi : streamItems) {
+            if (!rsi.hasTransaction()) {
+                continue;
+            }
+            final TransactionBody body;
+            try {
+                body = extractTransactionBody(rsi.transactionOrThrow());
+            } catch (Exception e) {
+                continue;
+            }
+            if (body != null && body.hasNodeStakeUpdate()) {
+                // +1ns so the new stakes apply to blocks AFTER this one
+                final String changes =
+                        nodeStakeRegistry.updateStakes(blockInstant.plusNanos(1), body.nodeStakeUpdateOrThrow());
+                if (changes != null) {
+                    PrettyPrint.clearProgress();
+                    System.out.println(
+                            Ansi.AUTO.string("@|yellow Node stake updated at block " + blockNum + ":|@ " + changes));
+                }
+            }
+        }
+    }
+
+    /**
+     * Extracts the {@link TransactionBody} from a transaction, handling all three encoding formats:
+     * direct body, bodyBytes, and signedTransactionBytes.
+     *
+     * @param t the transaction
+     * @return the parsed transaction body, or null if none could be extracted
+     * @throws Exception if parsing fails
+     */
+    private static TransactionBody extractTransactionBody(final Transaction t) throws Exception {
+        if (t.hasBody()) {
+            return t.body();
+        } else if (t.bodyBytes().length() > 0) {
+            return TransactionBody.PROTOBUF.parse(t.bodyBytes());
+        } else if (t.signedTransactionBytes().length() > 0) {
+            final SignedTransaction st = SignedTransaction.PROTOBUF.parse(t.signedTransactionBytes());
+            return TransactionBody.PROTOBUF.parse(st.bodyBytes());
+        }
+        return null;
     }
 }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
@@ -42,12 +42,14 @@ import org.hiero.block.tools.blocks.validation.HashRegistryValidation;
 import org.hiero.block.tools.blocks.validation.HbarSupplyValidation;
 import org.hiero.block.tools.blocks.validation.HistoricalBlockTreeValidation;
 import org.hiero.block.tools.blocks.validation.JumpstartValidation;
+import org.hiero.block.tools.blocks.validation.NodeStakeUpdateValidation;
 import org.hiero.block.tools.blocks.validation.RequiredItemsValidation;
 import org.hiero.block.tools.blocks.validation.SignatureValidation;
 import org.hiero.block.tools.blocks.validation.StreamingMerkleTreeValidation;
 import org.hiero.block.tools.blocks.wrapped.BalanceCheckpointValidator;
 import org.hiero.block.tools.config.NetworkConfig;
 import org.hiero.block.tools.days.model.AddressBookRegistry;
+import org.hiero.block.tools.days.model.NodeStakeRegistry;
 import org.hiero.block.tools.records.model.parsed.ValidationException;
 import org.hiero.block.tools.utils.PrettyPrint;
 import picocli.CommandLine.Command;
@@ -387,12 +389,13 @@ public class ValidateBlocksCommand implements Runnable {
         HbarSupplyValidation supplyValidation = skipSupply ? null : new HbarSupplyValidation();
         // Parallel validations (stateless, run in decompPool threads)
         final AddressBookRegistry abRegistry = addressBookRegistry;
+        final NodeStakeRegistry nodeStakeRegistry = new NodeStakeRegistry();
         List<BlockValidation> parallelValidations = new ArrayList<>();
         parallelValidations.add(new RequiredItemsValidation());
         parallelValidations.add(new BlockStructureValidation());
         SignatureValidation sigVal = null;
         if (!skipSignatures) {
-            sigVal = new SignatureValidation(abRegistry);
+            sigVal = new SignatureValidation(abRegistry, nodeStakeRegistry);
             parallelValidations.add(sigVal);
         } else {
             System.out.println(Ansi.AUTO.string("@|yellow Skipping:|@ Signature validation (--skip-signatures)"));
@@ -408,6 +411,8 @@ public class ValidateBlocksCommand implements Runnable {
         if (abRegistry != null) {
             sequentialValidations.add(new AddressBookUpdateValidation(abRegistry));
         }
+        // Node stake update comes after address book so stake weights are current for signature validation
+        sequentialValidations.add(new NodeStakeUpdateValidation(nodeStakeRegistry));
         sequentialValidations.add(chainValidation);
         sequentialValidations.add(treeValidation);
         if (supplyValidation != null) {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
@@ -33,7 +33,7 @@ public final class AddressBookUpdateValidation implements BlockValidation {
 
     private static final String SAVE_FILE_NAME = "addressBookHistory.json";
     private static final int MAX_DEPTH = 512;
-    private static final int MAX_RECORD_FILE_SIZE = 8 * 1024 * 1024;
+    private static final int MAX_RECORD_FILE_SIZE = 32 * 1024 * 1024;
 
     private final AddressBookRegistry addressBookRegistry;
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
@@ -33,7 +33,7 @@ public final class AddressBookUpdateValidation implements BlockValidation {
 
     private static final String SAVE_FILE_NAME = "addressBookHistory.json";
     private static final int MAX_DEPTH = 512;
-    private static final int MAX_RECORD_FILE_SIZE = 32 * 1024 * 1024;
+    private static final int MAX_RECORD_FILE_SIZE = 64 * 1024 * 1024;
 
     private final AddressBookRegistry addressBookRegistry;
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
@@ -32,6 +32,8 @@ import picocli.CommandLine.Help.Ansi;
 public final class AddressBookUpdateValidation implements BlockValidation {
 
     private static final String SAVE_FILE_NAME = "addressBookHistory.json";
+    private static final int MAX_DEPTH = 512;
+    private static final int MAX_RECORD_FILE_SIZE = 8 * 1024 * 1024;
 
     private final AddressBookRegistry addressBookRegistry;
 
@@ -100,7 +102,8 @@ public final class AddressBookUpdateValidation implements BlockValidation {
     }
 
     private static List<Transaction> extractTransactions(final Bytes recordFileBytes) throws Exception {
-        final RecordFileItem recordFileItem = RecordFileItem.PROTOBUF.parse(recordFileBytes);
+        final RecordFileItem recordFileItem = RecordFileItem.PROTOBUF.parse(
+                recordFileBytes.toReadableSequentialData(), false, false, MAX_DEPTH, MAX_RECORD_FILE_SIZE);
         if (!recordFileItem.hasRecordFileContents()) {
             return List.of();
         }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
@@ -32,7 +32,7 @@ public final class NodeStakeUpdateValidation implements BlockValidation {
 
     private static final String SAVE_FILE_NAME = "nodeStakeHistory.json";
     private static final int MAX_DEPTH = 512;
-    private static final int MAX_RECORD_FILE_SIZE = 8 * 1024 * 1024;
+    private static final int MAX_RECORD_FILE_SIZE = 32 * 1024 * 1024;
 
     private final NodeStakeRegistry nodeStakeRegistry;
     private boolean firstStakeUpdateSeen = false;

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
@@ -31,6 +31,8 @@ import picocli.CommandLine.Help.Ansi;
 public final class NodeStakeUpdateValidation implements BlockValidation {
 
     private static final String SAVE_FILE_NAME = "nodeStakeHistory.json";
+    private static final int MAX_DEPTH = 512;
+    private static final int MAX_RECORD_FILE_SIZE = 8 * 1024 * 1024;
 
     private final NodeStakeRegistry nodeStakeRegistry;
     private boolean firstStakeUpdateSeen = false;
@@ -79,7 +81,8 @@ public final class NodeStakeUpdateValidation implements BlockValidation {
     @SuppressWarnings("DataFlowIssue")
     private void processNodeStakeUpdates(
             final Bytes recordFileBytes, final Instant blockInstant, final long blockNumber) throws Exception {
-        final RecordFileItem recordFileItem = RecordFileItem.PROTOBUF.parse(recordFileBytes);
+        final RecordFileItem recordFileItem = RecordFileItem.PROTOBUF.parse(
+                recordFileBytes.toReadableSequentialData(), false, false, MAX_DEPTH, MAX_RECORD_FILE_SIZE);
         if (!recordFileItem.hasRecordFileContents()) {
             return;
         }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.blocks.validation;
+
+import com.hedera.hapi.block.stream.RecordFileItem;
+import com.hedera.hapi.block.stream.output.BlockHeader;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.transaction.SignedTransaction;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.hapi.streams.RecordStreamFile;
+import com.hedera.hapi.streams.RecordStreamItem;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.tools.days.model.NodeStakeRegistry;
+import org.hiero.block.tools.records.model.parsed.ValidationException;
+import picocli.CommandLine.Help.Ansi;
+
+/**
+ * Sequential validation that discovers {@code NodeStakeUpdate} transactions from
+ * RecordFile items in each block and keeps the {@link NodeStakeRegistry} up to date.
+ *
+ * <p>This allows stake-weighted signature validation to use the correct stake weights
+ * as they are discovered from the block stream. {@code NodeStakeUpdate} transactions
+ * are issued daily at midnight UTC.
+ */
+public final class NodeStakeUpdateValidation implements BlockValidation {
+
+    private static final String SAVE_FILE_NAME = "nodeStakeHistory.json";
+
+    private final NodeStakeRegistry nodeStakeRegistry;
+
+    /**
+     * Creates a new node stake update validation.
+     *
+     * @param nodeStakeRegistry the shared registry to update when stake changes are found
+     */
+    public NodeStakeUpdateValidation(final NodeStakeRegistry nodeStakeRegistry) {
+        this.nodeStakeRegistry = nodeStakeRegistry;
+    }
+
+    @Override
+    public String name() {
+        return "NodeStakeUpdate";
+    }
+
+    @Override
+    public String description() {
+        return "Discovers NodeStakeUpdate transactions from block data and keeps the stake registry current";
+    }
+
+    @Override
+    public boolean requiresGenesisStart() {
+        return false;
+    }
+
+    @Override
+    public void validate(final BlockUnparsed block, final long blockNumber) throws ValidationException {
+        try {
+            final Instant blockInstant = extractBlockInstant(block);
+            final Bytes recordFileBytes = extractRecordFileBytes(block);
+            if (recordFileBytes == null || recordFileBytes.length() == 0 || blockInstant == null) {
+                return;
+            }
+            processNodeStakeUpdates(recordFileBytes, blockInstant, blockNumber);
+        } catch (Exception e) {
+            // Don't fail validation for stake parse/extraction errors — the block's
+            // record file might be in a format we don't fully handle (e.g., genesis or very early blocks).
+            System.err.println("[NodeStakeUpdate] Block " + blockNumber + " - Error extracting stake data: "
+                    + e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    private void processNodeStakeUpdates(
+            final Bytes recordFileBytes, final Instant blockInstant, final long blockNumber) throws Exception {
+        final RecordFileItem recordFileItem = RecordFileItem.PROTOBUF.parse(recordFileBytes);
+        if (!recordFileItem.hasRecordFileContents()) {
+            return;
+        }
+        final RecordStreamFile recordStreamFile = recordFileItem.recordFileContentsOrThrow();
+        for (final RecordStreamItem rsi : recordStreamFile.recordStreamItems()) {
+            if (!rsi.hasTransaction()) {
+                continue;
+            }
+            final Transaction t = rsi.transactionOrThrow();
+            final TransactionBody body = extractTransactionBody(t);
+            if (body == null) {
+                continue;
+            }
+            if (body.hasNodeStakeUpdate()) {
+                // Store with timestamp +1ns so the new stakes apply to blocks AFTER
+                // this one, matching the AddressBookUpdateValidation pattern.
+                final String changes =
+                        nodeStakeRegistry.updateStakes(blockInstant.plusNanos(1), body.nodeStakeUpdateOrThrow());
+                if (changes != null) {
+                    System.out.println(
+                            Ansi.AUTO.string("@|yellow Node stake updated at block " + blockNumber + ":|@ " + changes));
+                }
+            }
+        }
+    }
+
+    private static TransactionBody extractTransactionBody(final Transaction t) throws Exception {
+        if (t.hasBody()) {
+            return t.body();
+        } else if (t.bodyBytes().length() > 0) {
+            return TransactionBody.PROTOBUF.parse(t.bodyBytes());
+        } else if (t.signedTransactionBytes().length() > 0) {
+            final SignedTransaction st = SignedTransaction.PROTOBUF.parse(t.signedTransactionBytes());
+            return TransactionBody.PROTOBUF.parse(st.bodyBytes());
+        }
+        return null;
+    }
+
+    private static Instant extractBlockInstant(final BlockUnparsed block) throws Exception {
+        for (final BlockItemUnparsed item : block.blockItems()) {
+            if (item.hasBlockHeader()) {
+                final BlockHeader header = BlockHeader.PROTOBUF.parse(item.blockHeaderOrThrow());
+                final Timestamp ts = header.blockTimestampOrThrow();
+                return Instant.ofEpochSecond(ts.seconds(), ts.nanos());
+            }
+        }
+        return null;
+    }
+
+    private static Bytes extractRecordFileBytes(final BlockUnparsed block) {
+        for (final BlockItemUnparsed item : block.blockItems()) {
+            if (item.hasRecordFile()) {
+                return item.recordFileOrThrow();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void save(final Path directory) throws IOException {
+        nodeStakeRegistry.saveToJsonFile(directory.resolve(SAVE_FILE_NAME));
+    }
+
+    @Override
+    public void load(final Path directory) throws IOException {
+        final Path saved = directory.resolve(SAVE_FILE_NAME);
+        if (saved.toFile().exists()) {
+            nodeStakeRegistry.reloadFromFile(saved);
+        }
+    }
+}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
@@ -13,6 +13,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.tools.days.model.NodeStakeRegistry;
@@ -32,6 +33,7 @@ public final class NodeStakeUpdateValidation implements BlockValidation {
     private static final String SAVE_FILE_NAME = "nodeStakeHistory.json";
 
     private final NodeStakeRegistry nodeStakeRegistry;
+    private boolean firstStakeUpdateSeen = false;
 
     /**
      * Creates a new node stake update validation.
@@ -82,7 +84,8 @@ public final class NodeStakeUpdateValidation implements BlockValidation {
             return;
         }
         final RecordStreamFile recordStreamFile = recordFileItem.recordFileContentsOrThrow();
-        for (final RecordStreamItem rsi : recordStreamFile.recordStreamItems()) {
+        final List<? extends RecordStreamItem> items = recordStreamFile.recordStreamItems();
+        for (final RecordStreamItem rsi : items) {
             if (!rsi.hasTransaction()) {
                 continue;
             }
@@ -92,6 +95,11 @@ public final class NodeStakeUpdateValidation implements BlockValidation {
                 continue;
             }
             if (body.hasNodeStakeUpdate()) {
+                if (!firstStakeUpdateSeen) {
+                    firstStakeUpdateSeen = true;
+                    System.out.println(Ansi.AUTO.string(
+                            "@|green First NodeStakeUpdate transaction found at block " + blockNumber + "|@"));
+                }
                 // Store with timestamp +1ns so the new stakes apply to blocks AFTER
                 // this one, matching the AddressBookUpdateValidation pattern.
                 final String changes =

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
@@ -32,7 +32,7 @@ public final class NodeStakeUpdateValidation implements BlockValidation {
 
     private static final String SAVE_FILE_NAME = "nodeStakeHistory.json";
     private static final int MAX_DEPTH = 512;
-    private static final int MAX_RECORD_FILE_SIZE = 32 * 1024 * 1024;
+    private static final int MAX_RECORD_FILE_SIZE = 64 * 1024 * 1024;
 
     private final NodeStakeRegistry nodeStakeRegistry;
     private boolean firstStakeUpdateSeen = false;

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureValidation.java
@@ -11,10 +11,12 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.tools.days.model.AddressBookRegistry;
+import org.hiero.block.tools.days.model.NodeStakeRegistry;
 import org.hiero.block.tools.records.SigFileUtils;
 import org.hiero.block.tools.records.model.parsed.ValidationException;
 
@@ -22,9 +24,10 @@ import org.hiero.block.tools.records.model.parsed.ValidationException;
  * Validates block signatures by verifying RSA signatures (for SignedRecordFileProof) or
  * checking non-empty TSS signatures (for SignedBlockProof).
  *
- * <p>For SignedRecordFileProof, at least 1/3 + 1 of address book nodes must have valid
- * RSA-SHA384 signatures. The signed hash is reconstructed from the block's RecordFileItem
- * and BlockHeader.
+ * <p>For SignedRecordFileProof, stake-weighted consensus is used when stake data is
+ * available: verified stake must be {@code >= ceil(totalStake / 3)}. When no stake data
+ * is available (pre-staking era, before ~July 2022), falls back to equal-weight mode
+ * where each node counts as weight 1 and threshold is {@code (nodeCount / 3) + 1}.
  *
  * <p>This is a stateless validation — no cross-block state is maintained.
  */
@@ -33,13 +36,28 @@ public final class SignatureValidation implements BlockValidation {
     /** The address book registry providing public keys for signature verification. */
     private final AddressBookRegistry addressBookRegistry;
 
+    /** Optional node stake registry for stake-weighted consensus. May be null. */
+    private final NodeStakeRegistry nodeStakeRegistry;
+
     /**
-     * Creates a new signature validation.
+     * Creates a new signature validation with equal-weight consensus (no stake data).
      *
      * @param addressBookRegistry the address book registry for public key lookups
      */
     public SignatureValidation(final AddressBookRegistry addressBookRegistry) {
+        this(addressBookRegistry, null);
+    }
+
+    /**
+     * Creates a new signature validation with optional stake-weighted consensus.
+     *
+     * @param addressBookRegistry the address book registry for public key lookups
+     * @param nodeStakeRegistry the node stake registry for stake weights (may be null for equal-weight)
+     */
+    public SignatureValidation(
+            final AddressBookRegistry addressBookRegistry, final NodeStakeRegistry nodeStakeRegistry) {
         this.addressBookRegistry = addressBookRegistry;
+        this.nodeStakeRegistry = nodeStakeRegistry;
     }
 
     @Override
@@ -147,11 +165,31 @@ public final class SignatureValidation implements BlockValidation {
         // Get the address book for this block's timestamp
         final NodeAddressBook addressBook = addressBookRegistry.getAddressBookForBlock(blockTime);
         final int totalNodes = addressBook.nodeAddress().size();
-        final int threshold = (totalNodes / 3) + 1;
+
+        // Determine stake-weighted vs equal-weight mode.
+        // Fall back to equal-weight if no stake data or if total stake is zero
+        // (e.g. early NodeStakeUpdate transactions before staking was enabled).
+        final Map<Long, Long> stakeMap =
+                nodeStakeRegistry != null ? nodeStakeRegistry.getStakeMapForBlock(blockTime) : null;
+        final long rawTotalStake = stakeMap != null
+                ? stakeMap.values().stream().mapToLong(Long::longValue).sum()
+                : 0;
+        final boolean stakeWeighted = stakeMap != null && rawTotalStake > 0;
+        final long totalStake;
+        final long threshold;
+        if (stakeWeighted) {
+            totalStake = rawTotalStake;
+            // Strong minority: ceil(totalStake / 3)
+            threshold = (totalStake / 3) + ((totalStake % 3 == 0) ? 0 : 1);
+        } else {
+            totalStake = totalNodes;
+            threshold = (totalNodes / 3) + 1;
+        }
 
         // Verify each signature, tracking unique nodes to avoid counting duplicates.
         // Early-exit once threshold is met — no need to verify remaining signatures.
         final Set<Long> validatedNodes = new HashSet<>();
+        long validatedStake = 0;
         final List<String> diagnostics = new ArrayList<>();
         for (final var sig : signatures) {
             final long accountNum = AddressBookRegistry.accountIdForNode(sig.nodeId());
@@ -161,10 +199,13 @@ public final class SignatureValidation implements BlockValidation {
                         pubKeyHex.length() > 16 ? pubKeyHex.substring(pubKeyHex.length() - 16) : pubKeyHex;
                 if (SigFileUtils.verifyRsaSha384(
                         pubKeyHex, signedHash, sig.signaturesBytes().toByteArray())) {
-                    validatedNodes.add(accountNum);
+                    if (validatedNodes.add(accountNum)) {
+                        final long weight = stakeWeighted ? stakeMap.getOrDefault(sig.nodeId(), 0L) : 1;
+                        validatedStake += weight;
+                    }
                     diagnostics.add(
                             "  node " + accountNum + " (id=" + sig.nodeId() + "): VERIFIED key=..." + keySnippet);
-                    if (validatedNodes.size() >= threshold) break;
+                    if (validatedStake >= threshold) break;
                 } else {
                     diagnostics.add("  node " + accountNum + " (id=" + sig.nodeId() + "): FAILED key=..." + keySnippet);
                 }
@@ -174,14 +215,22 @@ public final class SignatureValidation implements BlockValidation {
             }
         }
 
-        if (validatedNodes.size() < threshold) {
+        if (validatedStake < threshold) {
             final StringBuilder detail = new StringBuilder();
             detail.append("Block: ").append(blockNumber);
-            detail.append(" - Insufficient valid signatures: ");
-            detail.append(validatedNodes.size()).append(" unique nodes/").append(totalNodes);
-            detail.append(" verified, need ").append(threshold).append("/").append(totalNodes);
+            if (stakeWeighted) {
+                detail.append(" - Insufficient validated stake: ");
+                detail.append(validatedStake).append("/").append(totalStake);
+                detail.append(" (").append(validatedNodes.size()).append(" nodes)");
+                detail.append(", need ").append(threshold).append("/").append(totalStake);
+            } else {
+                detail.append(" - Insufficient valid signatures: ");
+                detail.append(validatedNodes.size()).append(" unique nodes/").append(totalNodes);
+                detail.append(" verified, need ").append(threshold).append("/").append(totalNodes);
+            }
             detail.append("\n  blockTime=").append(blockTime);
             detail.append(", signatures=").append(signatures.size());
+            detail.append(stakeWeighted ? ", mode=stake-weighted" : ", mode=equal-weight");
             detail.append("\n  Per-signature results:\n");
             diagnostics.forEach(d -> detail.append(d).append("\n"));
             throw new ValidationException(detail.toString());

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/AddressBookRegistry.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/AddressBookRegistry.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HexFormat;
 import java.util.List;
@@ -125,20 +126,25 @@ public class AddressBookRegistry {
      * @return the address book that was in effect at the given block time
      */
     public NodeAddressBook getAddressBookForBlock(Instant blockTime) {
-        // find the most recent address book with a timestamp less than or equal to the block time
-        for (int i = 0; i < addressBooks.size(); i++) {
-            DatedNodeAddressBook datedBook = addressBooks.get(i);
-            final Timestamp bookTimestamp = datedBook.blockTimestampOrThrow();
-            final Instant bookInstant = Instant.ofEpochSecond(bookTimestamp.seconds(), bookTimestamp.nanos());
-            if (bookInstant.isAfter(blockTime)) {
-                // return the previous address book
-                return i == 0
-                        ? datedBook.addressBook()
-                        : addressBooks.get(i - 1).addressBook();
-            }
+        // Binary search using a synthetic probe with the target timestamp
+        final Timestamp probeTs = toTimestamp(blockTime);
+        final DatedNodeAddressBook probe = new DatedNodeAddressBook(probeTs, NodeAddressBook.DEFAULT);
+        int idx = Collections.binarySearch(addressBooks, probe, (a, b) -> {
+            final Timestamp tsA = a.blockTimestampOrThrow();
+            final Timestamp tsB = b.blockTimestampOrThrow();
+            int cmp = Long.compare(tsA.seconds(), tsB.seconds());
+            return cmp != 0 ? cmp : Integer.compare(tsA.nanos(), tsB.nanos());
+        });
+        // If exact match, use that index. Otherwise binarySearch returns -(insertion point) - 1,
+        // and we want the entry just before the insertion point.
+        if (idx < 0) {
+            idx = -idx - 2; // insertion point - 1
         }
-        // if no address book is found after the block time, return the most recent address book
-        return addressBooks.getLast().addressBook();
+        // If blockTime is before all snapshots, return the earliest address book
+        if (idx < 0) {
+            return addressBooks.getFirst().addressBook();
+        }
+        return addressBooks.get(idx).addressBook();
     }
 
     /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/NodeStakeRegistry.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/NodeStakeRegistry.java
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.days.model;
+
+import static org.hiero.block.tools.utils.TimeUtils.toTimestamp;
+
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.transaction.NodeStake;
+import com.hedera.hapi.node.transaction.NodeStakeUpdateTransactionBody;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.hiero.block.internal.DatedNodeStake;
+import org.hiero.block.internal.NodeStakeEntry;
+import org.hiero.block.internal.NodeStakeHistory;
+import picocli.CommandLine.Help.Ansi;
+
+/**
+ * Registry of node stake snapshots discovered from {@code NodeStakeUpdate} transactions
+ * in the block stream. Snapshots are ordered by block timestamp (oldest first) and can
+ * be looked up by block time to determine the stake map in effect for a given block.
+ *
+ * <p>The registry starts empty. Stake data is populated as {@code NodeStakeUpdate}
+ * transactions are encountered. Before any stake data is available (pre-staking era),
+ * callers should fall back to equal-weight consensus.
+ */
+public class NodeStakeRegistry {
+    /** List of dated node stake snapshots, ordered by block timestamp, oldest first.
+     * Uses CopyOnWriteArrayList for thread-safe reads during parallel signature validation
+     * while the main thread may append new entries discovered from block data. */
+    private final List<DatedNodeStake> stakeSnapshots = new CopyOnWriteArrayList<>();
+
+    /**
+     * Create a new empty NodeStakeRegistry.
+     */
+    public NodeStakeRegistry() {}
+
+    /**
+     * Create a new NodeStakeRegistry by loading from a JSON file.
+     *
+     * @param jsonFile the path to the JSON file
+     */
+    public NodeStakeRegistry(Path jsonFile) {
+        try (var in = new ReadableStreamingData(Files.newInputStream(jsonFile))) {
+            NodeStakeHistory history = NodeStakeHistory.JSON.parse(in);
+            stakeSnapshots.addAll(history.stakeSnapshots());
+        } catch (IOException | ParseException e) {
+            throw new UncheckedIOException(
+                    new IOException("Error loading Node Stake History JSON file " + jsonFile, e));
+        }
+    }
+
+    /**
+     * Save the node stake registry to a JSON file.
+     *
+     * @param file the path to the JSON file
+     */
+    public void saveToJsonFile(Path file) {
+        try (var out = new WritableStreamingData(Files.newOutputStream(file))) {
+            NodeStakeHistory history = new NodeStakeHistory(stakeSnapshots);
+            NodeStakeHistory.JSON.write(history, out);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Reload the node stake registry from a JSON file, replacing all current entries.
+     *
+     * @param jsonFile the path to the JSON file
+     */
+    public void reloadFromFile(Path jsonFile) {
+        try (var in = new ReadableStreamingData(Files.newInputStream(jsonFile))) {
+            NodeStakeHistory history = NodeStakeHistory.JSON.parse(in);
+            stakeSnapshots.clear();
+            stakeSnapshots.addAll(history.stakeSnapshots());
+        } catch (IOException | ParseException e) {
+            throw new UncheckedIOException(
+                    new IOException("Error reloading Node Stake History JSON file " + jsonFile, e));
+        }
+    }
+
+    /**
+     * Update the stake registry with data from a {@code NodeStakeUpdate} transaction.
+     * A new snapshot is appended only if the stake data differs from the most recent snapshot.
+     *
+     * @param blockInstant the block timestamp (typically blockTime + 1ns so it applies to subsequent blocks)
+     * @param body the NodeStakeUpdateTransactionBody containing stake entries
+     * @return a description of changes, or null if no change
+     */
+    public String updateStakes(Instant blockInstant, NodeStakeUpdateTransactionBody body) {
+        final List<NodeStakeEntry> entries = new ArrayList<>();
+        for (NodeStake ns : body.nodeStake()) {
+            entries.add(new NodeStakeEntry(ns.nodeId(), ns.stake()));
+        }
+        // Check if this is a duplicate of the last snapshot
+        if (!stakeSnapshots.isEmpty()) {
+            final DatedNodeStake last = stakeSnapshots.getLast();
+            if (last.entries().equals(entries)) {
+                return null;
+            }
+        }
+        stakeSnapshots.add(new DatedNodeStake(toTimestamp(blockInstant), entries));
+        final long totalStake =
+                entries.stream().mapToLong(NodeStakeEntry::stake).sum();
+        final StringBuilder sb = new StringBuilder();
+        sb.append(entries.size())
+                .append(" nodes, totalStake=")
+                .append(totalStake)
+                .append("\n");
+        for (NodeStakeEntry entry : entries) {
+            final double pct = totalStake > 0 ? (entry.stake() * 100.0) / totalStake : 0;
+            sb.append(String.format("    node %d: stake=%d (%.2f%%)%n", entry.nodeId(), entry.stake(), pct));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Get the stake map that was in effect at the given block time.
+     *
+     * @param blockTime the block time to look up
+     * @return a map of nodeId to stake weight, or {@code null} if no stake data is available
+     */
+    public Map<Long, Long> getStakeMapForBlock(Instant blockTime) {
+        if (stakeSnapshots.isEmpty()) {
+            return null;
+        }
+        // Find the most recent snapshot with a timestamp less than or equal to blockTime
+        DatedNodeStake selected = null;
+        for (int i = 0; i < stakeSnapshots.size(); i++) {
+            DatedNodeStake snapshot = stakeSnapshots.get(i);
+            final Timestamp ts = snapshot.blockTimestampOrThrow();
+            final Instant snapshotInstant = Instant.ofEpochSecond(ts.seconds(), ts.nanos());
+            if (snapshotInstant.isAfter(blockTime)) {
+                break;
+            }
+            selected = snapshot;
+        }
+        if (selected == null) {
+            return null;
+        }
+        final Map<Long, Long> stakeMap = new LinkedHashMap<>();
+        for (NodeStakeEntry entry : selected.entries()) {
+            stakeMap.put(entry.nodeId(), entry.stake());
+        }
+        return Collections.unmodifiableMap(stakeMap);
+    }
+
+    /**
+     * Returns whether any stake data has been recorded.
+     *
+     * @return true if at least one snapshot exists
+     */
+    public boolean hasStakeData() {
+        return !stakeSnapshots.isEmpty();
+    }
+
+    /**
+     * Get the number of stake snapshots in the registry.
+     *
+     * @return the number of snapshots
+     */
+    public int getSnapshotCount() {
+        return stakeSnapshots.size();
+    }
+
+    /**
+     * Get a pretty string representation of the stake registry.
+     *
+     * @return a pretty string representation
+     */
+    public String toPrettyString() {
+        StringBuilder sb = new StringBuilder();
+        for (DatedNodeStake snapshot : stakeSnapshots) {
+            sb.append("@|yellow      Block Time:|@ ")
+                    .append(Instant.ofEpochSecond(
+                            snapshot.blockTimestampOrThrow().seconds(),
+                            snapshot.blockTimestampOrThrow().nanos()))
+                    .append("  @|yellow Node Count:|@ ")
+                    .append(snapshot.entries().size())
+                    .append("\n");
+        }
+        if (stakeSnapshots.isEmpty()) {
+            sb.append("No stake snapshots in registry.\n");
+        }
+        return Ansi.AUTO.string(sb.toString());
+    }
+}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/NodeStakeRegistry.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/NodeStakeRegistry.java
@@ -127,6 +127,7 @@ public class NodeStakeRegistry {
 
     /**
      * Get the stake map that was in effect at the given block time.
+     * Uses binary search for O(log n) lookup over the chronologically sorted snapshots.
      *
      * @param blockTime the block time to look up
      * @return a map of nodeId to stake weight, or {@code null} if no stake data is available
@@ -135,20 +136,24 @@ public class NodeStakeRegistry {
         if (stakeSnapshots.isEmpty()) {
             return null;
         }
-        // Find the most recent snapshot with a timestamp less than or equal to blockTime
-        DatedNodeStake selected = null;
-        for (int i = 0; i < stakeSnapshots.size(); i++) {
-            DatedNodeStake snapshot = stakeSnapshots.get(i);
-            final Timestamp ts = snapshot.blockTimestampOrThrow();
-            final Instant snapshotInstant = Instant.ofEpochSecond(ts.seconds(), ts.nanos());
-            if (snapshotInstant.isAfter(blockTime)) {
-                break;
-            }
-            selected = snapshot;
+        // Binary search using a synthetic probe with the target timestamp
+        final Timestamp probeTs = toTimestamp(blockTime);
+        final DatedNodeStake probe = new DatedNodeStake(probeTs, List.of());
+        int idx = Collections.binarySearch(stakeSnapshots, probe, (a, b) -> {
+            final Timestamp tsA = a.blockTimestampOrThrow();
+            final Timestamp tsB = b.blockTimestampOrThrow();
+            int cmp = Long.compare(tsA.seconds(), tsB.seconds());
+            return cmp != 0 ? cmp : Integer.compare(tsA.nanos(), tsB.nanos());
+        });
+        // If exact match, use that index. Otherwise binarySearch returns -(insertion point) - 1,
+        // and we want the entry just before the insertion point.
+        if (idx < 0) {
+            idx = -idx - 2; // insertion point - 1
         }
-        if (selected == null) {
+        if (idx < 0) {
             return null;
         }
+        final DatedNodeStake selected = stakeSnapshots.get(idx);
         final Map<Long, Long> stakeMap = new LinkedHashMap<>();
         for (NodeStakeEntry entry : selected.entries()) {
             stakeMap.put(entry.nodeId(), entry.stake());

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -69,6 +69,7 @@ import org.hiero.block.tools.blocks.validation.HashRegistryValidation;
 import org.hiero.block.tools.blocks.validation.HbarSupplyValidation;
 import org.hiero.block.tools.blocks.validation.HistoricalBlockTreeValidation;
 import org.hiero.block.tools.blocks.validation.JumpstartValidation;
+import org.hiero.block.tools.blocks.validation.NodeStakeUpdateValidation;
 import org.hiero.block.tools.blocks.validation.RequiredItemsValidation;
 import org.hiero.block.tools.blocks.validation.SignatureValidation;
 import org.hiero.block.tools.blocks.validation.StreamingMerkleTreeValidation;
@@ -78,6 +79,7 @@ import org.hiero.block.tools.days.download.DownloadDayLiveImpl;
 import org.hiero.block.tools.days.listing.DayListingFileReader;
 import org.hiero.block.tools.days.listing.ListingRecordFile;
 import org.hiero.block.tools.days.model.AddressBookRegistry;
+import org.hiero.block.tools.days.model.NodeStakeRegistry;
 import org.hiero.block.tools.metadata.MetadataFiles;
 import org.hiero.block.tools.mirrornode.BlockInfo;
 import org.hiero.block.tools.mirrornode.BlockTimeReader;
@@ -949,14 +951,16 @@ public class LiveSequential implements Runnable {
             HistoricalBlockTreeValidation treeValidation = new HistoricalBlockTreeValidation(chainValidation);
             HbarSupplyValidation supplyValidation = new HbarSupplyValidation();
 
+            final NodeStakeRegistry nodeStakeRegistry = new NodeStakeRegistry();
             List<BlockValidation> parallelValidations = new ArrayList<>();
             parallelValidations.add(new RequiredItemsValidation());
             parallelValidations.add(new BlockStructureValidation());
-            SignatureValidation signatureValidation = new SignatureValidation(addressBookRegistry);
+            SignatureValidation signatureValidation = new SignatureValidation(addressBookRegistry, nodeStakeRegistry);
             parallelValidations.add(signatureValidation);
 
             List<BlockValidation> sequentialValidations = new ArrayList<>();
             sequentialValidations.add(new AddressBookUpdateValidation(addressBookRegistry));
+            sequentialValidations.add(new NodeStakeUpdateValidation(nodeStakeRegistry));
             sequentialValidations.add(chainValidation);
             sequentialValidations.add(treeValidation);
             sequentialValidations.add(supplyValidation);

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidationTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidationTest.java
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.blocks.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.block.stream.RecordFileItem;
+import com.hedera.hapi.block.stream.output.BlockFooter;
+import com.hedera.hapi.block.stream.output.BlockHeader;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.transaction.NodeStake;
+import com.hedera.hapi.node.transaction.NodeStakeUpdateTransactionBody;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.hapi.node.transaction.TransactionRecord;
+import com.hedera.hapi.streams.HashAlgorithm;
+import com.hedera.hapi.streams.HashObject;
+import com.hedera.hapi.streams.RecordStreamFile;
+import com.hedera.hapi.streams.RecordStreamItem;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.nio.file.Path;
+import java.util.List;
+import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.tools.days.model.NodeStakeRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("NodeStakeUpdateValidation")
+class NodeStakeUpdateValidationTest {
+
+    private static final Timestamp BLOCK_TS =
+            Timestamp.newBuilder().seconds(1000).nanos(0).build();
+    private static final byte[] DUMMY_HASH = new byte[48];
+
+    private static BlockUnparsed toUnparsed(Block block) {
+        try {
+            return BlockUnparsed.PROTOBUF.parse(Block.PROTOBUF.toBytes(block));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Nested
+    @DisplayName("metadata")
+    class Metadata {
+
+        @Test
+        @DisplayName("name returns NodeStakeUpdate")
+        void name() {
+            NodeStakeUpdateValidation v = new NodeStakeUpdateValidation(new NodeStakeRegistry());
+            assertEquals("NodeStakeUpdate", v.name());
+        }
+
+        @Test
+        @DisplayName("description is non-empty")
+        void description() {
+            NodeStakeUpdateValidation v = new NodeStakeUpdateValidation(new NodeStakeRegistry());
+            assertFalse(v.description().isEmpty());
+        }
+
+        @Test
+        @DisplayName("does not require genesis start")
+        void requiresGenesisStart() {
+            NodeStakeUpdateValidation v = new NodeStakeUpdateValidation(new NodeStakeRegistry());
+            assertFalse(v.requiresGenesisStart());
+        }
+    }
+
+    @Nested
+    @DisplayName("validate")
+    class Validate {
+
+        @Test
+        @DisplayName("block without NodeStakeUpdate does not change registry")
+        void blockWithoutNodeStakeUpdateLeavesRegistryEmpty() throws Exception {
+            NodeStakeRegistry registry = new NodeStakeRegistry();
+            NodeStakeUpdateValidation validation = new NodeStakeUpdateValidation(registry);
+
+            // Block with empty RecordStreamFile (no NodeStakeUpdate transaction)
+            Block block = createBlockWithTransactions(List.of());
+            validation.validate(toUnparsed(block), 1);
+            assertFalse(registry.hasStakeData());
+        }
+
+        @Test
+        @DisplayName("block with NodeStakeUpdate updates registry")
+        void blockWithNodeStakeUpdatePopulatesRegistry() throws Exception {
+            NodeStakeRegistry registry = new NodeStakeRegistry();
+            NodeStakeUpdateValidation validation = new NodeStakeUpdateValidation(registry);
+
+            // Create a NodeStakeUpdate transaction
+            NodeStakeUpdateTransactionBody stakeUpdateBody = NodeStakeUpdateTransactionBody.newBuilder()
+                    .nodeStake(List.of(
+                            NodeStake.newBuilder().nodeId(0).stake(1000).build(),
+                            NodeStake.newBuilder().nodeId(1).stake(2000).build()))
+                    .build();
+            TransactionBody txBody = TransactionBody.newBuilder()
+                    .nodeStakeUpdate(stakeUpdateBody)
+                    .build();
+            Transaction tx = Transaction.newBuilder().body(txBody).build();
+
+            Block block = createBlockWithTransactions(List.of(tx));
+            validation.validate(toUnparsed(block), 1);
+            assertTrue(registry.hasStakeData());
+            assertEquals(1, registry.getSnapshotCount());
+        }
+    }
+
+    @Nested
+    @DisplayName("persistence")
+    class Persistence {
+
+        @Test
+        @DisplayName("save and load roundtrip preserves data")
+        void saveLoadRoundtrip(@TempDir Path tempDir) throws Exception {
+            NodeStakeRegistry registry = new NodeStakeRegistry();
+            NodeStakeUpdateValidation validation = new NodeStakeUpdateValidation(registry);
+
+            // Create a NodeStakeUpdate transaction and validate
+            NodeStakeUpdateTransactionBody stakeUpdateBody = NodeStakeUpdateTransactionBody.newBuilder()
+                    .nodeStake(
+                            List.of(NodeStake.newBuilder().nodeId(0).stake(5000).build()))
+                    .build();
+            TransactionBody txBody = TransactionBody.newBuilder()
+                    .nodeStakeUpdate(stakeUpdateBody)
+                    .build();
+            Transaction tx = Transaction.newBuilder().body(txBody).build();
+            Block block = createBlockWithTransactions(List.of(tx));
+            validation.validate(toUnparsed(block), 1);
+
+            // Save
+            validation.save(tempDir);
+
+            // Load into a fresh registry
+            NodeStakeRegistry freshRegistry = new NodeStakeRegistry();
+            NodeStakeUpdateValidation freshValidation = new NodeStakeUpdateValidation(freshRegistry);
+            freshValidation.load(tempDir);
+
+            assertTrue(freshRegistry.hasStakeData());
+            assertEquals(1, freshRegistry.getSnapshotCount());
+        }
+    }
+
+    private static Block createBlockWithTransactions(List<Transaction> transactions) {
+        HashObject runningHash = HashObject.newBuilder()
+                .algorithm(HashAlgorithm.SHA_384)
+                .length(48)
+                .hash(Bytes.wrap(DUMMY_HASH))
+                .build();
+
+        List<RecordStreamItem> rsis = transactions.stream()
+                .map(tx -> RecordStreamItem.newBuilder()
+                        .transaction(tx)
+                        .record(TransactionRecord.newBuilder()
+                                .consensusTimestamp(BLOCK_TS)
+                                .build())
+                        .build())
+                .toList();
+
+        RecordStreamFile rsf = RecordStreamFile.newBuilder()
+                .startObjectRunningHash(runningHash)
+                .endObjectRunningHash(runningHash)
+                .recordStreamItems(rsis)
+                .build();
+        RecordFileItem rfi = RecordFileItem.newBuilder()
+                .creationTime(BLOCK_TS)
+                .recordFileContents(rsf)
+                .build();
+
+        BlockHeader header =
+                BlockHeader.newBuilder().number(1).blockTimestamp(BLOCK_TS).build();
+
+        return new Block(List.of(
+                BlockItem.newBuilder().blockHeader(header).build(),
+                BlockItem.newBuilder().recordFile(rfi).build(),
+                BlockItem.newBuilder().blockFooter(BlockFooter.DEFAULT).build()));
+    }
+}

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/SignatureValidationTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/SignatureValidationTest.java
@@ -16,14 +16,20 @@ import com.hedera.hapi.block.stream.TssSignedBlockProof;
 import com.hedera.hapi.block.stream.output.BlockFooter;
 import com.hedera.hapi.block.stream.output.BlockHeader;
 import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.transaction.NodeStake;
+import com.hedera.hapi.node.transaction.NodeStakeUpdateTransactionBody;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.tools.blocks.TestBlockFactory;
 import org.hiero.block.tools.days.model.AddressBookRegistry;
+import org.hiero.block.tools.days.model.NodeStakeRegistry;
 import org.hiero.block.tools.records.model.parsed.ValidationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -274,5 +280,183 @@ class SignatureValidationTest {
         SignatureValidation validation = new SignatureValidation(registry);
         // 2 valid nodes >= threshold of 2 → should pass
         assertDoesNotThrow(() -> validation.validate(toUnparsed(blockWithUnknownSigner), 0));
+    }
+
+    @Nested
+    @DisplayName("Stake-weighted consensus")
+    class StakeWeightedTests {
+
+        @Test
+        @DisplayName("valid chain passes with null stake registry (equal-weight fallback)")
+        void validChainPassesWithNullStakeRegistry(@TempDir Path tempDir) throws Exception {
+            List<Block> chain = TestBlockFactory.createValidChain(1);
+            TestBlockFactory.writeAddressBookHistory(tempDir);
+            AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
+            // null stake registry → equal-weight mode
+            SignatureValidation validation = new SignatureValidation(abRegistry, null);
+            assertDoesNotThrow(() -> validation.validate(toUnparsed(chain.getFirst()), 0));
+        }
+
+        @Test
+        @DisplayName("valid chain passes with empty stake registry (equal-weight fallback)")
+        void validChainPassesWithEmptyStakeRegistry(@TempDir Path tempDir) throws Exception {
+            List<Block> chain = TestBlockFactory.createValidChain(1);
+            TestBlockFactory.writeAddressBookHistory(tempDir);
+            AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
+            NodeStakeRegistry stakeRegistry = new NodeStakeRegistry();
+            // Empty stake registry → equal-weight fallback
+            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry);
+            assertDoesNotThrow(() -> validation.validate(toUnparsed(chain.getFirst()), 0));
+        }
+
+        @Test
+        @DisplayName("two-arg constructor backward compatible with single-arg")
+        void twoArgConstructorBackwardCompatible(@TempDir Path tempDir) throws Exception {
+            List<Block> chain = TestBlockFactory.createValidChain(1);
+            TestBlockFactory.writeAddressBookHistory(tempDir);
+            AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
+            // Single-arg constructor should still work
+            SignatureValidation validation = new SignatureValidation(abRegistry);
+            assertDoesNotThrow(() -> validation.validate(toUnparsed(chain.getFirst()), 0));
+        }
+
+        @Test
+        @DisplayName("stake-weighted mode shows mode in error diagnostics")
+        void stakeWeightedModeShowsModeInDiagnostics(@TempDir Path tempDir) throws Exception {
+            List<Block> chain = TestBlockFactory.createValidChain(1);
+            Block block = chain.getFirst();
+            // Keep only 1 signature — below threshold
+            List<BlockItem> items = new ArrayList<>();
+            for (BlockItem item : block.items()) {
+                if (item.hasBlockProof()) {
+                    SignedRecordFileProof orig = item.blockProofOrThrow().signedRecordFileProofOrThrow();
+                    List<RecordFileSignature> oneSig =
+                            List.of(orig.recordFileSignatures().getFirst());
+                    SignedRecordFileProof newProof = SignedRecordFileProof.newBuilder()
+                            .version(orig.version())
+                            .recordFileSignatures(oneSig)
+                            .build();
+                    items.add(BlockItem.newBuilder()
+                            .blockProof(BlockProof.newBuilder()
+                                    .signedRecordFileProof(newProof)
+                                    .build())
+                            .build());
+                } else {
+                    items.add(item);
+                }
+            }
+            Block blockWith1Sig = new Block(items);
+            TestBlockFactory.writeAddressBookHistory(tempDir);
+            AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
+            // Empty stake registry → equal-weight fallback
+            NodeStakeRegistry stakeRegistry = new NodeStakeRegistry();
+            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry);
+            ValidationException ex =
+                    assertThrows(ValidationException.class, () -> validation.validate(toUnparsed(blockWith1Sig), 0));
+            assertTrue(ex.getMessage().contains("mode=equal-weight"), "Should show equal-weight mode");
+        }
+
+        @Test
+        @DisplayName("all signatures pass with stake-weighted threshold")
+        void allSignaturesPassStakeWeighted(@TempDir Path tempDir) throws Exception {
+            // TestBlockFactory: 5 nodes (IDs 0-4), block time ~1568411631
+            List<Block> chain = TestBlockFactory.createValidChain(1);
+            TestBlockFactory.writeAddressBookHistory(tempDir);
+            AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
+
+            // Populate stake registry with data before block time
+            NodeStakeRegistry stakeRegistry = new NodeStakeRegistry();
+            stakeRegistry.updateStakes(
+                    Instant.ofEpochSecond(1),
+                    NodeStakeUpdateTransactionBody.newBuilder()
+                            .nodeStake(List.of(
+                                    NodeStake.newBuilder().nodeId(0).stake(100).build(),
+                                    NodeStake.newBuilder().nodeId(1).stake(200).build(),
+                                    NodeStake.newBuilder().nodeId(2).stake(300).build(),
+                                    NodeStake.newBuilder().nodeId(3).stake(400).build(),
+                                    NodeStake.newBuilder().nodeId(4).stake(500).build()))
+                            .build());
+
+            // totalStake=1500, threshold=ceil(1500/3)=500. All 5 nodes sign → 1500 >= 500
+            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry);
+            assertDoesNotThrow(() -> validation.validate(toUnparsed(chain.getFirst()), 0));
+        }
+
+        @Test
+        @DisplayName("insufficient stake fails with stake-weighted diagnostic")
+        void insufficientStakeFailsStakeWeighted(@TempDir Path tempDir) throws Exception {
+            List<Block> chain = TestBlockFactory.createValidChain(1);
+            Block block = chain.getFirst();
+
+            // Keep only node 0's signature (stake=100)
+            List<BlockItem> items = new ArrayList<>();
+            for (BlockItem item : block.items()) {
+                if (item.hasBlockProof()) {
+                    SignedRecordFileProof orig = item.blockProofOrThrow().signedRecordFileProofOrThrow();
+                    List<RecordFileSignature> oneSig =
+                            List.of(orig.recordFileSignatures().getFirst());
+                    items.add(BlockItem.newBuilder()
+                            .blockProof(BlockProof.newBuilder()
+                                    .signedRecordFileProof(SignedRecordFileProof.newBuilder()
+                                            .version(orig.version())
+                                            .recordFileSignatures(oneSig)
+                                            .build())
+                                    .build())
+                            .build());
+                } else {
+                    items.add(item);
+                }
+            }
+            Block blockWith1Sig = new Block(items);
+
+            TestBlockFactory.writeAddressBookHistory(tempDir);
+            AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
+
+            // Give node 0 low stake, others high — threshold won't be met by node 0 alone
+            NodeStakeRegistry stakeRegistry = new NodeStakeRegistry();
+            stakeRegistry.updateStakes(
+                    Instant.ofEpochSecond(1),
+                    NodeStakeUpdateTransactionBody.newBuilder()
+                            .nodeStake(List.of(
+                                    NodeStake.newBuilder().nodeId(0).stake(100).build(),
+                                    NodeStake.newBuilder().nodeId(1).stake(200).build(),
+                                    NodeStake.newBuilder().nodeId(2).stake(300).build(),
+                                    NodeStake.newBuilder().nodeId(3).stake(400).build(),
+                                    NodeStake.newBuilder().nodeId(4).stake(500).build()))
+                            .build());
+
+            // totalStake=1500, threshold=500. Node 0 stake=100 < 500
+            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry);
+            ValidationException ex =
+                    assertThrows(ValidationException.class, () -> validation.validate(toUnparsed(blockWith1Sig), 0));
+            assertTrue(ex.getMessage().contains("mode=stake-weighted"), "Should show stake-weighted mode");
+            assertTrue(ex.getMessage().contains("Insufficient validated stake"), "Should show stake diagnostic");
+        }
+
+        @Test
+        @DisplayName("zero total stake falls back to equal-weight mode")
+        void zeroTotalStakeFallsBackToEqualWeight(@TempDir Path tempDir) throws Exception {
+            List<Block> chain = TestBlockFactory.createValidChain(1);
+            TestBlockFactory.writeAddressBookHistory(tempDir);
+            AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
+
+            // All nodes have stake=0
+            NodeStakeRegistry stakeRegistry = new NodeStakeRegistry();
+            stakeRegistry.updateStakes(
+                    Instant.ofEpochSecond(1),
+                    NodeStakeUpdateTransactionBody.newBuilder()
+                            .nodeStake(List.of(
+                                    NodeStake.newBuilder().nodeId(0).stake(0).build(),
+                                    NodeStake.newBuilder().nodeId(1).stake(0).build(),
+                                    NodeStake.newBuilder().nodeId(2).stake(0).build(),
+                                    NodeStake.newBuilder().nodeId(3).stake(0).build(),
+                                    NodeStake.newBuilder().nodeId(4).stake(0).build()))
+                            .build());
+
+            // totalStake=0 → should fall back to equal-weight, not pass with threshold=0
+            // 5 nodes all sign → passes equal-weight threshold of 2
+            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry);
+            assertDoesNotThrow(() -> validation.validate(toUnparsed(chain.getFirst()), 0));
+        }
     }
 }

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/model/NodeStakeRegistryTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/model/NodeStakeRegistryTest.java
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.days.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hapi.node.transaction.NodeStake;
+import com.hedera.hapi.node.transaction.NodeStakeUpdateTransactionBody;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayName("NodeStakeRegistry")
+class NodeStakeRegistryTest {
+
+    private static NodeStakeUpdateTransactionBody createStakeUpdate(long... nodeIdAndStakePairs) {
+        NodeStakeUpdateTransactionBody.Builder builder = NodeStakeUpdateTransactionBody.newBuilder();
+        List<NodeStake> stakes = new java.util.ArrayList<>();
+        for (int i = 0; i < nodeIdAndStakePairs.length; i += 2) {
+            stakes.add(NodeStake.newBuilder()
+                    .nodeId(nodeIdAndStakePairs[i])
+                    .stake(nodeIdAndStakePairs[i + 1])
+                    .build());
+        }
+        return builder.nodeStake(stakes).build();
+    }
+
+    @Nested
+    @DisplayName("empty registry")
+    class EmptyRegistry {
+
+        @Test
+        @DisplayName("returns null stake map when no data exists")
+        void returnsNullStakeMap() {
+            NodeStakeRegistry registry = new NodeStakeRegistry();
+            assertNull(registry.getStakeMapForBlock(Instant.now()));
+        }
+
+        @Test
+        @DisplayName("reports no stake data")
+        void hasNoStakeData() {
+            NodeStakeRegistry registry = new NodeStakeRegistry();
+            assertFalse(registry.hasStakeData());
+            assertEquals(0, registry.getSnapshotCount());
+        }
+    }
+
+    @Nested
+    @DisplayName("updateStakes")
+    class UpdateStakes {
+
+        @Test
+        @DisplayName("records a snapshot and returns change description")
+        void recordsSnapshot() {
+            NodeStakeRegistry registry = new NodeStakeRegistry();
+            String result =
+                    registry.updateStakes(Instant.ofEpochSecond(100), createStakeUpdate(0, 1000, 1, 2000, 2, 3000));
+            assertNotNull(result);
+            assertTrue(result.contains("3 nodes"));
+            assertTrue(result.contains("totalStake=6000"));
+            assertTrue(result.contains("node 0: stake=1000"));
+            assertTrue(result.contains("node 2: stake=3000"));
+            assertTrue(registry.hasStakeData());
+            assertEquals(1, registry.getSnapshotCount());
+        }
+
+        @Test
+        @DisplayName("does not duplicate identical consecutive snapshots")
+        void doesNotDuplicateIdenticalSnapshots() {
+            NodeStakeRegistry registry = new NodeStakeRegistry();
+            NodeStakeUpdateTransactionBody body = createStakeUpdate(0, 1000, 1, 2000);
+            registry.updateStakes(Instant.ofEpochSecond(100), body);
+            String result = registry.updateStakes(Instant.ofEpochSecond(200), body);
+            assertNull(result);
+            assertEquals(1, registry.getSnapshotCount());
+        }
+
+        @Test
+        @DisplayName("appends when stake data changes")
+        void appendsOnChange() {
+            NodeStakeRegistry registry = new NodeStakeRegistry();
+            registry.updateStakes(Instant.ofEpochSecond(100), createStakeUpdate(0, 1000, 1, 2000));
+            String result = registry.updateStakes(Instant.ofEpochSecond(200), createStakeUpdate(0, 1500, 1, 2500));
+            assertNotNull(result);
+            assertEquals(2, registry.getSnapshotCount());
+        }
+    }
+
+    @Nested
+    @DisplayName("getStakeMapForBlock")
+    class GetStakeMapForBlock {
+
+        @Test
+        @DisplayName("returns correct snapshot by block time")
+        void returnsCorrectSnapshotByTime() {
+            NodeStakeRegistry registry = new NodeStakeRegistry();
+            registry.updateStakes(Instant.ofEpochSecond(100), createStakeUpdate(0, 1000, 1, 2000));
+            registry.updateStakes(Instant.ofEpochSecond(200), createStakeUpdate(0, 3000, 1, 4000));
+
+            // Before first snapshot — no data
+            assertNull(registry.getStakeMapForBlock(Instant.ofEpochSecond(50)));
+
+            // After first, before second — returns first snapshot
+            Map<Long, Long> map = registry.getStakeMapForBlock(Instant.ofEpochSecond(150));
+            assertNotNull(map);
+            assertEquals(1000L, map.get(0L));
+            assertEquals(2000L, map.get(1L));
+
+            // After second — returns second snapshot
+            map = registry.getStakeMapForBlock(Instant.ofEpochSecond(250));
+            assertNotNull(map);
+            assertEquals(3000L, map.get(0L));
+            assertEquals(4000L, map.get(1L));
+        }
+
+        @Test
+        @DisplayName("returns snapshot at exact timestamp")
+        void returnsSnapshotAtExactTimestamp() {
+            NodeStakeRegistry registry = new NodeStakeRegistry();
+            registry.updateStakes(Instant.ofEpochSecond(100), createStakeUpdate(0, 1000));
+
+            Map<Long, Long> map = registry.getStakeMapForBlock(Instant.ofEpochSecond(100));
+            assertNotNull(map);
+            assertEquals(1000L, map.get(0L));
+        }
+    }
+
+    @Nested
+    @DisplayName("persistence")
+    class Persistence {
+
+        @Test
+        @DisplayName("save and reload preserves data")
+        void saveAndReloadPreservesData(@TempDir Path tempDir) {
+            NodeStakeRegistry registry = new NodeStakeRegistry();
+            registry.updateStakes(Instant.ofEpochSecond(100), createStakeUpdate(0, 1000, 1, 2000));
+            registry.updateStakes(Instant.ofEpochSecond(200), createStakeUpdate(0, 3000, 1, 4000));
+
+            Path file = tempDir.resolve("nodeStakeHistory.json");
+            registry.saveToJsonFile(file);
+
+            NodeStakeRegistry loaded = new NodeStakeRegistry(file);
+            assertEquals(2, loaded.getSnapshotCount());
+
+            Map<Long, Long> map = loaded.getStakeMapForBlock(Instant.ofEpochSecond(250));
+            assertNotNull(map);
+            assertEquals(3000L, map.get(0L));
+            assertEquals(4000L, map.get(1L));
+        }
+
+        @Test
+        @DisplayName("reloadFromFile replaces existing data")
+        void reloadFromFileReplacesData(@TempDir Path tempDir) {
+            NodeStakeRegistry original = new NodeStakeRegistry();
+            original.updateStakes(Instant.ofEpochSecond(100), createStakeUpdate(0, 1000));
+            Path file = tempDir.resolve("nodeStakeHistory.json");
+            original.saveToJsonFile(file);
+
+            NodeStakeRegistry registry = new NodeStakeRegistry();
+            registry.updateStakes(Instant.ofEpochSecond(50), createStakeUpdate(0, 500));
+            assertEquals(1, registry.getSnapshotCount());
+
+            registry.reloadFromFile(file);
+            assertEquals(1, registry.getSnapshotCount());
+            Map<Long, Long> map = registry.getStakeMapForBlock(Instant.ofEpochSecond(150));
+            assertNotNull(map);
+            assertEquals(1000L, map.get(0L));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add stake-weighted consensus to `SignatureValidation` using `NodeStakeUpdate` transactions discovered from the block stream
- When stake data is available, threshold is `ceil(totalStake / 3)` (Strong Minority). Falls back to equal-weight mode (`each node = weight 1`, `threshold = nodeCount/3 + 1`) for pre-staking era blocks (before ~July 2022)
- New `NodeStakeRegistry` + `NodeStakeUpdateValidation` follow the existing `AddressBookRegistry` + `AddressBookUpdateValidation` pattern exactly

## Changes
| Action | File |
|--------|------|
| Create | `protobuf-sources/src/main/proto/internal/node_stake_history.proto` |
| Create | `NodeStakeRegistry.java` — thread-safe registry of stake snapshots with time-based lookup and JSON persistence |
| Create | `NodeStakeUpdateValidation.java` — sequential validation discovering `NodeStakeUpdate` txns from blocks |
| Modify | `SignatureValidation.java` — stake-weighted threshold with equal-weight fallback; backward-compatible constructor |
| Modify | `ValidateBlocksCommand.java` — wire `NodeStakeRegistry` + `NodeStakeUpdateValidation` |
| Modify | `LiveSequential.java` — same wiring |
| Create | `NodeStakeRegistryTest.java` — empty registry, update, dedup, time-lookup, persistence |
| Create | `NodeStakeUpdateValidationTest.java` — metadata, block processing, save/load roundtrip |
| Modify | `SignatureValidationTest.java` — `@Nested` stake-weighted tests |


Fixes #2491
