### PR TITLE
chore: audit TRACE logs in block-access-service, blocks-file-recent, blocks-file-historic, facility-messaging, and s3-archive plugins

### DIFF
--- a/block-node/block-access-service/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
+++ b/block-node/block-access-service/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
@@ -101,7 +101,7 @@ public class BlockAccessServicePlugin implements BlockNodePlugin, BlockAccessSer
                     || (request.hasBlockNumber() && request.blockNumber() == -1)) {
                 blockNumberToRetrieve = blockProvider.availableBlocks().max();
                 LOGGER.log(
-                        TRACE, "Received 'retrieveLatest' BlockRequest, retrieving block={0}", blockNumberToRetrieve);
+                        DEBUG, "Received 'retrieveLatest' BlockRequest, retrieving block={0}", blockNumberToRetrieve);
             } else {
                 LOGGER.log(INFO, "Invalid request, 'retrieve_latest' or a valid 'block number' is required.");
                 return new BlockResponseUnparsed(Code.INVALID_REQUEST, null);
@@ -111,7 +111,7 @@ public class BlockAccessServicePlugin implements BlockNodePlugin, BlockAccessSer
                 long lowestBlockNumber = blockProvider.availableBlocks().min();
                 long highestBlockNumber = blockProvider.availableBlocks().max();
                 LOGGER.log(
-                        TRACE,
+                        DEBUG,
                         "Requested block {0} is outside available range [{1}, {2}]",
                         blockNumberToRetrieve,
                         lowestBlockNumber,

--- a/block-node/block-access-service/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
+++ b/block-node/block-access-service/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.access.service;
 
+import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
-import static java.lang.System.Logger.Level.TRACE;
 
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.Pipelines;
@@ -96,7 +96,7 @@ public class BlockAccessServicePlugin implements BlockNodePlugin, BlockAccessSer
             // if retrieveLatest is set, or the request is for the largest possible block number, get the latest block.
             if (request.hasBlockNumber() && request.blockNumber() >= 0) {
                 blockNumberToRetrieve = request.blockNumber();
-                LOGGER.log(TRACE, "Received `block_number` BlockRequest, retrieving block: {0}", blockNumberToRetrieve);
+                LOGGER.log(DEBUG, "Received `block_number` BlockRequest, retrieving block: {0}", blockNumberToRetrieve);
             } else if ((request.hasRetrieveLatest() && request.retrieveLatest())
                     || (request.hasBlockNumber() && request.blockNumber() == -1)) {
                 blockNumberToRetrieve = blockProvider.availableBlocks().max();

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
@@ -4,7 +4,6 @@ package org.hiero.block.node.blocks.files.historic;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
-import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
 import static java.nio.file.FileVisitResult.CONTINUE;
 import static org.hiero.block.node.base.BlockFile.nestedDirectoriesAllBlockNumbers;
@@ -401,7 +400,7 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
             BlockUnparsed.PROTOBUF.write(block, streamingData);
             streamingData.flush();
             streamingData.close();
-            LOGGER.log(TRACE, "Wrote verified block {0} to file {1}", blockNumber, verifiedBlockPath.toAbsolutePath());
+            LOGGER.log(DEBUG, "Wrote verified block {0} to file {1}", blockNumber, verifiedBlockPath.toAbsolutePath());
             // update the oldest and newest verified block numbers
             availableStagedBlocks.add(blockNumber);
         } catch (final IOException e) {
@@ -561,7 +560,7 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
                 } else {
                     // move the batch of blocks to a zip file
                     final String startMessage = "Moving batch of blocks [{0} -> {1}] to zip file.";
-                    plugin.LOGGER.log(TRACE, startMessage, batchFirstBlockNumber, batchLastBlockNumber);
+                    plugin.LOGGER.log(DEBUG, startMessage, batchFirstBlockNumber, batchLastBlockNumber);
 
                     // compute the exact path where we need to move the created zip file
                     final BlockPath firstBlockPath =
@@ -619,7 +618,7 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
                     plugin.availableBlocks.add(batchFirstBlockNumber, batchLastBlockNumber);
                     plugin.totalZipFiles.incrementAndGet();
                     final String successMessage = "Successfully moved batch of blocks[{0} -> {1}] to zip file.";
-                    plugin.LOGGER.log(TRACE, successMessage, batchFirstBlockNumber, batchLastBlockNumber);
+                    plugin.LOGGER.log(DEBUG, successMessage, batchFirstBlockNumber, batchLastBlockNumber);
                     // now all the blocks are in the zip file and accessible, send notification
                     // @todo is this needed? Does anything actually care when a zip file is completed?
                     plugin.context

--- a/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPlugin.java
+++ b/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPlugin.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.blocks.files.recent;
 
+import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.TRACE;
@@ -315,7 +316,7 @@ public final class BlockFileRecentPlugin implements BlockProviderPlugin, BlockNo
     public void handleVerification(VerificationNotification notification) {
         try {
             final long startTime = System.nanoTime();
-            LOGGER.log(TRACE, "Persistence Handle verification started for block {0}", notification.blockNumber());
+            LOGGER.log(DEBUG, "Persistence Handle verification started for block {0}", notification.blockNumber());
             if (notification != null && notification.success()) {
                 // write the block to the live path and send notification of block persisted
                 writeBlockToLivePath(notification.block(), notification.blockNumber(), notification.source());
@@ -409,7 +410,7 @@ public final class BlockFileRecentPlugin implements BlockProviderPlugin, BlockNo
             streamingData.close();
             // Add the size of the newly written file to our total bytes counter
             totalBytesStored.addAndGet(Files.size(verifiedBlockPath));
-            LOGGER.log(TRACE, "Wrote verified block {0} to file {1}", blockNumber, verifiedBlockPath.toAbsolutePath());
+            LOGGER.log(DEBUG, "Wrote verified block {0} to file {1}", blockNumber, verifiedBlockPath.toAbsolutePath());
             // update the oldest and newest verified block numbers
             availableBlocks.add(blockNumber);
             // Send block persisted notification
@@ -478,7 +479,7 @@ public final class BlockFileRecentPlugin implements BlockProviderPlugin, BlockNo
             // delete the block file and update counters
             final boolean deleted = Files.deleteIfExists(blockFilePath);
             if (deleted) {
-                LOGGER.log(TRACE, DELETE_MESSAGE.formatted("Success", blockFilePath));
+                LOGGER.log(DEBUG, DELETE_MESSAGE.formatted("Success", blockFilePath));
             } else {
                 LOGGER.log(INFO, DELETE_MESSAGE.formatted("File missing", blockFilePath));
             }

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.messaging;
 
+import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.TRACE;
 import static org.hiero.block.node.spi.BlockNodePlugin.METRICS_CATEGORY;
 
@@ -249,7 +250,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
 
         // log successful initialization
         LOGGER.log(
-                TRACE,
+                DEBUG,
                 "BlockMessagingFacility initialized with block item queue size: {0} and block notification queue size: {1}",
                 messagingConfig.blockItemQueueSize(),
                 messagingConfig.blockNotificationQueueSize());
@@ -373,7 +374,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
 
         // log the registration of the handler
         LOGGER.log(
-                TRACE,
+                DEBUG,
                 "Registering block item handler: {0}, cpuIntensive: {1}, handlerName: {2}",
                 handler.getClass().getSimpleName(),
                 cpuIntensiveHandler,
@@ -416,7 +417,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
 
         // log the registration of the handler
         LOGGER.log(
-                TRACE,
+                DEBUG,
                 "Registering no backpressure block item handler: {0}, cpuIntensive: {1}, handlerName: {2}",
                 handler.getClass().getSimpleName(),
                 cpuIntensiveHandler,
@@ -446,7 +447,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
             blockVerificationNotificationsCounter.increment();
             // logs
             LOGGER.log(
-                    TRACE,
+                    DEBUG,
                     "Sending block verification notification for block={0} blockSource={1} and success={2} ",
                     notification.blockNumber(),
                     notification.source(),
@@ -461,7 +462,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
     public void sendBlockPersisted(PersistedNotification notification) {
         messageForwarder.submit(() -> {
             LOGGER.log(
-                    TRACE,
+                    DEBUG,
                     "Sending block persisted notification: block={0} succeeded={1} source={2}",
                     notification.blockNumber(),
                     notification.succeeded(),
@@ -486,7 +487,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
     @Override
     public void sendNewestBlockKnownToNetwork(NewestBlockKnownToNetworkNotification notification) {
         messageForwarder.submit(() -> {
-            LOGGER.log(TRACE, "Sending NewestBlockKnownToNetwork notification: block={0}", notification.blockNumber());
+            LOGGER.log(DEBUG, "Sending NewestBlockKnownToNetwork notification: block={0}", notification.blockNumber());
             blockNotificationDisruptor.getRingBuffer().publishEvent((event, sequence) -> event.set(notification));
             newestBlockKnownToNetworkNotificationsCounter.increment();
         });
@@ -495,7 +496,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
     @Override
     public void sendPublisherStatusUpdate(final PublisherStatusUpdateNotification notification) {
         messageForwarder.submit(() -> {
-            LOGGER.log(TRACE, "Sending publisher status update notification: {0}", notification);
+            LOGGER.log(DEBUG, "Sending publisher status update notification: {0}", notification);
             blockNotificationDisruptor.getRingBuffer().publishEvent((event, sequence) -> event.set(notification));
             publisherStatusUpdateNotificationsCounter.increment();
         });
@@ -542,7 +543,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
 
         // log the registration of the handler
         LOGGER.log(
-                TRACE,
+                DEBUG,
                 "Registering block notification handler: {0}, cpuIntensive: {1}, handlerName: {2}",
                 handler.getClass().getSimpleName(),
                 cpuIntensiveHandler,
@@ -593,9 +594,9 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
         }
 
         // log successful start
-        if (LOGGER.isLoggable(TRACE)) {
+        if (LOGGER.isLoggable(DEBUG)) {
             LOGGER.log(
-                    TRACE,
+                    DEBUG,
                     "BlockMessagingFacility successfully started with block item queue size: {0} and block notification queue size: {1}",
                     blockItemDisruptor.getRingBuffer().getBufferSize(),
                     blockNotificationDisruptor.getRingBuffer().getBufferSize());
@@ -616,7 +617,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
         for (Thread thread : blockItemHandlerToThread.values()) {
             thread.interrupt();
             // log the stopping of the thread
-            LOGGER.log(TRACE, "Stopped block item handler thread: {0}", thread.getName());
+            LOGGER.log(DEBUG, "Stopped block item handler thread: {0}", thread.getName());
         }
         // Stop all the block notification event handlers
         for (var eventHandler : blockNotificationHandlerToEventProcessor.values()) {
@@ -630,7 +631,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
         for (Thread thread : blockNotificationHandlerToThread.values()) {
             thread.interrupt();
             // log the stopping of the thread
-            LOGGER.log(TRACE, "Stopped block notification handler thread: {0}", thread.getName());
+            LOGGER.log(DEBUG, "Stopped block notification handler thread: {0}", thread.getName());
         }
         messageForwarder.shutdown();
     }

--- a/block-node/s3-archive/src/main/java/org/hiero/block/node/archive/s3/S3ArchivePlugin.java
+++ b/block-node/s3-archive/src/main/java/org/hiero/block/node/archive/s3/S3ArchivePlugin.java
@@ -4,7 +4,6 @@ package org.hiero.block.node.archive.s3;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
-import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
 import static org.hiero.block.node.base.BlockFile.blockNumberFormated;
 
@@ -232,7 +231,7 @@ public class S3ArchivePlugin implements BlockNodePlugin, BlockNotificationHandle
             return;
         }
 
-        LOGGER.log(TRACE, "Scheduling S3 archive upload for blocks: {0} - {1}", startBlock, endBlock);
+        LOGGER.log(DEBUG, "Scheduling S3 archive upload for blocks: {0} - {1}", startBlock, endBlock);
 
         activeUploads.submit(new UploadTask(
                 startBlock, endBlock, lastArchivedBlockNumber, archiveConfig, context, pendingBatchStarts));


### PR DESCRIPTION
## Summary

  - Promotes 16 TRACE log statements to DEBUG across block-access-service, blocks-file-recent, blocks-file-historic, facility-messaging, and s3-archive plugins
  - All changes are DEBUG-only (no WARN promotions in this group)
  - 3 high-frequency messaging paths kept at TRACE: per-item block send, backfilled-block notification, handler unregistration

  ## Changes by plugin

  **block-access-service**
  - `BlockAccessServicePlugin`: client block request log → DEBUG (per-client request, useful for access pattern diagnosis)

  **blocks-file-recent**
  - `BlockFileRecentPlugin`: persistence-started, wrote-block, file-deleted → DEBUG (per-block write confirmation with file path; key for diagnosing storage issues)

  **blocks-file-historic**
  - `BlockFileHistoricPlugin`: wrote-block, batch-move-start, batch-move-success → DEBUG (per-batch archival events; operators monitoring historic archiving need these at DEBUG)

  **facility-messaging**
  - `BlockMessagingFacilityImpl`: 11 logs → DEBUG — init, handler registration (3 variants), verification/persisted/status-update notification sends, start success, stop threads. The `isLoggable(TRACE)` guard on the start-success log updated
  to `isLoggable(DEBUG)`.
  - Kept at TRACE: `sendBlockItems` (highest-frequency path in the system), backfilled-block notification (burst-rate during backfill), handler unregistration (frequency unknown in production)

  **s3-archive**
  - `S3ArchivePlugin`: archive upload scheduling → DEBUG (per-batch trigger with block range; essential for diagnosing upload coverage gaps)

## Related Issue(s)
Fixes #2573 
