### PR TITLE
Fix release missing chart package

### DIFF
--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -26,6 +26,11 @@ on:
         type: boolean
         required: false
         default: false
+      release_ref:
+        description: "Branch or tag to checkout for the release (e.g. v0.31.0). Leave empty to use the ref the workflow was triggered on."
+        type: string
+        required: false
+        default: ""
 
 defaults:
   run:
@@ -62,6 +67,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.release_ref || github.ref }}
 
       - name: Extract version
         id: extract_version
@@ -120,6 +126,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.release_ref || github.ref }}
 
       - name: Install JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -196,6 +203,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.release_ref || github.ref }}
 
       - name: Install GnuPG Tools
         if: "${{ github.event_name != 'workflow_dispatch' || github.event.inputs.publish == 'true' }}"
@@ -258,6 +266,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.release_ref || github.ref }}
 
       - name: Install JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -330,6 +339,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.release_ref || github.ref }}
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
@@ -371,6 +382,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.release_ref || github.ref }}
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -21,6 +21,11 @@ on:
         type: boolean
         required: false
         default: true
+      chart_only:
+        description: "Publish only the block-node-server helm chart (skip images, jars, simulator)"
+        type: boolean
+        required: false
+        default: false
 
 defaults:
   run:
@@ -43,6 +48,7 @@ env:
 
 jobs:
   package-protobuf-source:
+    if: "${{ github.event.inputs.chart_only != 'true' }}"
     timeout-minutes: 5
     runs-on: hiero-block-node-linux-medium
 
@@ -93,6 +99,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-app:
+    if: "${{ github.event.inputs.chart_only != 'true' }}"
     timeout-minutes: 30
     runs-on: hiero-block-node-linux-medium
     strategy:
@@ -175,6 +182,7 @@ jobs:
             distributions=./block-node/app/build/distributions
 
   publish-jars:
+    if: "${{ github.event.inputs.chart_only != 'true' }}"
     timeout-minutes: 30
     runs-on: hiero-block-node-linux-medium
 
@@ -236,6 +244,7 @@ jobs:
         run: ./gradlew publishAggregationToCentralPortal -PpublishSigningEnabled=true
 
   publish-simulator:
+    if: "${{ github.event.inputs.chart_only != 'true' }}"
     timeout-minutes: 30
     runs-on: hiero-block-node-linux-medium
 
@@ -307,6 +316,10 @@ jobs:
     needs:
       - publish-app
       - publish-jars
+    if: |
+      always() &&
+      (needs.publish-app.result == 'success' || needs.publish-app.result == 'skipped') &&
+      (needs.publish-jars.result == 'success' || needs.publish-jars.result == 'skipped')
     runs-on: hiero-block-node-linux-medium
 
     steps:
@@ -345,6 +358,7 @@ jobs:
           helm push block-node-server-${{ env.VERSION }}.tgz oci://ghcr.io/hiero-ledger/hiero-block-node
 
   helm-chart-release-simulator:
+    if: "${{ github.event.inputs.chart_only != 'true' }}"
     timeout-minutes: 15
     needs: publish-simulator
     runs-on: hiero-block-node-linux-medium


### PR DESCRIPTION
# Summary

Adds a `chart_only` manual trigger input to the release workflow so the `block-node-server` helm chart can be (re)published without rebuilding or re-pushing images, jars, or the simulator.

This unblocks recovery from situations where the chart package is missing on ghcr.io (e.g. accidentally deleted) but the images and jars for that version are already published — re-running the full release fails because Maven Central rejects the duplicate jar upload.

# Motivation

Release `v0.31.0` is missing the `block-node-server` helm chart on ghcr.io, but its images and jars are already published. Re-running the standard release workflow fails on `publishAggregationToCentralPortal` because the jars already exist, which blocks the chart publish from running. See failed run: https://github.com/hiero-ledger/hiero-block-node/actions/runs/24851113192

# Changes

- New `workflow_dispatch` input `chart_only` (boolean, default `false`).
- When `chart_only=true`, the following jobs are skipped:
  - `package-protobuf-source`
  - `publish-app`
  - `publish-jars`
  - `publish-simulator`
  - `helm-chart-release-simulator`
- `helm-chart-release-app` keeps `needs: [publish-app, publish-jars]` for ordering, but its `if` condition now accepts `skipped` dependency results so it still runs when upstream jobs are skipped via `chart_only`.
- Default behavior (tag push, push to `main`, or `workflow_dispatch` with `chart_only=false`) is unchanged.

# How to use (recovery path)

1. Actions → Release Workflow → Run workflow
2. Select the tag/ref for the version whose chart needs to be republished
3. Leave `publish` checked
4. Check `chart_only`
5. Run — only `helm-chart-release-app` executes and pushes `block-node-server-<version>.tgz` to `oci://ghcr.io/hiero-ledger/hiero-block-node`

Fixes #2633 