### PR TITLE
chore(chart): remove besu-maven and consensys repositories (#2309)

### DIFF
--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -108,10 +108,6 @@ plugins:
   repositories:
     - id: central
       url: https://repo1.maven.org/maven2
-    - id: besu-maven
-      url: https://artifacts.hashgraph.io/artifactory/hyperledger-besu-maven-external/
-    - id: consensys
-      url: https://artifacts.consensys.net/public/maven/maven/
     - id: sonatype-snapshots
       url: https://central.sonatype.com/repository/maven-snapshots
       snapshots: true


### PR DESCRIPTION
## Summary

- Remove `besu-maven` (Hyperledger Besu Artifactory) and `consensys` Maven repositories from the default `plugins.repositories` list in `charts/block-node-server/values.yaml`

Both repositories were previously needed because `swirlds-common` was pulled in transitively (`facility-messaging → common → swirlds-common:0.61.3 → secp256k1:0.8.2`), and `secp256k1` is not published on Maven Central — only on the Besu Artifactory.

`swirlds-common` has since been removed from the dependency tree. Confirmed by running `./gradlew :app:assemble` and inspecting the resolved plugin jars — no `secp256k1`, `swirlds-common`, or Besu artifacts appear in the output.

The `consensys` repository was always unnecessary: `secp256k1:0.8.2` only depends on `net.java.dev.jna:jna`, which is available on Maven Central.

## Test plan

- [x] Run `./gradlew :app:assemble` and verify no Besu/ConsenSys artifacts appear in `block-node/app/build/docker/plugins/`
- [x] Deploy to a test environment and confirm the init container (`mvn dependency:copy-dependencies`) resolves all plugins successfully using only `central` and `sonatype-snapshots`

Closes #2309
