### PR TITLE
chore: update Solo version to 0.72.0

### DIFF
--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew --no-daemon
-  SOLO_VERSION: "0.68.0"
+  SOLO_VERSION: "0.72.0"
 
 jobs:
   k6-tests:

--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -209,11 +209,11 @@ jobs:
             MN_VERSION="latest"
           fi
 
-          # Solo CLI version: use input if provided, otherwise default to 0.68.0 (as latest stable tested)
+          # Solo CLI version: use input if provided, otherwise default to 0.72.0 (as latest stable tested)
           if [[ -n "${{ inputs.solo-version }}" ]]; then
             SOLO_VERSION="${{ inputs.solo-version }}"
           else
-            SOLO_VERSION="0.68.0"
+            SOLO_VERSION="0.72.0"
           fi
 
           # Relay version: use input if provided, otherwise default to latest

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -32,7 +32,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         type: string
-        default: "0.68.0"
+        default: "0.72.0"
       tss-enabled:
         description: "Enable TSS/WRAPS on consensus nodes"
         type: boolean
@@ -116,7 +116,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         required: false
-        default: "0.68.0"
+        default: "0.72.0"
       tss-enabled:
         description: "Enable TSS (Threshold Signature Scheme) on consensus nodes"
         required: false

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/resolve-versions.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/resolve-versions.sh
@@ -37,11 +37,11 @@ readonly TCK_REPO="hiero-ledger/hiero-sdk-tck"
 #
 # | CN Version        | MN Minimum    | BN Minimum   | Notes                          |
 # |-------------------|---------------|--------------|--------------------------------|
-# | >= 0.73.0-rc.1    | 0.152.0-rc1   | 0.31.0-rc1   | TSS/WRAPS/hinTS support        |
+# | >= 0.74.0-rc.2    | 0.154.0-rc1   | 0.33.0-rc3   | TSS/WRAPS/hinTS support        |
 #
-readonly COMPAT_CN_MINS=("0.73.0-rc.1")
-readonly COMPAT_MN_MINS=("0.152.0-rc1")
-readonly COMPAT_BN_MINS=("0.31.0-rc1")
+readonly COMPAT_CN_MINS=("0.74.0-rc.2")
+readonly COMPAT_MN_MINS=("0.154.0-rc1")
+readonly COMPAT_BN_MINS=("0.33.0-rc3")
 
 # Lowest tier CN floor (used to enforce CN minimum before tier selection)
 # Note: bash 3.2 (macOS default) does not support negative array indices — use explicit last index


### PR DESCRIPTION
## Summary

Updates the Solo version used by E2E-related GitHub workflows from 0.68.0 to 0.72.0.

Closes #2642.

## Validation

- Searched the GitHub workflows for old Solo versions.
- Confirmed the workflow defaults now reference 0.72.0.