### PR TITLE
refactor: match PBJ parse size limit with consensus node

### DIFF
--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/historicalblocks/BlockAccessor.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/historicalblocks/BlockAccessor.java
@@ -16,10 +16,11 @@ import org.hiero.block.internal.BlockUnparsed;
  */
 public interface BlockAccessor extends AutoCloseable {
     /**
-     * Maximum protobuf parse size in bytes (100 MB). This accommodates the largest known
-     * block items (TSS Wraps transition blocks) which can exceed PBJ's default 2 MB limit.
+     * Maximum protobuf parse size in bytes (125 MB). This matches the consensus node limit
+     * and accommodates the largest known block items (TSS Wraps transition blocks) which
+     * can exceed PBJ's default 2 MB limit.
      */
-    int MAX_BLOCK_SIZE_BYTES = 100 * 1024 * 1024;
+    int MAX_BLOCK_SIZE_BYTES = 125 * 1024 * 1024;
 
     /**
      * The format of the block data. The consumer can choose the format that is most efficient for them.

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertToJson.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertToJson.java
@@ -32,8 +32,8 @@ import picocli.CommandLine.Parameters;
 @SuppressWarnings({"DataFlowIssue", "unused", "DuplicatedCode", "ConstantValue"})
 @Command(name = "json", description = "Converts a binary block stream to JSON")
 public class ConvertToJson implements Runnable {
-    // 36 MB — matches BlockAccessor.MAX_BLOCK_SIZE_BYTES in spi-plugins
-    private static final int MAX_BLOCK_SIZE_BYTES = 37_748_736;
+    /** Maximum protobuf parse size in bytes (120 MB). */
+    private static final int MAX_BLOCK_SIZE_BYTES = 120 * 1024 * 1024;
 
     @Parameters(index = "0..*")
     private Path[] files;

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/BlockReader.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/BlockReader.java
@@ -18,6 +18,7 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import org.hiero.block.node.base.BlockFile;
 import org.hiero.block.node.base.CompressionType;
+import org.hiero.block.tools.blocks.validation.ProtobufParsingConstants;
 
 /**
  * Class for reading blocks from disk as written by {@link BlockWriter}.
@@ -335,8 +336,8 @@ public class BlockReader {
         try (final ByteArrayInputStream byteStream = new ByteArrayInputStream(compressedBytes);
                 final InputStream decompressedStream = compressionType.wrapStream(byteStream);
                 final ReadableStreamingData in = new ReadableStreamingData(decompressedStream)) {
-            // 36 MB — matches BlockAccessor.MAX_BLOCK_SIZE_BYTES in spi-plugins
-            return Block.PROTOBUF.parse(in, false, false, Codec.DEFAULT_MAX_DEPTH, 37_748_736);
+            return Block.PROTOBUF.parse(
+                    in, false, false, Codec.DEFAULT_MAX_DEPTH, ProtobufParsingConstants.MAX_PARSE_SIZE);
         } catch (ParseException e) {
             throw new IOException("Failed to parse block from bytes", e);
         }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/BlockZipsUtilities.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/BlockZipsUtilities.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.base.CompressionType;
+import org.hiero.block.tools.blocks.validation.ProtobufParsingConstants;
 
 /**
  * Shared utilities for discovering, reading, decompressing and parsing block files from directories and zip archives.
@@ -348,7 +349,8 @@ public final class BlockZipsUtilities {
         } else {
             blockBytes = raw;
         }
-        return Block.PROTOBUF.parse(BufferedData.wrap(blockBytes), true, false, 1000, 100 * 1024 * 1024); // 100MB
+        return Block.PROTOBUF.parse(
+                BufferedData.wrap(blockBytes), true, false, 1000, ProtobufParsingConstants.MAX_PARSE_SIZE);
     }
     /**
      * Decompresses raw bytes and parses them as a {@link BlockUnparsed} protobuf. BlockUnparsed is shallow parsed so
@@ -375,7 +377,7 @@ public final class BlockZipsUtilities {
             blockBytes = raw;
         }
         return BlockUnparsed.PROTOBUF.parse(
-                BufferedData.wrap(blockBytes), true, false, 1000, 100 * 1024 * 1024); // 100MB
+                BufferedData.wrap(blockBytes), true, false, 1000, ProtobufParsingConstants.MAX_PARSE_SIZE);
     }
 
     /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/ProtobufParsingConstants.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/ProtobufParsingConstants.java
@@ -12,8 +12,8 @@ public final class ProtobufParsingConstants {
     /** Maximum record file size for protobuf parsing (128 MB). */
     public static final int MAX_RECORD_FILE_SIZE = 128 * 1024 * 1024;
 
-    /** Maximum parse size for protobuf messages (100 MB) to handle large blocks and StateChanges items. */
-    public static final int MAX_PARSE_SIZE = 100 * 1024 * 1024;
+    /** Maximum parse size for protobuf messages (120 MB) to handle large blocks and StateChanges items. */
+    public static final int MAX_PARSE_SIZE = 120 * 1024 * 1024;
 
     private ProtobufParsingConstants() {}
 }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/capacity/NetworkCapacityClient.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/capacity/NetworkCapacityClient.java
@@ -33,6 +33,7 @@ import org.hiero.block.api.BlockItemSet;
 import org.hiero.block.api.BlockStreamPublishServiceInterface;
 import org.hiero.block.api.PublishStreamRequest;
 import org.hiero.block.api.PublishStreamResponse;
+import org.hiero.block.tools.blocks.validation.ProtobufParsingConstants;
 import org.hiero.block.tools.config.HelidonWebClientConfig;
 
 public class NetworkCapacityClient {
@@ -137,9 +138,12 @@ public class NetworkCapacityClient {
         try (final var gzipInputStream = new GZIPInputStream(Files.newInputStream(blockFile))) {
             blockData = gzipInputStream.readAllBytes();
         }
-        // 36 MB — matches BlockAccessor.MAX_BLOCK_SIZE_BYTES in spi-plugins
         Block block = Block.PROTOBUF.parse(
-                Bytes.wrap(blockData).toReadableSequentialData(), false, false, Codec.DEFAULT_MAX_DEPTH, 37_748_736);
+                Bytes.wrap(blockData).toReadableSequentialData(),
+                false,
+                false,
+                Codec.DEFAULT_MAX_DEPTH,
+                ProtobufParsingConstants.MAX_PARSE_SIZE);
         long blockNumber = block.items().getFirst().blockHeader().number();
 
         List<BlockItem> items = block.items();

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -72,6 +72,7 @@ import org.hiero.block.tools.blocks.validation.HbarSupplyValidation;
 import org.hiero.block.tools.blocks.validation.HistoricalBlockTreeValidation;
 import org.hiero.block.tools.blocks.validation.JumpstartValidation;
 import org.hiero.block.tools.blocks.validation.NodeStakeUpdateValidation;
+import org.hiero.block.tools.blocks.validation.ProtobufParsingConstants;
 import org.hiero.block.tools.blocks.validation.RequiredItemsValidation;
 import org.hiero.block.tools.blocks.validation.SignatureBlockStats;
 import org.hiero.block.tools.blocks.validation.SignatureStatsCollector;
@@ -1173,7 +1174,11 @@ public class LiveSequential implements Runnable {
             Bytes wrappedBytes, long blockNum, ValidationConfig vc, WrapLoopState ls, Path checkpointDir)
             throws Exception {
         BlockUnparsed blockUnparsed = BlockUnparsed.PROTOBUF.parse(
-                wrappedBytes.toReadableSequentialData(), false, false, Codec.DEFAULT_MAX_DEPTH, 37_748_736);
+                wrappedBytes.toReadableSequentialData(),
+                false,
+                false,
+                Codec.DEFAULT_MAX_DEPTH,
+                ProtobufParsingConstants.MAX_PARSE_SIZE);
 
         for (BlockValidation v : vc.sequentialValidations()) {
             try {


### PR DESCRIPTION
## Summary
- Update `BlockAccessor.MAX_BLOCK_SIZE_BYTES` from 100 MB to **125 MB** to match the consensus node limit
- Consolidate all tools CLI parse sizes to **120 MB** via `ProtobufParsingConstants.MAX_PARSE_SIZE`, replacing stale 36 MB inline literals
- Centralise scattered inline constants to reference `ProtobufParsingConstants.MAX_PARSE_SIZE`

Fixes #2641