### PR TITLE
feat(tools): add CN verification hashes to jumpstart.bin

### DIFF
--- a/docs/block-node/Cutover-Process.md
+++ b/docs/block-node/Cutover-Process.md
@@ -29,9 +29,12 @@ node signature to Block Streams, Block Nodes, and HinTS/TSS signatures.
     adding Header and Footer details, and generating a Block Proof based
     on the individual node signatures produced for that Record File.</dd>
 <dt>Jumpstart Data</dt><dd>
-    A file containing the Block Hash for a specific WRB, the state of the
+    A file containing the Block Hash for a specific WRB, the Record File Hash
+    (SHA-384 of the raw record file bytes) for that block, the state of the
     historical block hash tree after hashing that block, and the block number
-    of that block. The historical block hash tree state is the minimal set of
+    of that block. The Record File Hash enables the Consensus Node to
+    cross-validate that its locally produced record file matches the one that
+    was wrapped. The historical block hash tree state is the minimal set of
     hashes needed to continue the streaming hash algorithm with the next
     block.</dd>
 <dt>WRB Catch Up</dt><dd>
@@ -130,97 +133,97 @@ timeline
 ## Process and Sequence
 
 * Release K (<= N)
-   * Include the "Powers of Tau" ceremony program with the Consensus Node
-     release package.
-   * Ensure the "Powers of Tau" ceremony executes during the duration of the
-     release to produce the WRAPS keys and Groth parameters.
-   * Block Nodes run in Preview mode
-   * Preview Block Streams produced with incomplete hash data
+  * Include the "Powers of Tau" ceremony program with the Consensus Node
+    release package.
+  * Ensure the "Powers of Tau" ceremony executes during the duration of the
+    release to produce the WRAPS keys and Groth parameters.
+  * Block Nodes run in Preview mode
+  * Preview Block Streams produced with incomplete hash data
 * Release N
-   * Consensus Node generates WRB subtree hashes
-   * Consensus Node stores WRB subtree hash data on disk
-   * "Offline" process downloading record files from S3
-      * Generate WRB blocks from record files
-      * WRB files added to "RBH" block node
-      * Produce Jumpstart Data occasionally (configurable, perhaps 1/hour).
-   * Block Nodes may _test_ backfill from RBH, but do not store backfilled WRBs
-      * Preview blocks are accepted and stored.
-   * Preview block streams continue with incomplete hashes
+  * Consensus Node generates WRB subtree hashes
+  * Consensus Node stores WRB subtree hash data on disk
+  * "Offline" process downloading record files from S3
+    * Generate WRB blocks from record files
+    * WRB files added to "RBH" Block Node
+    * Produce Jumpstart Data occasionally (configurable, perhaps 1/hour).
+  * Block Nodes may _test_ backfill from RBH, but do not store backfilled WRBs
+    * Preview blocks are accepted and stored.
+  * Preview block streams continue with incomplete hashes
 * Release N+1
-   * Jumpstart Data is included in the Consensus Node release package, and is
-     from approximately 8-10 days before the release date.
-   * Consensus Node reads Jumpstart Data
-      * WRB data is combined with the Jumpstart Data to complete "WRB Catch Up"
-      * Consensus Node begins creating WRB block root hash with all
-        necessary correct inputs.
-      * Consensus Node stores the correct WRB hash in BlockInfo in state at the
-        end of each block.
-      * Consensus Node stores the correct WRB streaming hash tree data in state
-        in BlockInfo at the end of each block.
-   * WRAPS proving key and parameters downloaded by Consensus Node
-   * WRAPS proving key hash read from configuration
-      * This data is stored in state as part of post-upgrade migration.
-      * The hash is used to validate the downloaded WRAPS data.
-   * TSS is enabled in Consensus Node but does not sign blocks
-      * TSS creates the Ledger ID and publishes LedgerID, Initial Roster, and
-        WRAPS verification key in record stream via TSS adoption transaction.
-      * Consensus Node creates WRAPS proofs for each new Roster.
-   * Offline process continues to generate WRB files for backfill via RBH.
-   * Block Nodes are prepared for cutover
-      * All "production" Tier 1 block nodes are reset to clear preview blocks.
-      * All "production" Tier 1 block nodes begin rapid backfill from RBH to
-        preload all history prior to cutover.
-   * Preview block streams continue to "testing" block nodes and are written
-     to "preview" buckets for testing and qualification.
-      * Preview block hashes continue to be entirely incomplete (to reduce
-        complexity).
+  * Jumpstart Data is included in the Consensus Node release package, and is
+    from approximately 8-10 days before the release date.
+  * Consensus Node reads Jumpstart Data
+    * WRB data is combined with the Jumpstart Data to complete "WRB Catch Up"
+    * Consensus Node begins creating WRB block root hash with all
+      necessary correct inputs.
+    * Consensus Node stores the correct WRB hash in BlockInfo in state at the
+      end of each block.
+    * Consensus Node stores the correct WRB streaming hash tree data in state
+      in BlockInfo at the end of each block.
+  * WRAPS proving key and parameters downloaded by Consensus Node
+  * WRAPS proving key hash read from configuration
+    * This data is stored in state as part of post-upgrade migration.
+    * The hash is used to validate the downloaded WRAPS data.
+  * TSS is enabled in Consensus Node but does not sign blocks
+    * TSS creates the Ledger ID and publishes LedgerID, Initial Roster, and
+      WRAPS verification key in Record Stream via TSS adoption transaction.
+    * Consensus Node creates WRAPS proofs for each new Roster.
+  * Offline process continues to generate WRB files for backfill via RBH.
+  * Block Nodes are prepared for cutover
+    * All "production" Tier 1 block nodes are reset to clear preview blocks.
+    * All "production" Tier 1 block nodes begin rapid backfill from RBH to
+      preload all history prior to cutover.
+  * Preview block streams continue to "testing" block nodes and are written
+    to "preview" buckets for testing and qualification.
+    * Preview block hashes continue to be entirely incomplete (to reduce
+      complexity).
 * Release N+2 (Cutover Release)
-   * Consensus Node performs cutover tasks during post upgrade processing.
-      * Consensus Node signs each block with TSS and WRAPS
-      * Consensus Node ceases producing Record Streams
-      * Consensus Node removes `BlockInfo` from state<br/>
-        `BlockStreamInfo` is used after cutover and is optimized for
-        block streams rather than record streams.
-      * Consensus Node begins producing Block Streams
-        and publishing to Block Nodes.
-   * Block Nodes complete final backfill and begin receiving Block Streams.
-      * Block Nodes verify TSS signature for each block.
-   * RBH node is shut down once all block nodes finish backfill.
-   * Block Streams become authoritative.
+  * Consensus Node performs cutover tasks during post upgrade processing.
+    * Consensus Node signs each block with TSS and WRAPS
+    * Consensus Node ceases producing Record Streams
+    * Consensus Node removes `BlockInfo` from state<br/>
+      `BlockStreamInfo` is used after cutover and is optimized for
+      block streams rather than record streams.
+    * Consensus Node begins producing Block Streams
+      and publishing to Block Nodes.
+  * Block Nodes complete final backfill and begin receiving Block Streams.
+    * Block Nodes verify TSS signature for each block.
+  * RBH node is shut down once all block nodes finish backfill.
+  * Block Streams become authoritative.
 
 ### How does the consensus node "catch up" with the last Wrapped Record Block hash?
 
 This is a roughly three part process.
 * The first part requires offline processing to do the following.
-   1. Download every record file from the beginning
-   1. Process each file to extract the record data, wrap that data in a block.
-   1. Record the block hash, block number, and state of the historical block
-      subtree
-       * Update the current Jumpstart Data with this data after each 1000
-         blocks.
+1. Download every record file from the beginning
+1. Process each file to extract the record data, wrap that data in a block.
+1. Record the block hash, block number, and state of the historical block
+subtree
+* Update the current Jumpstart Data with this data after each 1000
+blocks.
 * The second part requires that the Consensus Node Software record the following
-  values for each record file produced for the Record Stream.
-   1. Calculate the subtree hashes for the current record file data according
-      to the structure documented below.
-   1. For each new record, store the Consensus Time, block number, and subtree
-      hash for subtrees 3,4,5,6,7, and 8 in a hash-data file. Only the "output"
-      subtree is expected to have a non-zero value.
+values for each record file produced for the Record Stream.
+1. Calculate the subtree hashes for the current record file data according
+to the structure documented below.
+1. For each new record, store the Consensus Time, block number, and subtree
+hash for subtrees 3,4,5,6,7, and 8 in a hash-data file. Only the "output"
+subtree is expected to have a non-zero value.
 * The Consensus Node Software will store the hash data for each record for a
-  single release.
+single release.
 * The third part requires the following tasks
-   1. The Jumpstart Data from part one must be included in the upgrade package
-      for the consensus node.
-   1. The Consensus Node Software will read the Jumpstart Data, and find the
-      matching block in the hash-data file.
-   1. The Consensus Node Software will use the values in the Jumpstart Data to
-      calculate the Block Root for the matching wrapped record file block.
-      * The Consensus Node Software will use the calculated Block Root and
-        the data from the hash-data file to continue calculating the
-        Block Root for each record file block in order
-      * The Consensus Node Software will complete all Block Root calculations
-        forward until reaching the current wrapped record block.
-  1. The Consensus Node Software will, thereafter, maintain the previous Block
-     Root hash and the state of the historical block subtree in state.
+1. The Jumpstart Data from part one must be included in the upgrade package
+for the Consensus Node.
+1. The Consensus Node Software will read the Jumpstart Data, and find the
+matching block in the hash-data file.
+1. The Consensus Node Software will use the values in the Jumpstart Data to
+calculate the Block Root for the matching wrapped record file block.
+* The Consensus Node Software will use the calculated Block Root and
+the data from the hash-data file to continue calculating the
+Block Root for each record file block in order
+* The Consensus Node Software will complete all Block Root calculations
+forward until reaching the current wrapped record block.
+1. The Consensus Node Software will, thereafter, maintain the previous Block
+Root hash and the state of the historical block subtree in state.
 
 #### Block Root Tree Structure (16 fixed leaves)
 
@@ -246,15 +249,15 @@ PrevBlock  AllBlocks  State  ConsensusHeaders  Input Output  StateChanges  Trace
 
 #### Fixed Leaf Positions (from design doc)
 
-`1` Previous Block Root Hash - Links to previous block, forming the blockchain  
-`2` All Block Hashes Tree Root - Streaming merkle tree of all previous block hashes  
-`3` State Root Hash - State merkle tree root at block start  
-`4` Consensus Headers - EventHeader, RoundHeader items  
-`5` Input Items - SignedTransaction  
-`6` Output Items - BlockHeader, RecordFile items, TransactionResult, TransactionOutput items  
-`7` State Changes - StateChanges items  
-`8` Trace Data - TraceData items  
-`9-16` Reserved - For future expansion  
+`1` Previous Block Root Hash - Links to previous block, forming the blockchain
+`2` All Block Hashes Tree Root - Streaming merkle tree of all previous block hashes
+`3` State Root Hash - State merkle tree root at block start
+`4` Consensus Headers - EventHeader, RoundHeader items
+`5` Input Items - SignedTransaction
+`6` Output Items - BlockHeader, RecordFile items, TransactionResult, TransactionOutput items
+`7` State Changes - StateChanges items
+`8` Trace Data - TraceData items
+`9-16` Reserved - For future expansion
 
 #### Subtree Item Types
 

--- a/docs/block-node/Cutover-Process.md
+++ b/docs/block-node/Cutover-Process.md
@@ -137,97 +137,97 @@ timeline
 ## Process and Sequence
 
 * Release K (<= N)
-  * Include the "Powers of Tau" ceremony program with the Consensus Node
-    release package.
-  * Ensure the "Powers of Tau" ceremony executes during the duration of the
-    release to produce the WRAPS keys and Groth parameters.
-  * Block Nodes run in Preview mode
-  * Preview Block Streams produced with incomplete hash data
+   * Include the "Powers of Tau" ceremony program with the Consensus Node
+     release package.
+   * Ensure the "Powers of Tau" ceremony executes during the duration of the
+     release to produce the WRAPS keys and Groth parameters.
+   * Block Nodes run in Preview mode
+   * Preview Block Streams produced with incomplete hash data
 * Release N
-  * Consensus Node generates WRB subtree hashes
-  * Consensus Node stores WRB subtree hash data on disk
-  * "Offline" process downloading record files from S3
-    * Generate WRB blocks from record files
-    * WRB files added to "RBH" Block Node
-    * Produce Jumpstart Data occasionally (configurable, perhaps 1/hour).
-  * Block Nodes may _test_ backfill from RBH, but do not store backfilled WRBs
-    * Preview blocks are accepted and stored.
-  * Preview block streams continue with incomplete hashes
+   * Consensus Node generates WRB subtree hashes
+   * Consensus Node stores WRB subtree hash data on disk
+   * "Offline" process downloading record files from S3
+      * Generate WRB blocks from record files
+      * WRB files added to "RBH" block node
+      * Produce Jumpstart Data occasionally (configurable, perhaps 1/hour).
+   * Block Nodes may _test_ backfill from RBH, but do not store backfilled WRBs
+      * Preview blocks are accepted and stored.
+   * Preview block streams continue with incomplete hashes
 * Release N+1
-  * Jumpstart Data is included in the Consensus Node release package, and is
-    from approximately 8-10 days before the release date.
-  * Consensus Node reads Jumpstart Data
-    * WRB data is combined with the Jumpstart Data to complete "WRB Catch Up"
-    * Consensus Node begins creating WRB block root hash with all
-      necessary correct inputs.
-    * Consensus Node stores the correct WRB hash in BlockInfo in state at the
-      end of each block.
-    * Consensus Node stores the correct WRB streaming hash tree data in state
-      in BlockInfo at the end of each block.
-  * WRAPS proving key and parameters downloaded by Consensus Node
-  * WRAPS proving key hash read from configuration
-    * This data is stored in state as part of post-upgrade migration.
-    * The hash is used to validate the downloaded WRAPS data.
-  * TSS is enabled in Consensus Node but does not sign blocks
-    * TSS creates the Ledger ID and publishes LedgerID, Initial Roster, and
-      WRAPS verification key in Record Stream via TSS adoption transaction.
-    * Consensus Node creates WRAPS proofs for each new Roster.
-  * Offline process continues to generate WRB files for backfill via RBH.
-  * Block Nodes are prepared for cutover
-    * All "production" Tier 1 block nodes are reset to clear preview blocks.
-    * All "production" Tier 1 block nodes begin rapid backfill from RBH to
-      preload all history prior to cutover.
-  * Preview block streams continue to "testing" block nodes and are written
-    to "preview" buckets for testing and qualification.
-    * Preview block hashes continue to be entirely incomplete (to reduce
-      complexity).
+   * Jumpstart Data is included in the Consensus Node release package, and is
+     from approximately 8-10 days before the release date.
+   * Consensus Node reads Jumpstart Data
+      * WRB data is combined with the Jumpstart Data to complete "WRB Catch Up"
+      * Consensus Node begins creating WRB block root hash with all
+        necessary correct inputs.
+      * Consensus Node stores the correct WRB hash in BlockInfo in state at the
+        end of each block.
+      * Consensus Node stores the correct WRB streaming hash tree data in state
+        in BlockInfo at the end of each block.
+   * WRAPS proving key and parameters downloaded by Consensus Node
+   * WRAPS proving key hash read from configuration
+      * This data is stored in state as part of post-upgrade migration.
+      * The hash is used to validate the downloaded WRAPS data.
+   * TSS is enabled in Consensus Node but does not sign blocks
+      * TSS creates the Ledger ID and publishes LedgerID, Initial Roster, and
+        WRAPS verification key in record stream via TSS adoption transaction.
+      * Consensus Node creates WRAPS proofs for each new Roster.
+   * Offline process continues to generate WRB files for backfill via RBH.
+   * Block Nodes are prepared for cutover
+      * All "production" Tier 1 block nodes are reset to clear preview blocks.
+      * All "production" Tier 1 block nodes begin rapid backfill from RBH to
+        preload all history prior to cutover.
+   * Preview block streams continue to "testing" block nodes and are written
+     to "preview" buckets for testing and qualification.
+      * Preview block hashes continue to be entirely incomplete (to reduce
+        complexity).
 * Release N+2 (Cutover Release)
-  * Consensus Node performs cutover tasks during post upgrade processing.
-    * Consensus Node signs each block with TSS and WRAPS
-    * Consensus Node ceases producing Record Streams
-    * Consensus Node removes `BlockInfo` from state<br/>
-      `BlockStreamInfo` is used after cutover and is optimized for
-      block streams rather than record streams.
-    * Consensus Node begins producing Block Streams
-      and publishing to Block Nodes.
-  * Block Nodes complete final backfill and begin receiving Block Streams.
-    * Block Nodes verify TSS signature for each block.
-  * RBH node is shut down once all block nodes finish backfill.
-  * Block Streams become authoritative.
+   * Consensus Node performs cutover tasks during post upgrade processing.
+      * Consensus Node signs each block with TSS and WRAPS
+      * Consensus Node ceases producing Record Streams
+      * Consensus Node removes `BlockInfo` from state<br/>
+        `BlockStreamInfo` is used after cutover and is optimized for
+        block streams rather than record streams.
+      * Consensus Node begins producing Block Streams
+        and publishing to Block Nodes.
+   * Block Nodes complete final backfill and begin receiving Block Streams.
+      * Block Nodes verify TSS signature for each block.
+   * RBH node is shut down once all block nodes finish backfill.
+   * Block Streams become authoritative.
 
 ### How does the consensus node "catch up" with the last Wrapped Record Block hash?
 
 This is a roughly three part process.
 * The first part requires offline processing to do the following.
-1. Download every record file from the beginning
-1. Process each file to extract the record data, wrap that data in a block.
-1. Record the block hash, block number, and state of the historical block
-subtree
-* Update the current Jumpstart Data with this data after each 1000
-blocks.
+   1. Download every record file from the beginning
+   1. Process each file to extract the record data, wrap that data in a block.
+   1. Record the block hash, block number, and state of the historical block
+      subtree
+       * Update the current Jumpstart Data with this data after each 1000
+         blocks.
 * The second part requires that the Consensus Node Software record the following
-values for each record file produced for the Record Stream.
-1. Calculate the subtree hashes for the current record file data according
-to the structure documented below.
-1. For each new record, store the Consensus Time, block number, and subtree
-hash for subtrees 3,4,5,6,7, and 8 in a hash-data file. Only the "output"
-subtree is expected to have a non-zero value.
+  values for each record file produced for the Record Stream.
+   1. Calculate the subtree hashes for the current record file data according
+      to the structure documented below.
+   1. For each new record, store the Consensus Time, block number, and subtree
+      hash for subtrees 3,4,5,6,7, and 8 in a hash-data file. Only the "output"
+      subtree is expected to have a non-zero value.
 * The Consensus Node Software will store the hash data for each record for a
-single release.
+  single release.
 * The third part requires the following tasks
-1. The Jumpstart Data from part one must be included in the upgrade package
-for the Consensus Node.
-1. The Consensus Node Software will read the Jumpstart Data, and find the
-matching block in the hash-data file.
-1. The Consensus Node Software will use the values in the Jumpstart Data to
-calculate the Block Root for the matching wrapped record file block.
-* The Consensus Node Software will use the calculated Block Root and
-the data from the hash-data file to continue calculating the
-Block Root for each record file block in order
-* The Consensus Node Software will complete all Block Root calculations
-forward until reaching the current wrapped record block.
-1. The Consensus Node Software will, thereafter, maintain the previous Block
-Root hash and the state of the historical block subtree in state.
+   1. The Jumpstart Data from part one must be included in the upgrade package
+      for the consensus node.
+   1. The Consensus Node Software will read the Jumpstart Data, and find the
+      matching block in the hash-data file.
+   1. The Consensus Node Software will use the values in the Jumpstart Data to
+      calculate the Block Root for the matching wrapped record file block.
+      * The Consensus Node Software will use the calculated Block Root and
+        the data from the hash-data file to continue calculating the
+        Block Root for each record file block in order
+      * The Consensus Node Software will complete all Block Root calculations
+        forward until reaching the current wrapped record block.
+  1. The Consensus Node Software will, thereafter, maintain the previous Block
+     Root hash and the state of the historical block subtree in state.
 
 #### Block Root Tree Structure (16 fixed leaves)
 
@@ -253,15 +253,15 @@ PrevBlock  AllBlocks  State  ConsensusHeaders  Input Output  StateChanges  Trace
 
 #### Fixed Leaf Positions (from design doc)
 
-`1` Previous Block Root Hash - Links to previous block, forming the blockchain
-`2` All Block Hashes Tree Root - Streaming merkle tree of all previous block hashes
-`3` State Root Hash - State merkle tree root at block start
-`4` Consensus Headers - EventHeader, RoundHeader items
-`5` Input Items - SignedTransaction
-`6` Output Items - BlockHeader, RecordFile items, TransactionResult, TransactionOutput items
-`7` State Changes - StateChanges items
-`8` Trace Data - TraceData items
-`9-16` Reserved - For future expansion
+`1` Previous Block Root Hash - Links to previous block, forming the blockchain  
+`2` All Block Hashes Tree Root - Streaming merkle tree of all previous block hashes  
+`3` State Root Hash - State merkle tree root at block start  
+`4` Consensus Headers - EventHeader, RoundHeader items  
+`5` Input Items - SignedTransaction  
+`6` Output Items - BlockHeader, RecordFile items, TransactionResult, TransactionOutput items  
+`7` State Changes - StateChanges items  
+`8` Trace Data - TraceData items  
+`9-16` Reserved - For future expansion  
 
 #### Subtree Item Types
 

--- a/docs/block-node/Cutover-Process.md
+++ b/docs/block-node/Cutover-Process.md
@@ -29,14 +29,18 @@ node signature to Block Streams, Block Nodes, and HinTS/TSS signatures.
     adding Header and Footer details, and generating a Block Proof based
     on the individual node signatures produced for that Record File.</dd>
 <dt>Jumpstart Data</dt><dd>
-    A file containing the Block Hash for a specific WRB, the Record File Hash
-    (SHA-384 of the raw record file bytes) for that block, the state of the
-    historical block hash tree after hashing that block, and the block number
-    of that block. The Record File Hash enables the Consensus Node to
-    cross-validate that its locally produced record file matches the one that
-    was wrapped. The historical block hash tree state is the minimal set of
-    hashes needed to continue the streaming hash algorithm with the next
-    block.</dd>
+    A file containing the Block Hash for a specific WRB, the Consensus
+    Timestamp Hash (SHA-384 leaf hash of the block's first consensus
+    timestamp), the Output Items Tree Root Hash (streaming merkle root of all
+    output items: BlockHeader, RecordFile, TransactionResult,
+    TransactionOutput), the state of the historical block hash tree after
+    hashing that block, and the block number of that block. The Consensus
+    Timestamp Hash and Output Items Tree Root Hash enable the Consensus Node
+    to cross-validate that its locally produced wrapped record block hashes
+    match those from the offline wrapping process before running the
+    jumpstart migration. The historical block hash tree state is the minimal
+    set of hashes needed to continue the streaming hash algorithm with the
+    next block.</dd>
 <dt>WRB Catch Up</dt><dd>
     A process where the Consensus Node Software combines a Jumpstart Data with
     the Timestamp and root hashes for subtrees 3-8 to produce a valid WRB hash

--- a/tools-and-tests/tools/docs/blocks-commands.md
+++ b/tools-and-tests/tools/docs/blocks-commands.md
@@ -282,7 +282,7 @@ The command writes:
 - `blockStreamBlockHashes.bin` - registry of computed block hashes
 - `streamingMerkleTree.bin` and `completeMerkleTree.bin` - Merkle tree state for resume capability
 - `wrap-commit.bin` - durable commit watermark tracking the highest block number fully written to zip
-- `jumpstart.bin` - jumpstart data (block number, block hash, record file hash, streaming hasher state) for Consensus Node continuation
+- `jumpstart.bin` - jumpstart data (block number, block hash, consensus timestamp hash, output items tree root hash, streaming hasher state) for Consensus Node WRB catch-up integrity checks
 
 #### Notes
 

--- a/tools-and-tests/tools/docs/blocks-commands.md
+++ b/tools-and-tests/tools/docs/blocks-commands.md
@@ -282,7 +282,7 @@ The command writes:
 - `blockStreamBlockHashes.bin` - registry of computed block hashes
 - `streamingMerkleTree.bin` and `completeMerkleTree.bin` - Merkle tree state for resume capability
 - `wrap-commit.bin` - durable commit watermark tracking the highest block number fully written to zip
-- `jumpstart.bin` - jumpstart data (block number, hash, streaming hasher state) for Consensus Node continuation
+- `jumpstart.bin` - jumpstart data (block number, block hash, record file hash, streaming hasher state) for Consensus Node continuation
 
 #### Notes
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
@@ -5,7 +5,7 @@ import static org.hiero.block.tools.blocks.AmendmentProvider.createAmendmentProv
 import static org.hiero.block.tools.blocks.HasherStateFiles.saveStateCheckpoint;
 import static org.hiero.block.tools.blocks.model.BlockWriter.DEFAULT_COMPRESSION;
 import static org.hiero.block.tools.blocks.model.BlockWriter.DEFAULT_POWERS_OF_TEN_PER_ZIP;
-import static org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHasher.hashBlock;
+import static org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHasher.hashBlockDetailed;
 import static org.hiero.block.tools.blocks.validation.BlockExtractionUtils.extractTransactionBody;
 import static org.hiero.block.tools.mirrornode.DayBlockInfo.loadDayBlockInfoMap;
 import static org.hiero.block.tools.records.RecordFileDates.FIRST_BLOCK_TIME_INSTANT;
@@ -49,6 +49,7 @@ import org.hiero.block.tools.blocks.model.BlockWriter.BlockPath;
 import org.hiero.block.tools.blocks.model.BlockWriter.BlockZipAppender;
 import org.hiero.block.tools.blocks.model.PreVerifiedBlock;
 import org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHashRegistry;
+import org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHasher.BlockHashResult;
 import org.hiero.block.tools.blocks.model.hashing.StreamingHasher;
 import org.hiero.block.tools.blocks.validation.SignatureBlockStats;
 import org.hiero.block.tools.blocks.validation.SignatureStatsCollector;
@@ -466,7 +467,8 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
             // Track the last block number and hash in memory, write once at the end
             final AtomicLong jumpstartBlockNumber = new AtomicLong(-1);
             final AtomicReference<byte[]> jumpstartBlockHash = new AtomicReference<>(null);
-            final AtomicReference<byte[]> jumpstartRecordFileHash = new AtomicReference<>(null);
+            final AtomicReference<byte[]> jumpstartConsensusTimestampHash = new AtomicReference<>(null);
+            final AtomicReference<byte[]> jumpstartOutputItemsTreeRootHash = new AtomicReference<>(null);
 
             // Register a shutdown hook to request orderly drain on JVM exit (Ctrl+C, etc.)
             final Thread shutdownHook = new Thread(
@@ -529,7 +531,8 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
                                         jumpstartFile,
                                         jumpstartBlockNumber.get(),
                                         jumpstartBlockHash.get(),
-                                        jumpstartRecordFileHash.get(),
+                                        jumpstartConsensusTimestampHash.get(),
+                                        jumpstartOutputItemsTreeRootHash.get(),
                                         streamingHasher);
                             }
                         }
@@ -703,14 +706,15 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
 
                         // Update chain state under lock so the shutdown hook cannot read
                         // partially updated hashers while saving state.
-                        final byte[] blockStreamBlockHash = hashBlock(wrapped);
+                        final BlockHashResult hashResult = hashBlockDetailed(wrapped);
+                        final byte[] blockStreamBlockHash = hashResult.blockHash();
                         synchronized (chainStateLock) {
                             streamingHasher.addNodeByHash(blockStreamBlockHash);
                             blockRegistry.addBlock(blockNum, blockStreamBlockHash);
                             jumpstartBlockNumber.set(blockNum);
                             jumpstartBlockHash.set(blockStreamBlockHash);
-                            jumpstartRecordFileHash.set(
-                                    effectiveBlock.recordBlock().recordFile().signedHash());
+                            jumpstartConsensusTimestampHash.set(hashResult.consensusTimestampHash());
+                            jumpstartOutputItemsTreeRootHash.set(hashResult.outputItemsTreeRootHash());
                         }
 
                         // Pre-compute block path on the convert thread (pure arithmetic, fast).
@@ -862,7 +866,8 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
                         jumpstartFile,
                         jumpstartBlockNumber.get(),
                         jumpstartBlockHash.get(),
-                        jumpstartRecordFileHash.get(),
+                        jumpstartConsensusTimestampHash.get(),
+                        jumpstartOutputItemsTreeRootHash.get(),
                         streamingHasher);
             }
 
@@ -1033,7 +1038,8 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
      * <ul>
      *   <li>Block number (8 bytes, long)</li>
      *   <li>Previous block root hash (48 bytes, SHA-384)</li>
-     *   <li>Record file hash (48 bytes, SHA-384)</li>
+     *   <li>Consensus timestamp hash (48 bytes, SHA-384) — leaf hash of the block's first consensus timestamp</li>
+     *   <li>Output items tree root hash (48 bytes, SHA-384) — streaming merkle root of all output items</li>
      *   <li>Streaming hasher leaf count (8 bytes, long)</li>
      *   <li>Streaming hasher hash count (4 bytes, int)</li>
      *   <li>Streaming hasher pending subtree hashes (48 bytes x hash count)</li>
@@ -1042,18 +1048,26 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
      * @param file the file to write to
      * @param blockNumber the block number
      * @param blockHash the block hash (SHA-384, 48 bytes) - this is the previous block root hash
-     * @param recordFileHash the record file hash (SHA-384, 48 bytes) - hash of the raw record file bytes
+     * @param consensusTimestampHash the consensus timestamp leaf hash (SHA-384, 48 bytes)
+     * @param outputItemsTreeRootHash the output items tree root hash (SHA-384, 48 bytes)
      * @param streamingHasher the streaming hasher containing the merkle tree state
      */
     static void saveJumpstartData(
-            Path file, long blockNumber, byte[] blockHash, byte[] recordFileHash, StreamingHasher streamingHasher) {
+            Path file,
+            long blockNumber,
+            byte[] blockHash,
+            byte[] consensusTimestampHash,
+            byte[] outputItemsTreeRootHash,
+            StreamingHasher streamingHasher) {
         try (DataOutputStream out = new DataOutputStream(
                 Files.newOutputStream(file, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING))) {
             // Block number and hash (previous block root hash for the next block)
             out.writeLong(blockNumber);
             out.write(blockHash);
-            // Record file hash (SHA-384 of the raw record file bytes)
-            out.write(recordFileHash);
+            // Consensus timestamp hash (SHA-384 leaf hash of the block's first consensus timestamp)
+            out.write(consensusTimestampHash);
+            // Output items tree root hash (streaming merkle root of all output items)
+            out.write(outputItemsTreeRootHash);
 
             // Streaming hasher state for subtree 2 continuation
             out.writeLong(streamingHasher.leafCount());

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
@@ -466,6 +466,7 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
             // Track the last block number and hash in memory, write once at the end
             final AtomicLong jumpstartBlockNumber = new AtomicLong(-1);
             final AtomicReference<byte[]> jumpstartBlockHash = new AtomicReference<>(null);
+            final AtomicReference<byte[]> jumpstartRecordFileHash = new AtomicReference<>(null);
 
             // Register a shutdown hook to request orderly drain on JVM exit (Ctrl+C, etc.)
             final Thread shutdownHook = new Thread(
@@ -528,6 +529,7 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
                                         jumpstartFile,
                                         jumpstartBlockNumber.get(),
                                         jumpstartBlockHash.get(),
+                                        jumpstartRecordFileHash.get(),
                                         streamingHasher);
                             }
                         }
@@ -707,6 +709,8 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
                             blockRegistry.addBlock(blockNum, blockStreamBlockHash);
                             jumpstartBlockNumber.set(blockNum);
                             jumpstartBlockHash.set(blockStreamBlockHash);
+                            jumpstartRecordFileHash.set(
+                                    effectiveBlock.recordBlock().recordFile().signedHash());
                         }
 
                         // Pre-compute block path on the convert thread (pure arithmetic, fast).
@@ -854,7 +858,12 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
 
             // Save jumpstart data once at the end
             if (jumpstartBlockHash.get() != null) {
-                saveJumpstartData(jumpstartFile, jumpstartBlockNumber.get(), jumpstartBlockHash.get(), streamingHasher);
+                saveJumpstartData(
+                        jumpstartFile,
+                        jumpstartBlockNumber.get(),
+                        jumpstartBlockHash.get(),
+                        jumpstartRecordFileHash.get(),
+                        streamingHasher);
             }
 
             addressBookRegistry.saveAddressBookRegistryToJsonFile(addressBookFile);
@@ -1024,6 +1033,7 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
      * <ul>
      *   <li>Block number (8 bytes, long)</li>
      *   <li>Previous block root hash (48 bytes, SHA-384)</li>
+     *   <li>Record file hash (48 bytes, SHA-384)</li>
      *   <li>Streaming hasher leaf count (8 bytes, long)</li>
      *   <li>Streaming hasher hash count (4 bytes, int)</li>
      *   <li>Streaming hasher pending subtree hashes (48 bytes x hash count)</li>
@@ -1032,14 +1042,18 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
      * @param file the file to write to
      * @param blockNumber the block number
      * @param blockHash the block hash (SHA-384, 48 bytes) - this is the previous block root hash
+     * @param recordFileHash the record file hash (SHA-384, 48 bytes) - hash of the raw record file bytes
      * @param streamingHasher the streaming hasher containing the merkle tree state
      */
-    static void saveJumpstartData(Path file, long blockNumber, byte[] blockHash, StreamingHasher streamingHasher) {
+    static void saveJumpstartData(
+            Path file, long blockNumber, byte[] blockHash, byte[] recordFileHash, StreamingHasher streamingHasher) {
         try (DataOutputStream out = new DataOutputStream(
                 Files.newOutputStream(file, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING))) {
             // Block number and hash (previous block root hash for the next block)
             out.writeLong(blockNumber);
             out.write(blockHash);
+            // Record file hash (SHA-384 of the raw record file bytes)
+            out.write(recordFileHash);
 
             // Streaming hasher state for subtree 2 continuation
             out.writeLong(streamingHasher.leafCount());

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/hashing/BlockStreamBlockHasher.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/hashing/BlockStreamBlockHasher.java
@@ -72,6 +72,17 @@ import org.hiero.block.tools.utils.Sha384;
 public class BlockStreamBlockHasher {
 
     /**
+     * Result of a detailed block hash computation, containing the block root hash plus
+     * intermediate hashes needed by the Consensus Node for WRB catch-up integrity checks.
+     *
+     * @param blockHash the 48-byte SHA-384 block root hash
+     * @param consensusTimestampHash the SHA-384 leaf hash of the block's first consensus timestamp
+     * @param outputItemsTreeRootHash the streaming merkle root of all output items
+     *        (BlockHeader, RecordFile, TransactionResult, TransactionOutput)
+     */
+    public record BlockHashResult(byte[] blockHash, byte[] consensusTimestampHash, byte[] outputItemsTreeRootHash) {}
+
+    /**
      * Computes the root hash of a fully-parsed {@link Block} by re-serializing to bytes
      * and delegating to {@link #hashBlock(BlockUnparsed)}.
      *
@@ -82,14 +93,7 @@ public class BlockStreamBlockHasher {
      * @return the 48-byte SHA-384 block root hash
      */
     public static byte[] hashBlock(Block block) {
-        try {
-            Bytes bytes = Block.PROTOBUF.toBytes(block);
-            BlockUnparsed unparsed = BlockUnparsed.PROTOBUF.parse(
-                    bytes.toReadableSequentialData(), false, false, Codec.DEFAULT_MAX_DEPTH, MAX_PARSE_SIZE);
-            return hashBlock(unparsed);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Failed to hash block", e);
-        }
+        return hashBlockDetailed(block).blockHash();
     }
 
     /**
@@ -106,6 +110,36 @@ public class BlockStreamBlockHasher {
      * @throws IllegalArgumentException if the block is missing the required header or footer
      */
     public static byte[] hashBlock(BlockUnparsed block) {
+        return hashBlockDetailed(block).blockHash();
+    }
+
+    /**
+     * Computes the root hash of a fully-parsed {@link Block} and returns the full
+     * {@link BlockHashResult} including intermediate hashes needed by the Consensus Node.
+     *
+     * @param block the fully-parsed block to hash
+     * @return the detailed hash result containing block hash plus intermediate hashes
+     */
+    public static BlockHashResult hashBlockDetailed(Block block) {
+        try {
+            Bytes bytes = Block.PROTOBUF.toBytes(block);
+            BlockUnparsed unparsed = BlockUnparsed.PROTOBUF.parse(
+                    bytes.toReadableSequentialData(), false, false, Codec.DEFAULT_MAX_DEPTH, MAX_PARSE_SIZE);
+            return hashBlockInternal(unparsed);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to hash block", e);
+        }
+    }
+
+    /**
+     * Computes the root hash of a block using {@link BlockUnparsed} and returns the full
+     * {@link BlockHashResult} including intermediate hashes needed by the Consensus Node.
+     *
+     * @param block the unparsed block to hash (must contain BlockHeader and BlockFooter)
+     * @return the detailed hash result containing block hash plus intermediate hashes
+     * @throws IllegalArgumentException if the block is missing the required header or footer
+     */
+    public static BlockHashResult hashBlockDetailed(BlockUnparsed block) {
         try {
             return hashBlockInternal(block);
         } catch (Exception e) {
@@ -116,7 +150,7 @@ public class BlockStreamBlockHasher {
     /** Reusable varint encoding buffer (max 5 bytes for a 32-bit varint). */
     private static final ThreadLocal<byte[]> VARINT_BUF = ThreadLocal.withInitial(() -> new byte[5]);
 
-    private static byte[] hashBlockInternal(BlockUnparsed block) throws Exception {
+    private static BlockHashResult hashBlockInternal(BlockUnparsed block) throws Exception {
         // create SHA-384 digest instance for all hashing
         final MessageDigest digest = Sha384.sha384Digest();
         // selectively parse block header from the first item's raw bytes
@@ -199,8 +233,11 @@ public class BlockStreamBlockHasher {
         // combine all the merkle tree roots and other block data into final block hash
         // spotless:off
         // Code here won't be formatted by Spotless, Spotless makes it less readable
-        return hashInternalNode(digest,
-            hashLeaf(digest, Timestamp.PROTOBUF.toBytes(consensusTimestamp).toByteArray()),
+        // Capture intermediate hashes before folding them into the tree
+        final byte[] ctHash = hashLeaf(digest, Timestamp.PROTOBUF.toBytes(consensusTimestamp).toByteArray());
+        final byte[] oitHash = outputItemsHasher.computeRootHash();
+        final byte[] rootHash = hashInternalNode(digest,
+            ctHash,
             hashInternalNode(digest,
                 hashInternalNode(digest,
                     hashInternalNode(digest,
@@ -216,7 +253,7 @@ public class BlockStreamBlockHasher {
                     hashInternalNode(digest,
                         hashInternalNode(digest,
                             inputItemsHasher.computeRootHash(),
-                            outputItemsHasher.computeRootHash()
+                            oitHash
                         ),
                         hashInternalNode(digest,
                             stateChangeItemsHasher.computeRootHash(),
@@ -227,6 +264,7 @@ public class BlockStreamBlockHasher {
                 null // reserved for future use
             )
         );
+        return new BlockHashResult(rootHash, ctHash, oitHash);
         // spotless:on
     }
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/hashing/BlockStreamBlockHasher.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/hashing/BlockStreamBlockHasher.java
@@ -150,6 +150,14 @@ public class BlockStreamBlockHasher {
     /** Reusable varint encoding buffer (max 5 bytes for a 32-bit varint). */
     private static final ThreadLocal<byte[]> VARINT_BUF = ThreadLocal.withInitial(() -> new byte[5]);
 
+    /** Holds the five streaming hashers used during block item classification. */
+    private record ItemHashers(
+            StreamingHasher consensusHeaders,
+            StreamingHasher inputItems,
+            StreamingHasher outputItems,
+            StreamingHasher stateChangeItems,
+            StreamingHasher traceItems) {}
+
     private static BlockHashResult hashBlockInternal(BlockUnparsed block) throws Exception {
         // create SHA-384 digest instance for all hashing
         final MessageDigest digest = Sha384.sha384Digest();
@@ -179,6 +187,54 @@ public class BlockStreamBlockHasher {
                 ? EMPTY_TREE_HASH
                 : blockFooter.startOfBlockStateRootHash().toByteArray();
         // build streaming merkle trees of items in the block
+        final ItemHashers hashers = classifyBlockItems(digest, block);
+        // combine all the merkle tree roots and other block data into final block hash
+        // spotless:off
+        // Code here won't be formatted by Spotless, Spotless makes it less readable
+        // Capture intermediate hashes before folding them into the tree
+        final byte[] ctHash = hashLeaf(digest, Timestamp.PROTOBUF.toBytes(consensusTimestamp).toByteArray());
+        final byte[] oitHash = hashers.outputItems.computeRootHash();
+        final byte[] rootHash = hashInternalNode(digest,
+            ctHash,
+            hashInternalNode(digest,
+                hashInternalNode(digest,
+                    hashInternalNode(digest,
+                        hashInternalNode(digest,
+                            previousBlockHash,
+                            blockFooter.rootHashOfAllBlockHashesTree().toByteArray()
+                        ),
+                        hashInternalNode(digest,
+                            stateRootHash,
+                            hashers.consensusHeaders.computeRootHash()
+                        )
+                    ),
+                    hashInternalNode(digest,
+                        hashInternalNode(digest,
+                            hashers.inputItems.computeRootHash(),
+                            oitHash
+                        ),
+                        hashInternalNode(digest,
+                            hashers.stateChangeItems.computeRootHash(),
+                            hashers.traceItems.computeRootHash()
+                        )
+                    )
+                ),
+                null // reserved for future use
+            )
+        );
+        return new BlockHashResult(rootHash, ctHash, oitHash);
+        // spotless:on
+    }
+
+    /**
+     * Classifies each block item into its corresponding streaming hasher subtree.
+     *
+     * @param digest the SHA-384 digest to use for leaf hashing
+     * @param block the unparsed block whose items are classified
+     * @return the five populated streaming hashers
+     */
+    private static ItemHashers classifyBlockItems(final MessageDigest digest, final BlockUnparsed block)
+            throws Exception {
         final StreamingHasher consensusHeadersHasher = new StreamingHasher();
         final StreamingHasher inputItemsHasher = new StreamingHasher();
         final StreamingHasher outputItemsHasher = new StreamingHasher();
@@ -230,42 +286,8 @@ public class BlockStreamBlockHasher {
                 case BLOCK_PROOF -> {} // ignore, not hashed as it proves the hash so can't be part of it
             }
         }
-        // combine all the merkle tree roots and other block data into final block hash
-        // spotless:off
-        // Code here won't be formatted by Spotless, Spotless makes it less readable
-        // Capture intermediate hashes before folding them into the tree
-        final byte[] ctHash = hashLeaf(digest, Timestamp.PROTOBUF.toBytes(consensusTimestamp).toByteArray());
-        final byte[] oitHash = outputItemsHasher.computeRootHash();
-        final byte[] rootHash = hashInternalNode(digest,
-            ctHash,
-            hashInternalNode(digest,
-                hashInternalNode(digest,
-                    hashInternalNode(digest,
-                        hashInternalNode(digest,
-                            previousBlockHash,
-                            blockFooter.rootHashOfAllBlockHashesTree().toByteArray()
-                        ),
-                        hashInternalNode(digest,
-                            stateRootHash,
-                            consensusHeadersHasher.computeRootHash()
-                        )
-                    ),
-                    hashInternalNode(digest,
-                        hashInternalNode(digest,
-                            inputItemsHasher.computeRootHash(),
-                            oitHash
-                        ),
-                        hashInternalNode(digest,
-                            stateChangeItemsHasher.computeRootHash(),
-                            traceItemsHasher.computeRootHash()
-                        )
-                    )
-                ),
-                null // reserved for future use
-            )
-        );
-        return new BlockHashResult(rootHash, ctHash, oitHash);
-        // spotless:on
+        return new ItemHashers(
+                consensusHeadersHasher, inputItemsHasher, outputItemsHasher, stateChangeItemsHasher, traceItemsHasher);
     }
 
     /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/JumpstartValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/JumpstartValidation.java
@@ -21,7 +21,8 @@ import org.jspecify.annotations.Nullable;
  * <ol>
  *   <li>Block number (long)</li>
  *   <li>Block hash (48 bytes)</li>
- *   <li>Record file hash (48 bytes, SHA-384 of the raw record file bytes)</li>
+ *   <li>Consensus timestamp hash (48 bytes, SHA-384 leaf hash of the block's first consensus timestamp)</li>
+ *   <li>Output items tree root hash (48 bytes, streaming merkle root of all output items)</li>
  *   <li>Leaf count (long)</li>
  *   <li>Hash count (int) followed by that many 48-byte hashes (streaming hasher state)</li>
  * </ol>
@@ -86,8 +87,10 @@ public final class JumpstartValidation implements BlockValidation {
             long jBlockNum = din.readLong();
             byte[] jHash = new byte[48];
             din.readFully(jHash);
-            byte[] jRecordFileHash = new byte[48];
-            din.readFully(jRecordFileHash);
+            byte[] jConsensusTimestampHash = new byte[48];
+            din.readFully(jConsensusTimestampHash);
+            byte[] jOutputItemsTreeRootHash = new byte[48];
+            din.readFully(jOutputItemsTreeRootHash);
             long jLeafCount = din.readLong();
             int jHashCount = din.readInt();
             List<byte[]> jHashes = new ArrayList<>();

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/JumpstartValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/JumpstartValidation.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.Nullable;
  * <ol>
  *   <li>Block number (long)</li>
  *   <li>Block hash (48 bytes)</li>
+ *   <li>Record file hash (48 bytes, SHA-384 of the raw record file bytes)</li>
  *   <li>Leaf count (long)</li>
  *   <li>Hash count (int) followed by that many 48-byte hashes (streaming hasher state)</li>
  * </ol>
@@ -85,6 +86,8 @@ public final class JumpstartValidation implements BlockValidation {
             long jBlockNum = din.readLong();
             byte[] jHash = new byte[48];
             din.readFully(jHash);
+            byte[] jRecordFileHash = new byte[48];
+            din.readFully(jRecordFileHash);
             long jLeafCount = din.readLong();
             int jHashCount = din.readInt();
             List<byte[]> jHashes = new ArrayList<>();

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -249,6 +249,7 @@ public class LiveSequential implements Runnable {
         long blocksSinceWatermarkFlush;
         long blocksValidated;
         long lastCheckpointSaveMs = System.currentTimeMillis();
+        byte[] lastRecordFileHash;
     }
 
     /** A block whose file downloads have been fired but not yet joined. */
@@ -772,8 +773,13 @@ public class LiveSequential implements Runnable {
                 saveWatermark(watermarkFile, ls.durableWatermark);
                 saveStateCheckpoint(streamingMerkleTreeFile, streamingHasher);
                 byte[] lastBlockHash = blockRegistry.getBlockHash(ls.durableWatermark);
-                if (lastBlockHash != null) {
-                    saveJumpstart(vc.jumpstartPath(), ls.durableWatermark, lastBlockHash, streamingHasher);
+                if (lastBlockHash != null && ls.lastRecordFileHash != null) {
+                    saveJumpstart(
+                            vc.jumpstartPath(),
+                            ls.durableWatermark,
+                            lastBlockHash,
+                            ls.lastRecordFileHash,
+                            streamingHasher);
                 }
                 addressBookRegistry.saveAddressBookRegistryToJsonFile(addressBookFile);
 
@@ -1060,6 +1066,7 @@ public class LiveSequential implements Runnable {
         ParsedRecordBlock parsedBlock = unparsedBlock.parse();
         NodeAddressBook ab = addressBookRegistry.getAddressBookForBlock(parsedBlock.blockTime());
         byte[] signedHash = parsedBlock.recordFile().signedHash();
+        ls.lastRecordFileHash = signedHash;
         List<RecordFileSignature> verifiedSigs = parsedBlock.signatureFiles().stream()
                 .filter(psf -> psf.isValid(signedHash, ab))
                 .map(psf -> psf.toRecordFileSignature(ab))
@@ -1101,7 +1108,7 @@ public class LiveSequential implements Runnable {
         }
 
         // Save jumpstart.bin every block
-        saveJumpstart(vc.jumpstartPath(), blockNum, blockStreamBlockHash, streamingHasher);
+        saveJumpstart(vc.jumpstartPath(), blockNum, blockStreamBlockHash, ls.lastRecordFileHash, streamingHasher);
 
         // Periodic checkpoint save
         long nowMs = System.currentTimeMillis();
@@ -1655,16 +1662,21 @@ public class LiveSequential implements Runnable {
 
     /**
      * Save jumpstart.bin atomically. Format matches what {@link JumpstartValidation} reads:
-     * block number (long), block hash (48 bytes), leaf count (long), hash count (int),
-     * followed by hash count × 48-byte hashes (streaming hasher intermediate state).
+     * block number (long), block hash (48 bytes), record file hash (48 bytes), leaf count (long),
+     * hash count (int), followed by hash count × 48-byte hashes (streaming hasher intermediate state).
      */
     private static void saveJumpstart(
-            Path jumpstartPath, long blockNumber, byte[] blockHash, StreamingHasher streamingHasher) {
+            Path jumpstartPath,
+            long blockNumber,
+            byte[] blockHash,
+            byte[] recordFileHash,
+            StreamingHasher streamingHasher) {
         try {
             HasherStateFiles.saveAtomically(jumpstartPath, path -> {
                 try (var out = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(path), 8192))) {
                     out.writeLong(blockNumber);
                     out.write(blockHash);
+                    out.write(recordFileHash);
                     out.writeLong(streamingHasher.leafCount());
                     List<byte[]> hashes = streamingHasher.intermediateHashingState();
                     out.writeInt(hashes.size());

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -5,7 +5,7 @@ import static org.hiero.block.tools.blocks.AmendmentProvider.createAmendmentProv
 import static org.hiero.block.tools.blocks.HasherStateFiles.saveStateCheckpoint;
 import static org.hiero.block.tools.blocks.model.BlockWriter.DEFAULT_COMPRESSION;
 import static org.hiero.block.tools.blocks.model.BlockWriter.DEFAULT_POWERS_OF_TEN_PER_ZIP;
-import static org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHasher.hashBlock;
+import static org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHasher.hashBlockDetailed;
 import static org.hiero.block.tools.days.downloadlive.ValidateDownloadLive.findPrimaryRecord;
 import static org.hiero.block.tools.days.downloadlive.ValidateDownloadLive.findSidecars;
 import static org.hiero.block.tools.days.downloadlive.ValidateDownloadLive.findSignatures;
@@ -61,6 +61,7 @@ import org.hiero.block.tools.blocks.model.BlockWriter.BlockPath;
 import org.hiero.block.tools.blocks.model.BlockWriter.BlockZipAppender;
 import org.hiero.block.tools.blocks.model.PreVerifiedBlock;
 import org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHashRegistry;
+import org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHasher.BlockHashResult;
 import org.hiero.block.tools.blocks.model.hashing.StreamingHasher;
 import org.hiero.block.tools.blocks.validation.AddressBookUpdateValidation;
 import org.hiero.block.tools.blocks.validation.BlockChainValidation;
@@ -249,7 +250,8 @@ public class LiveSequential implements Runnable {
         long blocksSinceWatermarkFlush;
         long blocksValidated;
         long lastCheckpointSaveMs = System.currentTimeMillis();
-        byte[] lastRecordFileHash;
+        byte[] lastConsensusTimestampHash;
+        byte[] lastOutputItemsTreeRootHash;
     }
 
     /** A block whose file downloads have been fired but not yet joined. */
@@ -773,12 +775,13 @@ public class LiveSequential implements Runnable {
                 saveWatermark(watermarkFile, ls.durableWatermark);
                 saveStateCheckpoint(streamingMerkleTreeFile, streamingHasher);
                 byte[] lastBlockHash = blockRegistry.getBlockHash(ls.durableWatermark);
-                if (lastBlockHash != null && ls.lastRecordFileHash != null) {
+                if (lastBlockHash != null && ls.lastConsensusTimestampHash != null) {
                     saveJumpstart(
                             vc.jumpstartPath(),
                             ls.durableWatermark,
                             lastBlockHash,
-                            ls.lastRecordFileHash,
+                            ls.lastConsensusTimestampHash,
+                            ls.lastOutputItemsTreeRootHash,
                             streamingHasher);
                 }
                 addressBookRegistry.saveAddressBookRegistryToJsonFile(addressBookFile);
@@ -1066,7 +1069,6 @@ public class LiveSequential implements Runnable {
         ParsedRecordBlock parsedBlock = unparsedBlock.parse();
         NodeAddressBook ab = addressBookRegistry.getAddressBookForBlock(parsedBlock.blockTime());
         byte[] signedHash = parsedBlock.recordFile().signedHash();
-        ls.lastRecordFileHash = signedHash;
         List<RecordFileSignature> verifiedSigs = parsedBlock.signatureFiles().stream()
                 .filter(psf -> psf.isValid(signedHash, ab))
                 .map(psf -> psf.toRecordFileSignature(ab))
@@ -1090,7 +1092,10 @@ public class LiveSequential implements Runnable {
                 amendmentProvider);
 
         // Hash and update chain state
-        byte[] blockStreamBlockHash = hashBlock(wrapped);
+        BlockHashResult hashResult = hashBlockDetailed(wrapped);
+        byte[] blockStreamBlockHash = hashResult.blockHash();
+        ls.lastConsensusTimestampHash = hashResult.consensusTimestampHash();
+        ls.lastOutputItemsTreeRootHash = hashResult.outputItemsTreeRootHash();
         streamingHasher.addNodeByHash(blockStreamBlockHash);
         blockRegistry.addBlock(blockNum, blockStreamBlockHash);
 
@@ -1108,7 +1113,13 @@ public class LiveSequential implements Runnable {
         }
 
         // Save jumpstart.bin every block
-        saveJumpstart(vc.jumpstartPath(), blockNum, blockStreamBlockHash, ls.lastRecordFileHash, streamingHasher);
+        saveJumpstart(
+                vc.jumpstartPath(),
+                blockNum,
+                blockStreamBlockHash,
+                ls.lastConsensusTimestampHash,
+                ls.lastOutputItemsTreeRootHash,
+                streamingHasher);
 
         // Periodic checkpoint save
         long nowMs = System.currentTimeMillis();
@@ -1662,21 +1673,24 @@ public class LiveSequential implements Runnable {
 
     /**
      * Save jumpstart.bin atomically. Format matches what {@link JumpstartValidation} reads:
-     * block number (long), block hash (48 bytes), record file hash (48 bytes), leaf count (long),
-     * hash count (int), followed by hash count × 48-byte hashes (streaming hasher intermediate state).
+     * block number (long), block hash (48 bytes), consensus timestamp hash (48 bytes),
+     * output items tree root hash (48 bytes), leaf count (long), hash count (int),
+     * followed by hash count × 48-byte hashes (streaming hasher intermediate state).
      */
     private static void saveJumpstart(
             Path jumpstartPath,
             long blockNumber,
             byte[] blockHash,
-            byte[] recordFileHash,
+            byte[] consensusTimestampHash,
+            byte[] outputItemsTreeRootHash,
             StreamingHasher streamingHasher) {
         try {
             HasherStateFiles.saveAtomically(jumpstartPath, path -> {
                 try (var out = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(path), 8192))) {
                     out.writeLong(blockNumber);
                     out.write(blockHash);
-                    out.write(recordFileHash);
+                    out.write(consensusTimestampHash);
+                    out.write(outputItemsTreeRootHash);
                     out.writeLong(streamingHasher.leafCount());
                     List<byte[]> hashes = streamingHasher.intermediateHashingState();
                     out.writeInt(hashes.size());

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommandTest.java
@@ -698,9 +698,13 @@ class ToWrappedBlocksCommandTest {
                 }
                 assertFalse(allZero, "Jumpstart block hash should not be all zeros");
 
-                // Record file hash is 48 bytes (SHA-384)
-                final byte[] recordFileHash = new byte[48];
-                in.readFully(recordFileHash);
+                // Consensus timestamp hash is 48 bytes (SHA-384)
+                final byte[] consensusTimestampHash = new byte[48];
+                in.readFully(consensusTimestampHash);
+
+                // Output items tree root hash is 48 bytes (SHA-384)
+                final byte[] outputItemsTreeRootHash = new byte[48];
+                in.readFully(outputItemsTreeRootHash);
 
                 // Streaming hasher state
                 final long leafCount = in.readLong();
@@ -1161,8 +1165,10 @@ class ToWrappedBlocksCommandTest {
             }
 
             final Path file = jumpstartDir.resolve("jumpstart.bin");
-            final byte[] recordFileHash = new byte[48];
-            ToWrappedBlocksCommand.saveJumpstartData(file, 9, lastHash, recordFileHash, streamingHasher);
+            final byte[] consensusTimestampHash = new byte[48];
+            final byte[] outputItemsTreeRootHash = new byte[48];
+            ToWrappedBlocksCommand.saveJumpstartData(
+                    file, 9, lastHash, consensusTimestampHash, outputItemsTreeRootHash, streamingHasher);
 
             // Read back and verify format
             try (DataInputStream in = new DataInputStream(Files.newInputStream(file))) {
@@ -1172,9 +1178,13 @@ class ToWrappedBlocksCommandTest {
                 in.readFully(readHash);
                 assertArrayEquals(lastHash, readHash, "Block hash should match");
 
-                final byte[] readRecordFileHash = new byte[48];
-                in.readFully(readRecordFileHash);
-                assertArrayEquals(recordFileHash, readRecordFileHash, "Record file hash should match");
+                final byte[] readCtHash = new byte[48];
+                in.readFully(readCtHash);
+                assertArrayEquals(consensusTimestampHash, readCtHash, "Consensus timestamp hash should match");
+
+                final byte[] readOitHash = new byte[48];
+                in.readFully(readOitHash);
+                assertArrayEquals(outputItemsTreeRootHash, readOitHash, "Output items tree root hash should match");
 
                 assertEquals(10, in.readLong(), "Leaf count should be 10");
 
@@ -1199,16 +1209,19 @@ class ToWrappedBlocksCommandTest {
             streamingHasher.addNodeByHash(blockHash);
 
             final Path file = jumpstartDir.resolve("jumpstart.bin");
-            ToWrappedBlocksCommand.saveJumpstartData(file, 0, blockHash, new byte[48], streamingHasher);
+            ToWrappedBlocksCommand.saveJumpstartData(file, 0, blockHash, new byte[48], new byte[48], streamingHasher);
 
             try (DataInputStream in = new DataInputStream(Files.newInputStream(file))) {
                 assertEquals(0, in.readLong(), "Block number should be 0");
                 final byte[] readHash = new byte[48];
                 in.readFully(readHash);
                 assertArrayEquals(blockHash, readHash);
-                final byte[] readRecordFileHash = new byte[48];
-                in.readFully(readRecordFileHash);
-                assertArrayEquals(new byte[48], readRecordFileHash, "Record file hash should match");
+                final byte[] readCtHash = new byte[48];
+                in.readFully(readCtHash);
+                assertArrayEquals(new byte[48], readCtHash, "Consensus timestamp hash should match");
+                final byte[] readOitHash = new byte[48];
+                in.readFully(readOitHash);
+                assertArrayEquals(new byte[48], readOitHash, "Output items tree root hash should match");
                 assertEquals(1, in.readLong(), "Leaf count should be 1");
             }
         }
@@ -1225,7 +1238,7 @@ class ToWrappedBlocksCommandTest {
             }
 
             final Path file = jumpstartDir.resolve("jumpstart.bin");
-            ToWrappedBlocksCommand.saveJumpstartData(file, 5, hash5, new byte[48], hasher5);
+            ToWrappedBlocksCommand.saveJumpstartData(file, 5, hash5, new byte[48], new byte[48], hasher5);
 
             // Overwrite with block 10
             final StreamingHasher hasher10 = new StreamingHasher();
@@ -1234,7 +1247,7 @@ class ToWrappedBlocksCommandTest {
                 hash10 = BlockStreamBlockHasher.hashBlock(chain.get(i));
                 hasher10.addNodeByHash(hash10);
             }
-            ToWrappedBlocksCommand.saveJumpstartData(file, 10, hash10, new byte[48], hasher10);
+            ToWrappedBlocksCommand.saveJumpstartData(file, 10, hash10, new byte[48], new byte[48], hasher10);
 
             try (DataInputStream in = new DataInputStream(Files.newInputStream(file))) {
                 assertEquals(10, in.readLong(), "Block number should be 10 after overwrite");

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommandTest.java
@@ -698,6 +698,10 @@ class ToWrappedBlocksCommandTest {
                 }
                 assertFalse(allZero, "Jumpstart block hash should not be all zeros");
 
+                // Record file hash is 48 bytes (SHA-384)
+                final byte[] recordFileHash = new byte[48];
+                in.readFully(recordFileHash);
+
                 // Streaming hasher state
                 final long leafCount = in.readLong();
                 assertTrue(leafCount > 0, "Leaf count should be positive");
@@ -1157,7 +1161,8 @@ class ToWrappedBlocksCommandTest {
             }
 
             final Path file = jumpstartDir.resolve("jumpstart.bin");
-            ToWrappedBlocksCommand.saveJumpstartData(file, 9, lastHash, streamingHasher);
+            final byte[] recordFileHash = new byte[48];
+            ToWrappedBlocksCommand.saveJumpstartData(file, 9, lastHash, recordFileHash, streamingHasher);
 
             // Read back and verify format
             try (DataInputStream in = new DataInputStream(Files.newInputStream(file))) {
@@ -1166,6 +1171,10 @@ class ToWrappedBlocksCommandTest {
                 final byte[] readHash = new byte[48];
                 in.readFully(readHash);
                 assertArrayEquals(lastHash, readHash, "Block hash should match");
+
+                final byte[] readRecordFileHash = new byte[48];
+                in.readFully(readRecordFileHash);
+                assertArrayEquals(recordFileHash, readRecordFileHash, "Record file hash should match");
 
                 assertEquals(10, in.readLong(), "Leaf count should be 10");
 
@@ -1190,13 +1199,16 @@ class ToWrappedBlocksCommandTest {
             streamingHasher.addNodeByHash(blockHash);
 
             final Path file = jumpstartDir.resolve("jumpstart.bin");
-            ToWrappedBlocksCommand.saveJumpstartData(file, 0, blockHash, streamingHasher);
+            ToWrappedBlocksCommand.saveJumpstartData(file, 0, blockHash, new byte[48], streamingHasher);
 
             try (DataInputStream in = new DataInputStream(Files.newInputStream(file))) {
                 assertEquals(0, in.readLong(), "Block number should be 0");
                 final byte[] readHash = new byte[48];
                 in.readFully(readHash);
                 assertArrayEquals(blockHash, readHash);
+                final byte[] readRecordFileHash = new byte[48];
+                in.readFully(readRecordFileHash);
+                assertArrayEquals(new byte[48], readRecordFileHash, "Record file hash should match");
                 assertEquals(1, in.readLong(), "Leaf count should be 1");
             }
         }
@@ -1213,7 +1225,7 @@ class ToWrappedBlocksCommandTest {
             }
 
             final Path file = jumpstartDir.resolve("jumpstart.bin");
-            ToWrappedBlocksCommand.saveJumpstartData(file, 5, hash5, hasher5);
+            ToWrappedBlocksCommand.saveJumpstartData(file, 5, hash5, new byte[48], hasher5);
 
             // Overwrite with block 10
             final StreamingHasher hasher10 = new StreamingHasher();
@@ -1222,7 +1234,7 @@ class ToWrappedBlocksCommandTest {
                 hash10 = BlockStreamBlockHasher.hashBlock(chain.get(i));
                 hasher10.addNodeByHash(hash10);
             }
-            ToWrappedBlocksCommand.saveJumpstartData(file, 10, hash10, hasher10);
+            ToWrappedBlocksCommand.saveJumpstartData(file, 10, hash10, new byte[48], hasher10);
 
             try (DataInputStream in = new DataInputStream(Files.newInputStream(file))) {
                 assertEquals(10, in.readLong(), "Block number should be 10 after overwrite");

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/BlockValidationJimfsTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/BlockValidationJimfsTest.java
@@ -232,6 +232,8 @@ class BlockValidationJimfsTest {
                 DataOutputStream dos = new DataOutputStream(fos)) {
             dos.writeLong(blockNumber);
             dos.write(blockHash);
+            dos.write(new byte[48]); // consensus timestamp hash placeholder
+            dos.write(new byte[48]); // output items tree root hash placeholder
             dos.writeLong(hasher.leafCount());
             dos.writeInt(state.size());
             for (byte[] h : state) {

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/JumpstartValidationTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/JumpstartValidationTest.java
@@ -58,13 +58,19 @@ class JumpstartValidationTest {
      * Writes a jumpstart.bin file matching the given streaming hasher state.
      */
     private static void writeJumpstartFile(
-            Path path, long blockNum, byte[] blockHash, byte[] recordFileHash, StreamingHasher hasher)
+            Path path,
+            long blockNum,
+            byte[] blockHash,
+            byte[] consensusTimestampHash,
+            byte[] outputItemsTreeRootHash,
+            StreamingHasher hasher)
             throws Exception {
         List<byte[]> hashes = hasher.intermediateHashingState();
         try (DataOutputStream out = new DataOutputStream(Files.newOutputStream(path))) {
             out.writeLong(blockNum);
             out.write(blockHash);
-            out.write(recordFileHash);
+            out.write(consensusTimestampHash);
+            out.write(outputItemsTreeRootHash);
             out.writeLong(hasher.leafCount());
             out.writeInt(hashes.size());
             for (byte[] h : hashes) {
@@ -85,7 +91,7 @@ class JumpstartValidationTest {
         chain.commitState(toUnparsed(VALID_BLOCK), 0);
 
         Path jumpstartFile = tempDir.resolve("jumpstart.bin");
-        writeJumpstartFile(jumpstartFile, 0, blockHash, new byte[48], tree.getStreamingHasher());
+        writeJumpstartFile(jumpstartFile, 0, blockHash, new byte[48], new byte[48], tree.getStreamingHasher());
 
         JumpstartValidation validation = new JumpstartValidation(jumpstartFile, tree, null);
         assertDoesNotThrow(() -> validation.finalize(1, 0));
@@ -104,7 +110,7 @@ class JumpstartValidationTest {
 
         Path jumpstartFile = tempDir.resolve("jumpstart.bin");
         // Write block number 99 instead of 0
-        writeJumpstartFile(jumpstartFile, 99, blockHash, new byte[48], tree.getStreamingHasher());
+        writeJumpstartFile(jumpstartFile, 99, blockHash, new byte[48], new byte[48], tree.getStreamingHasher());
 
         JumpstartValidation validation = new JumpstartValidation(jumpstartFile, tree, null);
         ValidationException ex = assertThrows(ValidationException.class, () -> validation.finalize(1, 0));
@@ -128,7 +134,8 @@ class JumpstartValidationTest {
         try (DataOutputStream out = new DataOutputStream(Files.newOutputStream(jumpstartFile))) {
             out.writeLong(0); // correct block number
             out.write(blockHash);
-            out.write(new byte[48]); // record file hash
+            out.write(new byte[48]); // consensus timestamp hash
+            out.write(new byte[48]); // output items tree root hash
             out.writeLong(999); // wrong leaf count
             out.writeInt(hashes.size());
             for (byte[] h : hashes) {
@@ -157,7 +164,8 @@ class JumpstartValidationTest {
         try (DataOutputStream out = new DataOutputStream(Files.newOutputStream(jumpstartFile))) {
             out.writeLong(0);
             out.write(blockHash);
-            out.write(new byte[48]); // record file hash
+            out.write(new byte[48]); // consensus timestamp hash
+            out.write(new byte[48]); // output items tree root hash
             out.writeLong(1); // correct leaf count
             out.writeInt(1);
             out.write(new byte[48]); // wrong hash
@@ -169,7 +177,7 @@ class JumpstartValidationTest {
     }
 
     @Test
-    void wrongRecordFileHashFormatFails(@TempDir Path tempDir) throws Exception {
+    void wrongConsensusTimestampHashFormatFails(@TempDir Path tempDir) throws Exception {
         BlockChainValidation chain = new BlockChainValidation();
         HistoricalBlockTreeValidation tree = new HistoricalBlockTreeValidation(chain);
 
@@ -179,13 +187,14 @@ class JumpstartValidationTest {
         tree.commitState(toUnparsed(VALID_BLOCK), 0);
         chain.commitState(toUnparsed(VALID_BLOCK), 0);
 
-        // Write a jumpstart file with record file hash of wrong size (32 bytes instead of 48)
+        // Write a jumpstart file with consensus timestamp hash of wrong size (32 bytes instead of 48)
         Path jumpstartFile = tempDir.resolve("jumpstart.bin");
         List<byte[]> hashes = tree.getStreamingHasher().intermediateHashingState();
         try (DataOutputStream out = new DataOutputStream(Files.newOutputStream(jumpstartFile))) {
             out.writeLong(0);
             out.write(blockHash);
             out.write(new byte[32]); // wrong size — should be 48
+            out.write(new byte[48]); // output items tree root hash
             out.writeLong(tree.getStreamingHasher().leafCount());
             out.writeInt(hashes.size());
             for (byte[] h : hashes) {

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/JumpstartValidationTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/JumpstartValidationTest.java
@@ -57,12 +57,14 @@ class JumpstartValidationTest {
     /**
      * Writes a jumpstart.bin file matching the given streaming hasher state.
      */
-    private static void writeJumpstartFile(Path path, long blockNum, byte[] blockHash, StreamingHasher hasher)
+    private static void writeJumpstartFile(
+            Path path, long blockNum, byte[] blockHash, byte[] recordFileHash, StreamingHasher hasher)
             throws Exception {
         List<byte[]> hashes = hasher.intermediateHashingState();
         try (DataOutputStream out = new DataOutputStream(Files.newOutputStream(path))) {
             out.writeLong(blockNum);
             out.write(blockHash);
+            out.write(recordFileHash);
             out.writeLong(hasher.leafCount());
             out.writeInt(hashes.size());
             for (byte[] h : hashes) {
@@ -83,7 +85,7 @@ class JumpstartValidationTest {
         chain.commitState(toUnparsed(VALID_BLOCK), 0);
 
         Path jumpstartFile = tempDir.resolve("jumpstart.bin");
-        writeJumpstartFile(jumpstartFile, 0, blockHash, tree.getStreamingHasher());
+        writeJumpstartFile(jumpstartFile, 0, blockHash, new byte[48], tree.getStreamingHasher());
 
         JumpstartValidation validation = new JumpstartValidation(jumpstartFile, tree, null);
         assertDoesNotThrow(() -> validation.finalize(1, 0));
@@ -102,7 +104,7 @@ class JumpstartValidationTest {
 
         Path jumpstartFile = tempDir.resolve("jumpstart.bin");
         // Write block number 99 instead of 0
-        writeJumpstartFile(jumpstartFile, 99, blockHash, tree.getStreamingHasher());
+        writeJumpstartFile(jumpstartFile, 99, blockHash, new byte[48], tree.getStreamingHasher());
 
         JumpstartValidation validation = new JumpstartValidation(jumpstartFile, tree, null);
         ValidationException ex = assertThrows(ValidationException.class, () -> validation.finalize(1, 0));
@@ -126,6 +128,7 @@ class JumpstartValidationTest {
         try (DataOutputStream out = new DataOutputStream(Files.newOutputStream(jumpstartFile))) {
             out.writeLong(0); // correct block number
             out.write(blockHash);
+            out.write(new byte[48]); // record file hash
             out.writeLong(999); // wrong leaf count
             out.writeInt(hashes.size());
             for (byte[] h : hashes) {
@@ -154,6 +157,7 @@ class JumpstartValidationTest {
         try (DataOutputStream out = new DataOutputStream(Files.newOutputStream(jumpstartFile))) {
             out.writeLong(0);
             out.write(blockHash);
+            out.write(new byte[48]); // record file hash
             out.writeLong(1); // correct leaf count
             out.writeInt(1);
             out.write(new byte[48]); // wrong hash
@@ -162,6 +166,35 @@ class JumpstartValidationTest {
         JumpstartValidation validation = new JumpstartValidation(jumpstartFile, tree, null);
         ValidationException ex = assertThrows(ValidationException.class, () -> validation.finalize(1, 0));
         assertTrue(ex.getMessage().contains("root mismatch"));
+    }
+
+    @Test
+    void wrongRecordFileHashFormatFails(@TempDir Path tempDir) throws Exception {
+        BlockChainValidation chain = new BlockChainValidation();
+        HistoricalBlockTreeValidation tree = new HistoricalBlockTreeValidation(chain);
+
+        chain.validate(toUnparsed(VALID_BLOCK), 0);
+        tree.validate(toUnparsed(VALID_BLOCK), 0);
+        byte[] blockHash = chain.getStagedBlockHash();
+        tree.commitState(toUnparsed(VALID_BLOCK), 0);
+        chain.commitState(toUnparsed(VALID_BLOCK), 0);
+
+        // Write a jumpstart file with record file hash of wrong size (32 bytes instead of 48)
+        Path jumpstartFile = tempDir.resolve("jumpstart.bin");
+        List<byte[]> hashes = tree.getStreamingHasher().intermediateHashingState();
+        try (DataOutputStream out = new DataOutputStream(Files.newOutputStream(jumpstartFile))) {
+            out.writeLong(0);
+            out.write(blockHash);
+            out.write(new byte[32]); // wrong size — should be 48
+            out.writeLong(tree.getStreamingHasher().leafCount());
+            out.writeInt(hashes.size());
+            for (byte[] h : hashes) {
+                out.write(h);
+            }
+        }
+
+        JumpstartValidation validation = new JumpstartValidation(jumpstartFile, tree, null);
+        assertThrows(ValidationException.class, () -> validation.finalize(1, 0));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Replaces the single `record_file_hash` field in `jumpstart.bin` with two CN-compatible verification hashes that the Consensus Node needs for WRB catch-up integrity checks (see [CN PR #24986](https://github.com/hiero-ledger/hiero-consensus-node/pull/24986)):

- **Consensus Timestamp Hash** — `hashLeaf(Timestamp.PROTOBUF.toBytes(consensusTimestamp))` — SHA-384 leaf hash of the block's first consensus timestamp
- **Output Items Tree Root Hash** — `outputItemsHasher.computeRootHash()` — streaming merkle root of all output items (BlockHeader, RecordFile, TransactionResult, TransactionOutput)

Before running the jumpstart migration, the CN compares these two values from `jumpstart.bin` against its own on-disk wrapped record hashes file. If either mismatches, the migration is skipped.

### New `jumpstart.bin` format

```
Offset | Field                        | Size    | Type
-------|------------------------------|---------|------------------
0      | block_number                 | 8       | long
8      | block_hash                   | 48      | byte[] (SHA-384)
56     | consensus_timestamp_hash     | 48      | byte[] (SHA-384) ← NEW
104    | output_items_tree_root_hash  | 48      | byte[] (SHA-384) ← NEW
152    | leaf_count                   | 8       | long
160    | hash_count                   | 4       | int
164    | hashes[0..N-1]               | 48 × N  | byte[] (SHA-384)
```
