### PR TITLE
fix: skip malformed GCS filenames with trailing hash suffixes (#2539)

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/ChainFile.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/ChainFile.java
@@ -58,10 +58,18 @@ public record ChainFile(
      * @return the chain file, or null if unrecognized
      */
     public static ChainFile createOrNull(int nodeAccountId, String path, int size, String md5) {
-        if (Kind.fromFilePath(path) == null) {
+        Kind kind = Kind.fromFilePath(path);
+        if (kind == null) {
             return null;
         }
-        return new ChainFile(nodeAccountId, path, size, md5);
+        return new ChainFile(
+                kind,
+                nodeAccountId,
+                path,
+                blockTimeInstantToLong(extractRecordFileTime(path.substring(path.lastIndexOf('/') + 1))),
+                size,
+                md5,
+                extractSidecarIndex(path));
     }
 
     /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/ChainFile.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/ChainFile.java
@@ -48,6 +48,23 @@ public record ChainFile(
     }
 
     /**
+     * Creates a new chain file, or returns {@code null} if the file path has an
+     * unrecognized extension (e.g. malformed GCS files with trailing hash suffixes).
+     *
+     * @param nodeAccountId the node account ID
+     * @param path the path to the file in bucket
+     * @param size the size of the file
+     * @param md5 the MD5 hash of the file
+     * @return the chain file, or null if unrecognized
+     */
+    public static ChainFile createOrNull(int nodeAccountId, String path, int size, String md5) {
+        if (Kind.fromFilePath(path) == null) {
+            return null;
+        }
+        return new ChainFile(nodeAccountId, path, size, md5);
+    }
+
+    /**
      * Extracts the sidecar index from the file path. If the file is not a sidecar file, returns -1.
      * <p>
      *     Example: <code>https://storage.googleapis.com/hedera-mainnet-streams/recordstreams/record0.0.34/sidecar/2024-04-04T18_03_26.007683847Z_01.rcd.gz</code>
@@ -93,6 +110,11 @@ public record ChainFile(
         SIGNATURE,
         SIDECAR;
 
+        /**
+         * Determines the file kind from the given path, or {@code null} if unrecognized.
+         * Malformed files (e.g. with trailing hash suffixes from GCS blips) return null
+         * so callers can skip them gracefully.
+         */
         public static Kind fromFilePath(String filePath) {
             if (filePath.contains("sidecar")) {
                 return SIDECAR;
@@ -101,7 +123,7 @@ public record ChainFile(
             } else if (filePath.endsWith(".rcd_sig")) {
                 return SIGNATURE;
             } else {
-                throw new IllegalArgumentException("Unknown file type: " + filePath);
+                return null;
             }
         }
     }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/utils/gcp/MainNetBucket.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/utils/gcp/MainNetBucket.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.IntStream;
@@ -341,7 +342,7 @@ public class MainNetBucket {
                     return chainFiles;
                 }
             }
-            // create a list of ChainFiles
+            // create a list of ChainFiles, skipping malformed GCS entries
             List<ChainFile> chainFiles = IntStream.range(minNodeAccountId, maxNodeAccountId + 1)
                     .parallel()
                     .mapToObj(nodeAccountId -> Stream.concat(
@@ -359,11 +360,18 @@ public class MainNetBucket {
                                                                     + filePrefix,
                                                             REQUIRED_FIELDS))
                                             .streamAll())
-                            .map(blob -> new ChainFile(
-                                    nodeAccountId,
-                                    blob.getName(),
-                                    blob.getSize().intValue(),
-                                    blob.getMd5())))
+                            .map(blob -> {
+                                ChainFile cf = ChainFile.createOrNull(
+                                        nodeAccountId,
+                                        blob.getName(),
+                                        blob.getSize().intValue(),
+                                        blob.getMd5());
+                                if (cf == null) {
+                                    System.err.println("[WARN] Skipping unrecognized GCS file: " + blob.getName());
+                                }
+                                return cf;
+                            })
+                            .filter(Objects::nonNull))
                     .flatMap(Function.identity())
                     .toList();
             // save the list to cache

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/records/ChainFileTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/records/ChainFileTest.java
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.records;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ChainFile")
+class ChainFileTest {
+
+    @Nested
+    @DisplayName("Kind.fromFilePath")
+    class FromFilePath {
+
+        @Test
+        @DisplayName("recognizes .rcd files")
+        void recognizesRcd() {
+            assertEquals(
+                    ChainFile.Kind.RECORD,
+                    ChainFile.Kind.fromFilePath("recordstreams/record0.0.3/2026-03-21T00_00_00.000000000Z.rcd"));
+        }
+
+        @Test
+        @DisplayName("recognizes .rcd.gz files")
+        void recognizesRcdGz() {
+            assertEquals(
+                    ChainFile.Kind.RECORD,
+                    ChainFile.Kind.fromFilePath("recordstreams/record0.0.3/2026-03-21T00_00_00.000000000Z.rcd.gz"));
+        }
+
+        @Test
+        @DisplayName("recognizes .rcd_sig files")
+        void recognizesRcdSig() {
+            assertEquals(
+                    ChainFile.Kind.SIGNATURE,
+                    ChainFile.Kind.fromFilePath("recordstreams/record0.0.3/2026-03-21T00_00_00.000000000Z.rcd_sig"));
+        }
+
+        @Test
+        @DisplayName("recognizes sidecar files")
+        void recognizesSidecar() {
+            assertEquals(
+                    ChainFile.Kind.SIDECAR,
+                    ChainFile.Kind.fromFilePath(
+                            "recordstreams/record0.0.3/sidecar/2026-03-21T00_00_00.000000000Z_01.rcd.gz"));
+        }
+
+        @Test
+        @DisplayName("returns null for malformed file with trailing hash suffix on rcd_sig")
+        void returnsNullForMalformedRcdSig() {
+            assertNull(
+                    ChainFile.Kind.fromFilePath(
+                            "recordstreams/record0.0.15/2026-03-21T06_42_18.024923000Z.rcd_sig-d41d8cd98f00b204e9800998ecf8427e"));
+        }
+
+        @Test
+        @DisplayName("returns null for malformed file with trailing hash suffix on rcd.gz")
+        void returnsNullForMalformedRcdGz() {
+            assertNull(
+                    ChainFile.Kind.fromFilePath(
+                            "recordstreams/record0.0.15/2026-03-21T06_42_18.024923000Z.rcd.gz-d41d8cd98f00b204e9800998ecf8427e"));
+        }
+
+        @Test
+        @DisplayName("returns null for completely unknown extension")
+        void returnsNullForUnknownExtension() {
+            assertNull(ChainFile.Kind.fromFilePath("recordstreams/record0.0.3/somefile.txt"));
+        }
+    }
+
+    @Nested
+    @DisplayName("createOrNull")
+    class CreateOrNull {
+
+        @Test
+        @DisplayName("returns ChainFile for valid path")
+        void returnsChainFileForValidPath() {
+            ChainFile cf = ChainFile.createOrNull(
+                    3, "recordstreams/record0.0.3/2026-03-21T00_00_00.000000000Z.rcd.gz", 1024, "abc123");
+            assertNotNull(cf);
+            assertEquals(ChainFile.Kind.RECORD, cf.kind());
+            assertEquals(3, cf.nodeAccountId());
+        }
+
+        @Test
+        @DisplayName("returns null for malformed path")
+        void returnsNullForMalformedPath() {
+            ChainFile cf = ChainFile.createOrNull(
+                    15,
+                    "recordstreams/record0.0.15/2026-03-21T06_42_18.024923000Z.rcd_sig-d41d8cd98f00b204e9800998ecf8427e",
+                    0,
+                    "d41d8cd98f00b204e9800998ecf8427e");
+            assertNull(cf);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2539.

`updateDayListings` (and any other `MainNetBucket.listWithFilePrefix` caller) was crashing with `IllegalArgumentException: Unknown file type: ...rcd_sig-d41d8cd98f00b204e9800998ecf8427e` when the GCS bucket returned blobs with trailing hash suffixes. This happens when a network blip during upload leaves a corrupt/versioned object visible in the listing — SRE can't always clean them up immediately, and a single bad object shouldn't kill the entire listing run.

## Changes

- **`ChainFile.java`**
  - `Kind.fromFilePath()` now returns `null` instead of throwing for unrecognized paths.
  - New `ChainFile.createOrNull(nodeAccountId, path, size, md5)` static factory that returns `null` for unrecognized paths. The existing throwing constructor is preserved for callers with known-good paths.

- **`MainNetBucket.java`**
  - `listWithFilePrefix()` now uses `ChainFile.createOrNull` and filters nulls with `Objects::nonNull`.
  - Logs a `[WARN] Skipping unrecognized GCS file: <name>` line for each skipped file so operators have visibility into what was skipped.

- **`ChainFileTest.java`** (new)
  - 9 tests covering all recognized file types, both malformed variants (`.rcd_sig-<hash>`, `.rcd.gz-<hash>`), unknown extensions, and `createOrNull` success/null paths.

## Design notes

- **Backward compatible**: The original `new ChainFile(...)` constructor still throws via the underlying `Kind.fromFilePath()` result — only `createOrNull` opts into the null behavior. Anywhere else that constructs a `ChainFile` from a known-good path retains fail-fast semantics.
- **Warning log, not silent skip**: Silent skipping would hide real issues. The warning lets operators see what was skipped.
