### PR TITLE
docs: add missing CLI tool commands to documentation

### DIFF
--- a/tools-and-tests/tools/README.md
+++ b/tools-and-tests/tools/README.md
@@ -62,9 +62,9 @@ subcommands
 │   ├── json                  # Convert binary Block Stream to JSON
 │   ├── ls                    # List/inspect block files
 │   ├── validate              # Validate block hash chain and signatures
-│   ├── validate-wrapped      # Validate wrapped blocks with balance checks
 │   ├── wrap                  # Convert record files to wrapped blocks
-│   └── fetchBalanceCheckpoints # Fetch balance checkpoints from GCP
+│   ├── fetchBalanceCheckpoints # Fetch balance checkpoints from GCP
+│   └── repair-zips           # Repair corrupt zip CENs in wrapped-block dirs
 │
 ├── records                   # Tools for Record Stream files
 │   └── ls                    # List record file info
@@ -81,6 +81,7 @@ subcommands
 │   ├── download-days-v3      # Download days (v3 with Guava preload fix)
 │   ├── download-live         # Live download following Mirror Node
 │   ├── download-live2        # Live download with inline validation
+│   ├── live-sequential       # Download + validate + wrap in one pipeline
 │   ├── print-listing         # Print listing for one day
 │   ├── ls-day-listing        # Print all files in day listing
 │   ├── split-files-listing   # Split files.json into day listing files
@@ -98,9 +99,12 @@ subcommands
 │   ├── fetchRecordsCsv       # Download Mirror Node CSV dump
 │   ├── fetchMissingTransactions # Download mainnet errata for missing txns
 │   ├── extractDayBlock       # Extract per-day block info to JSON
+│   ├── extractDayBlocksFromApi # Generate day_blocks.json from REST API
 │   ├── update                # Update block data from Mirror Node
 │   ├── generateAddressBook   # Generate address book from CSV
-│   └── compareAddressBooks   # Compare two address book files
+│   ├── compareAddressBooks   # Compare two address book files
+│   ├── generateTestnetAddressBook # Generate testnet genesis address book
+│   └── generateTestnetAddressBookHistory # Generate testnet address book history
 │
 ├── metadata                  # Works with metadata files
 │   ├── ls                    # Display metadata file summary

--- a/tools-and-tests/tools/docs/blocks-commands.md
+++ b/tools-and-tests/tools/docs/blocks-commands.md
@@ -4,14 +4,14 @@ The `blocks` command contains utilities for working with Block Stream files (.bl
 
 ### Available Subcommands
 
-|          Command          |                                     Description                                     |
-|---------------------------|-------------------------------------------------------------------------------------|
-| `json`                    | Converts a binary Block Stream to JSON                                              |
-| `ls`                      | Prints info for block files (supports .blk, .blk.gz, .blk.zstd, and zip archives)   |
-| `validate`                | Validates a wrapped Block Stream (hash chain and signatures)                        |
-| `validate-wrapped`        | Validates wrapped blocks produced by `wrap` (chain, merkle tree, structure, supply) |
-| `wrap`                    | Convert record file blocks in day files to wrapped Block Stream blocks              |
-| `fetchBalanceCheckpoints` | Fetch balance checkpoint files from GCP and compile into a resource file            |
+|          Command          |                                    Description                                    |
+|---------------------------|-----------------------------------------------------------------------------------|
+| `json`                    | Converts a binary Block Stream to JSON                                            |
+| `ls`                      | Prints info for block files (supports .blk, .blk.gz, .blk.zstd, and zip archives) |
+| `validate`                | Validates a wrapped Block Stream (hash chain and signatures)                      |
+| `wrap`                    | Convert record file blocks in day files to wrapped Block Stream blocks            |
+| `fetchBalanceCheckpoints` | Fetch balance checkpoint files from GCP and compile into a resource file          |
+| `repair-zips`             | Repair corrupt zip CENs in wrapped-block directories                              |
 
 ---
 
@@ -133,7 +133,62 @@ blocks validate --no-validate-balances /path/to/testnetWrappedBlocks --network t
 
 ---
 
+### The `repair-zips` Subcommand
+
+Repair corrupt zip central directories (CEN) in wrapped-block directories, then optionally fill any blocks still missing from source day archives. This is a two-phase tool:
+
+- **Phase 1** (always runs): Scans all zip files, detects corrupt or missing central directories, and rebuilds them from intact local file entries.
+- **Phase 2** (optional, when `-i` is provided): Re-wraps missing blocks from source day archives and appends them to repaired zips.
+
+#### Usage
+
+```
+blocks repair-zips [--scan-threads=<N>] [--repair-threads=<N>] [--buffer-size=<MiB>]
+                   [--backup=<dir>] [--dry-run] [-i=<inputDir>] [-b=<blockTimesFile>]
+                   [-d=<dayBlocksFile>] <wrappedBlockDir>
+```
+
+#### Options
+
+|              Option              |                                             Description                                             |
+|----------------------------------|-----------------------------------------------------------------------------------------------------|
+| `<wrappedBlockDir>`              | Directory containing wrapped block zip files to scan and repair (required).                         |
+| `--scan-threads <N>`             | Number of threads for parallel CEN scan phase (default: 4).                                         |
+| `--repair-threads <N>`           | Number of threads for parallel CEN repair phase (default: 4).                                       |
+| `--buffer-size <MiB>`            | Per-thread buffer size in MiB for in-memory repair (default: auto-computed from heap size).         |
+| `--backup <dir>`                 | Directory to copy corrupt zip files before repairing. If not specified, repairs in-place.           |
+| `--dry-run`                      | Scan and report missing blocks without modifying files (Phase 2 only).                              |
+| `-i`, `--input-dir <dir>`        | Directory containing source record-file `.tar.zstd` day archives for Phase 2 missing-block filling. |
+| `-b`, `--blocktimes-file <file>` | Block-times binary file for mapping block numbers to timestamps (default: `block_times.bin`).       |
+| `-d`, `--day-blocks <file>`      | Day-blocks JSON file mapping calendar dates to block numbers (default: `day_blocks.json`).          |
+
+#### Example
+
+```bash
+# Phase 1 only: scan and repair corrupt zip CENs
+blocks repair-zips /path/to/wrappedBlocks
+
+# Phase 1 + Phase 2: repair CENs and fill missing blocks from day archives
+blocks repair-zips -i /path/to/compressedDays /path/to/wrappedBlocks
+
+# Dry run to see what's missing without modifying anything
+blocks repair-zips --dry-run -i /path/to/compressedDays /path/to/wrappedBlocks
+
+# Backup corrupt zips before repairing
+blocks repair-zips --backup /path/to/backup /path/to/wrappedBlocks
+```
+
+#### Notes
+
+- Phase 1 rebuilds the central directory from intact local file entries within each zip.
+- Phase 2 requires `-i` (source day archives), `-b` (block times), and `-d` (day blocks) to re-wrap and append missing blocks.
+- The `--buffer-size` defaults to approximately 75% of max heap divided by `2 × repairThreads`.
+
+---
+
 ### The `validate-wrapped` Subcommand
+
+> **Note:** The `validate-wrapped` command has been merged into the `validate` command. The `validate` command now includes all validation checks previously in `validate-wrapped` (chain, merkle tree, structure, supply, balance checkpoints). Use `blocks validate` instead.
 
 Validates wrapped block stream files produced by the `wrap` command. Walks all blocks in the input directory in order and performs the following checks:
 

--- a/tools-and-tests/tools/docs/days-commands.md
+++ b/tools-and-tests/tools/docs/days-commands.md
@@ -328,7 +328,11 @@ The command writes its state to `validateCmdStatus.json` in the output directory
 
 ### `live-sequential`
 
-Live sequential block download with inline validation and wrapping. This is an all-in-one pipeline that combines `download-live2`, `blocks wrap`, and `blocks validate` into a single optimized command. It downloads blocks sequentially from GCS, validates them (hash-chain + signatures), wraps them into block stream format, runs all block validation checks, and writes to hierarchical zip archives.
+Live sequential block download with inline validation and wrapping.
+This is an all-in-one pipeline that combines `download-live2`, `blocks wrap`, and `blocks validate`
+into a single optimized command. It downloads blocks sequentially from GCS, validates them
+(hash-chain + signatures), wraps them into Block Stream format, runs all block validation checks,
+and writes to hierarchical zip archives.
 
 #### Usage
 
@@ -343,7 +347,7 @@ days live-sequential [-l <listingDir>] [-o <outputDir>] [--wrap-output-dir <dir>
 |------------------------------------|-----------------------------------------------------------------------------------|
 | `-l`, `--listing-dir <listingDir>` | Directory where listing files are stored (default: `listingsByDay`).              |
 | `-o`, `--output-dir <outputDir>`   | Directory where compressed day archives are written (default: `compressedDays`).  |
-| `--wrap-output-dir <dir>`          | Directory to write wrapped block stream output (default: `wrappedBlocks`).        |
+| `--wrap-output-dir <dir>`          | Directory to write wrapped Block Stream output (default: `wrappedBlocks`).        |
 | `--start-date <YYYY-MM-DD>`        | Start date (default: auto-detect from Mirror Node).                               |
 | `--state-json <path>`              | Path to state JSON file for resume (default: `outputDir/validateCmdStatus.json`). |
 | `--address-book <path>`            | Path to address book file for signature validation.                               |

--- a/tools-and-tests/tools/docs/days-commands.md
+++ b/tools-and-tests/tools/docs/days-commands.md
@@ -17,6 +17,7 @@ The `days` top-level command works with compressed daily record file archives. D
 | `download-days-v3`       | Download many days (v3 with Guava preload fix)                        |
 | `download-live`          | Continuously follow Mirror Node for new block files                   |
 | `download-live2`         | Live block download with inline validation and automatic day rollover |
+| `live-sequential`        | Live sequential download with inline validation and wrapping          |
 | `print-listing`          | Print the listing for a given day                                     |
 | `ls-day-listing`         | Print all files in the listing for a day                              |
 | `split-files-listing`    | Split a giant JSON listing into per-day binary listing files          |
@@ -322,6 +323,61 @@ The command writes its state to `validateCmdStatus.json` in the output directory
 |---------------------------------------------|------------------------------------------------------------------------------------------|
 | `download-live2` writes -> `validate` reads | Works (validate ignores extra `blockNumber` field)                                       |
 | `validate` writes -> `download-live2` reads | `blockNumber` will be 0, so `download-live2` falls back to `--start-date` or auto-detect |
+
+---
+
+### `live-sequential`
+
+Live sequential block download with inline validation and wrapping. This is an all-in-one pipeline that combines `download-live2`, `blocks wrap`, and `blocks validate` into a single optimized command. It downloads blocks sequentially from GCS, validates them (hash-chain + signatures), wraps them into block stream format, runs all block validation checks, and writes to hierarchical zip archives.
+
+#### Usage
+
+```
+days live-sequential [-l <listingDir>] [-o <outputDir>] [--wrap-output-dir <dir>]
+                     [--start-date <YYYY-MM-DD>] [--state-json <path>] [--address-book <path>]
+```
+
+#### Options
+
+|               Option               |                                    Description                                    |
+|------------------------------------|-----------------------------------------------------------------------------------|
+| `-l`, `--listing-dir <listingDir>` | Directory where listing files are stored (default: `listingsByDay`).              |
+| `-o`, `--output-dir <outputDir>`   | Directory where compressed day archives are written (default: `compressedDays`).  |
+| `--wrap-output-dir <dir>`          | Directory to write wrapped block stream output (default: `wrappedBlocks`).        |
+| `--start-date <YYYY-MM-DD>`        | Start date (default: auto-detect from Mirror Node).                               |
+| `--state-json <path>`              | Path to state JSON file for resume (default: `outputDir/validateCmdStatus.json`). |
+| `--address-book <path>`            | Path to address book file for signature validation.                               |
+
+#### Features
+
+- **Combined pipeline**: Download → validate → wrap → validate-wrapped in a single pass, avoiding multiple disk reads.
+- **Inline validation**: Validates each block's running hash and signatures as it's downloaded.
+- **Block wrapping**: Converts record file blocks into wrapped Block Stream `Block` protobufs.
+- **Block validation**: Runs all 11 `BlockValidation` checks on wrapped blocks.
+- **Resume support**: Saves state periodically via checkpoints to allow resuming after interruption.
+- **Auto-detect start date**: Queries the Mirror Node to determine the current day if `--start-date` is not specified.
+
+#### Example
+
+```bash
+# Run the full pipeline from a specific date
+java -jar tools-all.jar days live-sequential \
+  -l /path/to/listingsByDay \
+  -o /path/to/compressedDays \
+  --wrap-output-dir /path/to/wrappedBlocks \
+  --start-date 2026-01-09
+
+# Auto-detect today and run continuously
+java -jar tools-all.jar days live-sequential \
+  -l /path/to/listingsByDay \
+  -o /path/to/compressedDays \
+  --wrap-output-dir /path/to/wrappedBlocks
+```
+
+#### Notes
+
+- This command supersedes the multi-step workflow of running `download-live2` → `blocks wrap` → `blocks validate` separately.
+- The state file (`validateCmdStatus.json`) is compatible with `download-live2` and `validate`.
 
 ---
 

--- a/tools-and-tests/tools/docs/mirror-node-commands.md
+++ b/tools-and-tests/tools/docs/mirror-node-commands.md
@@ -14,7 +14,7 @@ Available subcommands include:
 - `extractDayBlocksFromApi` - Generate or update `day_blocks.json` from the Mirror Node REST API
 - `generateAddressBook` - Generate address book history JSON from Mirror Node CSV export (**mainnet only**)
 - `compareAddressBooks` - Compare two address book history JSON files
-- `generateTestnetAddressBook` - Generate testnet genesis address book from mirror node CSV export
+- `generateTestnetAddressBook` - Generate testnet genesis address book from Mirror Node CSV export
 - `generateTestnetAddressBookHistory` - Generate testnet address book history JSON from bundled genesis
 
 > Important: many mirror commands download from public GCP buckets that are configured as Requester Pays. To access these you must have Google Cloud authentication configured locally. Typical steps:
@@ -347,7 +347,7 @@ Options:
 - `--end-date <date>` — Last day to fetch (inclusive), format `YYYY-MM-DD` (default: yesterday UTC).
 - `--day-blocks <file>` — Path to the output `day_blocks.json` file (default: `day_blocks.json`).
 - `--no-merge` — Replace the entire output file instead of merging with existing data (default: merge).
-- `--mirror-node-url <url>` — Base URL for the mirror node API. Must end with `/` (default: from network config).
+- `--mirror-node-url <url>` — Base URL for the Mirror Node API. Must end with `/` (default: from network config).
 
 Example:
 
@@ -373,7 +373,7 @@ Notes:
 
 ### `generateTestnetAddressBook`
 
-Generate the testnet genesis address book protobuf binary file from a Mirror Node database CSV export.
+Generate the testnet genesis address book protobuf binary file from a Mirror Node CSV export.
 
 Usage:
 
@@ -382,7 +382,7 @@ mirror generateTestnetAddressBook [--csv=<file>] [-o=<outputFile>]
 ```
 
 Options:
-- `--csv <file>` — Path to mirror node address book CSV export. The CSV should have columns `start_consensus_timestamp` and `file_data` (required).
+- `--csv <file>` — Path to Mirror Node address book CSV export. The CSV should have columns `start_consensus_timestamp` and `file_data` (required).
 - `-o`, `--output <file>` — Output file path for the proto binary (default: `testnet-genesis-address-book.proto.bin`).
 
 Example:
@@ -393,7 +393,7 @@ mirror generateTestnetAddressBook --csv address_book_export.csv -o testnet-genes
 ```
 
 Notes:
-- The CSV file is an export of the `address_book` table from the testnet mirror node database.
+- The CSV file is an export of the `address_book` table from the testnet Mirror Node database.
 - The genesis entry has `start_consensus_timestamp = 1` and `file_data` containing hex-encoded `NodeAddressBook` protobuf (prefixed with `\x`).
 - The generated file can be bundled as a classpath resource for testnet operations.
 
@@ -401,7 +401,7 @@ Notes:
 
 ### `generateTestnetAddressBookHistory`
 
-Generate testnet address book history JSON from the bundled genesis address book. Since testnet has no public mirror node CSV export bucket (unlike mainnet), this command loads the bundled `testnet-genesis-address-book.proto.bin` resource directly.
+Generate testnet address book history JSON from the bundled genesis address book. Since testnet has no public Mirror Node CSV export bucket (unlike mainnet), this command loads the bundled `testnet-genesis-address-book.proto.bin` resource directly.
 
 Usage:
 

--- a/tools-and-tests/tools/docs/mirror-node-commands.md
+++ b/tools-and-tests/tools/docs/mirror-node-commands.md
@@ -11,8 +11,11 @@ Available subcommands include:
 - `fetchMissingTransactions` - Download and compile mainnet errata for missing transactions (**mainnet only**)
 - `update` - Update `block_times.bin` and `day_blocks.json` with newer blocks from mirror node REST API
 - `extractDayBlocks` - (utility) Extract per-day block info from CSV/other sources
+- `extractDayBlocksFromApi` - Generate or update `day_blocks.json` from the Mirror Node REST API
 - `generateAddressBook` - Generate address book history JSON from Mirror Node CSV export (**mainnet only**)
 - `compareAddressBooks` - Compare two address book history JSON files
+- `generateTestnetAddressBook` - Generate testnet genesis address book from mirror node CSV export
+- `generateTestnetAddressBookHistory` - Generate testnet address book history JSON from bundled genesis
 
 > Important: many mirror commands download from public GCP buckets that are configured as Requester Pays. To access these you must have Google Cloud authentication configured locally. Typical steps:
 >
@@ -323,3 +326,99 @@ Features:
 Notes:
 - This is primarily used for mainnet historical data correction.
 - The output is used by block validation and conversion tools to handle known gaps in the transaction record.
+
+---
+
+### `extractDayBlocksFromApi`
+
+Generate or update `day_blocks.json` from the Hedera Mirror Node REST API. Unlike `extractDayBlocks` (which works from CSV files), this command queries the Mirror Node API directly — no GCP credentials required.
+
+For each day in the requested range, it issues two API calls to find the first block (`order=asc`) and last block (`order=desc`) of the day.
+
+Usage:
+
+```
+mirror extractDayBlocksFromApi [--start-date=<YYYY-MM-DD>] [--end-date=<YYYY-MM-DD>]
+                                [--day-blocks=<file>] [--no-merge] [--mirror-node-url=<url>]
+```
+
+Options:
+- `--start-date <date>` — First day to fetch (inclusive), format `YYYY-MM-DD` (default: network genesis date).
+- `--end-date <date>` — Last day to fetch (inclusive), format `YYYY-MM-DD` (default: yesterday UTC).
+- `--day-blocks <file>` — Path to the output `day_blocks.json` file (default: `day_blocks.json`).
+- `--no-merge` — Replace the entire output file instead of merging with existing data (default: merge).
+- `--mirror-node-url <url>` — Base URL for the mirror node API. Must end with `/` (default: from network config).
+
+Example:
+
+```bash
+# Generate day_blocks.json from API for all available mainnet days
+mirror extractDayBlocksFromApi
+
+# Generate for a specific date range
+mirror extractDayBlocksFromApi --start-date 2024-01-01 --end-date 2024-06-30
+
+# Testnet usage
+mirror extractDayBlocksFromApi --network testnet
+
+# Replace file instead of merging
+mirror extractDayBlocksFromApi --no-merge --day-blocks /path/to/day_blocks.json
+```
+
+Notes:
+- By default, merges fetched data into existing `day_blocks.json`, overwriting only entries in the requested date range.
+- Does not require GCP credentials — uses the public Mirror Node REST API.
+
+---
+
+### `generateTestnetAddressBook`
+
+Generate the testnet genesis address book protobuf binary file from a Mirror Node database CSV export.
+
+Usage:
+
+```
+mirror generateTestnetAddressBook [--csv=<file>] [-o=<outputFile>]
+```
+
+Options:
+- `--csv <file>` — Path to mirror node address book CSV export. The CSV should have columns `start_consensus_timestamp` and `file_data` (required).
+- `-o`, `--output <file>` — Output file path for the proto binary (default: `testnet-genesis-address-book.proto.bin`).
+
+Example:
+
+```bash
+# Generate from exported CSV
+mirror generateTestnetAddressBook --csv address_book_export.csv -o testnet-genesis-address-book.proto.bin
+```
+
+Notes:
+- The CSV file is an export of the `address_book` table from the testnet mirror node database.
+- The genesis entry has `start_consensus_timestamp = 1` and `file_data` containing hex-encoded `NodeAddressBook` protobuf (prefixed with `\x`).
+- The generated file can be bundled as a classpath resource for testnet operations.
+
+---
+
+### `generateTestnetAddressBookHistory`
+
+Generate testnet address book history JSON from the bundled genesis address book. Since testnet has no public mirror node CSV export bucket (unlike mainnet), this command loads the bundled `testnet-genesis-address-book.proto.bin` resource directly.
+
+Usage:
+
+```
+mirror generateTestnetAddressBookHistory [-o=<outputFile>]
+```
+
+Options:
+- `-o`, `--output <file>` — Output file path for the address book history JSON (default: `testnet-addressBookHistory.json`).
+
+Example:
+
+```bash
+# Generate testnet address book history
+mirror generateTestnetAddressBookHistory -o testnet-addressBookHistory.json
+```
+
+Notes:
+- Testnet has had only one address book (7 nodes, unchanged since the February 2024 reset).
+- The output JSON is compatible with `AddressBookHistory` and can be used by `blocks wrap` and `blocks validate` when `--network testnet` is specified.


### PR DESCRIPTION
## Summary

- Document 5 CLI commands that exist in code but were missing from the tools documentation:
  - `days live-sequential` — combined download + validate + wrap pipeline
  - `blocks repair-zips` — repair corrupt zip central directories in wrapped-block directories
  - `mirror extractDayBlocksFromApi` — generate/update `day_blocks.json` from Mirror Node REST API
  - `mirror generateTestnetAddressBook` — generate testnet genesis address book from CSV export
  - `mirror generateTestnetAddressBookHistory` — generate testnet address book history JSON from bundled genesis
- Remove stale `validate-wrapped` from README command tree (merged into `validate`)
- Add deprecation note to `validate-wrapped` section in `blocks-commands.md`

