### PR TITLE
feat: parallelize validate command by moving expensive work off main thread

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
@@ -46,6 +46,7 @@ import org.hiero.block.tools.blocks.validation.HistoricalBlockTreeValidation;
 import org.hiero.block.tools.blocks.validation.JumpstartValidation;
 import org.hiero.block.tools.blocks.validation.NodeStakeUpdateValidation;
 import org.hiero.block.tools.blocks.validation.ParallelBlockPreprocessor;
+import org.hiero.block.tools.blocks.validation.ParallelBlockPreprocessor.PreprocessedData;
 import org.hiero.block.tools.blocks.validation.RequiredItemsValidation;
 import org.hiero.block.tools.blocks.validation.SignatureBlockStats;
 import org.hiero.block.tools.blocks.validation.SignatureStatsCollector;
@@ -655,25 +656,7 @@ public class ValidateBlocksCommand implements Runnable {
                                     byte[] raw = Files.readAllBytes(path);
                                     BlockUnparsed block =
                                             BlockZipsUtilities.decompressAndPartialParse(raw, isZstd, isGz);
-                                    Object[] err = runParallelValidations(parallelValidations, block, bNum);
-                                    var ppd = ParallelBlockPreprocessor.preprocess(block);
-                                    return err != null
-                                            ? new PreValidatedBlock(
-                                                    block,
-                                                    bNum,
-                                                    (String) err[0],
-                                                    (Exception) err[1],
-                                                    ppd.blockHash(),
-                                                    ppd.blockInstant(),
-                                                    ppd.recordFileBytes())
-                                            : new PreValidatedBlock(
-                                                    block,
-                                                    bNum,
-                                                    null,
-                                                    null,
-                                                    ppd.blockHash(),
-                                                    ppd.blockInstant(),
-                                                    ppd.recordFileBytes());
+                                    return buildPreValidatedBlock(block, bNum, parallelValidations);
                                 }));
                                 i++;
                             } else {
@@ -702,8 +685,7 @@ public class ValidateBlocksCommand implements Runnable {
                                             "@|yellow Warning:|@ error streaming zip (blocks skipped): "
                                                     + zipPath.getFileName() + " — " + e.getMessage()));
                                     for (int k = i; k < runEnd; k++) {
-                                        blockQueue.put(CompletableFuture.completedFuture(
-                                                new PreValidatedBlock(null, -1, null, null, null, null, null)));
+                                        blockQueue.put(CompletableFuture.completedFuture(SKIPPED_BLOCK));
                                     }
                                 }
                                 i = runEnd;
@@ -798,26 +780,12 @@ public class ValidateBlocksCommand implements Runnable {
 
                         // Phase 1: validate sequential (stateful) validations only,
                         // passing pre-computed data to avoid redundant work on the main thread
+                        final PreprocessedData ppd = new PreprocessedData(
+                                preValidated.blockHash(), preValidated.blockInstant(), preValidated.recordFileBytes());
                         for (BlockValidation v : sequentialValidations) {
                             try {
                                 long vStart = verbose ? System.nanoTime() : 0;
-                                if (v == chainValidation) {
-                                    chainValidation.validate(block, blockNum, preValidated.blockHash());
-                                } else if (v instanceof AddressBookUpdateValidation abv) {
-                                    abv.validate(
-                                            block,
-                                            blockNum,
-                                            preValidated.blockInstant(),
-                                            preValidated.recordFileBytes());
-                                } else if (v instanceof NodeStakeUpdateValidation nsv) {
-                                    nsv.validate(
-                                            block,
-                                            blockNum,
-                                            preValidated.blockInstant(),
-                                            preValidated.recordFileBytes());
-                                } else {
-                                    v.validate(block, blockNum);
-                                }
+                                v.validate(block, blockNum, ppd);
                                 if (verbose) {
                                     perValidationNanos.get(v.name())[0] += System.nanoTime() - vStart;
                                 }
@@ -1167,25 +1135,7 @@ public class ValidateBlocksCommand implements Runnable {
                 final byte[] raw = zis.readAllBytes();
                 blockQueue.put(decompPool.submit(() -> {
                     BlockUnparsed block = BlockZipsUtilities.decompressAndPartialParse(raw, isZstd, isGz);
-                    Object[] err = runParallelValidations(parallelValidations, block, bNum);
-                    var ppd = ParallelBlockPreprocessor.preprocess(block);
-                    return err != null
-                            ? new PreValidatedBlock(
-                                    block,
-                                    bNum,
-                                    (String) err[0],
-                                    (Exception) err[1],
-                                    ppd.blockHash(),
-                                    ppd.blockInstant(),
-                                    ppd.recordFileBytes())
-                            : new PreValidatedBlock(
-                                    block,
-                                    bNum,
-                                    null,
-                                    null,
-                                    ppd.blockHash(),
-                                    ppd.blockInstant(),
-                                    ppd.recordFileBytes());
+                    return buildPreValidatedBlock(block, bNum, parallelValidations);
                 }));
             }
         } catch (IOException streamErr) {
@@ -1209,25 +1159,7 @@ public class ValidateBlocksCommand implements Runnable {
                     }
                     blockQueue.put(decompPool.submit(() -> {
                         BlockUnparsed block = BlockZipsUtilities.decompressAndPartialParse(raw, isZstd, isGz);
-                        Object[] err = runParallelValidations(parallelValidations, block, bNum);
-                        var ppd = ParallelBlockPreprocessor.preprocess(block);
-                        return err != null
-                                ? new PreValidatedBlock(
-                                        block,
-                                        bNum,
-                                        (String) err[0],
-                                        (Exception) err[1],
-                                        ppd.blockHash(),
-                                        ppd.blockInstant(),
-                                        ppd.recordFileBytes())
-                                : new PreValidatedBlock(
-                                        block,
-                                        bNum,
-                                        null,
-                                        null,
-                                        ppd.blockHash(),
-                                        ppd.blockInstant(),
-                                        ppd.recordFileBytes());
+                        return buildPreValidatedBlock(block, bNum, parallelValidations);
                     }));
                 }
             }
@@ -1259,25 +1191,7 @@ public class ValidateBlocksCommand implements Runnable {
                 final long bNum = BlockZipsUtilities.extractBlockNumber(fileName);
                 blockQueue.put(decompPool.submit(() -> {
                     BlockUnparsed block = BlockZipsUtilities.decompressAndPartialParse(raw, isZstd, isGz);
-                    Object[] err = runParallelValidations(parallelValidations, block, bNum);
-                    var ppd = ParallelBlockPreprocessor.preprocess(block);
-                    return err != null
-                            ? new PreValidatedBlock(
-                                    block,
-                                    bNum,
-                                    (String) err[0],
-                                    (Exception) err[1],
-                                    ppd.blockHash(),
-                                    ppd.blockInstant(),
-                                    ppd.recordFileBytes())
-                            : new PreValidatedBlock(
-                                    block,
-                                    bNum,
-                                    null,
-                                    null,
-                                    ppd.blockHash(),
-                                    ppd.blockInstant(),
-                                    ppd.recordFileBytes());
+                    return buildPreValidatedBlock(block, bNum, parallelValidations);
                 }));
             }
         }
@@ -1306,25 +1220,7 @@ public class ValidateBlocksCommand implements Runnable {
                 final long bNum = BlockZipsUtilities.extractBlockNumber(fileName);
                 blockQueue.put(decompPool.submit(() -> {
                     BlockUnparsed block = BlockZipsUtilities.decompressAndPartialParse(raw, isZstd, isGz);
-                    Object[] err = runParallelValidations(parallelValidations, block, bNum);
-                    var ppd = ParallelBlockPreprocessor.preprocess(block);
-                    return err != null
-                            ? new PreValidatedBlock(
-                                    block,
-                                    bNum,
-                                    (String) err[0],
-                                    (Exception) err[1],
-                                    ppd.blockHash(),
-                                    ppd.blockInstant(),
-                                    ppd.recordFileBytes())
-                            : new PreValidatedBlock(
-                                    block,
-                                    bNum,
-                                    null,
-                                    null,
-                                    ppd.blockHash(),
-                                    ppd.blockInstant(),
-                                    ppd.recordFileBytes());
+                    return buildPreValidatedBlock(block, bNum, parallelValidations);
                 }));
             }
         }
@@ -1348,5 +1244,26 @@ public class ValidateBlocksCommand implements Runnable {
             }
         }
         return null;
+    }
+
+    /** Sentinel for blocks that were skipped (e.g. corrupt zip mid-stream). */
+    private static final PreValidatedBlock SKIPPED_BLOCK =
+            new PreValidatedBlock(null, -1, null, null, null, null, null);
+
+    /**
+     * Runs parallel validations and preprocessing, then wraps the results into a {@link PreValidatedBlock}.
+     */
+    private static PreValidatedBlock buildPreValidatedBlock(
+            final BlockUnparsed block, final long blockNumber, final List<BlockValidation> parallelValidations) {
+        Object[] err = runParallelValidations(parallelValidations, block, blockNumber);
+        PreprocessedData ppd = ParallelBlockPreprocessor.preprocess(block);
+        return new PreValidatedBlock(
+                block,
+                blockNumber,
+                err != null ? (String) err[0] : null,
+                err != null ? (Exception) err[1] : null,
+                ppd.blockHash(),
+                ppd.blockInstant(),
+                ppd.recordFileBytes());
     }
 }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
@@ -95,6 +95,10 @@ public class ValidateBlocksCommand implements Runnable {
     /** Read buffer size for ZipInputStream — tunes sequential HDD I/O. */
     private static final int ZIP_READ_BUFFER = 1 << 20; // 1 MiB
 
+    /** Sentinel for blocks that were skipped (e.g. corrupt zip mid-stream). */
+    private static final PreValidatedBlock SKIPPED_BLOCK =
+            new PreValidatedBlock(null, -1, null, null, null, null, null);
+
     /** Number of zip files skipped because their central directory was corrupt. */
     private final AtomicLong corruptZipCount = new AtomicLong(0);
 
@@ -1245,10 +1249,6 @@ public class ValidateBlocksCommand implements Runnable {
         }
         return null;
     }
-
-    /** Sentinel for blocks that were skipped (e.g. corrupt zip mid-stream). */
-    private static final PreValidatedBlock SKIPPED_BLOCK =
-            new PreValidatedBlock(null, -1, null, null, null, null, null);
 
     /**
      * Runs parallel validations and preprocessing, then wraps the results into a {@link PreValidatedBlock}.

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ValidateBlocksCommand.java
@@ -14,9 +14,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -43,6 +45,7 @@ import org.hiero.block.tools.blocks.validation.HbarSupplyValidation;
 import org.hiero.block.tools.blocks.validation.HistoricalBlockTreeValidation;
 import org.hiero.block.tools.blocks.validation.JumpstartValidation;
 import org.hiero.block.tools.blocks.validation.NodeStakeUpdateValidation;
+import org.hiero.block.tools.blocks.validation.ParallelBlockPreprocessor;
 import org.hiero.block.tools.blocks.validation.RequiredItemsValidation;
 import org.hiero.block.tools.blocks.validation.SignatureBlockStats;
 import org.hiero.block.tools.blocks.validation.SignatureStatsCollector;
@@ -121,7 +124,7 @@ public class ValidateBlocksCommand implements Runnable {
     @Option(
             names = {"--prefetch"},
             description = "Number of blocks to buffer ahead for decompression (default: ${DEFAULT-VALUE})")
-    private int prefetch = 64;
+    private int prefetch = 256;
 
     @Option(
             names = {"--skip-signatures"},
@@ -653,9 +656,24 @@ public class ValidateBlocksCommand implements Runnable {
                                     BlockUnparsed block =
                                             BlockZipsUtilities.decompressAndPartialParse(raw, isZstd, isGz);
                                     Object[] err = runParallelValidations(parallelValidations, block, bNum);
+                                    var ppd = ParallelBlockPreprocessor.preprocess(block);
                                     return err != null
-                                            ? new PreValidatedBlock(block, bNum, (String) err[0], (Exception) err[1])
-                                            : new PreValidatedBlock(block, bNum, null, null);
+                                            ? new PreValidatedBlock(
+                                                    block,
+                                                    bNum,
+                                                    (String) err[0],
+                                                    (Exception) err[1],
+                                                    ppd.blockHash(),
+                                                    ppd.blockInstant(),
+                                                    ppd.recordFileBytes())
+                                            : new PreValidatedBlock(
+                                                    block,
+                                                    bNum,
+                                                    null,
+                                                    null,
+                                                    ppd.blockHash(),
+                                                    ppd.blockInstant(),
+                                                    ppd.recordFileBytes());
                                 }));
                                 i++;
                             } else {
@@ -685,7 +703,7 @@ public class ValidateBlocksCommand implements Runnable {
                                                     + zipPath.getFileName() + " — " + e.getMessage()));
                                     for (int k = i; k < runEnd; k++) {
                                         blockQueue.put(CompletableFuture.completedFuture(
-                                                new PreValidatedBlock(null, -1, null, null)));
+                                                new PreValidatedBlock(null, -1, null, null, null, null, null)));
                                     }
                                 }
                                 i = runEnd;
@@ -713,6 +731,17 @@ public class ValidateBlocksCommand implements Runnable {
         long failedBlockNumber = -1;
         long skippedBlockCount = 0;
 
+        // Timing accumulators (only populated when --verbose is set)
+        final long[] totalQueueTakeNanosRef = {0};
+        final long[] totalFutureGetNanosRef = {0};
+        final long[] totalCommitNanosRef = {0};
+        final Map<String, long[]> perValidationNanos = verbose ? new HashMap<>() : null;
+        if (verbose) {
+            for (BlockValidation v : sequentialValidations) {
+                perValidationNanos.put(v.name(), new long[] {0});
+            }
+        }
+
         try (final SignatureStatsCollector statsCollector = new SignatureStatsCollector(statsCsvPath)) {
             try {
                 long lastCheckpointSaveMs = System.currentTimeMillis();
@@ -721,10 +750,14 @@ public class ValidateBlocksCommand implements Runnable {
                 while (true) {
 
                     try {
+                        long t0 = verbose ? System.nanoTime() : 0;
                         Future<PreValidatedBlock> future = blockQueue.take();
                         if (future == endOfStream) break;
+                        if (verbose) totalQueueTakeNanosRef[0] += System.nanoTime() - t0;
 
+                        long t1 = verbose ? System.nanoTime() : 0;
                         PreValidatedBlock preValidated = future.get();
+                        if (verbose) totalFutureGetNanosRef[0] += System.nanoTime() - t1;
                         if (preValidated.block() == null) {
                             skippedBlockCount++;
                             continue; // block skipped (corrupt zip mid-stream)
@@ -763,10 +796,31 @@ public class ValidateBlocksCommand implements Runnable {
                         BlockUnparsed block = preValidated.block();
                         long blockNum = preValidated.blockNumber();
 
-                        // Phase 1: validate sequential (stateful) validations only
+                        // Phase 1: validate sequential (stateful) validations only,
+                        // passing pre-computed data to avoid redundant work on the main thread
                         for (BlockValidation v : sequentialValidations) {
                             try {
-                                v.validate(block, blockNum);
+                                long vStart = verbose ? System.nanoTime() : 0;
+                                if (v == chainValidation) {
+                                    chainValidation.validate(block, blockNum, preValidated.blockHash());
+                                } else if (v instanceof AddressBookUpdateValidation abv) {
+                                    abv.validate(
+                                            block,
+                                            blockNum,
+                                            preValidated.blockInstant(),
+                                            preValidated.recordFileBytes());
+                                } else if (v instanceof NodeStakeUpdateValidation nsv) {
+                                    nsv.validate(
+                                            block,
+                                            blockNum,
+                                            preValidated.blockInstant(),
+                                            preValidated.recordFileBytes());
+                                } else {
+                                    v.validate(block, blockNum);
+                                }
+                                if (verbose) {
+                                    perValidationNanos.get(v.name())[0] += System.nanoTime() - vStart;
+                                }
                             } catch (ValidationException e) {
                                 failedValidationName = v.name();
                                 failureMessage = e.getMessage();
@@ -811,6 +865,7 @@ public class ValidateBlocksCommand implements Runnable {
 
                         // Phase 2: commit all validations (under lock to prevent shutdown hook
                         // from saving a partially-committed state)
+                        long commitStart = verbose ? System.nanoTime() : 0;
                         synchronized (commitLock) {
                             for (BlockValidation v : validations) {
                                 v.commitState(block, blockNum);
@@ -820,6 +875,7 @@ public class ValidateBlocksCommand implements Runnable {
                             blocksValidated++;
                             blocksValidatedRef[0] = blocksValidated;
                         }
+                        if (verbose) totalCommitNanosRef[0] += System.nanoTime() - commitStart;
 
                         // Collect signature stats from the validation
                         if (signatureValidation != null) {
@@ -1012,6 +1068,29 @@ public class ValidateBlocksCommand implements Runnable {
 
         long elapsedSeconds = (System.nanoTime() - startNanos) / 1_000_000_000L;
         System.out.println(Ansi.AUTO.string("@|yellow Time elapsed:|@ " + elapsedSeconds + " seconds"));
+
+        // Print timing breakdown when --verbose is enabled
+        if (verbose && blocksValidated > 0) {
+            System.out.println();
+            System.out.println(Ansi.AUTO.string("@|bold,cyan TIMING BREAKDOWN|@"));
+            System.out.printf(
+                    "  Queue take:          %,d ms (%.1f us/block)%n",
+                    totalQueueTakeNanosRef[0] / 1_000_000L, totalQueueTakeNanosRef[0] / 1000.0 / blocksValidated);
+            System.out.printf(
+                    "  Future get:          %,d ms (%.1f us/block)%n",
+                    totalFutureGetNanosRef[0] / 1_000_000L, totalFutureGetNanosRef[0] / 1000.0 / blocksValidated);
+            for (BlockValidation v : sequentialValidations) {
+                long[] nanos = perValidationNanos.get(v.name());
+                if (nanos != null) {
+                    System.out.printf(
+                            "  %-22s %,d ms (%.1f us/block)%n",
+                            v.name() + ":", nanos[0] / 1_000_000L, nanos[0] / 1000.0 / blocksValidated);
+                }
+            }
+            System.out.printf(
+                    "  Commit:              %,d ms (%.1f us/block)%n",
+                    totalCommitNanosRef[0] / 1_000_000L, totalCommitNanosRef[0] / 1000.0 / blocksValidated);
+        }
     }
 
     /**
@@ -1089,9 +1168,24 @@ public class ValidateBlocksCommand implements Runnable {
                 blockQueue.put(decompPool.submit(() -> {
                     BlockUnparsed block = BlockZipsUtilities.decompressAndPartialParse(raw, isZstd, isGz);
                     Object[] err = runParallelValidations(parallelValidations, block, bNum);
+                    var ppd = ParallelBlockPreprocessor.preprocess(block);
                     return err != null
-                            ? new PreValidatedBlock(block, bNum, (String) err[0], (Exception) err[1])
-                            : new PreValidatedBlock(block, bNum, null, null);
+                            ? new PreValidatedBlock(
+                                    block,
+                                    bNum,
+                                    (String) err[0],
+                                    (Exception) err[1],
+                                    ppd.blockHash(),
+                                    ppd.blockInstant(),
+                                    ppd.recordFileBytes())
+                            : new PreValidatedBlock(
+                                    block,
+                                    bNum,
+                                    null,
+                                    null,
+                                    ppd.blockHash(),
+                                    ppd.blockInstant(),
+                                    ppd.recordFileBytes());
                 }));
             }
         } catch (IOException streamErr) {
@@ -1116,9 +1210,24 @@ public class ValidateBlocksCommand implements Runnable {
                     blockQueue.put(decompPool.submit(() -> {
                         BlockUnparsed block = BlockZipsUtilities.decompressAndPartialParse(raw, isZstd, isGz);
                         Object[] err = runParallelValidations(parallelValidations, block, bNum);
+                        var ppd = ParallelBlockPreprocessor.preprocess(block);
                         return err != null
-                                ? new PreValidatedBlock(block, bNum, (String) err[0], (Exception) err[1])
-                                : new PreValidatedBlock(block, bNum, null, null);
+                                ? new PreValidatedBlock(
+                                        block,
+                                        bNum,
+                                        (String) err[0],
+                                        (Exception) err[1],
+                                        ppd.blockHash(),
+                                        ppd.blockInstant(),
+                                        ppd.recordFileBytes())
+                                : new PreValidatedBlock(
+                                        block,
+                                        bNum,
+                                        null,
+                                        null,
+                                        ppd.blockHash(),
+                                        ppd.blockInstant(),
+                                        ppd.recordFileBytes());
                     }));
                 }
             }
@@ -1151,9 +1260,24 @@ public class ValidateBlocksCommand implements Runnable {
                 blockQueue.put(decompPool.submit(() -> {
                     BlockUnparsed block = BlockZipsUtilities.decompressAndPartialParse(raw, isZstd, isGz);
                     Object[] err = runParallelValidations(parallelValidations, block, bNum);
+                    var ppd = ParallelBlockPreprocessor.preprocess(block);
                     return err != null
-                            ? new PreValidatedBlock(block, bNum, (String) err[0], (Exception) err[1])
-                            : new PreValidatedBlock(block, bNum, null, null);
+                            ? new PreValidatedBlock(
+                                    block,
+                                    bNum,
+                                    (String) err[0],
+                                    (Exception) err[1],
+                                    ppd.blockHash(),
+                                    ppd.blockInstant(),
+                                    ppd.recordFileBytes())
+                            : new PreValidatedBlock(
+                                    block,
+                                    bNum,
+                                    null,
+                                    null,
+                                    ppd.blockHash(),
+                                    ppd.blockInstant(),
+                                    ppd.recordFileBytes());
                 }));
             }
         }
@@ -1183,9 +1307,24 @@ public class ValidateBlocksCommand implements Runnable {
                 blockQueue.put(decompPool.submit(() -> {
                     BlockUnparsed block = BlockZipsUtilities.decompressAndPartialParse(raw, isZstd, isGz);
                     Object[] err = runParallelValidations(parallelValidations, block, bNum);
+                    var ppd = ParallelBlockPreprocessor.preprocess(block);
                     return err != null
-                            ? new PreValidatedBlock(block, bNum, (String) err[0], (Exception) err[1])
-                            : new PreValidatedBlock(block, bNum, null, null);
+                            ? new PreValidatedBlock(
+                                    block,
+                                    bNum,
+                                    (String) err[0],
+                                    (Exception) err[1],
+                                    ppd.blockHash(),
+                                    ppd.blockInstant(),
+                                    ppd.recordFileBytes())
+                            : new PreValidatedBlock(
+                                    block,
+                                    bNum,
+                                    null,
+                                    null,
+                                    ppd.blockHash(),
+                                    ppd.blockInstant(),
+                                    ppd.recordFileBytes());
                 }));
             }
         }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/BlockZipsUtilities.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/BlockZipsUtilities.java
@@ -4,6 +4,7 @@ package org.hiero.block.tools.blocks.model;
 import com.github.luben.zstd.ZstdInputStream;
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,6 +12,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -23,6 +25,7 @@ import java.util.zip.GZIPInputStream;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.base.CompressionType;
 import org.hiero.block.tools.blocks.validation.ProtobufParsingConstants;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Shared utilities for discovering, reading, decompressing and parsing block files from directories and zip archives.
@@ -77,9 +80,18 @@ public final class BlockZipsUtilities {
      * @param blockNumber the block number
      * @param preValidationName the name of the validation that failed, or null if all passed
      * @param preValidationError the first validation failure from the parallel stage, or null if all passed
+     * @param blockHash pre-computed block hash via {@code hashBlock()}, or null if not computed
+     * @param blockInstant block timestamp extracted from BlockHeader, or null if not extracted
+     * @param recordFileBytes raw RecordFile bytes extracted from the block, or null if not found
      */
     public record PreValidatedBlock(
-            BlockUnparsed block, long blockNumber, String preValidationName, Exception preValidationError) {}
+            BlockUnparsed block,
+            long blockNumber,
+            String preValidationName,
+            Exception preValidationError,
+            byte @Nullable [] blockHash,
+            @Nullable Instant blockInstant,
+            @Nullable Bytes recordFileBytes) {}
 
     /**
      * Extract a block number from a filename matching block file patterns.

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.tools.blocks.validation.ParallelBlockPreprocessor.PreprocessedData;
 import org.hiero.block.tools.days.model.AddressBookRegistry;
 import org.hiero.block.tools.records.model.parsed.ValidationException;
 import org.jspecify.annotations.Nullable;
@@ -64,7 +65,17 @@ public final class AddressBookUpdateValidation implements BlockValidation {
 
     @Override
     public void validate(final BlockUnparsed block, final long blockNumber) throws ValidationException {
-        validate(block, blockNumber, null, null);
+        validate(block, blockNumber, (Instant) null, null);
+    }
+
+    @Override
+    public void validate(final BlockUnparsed block, final long blockNumber, final PreprocessedData preprocessed)
+            throws ValidationException {
+        validate(
+                block,
+                blockNumber,
+                preprocessed != null ? preprocessed.blockInstant() : null,
+                preprocessed != null ? preprocessed.recordFileBytes() : null);
     }
 
     /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.tools.days.model.AddressBookRegistry;
 import org.hiero.block.tools.records.model.parsed.ValidationException;
+import org.jspecify.annotations.Nullable;
 import picocli.CommandLine.Help.Ansi;
 
 /**
@@ -63,9 +64,29 @@ public final class AddressBookUpdateValidation implements BlockValidation {
 
     @Override
     public void validate(final BlockUnparsed block, final long blockNumber) throws ValidationException {
+        validate(block, blockNumber, null, null);
+    }
+
+    /**
+     * Validates with optional pre-extracted block instant and record file bytes.
+     *
+     * @param block the shallow-parsed block
+     * @param blockNumber the block number
+     * @param preExtractedInstant pre-extracted block timestamp, or null to extract here
+     * @param preExtractedRecordFileBytes pre-extracted RecordFile bytes, or null to extract here
+     * @throws ValidationException if validation fails
+     */
+    public void validate(
+            final BlockUnparsed block,
+            final long blockNumber,
+            final @Nullable Instant preExtractedInstant,
+            final @Nullable Bytes preExtractedRecordFileBytes)
+            throws ValidationException {
         try {
-            final Instant blockInstant = extractBlockInstant(block);
-            final Bytes recordFileBytes = extractRecordFileBytes(block);
+            final Instant blockInstant =
+                    (preExtractedInstant != null) ? preExtractedInstant : extractBlockInstant(block);
+            final Bytes recordFileBytes =
+                    (preExtractedRecordFileBytes != null) ? preExtractedRecordFileBytes : extractRecordFileBytes(block);
             if (recordFileBytes == null || recordFileBytes.length() == 0 || blockInstant == null) {
                 return;
             }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/BlockChainValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/BlockChainValidation.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.tools.blocks.HasherStateFiles;
+import org.hiero.block.tools.blocks.validation.ParallelBlockPreprocessor.PreprocessedData;
 import org.hiero.block.tools.records.model.parsed.ValidationException;
 import org.jspecify.annotations.Nullable;
 
@@ -51,7 +52,13 @@ public final class BlockChainValidation implements BlockValidation {
 
     @Override
     public void validate(final BlockUnparsed block, final long blockNumber) throws ValidationException {
-        validate(block, blockNumber, null);
+        validate(block, blockNumber, (byte[]) null);
+    }
+
+    @Override
+    public void validate(final BlockUnparsed block, final long blockNumber, final PreprocessedData preprocessed)
+            throws ValidationException {
+        validate(block, blockNumber, preprocessed != null ? preprocessed.blockHash() : null);
     }
 
     /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/BlockChainValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/BlockChainValidation.java
@@ -51,6 +51,19 @@ public final class BlockChainValidation implements BlockValidation {
 
     @Override
     public void validate(final BlockUnparsed block, final long blockNumber) throws ValidationException {
+        validate(block, blockNumber, null);
+    }
+
+    /**
+     * Validates the block chain with an optional pre-computed block hash.
+     *
+     * @param block the shallow-parsed block
+     * @param blockNumber the block number
+     * @param preComputedHash pre-computed hash from parallel preprocessing, or null to compute here
+     * @throws ValidationException if the chain is broken
+     */
+    public void validate(final BlockUnparsed block, final long blockNumber, final byte @Nullable [] preComputedHash)
+            throws ValidationException {
         // Find the footer and selectively parse it
         BlockFooter footer = null;
         try {
@@ -82,8 +95,8 @@ public final class BlockChainValidation implements BlockValidation {
                         + " - First block should have empty-tree previous hash. readHash= " + simpleHash(readHash));
             }
         }
-        // Stage the block hash for commit
-        stagedBlockHash = hashBlock(block);
+        // Stage the block hash for commit — use pre-computed hash if available
+        stagedBlockHash = (preComputedHash != null) ? preComputedHash : hashBlock(block);
     }
 
     @Override

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/BlockValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/BlockValidation.java
@@ -4,6 +4,7 @@ package org.hiero.block.tools.blocks.validation;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.tools.blocks.validation.ParallelBlockPreprocessor.PreprocessedData;
 import org.hiero.block.tools.records.model.parsed.ValidationException;
 
 /**
@@ -72,6 +73,22 @@ public interface BlockValidation {
      * @throws ValidationException if the block fails this validation
      */
     void validate(BlockUnparsed block, long blockNumber) throws ValidationException;
+
+    /**
+     * Validate a single block with optional pre-computed data from parallel preprocessing.
+     * The default implementation ignores the preprocessed data and delegates to
+     * {@link #validate(BlockUnparsed, long)}. Implementations that can benefit from
+     * pre-computed block hashes, block instants, or record file bytes should override.
+     *
+     * @param block the block to validate
+     * @param blockNumber the block number
+     * @param preprocessed pre-computed data from the parallel pool, or null
+     * @throws ValidationException if the block fails this validation
+     */
+    default void validate(BlockUnparsed block, long blockNumber, PreprocessedData preprocessed)
+            throws ValidationException {
+        validate(block, blockNumber);
+    }
 
     /**
      * Commit any staged state changes after ALL validations pass for a block. Called only

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.tools.blocks.validation.ParallelBlockPreprocessor.PreprocessedData;
 import org.hiero.block.tools.days.model.NodeStakeRegistry;
 import org.hiero.block.tools.records.model.parsed.ValidationException;
 import org.jspecify.annotations.Nullable;
@@ -64,7 +65,17 @@ public final class NodeStakeUpdateValidation implements BlockValidation {
 
     @Override
     public void validate(final BlockUnparsed block, final long blockNumber) throws ValidationException {
-        validate(block, blockNumber, null, null);
+        validate(block, blockNumber, (Instant) null, null);
+    }
+
+    @Override
+    public void validate(final BlockUnparsed block, final long blockNumber, final PreprocessedData preprocessed)
+            throws ValidationException {
+        validate(
+                block,
+                blockNumber,
+                preprocessed != null ? preprocessed.blockInstant() : null,
+                preprocessed != null ? preprocessed.recordFileBytes() : null);
     }
 
     /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.tools.days.model.NodeStakeRegistry;
 import org.hiero.block.tools.records.model.parsed.ValidationException;
+import org.jspecify.annotations.Nullable;
 import picocli.CommandLine.Help.Ansi;
 
 /**
@@ -63,9 +64,29 @@ public final class NodeStakeUpdateValidation implements BlockValidation {
 
     @Override
     public void validate(final BlockUnparsed block, final long blockNumber) throws ValidationException {
+        validate(block, blockNumber, null, null);
+    }
+
+    /**
+     * Validates with optional pre-extracted block instant and record file bytes.
+     *
+     * @param block the shallow-parsed block
+     * @param blockNumber the block number
+     * @param preExtractedInstant pre-extracted block timestamp, or null to extract here
+     * @param preExtractedRecordFileBytes pre-extracted RecordFile bytes, or null to extract here
+     * @throws ValidationException if validation fails
+     */
+    public void validate(
+            final BlockUnparsed block,
+            final long blockNumber,
+            final @Nullable Instant preExtractedInstant,
+            final @Nullable Bytes preExtractedRecordFileBytes)
+            throws ValidationException {
         try {
-            final Instant blockInstant = extractBlockInstant(block);
-            final Bytes recordFileBytes = extractRecordFileBytes(block);
+            final Instant blockInstant =
+                    (preExtractedInstant != null) ? preExtractedInstant : extractBlockInstant(block);
+            final Bytes recordFileBytes =
+                    (preExtractedRecordFileBytes != null) ? preExtractedRecordFileBytes : extractRecordFileBytes(block);
             if (recordFileBytes == null || recordFileBytes.length() == 0 || blockInstant == null) {
                 return;
             }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/ParallelBlockPreprocessor.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/ParallelBlockPreprocessor.java
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.blocks.validation;
+
+import static org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHasher.hashBlock;
+import static org.hiero.block.tools.blocks.validation.BlockExtractionUtils.extractBlockInstant;
+import static org.hiero.block.tools.blocks.validation.BlockExtractionUtils.extractRecordFileBytes;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.time.Instant;
+import org.hiero.block.internal.BlockUnparsed;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Stateless, thread-safe utility that pre-computes expensive per-block data in the
+ * decompression pool. This moves three costly operations off the main validation thread:
+ * <ol>
+ *   <li>{@code hashBlock()} — builds a 16-leaf SHA-384 merkle tree (most expensive per-block op)</li>
+ *   <li>{@code extractBlockInstant()} — parses the BlockHeader for the block timestamp</li>
+ *   <li>{@code extractRecordFileBytes()} — finds the RecordFile item bytes</li>
+ * </ol>
+ *
+ * <p>Each extraction is independently try/caught so a failure in one does not prevent the others.
+ */
+public final class ParallelBlockPreprocessor {
+
+    /** Result record holding the three pre-computed values (any may be null on failure). */
+    public record PreprocessedData(
+            byte @Nullable [] blockHash,
+            @Nullable Instant blockInstant,
+            @Nullable Bytes recordFileBytes) {}
+
+    private ParallelBlockPreprocessor() {}
+
+    /**
+     * Pre-computes block hash, block instant, and record file bytes from the given block.
+     * Each extraction is independent and wrapped in try/catch — a failure in one does not
+     * affect the others. Callers on the main thread should fall back to on-demand computation
+     * when a field is null.
+     *
+     * @param block the shallow-parsed block
+     * @return pre-computed data (fields may be null if extraction failed)
+     */
+    public static PreprocessedData preprocess(final BlockUnparsed block) {
+        byte[] blockHash = null;
+        Instant blockInstant = null;
+        Bytes recordFileBytes = null;
+
+        try {
+            blockHash = hashBlock(block);
+        } catch (Exception ignored) {
+            // Fall back to main-thread computation
+        }
+
+        try {
+            blockInstant = extractBlockInstant(block);
+        } catch (Exception ignored) {
+            // Fall back to main-thread extraction
+        }
+
+        try {
+            recordFileBytes = extractRecordFileBytes(block);
+        } catch (Exception ignored) {
+            // Fall back to main-thread extraction
+        }
+
+        return new PreprocessedData(blockHash, blockInstant, recordFileBytes);
+    }
+}

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/BlockChainValidationTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/BlockChainValidationTest.java
@@ -184,7 +184,7 @@ class BlockChainValidationTest {
     void nullPreComputedHash_fallsBackToHashBlock() throws ValidationException {
         BlockChainValidation validation = new BlockChainValidation();
         // Validate with null pre-computed hash — should compute it
-        validation.validate(VALID_BLOCK, 0, null);
+        validation.validate(VALID_BLOCK, 0, (byte[]) null);
         byte[] expectedHash = hashBlock(VALID_BLOCK);
         assertArrayEquals(expectedHash, validation.getStagedBlockHash());
     }

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/BlockChainValidationTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/BlockChainValidationTest.java
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.blocks.validation;
 
+import static org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHasher.hashBlock;
 import static org.hiero.block.tools.blocks.model.hashing.HashingUtils.EMPTY_TREE_HASH;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -166,6 +168,38 @@ class BlockChainValidationTest {
         Block block = new Block(List.of(HEADER_ITEM, RECORD_FILE_ITEM, emptyHashFooter, PROOF_ITEM));
         ValidationException ex =
                 assertThrows(ValidationException.class, () -> validation.validate(toUnparsed(block), 1));
+        assertTrue(ex.getMessage().contains("previous block hash mismatch"));
+    }
+
+    @Test
+    void preComputedHash_usedWhenProvided() throws ValidationException {
+        BlockChainValidation validation = new BlockChainValidation();
+        byte[] preComputedHash = hashBlock(VALID_BLOCK);
+        // Validate with pre-computed hash — should use it instead of recomputing
+        validation.validate(VALID_BLOCK, 0, preComputedHash);
+        assertArrayEquals(preComputedHash, validation.getStagedBlockHash());
+    }
+
+    @Test
+    void nullPreComputedHash_fallsBackToHashBlock() throws ValidationException {
+        BlockChainValidation validation = new BlockChainValidation();
+        // Validate with null pre-computed hash — should compute it
+        validation.validate(VALID_BLOCK, 0, null);
+        byte[] expectedHash = hashBlock(VALID_BLOCK);
+        assertArrayEquals(expectedHash, validation.getStagedBlockHash());
+    }
+
+    @Test
+    void chainMismatch_stillCaughtWithPreComputedHash() throws ValidationException {
+        BlockChainValidation validation = new BlockChainValidation();
+        // Commit first block
+        validation.validate(VALID_BLOCK, 0);
+        validation.commitState(VALID_BLOCK, 0);
+        // The footer in VALID_BLOCK has EMPTY_TREE_HASH as previousBlockRootHash,
+        // which won't match the committed hash from block 0
+        byte[] preComputedHash = hashBlock(VALID_BLOCK);
+        ValidationException ex =
+                assertThrows(ValidationException.class, () -> validation.validate(VALID_BLOCK, 1, preComputedHash));
         assertTrue(ex.getMessage().contains("previous block hash mismatch"));
     }
 }

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/BlockChainValidationTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/BlockChainValidationTest.java
@@ -172,7 +172,7 @@ class BlockChainValidationTest {
     }
 
     @Test
-    void preComputedHash_usedWhenProvided() throws ValidationException {
+    void preComputedHashUsedWhenProvided() throws ValidationException {
         BlockChainValidation validation = new BlockChainValidation();
         byte[] preComputedHash = hashBlock(VALID_BLOCK);
         // Validate with pre-computed hash — should use it instead of recomputing
@@ -181,7 +181,7 @@ class BlockChainValidationTest {
     }
 
     @Test
-    void nullPreComputedHash_fallsBackToHashBlock() throws ValidationException {
+    void nullPreComputedHashFallsBackToHashBlock() throws ValidationException {
         BlockChainValidation validation = new BlockChainValidation();
         // Validate with null pre-computed hash — should compute it
         validation.validate(VALID_BLOCK, 0, (byte[]) null);
@@ -190,7 +190,7 @@ class BlockChainValidationTest {
     }
 
     @Test
-    void chainMismatch_stillCaughtWithPreComputedHash() throws ValidationException {
+    void chainMismatchStillCaughtWithPreComputedHash() throws ValidationException {
         BlockChainValidation validation = new BlockChainValidation();
         // Commit first block
         validation.validate(VALID_BLOCK, 0);

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/ParallelBlockPreprocessorTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/ParallelBlockPreprocessorTest.java
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.blocks.validation;
+
+import static org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHasher.hashBlock;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.block.stream.BlockProof;
+import com.hedera.hapi.block.stream.RecordFileItem;
+import com.hedera.hapi.block.stream.output.BlockFooter;
+import com.hedera.hapi.block.stream.output.BlockHeader;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.tools.blocks.validation.ParallelBlockPreprocessor.PreprocessedData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link ParallelBlockPreprocessor}. */
+class ParallelBlockPreprocessorTest {
+
+    private static final BlockItem HEADER_ITEM = BlockItem.newBuilder()
+            .blockHeader(BlockHeader.newBuilder()
+                    .number(0)
+                    .blockTimestamp(Timestamp.newBuilder()
+                            .seconds(1700000000L)
+                            .nanos(123456789)
+                            .build())
+                    .build())
+            .build();
+    private static final BlockItem RECORD_FILE_ITEM =
+            BlockItem.newBuilder().recordFile(RecordFileItem.DEFAULT).build();
+    private static final BlockItem FOOTER_ITEM = BlockItem.newBuilder()
+            .blockFooter(BlockFooter.newBuilder()
+                    .previousBlockRootHash(Bytes.EMPTY)
+                    .rootHashOfAllBlockHashesTree(Bytes.EMPTY)
+                    .startOfBlockStateRootHash(Bytes.EMPTY)
+                    .build())
+            .build();
+    private static final BlockItem PROOF_ITEM =
+            BlockItem.newBuilder().blockProof(BlockProof.DEFAULT).build();
+
+    private static final BlockUnparsed VALID_BLOCK =
+            toUnparsed(new Block(List.of(HEADER_ITEM, RECORD_FILE_ITEM, FOOTER_ITEM, PROOF_ITEM)));
+
+    /** Block with no header — instant extraction should return null. */
+    private static final BlockUnparsed NO_HEADER_BLOCK =
+            toUnparsed(new Block(List.of(RECORD_FILE_ITEM, FOOTER_ITEM, PROOF_ITEM)));
+
+    /** Block with no record file — recordFileBytes extraction should return null. */
+    private static final BlockUnparsed NO_RECORD_FILE_BLOCK =
+            toUnparsed(new Block(List.of(HEADER_ITEM, FOOTER_ITEM, PROOF_ITEM)));
+
+    private static BlockUnparsed toUnparsed(Block block) {
+        try {
+            return BlockUnparsed.PROTOBUF.parse(Block.PROTOBUF.toBytes(block));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Nested
+    @DisplayName("Hash computation")
+    class HashTests {
+        @Test
+        @DisplayName("Pre-computed hash matches direct hashBlock() call")
+        void hashMatchesDirectCall() {
+            PreprocessedData ppd = ParallelBlockPreprocessor.preprocess(VALID_BLOCK);
+            byte[] directHash = hashBlock(VALID_BLOCK);
+            assertNotNull(ppd.blockHash());
+            assertArrayEquals(directHash, ppd.blockHash());
+        }
+    }
+
+    @Nested
+    @DisplayName("Block instant extraction")
+    class InstantTests {
+        @Test
+        @DisplayName("Extracts correct instant from BlockHeader")
+        void extractsCorrectInstant() {
+            PreprocessedData ppd = ParallelBlockPreprocessor.preprocess(VALID_BLOCK);
+            assertNotNull(ppd.blockInstant());
+            assertEquals(Instant.ofEpochSecond(1700000000L, 123456789), ppd.blockInstant());
+        }
+
+        @Test
+        @DisplayName("Returns null when no BlockHeader present")
+        void returnsNullForMissingHeader() {
+            PreprocessedData ppd = ParallelBlockPreprocessor.preprocess(NO_HEADER_BLOCK);
+            assertNull(ppd.blockInstant());
+        }
+    }
+
+    @Nested
+    @DisplayName("RecordFile bytes extraction")
+    class RecordFileBytesTests {
+        @Test
+        @DisplayName("Extracts non-null RecordFile bytes when present")
+        void extractsRecordFileBytes() {
+            PreprocessedData ppd = ParallelBlockPreprocessor.preprocess(VALID_BLOCK);
+            assertNotNull(ppd.recordFileBytes());
+        }
+
+        @Test
+        @DisplayName("Returns null when no RecordFile item present")
+        void returnsNullForMissingRecordFile() {
+            PreprocessedData ppd = ParallelBlockPreprocessor.preprocess(NO_RECORD_FILE_BLOCK);
+            assertNull(ppd.recordFileBytes());
+        }
+    }
+
+    @Nested
+    @DisplayName("Thread safety")
+    class ThreadSafetyTests {
+        @Test
+        @DisplayName("Parallel invocations produce consistent results")
+        void parallelInvocationsProduceConsistentResults() throws Exception {
+            int threadCount = 8;
+            ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+            List<Future<PreprocessedData>> futures = new ArrayList<>();
+            for (int i = 0; i < threadCount; i++) {
+                futures.add(pool.submit(() -> ParallelBlockPreprocessor.preprocess(VALID_BLOCK)));
+            }
+            byte[] expectedHash = hashBlock(VALID_BLOCK);
+            Instant expectedInstant = Instant.ofEpochSecond(1700000000L, 123456789);
+            for (Future<PreprocessedData> f : futures) {
+                PreprocessedData ppd = f.get();
+                assertArrayEquals(expectedHash, ppd.blockHash());
+                assertEquals(expectedInstant, ppd.blockInstant());
+                assertNotNull(ppd.recordFileBytes());
+            }
+            pool.shutdown();
+        }
+    }
+}

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/ParallelBlockPreprocessorTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/ParallelBlockPreprocessorTest.java
@@ -66,7 +66,7 @@ class ParallelBlockPreprocessorTest {
         try {
             return BlockUnparsed.PROTOBUF.parse(Block.PROTOBUF.toBytes(block));
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException("Failed to parse block", e);
         }
     }
 


### PR DESCRIPTION
## Summary

Moves three expensive per-block operations from the single-threaded main validation loop into the existing decompression pool:

- **`hashBlock()`** - builds a 16-leaf SHA-384 merkle tree (previously the most expensive per-block operation)
- **`extractBlockInstant()`** - parses BlockHeader for the block timestamp
- **`extractRecordFileBytes()`** - finds RecordFile item bytes

Also increases the default prefetch queue from 64 to 256 blocks and adds timing instrumentation behind the `--verbose` flag.

## Performance Results (mainnet, 48-core server)

Completed remaining ~10M blocks of a full 92.3M block mainnet validation in **1,493 seconds** (~25 minutes).

**Before**: ~4.7 blocks/sec (single-threaded bottleneck, 91% CPU idle)
**After**: ~61,800 blocks/sec for the tail segment

### Timing Breakdown (per-block, main thread)

| Operation | Time | Per Block |
|-----------|------|-----------|
| Queue take | 76,681 ms | 0.8 us |
| Future get | 134,052 ms | 1.5 us |
| AddressBookUpdate | 543,692 ms | 5.9 us |
| NodeStakeUpdate | 509,882 ms | 5.5 us |
| Block Chain (hashBlock) | 6,474 ms | **0.1 us** |
| Historical Block Tree | 56,177 ms | 0.6 us |
| Hash Registry | 34,750 ms | 0.4 us |
| Commit | 7,846 ms | 0.1 us |

`hashBlock()` dropped from being the dominant cost to **0.1 us/block** since it is now pre-computed in the parallel pool.

## Changes

| Action | File |
|--------|------|
| Modify | `BlockZipsUtilities.java` - expanded `PreValidatedBlock` record with `blockHash`, `blockInstant`, `recordFileBytes` |
| Create | `ParallelBlockPreprocessor.java` - stateless, thread-safe preprocessing utility |
| Modify | `ValidateBlocksCommand.java` - wired preprocessing into pool lambdas, targeted dispatch, prefetch 64 to 256, timing instrumentation |
| Modify | `BlockChainValidation.java` - overloaded `validate()` accepting pre-computed hash |
| Modify | `AddressBookUpdateValidation.java` - overloaded `validate()` accepting pre-extracted data |
| Modify | `NodeStakeUpdateValidation.java` - overloaded `validate()` accepting pre-extracted data |
| Create | `ParallelBlockPreprocessorTest.java` - hash consistency, extraction, null handling, thread safety |
| Modify | `BlockChainValidationTest.java` - tests for pre-computed hash overload |

