### PR TITLE
chore: audit TRACE logs in publisher, verification,  health, and backfill plugins

### DIFF
--- a/block-node/app/docker/ci-logging.properties
+++ b/block-node/app/docker/ci-logging.properties
@@ -13,8 +13,8 @@
 # Available Levels are (from most verbose to least verbose):
 # ALL FINEST FINER FINE CONFIG INFO WARNING SEVERE OFF
 .level=INFO
-# logs for Block Node components FINEST temporarily
-org.hiero.block.level=FINEST
+# logs for Block Node components FINE (DEBUG) temporarily
+org.hiero.block.level=FINE
 # Helidon loggers
 io.helidon.level=INFO
 io.helidon.webserver.level=INFO

--- a/block-node/app/docker/logging.properties
+++ b/block-node/app/docker/logging.properties
@@ -14,8 +14,8 @@
 # Available Levels are (from most verbose to least verbose):
 # ALL FINEST FINER FINE CONFIG INFO WARNING SEVERE OFF
 .level=INFO
-# logs for Block Node components FINEST temporarily
-org.hiero.block.level=FINEST
+# logs for Block Node components FINE (DEBUG) temporarily
+org.hiero.block.level=FINE
 # Helidon loggers
 io.helidon.level=INFO
 io.helidon.webserver.level=INFO

--- a/block-node/app/docker/logging.properties
+++ b/block-node/app/docker/logging.properties
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-
 # Log Level Values
 #
 # SEVERE: indicates a critical error or failure

--- a/block-node/app/src/main/resources/logging.properties
+++ b/block-node/app/src/main/resources/logging.properties
@@ -24,8 +24,8 @@
 # Available Levels are (from most verbose to least verbose):
 # ALL FINEST FINER FINE CONFIG INFO WARNING SEVERE OFF
 .level=INFO
-# logs for Block Node components FINEST temporarily
-org.hiero.block.level=FINEST
+# logs for Block Node components FINE (DEBUG) temporarily
+org.hiero.block.level=FINE
 # Configuration logging
 #org.hiero.block.simulator.config.logging.SimulatorConfigurationLogger.level=OFF
 

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillFetcher.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillFetcher.java
@@ -3,7 +3,7 @@ package org.hiero.block.node.backfill;
 
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
-import static java.lang.System.Logger.Level.TRACE;
+import static java.lang.System.Logger.Level.WARNING;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
@@ -116,7 +116,7 @@ public class BackfillFetcher implements PriorityHealthBasedStrategy.NodeHealthPr
 
         for (BackfillSourceConfig node : blockNodeSource.nodes()) {
             if (isInBackoff(node)) {
-                LOGGER.log(TRACE, "Node [{0}] is in backoff, skipping range discovery", node.address());
+                LOGGER.log(DEBUG, "Node [{0}] is in backoff, skipping range discovery", node.address());
                 continue;
             }
             BlockNodeClient currentNodeClient = getNodeClient(node);
@@ -152,7 +152,7 @@ public class BackfillFetcher implements PriorityHealthBasedStrategy.NodeHealthPr
 
         final String determinedAvailableRangeMsg =
                 "Determined available range from peer blocks nodes start=[{0}] to end=[{1}]";
-        LOGGER.log(TRACE, determinedAvailableRangeMsg, startBlock, latestPeerBlock);
+        LOGGER.log(DEBUG, determinedAvailableRangeMsg, startBlock, latestPeerBlock);
         return new LongRange(startBlock, latestPeerBlock);
     }
 
@@ -288,7 +288,7 @@ public class BackfillFetcher implements PriorityHealthBasedStrategy.NodeHealthPr
                 if (attempt == maxRetries) {
                     markFailure(nodeConfig);
                     // Log exception details on final failure for debugging
-                    LOGGER.log(TRACE, "Final failure stack trace.\n", e);
+                    LOGGER.log(WARNING, "Final failure stack trace.\n", e);
                 } else {
                     long delay = Math.multiplyExact(initialRetryDelayMs, attempt);
                     try {

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillFetcher.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillFetcher.java
@@ -3,7 +3,6 @@ package org.hiero.block.node.backfill;
 
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
-import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -305,7 +304,7 @@ public class BackfillFetcher implements PriorityHealthBasedStrategy.NodeHealthPr
 
         final String allAttemptsExhaustedMsg = "All {0} attempts exhausted for blocks [{1}->{2}] from node [{3}]";
         LOGGER.log(
-                TRACE, allAttemptsExhaustedMsg, maxRetries, blockRange.start(), blockRange.end(), nodeConfig.address());
+                DEBUG, allAttemptsExhaustedMsg, maxRetries, blockRange.start(), blockRange.end(), nodeConfig.address());
         return Collections.emptyList();
     }
 

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillFetcher.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillFetcher.java
@@ -3,6 +3,7 @@ package org.hiero.block.node.backfill;
 
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
+import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.backfill;
 
+import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.TRACE;
+import static java.lang.System.Logger.Level.WARNING;
 
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -130,7 +132,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
         // Validate block node sources configuration
         final String sourcesPath = backfillConfiguration.blockNodeSourcesPath();
         if (sourcesPath == null || sourcesPath.isBlank()) {
-            LOGGER.log(TRACE, "No block node sources path configured, backfill will not run");
+            LOGGER.log(DEBUG, "No block node sources path configured, backfill will not run");
             return;
         }
 
@@ -138,7 +140,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
         if (!Files.isRegularFile(blockNodeSourcesPath)) {
             final String blockNodeSourcesPathNotFoundMsg =
                     "Block node sources path does not exist or is not a regular file: [{0}], backfill will not run";
-            LOGGER.log(TRACE, blockNodeSourcesPathNotFoundMsg, backfillConfiguration.blockNodeSourcesPath());
+            LOGGER.log(WARNING, blockNodeSourcesPathNotFoundMsg, backfillConfiguration.blockNodeSourcesPath());
             return;
         }
 
@@ -148,7 +150,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
             final String parseFailedMsg =
                     "Failed to parse block node sources from path: [%s], backfill will not run: %s"
                             .formatted(backfillConfiguration.blockNodeSourcesPath(), e.getMessage());
-            LOGGER.log(TRACE, parseFailedMsg, e);
+            LOGGER.log(WARNING, parseFailedMsg, e);
             return;
         }
 
@@ -169,7 +171,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
         }
 
         final String schedulingMsg = "Scheduling backfill process to start in [{0}] milliseconds";
-        LOGGER.log(TRACE, schedulingMsg, backfillConfiguration.initialDelay());
+        LOGGER.log(DEBUG, schedulingMsg, backfillConfiguration.initialDelay());
 
         // Create platform thread executors via threadPoolManager.
         // Platform threads required because Helidon WebClient HTTP/2 has issues with virtual threads in containers.
@@ -205,7 +207,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
         final String initializedSchedulersMsg =
                 "Initialized dual schedulers: historical(cap=[{0}]), liveTail(cap=[{1}])";
         LOGGER.log(
-                TRACE,
+                DEBUG,
                 initializedSchedulersMsg,
                 backfillConfiguration.historicalQueueCapacity(),
                 backfillConfiguration.liveTailQueueCapacity());
@@ -265,7 +267,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
         shutdownExecutor(historicalExecutor, "historicalExecutor");
         shutdownExecutor(liveTailExecutor, "liveTailExecutor");
 
-        LOGGER.log(TRACE, "Stopped backfill plugin");
+        LOGGER.log(DEBUG, "Stopped backfill plugin");
     }
 
     private void shutdownExecutor(ExecutorService executor, String name) {
@@ -314,7 +316,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
         // 4. Submit each gap to appropriate scheduler
         final String detectedGapMsg = "Detected gap type=[{0}] range=[{1}]";
         for (GapDetector.Gap gap : gaps) {
-            LOGGER.log(TRACE, detectedGapMsg, gap.type(), gap.range());
+            LOGGER.log(DEBUG, detectedGapMsg, gap.type(), gap.range());
             scheduleGap(gap);
             metricsHolder.backfillGapsDetected.increment();
         }
@@ -349,7 +351,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
             return peerRange != null && peerRange.size() > 0 ? peerRange.end() : -1;
         } catch (RuntimeException e) {
             final String peerAvailabilityFailedMsg = "Failed to get peer availability: %s".formatted(e.getMessage());
-            LOGGER.log(TRACE, peerAvailabilityFailedMsg, e);
+            LOGGER.log(WARNING, peerAvailabilityFailedMsg, e);
             return -1;
         }
     }
@@ -365,7 +367,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
                 && historicalScheduler != null
                 && historicalScheduler.isRunning()) {
             final String skippingHistoricalGapMsg = "Skipping historical gap [{0}], scheduler already running";
-            LOGGER.log(TRACE, skippingHistoricalGapMsg, gap.range());
+            LOGGER.log(DEBUG, skippingHistoricalGapMsg, gap.range());
             return;
         }
 
@@ -386,7 +388,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
                 effectiveGap =
                         new GapDetector.Gap(new LongRange(newStart, gap.range().end()), GapDetector.Type.LIVE_TAIL);
                 final String adjustedLiveTailGapMsg = "Adjusted live-tail gap from [{0}] to [{1}]";
-                LOGGER.log(TRACE, adjustedLiveTailGapMsg, gap.range(), effectiveGap.range());
+                LOGGER.log(DEBUG, adjustedLiveTailGapMsg, gap.range(), effectiveGap.range());
             }
             // Update high-water mark
             liveTailHighWaterMark.updateAndGet(
@@ -397,7 +399,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
 
         // Submit the (possibly adjusted) gap to the appropriate scheduler
         final String submittingGapMsg = "Submitting gap type=[{0}] range=[{1}] to scheduler";
-        LOGGER.log(TRACE, submittingGapMsg, effectiveGap.type(), effectiveGap.range());
+        LOGGER.log(DEBUG, submittingGapMsg, effectiveGap.type(), effectiveGap.range());
         submitGap(effectiveGap);
     }
 
@@ -460,7 +462,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
     @Override
     public void handleNewestBlockKnownToNetwork(NewestBlockKnownToNetworkNotification notification) {
         if (!hasBNSourcesPath) {
-            LOGGER.log(TRACE, "No block node sources path configured, skipping on-demand backfill");
+            LOGGER.log(DEBUG, "No block node sources path configured, skipping on-demand backfill");
             return;
         }
 
@@ -474,7 +476,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
         if (cappedEnd < startBackfillFrom) {
             final String skippingOnDemandBackfillMsg =
                     "Newest block [{0}] is before startBackfillFrom [{1}], skipping on-demand backfill";
-            LOGGER.log(TRACE, skippingOnDemandBackfillMsg, cappedEnd, startBackfillFrom);
+            LOGGER.log(DEBUG, skippingOnDemandBackfillMsg, cappedEnd, startBackfillFrom);
             return;
         }
         scheduleGap(new GapDetector.Gap(new LongRange(startBackfillFrom, cappedEnd), GapDetector.Type.LIVE_TAIL));
@@ -496,7 +498,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
         public void accept(GapDetector.Gap gap) {
             try {
                 final String processingGapMsg = "Scheduler processing gap type=[{0}] range=[{1}] for [{2}]";
-                LOGGER.log(TRACE, processingGapMsg, gap.type(), gap.range(), schedulerName);
+                LOGGER.log(DEBUG, processingGapMsg, gap.type(), gap.range(), schedulerName);
                 long lastSuccessfulBlock = runner.run(gap);
                 // Reset highWaterMark if the gap didn't complete, allowing re-detection
                 if (gap.type() == GapDetector.Type.LIVE_TAIL

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/BlockStreamSubscribeUnparsedClient.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/BlockStreamSubscribeUnparsedClient.java
@@ -2,7 +2,7 @@
 package org.hiero.block.node.backfill.client;
 
 import static java.lang.System.Logger.Level.DEBUG;
-import static java.lang.System.Logger.Level.TRACE;
+import static java.lang.System.Logger.Level.WARNING;
 import static java.util.Objects.requireNonNull;
 import static org.hiero.block.api.BlockStreamSubscribeServiceInterface.FULL_NAME;
 
@@ -165,7 +165,7 @@ public class BlockStreamSubscribeUnparsedClient {
 
         @Override
         public void onSubscribe(Flow.Subscription subscription) {
-            LOGGER.log(TRACE, "received onSubscribe confirmation");
+            LOGGER.log(DEBUG, "received onSubscribe confirmation");
             // No backpressure negotiation needed for this pattern.
         }
 
@@ -213,13 +213,13 @@ public class BlockStreamSubscribeUnparsedClient {
 
         @Override
         public void onError(Throwable throwable) {
-            LOGGER.log(TRACE, "received onError", throwable);
+            LOGGER.log(WARNING, "received onError", throwable);
             ctx.fail(throwable);
         }
 
         @Override
         public void onComplete() {
-            LOGGER.log(TRACE, "received onComplete");
+            LOGGER.log(DEBUG, "received onComplete");
             ctx.complete();
         }
     }

--- a/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.health;
 
+import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
@@ -33,7 +34,7 @@ public class HealthServicePlugin implements BlockNodePlugin {
         serviceBuilder.registerHttpService(
                 HEALTHZ_PATH,
                 httpRules -> httpRules.get(LIVEZ_PATH, this::handleLivez).get(READYZ_PATH, this::handleReadyz));
-        LOGGER.log(TRACE, "Completed health facility initialization");
+        LOGGER.log(DEBUG, "Completed health facility initialization");
     }
 
     /**

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -144,7 +144,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         // for the new publisher.
         metrics.currentPublisherCount().set(handlers.size());
         sendPublisherStatusUpdate(UpdateType.PUBLISHER_CONNECTED, handlers);
-        LOGGER.log(TRACE, "Added new handler {0}", handlerId);
+        LOGGER.log(DEBUG, "Added new handler {0}", handlerId);
         return newHandler;
     }
 
@@ -159,7 +159,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         // Update metrics and publish the status update
         metrics.currentPublisherCount().set(handlers.size());
         sendPublisherStatusUpdate(UpdateType.PUBLISHER_DISCONNECTED, handlers);
-        LOGGER.log(TRACE, "Removed handler {0}", handlerId);
+        LOGGER.log(DEBUG, "Removed handler {0}", handlerId);
     }
 
     @Override

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -829,7 +829,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
                                 .formatted(handlerId, correlationIdPrefix),
                         e);
             }
-            LOGGER.log(TRACE, "[{0}] Handler {1} issued onComplete/closeConnection", correlationIdPrefix, handlerId);
+            LOGGER.log(DEBUG, "[{0}] Handler {1} issued onComplete/closeConnection", correlationIdPrefix, handlerId);
         }
     }
 

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
@@ -301,7 +301,7 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                     // end working time
                     long blockWorkEndTime = System.nanoTime() - startVerificationHandlingTime;
                     LOGGER.log(
-                            TRACE,
+                            DEBUG,
                             "Finished verification handling block items for block={0,number,#} nsVerificationDuration={1,number,#}",
                             currentBlockNumber,
                             blockWorkEndTime);

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.verification;
 
+import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
-import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
 
 import com.hedera.cryptography.tss.TSS;
@@ -173,7 +173,7 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
         context.blockMessaging().registerBlockNotificationHandler(this, false, "VerificationServicePlugin");
         // initialize metrics
         initMetrics(context);
-        LOGGER.log(TRACE, "VerificationServicePlugin initialized successfully.");
+        LOGGER.log(DEBUG, "VerificationServicePlugin initialized successfully.");
         // initialize all previous blocks hasher if enabled and available
         initAllBlocksHasherIfEnabled();
     }
@@ -191,11 +191,11 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                 && (earliestManagedBlock == 0 || hasherHasData)) {
             previousBlockHash = Bytes.wrap(allBlocksHasherHandler.lastBlockHash());
             final String message = "All previous blocks hasher initialized with {0} hashes, last block hash: {1}";
-            LOGGER.log(TRACE, message, allBlocksHasherHandler.getNumberOfBlocks(), previousBlockHash);
+            LOGGER.log(DEBUG, message, allBlocksHasherHandler.getNumberOfBlocks(), previousBlockHash);
         } else {
             final String message =
                     "All previous blocks hasher not available, falling back to BlockFooter-provided values.";
-            LOGGER.log(TRACE, message);
+            LOGGER.log(DEBUG, message);
         }
     }
 
@@ -208,7 +208,7 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
         // specify that we are cpu intensive and should be run on a separate non-virtual thread
         context.blockMessaging().registerBlockItemHandler(this, true, VerificationServicePlugin.class.getSimpleName());
         // we do not need to unregister the handler as it will be unregistered when the message service is stopped
-        LOGGER.log(TRACE, "VerificationServicePlugin started successfully.");
+        LOGGER.log(DEBUG, "VerificationServicePlugin started successfully.");
 
         allBlocksHasherHandler.start();
     }
@@ -258,7 +258,7 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                         previousHash,
                         getRootOfAllPreviousBlocks(),
                         activeLedgerId);
-                LOGGER.log(TRACE, "Started new block verification session for block number {0}", currentBlockNumber);
+                LOGGER.log(DEBUG, "Started new block verification session for block number {0}", currentBlockNumber);
             } else {
                 headerValid = true; // header not present, assume it was valid
             }
@@ -270,7 +270,7 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                 LOGGER.log(INFO, "Received block items before a block header, ignoring.");
             } else if (headerValid) {
                 final String traceMessage = "Appending {0} block items to the current session for block number: {1}";
-                LOGGER.log(TRACE, traceMessage, blockItems.blockItems().size(), currentBlockNumber);
+                LOGGER.log(DEBUG, traceMessage, blockItems.blockItems().size(), currentBlockNumber);
                 long startHashingTime = System.nanoTime();
                 // processBlockItems returns notification when isEndOfBlock(), null otherwise
                 VerificationNotification notification = currentSession.processBlockItems(blockItems);
@@ -278,14 +278,14 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                 hashingBlockTimeNs.increment(hashingTime);
                 // if this is the end of the block, handle verification result
                 if (notification != null) {
-                    LOGGER.log(TRACE, COMPLETED_MESSAGE, currentBlockNumber, notification.success());
+                    LOGGER.log(DEBUG, COMPLETED_MESSAGE, currentBlockNumber, notification.success());
                     if (notification.success()) {
                         if (currentBlockNumber == 0) {
                             persistTssParameters();
                         }
                         verificationBlocksVerified.increment();
                         // send the notification to the block messaging service
-                        LOGGER.log(TRACE, "Sending verification notification for block={0}", currentBlockNumber);
+                        LOGGER.log(DEBUG, "Sending verification notification for block={0}", currentBlockNumber);
                         context.blockMessaging().sendBlockVerification(notification);
                         // Update previousBlockHash and previousVerifiedBlockNumber for next block verification
                         this.previousBlockHash = notification.blockHash();
@@ -398,7 +398,7 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
     public void handleBackfilled(BackfilledBlockNotification notification) {
         try {
             // log the backfilled block notification received
-            LOGGER.log(TRACE, "Received backfill notification for block={0}", notification.blockNumber());
+            LOGGER.log(DEBUG, "Received backfill notification for block={0}", notification.blockNumber());
             // create a new verification session for the backfilled block
             BlockHeader blockHeader = BlockHeader.PROTOBUF.parse(
                     notification.block().blockItems().getFirst().blockHeader());
@@ -421,7 +421,7 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                 VerificationNotification backfillNotification = backfillSession.processBlockItems(backfillBlockItems);
                 if (backfillNotification != null) {
                     // Log the backfill verification result
-                    LOGGER.log(TRACE, COMPLETED_MESSAGE, notification.blockNumber(), backfillNotification.success());
+                    LOGGER.log(DEBUG, COMPLETED_MESSAGE, notification.blockNumber(), backfillNotification.success());
                     if (backfillNotification.success()) {
                         if (notification.blockNumber() == 0) {
                             persistTssParameters();

--- a/charts/block-node-server/values-overrides/lfh-values.yaml
+++ b/charts/block-node-server/values-overrides/lfh-values.yaml
@@ -5,7 +5,7 @@ blockNode:
         logs:
             level: "INFO"
             loggingProperties:
-                org.hiero.block.level: "FINEST"
+                org.hiero.block.level: "FINE"
                 java.util.logging.ConsoleHandler.level: "FINEST"
                 java.util.logging.FileHandler.level: "FINEST"
         initContainers:

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -255,8 +255,8 @@ blockNode:
     level: "INFO"
     configMountPath: "/opt/hiero/block-node/logs/config"
     loggingProperties:
-      # logs for Block Node components FINEST temporarily while testing is ongoing
-      org.hiero.block.level: "FINEST"
+      # logs for Block Node components FINE (DEBUG) temporarily while testing is ongoing
+      org.hiero.block.level: "FINE"
       io.helidon.level: "INFO"
       io.helidon.webserver.level: "INFO"
       io.helidon.webserver.access.level: "INFO"


### PR DESCRIPTION
## Summary

  - Promotes 35 TRACE log statements to DEBUG or WARNING across stream-publisher, verification, health, and backfill plugins
  - All promoted logs are lifecycle events, per-block milestones, or error/misconfiguration conditions — not high-frequency per-item paths
  - High-frequency logs (Kubernetes probe responses, per-block-item backfill tracking, scan-cycle no-ops) intentionally kept at TRACE

  ## Changes by plugin

  **stream-publisher**
  - `PublisherHandler`: `onComplete/closeConnection` → DEBUG (stream lifecycle, once per publisher disconnect)
  - `LiveStreamPublisherManager`: handler add/remove → DEBUG (rare connection events)

  **verification**
  - `VerificationServicePlugin`: all 10 TRACE logs → DEBUG — init state, per-block session start/complete/notification, backfill verification path. The per-block verification outcome (`Completed block=[N] with result=[X]`) was previously
  invisible without TRACE.

  **health**
  - `HealthServicePlugin`: init completion → DEBUG. Liveness/readiness probe responses kept at TRACE (fire every few seconds from Kubernetes).

  **backfill**
  - `BackfillPlugin`: 11 logs → DEBUG (init guards, gap detection, scheduling decisions, shutdown), 3 → WARNING (path-not-found, parse-failed, peer-availability-failure — all silent no-ops that operators must see)
  - `BackfillFetcher`: backoff skip, available-range discovery → DEBUG; final fetch failure → WARNING
  - `BlockStreamSubscribeUnparsedClient`: onSubscribe/onComplete → DEBUG; onError → WARNING


## Related Issue(s)
Fixes #2573 
