### PR TITLE
fix: bind metrics server to all interfaces and expose chart values

### DIFF
--- a/block-node/app-config/src/main/resources/app.properties
+++ b/block-node/app-config/src/main/resources/app.properties
@@ -1,2 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 metrics.exporter.openmetrics.http.port=16007
+metrics.exporter.openmetrics.http.hostname=0.0.0.0

--- a/block-node/app/docker/docker-compose.yml
+++ b/block-node/app/docker/docker-compose.yml
@@ -12,8 +12,6 @@ services:
       - ./backfill-sources.json:/opt/hiero/block-node/backfill/backfill-sources.json
     env_file:
       - .env
-    environment:
-      JAVA_TOOL_OPTIONS: "-Dmetrics.exporter.openmetrics.http.hostname=0.0.0.0"
     ports:
       - "40840:40840"
       - "5005:5005"

--- a/block-node/app/src/main/resources/app.properties
+++ b/block-node/app/src/main/resources/app.properties
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 metrics.exporter.openmetrics.http.port=16007
+metrics.exporter.openmetrics.http.hostname=0.0.0.0
 server.port=40840
 
 # Ring buffer sizes for the mediator and notifier

--- a/charts/block-node-server/templates/_helpers.tpl
+++ b/charts/block-node-server/templates/_helpers.tpl
@@ -80,6 +80,19 @@ Usage: {{ include "hiero-block-node.app.version" . }}
 {{- end -}}
 
 {{/*
+Build JAVA_TOOL_OPTIONS combining logging config and metrics system properties.
+*/}}
+{{- define "hiero-block-node.javaToolOptions" -}}
+-Djava.util.logging.config.file=/opt/hiero/block-node/logs/config/logging.properties
+{{- with .Values.blockNode.metrics }}
+{{- if .hostname }} -Dmetrics.exporter.openmetrics.http.hostname={{ .hostname }}{{ end }}
+{{- if .port }} -Dmetrics.exporter.openmetrics.http.port={{ .port }}{{ end }}
+{{- if .path }} -Dmetrics.exporter.openmetrics.http.path={{ .path }}{{ end }}
+{{- if .decimalFormat }} -Dmetrics.exporter.openmetrics.http.decimalFormat={{ .decimalFormat }}{{ end }}
+{{- end }}
+{{- end }}
+
+{{/*
 The service name to connect to Loki. Defaults to the same logic as "loki.fullname"
 */}}
 {{- define "loki.serviceName" -}}

--- a/charts/block-node-server/templates/configmap.yaml
+++ b/charts/block-node-server/templates/configmap.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ include "hiero-block-node.fullname" . }}-config
 data:
   VERSION: {{ include "hiero-block-node.appVersion" .  | quote }}
+  JAVA_TOOL_OPTIONS: {{ printf "%s %s" (include "hiero-block-node.javaToolOptions" .) (default "" (index .Values.blockNode.config "JAVA_TOOL_OPTIONS")) | trim | quote }}
 {{- range $key, $value := .Values.blockNode.config }}
+{{- if ne $key "JAVA_TOOL_OPTIONS" }}
   {{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}

--- a/charts/block-node-server/templates/service.yaml
+++ b/charts/block-node-server/templates/service.yaml
@@ -21,7 +21,7 @@ spec:
       protocol: TCP
       name: http
     - name: metrics
-      port: {{ .Values.blockNode.health.metrics.port }}
+      port: {{ .Values.blockNode.metrics.port }}
       targetPort: metrics
   selector:
     {{- include "hiero-block-node.selectorLabels" . | nindent 4 }}

--- a/charts/block-node-server/templates/statefulset.yaml
+++ b/charts/block-node-server/templates/statefulset.yaml
@@ -212,7 +212,7 @@ spec:
             {{- end }}
             protocol: TCP
           - name: metrics
-            containerPort: {{ .Values.blockNode.health.metrics.port }}
+            containerPort: {{ .Values.blockNode.metrics.port }}
             {{- if hasKey $hostPorts "metrics" }}
             hostPort: {{ index $hostPorts "metrics" }}
             {{- end }}

--- a/charts/block-node-server/values-overrides/rfh-values.yaml
+++ b/charts/block-node-server/values-overrides/rfh-values.yaml
@@ -5,25 +5,24 @@ resources:
 
 blockNode:
     secretRef: "bn-<env>-s3-creds"
-        config:
-            JAVA_OPTS: '-Xms8G -Xmx8G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
-            # Change the following Value with the next expected Block to be
-            # published by the Network.
-            # BLOCK_NODE_EARLIEST_MANAGED_BLOCK: "0"
-            # Archive Node Configuration
-            ARCHIVE_BLOCKS_PER_FILE: "10000" # Default is 100_000
-            ARCHIVE_BUCKET_NAME: "bn-eng-archive-bucket"
-            ARCHIVE_ENDPOINT_URL: "https://storage.googleapis.com"
-            ARCHIVE_BASE_PATH: "previewnet/archive1"
-            ARCHIVE_STORAGE_CLASS: "ARCHIVE"
-            ARCHIVE_REGION_NAME: "us-central1"
-
-        persistence:
-            archive:
-                size: 50Gi
-            live:
-                size: 10Gi
-            logging:
-                size: 2Gi
-            verification:
-                size: 500Mi
+    config:
+        JAVA_OPTS: '-Xms8G -Xmx8G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
+        # Change the following Value with the next expected Block to be
+        # published by the Network.
+        # BLOCK_NODE_EARLIEST_MANAGED_BLOCK: "0"
+        # Archive Node Configuration
+        ARCHIVE_BLOCKS_PER_FILE: "10000" # Default is 100_000
+        ARCHIVE_BUCKET_NAME: "bn-eng-archive-bucket"
+        ARCHIVE_ENDPOINT_URL: "https://storage.googleapis.com"
+        ARCHIVE_BASE_PATH: "previewnet/archive1"
+        ARCHIVE_STORAGE_CLASS: "ARCHIVE"
+        ARCHIVE_REGION_NAME: "us-central1"
+    persistence:
+        archive:
+            size: 50Gi
+        live:
+            size: 10Gi
+        logging:
+            size: 2Gi
+        verification:
+            size: 500Mi

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -162,15 +162,15 @@ blockNode:
   config:
     # Add any additional env configuration here
     # key: value
-    JAVA_TOOL_OPTIONS: "-Djava.util.logging.config.file=/opt/hiero/block-node/logs/config/logging.properties"
+    # JAVA_TOOL_OPTIONS is merged with auto-generated metrics and logging flags.
+    # Add extra JVM flags here (e.g., debug agent, profiler).
+    JAVA_TOOL_OPTIONS: ""
     JAVA_OPTS: '-Xms16G -Xmx16G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
     # PRODUCER_TYPE: "NO_OP"
     # PERSISTENCE_STORAGE_TYPE: "NO_OP"
     # VERIFICATION_TYPE: "NO_OP"
     # MESSAGING_BLOCK_ITEM_QUEUE_SIZE: "512"
     # MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE: "16"
-    PROMETHEUS_ENDPOINT_ENABLED: true
-    PROMETHEUS_ENDPOINT_PORT_NUMBER: "16007"
     SERVER_PORT: "40840"
     # The path to the block-node-sources.json file must match the path property in the backfill.sources.path
     # if using the backfill sources created with this helm chart
@@ -245,8 +245,14 @@ blockNode:
       timeoutSeconds: 2
       successThreshold: 1
       failureThreshold: 3
-    metrics:
-      port: 16007
+  metrics:
+    # Metrics HTTP server configuration (hiero-metrics openmetrics-httpserver).
+    # These are injected as JVM system properties via JAVA_TOOL_OPTIONS
+    # and override the defaults in app.properties.
+    hostname: "0.0.0.0"
+    port: 16007
+    path: "/metrics"
+    # decimalFormat: ""
   logs:
     # Available Levels are (from most verbose to least verbose):
     # ALL FINEST FINER FINE CONFIG INFO WARNING SEVERE OFF

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -59,11 +59,24 @@ Each plugin has its own properties, but this focuses on core options and core pl
 
 ### Metrics Endpoint Configuration
 
-| ConfigKey                 | Description                          | Default |
-|:--------------------------|:-------------------------------------|--------:|
-| enableEndpoint            | Enable/disable Prometheus endpoint.  |    true |
-| endpointPortNumber        | Prometheus endpoint port.            |   16007 |
-| endpointMaxBacklogAllowed | Max queued incoming TCP connections. |       1 |
+The metrics HTTP server is provided by the `hiero-metrics` library and exposes
+Prometheus-format metrics. Its properties are prefixed with
+`metrics.exporter.openmetrics.http.` and can be set via:
+
+- `app.properties` (classpath, lowest priority)
+- JVM system properties (`-D` flags via `JAVA_TOOL_OPTIONS`, highest priority)
+- Helm chart `blockNode.metrics.*` values (which inject `-D` flags automatically)
+
+| Chart Value                  | JVM Property                                 | Description                         |  Default |
+|:-----------------------------|:---------------------------------------------|:------------------------------------|---------:|
+| `blockNode.metrics.hostname` | `metrics.exporter.openmetrics.http.hostname` | Bind address for the metrics server |  0.0.0.0 |
+| `blockNode.metrics.port`     | `metrics.exporter.openmetrics.http.port`     | Prometheus endpoint port            |    16007 |
+| `blockNode.metrics.path`     | `metrics.exporter.openmetrics.http.path`     | HTTP path for metrics endpoint      | /metrics |
+
+> **Note:** These properties come from the `hiero-metrics` library, not from a Block
+> Node `@ConfigData` record. They cannot be set via environment variable
+> mapping (`AutomaticEnvironmentVariableConfigSource`). The chart injects them as
+> JVM system properties through `JAVA_TOOL_OPTIONS`.
 
 ## Configurations By Plugin
 

--- a/docs/block-node/metrics.md
+++ b/docs/block-node/metrics.md
@@ -34,15 +34,20 @@ The purpose of metrics is to provide a way to measure the performance of the sys
 
 ## Configuration
 
-### Prometheus
+### Metrics HTTP Server
 
-Prefix: prometheus, ie. `prometheus.configKey`
+The metrics endpoint is served by the `hiero-metrics` library (`openmetrics-httpserver` module).
+Properties are prefixed with `metrics.exporter.openmetrics.http.` and can be set via
+`app.properties`, JVM system properties (`-D` flags), or Helm chart values under `blockNode.metrics`.
 
-| ConfigKey                 | Description                                                                           | Default |
-|:--------------------------|:--------------------------------------------------------------------------------------|--------:|
-| enableEndpoint            | either `true` or `false`. Enables or disables the endpoint for metrics                |    true |
-| endpointPortNumber        | Port of the Prometheus endpoint                                                       |   16007 |
-| endpointMaxBacklogAllowed | The maximum number of incoming TCP connections which the system will queue internally |       1 |
+| Chart Value                  | JVM Property                                 | Description                         |  Default |
+|:-----------------------------|:---------------------------------------------|:------------------------------------|---------:|
+| `blockNode.metrics.hostname` | `metrics.exporter.openmetrics.http.hostname` | Bind address for the metrics server |  0.0.0.0 |
+| `blockNode.metrics.port`     | `metrics.exporter.openmetrics.http.port`     | Prometheus endpoint port            |    16007 |
+| `blockNode.metrics.path`     | `metrics.exporter.openmetrics.http.path`     | HTTP path for metrics endpoint      | /metrics |
+
+See the [Configuration Document](configuration.md#metrics-endpoint-configuration) for details
+on how these properties are injected.
 
 ## How to Access Metrics
 

--- a/docs/block-node/troubleshooting.md
+++ b/docs/block-node/troubleshooting.md
@@ -200,24 +200,32 @@ Use the runbooks below during incidents. Each follows a consistent pattern:
        - Success: HTTP 200 with Prometheus text output.
        - Failure: connection refused / timeout.
 2. **Node-local checks**
-   - Ensure metrics are enabled in the Block Node configuration (`prometheus.enableEndpoint=true`).
    - From the node itself:
      - `curl -v http://localhost:16007/metrics`
        - If this fails, suspect local config or process issues.
-   - Confirm `prometheus.endpointPortNumber` matches the expected port (default `16007`).
-3. **Network and firewall**
-   - If [localhost](http://localhost) works but remote scrape fails:
+   - Confirm `metrics.exporter.openmetrics.http.port` matches the expected port (default `16007`).
+     In Kubernetes, check `blockNode.metrics.port` in your Helm values.
+3. **Bind address**
+   - If localhost works but remote scrape fails, verify the metrics server binds to
+     `0.0.0.0` (all interfaces) and not `127.0.0.1` (localhost only).
+   - Check `blockNode.metrics.hostname` in your Helm values (default: `0.0.0.0`).
+   - Outside Kubernetes, check `metrics.exporter.openmetrics.http.hostname` in
+     `app.properties` or via `-Dmetrics.exporter.openmetrics.http.hostname=0.0.0.0`.
+   - Binding to `127.0.0.1` will cause all remote Prometheus scrapes to fail with
+     "connection refused".
+4. **Network and firewall**
+   - If the bind address is correct but remote scrape still fails:
      - Check host firewall / security group rules for port `16007`.
      - Confirm any load balancers or service meshes expose the metrics port.
-4. **Scraper configuration**
+5. **Scraper configuration**
    - Verify Prometheus target configuration:
      - Correct job name, scheme (http / https), and port.
      - No incorrect path overrides.
-5. **Resolution**
+6. **Resolution**
    - Enable metrics in config and restart the Block Node if required.
    - Open or adjust firewall / security rules for the metrics port.
    - Fix Prometheus / Grafana scrape configuration.
-6. **Verification**
+7. **Verification**
    - Confirm the Prometheus target is `UP` and `up\{job="block-node-metrics", instance="\<node\>"\} == 1`.
    - Grafana dashboards populate and scrape errors clear.
 


### PR DESCRIPTION
## Summary

Fixes #2537

The `hiero-metrics` `openmetrics-httpserver` module binds to `127.0.0.1` by default. In Kubernetes, Prometheus scrapes from the pod's cluster IP (not localhost), so metrics requests are refused with "connection refused". This PR fixes the default and exposes metrics server configuration through the Helm chart.

### What changed

**App-level default fix:**
- Added `metrics.exporter.openmetrics.http.hostname=0.0.0.0` to `app.properties` so the metrics server binds to all interfaces out of the box — fixes Docker, bare metal, and Kubernetes deployments alike.
- Removed the now-redundant `JAVA_TOOL_OPTIONS` workaround from `docker-compose.yml`.

**Helm chart — new `blockNode.metrics` section:**
- Exposes `hostname`, `port`, `path`, and `decimalFormat` as operator-configurable values.
- These are injected as JVM system properties (`-D` flags) via `JAVA_TOOL_OPTIONS`, which override the `app.properties` defaults.
- User-provided `JAVA_TOOL_OPTIONS` in `blockNode.config` is preserved and merged with the auto-generated flags (e.g., debug agents, profilers).

**Chart cleanup:**
- Removed `PROMETHEUS_ENDPOINT_ENABLED` and `PROMETHEUS_ENDPOINT_PORT_NUMBER` from `blockNode.config` — the block node app never reads these env vars (only the simulator has the `MappedConfigSource` mapping). They were dead config giving operators a false sense of control.
- Moved metrics port from `blockNode.health.metrics.port` to `blockNode.metrics.port` since metrics server config is not a health concern.

**Documentation:**
- Updated `configuration.md`, `metrics.md`, and `troubleshooting.md` with new property names, chart value references, and bind address troubleshooting guidance.

### Configuration override chain

1. `app.properties` (classpath, lowest priority) — sets defaults
2. `blockNode.metrics.*` chart values → auto-generated `-D` flags in `JAVA_TOOL_OPTIONS` (highest priority) — operator overrides

### Migration for existing deployments

| Before | After |
|--------|-------|
| `PROMETHEUS_ENDPOINT_ENABLED: true` | Removed (no effect on block node) |
| `PROMETHEUS_ENDPOINT_PORT_NUMBER: "16007"` | `blockNode.metrics.port: 16007` |
| `blockNode.health.metrics.port: 16007` | `blockNode.metrics.port: 16007` |

## Test plan

- [x] `helm template` renders `JAVA_TOOL_OPTIONS` with logging + metrics `-D` flags
- [x] `helm template --set blockNode.metrics.port=9090` correctly overrides the port in ConfigMap, Service, and StatefulSet
- [x] `helm template --set blockNode.config.JAVA_TOOL_OPTIONS="-agentlib:..."` merges custom flags with auto-generated ones
- [x] `./gradlew :app:assemble` builds successfully with new `app.properties`
- [ ] Deploy to test cluster and verify `curl http://<pod-ip>:16007/metrics` returns metrics (proving `0.0.0.0` binding)
- [ ] Verify ServiceMonitor scraping works when `kubepromstack.enabled: true`
