### PR TITLE
fix: off-by-one in clearObsoleteQueueItems

### DIFF
--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -388,13 +388,13 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     /// This will discard buffered data for blocks that will never be forwarded
     /// and prevent the forwarder becoming "stuck" on an incomplete block.
     ///
-    /// @param blockNumber the latest persisted block number. Only queue
-    ///     entries whose key is strictly less than this value are candidates
+    /// @param blockNumber the latest persisted block number. Queue entries
+    ///     whose key is less than or equal to this value are candidates
     ///     for removal.
     private void clearObsoleteQueueItems(final long blockNumber) {
         if (queueByBlockMap != null && !queueByBlockMap.isEmpty()) {
             final NavigableSet<Long> keysBeforeBlock = new TreeSet<>();
-            keysBeforeBlock.addAll(queueByBlockMap.headMap(blockNumber).keySet());
+            keysBeforeBlock.addAll(queueByBlockMap.headMap(blockNumber, true).keySet());
             for (final Long candidate : keysBeforeBlock) {
                 if (!(blockProofs.containsKey(candidate) || hasBlockProof(queueByBlockMap.get(candidate)))) {
                     queueByBlockMap.remove(candidate);

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherManagerRegressionTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherManagerRegressionTest.java
@@ -17,6 +17,7 @@ import org.hiero.block.node.app.fixtures.TestUtils;
 import org.hiero.block.node.app.fixtures.async.BlockingExecutor;
 import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
 import org.hiero.block.node.app.fixtures.async.TestThreadPoolManager;
+import org.hiero.block.node.app.fixtures.blocks.TestBlock;
 import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
 import org.hiero.block.node.app.fixtures.pipeline.TestResponsePipeline;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleBlockRangeSet;
@@ -44,6 +45,8 @@ import org.junit.jupiter.api.Test;
 class PublisherManagerRegressionTest {
 
     private SimpleInMemoryHistoricalBlockFacility historicalBlockFacility;
+    private TestThreadPoolManager<BlockingExecutor, ScheduledBlockingExecutor> threadPoolManager;
+    private TestBlockMessagingFacility messagingFacility;
     private LiveStreamPublisherManager toTest;
     private MetricsHolder managerMetrics;
     private PublisherHandler.MetricsHolder sharedHandlerMetrics;
@@ -58,11 +61,10 @@ class PublisherManagerRegressionTest {
     @BeforeEach
     void setup() {
         historicalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
-        final TestThreadPoolManager<BlockingExecutor, ScheduledBlockingExecutor> threadPoolManager =
-                new TestThreadPoolManager<>(
-                        new BlockingExecutor(new LinkedBlockingQueue<>()),
-                        new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
-        final TestBlockMessagingFacility messagingFacility = new TestBlockMessagingFacility();
+        threadPoolManager = new TestThreadPoolManager<>(
+                new BlockingExecutor(new LinkedBlockingQueue<>()),
+                new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+        messagingFacility = new TestBlockMessagingFacility();
         final BlockNodeContext context = generateContext(historicalBlockFacility, threadPoolManager, messagingFacility);
         historicalBlockFacility.init(context, null);
 
@@ -155,6 +157,74 @@ class PublisherManagerRegressionTest {
                 .describedAs(
                         "After backfill persisted blocks 0-2, block %d should be ACCEPT not SEND_BEHIND", nextLiveBlock)
                 .isEqualTo(BlockAction.ACCEPT);
+    }
+
+    /// Reproduces the previewnet 0.31.0-rc1 forwarder deadlock.
+    ///
+    /// A handler goes silent mid-block N. Backfill persists block N,
+    /// advancing {@code lastPersistedBlockNumber} to N. Handler 2 then
+    /// sends block N+1. The forwarder must deliver block N+1 to messaging.
+    ///
+    /// The bug: {@code clearObsoleteQueueItems(N)} uses
+    /// {@code headMap(N)} (strictly less than), so block N's incomplete
+    /// queue is never removed. The forwarder's
+    /// {@code determineCurrentBlockNumber()} picks it via
+    /// {@code firstEntry()} and gets stuck forever — block N+1 never
+    /// reaches messaging even though the manager returned ACCEPT.
+    @Test
+    @DisplayName("forwarder advances past stalled block after backfill persists it — previewnet 0.31.0-rc1")
+    void testForwarderAdvancesPastStalledBlockAfterBackfill() {
+        // Blocks 0-4 already persisted. Handler 1 stalls on block 5.
+        final long lastPreStallBlock = 4L;
+        final long stalledBlock = 5L;
+
+        // Establish initial persisted state: blocks 0-4 are already known.
+        final SimpleBlockRangeSet initialBlocks = new SimpleBlockRangeSet();
+        initialBlocks.add(0L, lastPreStallBlock);
+        historicalBlockFacility.setTemporaryAvailableBlocks(initialBlocks);
+        toTest.handlePersisted(new PersistedNotification(lastPreStallBlock, true, 0, BlockSource.PUBLISHER));
+
+        // Handler 1 wins ACCEPT for block 5, sends only the header, then goes silent.
+        sendHeaderOnly(publisherHandler, stalledBlock);
+
+        // Handler 2 sends block 5 — receives SKIP because handler 1 holds ACCEPT.
+        responsePipeline2.clear();
+        final PublishStreamRequestUnparsed fullStalledBlock = PublishStreamRequestUnparsed.newBuilder()
+                .blockItems(
+                        TestBlockBuilder.generateBlockWithNumber(stalledBlock).asItemSetUnparsed())
+                .build();
+        publisherHandler2.onNext(fullStalledBlock);
+        assertThat(responsePipeline2.getOnNextCalls())
+                .as("handler 2 must receive SKIP for block %d", stalledBlock)
+                .hasSize(1)
+                .first()
+                .returns(ResponseOneOfType.SKIP_BLOCK, response -> response.response()
+                        .kind());
+
+        // Backfill persists block 5, advancing lastPersisted to 5.
+        // clearObsoleteQueueItems(5) uses headMap(5) which does NOT
+        // include block 5 — the stalled queue stays in the map.
+        final SimpleBlockRangeSet backfilledBlocks = new SimpleBlockRangeSet();
+        backfilledBlocks.add(0L, stalledBlock);
+        historicalBlockFacility.setTemporaryAvailableBlocks(backfilledBlocks);
+        toTest.handlePersisted(new PersistedNotification(stalledBlock, true, 0, BlockSource.BACKFILL));
+
+        // Handler 2 sends a complete block 6.
+        responsePipeline2.clear();
+        final long nextLiveBlock = stalledBlock + 1;
+        final TestBlock nextBlock = TestBlockBuilder.generateBlockWithNumber(nextLiveBlock);
+        publisherHandler2.onNext(nextBlock.asPublishStreamRequestUnparsed());
+        endThisBlock(publisherHandler2, nextLiveBlock);
+
+        // Run the forwarder. If the stalled block 5's queue is still
+        // in queueByBlockMap, determineCurrentBlockNumber() returns 5
+        // and the forwarder never reaches block 6.
+        threadPoolManager.executor().executeAsync(1_000L, false);
+
+        // Block 6 must have been forwarded to the messaging facility.
+        assertThat(messagingFacility.getSentBlockItems())
+                .as("block %d must be forwarded to messaging after backfill unblocked the pipeline", nextLiveBlock)
+                .anyMatch(items -> items.blockNumber() == nextLiveBlock);
     }
 
     /// Verifies the 2-block stall detection and recovery mechanism:

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginRegressionTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginRegressionTest.java
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.stream.publisher;
+
+import static java.util.concurrent.locks.LockSupport.parkNanos;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.endThisBlock;
+
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.UncheckedParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Function;
+import org.hiero.block.api.PublishStreamResponse;
+import org.hiero.block.api.PublishStreamResponse.ResponseOneOfType;
+import org.hiero.block.internal.BlockItemSetUnparsed;
+import org.hiero.block.internal.PublishStreamRequestUnparsed;
+import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
+import org.hiero.block.node.app.fixtures.blocks.TestBlock;
+import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
+import org.hiero.block.node.app.fixtures.plugintest.GrpcPluginTestBase;
+import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
+import org.hiero.block.node.app.fixtures.plugintest.TestVerificationPlugin;
+import org.hiero.block.node.spi.BlockNodePlugin;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
+import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/// Plugin-level regression tests for the previewnet 0.31.0-rc1 forwarder
+/// deadlock. These tests exercise the full chain through the
+/// [StreamPublisherPlugin]: gRPC bytes in -> forwarder -> messaging ->
+/// persist -> ACK response out.
+@DisplayName("StreamPublisherPlugin Regression Tests")
+class StreamPublisherPluginRegressionTest
+        extends GrpcPluginTestBase<StreamPublisherPlugin, ExecutorService, ScheduledBlockingExecutor> {
+
+    private static final Function<Bytes, PublishStreamResponse> RESPONSE_PARSER = bytes -> {
+        try {
+            return PublishStreamResponse.PROTOBUF.parse(bytes);
+        } catch (final ParseException e) {
+            throw new UncheckedParseException(e);
+        }
+    };
+    private static final Function<PublishStreamResponse, ResponseOneOfType> RESPONSE_KIND =
+            response -> response.response().kind();
+    private static final Function<PublishStreamResponse, Long> ACK_BLOCK_NUMBER =
+            response -> Objects.requireNonNull(response.acknowledgement()).blockNumber();
+
+    private final SimpleInMemoryHistoricalBlockFacility historicalBlockFacility;
+
+    StreamPublisherPluginRegressionTest() {
+        super(Executors.newSingleThreadExecutor(), new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+        historicalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
+        final StreamPublisherPlugin plugin = new StreamPublisherPlugin();
+        final TestVerificationPlugin verificationPlugin = new TestVerificationPlugin();
+        final List<BlockNodePlugin> additionalPlugins = List.of(verificationPlugin);
+        start(plugin, plugin.methods().getFirst(), historicalBlockFacility, additionalPlugins);
+    }
+
+    /// Reproduces the previewnet 0.31.0-rc1 forwarder deadlock end-to-end
+    /// through the plugin.
+    ///
+    /// Publisher 1 streams blocks 0-4 (ACKed), then sends only the header
+    /// for block 5 and goes silent. Publisher 2 receives SKIP for block 5.
+    /// Backfill persists block 5 via [PersistedNotification]. Publisher 2
+    /// then streams block 6. The full chain must deliver an ACK for block 6.
+    ///
+    /// The bug: {@code clearObsoleteQueueItems(5)} uses
+    /// {@code headMap(5)} (strictly less than), so block 5's incomplete
+    /// queue is never removed. The forwarder's
+    /// {@code determineCurrentBlockNumber()} picks it via
+    /// {@code firstEntry()} and gets stuck forever — block 6 never
+    /// reaches messaging.
+    @Test
+    @DisplayName("forwarder delivers block N+1 after backfill persists stalled block N — previewnet 0.31.0-rc1")
+    void testForwarderAdvancesPastStalledBlockAfterBackfill() {
+        final long stalledBlock = 5L;
+
+        // Publisher 1 streams blocks 0-4 and receives ACK for each.
+        for (long blockNumber = 0; blockNumber <= 4L; blockNumber++) {
+            final TestBlock block = TestBlockBuilder.generateBlockWithNumber(blockNumber);
+            sendBlock(toPluginPipe, block);
+            endThisBlock(toPluginPipe, blockNumber);
+            awaitPluginResponses(1);
+            assertThat(fromPluginBytes)
+                    .as("publisher 1 must receive ACK for block %d", blockNumber)
+                    .hasSize(1)
+                    .first()
+                    .extracting(RESPONSE_PARSER)
+                    .returns(ResponseOneOfType.ACKNOWLEDGEMENT, RESPONSE_KIND)
+                    .returns(blockNumber, ACK_BLOCK_NUMBER);
+            fromPluginBytes.clear();
+        }
+
+        // Disable the historical facility while block 5 stalls. The
+        // forwarder will send block 5's partial header to messaging, but
+        // the facility ignores it — preventing an orphaned partial block
+        // that would crash when block 6 arrives later.
+        historicalBlockFacility.setDisablePlugin();
+
+        // Publisher 1 sends only the header for block 5, then goes silent.
+        sendHeaderOnly(toPluginPipe, stalledBlock);
+
+        // Publisher 2 connects and sends block 5 — expects SKIP.
+        final TestPipeline publisher2 = createNewPipeline();
+        final TestBlock fullBlock5 = TestBlockBuilder.generateBlockWithNumber(stalledBlock);
+        sendBlock(publisher2.toPluginPipe(), fullBlock5);
+        endThisBlock(publisher2.toPluginPipe(), stalledBlock);
+        awaitPluginResponses(List.of(publisher2.fromPluginBytes()), 1);
+        assertThat(publisher2.fromPluginBytes())
+                .as("publisher 2 must receive SKIP for block %d", stalledBlock)
+                .hasSize(1)
+                .first()
+                .extracting(RESPONSE_PARSER)
+                .returns(ResponseOneOfType.SKIP_BLOCK, RESPONSE_KIND);
+        publisher2.fromPluginBytes().clear();
+
+        // Simulate LIVE_TAIL greedy backfill persisting block 5 from a peer.
+        blockMessaging.sendBlockPersisted(new PersistedNotification(stalledBlock, true, 0, BlockSource.BACKFILL));
+
+        // Re-enable the historical facility now that block 5's stalled
+        // queue has been cleared by the headMap fix.
+        historicalBlockFacility.clearDisablePlugin();
+
+        // Publisher 2 streams block 6.
+        final long nextLiveBlock = stalledBlock + 1;
+        final TestBlock block6 = TestBlockBuilder.generateBlockWithNumber(nextLiveBlock);
+        sendBlock(publisher2.toPluginPipe(), block6);
+        endThisBlock(publisher2.toPluginPipe(), nextLiveBlock);
+
+        // Publisher 2 streams block 7 — the manager ACCEPTs it (decision
+        // layer works), but the forwarder is stuck on block 5's stalled
+        // queue so neither block 6 nor 7 will ever be forwarded or ACKed.
+        final long block7Number = nextLiveBlock + 1;
+        final TestBlock block7 = TestBlockBuilder.generateBlockWithNumber(block7Number);
+        sendBlock(publisher2.toPluginPipe(), block7);
+        endThisBlock(publisher2.toPluginPipe(), block7Number);
+
+        // Wait long enough for any async processing to complete.
+        parkNanos(500_000_000L);
+
+        // Publisher 2 must receive ACK for blocks 6 and 7 — the full chain:
+        // forwarder -> messaging -> historical facility -> persist -> ACK.
+        // The bug: forwarder is stuck on block 5's incomplete queue, so
+        // blocks 6 and 7 are silently dropped — no ACK is ever sent.
+        final List<PublishStreamResponse> publisher2Responses =
+                publisher2.fromPluginBytes().stream().map(RESPONSE_PARSER).toList();
+        assertThat(publisher2Responses)
+                .as("publisher 2 must receive ACK for block %d", nextLiveBlock)
+                .anySatisfy(response -> assertThat(response)
+                        .returns(ResponseOneOfType.ACKNOWLEDGEMENT, RESPONSE_KIND)
+                        .returns(nextLiveBlock, ACK_BLOCK_NUMBER));
+        assertThat(publisher2Responses)
+                .as("publisher 2 must receive ACK for block %d", block7Number)
+                .anySatisfy(response -> assertThat(response)
+                        .returns(ResponseOneOfType.ACKNOWLEDGEMENT, RESPONSE_KIND)
+                        .returns(block7Number, ACK_BLOCK_NUMBER));
+    }
+
+    private static void sendBlock(
+            final com.hedera.pbj.runtime.grpc.Pipeline<? super Bytes> requestSender, final TestBlock block) {
+        final PublishStreamRequestUnparsed request = PublishStreamRequestUnparsed.newBuilder()
+                .blockItems(block.asItemSetUnparsed())
+                .build();
+        requestSender.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
+    }
+
+    private static void sendHeaderOnly(
+            final com.hedera.pbj.runtime.grpc.Pipeline<? super Bytes> requestSender, final long blockNumber) {
+        final BlockItemSetUnparsed headerOnly = BlockItemSetUnparsed.newBuilder()
+                .blockItems(List.of(
+                        TestBlockBuilder.generateBlockWithNumber(blockNumber).getHeaderUnparsed()))
+                .build();
+        final PublishStreamRequestUnparsed request =
+                PublishStreamRequestUnparsed.newBuilder().blockItems(headerOnly).build();
+        requestSender.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
+    }
+}


### PR DESCRIPTION
Fixes #2517 

## Post-Mortem: Previewnet 0.31.0-rc1 Forwarder Deadlock

### Incident

On previewnet `0.31.0-rc1`, BN `lfh01` experienced a total pipeline stall when a CN stopped sending mid-block (sent header + items, never sent end-of-block). This can happen at any time — a CN crash, network partition, or process restart is sufficient to trigger it. Once triggered, the pipeline freezes indefinitely with no recovery:

- **776 blocks silently dropped** (1,175,214 -> 1,175,990) over 29 minutes
- **766 phantom "Completed blocks" increments** — counter climbed while zero blocks were verified, persisted, or ACKed
- **Stalled handler was never evicted** — no timeout, no EndStream, no removal

### Known limitation: stalled handler holds the pipeline

`LiveStreamPublisherManager` has no timeout for incomplete blocks (Bug 1 / #1841 and #2055). When a handler wins ACCEPT for a block and goes silent mid-stream, the forwarder's `queueByBlockMap` holds that block's incomplete queue indefinitely. `determineCurrentBlockNumber()` picks it via `firstEntry()` and the forwarder loops on an empty queue forever. All subsequent blocks are accepted by the decision layer but never forwarded.

### Expected mitigation: LIVE_TAIL greedy backfill

The LIVE_TAIL backfill mechanism was designed to mitigate this. When a peer BN has blocks that the local BN is missing, the backfill plugin fetches them and fires a `PersistedNotification`. The publisher manager's `handlePersisted()` then calls `clearObsoleteQueueItems()` to remove stale queues, unsticking the forwarder. This worked correctly in **v0.30.0**.

### Regression: PR #2419 / #2454 (2026-03-27)

PR #2454 (`chore: Revisit and Update BlockActions Returned by Manager`, commit `b11c8147`) introduced `clearObsoleteQueueItems()` with an off-by-one error:

```java
queueByBlockMap.headMap(blockNumber).keySet()
```

`ConcurrentNavigableMap.headMap(key)` returns entries **strictly less than** `key`. When backfill persists block N and `clearObsoleteQueueItems(N)` is called, block N's stalled queue is **excluded** from removal. The forwarder's `determineCurrentBlockNumber()` picks it via `firstEntry()` and remains stuck forever.

Additionally, if peer BNs are unreachable (restart, network partition, or simply no peers configured), the `autonomousFetcher` can't detect the gap and backfill never fires — leaving the stall completely unrecoverable. Rolling upgrades are recommended to ensure at least one peer is always available.

### Two compounding failures

1. **Backfill unavailable**: If peers are unreachable for any reason -> no LIVE_TAIL gap detected -> backfill never fires
2. **Backfill ineffective even when it fires**: `headMap(N)` off-by-one -> stalled block N's queue survives cleanup -> forwarder stays stuck

### Fix

Change `headMap(blockNumber)` to `headMap(blockNumber, true)` (inclusive), so that when `clearObsoleteQueueItems(N)` is called, block N's stalled queue is included in the removal set.

### Tests

Two new regression tests that reproduce the exact forwarder deadlock:

1. **`PublisherManagerRegressionTest.testForwarderAdvancesPastStalledBlockAfterBackfill`** — Manager-level: pre-loads blocks 0-4, stalls on block 5, backfill persists block 5, asserts block 6 reaches the messaging facility via the forwarder
2. **`StreamPublisherPluginRegressionTest.testForwarderAdvancesPastStalledBlockAfterBackfill`** — Plugin-level end-to-end: streams blocks 0-4 live with ACK verification, stalls on block 5, simulates LIVE_TAIL greedy backfill persisting block 5, streams blocks 6-7, asserts ACK for both

Both tests fail on `0.31.0-rc1` code and pass with the `headMap` fix.

### Remaining work

- **#1841**: Stalled handler timeout detection — the definitive fix for zombie handlers that eliminates the dependency on backfill as a recovery mechanism
