### PR TITLE
feat: add stake weight histogram to validation stats

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
@@ -50,6 +50,8 @@ import org.hiero.block.tools.blocks.model.BlockWriter.BlockZipAppender;
 import org.hiero.block.tools.blocks.model.PreVerifiedBlock;
 import org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHashRegistry;
 import org.hiero.block.tools.blocks.model.hashing.StreamingHasher;
+import org.hiero.block.tools.blocks.validation.SignatureBlockStats;
+import org.hiero.block.tools.blocks.validation.SignatureStatsCollector;
 import org.hiero.block.tools.config.NetworkConfig;
 import org.hiero.block.tools.days.model.AddressBookRegistry;
 import org.hiero.block.tools.days.model.NodeStakeRegistry;
@@ -295,6 +297,10 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
         // Create an amendment provider based on network selection
         final AmendmentProvider amendmentProvider =
                 createAmendmentProvider(NetworkConfig.current().networkName());
+
+        // Create signature stats collector for CSV output
+        final SignatureStatsCollector statsCollector =
+                new SignatureStatsCollector(outputBlocksDir.resolve("signature_statistics_wrap.csv"));
 
         // ---- Pipeline executor services ----
         final int resolvedPrefetch = prefetchSize < 1 ? parseThreads : prefetchSize;
@@ -650,6 +656,26 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
                             System.err.printf("Warning: node stake auto-update failed at block %d: %s%n", blockNum, e);
                         }
 
+                        // Collect signature stats from pre-verified data
+                        {
+                            final var blockTime = effectiveBlock.recordBlock().blockTime();
+                            final List<Long> verifiedNodeIds = effectiveBlock.verifiedSignatures().stream()
+                                    .map(RecordFileSignature::nodeId)
+                                    .toList();
+                            final List<Long> addressBookNodeIds = effectiveBlock.addressBook().nodeAddress().stream()
+                                    .map(na -> na.nodeId())
+                                    .toList();
+                            final Map<Long, Long> stakeMap = nodeStakeRegistry.getStakeMapForBlock(blockTime);
+                            final SignatureBlockStats blockStats = SignatureBlockStats.fromPreVerifiedData(
+                                    blockNum,
+                                    blockTime,
+                                    verifiedNodeIds,
+                                    effectiveBlock.verifiedSignatures().size(),
+                                    addressBookNodeIds,
+                                    stakeMap);
+                            statsCollector.accept(blockStats);
+                        }
+
                         // Monthly checkpoint: save state once per calendar month of blockchain data.
                         // Worst-case on corruption: re-process at most ~1 month of blocks.
                         // Check BEFORE updating chain state so the saved state is consistent with
@@ -833,6 +859,11 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
 
             addressBookRegistry.saveAddressBookRegistryToJsonFile(addressBookFile);
             nodeStakeRegistry.saveToJsonFile(nodeStakeFile);
+
+            // Finalize and close signature stats collector
+            statsCollector.finalizeDayStats();
+            statsCollector.printFinalSummary();
+            statsCollector.close();
 
             // If we stopped due to a parse failure, throw after saving state
             if (parseFailureMessage != null) {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
@@ -44,6 +44,8 @@ import org.hiero.block.tools.blocks.validation.HistoricalBlockTreeValidation;
 import org.hiero.block.tools.blocks.validation.JumpstartValidation;
 import org.hiero.block.tools.blocks.validation.NodeStakeUpdateValidation;
 import org.hiero.block.tools.blocks.validation.RequiredItemsValidation;
+import org.hiero.block.tools.blocks.validation.SignatureBlockStats;
+import org.hiero.block.tools.blocks.validation.SignatureStatsCollector;
 import org.hiero.block.tools.blocks.validation.SignatureValidation;
 import org.hiero.block.tools.blocks.validation.StreamingMerkleTreeValidation;
 import org.hiero.block.tools.blocks.wrapped.BalanceCheckpointValidator;
@@ -546,6 +548,12 @@ public class ValidateBlocksCommand implements Runnable {
             }
         }
 
+        // Create signature stats collector
+        final Path statsOutputDir =
+                Arrays.stream(files).filter(Files::isDirectory).findFirst().orElse(files[0]);
+        final SignatureStatsCollector statsCollector =
+                new SignatureStatsCollector(statsOutputDir.resolve("signature_statistics_validate_block_command.csv"));
+
         // Track validation progress
         final long startNanos = System.nanoTime();
         long blocksValidated = checkpoint != null ? checkpoint.blocksValidated() : 0;
@@ -809,6 +817,14 @@ public class ValidateBlocksCommand implements Runnable {
                         blocksValidatedRef[0] = blocksValidated;
                     }
 
+                    // Collect signature stats from the validation
+                    if (signatureValidation != null) {
+                        SignatureBlockStats blockStats = signatureValidation.popBlockStats(blockNum);
+                        if (blockStats != null) {
+                            statsCollector.accept(blockStats);
+                        }
+                    }
+
                     // Periodic registry sync for crash safety (~every 100 blocks)
                     if (registry != null && blocksValidated % 100 == 0) {
                         registry.sync();
@@ -928,6 +944,10 @@ public class ValidateBlocksCommand implements Runnable {
             for (BlockValidation v : validations) {
                 v.close();
             }
+            // Finalize signature statistics
+            statsCollector.finalizeDayStats();
+            statsCollector.printFinalSummary();
+            statsCollector.close();
         }
 
         // Determine overall result

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
@@ -397,7 +397,7 @@ public class ValidateBlocksCommand implements Runnable {
         parallelValidations.add(new BlockStructureValidation());
         SignatureValidation sigVal = null;
         if (!skipSignatures) {
-            sigVal = new SignatureValidation(abRegistry, nodeStakeRegistry);
+            sigVal = new SignatureValidation(abRegistry, nodeStakeRegistry, true);
             parallelValidations.add(sigVal);
         } else {
             System.out.println(Ansi.AUTO.string("@|yellow Skipping:|@ Signature validation (--skip-signatures)"));
@@ -548,11 +548,13 @@ public class ValidateBlocksCommand implements Runnable {
             }
         }
 
-        // Create signature stats collector
-        final Path statsOutputDir =
-                Arrays.stream(files).filter(Files::isDirectory).findFirst().orElse(files[0]);
-        final SignatureStatsCollector statsCollector =
-                new SignatureStatsCollector(statsOutputDir.resolve("signature_statistics_validate_block_command.csv"));
+        // Determine signature stats output directory. If files[0] is a regular file (e.g. a
+        // .blk.zip), fall back to its parent directory so the CSV is written alongside it.
+        final Path statsOutputDir = Arrays.stream(files)
+                .filter(Files::isDirectory)
+                .findFirst()
+                .orElseGet(() -> files[0].getParent() != null ? files[0].getParent() : Path.of("."));
+        final Path statsCsvPath = statsOutputDir.resolve("signature_statistics_validate_block_command.csv");
 
         // Track validation progress
         final long startNanos = System.nanoTime();
@@ -711,243 +713,245 @@ public class ValidateBlocksCommand implements Runnable {
         long failedBlockNumber = -1;
         long skippedBlockCount = 0;
 
-        try {
-            long lastCheckpointSaveMs = System.currentTimeMillis();
-            long lastProgressMs = System.currentTimeMillis();
+        try (final SignatureStatsCollector statsCollector = new SignatureStatsCollector(statsCsvPath)) {
+            try {
+                long lastCheckpointSaveMs = System.currentTimeMillis();
+                long lastProgressMs = System.currentTimeMillis();
 
-            while (true) {
+                while (true) {
 
-                try {
-                    Future<PreValidatedBlock> future = blockQueue.take();
-                    if (future == endOfStream) break;
+                    try {
+                        Future<PreValidatedBlock> future = blockQueue.take();
+                        if (future == endOfStream) break;
 
-                    PreValidatedBlock preValidated = future.get();
-                    if (preValidated.block() == null) {
-                        skippedBlockCount++;
-                        continue; // block skipped (corrupt zip mid-stream)
-                    }
+                        PreValidatedBlock preValidated = future.get();
+                        if (preValidated.block() == null) {
+                            skippedBlockCount++;
+                            continue; // block skipped (corrupt zip mid-stream)
+                        }
 
-                    // Check for pre-validation errors (from parallel stage)
-                    // Signature errors may be caused by a stale address book — the prefetch
-                    // queue may have validated this block before AddressBookUpdateValidation
-                    // discovered an address book change in an earlier block. We defer the
-                    // error and retry after running sequential validations (which update
-                    // the address book).
-                    boolean signatureRetryNeeded = false;
-                    if (preValidated.preValidationError() != null) {
-                        if ("Signatures".equals(preValidated.preValidationName()) && signatureValidation != null) {
-                            // Defer — will retry after sequential validations update the address book
-                            signatureRetryNeeded = true;
-                        } else {
-                            failedValidationName = preValidated.preValidationName();
-                            failureMessage = preValidated.preValidationError().getMessage();
-                            failedBlockNumber = preValidated.blockNumber();
+                        // Check for pre-validation errors (from parallel stage)
+                        // Signature errors may be caused by a stale address book — the prefetch
+                        // queue may have validated this block before AddressBookUpdateValidation
+                        // discovered an address book change in an earlier block. We defer the
+                        // error and retry after running sequential validations (which update
+                        // the address book).
+                        boolean signatureRetryNeeded = false;
+                        if (preValidated.preValidationError() != null) {
+                            if ("Signatures".equals(preValidated.preValidationName()) && signatureValidation != null) {
+                                // Defer — will retry after sequential validations update the address book
+                                signatureRetryNeeded = true;
+                            } else {
+                                failedValidationName = preValidated.preValidationName();
+                                failureMessage =
+                                        preValidated.preValidationError().getMessage();
+                                failedBlockNumber = preValidated.blockNumber();
+                                try {
+                                    Files.createDirectories(checkpointDir);
+                                } catch (IOException ignored) {
+                                }
+                                saveCheckpoint(
+                                        checkpointDir,
+                                        lastValidatedRef[0],
+                                        blocksValidatedRef[0],
+                                        chainValidation,
+                                        validations);
+                                break;
+                            }
+                        }
+
+                        BlockUnparsed block = preValidated.block();
+                        long blockNum = preValidated.blockNumber();
+
+                        // Phase 1: validate sequential (stateful) validations only
+                        for (BlockValidation v : sequentialValidations) {
+                            try {
+                                v.validate(block, blockNum);
+                            } catch (ValidationException e) {
+                                failedValidationName = v.name();
+                                failureMessage = e.getMessage();
+                                failedBlockNumber = blockNum;
+                                // Save checkpoint before reporting
+                                try {
+                                    Files.createDirectories(checkpointDir);
+                                } catch (IOException ignored) {
+                                }
+                                saveCheckpoint(
+                                        checkpointDir,
+                                        lastValidatedRef[0],
+                                        blocksValidatedRef[0],
+                                        chainValidation,
+                                        validations);
+                                break;
+                            }
+                        }
+                        if (failedValidationName != null) break;
+
+                        // Retry signature validation with the (now potentially updated) address book
+                        if (signatureRetryNeeded) {
+                            try {
+                                signatureValidation.validate(block, blockNum);
+                            } catch (ValidationException e) {
+                                failedValidationName = signatureValidation.name();
+                                failureMessage = e.getMessage();
+                                failedBlockNumber = blockNum;
+                                try {
+                                    Files.createDirectories(checkpointDir);
+                                } catch (IOException ignored) {
+                                }
+                                saveCheckpoint(
+                                        checkpointDir,
+                                        lastValidatedRef[0],
+                                        blocksValidatedRef[0],
+                                        chainValidation,
+                                        validations);
+                                break;
+                            }
+                        }
+
+                        // Phase 2: commit all validations (under lock to prevent shutdown hook
+                        // from saving a partially-committed state)
+                        synchronized (commitLock) {
+                            for (BlockValidation v : validations) {
+                                v.commitState(block, blockNum);
+                            }
+
+                            lastValidatedRef[0] = blockNum;
+                            blocksValidated++;
+                            blocksValidatedRef[0] = blocksValidated;
+                        }
+
+                        // Collect signature stats from the validation
+                        if (signatureValidation != null) {
+                            SignatureBlockStats blockStats = signatureValidation.popBlockStats(blockNum);
+                            if (blockStats != null) {
+                                statsCollector.accept(blockStats);
+                            }
+                        }
+
+                        // Periodic registry sync for crash safety (~every 100 blocks)
+                        if (registry != null && blocksValidated % 100 == 0) {
+                            registry.sync();
+                        }
+
+                        // Periodic checkpoint save
+                        long nowMs = System.currentTimeMillis();
+                        if (nowMs - lastCheckpointSaveMs >= 60_000L) {
                             try {
                                 Files.createDirectories(checkpointDir);
                             } catch (IOException ignored) {
                             }
-                            saveCheckpoint(
-                                    checkpointDir,
-                                    lastValidatedRef[0],
-                                    blocksValidatedRef[0],
-                                    chainValidation,
-                                    validations);
-                            break;
-                        }
-                    }
-
-                    BlockUnparsed block = preValidated.block();
-                    long blockNum = preValidated.blockNumber();
-
-                    // Phase 1: validate sequential (stateful) validations only
-                    for (BlockValidation v : sequentialValidations) {
-                        try {
-                            v.validate(block, blockNum);
-                        } catch (ValidationException e) {
-                            failedValidationName = v.name();
-                            failureMessage = e.getMessage();
-                            failedBlockNumber = blockNum;
-                            // Save checkpoint before reporting
-                            try {
-                                Files.createDirectories(checkpointDir);
-                            } catch (IOException ignored) {
-                            }
-                            saveCheckpoint(
-                                    checkpointDir,
-                                    lastValidatedRef[0],
-                                    blocksValidatedRef[0],
-                                    chainValidation,
-                                    validations);
-                            break;
-                        }
-                    }
-                    if (failedValidationName != null) break;
-
-                    // Retry signature validation with the (now potentially updated) address book
-                    if (signatureRetryNeeded) {
-                        try {
-                            signatureValidation.validate(block, blockNum);
-                        } catch (ValidationException e) {
-                            failedValidationName = signatureValidation.name();
-                            failureMessage = e.getMessage();
-                            failedBlockNumber = blockNum;
-                            try {
-                                Files.createDirectories(checkpointDir);
-                            } catch (IOException ignored) {
-                            }
-                            saveCheckpoint(
-                                    checkpointDir,
-                                    lastValidatedRef[0],
-                                    blocksValidatedRef[0],
-                                    chainValidation,
-                                    validations);
-                            break;
-                        }
-                    }
-
-                    // Phase 2: commit all validations (under lock to prevent shutdown hook
-                    // from saving a partially-committed state)
-                    synchronized (commitLock) {
-                        for (BlockValidation v : validations) {
-                            v.commitState(block, blockNum);
+                            saveCheckpoint(checkpointDir, blockNum, blocksValidated, chainValidation, validations);
+                            lastCheckpointSaveMs = nowMs;
                         }
 
-                        lastValidatedRef[0] = blockNum;
-                        blocksValidated++;
-                        blocksValidatedRef[0] = blocksValidated;
-                    }
-
-                    // Collect signature stats from the validation
-                    if (signatureValidation != null) {
-                        SignatureBlockStats blockStats = signatureValidation.popBlockStats(blockNum);
-                        if (blockStats != null) {
-                            statsCollector.accept(blockStats);
+                        if (verbose) {
+                            final String blockHash = (chainValidation.getPreviousBlockHash() != null)
+                                    ? Bytes.wrap(chainValidation.getPreviousBlockHash())
+                                            .toHex()
+                                    : "null";
+                            System.out.println("Block " + blockNum + ": "
+                                    + Ansi.AUTO.string("@|green VALID|@") + " (hash: "
+                                    + blockHash
+                                    + ")");
                         }
-                    }
 
-                    // Periodic registry sync for crash safety (~every 100 blocks)
-                    if (registry != null && blocksValidated % 100 == 0) {
-                        registry.sync();
-                    }
+                        // Progress every 5 seconds
+                        if (nowMs - lastProgressMs >= 5_000L) {
+                            long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+                            long currentPercent = (blocksValidated * 100) / estimatedTotalBlocks;
+                            long remainingMillis = PrettyPrint.computeRemainingMilliseconds(
+                                    blocksValidated, estimatedTotalBlocks, elapsedMillis);
 
-                    // Periodic checkpoint save
-                    long nowMs = System.currentTimeMillis();
-                    if (nowMs - lastCheckpointSaveMs >= 60_000L) {
-                        try {
-                            Files.createDirectories(checkpointDir);
-                        } catch (IOException ignored) {
-                        }
-                        saveCheckpoint(checkpointDir, blockNum, blocksValidated, chainValidation, validations);
-                        lastCheckpointSaveMs = nowMs;
-                    }
-
-                    if (verbose) {
-                        final String blockHash = (chainValidation.getPreviousBlockHash() != null)
-                                ? Bytes.wrap(chainValidation.getPreviousBlockHash())
-                                        .toHex()
-                                : "null";
-                        System.out.println("Block " + blockNum + ": "
-                                + Ansi.AUTO.string("@|green VALID|@") + " (hash: "
-                                + blockHash
-                                + ")");
-                    }
-
-                    // Progress every 5 seconds
-                    if (nowMs - lastProgressMs >= 5_000L) {
-                        long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
-                        long currentPercent = (blocksValidated * 100) / estimatedTotalBlocks;
-                        long remainingMillis = PrettyPrint.computeRemainingMilliseconds(
-                                blocksValidated, estimatedTotalBlocks, elapsedMillis);
-
-                        // Compute speed multiplier (consensus-time / wall-clock)
-                        BlockHeader parsedHeader = BlockHeader.PROTOBUF.parse(
-                                block.blockItems().getFirst().blockHeaderOrThrow());
-                        Timestamp blockTs = parsedHeader.blockTimestampOrThrow();
-                        long blockEpochMillis = blockTs.seconds() * 1000L + blockTs.nanos() / 1_000_000L;
-                        long currentNanos = System.nanoTime();
-                        if (speedCalcBlockTimeMillis == 0) {
-                            speedCalcBlockTimeMillis = blockEpochMillis;
-                            speedCalcRealTimeNanos = currentNanos;
-                            speedString = "";
-                        } else {
-                            long realElapsedNanos = currentNanos - speedCalcRealTimeNanos;
-                            // Reset tracking window every 10 seconds of real time
-                            if (realElapsedNanos >= 10_000_000_000L) {
-                                long dataTimeMs = blockEpochMillis - speedCalcBlockTimeMillis;
-                                long realTimeMs = realElapsedNanos / 1_000_000L;
-                                double multiplier = (double) dataTimeMs / (double) realTimeMs;
-                                speedString = String.format(" speed %.1fx", multiplier);
+                            // Compute speed multiplier (consensus-time / wall-clock)
+                            BlockHeader parsedHeader = BlockHeader.PROTOBUF.parse(
+                                    block.blockItems().getFirst().blockHeaderOrThrow());
+                            Timestamp blockTs = parsedHeader.blockTimestampOrThrow();
+                            long blockEpochMillis = blockTs.seconds() * 1000L + blockTs.nanos() / 1_000_000L;
+                            long currentNanos = System.nanoTime();
+                            if (speedCalcBlockTimeMillis == 0) {
                                 speedCalcBlockTimeMillis = blockEpochMillis;
                                 speedCalcRealTimeNanos = currentNanos;
-                            } else if (realElapsedNanos >= 1_000_000_000L) {
-                                long dataTimeMs = blockEpochMillis - speedCalcBlockTimeMillis;
-                                long realTimeMs = realElapsedNanos / 1_000_000L;
-                                double multiplier = (double) dataTimeMs / (double) realTimeMs;
-                                speedString = String.format(" speed %.1fx", multiplier);
+                                speedString = "";
+                            } else {
+                                long realElapsedNanos = currentNanos - speedCalcRealTimeNanos;
+                                // Reset tracking window every 10 seconds of real time
+                                if (realElapsedNanos >= 10_000_000_000L) {
+                                    long dataTimeMs = blockEpochMillis - speedCalcBlockTimeMillis;
+                                    long realTimeMs = realElapsedNanos / 1_000_000L;
+                                    double multiplier = (double) dataTimeMs / (double) realTimeMs;
+                                    speedString = String.format(" speed %.1fx", multiplier);
+                                    speedCalcBlockTimeMillis = blockEpochMillis;
+                                    speedCalcRealTimeNanos = currentNanos;
+                                } else if (realElapsedNanos >= 1_000_000_000L) {
+                                    long dataTimeMs = blockEpochMillis - speedCalcBlockTimeMillis;
+                                    long realTimeMs = realElapsedNanos / 1_000_000L;
+                                    double multiplier = (double) dataTimeMs / (double) realTimeMs;
+                                    speedString = String.format(" speed %.1fx", multiplier);
+                                }
                             }
+
+                            String progressString = "Validated " + blocksValidated + "/~" + estimatedTotalBlocks
+                                    + " blocks" + speedString;
+                            PrettyPrint.printProgressWithEta(currentPercent, progressString, remainingMillis);
+                            lastProgressMs = nowMs;
                         }
 
-                        String progressString =
-                                "Validated " + blocksValidated + "/~" + estimatedTotalBlocks + " blocks" + speedString;
-                        PrettyPrint.printProgressWithEta(currentPercent, progressString, remainingMillis);
-                        lastProgressMs = nowMs;
-                    }
-
-                } catch (Exception e) {
-                    failedValidationName = "Block Processing";
-                    // Unwrap ExecutionException to surface the actual cause
-                    Throwable cause = (e instanceof java.util.concurrent.ExecutionException && e.getCause() != null)
-                            ? e.getCause()
-                            : e;
-                    failureMessage = cause.getMessage() != null ? cause.getMessage() : cause.toString();
-                    failedBlockNumber = lastValidatedRef[0] + 1;
-                    // Always print for unexpected errors (not just in verbose mode)
-                    System.err.println("Unexpected error near block " + failedBlockNumber + ": " + failureMessage);
-                    cause.printStackTrace();
-                    break;
-                }
-            }
-
-            // Stop reader and decompression pool
-            readerThread.interrupt();
-            decompPool.shutdownNow();
-
-            // ── Finalize all validations (end-of-stream checks) ─────────────
-            if (failedValidationName == null && failureMessage == null) {
-                for (BlockValidation v : validations) {
-                    try {
-                        v.finalize(blocksValidated, lastValidatedRef[0]);
-                    } catch (ValidationException e) {
-                        failedValidationName = v.name();
-                        failureMessage = e.getMessage();
-                        failedBlockNumber = -1; // not a per-block error
+                    } catch (Exception e) {
+                        failedValidationName = "Block Processing";
+                        // Unwrap ExecutionException to surface the actual cause
+                        Throwable cause = (e instanceof java.util.concurrent.ExecutionException && e.getCause() != null)
+                                ? e.getCause()
+                                : e;
+                        failureMessage = cause.getMessage() != null ? cause.getMessage() : cause.toString();
+                        failedBlockNumber = lastValidatedRef[0] + 1;
+                        // Always print for unexpected errors (not just in verbose mode)
+                        System.err.println("Unexpected error near block " + failedBlockNumber + ": " + failureMessage);
+                        cause.printStackTrace();
                         break;
                     }
                 }
-            }
 
-            // Fail if blocks were skipped due to corrupt zips
-            if (failedValidationName == null && failureMessage == null && skippedBlockCount > 0) {
-                failedValidationName = "Skipped Blocks";
-                failureMessage =
-                        skippedBlockCount + " blocks were skipped (corrupt zip files) and could not be" + " validated";
-            }
+                // Stop reader and decompression pool
+                readerThread.interrupt();
+                decompPool.shutdownNow();
 
-        } finally {
-            completed[0] = true;
-            try {
-                Runtime.getRuntime().removeShutdownHook(shutdownHook);
-            } catch (IllegalStateException ignored) {
-                // JVM already shutting down
+                // ── Finalize all validations (end-of-stream checks) ─────────────
+                if (failedValidationName == null && failureMessage == null) {
+                    for (BlockValidation v : validations) {
+                        try {
+                            v.finalize(blocksValidated, lastValidatedRef[0]);
+                        } catch (ValidationException e) {
+                            failedValidationName = v.name();
+                            failureMessage = e.getMessage();
+                            failedBlockNumber = -1; // not a per-block error
+                            break;
+                        }
+                    }
+                }
+
+                // Fail if blocks were skipped due to corrupt zips
+                if (failedValidationName == null && failureMessage == null && skippedBlockCount > 0) {
+                    failedValidationName = "Skipped Blocks";
+                    failureMessage = skippedBlockCount + " blocks were skipped (corrupt zip files) and could not be"
+                            + " validated";
+                }
+
+            } finally {
+                completed[0] = true;
+                try {
+                    Runtime.getRuntime().removeShutdownHook(shutdownHook);
+                } catch (IllegalStateException ignored) {
+                    // JVM already shutting down
+                }
+                // Close all validations
+                for (BlockValidation v : validations) {
+                    v.close();
+                }
+                // Finalize signature statistics (statsCollector is closed automatically by try-with-resources)
+                statsCollector.finalizeDayStats();
+                statsCollector.printFinalSummary();
             }
-            // Close all validations
-            for (BlockValidation v : validations) {
-                v.close();
-            }
-            // Finalize signature statistics
-            statsCollector.finalizeDayStats();
-            statsCollector.printFinalSummary();
-            statsCollector.close();
         }
 
         // Determine overall result

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
@@ -33,7 +33,7 @@ public final class AddressBookUpdateValidation implements BlockValidation {
 
     private static final String SAVE_FILE_NAME = "addressBookHistory.json";
     private static final int MAX_DEPTH = 512;
-    private static final int MAX_RECORD_FILE_SIZE = 64 * 1024 * 1024;
+    private static final int MAX_RECORD_FILE_SIZE = 128 * 1024 * 1024;
 
     private final AddressBookRegistry addressBookRegistry;
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
@@ -32,7 +32,7 @@ public final class NodeStakeUpdateValidation implements BlockValidation {
 
     private static final String SAVE_FILE_NAME = "nodeStakeHistory.json";
     private static final int MAX_DEPTH = 512;
-    private static final int MAX_RECORD_FILE_SIZE = 64 * 1024 * 1024;
+    private static final int MAX_RECORD_FILE_SIZE = 128 * 1024 * 1024;
 
     private final NodeStakeRegistry nodeStakeRegistry;
     private boolean firstStakeUpdateSeen = false;

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureBlockStats.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureBlockStats.java
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.blocks.validation;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Per-block signature validation statistics, providing richer data than the
+ * simple pass/fail result of {@link SignatureValidation#validate}.
+ *
+ * <p>Collected by {@link SignatureValidation} when detailed stats are enabled,
+ * and delivered to {@link SignatureStatsCollector} for per-day aggregation and CSV output.
+ *
+ * @param blockNumber the block number
+ * @param blockTime the block's consensus timestamp
+ * @param stakeWeighted true if stake-weighted consensus was used
+ * @param totalNodes total nodes in the address book
+ * @param totalStake total stake across all nodes (equal to totalNodes in equal-weight mode)
+ * @param threshold minimum stake required for consensus
+ * @param validatedNodes set of node IDs that produced valid signatures
+ * @param validatedStake accumulated stake from validated nodes
+ * @param totalSignatures total signature entries in the block proof
+ * @param nodeStakes stake weights per node (nodeId to stake); empty in equal-weight mode
+ * @param perNodeResults per-node verification outcome (keyed by nodeId)
+ */
+public record SignatureBlockStats(
+        long blockNumber,
+        Instant blockTime,
+        boolean stakeWeighted,
+        int totalNodes,
+        long totalStake,
+        long threshold,
+        Set<Long> validatedNodes,
+        long validatedStake,
+        int totalSignatures,
+        Map<Long, Long> nodeStakes,
+        Map<Long, NodeResult> perNodeResults) {
+
+    /** Result of signature verification for a single node. */
+    public enum NodeResult {
+        /** Signature was verified successfully. */
+        VERIFIED,
+        /** Signature verification failed (bad signature). */
+        FAILED,
+        /** Error during verification (e.g. unknown node, key lookup failure). */
+        ERROR,
+        /** Node is in the address book but no signature was present. */
+        NOT_PRESENT
+    }
+
+    /**
+     * Builds a {@link SignatureBlockStats} from pre-verified signature data. This is used by
+     * commands that verify signatures outside of {@link SignatureValidation} (e.g. the wrap
+     * command's Stage 1 pre-verification).
+     *
+     * @param blockNumber the block number
+     * @param blockTime the block's consensus timestamp
+     * @param verifiedNodeIds node IDs that produced valid signatures
+     * @param totalSignatures total signature entries
+     * @param addressBookNodeIds all node IDs from the address book
+     * @param stakeMap node stake weights (nodeId to stake), or null for equal-weight
+     * @return the constructed stats record
+     */
+    public static SignatureBlockStats fromPreVerifiedData(
+            long blockNumber,
+            Instant blockTime,
+            List<Long> verifiedNodeIds,
+            int totalSignatures,
+            List<Long> addressBookNodeIds,
+            Map<Long, Long> stakeMap) {
+
+        int totalNodes = addressBookNodeIds.size();
+        long rawTotalStake = stakeMap != null
+                ? stakeMap.values().stream().mapToLong(Long::longValue).sum()
+                : 0;
+        boolean stakeWeighted = stakeMap != null && rawTotalStake > 0;
+        long totalStake = stakeWeighted ? rawTotalStake : totalNodes;
+        long threshold = stakeWeighted ? (totalStake / 3) + ((totalStake % 3 == 0) ? 0 : 1) : (totalNodes / 3) + 1;
+
+        Set<Long> uniqueValidated = new HashSet<>();
+        long validatedStake = 0;
+        Map<Long, NodeResult> perNodeResults = new LinkedHashMap<>();
+        for (long nodeId : verifiedNodeIds) {
+            if (uniqueValidated.add(nodeId)) {
+                long weight = stakeWeighted ? stakeMap.getOrDefault(nodeId, 0L) : 1;
+                validatedStake += weight;
+            }
+            perNodeResults.put(nodeId, NodeResult.VERIFIED);
+        }
+        for (long nodeId : addressBookNodeIds) {
+            perNodeResults.putIfAbsent(nodeId, NodeResult.NOT_PRESENT);
+        }
+
+        return new SignatureBlockStats(
+                blockNumber,
+                blockTime,
+                stakeWeighted,
+                totalNodes,
+                totalStake,
+                threshold,
+                Set.copyOf(uniqueValidated),
+                validatedStake,
+                totalSignatures,
+                stakeMap != null ? Map.copyOf(stakeMap) : Map.of(),
+                Map.copyOf(perNodeResults));
+    }
+}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureStatsCollector.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureStatsCollector.java
@@ -471,7 +471,7 @@ public class SignatureStatsCollector implements Consumer<SignatureBlockStats>, A
 
             Files.writeString(csvOutputFile, row.toString(), StandardCharsets.UTF_8, APPEND, CREATE);
 
-            System.out.println("[CSV] Written statistics for " + dayStats.date + " to " + csvOutputFile);
+            System.out.println("\n[CSV] Written statistics for " + dayStats.date + " to " + csvOutputFile);
         } catch (IOException e) {
             System.err.println("Failed to write day stats to CSV for " + dayStats.date + ": " + e.getMessage());
         }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureStatsCollector.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureStatsCollector.java
@@ -431,43 +431,44 @@ public class SignatureStatsCollector implements Consumer<SignatureBlockStats>, A
                 writeCsvHeader();
             }
 
-            StringBuilder row = new StringBuilder();
-            row.append(dayStats.date).append(",");
-            row.append(String.format("%.4f", dayStats.getAveragePercentage())).append(",");
-            row.append(dayStats.totalBlocks).append(",");
-            row.append(dayStats.getAverageAddressBookNodeCount()).append(",");
-            row.append(dayStats.totalValidSignatures).append(",");
-            row.append(String.format("%.4f", dayStats.getMinPercentage())).append(",");
-            row.append(String.format("%.4f", dayStats.getAveragePercentagePerBlock()));
+            Formatter row = new Formatter(new StringBuilder());
+            // First parameter is a date, we're using string format, but that might not be the ideal choice.
+            final String baseColumns = "%s,%.4f,%d,%d,%d,%.4f,%.4f";
+            row.format(baseColumns,
+                    dayStats.date,
+                    dayStats.getAveragePercentage(),
+                    dayStats.totalBlocks(),
+                    dayStats.getAverageAddressBookNodeCount(),
+                    dayStats.totalValidSignatures(),
+                    dayStats.getMinPercentage(),
+                    dayStats.getAveragePercentagePerBlock());
 
             // Histogram columns
             for (int i = 1; i <= MAX_SIG_COUNT; i++) {
                 int blockCount = dayStats.blocksBySignatureCount.getOrDefault(i, 0);
-                row.append(",").append(blockCount);
+                row.format(",%d").append(blockCount);
             }
-
             // Stake weight columns
             if (dayStats.hasStakeData()) {
-                row.append(",").append(dayStats.mode);
-                row.append(",").append(dayStats.totalStake);
-                row.append(",").append(String.format("%.4f", dayStats.minValidatedStakePct));
-                row.append(",").append(String.format("%.4f", dayStats.maxValidatedStakePct));
-                row.append(",").append(String.format("%.4f", dayStats.getMeanValidatedStakePct()));
-                row.append(",").append(dayStats.closestThresholdMargin);
-                row.append(",").append(dayStats.minSigningNodes);
-                row.append(",").append(dayStats.maxSigningNodes);
-                row.append(",").append(String.format("%.1f", dayStats.getMeanSigningNodes()));
+                final String stakeColumns = ",%s,%d,%.4f,%.4f,%.4f,%d,%d,%d,%.1f";
+                row.format(stakeColumns,
+                        dayStats.mode,
+                        dayStats.totalStake,
+                        dayStats.minValidatedStakePct,
+                        dayStats.maxValidatedStakePct,
+                        dayStats.getMeanValidatedStakePct(),
+                        dayStats.closestThresholdMargin,
+                        dayStats.minSigningNodes,
+                        dayStats.maxSigningNodes,
+                        dayStats.getMeanSigningNodes());
                 appendNodeStakeDistribution(row, dayStats);
-                row.append(",").append(dayStats.getMissingSigners());
-                row.append(",").append(dayStats.getReliableSigners());
-            } else {
-                // Empty stake columns
-                for (int i = 0; i < STAKE_COLUMN_COUNT; i++) {
-                    row.append(",");
-                }
+                row.format(",%d,%d,,,,,,,,,,,,,,,,,",
+                        dayStats.getMissingSigners(),
+                        dayStats.getReliableSigners()
+                    row.append(",").append(dayStats.mode);
             }
-
-            row.append("\n");
+            row.format("%n");
+            final String result = row.out().toString();
 
             Files.writeString(csvOutputFile, row.toString(), StandardCharsets.UTF_8, APPEND, CREATE);
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureStatsCollector.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureStatsCollector.java
@@ -1,0 +1,524 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.blocks.validation;
+
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static java.nio.file.StandardOpenOption.WRITE;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+import org.hiero.block.tools.records.model.unparsed.InMemoryFile;
+import org.hiero.block.tools.utils.PrettyPrint;
+
+/**
+ * Collects per-day signature statistics and writes them to a CSV file.
+ *
+ * <p>Extracted from {@code ValidateWithStats} to be reusable across all commands.
+ * Extends the original CSV format with stake weight columns when
+ * {@link SignatureBlockStats} data is available.
+ *
+ * <p>Supports two recording modes:
+ * <ul>
+ *   <li><b>Legacy</b>: {@link #recordBlock(List, int, int)} for pre-wrapped record file
+ *       validation (e.g. {@code ValidateWithStats}). Stake columns are empty.
+ *   <li><b>Rich</b>: {@link #accept(SignatureBlockStats)} for wrapped block validation
+ *       with full stake weight data. Auto-detects day boundaries from block timestamps.
+ * </ul>
+ */
+public class SignatureStatsCollector implements Consumer<SignatureBlockStats>, AutoCloseable {
+
+    /** Maximum number of signature-count histogram columns in the CSV. */
+    private static final int MAX_SIG_COUNT = 40;
+
+    /** Number of stake weight columns appended after the histogram. */
+    private static final int STAKE_COLUMN_COUNT = 17;
+
+    private final Path csvOutputFile;
+    private boolean csvHeaderWritten = false;
+    private LocalDate currentDay = null;
+    private DayStatistics currentDayStats = null;
+    private final List<DayStatistics> dailyStatistics = new ArrayList<>();
+
+    /** Per-day statistics for signature validation. */
+    static class DayStatistics {
+        final LocalDate date;
+        int totalBlocks = 0;
+        int totalSignatures = 0;
+        int totalValidSignatures = 0;
+        long totalNodeSlots = 0;
+        int minSignaturesInBlock = Integer.MAX_VALUE;
+        final Map<Integer, Integer> blocksBySignatureCount = new TreeMap<>();
+
+        // Stake weight fields (populated when accept() provides SignatureBlockStats)
+        String mode = null;
+        long totalStake = 0;
+        double minValidatedStakePct = Double.MAX_VALUE;
+        double maxValidatedStakePct = -1;
+        double sumValidatedStakePct = 0;
+        long closestThresholdMargin = Long.MAX_VALUE;
+        int minSigningNodes = Integer.MAX_VALUE;
+        int maxSigningNodes = 0;
+        long sumSigningNodes = 0;
+        Map<Long, Long> latestNodeStakes = null;
+        final Set<Long> allNodes = new HashSet<>();
+        final Map<Long, Integer> nodeBlockSignCount = new HashMap<>();
+        int blocksWithStakeData = 0;
+
+        DayStatistics(LocalDate date) {
+            this.date = date;
+        }
+
+        void recordBlock(int signatureCount, int validSignatureCount, int addressBookNodeCount) {
+            totalBlocks++;
+            totalSignatures += signatureCount;
+            totalValidSignatures += validSignatureCount;
+            totalNodeSlots += addressBookNodeCount;
+            if (signatureCount < minSignaturesInBlock) {
+                minSignaturesInBlock = signatureCount;
+            }
+            blocksBySignatureCount.merge(signatureCount, 1, Integer::sum);
+        }
+
+        void recordStakeStats(SignatureBlockStats stats) {
+            blocksWithStakeData++;
+            if (mode == null) {
+                mode = stats.stakeWeighted() ? "stake-weighted" : "equal-weight";
+            }
+            totalStake = stats.totalStake();
+            updateValidatedStakePct(stats);
+            updateThresholdMargin(stats);
+            updateSigningNodeCounts(stats);
+            updateNodeParticipation(stats);
+        }
+
+        private void updateValidatedStakePct(SignatureBlockStats stats) {
+            double stakePct = stats.totalStake() > 0 ? (100.0 * stats.validatedStake()) / stats.totalStake() : 0;
+            minValidatedStakePct = Math.min(minValidatedStakePct, stakePct);
+            maxValidatedStakePct = Math.max(maxValidatedStakePct, stakePct);
+            sumValidatedStakePct += stakePct;
+        }
+
+        private void updateThresholdMargin(SignatureBlockStats stats) {
+            long margin = stats.validatedStake() - stats.threshold();
+            closestThresholdMargin = Math.min(closestThresholdMargin, margin);
+        }
+
+        private void updateSigningNodeCounts(SignatureBlockStats stats) {
+            int signingNodes = stats.validatedNodes().size();
+            minSigningNodes = Math.min(minSigningNodes, signingNodes);
+            maxSigningNodes = Math.max(maxSigningNodes, signingNodes);
+            sumSigningNodes += signingNodes;
+            if (stats.nodeStakes() != null && !stats.nodeStakes().isEmpty()) {
+                latestNodeStakes = stats.nodeStakes();
+            }
+        }
+
+        private void updateNodeParticipation(SignatureBlockStats stats) {
+            for (Map.Entry<Long, SignatureBlockStats.NodeResult> entry :
+                    stats.perNodeResults().entrySet()) {
+                allNodes.add(entry.getKey());
+                if (entry.getValue() == SignatureBlockStats.NodeResult.VERIFIED) {
+                    nodeBlockSignCount.merge(entry.getKey(), 1, Integer::sum);
+                }
+            }
+        }
+
+        int getAverageAddressBookNodeCount() {
+            if (totalBlocks == 0) return 0;
+            return (int) (totalNodeSlots / totalBlocks);
+        }
+
+        double getAveragePercentage() {
+            if (totalBlocks == 0 || totalNodeSlots == 0) return 0.0;
+            return (100.0 * totalSignatures) / totalNodeSlots;
+        }
+
+        double getValidPercentage() {
+            if (totalBlocks == 0 || totalNodeSlots == 0) return 0.0;
+            return (100.0 * totalValidSignatures) / totalNodeSlots;
+        }
+
+        double getMinPercentage() {
+            int avgNodes = getAverageAddressBookNodeCount();
+            if (totalBlocks == 0 || avgNodes == 0 || minSignaturesInBlock == Integer.MAX_VALUE) return 0.0;
+            return (100.0 * minSignaturesInBlock) / avgNodes;
+        }
+
+        double getAveragePercentagePerBlock() {
+            if (totalBlocks == 0) return 0.0;
+            double avgSigsPerBlock = (double) totalSignatures / totalBlocks;
+            int avgNodes = getAverageAddressBookNodeCount();
+            if (avgNodes == 0) return 0.0;
+            return (100.0 * avgSigsPerBlock) / avgNodes;
+        }
+
+        boolean hasStakeData() {
+            return blocksWithStakeData > 0;
+        }
+
+        double getMeanValidatedStakePct() {
+            return blocksWithStakeData > 0 ? sumValidatedStakePct / blocksWithStakeData : 0;
+        }
+
+        double getMeanSigningNodes() {
+            return blocksWithStakeData > 0 ? (double) sumSigningNodes / blocksWithStakeData : 0;
+        }
+
+        int getMissingSigners() {
+            int count = 0;
+            for (long nodeId : allNodes) {
+                if (!nodeBlockSignCount.containsKey(nodeId) || nodeBlockSignCount.get(nodeId) == 0) {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        int getReliableSigners() {
+            if (totalBlocks == 0) return 0;
+            int count = 0;
+            for (int signCount : nodeBlockSignCount.values()) {
+                if (signCount >= totalBlocks) {
+                    count++;
+                }
+            }
+            return count;
+        }
+    }
+
+    /**
+     * Creates a new collector that writes CSV to the given path.
+     *
+     * @param csvOutputFile path to the CSV output file, or null to skip CSV output
+     */
+    public SignatureStatsCollector(Path csvOutputFile) {
+        this.csvOutputFile = csvOutputFile;
+    }
+
+    /**
+     * Starts a new day, flushing the previous day's statistics to CSV.
+     *
+     * @param day the date of the new day
+     * @param addressBookNodeCount the number of nodes in the address book
+     */
+    public void startDay(LocalDate day, int addressBookNodeCount) {
+        if (currentDay != null && currentDayStats != null) {
+            dailyStatistics.add(currentDayStats);
+            writeDayToCsv(currentDayStats);
+        }
+        currentDay = day;
+        currentDayStats = new DayStatistics(day);
+    }
+
+    /**
+     * Records block statistics from pre-wrapped record file validation.
+     * Stake weight columns will be empty in CSV output.
+     *
+     * @param signatureFiles the signature files for the block
+     * @param validSignatureCount the number of valid signatures
+     * @param addressBookNodeCount the number of nodes in the address book
+     */
+    public void recordBlock(List<InMemoryFile> signatureFiles, int validSignatureCount, int addressBookNodeCount) {
+        int totalSignaturesInBlock = 0;
+        for (InMemoryFile sigFile : signatureFiles) {
+            String fileName = sigFile.path().getFileName().toString();
+            if (fileName.startsWith("node_") && (fileName.endsWith(".rcd_sig") || fileName.endsWith(".rcs_sig"))) {
+                totalSignaturesInBlock++;
+            }
+        }
+        if (currentDayStats != null) {
+            currentDayStats.recordBlock(totalSignaturesInBlock, validSignatureCount, addressBookNodeCount);
+        }
+    }
+
+    /**
+     * Accepts a {@link SignatureBlockStats} from wrapped block validation.
+     * Auto-detects day boundaries from block timestamps and records both
+     * basic and stake weight statistics.
+     *
+     * @param stats the per-block signature validation statistics
+     */
+    @Override
+    public void accept(SignatureBlockStats stats) {
+        LocalDate blockDay = stats.blockTime().atZone(ZoneOffset.UTC).toLocalDate();
+        if (currentDay == null || !currentDay.equals(blockDay)) {
+            startDay(blockDay, stats.totalNodes());
+        }
+        if (currentDayStats != null) {
+            currentDayStats.recordBlock(
+                    stats.totalSignatures(), stats.validatedNodes().size(), stats.totalNodes());
+            currentDayStats.recordStakeStats(stats);
+        }
+    }
+
+    /**
+     * Finalizes the last day's statistics and writes them to CSV.
+     * Call this after all blocks have been processed.
+     */
+    public void finalizeDayStats() {
+        if (currentDay != null && currentDayStats != null) {
+            dailyStatistics.add(currentDayStats);
+            writeDayToCsv(currentDayStats);
+        }
+    }
+
+    /**
+     * Prints an overall summary of all collected statistics.
+     */
+    public void printFinalSummary() {
+        System.out.println("\n" + "=".repeat(80));
+        System.out.println("VALIDATION COMPLETE - ALL STATISTICS WRITTEN TO CSV");
+        System.out.println("=".repeat(80));
+
+        if (dailyStatistics.isEmpty()) {
+            System.out.println("No daily statistics collected.");
+            return;
+        }
+
+        long totalBlocks =
+                dailyStatistics.stream().mapToLong(ds -> ds.totalBlocks).sum();
+        long totalSignatures =
+                dailyStatistics.stream().mapToLong(ds -> ds.totalSignatures).sum();
+        int totalDays = dailyStatistics.size();
+
+        System.out.printf("Total Days:        %d%n", totalDays);
+        System.out.printf("Total Blocks:      %,d%n", totalBlocks);
+        System.out.printf("Total Signatures:  %,d%n", totalSignatures);
+
+        if (totalBlocks > 0) {
+            double avgSigsPerBlock = (double) totalSignatures / (double) totalBlocks;
+            System.out.printf("Avg Sigs/Block:    %.2f%n", avgSigsPerBlock);
+        }
+
+        System.out.println("\nDetailed per-day statistics have been written to:");
+        System.out.println("  " + csvOutputFile);
+        System.out.println("\n" + "=".repeat(80));
+    }
+
+    /**
+     * Prints a summary of a completed day's statistics.
+     *
+     * @param day the date to print statistics for
+     */
+    public void printDayCompletedSummary(LocalDate day) {
+        final DayStatistics dayStats;
+        if (currentDayStats != null && currentDayStats.date.equals(day)) {
+            dayStats = currentDayStats;
+        } else {
+            dayStats = dailyStatistics.stream()
+                    .filter(ds -> ds.date.equals(day))
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        if (dayStats == null) {
+            System.out.println("\n[WARNING] No statistics found for day: " + day);
+            return;
+        }
+
+        PrettyPrint.clearProgress();
+        System.out.println("\n" + "\u2550".repeat(80));
+        System.out.println("DAY COMPLETED: " + day);
+        System.out.println("\u2550".repeat(80));
+        System.out.printf("  Date:                     %s%n", dayStats.date);
+        System.out.printf("  Total Blocks:             %,d%n", dayStats.totalBlocks);
+        System.out.printf("  Total Signatures:         %,d%n", dayStats.totalSignatures);
+        System.out.printf("  Valid Signatures:         %,d%n", dayStats.totalValidSignatures);
+        System.out.printf("  Address Book Nodes (avg): %d%n", dayStats.getAverageAddressBookNodeCount());
+        System.out.printf("  Worst Block Coverage:     %.2f%%%n", dayStats.getMinPercentage());
+        System.out.printf("  Avg Percentage Per Block: %.2f%%%n", dayStats.getAveragePercentagePerBlock());
+        System.out.printf("  Average Percentage:       %.2f%%%n", dayStats.getAveragePercentage());
+        System.out.printf("  Valid Percentage:         %.2f%%%n", dayStats.getValidPercentage());
+
+        if (dayStats.hasStakeData()) {
+            System.out.printf("  Mode:                     %s%n", dayStats.mode);
+            System.out.printf("  Total Stake:              %,d%n", dayStats.totalStake);
+            System.out.printf(
+                    "  Validated Stake %%:        %.2f%% - %.2f%% (mean %.2f%%)%n",
+                    dayStats.minValidatedStakePct, dayStats.maxValidatedStakePct, dayStats.getMeanValidatedStakePct());
+            System.out.printf("  Closest Threshold Margin: %,d%n", dayStats.closestThresholdMargin);
+            System.out.printf(
+                    "  Signing Nodes:            %d - %d (mean %.1f)%n",
+                    dayStats.minSigningNodes, dayStats.maxSigningNodes, dayStats.getMeanSigningNodes());
+            System.out.printf("  Missing Signers:          %d%n", dayStats.getMissingSigners());
+            System.out.printf("  Reliable Signers:         %d%n", dayStats.getReliableSigners());
+        }
+
+        if (!dayStats.blocksBySignatureCount.isEmpty()) {
+            System.out.println("\n  Signature Distribution:");
+            System.out.println("  " + "\u2500".repeat(60));
+            System.out.printf("  %-20s %10s %10s%n", "Signatures/Block", "Block Count", "Percentage");
+            System.out.println("  " + "\u2500".repeat(60));
+
+            dayStats.blocksBySignatureCount.entrySet().stream()
+                    .sorted((a, b) -> b.getValue().compareTo(a.getValue()))
+                    .limit(10)
+                    .forEach(entry -> {
+                        int sigCount = entry.getKey();
+                        int blockCount = entry.getValue();
+                        double percentage = (100.0 * blockCount) / dayStats.totalBlocks;
+                        System.out.printf("  %-20d %,10d %9.2f%%%n", sigCount, blockCount, percentage);
+                    });
+
+            System.out.println("  " + "\u2500".repeat(60));
+        }
+        System.out.println("\u2550".repeat(80) + "\n");
+    }
+
+    @Override
+    public void close() {
+        // No-op; CSV is flushed per day in writeDayToCsv
+    }
+
+    // ── CSV output ───────────────────────────────────────────────────────────
+
+    private void writeCsvHeader() {
+        if (csvHeaderWritten || csvOutputFile == null) return;
+        try {
+            if (Files.exists(csvOutputFile)) {
+                long fileSize = Files.size(csvOutputFile);
+                if (fileSize > 0) {
+                    csvHeaderWritten = true;
+                    System.out.println(
+                            "[CSV] Resuming - appending to existing file (" + fileSize + " bytes): " + csvOutputFile);
+                    return;
+                }
+                System.out.println("[CSV] Removing empty CSV file: " + csvOutputFile);
+                Files.delete(csvOutputFile);
+            }
+            StringBuilder header = new StringBuilder();
+            header.append(
+                    "date,percentage,number_of_blocks,number_of_nodes,valid_signatures,worst_block_signature_coverage_percentage,avg_percentage_per_block");
+            for (int i = 1; i <= MAX_SIG_COUNT; i++) {
+                header.append(",blocks_with_").append(i).append("_sig");
+            }
+            // Stake weight columns
+            header.append(",mode,total_stake");
+            header.append(",min_validated_stake_pct,max_validated_stake_pct,mean_validated_stake_pct");
+            header.append(",closest_threshold_margin");
+            header.append(",min_signing_nodes,max_signing_nodes,mean_signing_nodes");
+            header.append(",min_node_stake,max_node_stake,mean_node_stake,median_node_stake,std_dev_node_stake");
+            header.append(",top3_concentration_pct,missing_signers,reliable_signers");
+            header.append("\n");
+
+            Files.writeString(csvOutputFile, header.toString(), StandardCharsets.UTF_8, CREATE_NEW, WRITE);
+            csvHeaderWritten = true;
+            System.out.println("[CSV] Created new CSV file: " + csvOutputFile);
+        } catch (IOException e) {
+            System.err.println("Failed to write CSV header to " + csvOutputFile + ": " + e.getMessage());
+        }
+    }
+
+    private void writeDayToCsv(DayStatistics dayStats) {
+        if (csvOutputFile == null) return;
+
+        try {
+            if (!csvHeaderWritten) {
+                writeCsvHeader();
+            }
+
+            StringBuilder row = new StringBuilder();
+            row.append(dayStats.date).append(",");
+            row.append(String.format("%.4f", dayStats.getAveragePercentage())).append(",");
+            row.append(dayStats.totalBlocks).append(",");
+            row.append(dayStats.getAverageAddressBookNodeCount()).append(",");
+            row.append(dayStats.totalValidSignatures).append(",");
+            row.append(String.format("%.4f", dayStats.getMinPercentage())).append(",");
+            row.append(String.format("%.4f", dayStats.getAveragePercentagePerBlock()));
+
+            // Histogram columns
+            for (int i = 1; i <= MAX_SIG_COUNT; i++) {
+                int blockCount = dayStats.blocksBySignatureCount.getOrDefault(i, 0);
+                row.append(",").append(blockCount);
+            }
+
+            // Stake weight columns
+            if (dayStats.hasStakeData()) {
+                row.append(",").append(dayStats.mode);
+                row.append(",").append(dayStats.totalStake);
+                row.append(",").append(String.format("%.4f", dayStats.minValidatedStakePct));
+                row.append(",").append(String.format("%.4f", dayStats.maxValidatedStakePct));
+                row.append(",").append(String.format("%.4f", dayStats.getMeanValidatedStakePct()));
+                row.append(",").append(dayStats.closestThresholdMargin);
+                row.append(",").append(dayStats.minSigningNodes);
+                row.append(",").append(dayStats.maxSigningNodes);
+                row.append(",").append(String.format("%.1f", dayStats.getMeanSigningNodes()));
+                appendNodeStakeDistribution(row, dayStats);
+                row.append(",").append(dayStats.getMissingSigners());
+                row.append(",").append(dayStats.getReliableSigners());
+            } else {
+                // Empty stake columns
+                for (int i = 0; i < STAKE_COLUMN_COUNT; i++) {
+                    row.append(",");
+                }
+            }
+
+            row.append("\n");
+
+            Files.writeString(csvOutputFile, row.toString(), StandardCharsets.UTF_8, APPEND, CREATE);
+
+            System.out.println("[CSV] Written statistics for " + dayStats.date + " to " + csvOutputFile);
+        } catch (IOException e) {
+            System.err.println("Failed to write day stats to CSV for " + dayStats.date + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Appends node stake distribution columns (min, max, mean, median, stddev)
+     * and top-3 concentration percentage to the CSV row.
+     */
+    private static void appendNodeStakeDistribution(StringBuilder row, DayStatistics dayStats) {
+        if (dayStats.latestNodeStakes == null || dayStats.latestNodeStakes.isEmpty()) {
+            // 6 empty columns: min/max/mean/median/stddev + top3
+            row.append(",,,,,,");
+            return;
+        }
+
+        List<Long> stakes = new ArrayList<>(dayStats.latestNodeStakes.values());
+        Collections.sort(stakes);
+
+        long minStake = stakes.getFirst();
+        long maxStake = stakes.getLast();
+        double meanStake = (double) dayStats.totalStake / stakes.size();
+
+        // Median
+        int mid = stakes.size() / 2;
+        double medianStake = (stakes.size() % 2 == 0) ? (stakes.get(mid - 1) + stakes.get(mid)) / 2.0 : stakes.get(mid);
+
+        // Standard deviation
+        double sumSquareDiff = 0;
+        for (long s : stakes) {
+            double diff = s - meanStake;
+            sumSquareDiff += diff * diff;
+        }
+        double stdDevStake = Math.sqrt(sumSquareDiff / stakes.size());
+
+        row.append(",").append(minStake);
+        row.append(",").append(maxStake);
+        row.append(",").append(String.format("%.0f", meanStake));
+        row.append(",").append(String.format("%.0f", medianStake));
+        row.append(",").append(String.format("%.0f", stdDevStake));
+
+        // Top 3 concentration (take last 3 from already-sorted ascending list)
+        long top3Sum = 0;
+        for (int i = Math.max(0, stakes.size() - 3); i < stakes.size(); i++) {
+            top3Sum += stakes.get(i);
+        }
+        double top3Pct = dayStats.totalStake > 0 ? (100.0 * top3Sum) / dayStats.totalStake : 0;
+        row.append(",").append(String.format("%.4f", top3Pct));
+    }
+}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureStatsCollector.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureStatsCollector.java
@@ -14,6 +14,7 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Formatter;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -432,26 +433,26 @@ public class SignatureStatsCollector implements Consumer<SignatureBlockStats>, A
             }
 
             Formatter row = new Formatter(new StringBuilder());
-            // First parameter is a date, we're using string format, but that might not be the ideal choice.
-            final String baseColumns = "%s,%.4f,%d,%d,%d,%.4f,%.4f";
-            row.format(baseColumns,
+            row.format(
+                    "%s,%.4f,%d,%d,%d,%.4f,%.4f",
                     dayStats.date,
                     dayStats.getAveragePercentage(),
-                    dayStats.totalBlocks(),
+                    dayStats.totalBlocks,
                     dayStats.getAverageAddressBookNodeCount(),
-                    dayStats.totalValidSignatures(),
+                    dayStats.totalValidSignatures,
                     dayStats.getMinPercentage(),
                     dayStats.getAveragePercentagePerBlock());
 
             // Histogram columns
             for (int i = 1; i <= MAX_SIG_COUNT; i++) {
                 int blockCount = dayStats.blocksBySignatureCount.getOrDefault(i, 0);
-                row.format(",%d").append(blockCount);
+                row.format(",%d", blockCount);
             }
+
             // Stake weight columns
             if (dayStats.hasStakeData()) {
-                final String stakeColumns = ",%s,%d,%.4f,%.4f,%.4f,%d,%d,%d,%.1f";
-                row.format(stakeColumns,
+                row.format(
+                        ",%s,%d,%.4f,%.4f,%.4f,%d,%d,%d,%.1f",
                         dayStats.mode,
                         dayStats.totalStake,
                         dayStats.minValidatedStakePct,
@@ -462,13 +463,15 @@ public class SignatureStatsCollector implements Consumer<SignatureBlockStats>, A
                         dayStats.maxSigningNodes,
                         dayStats.getMeanSigningNodes());
                 appendNodeStakeDistribution(row, dayStats);
-                row.format(",%d,%d,,,,,,,,,,,,,,,,,",
-                        dayStats.getMissingSigners(),
-                        dayStats.getReliableSigners()
-                    row.append(",").append(dayStats.mode);
+                row.format(",%d,%d", dayStats.getMissingSigners(), dayStats.getReliableSigners());
+            } else {
+                // Empty stake columns
+                for (int i = 0; i < STAKE_COLUMN_COUNT; i++) {
+                    row.format(",");
+                }
             }
+
             row.format("%n");
-            final String result = row.out().toString();
 
             Files.writeString(csvOutputFile, row.toString(), StandardCharsets.UTF_8, APPEND, CREATE);
 
@@ -482,10 +485,10 @@ public class SignatureStatsCollector implements Consumer<SignatureBlockStats>, A
      * Appends node stake distribution columns (min, max, mean, median, stddev)
      * and top-3 concentration percentage to the CSV row.
      */
-    private static void appendNodeStakeDistribution(StringBuilder row, DayStatistics dayStats) {
+    private static void appendNodeStakeDistribution(Formatter row, DayStatistics dayStats) {
         if (dayStats.latestNodeStakes == null || dayStats.latestNodeStakes.isEmpty()) {
             // 6 empty columns: min/max/mean/median/stddev + top3
-            row.append(",,,,,,");
+            row.format(",,,,,,");
             return;
         }
 
@@ -508,11 +511,7 @@ public class SignatureStatsCollector implements Consumer<SignatureBlockStats>, A
         }
         double stdDevStake = Math.sqrt(sumSquareDiff / stakes.size());
 
-        row.append(",").append(minStake);
-        row.append(",").append(maxStake);
-        row.append(",").append(String.format("%.0f", meanStake));
-        row.append(",").append(String.format("%.0f", medianStake));
-        row.append(",").append(String.format("%.0f", stdDevStake));
+        row.format(",%d,%d,%.0f,%.0f,%.0f", minStake, maxStake, meanStake, medianStake, stdDevStake);
 
         // Top 3 concentration (take last 3 from already-sorted ascending list)
         long top3Sum = 0;
@@ -520,6 +519,6 @@ public class SignatureStatsCollector implements Consumer<SignatureBlockStats>, A
             top3Sum += stakes.get(i);
         }
         double top3Pct = dayStats.totalStake > 0 ? (100.0 * top3Sum) / dayStats.totalStake : 0;
-        row.append(",").append(String.format("%.4f", top3Pct));
+        row.format(",%.4f", top3Pct);
     }
 }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureValidation.java
@@ -60,18 +60,6 @@ public final class SignatureValidation implements BlockValidation {
     }
 
     /**
-     * Creates a new signature validation with optional stake-weighted consensus.
-     * Detailed stats collection is enabled by default.
-     *
-     * @param addressBookRegistry the address book registry for public key lookups
-     * @param nodeStakeRegistry the node stake registry for stake weights (may be null for equal-weight)
-     */
-    public SignatureValidation(
-            final AddressBookRegistry addressBookRegistry, final NodeStakeRegistry nodeStakeRegistry) {
-        this(addressBookRegistry, nodeStakeRegistry, true);
-    }
-
-    /**
      * Creates a new signature validation with optional stake-weighted consensus and
      * optional detailed stats collection.
      *

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SignatureValidation.java
@@ -8,11 +8,11 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.tools.days.model.AddressBookRegistry;
@@ -29,6 +29,11 @@ import org.hiero.block.tools.records.model.parsed.ValidationException;
  * is available (pre-staking era, before ~July 2022), falls back to equal-weight mode
  * where each node counts as weight 1 and threshold is {@code (nodeCount / 3) + 1}.
  *
+ * <p>When {@code collectDetailedStats} is enabled, all signatures are verified (no early
+ * exit after threshold) to produce complete per-node participation data as
+ * {@link SignatureBlockStats}. Stats are stored in a thread-safe map and retrieved via
+ * {@link #popBlockStats(long)}.
+ *
  * <p>This is a stateless validation — no cross-block state is maintained.
  */
 public final class SignatureValidation implements BlockValidation {
@@ -39,25 +44,64 @@ public final class SignatureValidation implements BlockValidation {
     /** Optional node stake registry for stake-weighted consensus. May be null. */
     private final NodeStakeRegistry nodeStakeRegistry;
 
+    /** Whether to collect detailed per-block stats (disables early exit). */
+    private final boolean collectDetailedStats;
+
+    /** Thread-safe map of collected stats, keyed by block number. Null when stats disabled. */
+    private final ConcurrentHashMap<Long, SignatureBlockStats> collectedStats;
+
     /**
      * Creates a new signature validation with equal-weight consensus (no stake data).
      *
      * @param addressBookRegistry the address book registry for public key lookups
      */
     public SignatureValidation(final AddressBookRegistry addressBookRegistry) {
-        this(addressBookRegistry, null);
+        this(addressBookRegistry, null, false);
     }
 
     /**
      * Creates a new signature validation with optional stake-weighted consensus.
+     * Detailed stats collection is enabled by default.
      *
      * @param addressBookRegistry the address book registry for public key lookups
      * @param nodeStakeRegistry the node stake registry for stake weights (may be null for equal-weight)
      */
     public SignatureValidation(
             final AddressBookRegistry addressBookRegistry, final NodeStakeRegistry nodeStakeRegistry) {
+        this(addressBookRegistry, nodeStakeRegistry, true);
+    }
+
+    /**
+     * Creates a new signature validation with optional stake-weighted consensus and
+     * optional detailed stats collection.
+     *
+     * <p>When {@code collectDetailedStats} is true, all signatures are verified (no early
+     * exit) and per-block {@link SignatureBlockStats} are stored for retrieval via
+     * {@link #popBlockStats(long)}.
+     *
+     * @param addressBookRegistry the address book registry for public key lookups
+     * @param nodeStakeRegistry the node stake registry for stake weights (may be null for equal-weight)
+     * @param collectDetailedStats true to collect detailed stats (disables early exit)
+     */
+    public SignatureValidation(
+            final AddressBookRegistry addressBookRegistry,
+            final NodeStakeRegistry nodeStakeRegistry,
+            final boolean collectDetailedStats) {
         this.addressBookRegistry = addressBookRegistry;
         this.nodeStakeRegistry = nodeStakeRegistry;
+        this.collectDetailedStats = collectDetailedStats;
+        this.collectedStats = collectDetailedStats ? new ConcurrentHashMap<>() : null;
+    }
+
+    /**
+     * Retrieves and removes the collected stats for the given block number.
+     * Returns null if stats collection is disabled or no stats exist for the block.
+     *
+     * @param blockNumber the block number to retrieve stats for
+     * @return the stats, or null
+     */
+    public SignatureBlockStats popBlockStats(long blockNumber) {
+        return collectedStats != null ? collectedStats.remove(blockNumber) : null;
     }
 
     @Override
@@ -169,11 +213,10 @@ public final class SignatureValidation implements BlockValidation {
         // Determine stake-weighted vs equal-weight mode.
         // Fall back to equal-weight if no stake data or if total stake is zero
         // (e.g. early NodeStakeUpdate transactions before staking was enabled).
-        final Map<Long, Long> stakeMap =
-                nodeStakeRegistry != null ? nodeStakeRegistry.getStakeMapForBlock(blockTime) : null;
-        final long rawTotalStake = stakeMap != null
-                ? stakeMap.values().stream().mapToLong(Long::longValue).sum()
-                : 0;
+        final NodeStakeRegistry.StakeMapWithTotal stakeResult =
+                nodeStakeRegistry != null ? nodeStakeRegistry.getStakeMapWithTotalForBlock(blockTime) : null;
+        final Map<Long, Long> stakeMap = stakeResult != null ? stakeResult.stakeMap() : null;
+        final long rawTotalStake = stakeResult != null ? stakeResult.totalStake() : 0;
         final boolean stakeWeighted = stakeMap != null && rawTotalStake > 0;
         final long totalStake;
         final long threshold;
@@ -187,35 +230,43 @@ public final class SignatureValidation implements BlockValidation {
         }
 
         // Verify each signature, tracking unique nodes to avoid counting duplicates.
-        // Early-exit once threshold is met — no need to verify remaining signatures.
+        // When collecting stats, verify ALL signatures (no early exit) for complete data.
+        // Diagnostics are built lazily — only when validation fails.
         final Set<Long> validatedNodes = new HashSet<>();
         long validatedStake = 0;
-        final List<String> diagnostics = new ArrayList<>();
+        final Map<Long, SignatureBlockStats.NodeResult> nodeResults =
+                collectDetailedStats ? new LinkedHashMap<>() : null;
+
         for (final var sig : signatures) {
             final long accountNum = AddressBookRegistry.accountIdForNode(sig.nodeId());
             try {
                 final String pubKeyHex = AddressBookRegistry.publicKeyForNode(addressBook, 0, 0, accountNum);
-                final String keySnippet =
-                        pubKeyHex.length() > 16 ? pubKeyHex.substring(pubKeyHex.length() - 16) : pubKeyHex;
                 if (SigFileUtils.verifyRsaSha384(
                         pubKeyHex, signedHash, sig.signaturesBytes().toByteArray())) {
                     if (validatedNodes.add(accountNum)) {
                         final long weight = stakeWeighted ? stakeMap.getOrDefault(sig.nodeId(), 0L) : 1;
                         validatedStake += weight;
                     }
-                    diagnostics.add(
-                            "  node " + accountNum + " (id=" + sig.nodeId() + "): VERIFIED key=..." + keySnippet);
-                    if (validatedStake >= threshold) break;
+                    if (nodeResults != null) {
+                        nodeResults.put(sig.nodeId(), SignatureBlockStats.NodeResult.VERIFIED);
+                    }
+                    // Early exit only when not collecting detailed stats
+                    if (validatedStake >= threshold && !collectDetailedStats) break;
                 } else {
-                    diagnostics.add("  node " + accountNum + " (id=" + sig.nodeId() + "): FAILED key=..." + keySnippet);
+                    if (nodeResults != null) {
+                        nodeResults.putIfAbsent(sig.nodeId(), SignatureBlockStats.NodeResult.FAILED);
+                    }
                 }
             } catch (Exception e) {
-                diagnostics.add("  node " + accountNum + " (id=" + sig.nodeId() + "): ERROR "
-                        + e.getClass().getSimpleName());
+                if (nodeResults != null) {
+                    nodeResults.putIfAbsent(sig.nodeId(), SignatureBlockStats.NodeResult.ERROR);
+                }
             }
         }
 
         if (validatedStake < threshold) {
+            // Build diagnostics lazily — re-verify signatures to produce detailed error message.
+            // This path is rare (validation failure) so the extra RSA cost is acceptable.
             final StringBuilder detail = new StringBuilder();
             detail.append("Block: ").append(blockNumber);
             if (stakeWeighted) {
@@ -232,8 +283,62 @@ public final class SignatureValidation implements BlockValidation {
             detail.append(", signatures=").append(signatures.size());
             detail.append(stakeWeighted ? ", mode=stake-weighted" : ", mode=equal-weight");
             detail.append("\n  Per-signature results:\n");
-            diagnostics.forEach(d -> detail.append(d).append("\n"));
+            for (final var sig : signatures) {
+                final long accountNum = AddressBookRegistry.accountIdForNode(sig.nodeId());
+                try {
+                    final String pubKeyHex = AddressBookRegistry.publicKeyForNode(addressBook, 0, 0, accountNum);
+                    final String keySnippet =
+                            pubKeyHex.length() > 16 ? pubKeyHex.substring(pubKeyHex.length() - 16) : pubKeyHex;
+                    if (SigFileUtils.verifyRsaSha384(
+                            pubKeyHex, signedHash, sig.signaturesBytes().toByteArray())) {
+                        detail.append("  node ")
+                                .append(accountNum)
+                                .append(" (id=")
+                                .append(sig.nodeId())
+                                .append("): VERIFIED key=...")
+                                .append(keySnippet)
+                                .append("\n");
+                    } else {
+                        detail.append("  node ")
+                                .append(accountNum)
+                                .append(" (id=")
+                                .append(sig.nodeId())
+                                .append("): FAILED key=...")
+                                .append(keySnippet)
+                                .append("\n");
+                    }
+                } catch (Exception e) {
+                    detail.append("  node ")
+                            .append(accountNum)
+                            .append(" (id=")
+                            .append(sig.nodeId())
+                            .append("): ERROR ")
+                            .append(e.getClass().getSimpleName())
+                            .append("\n");
+                }
+            }
             throw new ValidationException(detail.toString());
+        }
+
+        // Store detailed stats on successful validation
+        if (collectDetailedStats && nodeResults != null) {
+            // Add NOT_PRESENT for address book nodes without signatures
+            for (var na : addressBook.nodeAddress()) {
+                nodeResults.putIfAbsent(na.nodeId(), SignatureBlockStats.NodeResult.NOT_PRESENT);
+            }
+            final SignatureBlockStats stats = new SignatureBlockStats(
+                    blockNumber,
+                    blockTime,
+                    stakeWeighted,
+                    totalNodes,
+                    totalStake,
+                    threshold,
+                    Set.copyOf(validatedNodes),
+                    validatedStake,
+                    signatures.size(),
+                    stakeMap != null ? Map.copyOf(stakeMap) : Map.of(),
+                    Map.copyOf(nodeResults));
+            collectedStats.put(blockNumber, stats);
         }
     }
 }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/NodeStakeRegistry.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/NodeStakeRegistry.java
@@ -126,6 +126,14 @@ public class NodeStakeRegistry {
     }
 
     /**
+     * A stake map together with its pre-computed total stake.
+     *
+     * @param stakeMap the nodeId-to-stake mapping
+     * @param totalStake the sum of all stake values
+     */
+    public record StakeMapWithTotal(Map<Long, Long> stakeMap, long totalStake) {}
+
+    /**
      * Get the stake map that was in effect at the given block time.
      * Uses binary search for O(log n) lookup over the chronologically sorted snapshots.
      *
@@ -133,6 +141,18 @@ public class NodeStakeRegistry {
      * @return a map of nodeId to stake weight, or {@code null} if no stake data is available
      */
     public Map<Long, Long> getStakeMapForBlock(Instant blockTime) {
+        final StakeMapWithTotal result = getStakeMapWithTotalForBlock(blockTime);
+        return result != null ? result.stakeMap() : null;
+    }
+
+    /**
+     * Get the stake map and pre-computed total stake for the given block time.
+     * Avoids recomputing the total on every call.
+     *
+     * @param blockTime the block time to look up
+     * @return the stake map with total, or {@code null} if no stake data is available
+     */
+    public StakeMapWithTotal getStakeMapWithTotalForBlock(Instant blockTime) {
         if (stakeSnapshots.isEmpty()) {
             return null;
         }
@@ -155,10 +175,12 @@ public class NodeStakeRegistry {
         }
         final DatedNodeStake selected = stakeSnapshots.get(idx);
         final Map<Long, Long> stakeMap = new LinkedHashMap<>();
+        long totalStake = 0;
         for (NodeStakeEntry entry : selected.entries()) {
             stakeMap.put(entry.nodeId(), entry.stake());
+            totalStake += entry.stake();
         }
-        return Collections.unmodifiableMap(stakeMap);
+        return new StakeMapWithTotal(Collections.unmodifiableMap(stakeMap), totalStake);
     }
 
     /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -957,7 +957,8 @@ public class LiveSequential implements Runnable {
             List<BlockValidation> parallelValidations = new ArrayList<>();
             parallelValidations.add(new RequiredItemsValidation());
             parallelValidations.add(new BlockStructureValidation());
-            SignatureValidation signatureValidation = new SignatureValidation(addressBookRegistry, nodeStakeRegistry);
+            SignatureValidation signatureValidation =
+                    new SignatureValidation(addressBookRegistry, nodeStakeRegistry, true);
             parallelValidations.add(signatureValidation);
 
             // Create signature stats collector for CSV output

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -71,6 +71,8 @@ import org.hiero.block.tools.blocks.validation.HistoricalBlockTreeValidation;
 import org.hiero.block.tools.blocks.validation.JumpstartValidation;
 import org.hiero.block.tools.blocks.validation.NodeStakeUpdateValidation;
 import org.hiero.block.tools.blocks.validation.RequiredItemsValidation;
+import org.hiero.block.tools.blocks.validation.SignatureBlockStats;
+import org.hiero.block.tools.blocks.validation.SignatureStatsCollector;
 import org.hiero.block.tools.blocks.validation.SignatureValidation;
 import org.hiero.block.tools.blocks.validation.StreamingMerkleTreeValidation;
 import org.hiero.block.tools.config.NetworkConfig;
@@ -958,6 +960,10 @@ public class LiveSequential implements Runnable {
             SignatureValidation signatureValidation = new SignatureValidation(addressBookRegistry, nodeStakeRegistry);
             parallelValidations.add(signatureValidation);
 
+            // Create signature stats collector for CSV output
+            final SignatureStatsCollector statsCollector =
+                    new SignatureStatsCollector(wrapOutputDir.resolve("signature_statistics_live_sequential.csv"));
+
             List<BlockValidation> sequentialValidations = new ArrayList<>();
             sequentialValidations.add(new AddressBookUpdateValidation(addressBookRegistry));
             sequentialValidations.add(new NodeStakeUpdateValidation(nodeStakeRegistry));
@@ -1191,6 +1197,12 @@ public class LiveSequential implements Runnable {
 
                     blocksValidated++;
 
+                    // Collect signature stats from the validation
+                    SignatureBlockStats blockStats = signatureValidation.popBlockStats(blockNum);
+                    if (blockStats != null) {
+                        statsCollector.accept(blockStats);
+                    }
+
                     // Save jumpstart.bin every block (tiny ~1KB write)
                     saveJumpstart(jumpstartPath, blockNum, blockStreamBlockHash, streamingHasher);
 
@@ -1244,6 +1256,11 @@ public class LiveSequential implements Runnable {
                         System.err.println("[WRAP] Warning: finalize failed for " + v.name() + ": " + e.getMessage());
                     }
                 }
+
+                // Finalize and close signature stats collector
+                statsCollector.finalizeDayStats();
+                statsCollector.printFinalSummary();
+                statsCollector.close();
 
                 // Close all validations
                 for (BlockValidation v : allValidations) {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/ValidateWithStats.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/ValidateWithStats.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.days.subcommands;
 
-import static java.nio.file.StandardOpenOption.*;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.time.ZoneOffset.UTC;
@@ -20,22 +19,19 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HexFormat;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import org.hiero.block.tools.blocks.validation.SignatureStatsCollector;
 import org.hiero.block.tools.days.model.AddressBookRegistry;
 import org.hiero.block.tools.days.model.TarZstdDayReaderUsingExec;
 import org.hiero.block.tools.days.model.TarZstdDayUtils;
 import org.hiero.block.tools.mirrornode.DayBlockInfo;
-import org.hiero.block.tools.records.model.unparsed.InMemoryFile;
 import org.hiero.block.tools.records.model.unparsed.UnparsedRecordBlock;
 import org.hiero.block.tools.records.model.unparsed.UnparsedRecordBlock.ValidationResult;
 import org.hiero.block.tools.utils.PrettyPrint;
@@ -82,322 +78,7 @@ public class ValidateWithStats implements Runnable {
     /** Gson instance for Status JSON serialization */
     private static final Gson GSON = new GsonBuilder().create();
 
-    /**
-     * Per-day statistics for signature validation
-     */
-    private static class DayStatistics {
-        final LocalDate date;
-        int totalBlocks = 0;
-        int totalSignatures = 0;
-        int totalValidSignatures = 0;
-        long totalNodeSlots = 0; // Sum of address book node counts across all blocks
-        int minSignaturesInBlock = Integer.MAX_VALUE;
-        // Histogram: blocks grouped by total signature count (index = sig count, value = block count)
-        final Map<Integer, Integer> blocksBySignatureCount = new TreeMap<>();
-
-        DayStatistics(LocalDate date) {
-            this.date = date;
-        }
-
-        void recordBlock(int signatureCount, int validSignatureCount, int addressBookNodeCount) {
-            totalBlocks++;
-            totalSignatures += signatureCount;
-            totalValidSignatures += validSignatureCount;
-            totalNodeSlots += addressBookNodeCount;
-            if (signatureCount < minSignaturesInBlock) {
-                minSignaturesInBlock = signatureCount;
-            }
-            blocksBySignatureCount.merge(signatureCount, 1, Integer::sum);
-        }
-
-        int getAverageAddressBookNodeCount() {
-            if (totalBlocks == 0) return 0;
-            return (int) (totalNodeSlots / totalBlocks);
-        }
-
-        double getAveragePercentage() {
-            if (totalBlocks == 0 || totalNodeSlots == 0) return 0.0;
-            return (100.0 * totalSignatures) / totalNodeSlots;
-        }
-
-        double getValidPercentage() {
-            if (totalBlocks == 0 || totalNodeSlots == 0) return 0.0;
-            return (100.0 * totalValidSignatures) / totalNodeSlots;
-        }
-
-        double getMinPercentage() {
-            int avgNodes = getAverageAddressBookNodeCount();
-            if (totalBlocks == 0 || avgNodes == 0 || minSignaturesInBlock == Integer.MAX_VALUE) return 0.0;
-            return (100.0 * minSignaturesInBlock) / avgNodes;
-        }
-
-        double getAveragePercentagePerBlock() {
-            if (totalBlocks == 0) return 0.0;
-            double avgSigsPerBlock = (double) totalSignatures / totalBlocks;
-            int avgNodes = getAverageAddressBookNodeCount();
-            if (avgNodes == 0) return 0.0;
-            return (100.0 * avgSigsPerBlock) / avgNodes;
-        }
-    }
-
-    /**
-     * Statistics tracker for signature counts per node
-     */
-    private static class SignatureStats {
-        // Node ID -> list of signature counts per block
-        private final Map<String, List<Integer>> nodeSignatureCounts = new TreeMap<>();
-        // Node ID -> list of signature counts per day
-        private final Map<String, List<DayStats>> nodeDayStats = new TreeMap<>();
-        // Per-day statistics
-        private final List<DayStatistics> dailyStatistics = new ArrayList<>();
-        // Current day being tracked
-        private LocalDate currentDay = null;
-        // Current day signature counts per node
-        private final Map<String, Integer> currentDaySignatures = new TreeMap<>();
-        // Current day statistics
-        private DayStatistics currentDayStats = null;
-        // Rolling window for rolling average (last N blocks)
-        private final int rollingWindowSize = 1000;
-        private final Map<String, LinkedList<Integer>> rollingWindows = new TreeMap<>();
-        // CSV output file
-        private final Path csvOutputFile;
-        private boolean csvHeaderWritten = false;
-
-        private static class DayStats {
-            final LocalDate date;
-            final int count;
-
-            DayStats(LocalDate date, int count) {
-                this.date = date;
-                this.count = count;
-            }
-        }
-
-        SignatureStats(Path csvOutputFile) {
-            this.csvOutputFile = csvOutputFile;
-        }
-
-        void startDay(LocalDate day, int addressBookNodeCount) {
-            // Save previous day stats if any
-            if (currentDay != null && currentDayStats != null) {
-                for (Map.Entry<String, Integer> entry : currentDaySignatures.entrySet()) {
-                    nodeDayStats
-                            .computeIfAbsent(entry.getKey(), k -> new ArrayList<>())
-                            .add(new DayStats(currentDay, entry.getValue()));
-                }
-                dailyStatistics.add(currentDayStats);
-                writeDayToCsv(currentDayStats);
-                currentDaySignatures.clear();
-            }
-            currentDay = day;
-            currentDayStats = new DayStatistics(day);
-        }
-
-        void recordBlock(List<InMemoryFile> signatureFiles, int validSignatureCount, int addressBookNodeCount) {
-            // Count signatures per node
-            Map<String, Integer> blockSignatures = new TreeMap<>();
-            int totalSignaturesInBlock = 0;
-
-            for (InMemoryFile sigFile : signatureFiles) {
-                String fileName = sigFile.path().getFileName().toString();
-                // Extract node ID from filename like "node_0.0.3.rcd_sig" or "node_0.0.3.rcs_sig"
-                if (fileName.startsWith("node_") && (fileName.endsWith(".rcd_sig") || fileName.endsWith(".rcs_sig"))) {
-                    String nodeId = fileName.substring(5, fileName.lastIndexOf('.'));
-                    blockSignatures.merge(nodeId, 1, Integer::sum);
-                    totalSignaturesInBlock++;
-                }
-            }
-
-            // Record total signatures for this block in daily statistics
-            if (currentDayStats != null) {
-                currentDayStats.recordBlock(totalSignaturesInBlock, validSignatureCount, addressBookNodeCount);
-            }
-
-            // Record per-block counts
-            for (Map.Entry<String, Integer> entry : blockSignatures.entrySet()) {
-                String nodeId = entry.getKey();
-                int count = entry.getValue();
-
-                nodeSignatureCounts
-                        .computeIfAbsent(nodeId, k -> new ArrayList<>())
-                        .add(count);
-                currentDaySignatures.merge(nodeId, count, Integer::sum);
-
-                // Update rolling window
-                LinkedList<Integer> window = rollingWindows.computeIfAbsent(nodeId, k -> new LinkedList<>());
-                window.addLast(count);
-                if (window.size() > rollingWindowSize) {
-                    window.removeFirst();
-                }
-            }
-        }
-
-        void finalizeDayStats() {
-            if (currentDay != null && currentDayStats != null) {
-                for (Map.Entry<String, Integer> entry : currentDaySignatures.entrySet()) {
-                    nodeDayStats
-                            .computeIfAbsent(entry.getKey(), k -> new ArrayList<>())
-                            .add(new DayStats(currentDay, entry.getValue()));
-                }
-                dailyStatistics.add(currentDayStats);
-                writeDayToCsv(currentDayStats);
-            }
-        }
-
-        private void writeCsvHeader() {
-            if (csvHeaderWritten || csvOutputFile == null) return;
-            try {
-                // If file exists, always append (resume case) - never overwrite existing data
-                if (Files.exists(csvOutputFile)) {
-                    long fileSize = Files.size(csvOutputFile);
-                    if (fileSize > 0) {
-                        csvHeaderWritten = true;
-                        System.out.println("[CSV] Resuming - appending to existing file (" + fileSize + " bytes): "
-                                + csvOutputFile);
-                        return;
-                    }
-                    // File exists but is empty - delete it so we can create fresh
-                    System.out.println("[CSV] Removing empty CSV file: " + csvOutputFile);
-                    Files.delete(csvOutputFile);
-                }
-                // Create new file with header
-                int maxSigCount = 40;
-                StringBuilder header = new StringBuilder();
-                header.append(
-                        "date,percentage,number_of_blocks,number_of_nodes,valid_signatures,worst_block_signature_coverage_percentage,avg_percentage_per_block");
-                for (int i = 1; i <= maxSigCount; i++) {
-                    header.append(",blocks_with_").append(i).append("_sig");
-                }
-                header.append("\n");
-
-                // Use CREATE_NEW to fail if file somehow exists (safety check)
-                Files.writeString(csvOutputFile, header.toString(), StandardCharsets.UTF_8, CREATE_NEW, WRITE);
-                csvHeaderWritten = true;
-                System.out.println("[CSV] Created new CSV file: " + csvOutputFile);
-            } catch (IOException e) {
-                System.err.println("Failed to write CSV header to " + csvOutputFile + ": " + e.getMessage());
-            }
-        }
-
-        private void writeDayToCsv(DayStatistics dayStats) {
-            if (csvOutputFile == null) return;
-
-            try {
-                if (!csvHeaderWritten) {
-                    writeCsvHeader();
-                }
-
-                StringBuilder row = new StringBuilder();
-                row.append(dayStats.date).append(",");
-                row.append(String.format("%.4f", dayStats.getAveragePercentage()))
-                        .append(",");
-                row.append(dayStats.totalBlocks).append(",");
-                row.append(dayStats.getAverageAddressBookNodeCount()).append(",");
-                row.append(dayStats.totalValidSignatures).append(",");
-                row.append(String.format("%.4f", dayStats.getMinPercentage())).append(",");
-                row.append(String.format("%.4f", dayStats.getAveragePercentagePerBlock()));
-
-                // Write histogram data (blocks with 1 sig, blocks with 2 sigs, etc.)
-                int maxSigCount = 40;
-                for (int i = 1; i <= maxSigCount; i++) {
-                    int blockCount = dayStats.blocksBySignatureCount.getOrDefault(i, 0);
-                    row.append(",").append(blockCount);
-                }
-                row.append("\n");
-
-                Files.writeString(csvOutputFile, row.toString(), StandardCharsets.UTF_8, APPEND, CREATE);
-
-                System.out.println("[CSV] Written statistics for " + dayStats.date + " to " + csvOutputFile);
-            } catch (IOException e) {
-                System.err.println("Failed to write day stats to CSV for " + dayStats.date + ": " + e.getMessage());
-            }
-        }
-
-        void printStatistics() {
-            System.out.println("\n" + "=".repeat(80));
-            System.out.println("VALIDATION COMPLETE - ALL STATISTICS WRITTEN TO CSV");
-            System.out.println("=".repeat(80));
-
-            if (dailyStatistics.isEmpty()) {
-                System.out.println("No daily statistics collected.");
-                return;
-            }
-
-            // Print overall summary
-            long totalBlocks =
-                    dailyStatistics.stream().mapToLong(ds -> ds.totalBlocks).sum();
-            long totalSignatures =
-                    dailyStatistics.stream().mapToLong(ds -> ds.totalSignatures).sum();
-            int totalDays = dailyStatistics.size();
-
-            System.out.printf("Total Days:        %d%n", totalDays);
-            System.out.printf("Total Blocks:      %,d%n", totalBlocks);
-            System.out.printf("Total Signatures:  %,d%n", totalSignatures);
-
-            if (totalBlocks > 0) {
-                double avgSigsPerBlock = (double) totalSignatures / (double) totalBlocks;
-                System.out.printf("Avg Sigs/Block:    %.2f%n", avgSigsPerBlock);
-            }
-
-            System.out.println("\nDetailed per-day statistics have been written to:");
-            System.out.println("  " + csvOutputFile);
-            System.out.println("\n" + "=".repeat(80));
-        }
-
-        void printDayCompletedSummary(LocalDate day) {
-            // Use currentDayStats if it matches, otherwise search in dailyStatistics
-            final DayStatistics dayStats;
-            if (currentDayStats != null && currentDayStats.date.equals(day)) {
-                dayStats = currentDayStats;
-            } else {
-                dayStats = dailyStatistics.stream()
-                        .filter(ds -> ds.date.equals(day))
-                        .findFirst()
-                        .orElse(null);
-            }
-
-            if (dayStats == null) {
-                System.out.println("\n[WARNING] No statistics found for day: " + day);
-                return;
-            }
-
-            PrettyPrint.clearProgress();
-            System.out.println("\n" + "═".repeat(80));
-            System.out.println("DAY COMPLETED: " + day);
-            System.out.println("═".repeat(80));
-            System.out.printf("  Date:                     %s%n", dayStats.date);
-            System.out.printf("  Total Blocks:             %,d%n", dayStats.totalBlocks);
-            System.out.printf("  Total Signatures:         %,d%n", dayStats.totalSignatures);
-            System.out.printf("  Valid Signatures:         %,d%n", dayStats.totalValidSignatures);
-            System.out.printf("  Address Book Nodes (avg): %d%n", dayStats.getAverageAddressBookNodeCount());
-            System.out.printf("  Worst Block Coverage:     %.2f%%%n", dayStats.getMinPercentage());
-            System.out.printf("  Avg Percentage Per Block: %.2f%%%n", dayStats.getAveragePercentagePerBlock());
-            System.out.printf("  Average Percentage:       %.2f%%%n", dayStats.getAveragePercentage());
-            System.out.printf("  Valid Percentage:         %.2f%%%n", dayStats.getValidPercentage());
-
-            // Print histogram summary (show top signature counts)
-            if (!dayStats.blocksBySignatureCount.isEmpty()) {
-                System.out.println("\n  Signature Distribution:");
-                System.out.println("  " + "─".repeat(60));
-                System.out.printf("  %-20s %10s %10s%n", "Signatures/Block", "Block Count", "Percentage");
-                System.out.println("  " + "─".repeat(60));
-
-                // Show top 10 most common signature counts
-                dayStats.blocksBySignatureCount.entrySet().stream()
-                        .sorted((a, b) -> b.getValue().compareTo(a.getValue()))
-                        .limit(10)
-                        .forEach(entry -> {
-                            int sigCount = entry.getKey();
-                            int blockCount = entry.getValue();
-                            double percentage = (100.0 * blockCount) / dayStats.totalBlocks;
-                            System.out.printf("  %-20d %,10d %9.2f%%%n", sigCount, blockCount, percentage);
-                        });
-
-                System.out.println("  " + "─".repeat(60));
-            }
-            System.out.println("═".repeat(80) + "\n");
-        }
-    }
+    // Statistics tracking is delegated to SignatureStatsCollector
 
     /**
      * Simple wrapper for producer-consumer communication (day boundaries + blocks)
@@ -514,7 +195,7 @@ public class ValidateWithStats implements Runnable {
         System.out.println("CSV output will be written to: " + csvOutputFile);
 
         // Initialize statistics tracker
-        final SignatureStats stats = new SignatureStats(csvOutputFile);
+        final SignatureStatsCollector stats = new SignatureStatsCollector(csvOutputFile);
 
         // create AddressBookRegistry
         final Path addressBookFile = compressedDaysDir.toPath().resolve("addressBookHistory.json");
@@ -635,7 +316,7 @@ public class ValidateWithStats implements Runnable {
                             }
                             // Print statistics on shutdown
                             stats.finalizeDayStats();
-                            stats.printStatistics();
+                            stats.printFinalSummary();
                         },
                         "validate-shutdown-hook"));
 
@@ -903,7 +584,7 @@ public class ValidateWithStats implements Runnable {
 
         // Finalize and print statistics
         stats.finalizeDayStats();
-        stats.printStatistics();
+        stats.printFinalSummary();
 
         Status sFinal = lastGood.get();
         if (sFinal != null) Status.writeStatusFile(statusFile, sFinal);

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/SignatureStatsCollectorTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/SignatureStatsCollectorTest.java
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.blocks.validation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Tests for {@link SignatureStatsCollector}. */
+class SignatureStatsCollectorTest {
+
+    @Nested
+    @DisplayName("Per-day aggregation")
+    class PerDayAggregation {
+
+        @Test
+        @DisplayName("single block creates one day entry")
+        void singleBlockCreatesOneDayEntry(@TempDir Path tempDir) {
+            Path csvFile = tempDir.resolve("stats.csv");
+            SignatureStatsCollector collector = new SignatureStatsCollector(csvFile);
+
+            Instant blockTime = Instant.parse("2023-06-15T12:00:00Z");
+            collector.accept(new SignatureBlockStats(
+                    100,
+                    blockTime,
+                    true,
+                    5,
+                    1500,
+                    500,
+                    Set.of(0L, 1L, 2L),
+                    600,
+                    5,
+                    Map.of(0L, 100L, 1L, 200L, 2L, 300L, 3L, 400L, 4L, 500L),
+                    Map.of(
+                            0L, SignatureBlockStats.NodeResult.VERIFIED,
+                            1L, SignatureBlockStats.NodeResult.VERIFIED,
+                            2L, SignatureBlockStats.NodeResult.VERIFIED,
+                            3L, SignatureBlockStats.NodeResult.NOT_PRESENT,
+                            4L, SignatureBlockStats.NodeResult.NOT_PRESENT)));
+
+            collector.finalizeDayStats();
+            collector.close();
+
+            assertTrue(Files.exists(csvFile));
+        }
+
+        @Test
+        @DisplayName("multiple blocks same day aggregated together")
+        void multipleBlocksSameDayAggregated(@TempDir Path tempDir) throws IOException {
+            Path csvFile = tempDir.resolve("stats.csv");
+            SignatureStatsCollector collector = new SignatureStatsCollector(csvFile);
+
+            Instant time1 = Instant.parse("2023-06-15T10:00:00Z");
+            Instant time2 = Instant.parse("2023-06-15T14:00:00Z");
+            Map<Long, Long> stakeMap = Map.of(0L, 100L, 1L, 200L, 2L, 300L);
+
+            collector.accept(new SignatureBlockStats(
+                    1,
+                    time1,
+                    true,
+                    3,
+                    600,
+                    200,
+                    Set.of(0L, 1L),
+                    300,
+                    3,
+                    stakeMap,
+                    Map.of(
+                            0L, SignatureBlockStats.NodeResult.VERIFIED,
+                            1L, SignatureBlockStats.NodeResult.VERIFIED,
+                            2L, SignatureBlockStats.NodeResult.NOT_PRESENT)));
+
+            collector.accept(new SignatureBlockStats(
+                    2,
+                    time2,
+                    true,
+                    3,
+                    600,
+                    200,
+                    Set.of(0L, 1L, 2L),
+                    600,
+                    3,
+                    stakeMap,
+                    Map.of(
+                            0L, SignatureBlockStats.NodeResult.VERIFIED,
+                            1L, SignatureBlockStats.NodeResult.VERIFIED,
+                            2L, SignatureBlockStats.NodeResult.VERIFIED)));
+
+            collector.finalizeDayStats();
+            collector.close();
+
+            String csv = Files.readString(csvFile);
+            String[] lines = csv.split("\n");
+            assertEquals(2, lines.length, "Should have header + 1 day row");
+            assertTrue(lines[1].startsWith("2023-06-15"), "Row should start with the day date");
+        }
+
+        @Test
+        @DisplayName("blocks on different days create separate entries")
+        void differentDaysCreateSeparateEntries(@TempDir Path tempDir) throws IOException {
+            Path csvFile = tempDir.resolve("stats.csv");
+            SignatureStatsCollector collector = new SignatureStatsCollector(csvFile);
+
+            Map<Long, Long> stakeMap = Map.of(0L, 100L, 1L, 200L);
+
+            collector.accept(new SignatureBlockStats(
+                    1,
+                    Instant.parse("2023-06-15T12:00:00Z"),
+                    true,
+                    2,
+                    300,
+                    100,
+                    Set.of(0L, 1L),
+                    300,
+                    2,
+                    stakeMap,
+                    Map.of(
+                            0L, SignatureBlockStats.NodeResult.VERIFIED,
+                            1L, SignatureBlockStats.NodeResult.VERIFIED)));
+
+            collector.accept(new SignatureBlockStats(
+                    2,
+                    Instant.parse("2023-06-16T12:00:00Z"),
+                    true,
+                    2,
+                    300,
+                    100,
+                    Set.of(0L, 1L),
+                    300,
+                    2,
+                    stakeMap,
+                    Map.of(
+                            0L, SignatureBlockStats.NodeResult.VERIFIED,
+                            1L, SignatureBlockStats.NodeResult.VERIFIED)));
+
+            collector.finalizeDayStats();
+            collector.close();
+
+            String csv = Files.readString(csvFile);
+            String[] lines = csv.split("\n");
+            assertEquals(3, lines.length, "Should have header + 2 day rows");
+            assertTrue(lines[1].startsWith("2023-06-15"));
+            assertTrue(lines[2].startsWith("2023-06-16"));
+        }
+    }
+
+    @Nested
+    @DisplayName("CSV output")
+    class CsvOutput {
+
+        @Test
+        @DisplayName("header includes stake weight columns")
+        void headerIncludesStakeWeightColumns(@TempDir Path tempDir) throws IOException {
+            Path csvFile = tempDir.resolve("stats.csv");
+            SignatureStatsCollector collector = new SignatureStatsCollector(csvFile);
+
+            collector.accept(new SignatureBlockStats(
+                    1,
+                    Instant.parse("2023-06-15T12:00:00Z"),
+                    true,
+                    3,
+                    600,
+                    200,
+                    Set.of(0L, 1L),
+                    300,
+                    3,
+                    Map.of(0L, 100L, 1L, 200L, 2L, 300L),
+                    Map.of(
+                            0L, SignatureBlockStats.NodeResult.VERIFIED,
+                            1L, SignatureBlockStats.NodeResult.VERIFIED,
+                            2L, SignatureBlockStats.NodeResult.NOT_PRESENT)));
+
+            collector.finalizeDayStats();
+            collector.close();
+
+            String header = Files.readAllLines(csvFile).getFirst();
+            assertTrue(header.contains("mode"), "Header should contain mode column");
+            assertTrue(header.contains("total_stake"), "Header should contain total_stake column");
+            assertTrue(header.contains("min_validated_stake_pct"));
+            assertTrue(header.contains("max_validated_stake_pct"));
+            assertTrue(header.contains("mean_validated_stake_pct"));
+            assertTrue(header.contains("closest_threshold_margin"));
+            assertTrue(header.contains("min_signing_nodes"));
+            assertTrue(header.contains("max_signing_nodes"));
+            assertTrue(header.contains("mean_signing_nodes"));
+            assertTrue(header.contains("min_node_stake"));
+            assertTrue(header.contains("max_node_stake"));
+            assertTrue(header.contains("mean_node_stake"));
+            assertTrue(header.contains("median_node_stake"));
+            assertTrue(header.contains("std_dev_node_stake"));
+            assertTrue(header.contains("top3_concentration_pct"));
+            assertTrue(header.contains("missing_signers"));
+            assertTrue(header.contains("reliable_signers"));
+        }
+
+        @Test
+        @DisplayName("stake-weighted row contains mode and stake data")
+        void stakeWeightedRowContainsModeAndStakeData(@TempDir Path tempDir) throws IOException {
+            Path csvFile = tempDir.resolve("stats.csv");
+            SignatureStatsCollector collector = new SignatureStatsCollector(csvFile);
+
+            collector.accept(new SignatureBlockStats(
+                    1,
+                    Instant.parse("2023-06-15T12:00:00Z"),
+                    true,
+                    3,
+                    600,
+                    200,
+                    Set.of(0L, 1L, 2L),
+                    600,
+                    3,
+                    Map.of(0L, 100L, 1L, 200L, 2L, 300L),
+                    Map.of(
+                            0L, SignatureBlockStats.NodeResult.VERIFIED,
+                            1L, SignatureBlockStats.NodeResult.VERIFIED,
+                            2L, SignatureBlockStats.NodeResult.VERIFIED)));
+
+            collector.finalizeDayStats();
+            collector.close();
+
+            String dataRow = Files.readAllLines(csvFile).get(1);
+            assertTrue(dataRow.contains("stake-weighted"), "Row should contain stake-weighted mode");
+            assertTrue(dataRow.contains("600"), "Row should contain total stake");
+        }
+
+        @Test
+        @DisplayName("null csv path does not throw")
+        void nullCsvPathDoesNotThrow() {
+            assertDoesNotThrow(() -> {
+                SignatureStatsCollector collector = new SignatureStatsCollector(null);
+                collector.accept(new SignatureBlockStats(
+                        1,
+                        Instant.parse("2023-06-15T12:00:00Z"),
+                        false,
+                        3,
+                        3,
+                        2,
+                        Set.of(0L, 1L),
+                        2,
+                        3,
+                        Map.of(),
+                        Map.of(
+                                0L, SignatureBlockStats.NodeResult.VERIFIED,
+                                1L, SignatureBlockStats.NodeResult.VERIFIED,
+                                2L, SignatureBlockStats.NodeResult.NOT_PRESENT)));
+                collector.finalizeDayStats();
+                collector.printFinalSummary();
+                collector.close();
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("Stake weight distribution")
+    class StakeWeightDistribution {
+
+        @Test
+        @DisplayName("min/max/mean/median calculated correctly")
+        void stakeDistributionCalculatedCorrectly(@TempDir Path tempDir) throws IOException {
+            Path csvFile = tempDir.resolve("stats.csv");
+            SignatureStatsCollector collector = new SignatureStatsCollector(csvFile);
+
+            // Stakes: 100, 200, 300 -> min=100, max=300, mean=200, median=200
+            collector.accept(new SignatureBlockStats(
+                    1,
+                    Instant.parse("2023-06-15T12:00:00Z"),
+                    true,
+                    3,
+                    600,
+                    200,
+                    Set.of(0L, 1L, 2L),
+                    600,
+                    3,
+                    Map.of(0L, 100L, 1L, 200L, 2L, 300L),
+                    Map.of(
+                            0L, SignatureBlockStats.NodeResult.VERIFIED,
+                            1L, SignatureBlockStats.NodeResult.VERIFIED,
+                            2L, SignatureBlockStats.NodeResult.VERIFIED)));
+
+            collector.finalizeDayStats();
+            collector.close();
+
+            String dataRow = Files.readAllLines(csvFile).get(1);
+            assertTrue(dataRow.contains(",100,"), "Should contain min stake of 100");
+            assertTrue(dataRow.contains(",300,"), "Should contain max stake of 300");
+        }
+
+        @Test
+        @DisplayName("top3 concentration calculates correctly with fewer than 3 nodes")
+        void top3ConcentrationWithFewerThan3Nodes(@TempDir Path tempDir) throws IOException {
+            Path csvFile = tempDir.resolve("stats.csv");
+            SignatureStatsCollector collector = new SignatureStatsCollector(csvFile);
+
+            // Only 2 nodes -> top3 = both = 100%
+            collector.accept(new SignatureBlockStats(
+                    1,
+                    Instant.parse("2023-06-15T12:00:00Z"),
+                    true,
+                    2,
+                    500,
+                    167,
+                    Set.of(0L, 1L),
+                    500,
+                    2,
+                    Map.of(0L, 200L, 1L, 300L),
+                    Map.of(
+                            0L, SignatureBlockStats.NodeResult.VERIFIED,
+                            1L, SignatureBlockStats.NodeResult.VERIFIED)));
+
+            collector.finalizeDayStats();
+            collector.close();
+
+            String dataRow = Files.readAllLines(csvFile).get(1);
+            assertTrue(dataRow.contains("100.0000"), "Top3 with 2 nodes should be 100%");
+        }
+    }
+
+    @Nested
+    @DisplayName("Missing and reliable signers")
+    class MissingAndReliableSigners {
+
+        @Test
+        @DisplayName("node that never signs is counted as missing")
+        void nodeThatNeverSignsIsMissing(@TempDir Path tempDir) throws IOException {
+            Path csvFile = tempDir.resolve("stats.csv");
+            SignatureStatsCollector collector = new SignatureStatsCollector(csvFile);
+
+            Map<Long, Long> stakeMap = Map.of(0L, 100L, 1L, 200L, 2L, 300L);
+            Map<Long, SignatureBlockStats.NodeResult> results = Map.of(
+                    0L, SignatureBlockStats.NodeResult.VERIFIED,
+                    1L, SignatureBlockStats.NodeResult.VERIFIED,
+                    2L, SignatureBlockStats.NodeResult.NOT_PRESENT);
+
+            // Node 2 never signs across 2 blocks
+            collector.accept(new SignatureBlockStats(
+                    1,
+                    Instant.parse("2023-06-15T10:00:00Z"),
+                    true,
+                    3,
+                    600,
+                    200,
+                    Set.of(0L, 1L),
+                    300,
+                    2,
+                    stakeMap,
+                    results));
+
+            collector.accept(new SignatureBlockStats(
+                    2,
+                    Instant.parse("2023-06-15T14:00:00Z"),
+                    true,
+                    3,
+                    600,
+                    200,
+                    Set.of(0L, 1L),
+                    300,
+                    2,
+                    stakeMap,
+                    results));
+
+            collector.finalizeDayStats();
+            collector.close();
+
+            String dataRow = Files.readAllLines(csvFile).get(1);
+            assertTrue(dataRow.endsWith(",1,2"), "Should end with 1 missing, 2 reliable signers");
+        }
+    }
+
+    @Nested
+    @DisplayName("SignatureBlockStats.fromPreVerifiedData")
+    class FromPreVerifiedData {
+
+        @Test
+        @DisplayName("builds stats correctly from pre-verified data")
+        void buildsStatsFromPreVerifiedData() {
+            SignatureBlockStats stats = SignatureBlockStats.fromPreVerifiedData(
+                    42,
+                    Instant.parse("2023-06-15T12:00:00Z"),
+                    List.of(0L, 1L, 2L),
+                    3,
+                    List.of(0L, 1L, 2L, 3L, 4L),
+                    Map.of(0L, 100L, 1L, 200L, 2L, 300L, 3L, 400L, 4L, 500L));
+
+            assertEquals(42, stats.blockNumber());
+            assertTrue(stats.stakeWeighted());
+            assertEquals(5, stats.totalNodes());
+            assertEquals(1500, stats.totalStake());
+            assertEquals(500, stats.threshold());
+            assertEquals(Set.of(0L, 1L, 2L), stats.validatedNodes());
+            assertEquals(600, stats.validatedStake());
+            assertEquals(3, stats.totalSignatures());
+            assertEquals(5, stats.perNodeResults().size());
+            assertEquals(
+                    SignatureBlockStats.NodeResult.VERIFIED,
+                    stats.perNodeResults().get(0L));
+            assertEquals(
+                    SignatureBlockStats.NodeResult.NOT_PRESENT,
+                    stats.perNodeResults().get(3L));
+        }
+
+        @Test
+        @DisplayName("null stake map falls back to equal-weight")
+        void nullStakeMapFallsBackToEqualWeight() {
+            SignatureBlockStats stats = SignatureBlockStats.fromPreVerifiedData(
+                    1, Instant.parse("2023-06-15T12:00:00Z"), List.of(0L, 1L), 2, List.of(0L, 1L, 2L), null);
+
+            assertFalse(stats.stakeWeighted());
+            assertEquals(3, stats.totalNodes());
+            assertEquals(3, stats.totalStake());
+            assertEquals(2, stats.threshold());
+            assertEquals(2, stats.validatedStake());
+        }
+
+        @Test
+        @DisplayName("duplicate verified node IDs counted once")
+        void duplicateVerifiedNodeIdsCountedOnce() {
+            SignatureBlockStats stats = SignatureBlockStats.fromPreVerifiedData(
+                    1,
+                    Instant.parse("2023-06-15T12:00:00Z"),
+                    List.of(0L, 0L, 1L),
+                    3,
+                    List.of(0L, 1L, 2L),
+                    Map.of(0L, 100L, 1L, 200L, 2L, 300L));
+
+            assertEquals(Set.of(0L, 1L), stats.validatedNodes());
+            assertEquals(300, stats.validatedStake());
+        }
+    }
+}

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/SignatureValidationTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/SignatureValidationTest.java
@@ -2,7 +2,10 @@
 package org.hiero.block.tools.blocks.validation;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -457,6 +460,136 @@ class SignatureValidationTest {
             // 5 nodes all sign → passes equal-weight threshold of 2
             SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry);
             assertDoesNotThrow(() -> validation.validate(toUnparsed(chain.getFirst()), 0));
+        }
+    }
+
+    @Nested
+    @DisplayName("Detailed stats collection")
+    class DetailedStatsCollection {
+
+        @Test
+        @DisplayName("stats collected on successful validation")
+        void statsCollectedOnSuccess(@TempDir Path tempDir) throws Exception {
+            List<Block> chain = TestBlockFactory.createValidChain(1);
+            TestBlockFactory.writeAddressBookHistory(tempDir);
+            AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
+
+            SignatureValidation validation = new SignatureValidation(abRegistry, null, true);
+            assertDoesNotThrow(() -> validation.validate(toUnparsed(chain.getFirst()), 0));
+
+            SignatureBlockStats stats = validation.popBlockStats(0);
+            assertNotNull(stats, "Should have stats for block 0");
+            assertEquals(0, stats.blockNumber());
+            assertFalse(stats.validatedNodes().isEmpty(), "Should have validated nodes");
+            assertTrue(stats.validatedStake() > 0, "Should have positive validated stake");
+        }
+
+        @Test
+        @DisplayName("stats not collected when disabled")
+        void statsNotCollectedWhenDisabled(@TempDir Path tempDir) throws Exception {
+            List<Block> chain = TestBlockFactory.createValidChain(1);
+            TestBlockFactory.writeAddressBookHistory(tempDir);
+            AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
+
+            // Default constructor — stats disabled
+            SignatureValidation validation = new SignatureValidation(abRegistry);
+            assertDoesNotThrow(() -> validation.validate(toUnparsed(chain.getFirst()), 0));
+
+            assertNull(validation.popBlockStats(0), "Should not have stats when disabled");
+        }
+
+        @Test
+        @DisplayName("stats not collected on validation failure")
+        void statsNotCollectedOnFailure(@TempDir Path tempDir) throws Exception {
+            List<Block> chain = TestBlockFactory.createValidChain(1);
+            Block block = chain.getFirst();
+            // Keep only 1 signature — below threshold
+            List<BlockItem> items = new ArrayList<>();
+            for (BlockItem item : block.items()) {
+                if (item.hasBlockProof()) {
+                    SignedRecordFileProof orig = item.blockProofOrThrow().signedRecordFileProofOrThrow();
+                    List<RecordFileSignature> oneSig =
+                            List.of(orig.recordFileSignatures().getFirst());
+                    items.add(BlockItem.newBuilder()
+                            .blockProof(BlockProof.newBuilder()
+                                    .signedRecordFileProof(SignedRecordFileProof.newBuilder()
+                                            .version(orig.version())
+                                            .recordFileSignatures(oneSig)
+                                            .build())
+                                    .build())
+                            .build());
+                } else {
+                    items.add(item);
+                }
+            }
+            Block blockWith1Sig = new Block(items);
+
+            TestBlockFactory.writeAddressBookHistory(tempDir);
+            AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
+
+            SignatureValidation validation = new SignatureValidation(abRegistry, null, true);
+            assertThrows(ValidationException.class, () -> validation.validate(toUnparsed(blockWith1Sig), 0));
+
+            assertNull(validation.popBlockStats(0), "Should not have stats on failure");
+        }
+
+        @Test
+        @DisplayName("popBlockStats removes entry after retrieval")
+        void popBlockStatsRemovesEntry(@TempDir Path tempDir) throws Exception {
+            List<Block> chain = TestBlockFactory.createValidChain(1);
+            TestBlockFactory.writeAddressBookHistory(tempDir);
+            AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
+
+            SignatureValidation validation = new SignatureValidation(abRegistry, null, true);
+            assertDoesNotThrow(() -> validation.validate(toUnparsed(chain.getFirst()), 0));
+
+            assertNotNull(validation.popBlockStats(0), "First pop should return stats");
+            assertNull(validation.popBlockStats(0), "Second pop should return null");
+        }
+
+        @Test
+        @DisplayName("stats include per-node results with NOT_PRESENT for non-signers")
+        void statsIncludePerNodeResults(@TempDir Path tempDir) throws Exception {
+            List<Block> chain = TestBlockFactory.createValidChain(1);
+            TestBlockFactory.writeAddressBookHistory(tempDir);
+            AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
+
+            // Remove all but 2 signatures to have some NOT_PRESENT nodes
+            Block block = chain.getFirst();
+            List<BlockItem> items = new ArrayList<>();
+            for (BlockItem item : block.items()) {
+                if (item.hasBlockProof()) {
+                    SignedRecordFileProof orig = item.blockProofOrThrow().signedRecordFileProofOrThrow();
+                    List<RecordFileSignature> twoSigs =
+                            new ArrayList<>(orig.recordFileSignatures().subList(0, 2));
+                    items.add(BlockItem.newBuilder()
+                            .blockProof(BlockProof.newBuilder()
+                                    .signedRecordFileProof(SignedRecordFileProof.newBuilder()
+                                            .version(orig.version())
+                                            .recordFileSignatures(twoSigs)
+                                            .build())
+                                    .build())
+                            .build());
+                } else {
+                    items.add(item);
+                }
+            }
+            Block blockWith2Sigs = new Block(items);
+
+            SignatureValidation validation = new SignatureValidation(abRegistry, null, true);
+            assertDoesNotThrow(() -> validation.validate(toUnparsed(blockWith2Sigs), 0));
+
+            SignatureBlockStats stats = validation.popBlockStats(0);
+            assertNotNull(stats);
+
+            // Should have 5 nodes total (TestBlockFactory creates 5)
+            assertEquals(5, stats.perNodeResults().size(), "Should have results for all 5 address book nodes");
+
+            // Count NOT_PRESENT
+            long notPresent = stats.perNodeResults().values().stream()
+                    .filter(r -> r == SignatureBlockStats.NodeResult.NOT_PRESENT)
+                    .count();
+            assertEquals(3, notPresent, "3 nodes should be NOT_PRESENT");
         }
     }
 }

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/SignatureValidationTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/SignatureValidationTest.java
@@ -296,7 +296,7 @@ class SignatureValidationTest {
             TestBlockFactory.writeAddressBookHistory(tempDir);
             AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
             // null stake registry → equal-weight mode
-            SignatureValidation validation = new SignatureValidation(abRegistry, null);
+            SignatureValidation validation = new SignatureValidation(abRegistry, null, true);
             assertDoesNotThrow(() -> validation.validate(toUnparsed(chain.getFirst()), 0));
         }
 
@@ -308,18 +308,7 @@ class SignatureValidationTest {
             AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
             NodeStakeRegistry stakeRegistry = new NodeStakeRegistry();
             // Empty stake registry → equal-weight fallback
-            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry);
-            assertDoesNotThrow(() -> validation.validate(toUnparsed(chain.getFirst()), 0));
-        }
-
-        @Test
-        @DisplayName("two-arg constructor backward compatible with single-arg")
-        void twoArgConstructorBackwardCompatible(@TempDir Path tempDir) throws Exception {
-            List<Block> chain = TestBlockFactory.createValidChain(1);
-            TestBlockFactory.writeAddressBookHistory(tempDir);
-            AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
-            // Single-arg constructor should still work
-            SignatureValidation validation = new SignatureValidation(abRegistry);
+            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry, true);
             assertDoesNotThrow(() -> validation.validate(toUnparsed(chain.getFirst()), 0));
         }
 
@@ -353,7 +342,7 @@ class SignatureValidationTest {
             AddressBookRegistry abRegistry = new AddressBookRegistry(tempDir.resolve("addressBookHistory.json"));
             // Empty stake registry → equal-weight fallback
             NodeStakeRegistry stakeRegistry = new NodeStakeRegistry();
-            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry);
+            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry, true);
             ValidationException ex =
                     assertThrows(ValidationException.class, () -> validation.validate(toUnparsed(blockWith1Sig), 0));
             assertTrue(ex.getMessage().contains("mode=equal-weight"), "Should show equal-weight mode");
@@ -381,7 +370,7 @@ class SignatureValidationTest {
                             .build());
 
             // totalStake=1500, threshold=ceil(1500/3)=500. All 5 nodes sign → 1500 >= 500
-            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry);
+            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry, true);
             assertDoesNotThrow(() -> validation.validate(toUnparsed(chain.getFirst()), 0));
         }
 
@@ -429,7 +418,7 @@ class SignatureValidationTest {
                             .build());
 
             // totalStake=1500, threshold=500. Node 0 stake=100 < 500
-            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry);
+            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry, true);
             ValidationException ex =
                     assertThrows(ValidationException.class, () -> validation.validate(toUnparsed(blockWith1Sig), 0));
             assertTrue(ex.getMessage().contains("mode=stake-weighted"), "Should show stake-weighted mode");
@@ -458,7 +447,7 @@ class SignatureValidationTest {
 
             // totalStake=0 → should fall back to equal-weight, not pass with threshold=0
             // 5 nodes all sign → passes equal-weight threshold of 2
-            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry);
+            SignatureValidation validation = new SignatureValidation(abRegistry, stakeRegistry, true);
             assertDoesNotThrow(() -> validation.validate(toUnparsed(chain.getFirst()), 0));
         }
     }


### PR DESCRIPTION
## Summary
- Extract `DayStatistics` and `SignatureStats` from `ValidateWithStats` into reusable `SignatureStatsCollector` class
- Add `SignatureBlockStats` record for per-block signature validation data with `NodeResult` enum and `fromPreVerifiedData()` factory
- Extend CSV output with 17 new stake weight columns: mode, total_stake, validated stake % (min/max/mean), closest threshold margin, signing node counts (min/max/mean), node stake distribution (min/max/mean/median/stddev), top-3 concentration %, missing signers, reliable signers
- Wire stats collection into `ValidateBlocksCommand`, `LiveSequential`, and `ToWrappedBlocksCommand` with command-specific CSV filenames
- Add `StakeMapWithTotal` to `NodeStakeRegistry` to avoid recomputing total stake per block
- Optimize `SignatureValidation` with lazy diagnostics — no string formatting on the happy path
- Stats collection enabled by default on the 2-arg constructor

closes: #2504 