### PR TITLE
feat: extract shared constants and helpers from validation classes

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
@@ -6,6 +6,7 @@ import static org.hiero.block.tools.blocks.HasherStateFiles.saveStateCheckpoint;
 import static org.hiero.block.tools.blocks.model.BlockWriter.DEFAULT_COMPRESSION;
 import static org.hiero.block.tools.blocks.model.BlockWriter.DEFAULT_POWERS_OF_TEN_PER_ZIP;
 import static org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHasher.hashBlock;
+import static org.hiero.block.tools.blocks.validation.BlockExtractionUtils.extractTransactionBody;
 import static org.hiero.block.tools.mirrornode.DayBlockInfo.loadDayBlockInfoMap;
 import static org.hiero.block.tools.records.RecordFileDates.FIRST_BLOCK_TIME_INSTANT;
 
@@ -13,7 +14,6 @@ import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.RecordFileSignature;
 import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.hapi.node.base.Transaction;
-import com.hedera.hapi.node.transaction.SignedTransaction;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.streams.RecordStreamItem;
 import java.io.DataOutputStream;
@@ -1161,25 +1161,5 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
                 }
             }
         }
-    }
-
-    /**
-     * Extracts the {@link TransactionBody} from a transaction, handling all three encoding formats:
-     * direct body, bodyBytes, and signedTransactionBytes.
-     *
-     * @param t the transaction
-     * @return the parsed transaction body, or null if none could be extracted
-     * @throws Exception if parsing fails
-     */
-    private static TransactionBody extractTransactionBody(final Transaction t) throws Exception {
-        if (t.hasBody()) {
-            return t.body();
-        } else if (t.bodyBytes().length() > 0) {
-            return TransactionBody.PROTOBUF.parse(t.bodyBytes());
-        } else if (t.signedTransactionBytes().length() > 0) {
-            final SignedTransaction st = SignedTransaction.PROTOBUF.parse(t.signedTransactionBytes());
-            return TransactionBody.PROTOBUF.parse(st.bodyBytes());
-        }
-        return null;
     }
 }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/hashing/BlockStreamBlockHasher.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/hashing/BlockStreamBlockHasher.java
@@ -4,6 +4,7 @@ package org.hiero.block.tools.blocks.model.hashing;
 import static org.hiero.block.tools.blocks.model.hashing.HashingUtils.EMPTY_TREE_HASH;
 import static org.hiero.block.tools.blocks.model.hashing.HashingUtils.hashInternalNode;
 import static org.hiero.block.tools.blocks.model.hashing.HashingUtils.hashLeaf;
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_PARSE_SIZE;
 
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.output.BlockFooter;
@@ -69,9 +70,6 @@ import org.hiero.block.tools.utils.Sha384;
  * @see HashingUtils
  */
 public class BlockStreamBlockHasher {
-
-    /** Maximum parse size for protobuf messages (100 MB) to handle large blocks. */
-    private static final int MAX_PARSE_SIZE = 100 * 1024 * 1024;
 
     /**
      * Computes the root hash of a fully-parsed {@link Block} by re-serializing to bytes

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.blocks.validation;
 
+import static org.hiero.block.tools.blocks.validation.BlockExtractionUtils.extractBlockInstant;
+import static org.hiero.block.tools.blocks.validation.BlockExtractionUtils.extractRecordFileBytes;
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_DEPTH;
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_RECORD_FILE_SIZE;
+
 import com.hedera.hapi.block.stream.RecordFileItem;
-import com.hedera.hapi.block.stream.output.BlockHeader;
-import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.streams.RecordStreamFile;
@@ -14,7 +17,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.tools.days.model.AddressBookRegistry;
 import org.hiero.block.tools.records.model.parsed.ValidationException;
@@ -32,8 +34,6 @@ import picocli.CommandLine.Help.Ansi;
 public final class AddressBookUpdateValidation implements BlockValidation {
 
     private static final String SAVE_FILE_NAME = "addressBookHistory.json";
-    private static final int MAX_DEPTH = 512;
-    private static final int MAX_RECORD_FILE_SIZE = 128 * 1024 * 1024;
 
     private final AddressBookRegistry addressBookRegistry;
 
@@ -79,26 +79,6 @@ public final class AddressBookUpdateValidation implements BlockValidation {
             // record file might be in a format we don't fully handle (e.g., genesis or very early blocks).
             // Signature validation will catch if the address book is actually wrong.
         }
-    }
-
-    private static Instant extractBlockInstant(final BlockUnparsed block) throws Exception {
-        for (final BlockItemUnparsed item : block.blockItems()) {
-            if (item.hasBlockHeader()) {
-                final BlockHeader header = BlockHeader.PROTOBUF.parse(item.blockHeaderOrThrow());
-                final Timestamp ts = header.blockTimestampOrThrow();
-                return Instant.ofEpochSecond(ts.seconds(), ts.nanos());
-            }
-        }
-        return null;
-    }
-
-    private static Bytes extractRecordFileBytes(final BlockUnparsed block) {
-        for (final BlockItemUnparsed item : block.blockItems()) {
-            if (item.hasRecordFile()) {
-                return item.recordFileOrThrow();
-            }
-        }
-        return null;
     }
 
     private static List<Transaction> extractTransactions(final Bytes recordFileBytes) throws Exception {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/BlockExtractionUtils.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/BlockExtractionUtils.java
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.blocks.validation;
+
+import com.hedera.hapi.block.stream.output.BlockHeader;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.transaction.SignedTransaction;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.time.Instant;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.internal.BlockUnparsed;
+
+/**
+ * Shared utility methods for extracting data from unparsed blocks and transactions.
+ */
+public final class BlockExtractionUtils {
+
+    private BlockExtractionUtils() {}
+
+    /**
+     * Extracts the block timestamp as an {@link Instant} from the block header.
+     *
+     * @param block the unparsed block
+     * @return the block timestamp, or {@code null} if no block header is found
+     * @throws ParseException if the block header cannot be parsed
+     */
+    public static Instant extractBlockInstant(final BlockUnparsed block) throws ParseException {
+        for (final BlockItemUnparsed item : block.blockItems()) {
+            if (item.hasBlockHeader()) {
+                final BlockHeader header = BlockHeader.PROTOBUF.parse(item.blockHeaderOrThrow());
+                final Timestamp ts = header.blockTimestampOrThrow();
+                return Instant.ofEpochSecond(ts.seconds(), ts.nanos());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Extracts the record file bytes from the block.
+     *
+     * @param block the unparsed block
+     * @return the record file bytes, or {@code null} if no record file item is found
+     */
+    public static Bytes extractRecordFileBytes(final BlockUnparsed block) {
+        for (final BlockItemUnparsed item : block.blockItems()) {
+            if (item.hasRecordFile()) {
+                return item.recordFileOrThrow();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Extracts the {@link TransactionBody} from a transaction, handling all three encoding
+     * formats: direct body, bodyBytes, and signedTransactionBytes.
+     *
+     * @param t the transaction
+     * @return the parsed transaction body, or {@code null} if none could be extracted
+     * @throws ParseException if parsing fails
+     */
+    public static TransactionBody extractTransactionBody(final Transaction t) throws ParseException {
+        if (t.hasBody()) {
+            return t.body();
+        } else if (t.bodyBytes().length() > 0) {
+            return TransactionBody.PROTOBUF.parse(t.bodyBytes());
+        } else if (t.signedTransactionBytes().length() > 0) {
+            final SignedTransaction st = SignedTransaction.PROTOBUF.parse(t.signedTransactionBytes());
+            return TransactionBody.PROTOBUF.parse(st.bodyBytes());
+        }
+        return null;
+    }
+}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/HbarSupplyValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/HbarSupplyValidation.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.blocks.validation;
 
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_PARSE_SIZE;
+
 import com.hedera.hapi.block.stream.output.MapChangeKey;
 import com.hedera.hapi.block.stream.output.MapChangeValue;
 import com.hedera.hapi.block.stream.output.MapUpdateChange;
@@ -56,9 +58,6 @@ public final class HbarSupplyValidation implements BlockValidation {
 
     /** Total HBAR supply expressed in tinybar (50 billion HBAR * 100 million tinybar per HBAR). */
     public static final long FIFTY_BILLION_HBAR_IN_TINYBAR = 5_000_000_000_000_000_000L;
-
-    /** Maximum parse size for protobuf messages (100 MB) to handle large StateChanges items. */
-    private static final int MAX_PARSE_SIZE = 100 * 1024 * 1024;
 
     /** The running account state. */
     private final RunningAccountsState accounts = new RunningAccountsState();

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.blocks.validation;
 
+import static org.hiero.block.tools.blocks.validation.BlockExtractionUtils.extractBlockInstant;
+import static org.hiero.block.tools.blocks.validation.BlockExtractionUtils.extractRecordFileBytes;
+import static org.hiero.block.tools.blocks.validation.BlockExtractionUtils.extractTransactionBody;
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_DEPTH;
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_RECORD_FILE_SIZE;
+
 import com.hedera.hapi.block.stream.RecordFileItem;
-import com.hedera.hapi.block.stream.output.BlockHeader;
-import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.base.Transaction;
-import com.hedera.hapi.node.transaction.SignedTransaction;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.streams.RecordStreamFile;
 import com.hedera.hapi.streams.RecordStreamItem;
@@ -14,7 +17,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
-import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.tools.days.model.NodeStakeRegistry;
 import org.hiero.block.tools.records.model.parsed.ValidationException;
@@ -31,8 +33,6 @@ import picocli.CommandLine.Help.Ansi;
 public final class NodeStakeUpdateValidation implements BlockValidation {
 
     private static final String SAVE_FILE_NAME = "nodeStakeHistory.json";
-    private static final int MAX_DEPTH = 512;
-    private static final int MAX_RECORD_FILE_SIZE = 128 * 1024 * 1024;
 
     private final NodeStakeRegistry nodeStakeRegistry;
     private boolean firstStakeUpdateSeen = false;
@@ -113,38 +113,6 @@ public final class NodeStakeUpdateValidation implements BlockValidation {
                 }
             }
         }
-    }
-
-    private static TransactionBody extractTransactionBody(final Transaction t) throws Exception {
-        if (t.hasBody()) {
-            return t.body();
-        } else if (t.bodyBytes().length() > 0) {
-            return TransactionBody.PROTOBUF.parse(t.bodyBytes());
-        } else if (t.signedTransactionBytes().length() > 0) {
-            final SignedTransaction st = SignedTransaction.PROTOBUF.parse(t.signedTransactionBytes());
-            return TransactionBody.PROTOBUF.parse(st.bodyBytes());
-        }
-        return null;
-    }
-
-    private static Instant extractBlockInstant(final BlockUnparsed block) throws Exception {
-        for (final BlockItemUnparsed item : block.blockItems()) {
-            if (item.hasBlockHeader()) {
-                final BlockHeader header = BlockHeader.PROTOBUF.parse(item.blockHeaderOrThrow());
-                final Timestamp ts = header.blockTimestampOrThrow();
-                return Instant.ofEpochSecond(ts.seconds(), ts.nanos());
-            }
-        }
-        return null;
-    }
-
-    private static Bytes extractRecordFileBytes(final BlockUnparsed block) {
-        for (final BlockItemUnparsed item : block.blockItems()) {
-            if (item.hasRecordFile()) {
-                return item.recordFileOrThrow();
-            }
-        }
-        return null;
     }
 
     @Override

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/ProtobufParsingConstants.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/ProtobufParsingConstants.java
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.blocks.validation;
+
+/**
+ * Shared protobuf parsing constants used across validation and hashing classes.
+ */
+public final class ProtobufParsingConstants {
+
+    /** Maximum protobuf nesting depth for parsing. */
+    public static final int MAX_DEPTH = 512;
+
+    /** Maximum record file size for protobuf parsing (128 MB). */
+    public static final int MAX_RECORD_FILE_SIZE = 128 * 1024 * 1024;
+
+    /** Maximum parse size for protobuf messages (100 MB) to handle large blocks and StateChanges items. */
+    public static final int MAX_PARSE_SIZE = 100 * 1024 * 1024;
+
+    private ProtobufParsingConstants() {}
+}


### PR DESCRIPTION
## Summary
- Extracted duplicated protobuf parsing constants (`MAX_DEPTH`, `MAX_RECORD_FILE_SIZE`, `MAX_PARSE_SIZE`) into a shared `ProtobufParsingConstants` utility class
- Extracted duplicated block extraction methods (`extractBlockInstant`, `extractRecordFileBytes`, `extractTransactionBody`) into a shared `BlockExtractionUtils` utility class
- Updated `AddressBookUpdateValidation`, `NodeStakeUpdateValidation`, `HbarSupplyValidation`, `BlockStreamBlockHasher`, and `ToWrappedBlocksCommand` to use the shared utilities via static imports

closes #2605 