### PR TITLE
fix: add in gh workflow steps to copy plugins to the solo-dev docker image.

### DIFF
--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -124,7 +124,7 @@ jobs:
         run: ${GRADLE_EXEC} clean assemble
 
       - name: Prepare plugin JARs for solo-dev image
-        run: ${GRADLE_EXEC} :block-node:app:prepareDockerPlugins
+        run: ${GRADLE_EXEC} :app:prepareDockerPlugins
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -123,6 +123,9 @@ jobs:
       - name: Build
         run: ${GRADLE_EXEC} clean assemble
 
+      - name: Prepare plugin JARs for solo-dev image
+        run: ${GRADLE_EXEC} :block-node:app:prepareDockerPlugins
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -157,7 +160,7 @@ jobs:
       - name: Server - Build and push image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
-          context: ./block-node/app/docker
+          context: ./block-node/app/build/docker
           file: ./block-node/app/docker/Dockerfile
           target: ${{ matrix.target }}
           cache-from: type=gha


### PR DESCRIPTION
The local gradle build has an additional step for staging the plugins that is missing from the GH workflow. This missing step is causing the solo-dev image to not have any plugins. This pr adds the missing step to the github workflow and correctly sets the docker context so that docker build can find the plugins.
 
- add in steps to generate the plugins directory so that they are available
____________________________________________________________________

## Reviewer Notes
Steps to Verify plugins are in the image:

Pull the published solo-dev image and inspect its plugins directory:

docker run --rm --entrypoint ls \
  ghcr.io/hiero-ledger/hiero-block-node-solo-dev:<version> \
  /opt/hiero/block-node/app-<version>/plugins
Expected: plugin JARs.

## Related Issue(s)
Closes #2525 
