### PR TITLE
feat: Improved and Extended Verification Notification

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestVerificationPlugin.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestVerificationPlugin.java
@@ -20,13 +20,15 @@ import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureType;
 
 public class TestVerificationPlugin implements BlockNodePlugin, BlockNotificationHandler, BlockItemHandler {
     private final Set<Long> blocksToFail = new ConcurrentSkipListSet<>();
     private final ConcurrentNavigableMap<Long, Long> blocksThatHaveFailed = new ConcurrentSkipListMap<>();
     private BlockNodeContext context;
     private VerificationSession currentSession;
-    private BlockSource blockSource = BlockSource.PUBLISHER;
+    private volatile BlockSource blockSource = BlockSource.PUBLISHER;
+    private volatile FailureType failureType = FailureType.BAD_BLOCK_PROOF;
 
     @Override
     public String name() {
@@ -48,7 +50,8 @@ public class TestVerificationPlugin implements BlockNodePlugin, BlockNotificatio
     public void handleBlockItemsReceived(final BlockItems blockItems) {
         if (blockItems.isStartOfNewBlock()) {
             final long blockNumber = blockItems.blockNumber();
-            currentSession = new VerificationSession(blockNumber, blocksToFail.remove(blockNumber), blockSource);
+            currentSession =
+                    new VerificationSession(blockNumber, blocksToFail.remove(blockNumber), blockSource, failureType);
         }
         if (currentSession.processBlockItems(blockItems)) {
             // first send the notification, most likely it will be handled on the same thread
@@ -69,6 +72,10 @@ public class TestVerificationPlugin implements BlockNodePlugin, BlockNotificatio
 
     public void setBlockSource(final BlockSource blockSource) {
         this.blockSource = Objects.requireNonNull(blockSource);
+    }
+
+    public void setFailureType(final FailureType failureType) {
+        this.failureType = Objects.requireNonNull(failureType);
     }
 
     public void failBlocks(long... blockNumbers) {
@@ -95,12 +102,18 @@ public class TestVerificationPlugin implements BlockNodePlugin, BlockNotificatio
         private final boolean shouldFail;
         private final BlockSource blockSource;
         private final List<BlockItemUnparsed> blockItems;
+        private final FailureType failureType;
 
-        private VerificationSession(final long blockNumber, final boolean shouldFail, final BlockSource blockSource) {
+        private VerificationSession(
+                final long blockNumber,
+                final boolean shouldFail,
+                final BlockSource blockSource,
+                final FailureType failureType) {
             assertNotNull(blockSource, NULL_SOURCE_MESSAGE);
             this.blockNumber = blockNumber;
             this.shouldFail = shouldFail;
             this.blockSource = blockSource;
+            this.failureType = failureType;
             this.blockItems = new ArrayList<>();
         }
 
@@ -111,12 +124,12 @@ public class TestVerificationPlugin implements BlockNodePlugin, BlockNotificatio
 
         private VerificationNotification completeSession() {
             if (shouldFail) {
-                return new VerificationNotification(false, blockNumber, null, null, blockSource);
+                return new VerificationNotification(false, failureType, blockNumber, null, null, blockSource);
             } else {
                 // @todo() add a way to either generate a block hash, or be able to add a custom block hash for a given
                 //   block. This is based on needs.
                 return new VerificationNotification(
-                        true, blockNumber, null, new BlockUnparsed(blockItems), blockSource);
+                        true, null, blockNumber, null, new BlockUnparsed(blockItems), blockSource);
             }
         }
     }

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPersistenceAwaiterTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPersistenceAwaiterTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -243,8 +244,8 @@ class BackfillPersistenceAwaiterTest {
             subject.trackBlock(blockNumber);
 
             // when - verification failed
-            subject.handleVerification(
-                    new VerificationNotification(false, blockNumber, null, null, BlockSource.BACKFILL));
+            subject.handleVerification(new VerificationNotification(
+                    false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, BlockSource.BACKFILL));
 
             // then - await should return immediately
             boolean result = subject.awaitPersistence(blockNumber, 100);
@@ -260,7 +261,7 @@ class BackfillPersistenceAwaiterTest {
 
             // when - verification succeeded
             subject.handleVerification(
-                    new VerificationNotification(true, blockNumber, null, null, BlockSource.BACKFILL));
+                    new VerificationNotification(true, null, blockNumber, null, null, BlockSource.BACKFILL));
 
             // then - block should still be pending (waiting for persistence), await times out
             boolean result = subject.awaitPersistence(blockNumber, 50);
@@ -275,8 +276,8 @@ class BackfillPersistenceAwaiterTest {
             subject.trackBlock(blockNumber);
 
             // when - verification failure from PUBLISHER source
-            subject.handleVerification(
-                    new VerificationNotification(false, blockNumber, null, null, BlockSource.PUBLISHER));
+            subject.handleVerification(new VerificationNotification(
+                    false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, BlockSource.PUBLISHER));
 
             // then - block should still be pending, await times out
             boolean result = subject.awaitPersistence(blockNumber, 50);

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginHelperTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginHelperTest.java
@@ -118,7 +118,7 @@ class BackfillPluginHelperTest {
             final BackfillPlugin plugin = new BackfillPlugin();
             // Create a verification notification with PUBLISHER source
             VerificationNotification notification =
-                    new VerificationNotification(true, 100L, Bytes.wrap("hash"), null, BlockSource.PUBLISHER);
+                    new VerificationNotification(true, null, 100L, Bytes.wrap("hash"), null, BlockSource.PUBLISHER);
 
             // Should not throw - does nothing for non-BACKFILL source
             assertDoesNotThrow(() -> plugin.handleVerification(notification));

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
@@ -1430,6 +1430,7 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
                                 .blockMessaging()
                                 .sendBlockVerification(new VerificationNotification(
                                         true,
+                                        null,
                                         notification.blockNumber(),
                                         Bytes.wrap("123"),
                                         notification.block(),

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
@@ -315,7 +315,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -350,7 +350,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 20 blocks are zipped yet
             for (int i = 0; i < 20; i++) {
@@ -385,7 +385,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 20 blocks are zipped yet
             for (int i = 0; i < 14; i++) {
@@ -417,7 +417,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 20 blocks are zipped yet
             for (int i = 0; i < 20; i++) {
@@ -458,7 +458,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
                 expectedBlocks.add(new BlockUnparsed(block.blockItems()));
             }
             // assert that none of the first 10 blocks are zipped yet
@@ -510,7 +510,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 5 blocks are zipped yet
             for (int i = 0; i < 5; i++) {
@@ -530,7 +530,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -565,7 +565,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // generate next blocks with a gap and make sure we reach the
             // threshold and add them to the test historical block facility
@@ -574,7 +574,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // we now have blocks 0-2 and 5-9, so we have a gap
             // assert that none of the first 10 blocks are zipped yet
@@ -609,7 +609,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
 
             // This should pass, as we have a whole batch in the queue
@@ -634,7 +634,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
 
             pluginExecutor.executeSerially();
@@ -658,7 +658,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
 
             pluginExecutor.executeSerially();
@@ -686,7 +686,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
 
             pluginExecutor.executeSerially();
@@ -715,7 +715,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
 
             // assert that no zipping task was submited since last check,
@@ -742,7 +742,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // generate next blocks with a gap and make sure we reach the
             // threshold and add them to the test historical block facility
@@ -751,7 +751,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // we now have blocks 0-2 and 5-9, so we have a gap
             // assert that none of the first 10 blocks are zipped yet
@@ -784,7 +784,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -820,7 +820,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks have accessors yet
             for (int i = 0; i < 10; i++) {
@@ -849,7 +849,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
                 expectedBlocks.add(new BlockUnparsed(block.blockItems()));
             }
             // assert that none of the first 10 blocks have accessors yet
@@ -881,7 +881,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -915,7 +915,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks appear in the available range
             for (int i = 0; i < 10; i++) {
@@ -945,7 +945,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -976,7 +976,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -1010,7 +1010,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -1043,7 +1043,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -1076,7 +1076,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
             for (int i = 0; i < 10; i++) {
@@ -1107,7 +1107,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 150 blocks are zipped yet and are
             // not present in the available blocks
@@ -1133,7 +1133,7 @@ class BlockFileHistoricPluginTest {
             final BlockUnparsed block =
                     TestBlockBuilder.generateBlockWithNumber(150).blockUnparsed();
             blockMessaging.sendBlockVerification(new VerificationNotification(
-                    true, 150, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                    true, null, 150, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             // assert that the size of the available blocks is now 100 (post retention policy cleanup)
             assertThat(plugin.availableBlocks().size()).isEqualTo(100);
             // assert that the first 50 blocks were cleaned up and that the
@@ -1168,7 +1168,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 150 blocks are zipped yet and are
             // not present in the available blocks
@@ -1191,7 +1191,7 @@ class BlockFileHistoricPluginTest {
             final BlockUnparsed block =
                     TestBlockBuilder.generateBlockWithNumber(150).blockUnparsed();
             blockMessaging.sendBlockVerification(new VerificationNotification(
-                    true, 150, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                    true, null, 150, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             // assert that the size of the available blocks is still 150 (post retention policy cleanup)
             assertThat(plugin.availableBlocks().size()).isEqualTo(150);
             // assert that all the blocks are still zipped and that
@@ -1219,7 +1219,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 100; i < 200; i++) {
                 final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             }
 
             // Execute all pending archival tasks to zip the first batch
@@ -1238,7 +1238,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 200; i < 210; i++) {
                 final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             }
 
             // Execute all pending archival tasks. The retention policy should kick in
@@ -1320,7 +1320,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             }
 
             // Execute all pending archival tasks. This should zip blocks 0-9 into a single archive.
@@ -1345,7 +1345,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             }
 
             // Execute pending tasks. With allowZippingMultipleTimes = true, this should
@@ -1372,7 +1372,7 @@ class BlockFileHistoricPluginTest {
             for (int i = startInclusive; i < endExclusive; i++) {
                 final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             }
         }
 
@@ -1513,7 +1513,7 @@ class BlockFileHistoricPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
 
             // Execute archival tasks to create the zip files

--- a/block-node/blocks-file-recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPluginTest.java
+++ b/block-node/blocks-file-recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPluginTest.java
@@ -28,6 +28,7 @@ import org.hiero.block.node.base.BlockFile;
 import org.hiero.block.node.base.CompressionType;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureType;
 import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -197,7 +198,7 @@ class BlockFileRecentPluginTest {
             assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().min());
             // send verified block notification
             blockMessaging.sendBlockVerification(new VerificationNotification(
-                    true, blockNumber, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
+                    true, null, blockNumber, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             // now try and read it back
             final BlockUnparsed blockFromPlugin = plugin.block(blockNumber).blockUnparsed();
             // check we got the correct block
@@ -229,7 +230,12 @@ class BlockFileRecentPluginTest {
             assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().min());
             // send verified block notification with failure
             blockMessaging.sendBlockVerification(new VerificationNotification(
-                    false, blockNumber, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
+                    false,
+                    FailureType.BAD_BLOCK_PROOF,
+                    blockNumber,
+                    Bytes.EMPTY,
+                    block.blockUnparsed(),
+                    BlockSource.PUBLISHER));
             assertNull(plugin.block(blockNumber));
             assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().max());
             assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().min());
@@ -256,8 +262,8 @@ class BlockFileRecentPluginTest {
             assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().max());
             assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().min());
             // send verified block notification
-            blockMessaging.sendBlockVerification(
-                    new VerificationNotification(true, blockNumber, Bytes.EMPTY, blockOrig, BlockSource.PUBLISHER));
+            blockMessaging.sendBlockVerification(new VerificationNotification(
+                    true, null, blockNumber, Bytes.EMPTY, blockOrig, BlockSource.PUBLISHER));
             // now try and read it back
             final BlockUnparsed blockFromPlugin = plugin.block(blockNumber).blockUnparsed();
             // check we got the correct block
@@ -284,7 +290,7 @@ class BlockFileRecentPluginTest {
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 // send the block items to the plugin
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
                 // assert that the block is persisted
                 final Path persistedBlock = BlockFile.nestedDirectoriesBlockFilePath(
                         blocksRootPath, i, filesRecentConfig.compression(), filesRecentConfig.maxFilesPerDir());
@@ -341,7 +347,7 @@ class BlockFileRecentPluginTest {
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 // send the block items to the plugin
                 blockMessaging.sendBlockVerification(new VerificationNotification(
-                        true, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
                 // assert that the block is persisted
                 final Path persistedBlock = BlockFile.nestedDirectoriesBlockFilePath(
                         blocksRootPath,

--- a/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationRingEventTest.java
+++ b/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationRingEventTest.java
@@ -42,7 +42,7 @@ class BlockNotificationRingEventTest {
     void shouldSetAndGetVerificationNotification() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
         final VerificationNotification notification =
-                new VerificationNotification(true, 1, null, null, BlockSource.PUBLISHER);
+                new VerificationNotification(true, null, 1, null, null, BlockSource.PUBLISHER);
         event.set(notification);
         assertEquals(notification, event.getVerificationNotification());
         assertNull(event.getPersistedNotification(), "Persisted notification should be null");
@@ -135,7 +135,7 @@ class BlockNotificationRingEventTest {
         final PersistedNotification persistedNotification =
                 new PersistedNotification(2, true, 10, BlockSource.PUBLISHER);
         final VerificationNotification verificationNotification =
-                new VerificationNotification(true, 1, null, null, BlockSource.PUBLISHER);
+                new VerificationNotification(true, null, 1, null, null, BlockSource.PUBLISHER);
 
         // First set persisted notification
         event.set(persistedNotification);
@@ -156,7 +156,7 @@ class BlockNotificationRingEventTest {
     void settingPersistedNotificationShouldClearVerificationNotification() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
         final VerificationNotification verificationNotification =
-                new VerificationNotification(true, 1, null, null, BlockSource.PUBLISHER);
+                new VerificationNotification(true, null, 1, null, null, BlockSource.PUBLISHER);
         final PersistedNotification persistedNotification =
                 new PersistedNotification(2, true, 10, BlockSource.PUBLISHER);
 
@@ -179,9 +179,9 @@ class BlockNotificationRingEventTest {
     void shouldAllowReuseWithDifferentVerificationNotifications() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
         final VerificationNotification notification1 =
-                new VerificationNotification(true, 1, null, null, BlockSource.PUBLISHER);
+                new VerificationNotification(true, null, 1, null, null, BlockSource.PUBLISHER);
         final VerificationNotification notification2 =
-                new VerificationNotification(true, 1, null, null, BlockSource.PUBLISHER);
+                new VerificationNotification(true, null, 1, null, null, BlockSource.PUBLISHER);
 
         event.set(notification1);
         assertEquals(notification1, event.getVerificationNotification());

--- a/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationTest.java
+++ b/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationTest.java
@@ -260,7 +260,7 @@ public class BlockNotificationTest {
                 LockSupport.parkNanos(500_000);
             }
             messagingService.sendBlockVerification(
-                    new VerificationNotification(true, i, null, null, BlockSource.PUBLISHER));
+                    new VerificationNotification(true, null, i, null, null, BlockSource.PUBLISHER));
             // have to slow down production to make test reliable
             LockSupport.parkNanos(500_000);
         }
@@ -341,7 +341,7 @@ public class BlockNotificationTest {
         public void run() {
             for (int i = 0; i < TEST_DATA_COUNT; i++) {
                 messagingService.sendBlockVerification(
-                        new VerificationNotification(true, i, null, null, BlockSource.PUBLISHER));
+                        new VerificationNotification(true, null, i, null, null, BlockSource.PUBLISHER));
                 int totalSent = sentCounter.incrementAndGet();
                 if (pauseControl != null) {
                     // release the pause control occasionally, to slow a handler by some amount.

--- a/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/FacilityExceptionTest.java
+++ b/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/FacilityExceptionTest.java
@@ -152,7 +152,7 @@ public class FacilityExceptionTest {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-        service.sendBlockVerification(new VerificationNotification(true, 1, null, null, BlockSource.PUBLISHER));
+        service.sendBlockVerification(new VerificationNotification(true, null, 1, null, null, BlockSource.PUBLISHER));
         service.sendBlockPersisted(new PersistedNotification(1, true, 1, BlockSource.PUBLISHER));
         service.sendBackfilledBlockNotification(
                 new BackfilledBlockNotification(1, BlockUnparsed.newBuilder().build()));

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/VerificationNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/VerificationNotification.java
@@ -3,18 +3,37 @@ package org.hiero.block.node.spi.blockmessaging;
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 
-/**
- * Simple record for block verification notifications.
- *
- * @param success     true if the block was verified successfully, false otherwise
- * @param blockNumber the block number this notification is for
- * @param blockHash   the hash of the block, if the type is BLOCK_VERIFIED
- * @param block       the block, if the type is BLOCK_VERIFIED
- * @param source      the source of the message
- */
+/// Simple record for block verification notifications.
+///
+/// @param success     `true` if the block was verified successfully, `false` otherwise
+/// @param failureType the type of the failure; must be `null` if verification is successful and `non-null` otherwise
+/// @param blockNumber the block number this notification is for
+/// @param blockHash   the hash of the block, if verification is successful
+/// @param block       the block, if verification is successful
+/// @param source      the source of the message
 public record VerificationNotification(
         boolean success,
+        FailureType failureType,
         long blockNumber,
         Bytes blockHash,
         org.hiero.block.internal.BlockUnparsed block,
-        BlockSource source) {}
+        BlockSource source) {
+    public VerificationNotification {
+        if (success && failureType != null) {
+            throw new IllegalArgumentException("Verification is successful, but a failure reason is provided");
+        }
+        if (!success && failureType == null) {
+            throw new IllegalArgumentException("Verification failed, but no failure reason is provided");
+        }
+    }
+
+    /// The type of failure when verification fails.
+    public enum FailureType {
+        /// This type indicates that the proof was bad
+        BAD_BLOCK_PROOF,
+        /// This type indicates that the block could not be parsed
+        UNABLE_TO_PARSE,
+        /// This type indicates that the block is missing a mandatory item
+        MISSING_MANDATORY_ITEM,
+    }
+}

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -49,6 +49,7 @@ import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification;
 import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification.UpdateType;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureType;
 import org.hiero.block.node.spi.health.HealthFacility;
 import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
 import org.hiero.block.node.spi.threading.ThreadPoolManager;
@@ -667,7 +668,7 @@ class LiveStreamPublisherManagerTest {
                 // Build a verification notification with passed verification.
                 // Source must be publisher.
                 final VerificationNotification notification =
-                        new VerificationNotification(true, block.number(), null, null, BlockSource.PUBLISHER);
+                        new VerificationNotification(true, null, block.number(), null, null, BlockSource.PUBLISHER);
                 // Call
                 toTest.handleVerification(notification);
                 // Assert that no responses have been sent.
@@ -727,8 +728,8 @@ class LiveStreamPublisherManagerTest {
                 responsePipeline.clear();
                 // Build a verification notification with block number equal to the latest known.
                 // Source must be publisher.
-                final VerificationNotification notification =
-                        new VerificationNotification(false, block.number(), null, null, BlockSource.PUBLISHER);
+                final VerificationNotification notification = new VerificationNotification(
+                        false, FailureType.BAD_BLOCK_PROOF, block.number(), null, null, BlockSource.PUBLISHER);
                 // Call
                 toTest.handleVerification(notification);
                 // Assert that only an Acknowledgement response has been sent,
@@ -785,8 +786,8 @@ class LiveStreamPublisherManagerTest {
                 responsePipeline.clear();
                 // Build a verification notification with block number lower than the latest known.
                 // Source must be publisher.
-                final VerificationNotification notification =
-                        new VerificationNotification(false, block.number() - 1L, null, null, BlockSource.PUBLISHER);
+                final VerificationNotification notification = new VerificationNotification(
+                        false, FailureType.BAD_BLOCK_PROOF, block.number() - 1L, null, null, BlockSource.PUBLISHER);
                 // Call
                 toTest.handleVerification(notification);
                 // Assert that only an Acknowledgement response has been sent,
@@ -811,8 +812,8 @@ class LiveStreamPublisherManagerTest {
             void testHandleVerificationEqualToNext() {
                 // Initially, the next unstreamed block number is 0L.
                 final long streamedBlockNumber = 0L;
-                final VerificationNotification notification =
-                        new VerificationNotification(false, streamedBlockNumber, null, null, BlockSource.PUBLISHER);
+                final VerificationNotification notification = new VerificationNotification(
+                        false, FailureType.BAD_BLOCK_PROOF, streamedBlockNumber, null, null, BlockSource.PUBLISHER);
                 // Call
                 toTest.handleVerification(notification);
                 // Assert that no responses have been sent.
@@ -835,8 +836,8 @@ class LiveStreamPublisherManagerTest {
             void testHandleVerificationHigherThanNext() {
                 // Initially, the next unstreamed block number is 0L.
                 final long streamedBlockNumber = 1L;
-                final VerificationNotification notification =
-                        new VerificationNotification(false, streamedBlockNumber, null, null, BlockSource.PUBLISHER);
+                final VerificationNotification notification = new VerificationNotification(
+                        false, FailureType.BAD_BLOCK_PROOF, streamedBlockNumber, null, null, BlockSource.PUBLISHER);
                 // Call
                 toTest.handleVerification(notification);
                 // Assert that no responses have been sent.
@@ -878,8 +879,8 @@ class LiveStreamPublisherManagerTest {
                 endThisBlock(publisherHandler, block.number());
                 // Now, the publisher has sent the targeted block with broken proof.
                 // We can now build a verification notification with failed verification.
-                final VerificationNotification notification =
-                        new VerificationNotification(false, block.number(), null, null, BlockSource.PUBLISHER);
+                final VerificationNotification notification = new VerificationNotification(
+                        false, FailureType.BAD_BLOCK_PROOF, block.number(), null, null, BlockSource.PUBLISHER);
                 // Call
                 toTest.handleVerification(notification);
                 // Assert that the response pipeline has received a BAD_BLOCK_PROOF response, because the
@@ -944,8 +945,8 @@ class LiveStreamPublisherManagerTest {
                 endThisBlock(publisherHandler, block.number());
                 // Now, the publisher has sent the targeted block with broken proof.
                 // We can now build a verification notification with failed verification.
-                final VerificationNotification notification =
-                        new VerificationNotification(false, block.number(), null, null, blockSource);
+                final VerificationNotification notification = new VerificationNotification(
+                        false, FailureType.BAD_BLOCK_PROOF, block.number(), null, null, blockSource);
                 // Call
                 toTest.handleVerification(notification);
                 // Assert that no shared metrics are updated
@@ -993,8 +994,8 @@ class LiveStreamPublisherManagerTest {
                 publisherHandler2.onNext(request);
                 endThisBlock(publisherHandler2, block.number());
                 // Build a verification notification with failed verification.
-                final VerificationNotification notification =
-                        new VerificationNotification(false, block.number(), null, null, BlockSource.PUBLISHER);
+                final VerificationNotification notification = new VerificationNotification(
+                        false, FailureType.BAD_BLOCK_PROOF, block.number(), null, null, BlockSource.PUBLISHER);
                 // Call
                 toTest.handleVerification(notification);
                 // As a pre-check, we expect the pipeline to be empty
@@ -1060,8 +1061,8 @@ class LiveStreamPublisherManagerTest {
                 // Then, we need to simulate that the publisher has sent a block with invalid proof, i.e. call
                 // handleVerification with failed verification.
                 // Build a verification notification with failed verification.
-                final VerificationNotification notification =
-                        new VerificationNotification(false, testBlock.number(), null, null, BlockSource.PUBLISHER);
+                final VerificationNotification notification = new VerificationNotification(
+                        false, FailureType.BAD_BLOCK_PROOF, testBlock.number(), null, null, BlockSource.PUBLISHER);
                 // Call
                 toTest.handleVerification(notification);
                 // As a pre-check, we expect the pipeline to be empty
@@ -2295,7 +2296,12 @@ class LiveStreamPublisherManagerTest {
                 publisherHandler2.onNext(block1.asPublishStreamRequestUnparsed());
                 // Handling a failed verification notification will schedule the block that failed to be resent
                 toTest.handleVerification(new VerificationNotification(
-                        false, blockThatFailsVerification.number(), null, null, BlockSource.PUBLISHER));
+                        false,
+                        FailureType.BAD_BLOCK_PROOF,
+                        blockThatFailsVerification.number(),
+                        null,
+                        null,
+                        BlockSource.PUBLISHER));
                 // Call, end block 1
                 final ActionForBlock actionForBlock = toTest.endOfBlock(block1.number());
                 // Assert resend received

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
@@ -29,6 +29,7 @@ import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureType;
 import org.hiero.block.node.verification.session.HapiVersionSessionFactory;
 import org.hiero.block.node.verification.session.VerificationSession;
 import org.hiero.metrics.LongCounter;
@@ -383,7 +384,8 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
     private void sendFailureNotification(final long blockNumber, final BlockSource source) {
         verificationBlocksError.increment();
         // Return a success=false notification to indicate failure and include the block number.
-        VerificationNotification notification = new VerificationNotification(false, blockNumber, null, null, source);
+        VerificationNotification notification =
+                new VerificationNotification(false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, source);
         context.blockMessaging().sendBlockVerification(notification);
     }
 

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/DummyVerificationSession.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/DummyVerificationSession.java
@@ -56,7 +56,7 @@ public class DummyVerificationSession implements VerificationSession {
             block = BlockUnparsed.newBuilder().blockItems(this.blockItems).build();
             blockHash = Bytes.wrap("0x00");
             LOGGER.log(TRACE, "Returning always True verification notification for block {0}", blockNumber);
-            return new VerificationNotification(true, blockNumber, blockHash, block, blockSource);
+            return new VerificationNotification(true, null, blockNumber, blockHash, block, blockSource);
         }
         return null;
     }

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
@@ -29,6 +29,7 @@ import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureType;
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 import org.hiero.block.node.verification.VerificationServicePlugin;
 import org.hiero.block.node.verification.session.VerificationSession;
@@ -153,7 +154,8 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
         // since we always need block footer to finalize, we check for its presence
         if (this.blockFooter == null) {
             // return failed verification notification
-            return new VerificationNotification(false, blockNumber, null, null, blockSource);
+            return new VerificationNotification(
+                    false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
         }
 
         // if provided, use the provided root hash of all previous block hashes tree, otherwise use the one from the
@@ -207,7 +209,12 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
                 verifySignature(blockRootHash, blockProof.signedBlockProof().blockSignature());
 
         return new VerificationNotification(
-                verified, blockNumber, blockRootHash, verified ? new BlockUnparsed(blockItems) : null, blockSource);
+                verified,
+                verified ? null : FailureType.BAD_BLOCK_PROOF,
+                blockNumber,
+                blockRootHash,
+                verified ? new BlockUnparsed(blockItems) : null,
+                blockSource);
     }
 
     protected Boolean verifySignature(@NonNull Bytes hash, @NonNull Bytes signature) {


### PR DESCRIPTION
* Introduced a new `FailureType` for the verification notification
  * If verification has failed, the `FailureType` must not be `null`
  * If verification has succeeded, the `FailureType` must be `null`

## Reviewer Notes

## Related Issue(s)

Closes #2529
