### PR TITLE
fix: Add detection and handling for stalled publishers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,8 @@ protobuf-sources/hiero-consensus-node/
 node_modules/
 k6-proto/
 k6-out/
+
+# LLM agent files
+.agent/**
+agent/**
+

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -4,6 +4,7 @@ package org.hiero.block.node.stream.publisher;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.TRACE;
+import static org.hiero.block.api.PublishStreamResponse.EndOfStream.Code.TIMEOUT;
 import static org.hiero.block.node.spi.BlockNodePlugin.UNKNOWN_BLOCK_NUMBER;
 import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_BLOCKS_CLOSED_COMPLETE;
 import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_BATCHES_MESSAGED;
@@ -12,6 +13,7 @@ import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC
 import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_LATEST_BLOCK_NUMBER_ACKNOWLEDGED;
 import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_LOWEST_BLOCK_NUMBER_INBOUND;
 import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_OPEN_CONNECTIONS;
+import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_STALL_TIMEOUTS_SENT;
 
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -19,6 +21,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableSet;
 import java.util.NoSuchElementException;
@@ -40,6 +43,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import org.hiero.block.api.PublishStreamResponse;
+import org.hiero.block.api.PublishStreamResponse.EndOfStream.Code;
 import org.hiero.block.internal.BlockItemSetUnparsed;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.node.app.config.node.NodeConfig;
@@ -60,6 +64,9 @@ import org.hiero.metrics.core.MetricRegistry;
 /// todo(1420) add documentation
 public final class LiveStreamPublisherManager implements StreamPublisherManager {
     private static final int DATA_READY_WAIT_MICROSECONDS = 5000;
+    private static final int MAX_ADVANCE_FOR_STALL_DETECTION = 2;
+    private static final String STALL_DETECTED_LOG_MESSAGE =
+            "Stall detected: handler {0} has not completed block {1}, another handler completed block {2}";
     private final System.Logger LOGGER = System.getLogger(LiveStreamPublisherManager.class.getName());
     private final MetricsHolder metrics;
     private final BlockNodeContext serverContext;
@@ -93,6 +100,11 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     private final ConcurrentNavigableMap<Long, BlockItemUnparsed> blockProofs;
     private final NavigableSet<Long> endBlocksReceived;
     private final NavigableSet<Long> blocksToResend;
+    /// Maps block number to the ID of the handler that currently holds ACCEPT for that block.
+    /// An entry is added when a handler wins ACCEPT via registerQueueForBlock().
+    /// An entry is removed when endOfBlock() is called for that block, when blockIsEnding()
+    /// fires for a mid-block drop, when stall detection removes it, or on shutdown.
+    private final ConcurrentNavigableMap<Long, Long> activeStreamHandlerByBlock;
 
     /// todo(1420) add documentation
     public LiveStreamPublisherManager(
@@ -121,6 +133,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         blockProofs = new ConcurrentSkipListMap<>();
         endBlocksReceived = new ConcurrentSkipListSet<>();
         blocksToResend = new ConcurrentSkipListSet<>();
+        activeStreamHandlerByBlock = new ConcurrentSkipListMap<>();
         initializeBlockNumbers(serverContext);
     }
 
@@ -164,7 +177,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             final long blockNumber, final BlockAction previousAction, final long handlerId) {
         return switch (previousAction) {
             case null -> getActionForHeader(blockNumber);
-            case ACCEPT -> getActionForCurrentlyStreaming(blockNumber);
+            case ACCEPT -> getActionForCurrentlyStreaming(blockNumber, handlerId);
             case END_ERROR, END_DUPLICATE ->
                 // This should not happen because the Handler should have shut down.
                 BlockAction.END_ERROR;
@@ -183,6 +196,9 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             // re-starting it mid-block. We need to remove a potentially collected block proof.
             blockProofs.remove(blockNumber);
         }
+        // Record which handler won ACCEPT for this block so stall detection
+        // can identify and terminate a silent publisher.
+        activeStreamHandlerByBlock.put(blockNumber, handlerId);
     }
 
     @Override
@@ -200,6 +216,11 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             // Remove a proof in case it is collected
             blockProofs.remove(blockNumber);
         }
+        // The completing block is no longer an ACCEPT candidate for stall detection.
+        activeStreamHandlerByBlock.remove(blockNumber);
+        // After removing the completing block, check whether any remaining
+        // ACCEPT holders are stalled relative to this completion.
+        checkForStalledHandlers(blockNumber);
         final long blockToResend = nextBlockToResend();
         if (blockToResend != UNKNOWN_BLOCK_NUMBER) {
             return new ActionForBlock(BlockAction.RESEND, blockToResend);
@@ -213,6 +234,9 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         // @todo(2344) we can further improve this
         LOGGER.log(INFO, "Handler {0} is ending mid-block {1}", handlerId, blockNumber);
         final Deque<BlockItemSetUnparsed> deque = queueByBlockMap.remove(blockNumber);
+        // Remove this block from the ACCEPT winner tracking in all cases;
+        // if the handler dropped mid-block there is no stall to detect here.
+        activeStreamHandlerByBlock.remove(blockNumber);
         if (deque != null) {
             if (blockNumber > lastPersistedBlockNumber.get() && blockNumber < nextUnstreamedBlockNumber.get()) {
                 final String message = "Block {0} will be resent due to handler {1} ending mid block";
@@ -248,7 +272,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         for (final Long nextKey : handlers.keySet()) {
             final PublisherHandler value = handlers.remove(nextKey);
             if (value != null) {
-                value.closeCommunication();
+                value.endStreamWithCode(Code.SUCCESS, false);
                 value.onComplete();
             }
         }
@@ -259,6 +283,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             lastResult.cancel(true);
         }
         queueByBlockMap.clear();
+        activeStreamHandlerByBlock.clear();
         // We can safely shut down the scheduled executor abruptly. The timeout
         // tasks can be ignored completely as we shut down the manager.
         scheduledExecutor.shutdownNow();
@@ -299,6 +324,8 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             blocksToResend.add(blockNumber);
             // Iterate over all handlers and attempt to send the
             // bad block proof message.
+            // @todo(2339) improve the loop below, find the handler that should send the bad block proof code
+            //    and then let it handle the failed verification.
             for (final PublisherHandler handler : handlers.values()) {
                 if (handler.handleFailedVerification(blockNumber)) {
                     // There will always be only one handler that will send the
@@ -357,7 +384,9 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 final long blockNumber = notification.blockNumber();
                 // @todo(2198): We may have an extremely rare race condition here
                 nextUnstreamedBlockNumber.set(blockNumber);
-                handlers.values().parallelStream().unordered().forEach(PublisherHandler::handleFailedPersistence);
+                handlers.values().parallelStream()
+                        .unordered()
+                        .forEach((handler) -> handler.endStreamWithCode(Code.PERSISTENCE_FAILED, false));
             }
         }
     }
@@ -396,6 +425,8 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                     queueByBlockMap.remove(candidate);
                     // possibly remove a just collected block proof
                     blockProofs.remove(candidate);
+                    // remove from stall-detection tracking; this block is now obsolete
+                    activeStreamHandlerByBlock.remove(candidate);
                 }
             }
         }
@@ -443,6 +474,50 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             }
         } catch (final NoSuchElementException e) {
             return null;
+        }
+    }
+
+    /// Checks whether any currently accepted block is stalled relative to the
+    /// block that just completed. A handler is considered stalled when it holds
+    /// ACCEPT for block N, has not yet called endOfBlock(N), and another handler
+    /// has just called endOfBlock(M) where M > N + 2.
+    ///
+    /// The +2 threshold respects the protocol requirement that a publisher may
+    /// reasonably require up to 2 block times to complete a block due to
+    /// signature gathering.
+    ///
+    /// For each stalled block found:
+    /// - Its queue and proof entries are removed so the forwarder can advance.
+    /// - Its block number is added to blocksToResend.
+    /// - The owning handler receives EndStream(TIMEOUT) and is shut down.
+    /// - The stall-timeout metric is incremented.
+    ///
+    /// Thread safety: multiple handler threads may call this concurrently for
+    /// different values of completedBlockNumber. The
+    /// ConcurrentNavigableMap.remove(key, value) CAS ensures that only one
+    /// caller acts on each stalled block even if two threads detect it
+    /// simultaneously.
+    ///
+    /// @param completedBlockNumber the block number that just finished via endOfBlock()
+    private void checkForStalledHandlers(final long completedBlockNumber) {
+        for (final Map.Entry<Long, Long> entry : activeStreamHandlerByBlock.entrySet()) {
+            final long stalledBlock = entry.getKey();
+            final long handlerId = entry.getValue();
+            if (completedBlockNumber > stalledBlock + MAX_ADVANCE_FOR_STALL_DETECTION
+                    && !endBlocksReceived.contains(stalledBlock)
+                    && !blocksToResend.contains(stalledBlock)
+                    && activeStreamHandlerByBlock.remove(stalledBlock, handlerId)) {
+                // This thread won the CAS — execute the stall action.
+                LOGGER.log(DEBUG, STALL_DETECTED_LOG_MESSAGE, handlerId, stalledBlock, completedBlockNumber);
+                queueByBlockMap.remove(stalledBlock);
+                blockProofs.remove(stalledBlock);
+                blocksToResend.add(stalledBlock);
+                final PublisherHandler stalledHandler = handlers.get(handlerId);
+                if (stalledHandler != null) {
+                    stalledHandler.endStreamWithCode(TIMEOUT, true);
+                }
+                metrics.stallTimeoutsSent().increment();
+            }
         }
     }
 
@@ -596,7 +671,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     }
 
     /// todo(1420) add documentation
-    private BlockAction getActionForCurrentlyStreaming(final long blockNumber) {
+    private BlockAction getActionForCurrentlyStreaming(final long blockNumber, final long handlerId) {
         if (queueByBlockMap.containsKey(blockNumber)) {
             updateHighestBlockMetric(blockNumber);
             // We're one of the handlers currently streaming, keep going.
@@ -871,7 +946,8 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             LongGauge.Measurement lowestBlockNumber,
             LongGauge.Measurement highestBlockNumber,
             LongGauge.Measurement latestBlockNumberAcknowledged,
-            LongCounter.Measurement blocksClosedComplete) {
+            LongCounter.Measurement blocksClosedComplete,
+            LongCounter.Measurement stallTimeoutsSent) {
         /// todo(1420) add documentation
         static MetricsHolder createMetrics(@NonNull final MetricRegistry metricRegistry) {
             final LongCounter.Measurement blockItemsMessaged = metricRegistry
@@ -886,6 +962,10 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                     .register(LongCounter.builder(METRIC_PUBLISHER_BLOCKS_CLOSED_COMPLETE)
                             .setDescription("Blocks received complete (with both header and proof) by any Handler"))
                     .getOrCreateLabeled();
+            final LongCounter.Measurement stallTimeoutsSent = metricRegistry
+                    .register(LongCounter.builder(METRIC_PUBLISHER_STALL_TIMEOUTS_SENT)
+                            .setDescription("Publishers terminated due to stall detection (silent ACCEPT winner)"))
+                    .getOrCreateNotLabeled();
             final LongGauge.Measurement numberOfProducers = metricRegistry
                     .register(
                             LongGauge.builder(METRIC_PUBLISHER_OPEN_CONNECTIONS).setDescription("Connected publishers"))
@@ -909,7 +989,8 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                     lowestBlockNumber,
                     highestBlockNumber,
                     latestBlockNumberAcknowledged,
-                    blocksClosedComplete);
+                    blocksClosedComplete,
+                    stallTimeoutsSent);
         }
     }
 

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -177,7 +177,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             final long blockNumber, final BlockAction previousAction, final long handlerId) {
         return switch (previousAction) {
             case null -> getActionForHeader(blockNumber);
-            case ACCEPT -> getActionForCurrentlyStreaming(blockNumber, handlerId);
+            case ACCEPT -> getActionForCurrentlyStreaming(blockNumber);
             case END_ERROR, END_DUPLICATE ->
                 // This should not happen because the Handler should have shut down.
                 BlockAction.END_ERROR;
@@ -324,8 +324,6 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             blocksToResend.add(blockNumber);
             // Iterate over all handlers and attempt to send the
             // bad block proof message.
-            // @todo(2339) improve the loop below, find the handler that should send the bad block proof code
-            //    and then let it handle the failed verification.
             for (final PublisherHandler handler : handlers.values()) {
                 if (handler.handleFailedVerification(blockNumber)) {
                     // There will always be only one handler that will send the
@@ -505,9 +503,13 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             final long handlerId = entry.getValue();
             if (completedBlockNumber > stalledBlock + MAX_ADVANCE_FOR_STALL_DETECTION
                     && !endBlocksReceived.contains(stalledBlock)
+                    // TODO: Blocks to resend isn't enough here, need a better check...
                     && !blocksToResend.contains(stalledBlock)
                     && activeStreamHandlerByBlock.remove(stalledBlock, handlerId)) {
                 // This thread won the CAS — execute the stall action.
+                // @todo: Add CorrelationID _for the handler that is stalled_
+                //        (not the thread that called this method).
+                //     This requires making correlation ID accessible in Handler.
                 LOGGER.log(DEBUG, STALL_DETECTED_LOG_MESSAGE, handlerId, stalledBlock, completedBlockNumber);
                 queueByBlockMap.remove(stalledBlock);
                 blockProofs.remove(stalledBlock);
@@ -671,7 +673,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     }
 
     /// todo(1420) add documentation
-    private BlockAction getActionForCurrentlyStreaming(final long blockNumber, final long handlerId) {
+    private BlockAction getActionForCurrentlyStreaming(final long blockNumber) {
         if (queueByBlockMap.containsKey(blockNumber)) {
             updateHighestBlockMetric(blockNumber);
             // We're one of the handlers currently streaming, keep going.

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -228,9 +228,9 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
             // if response was sent successfully, we can remove
             // all unacknowledged blocks that are less than or equal to the
             // new last acknowledged block number.
-            // @todo(1582) we have to remove all history, i.e. get an inclusive head set up to
-            //    the new last ackd block and remove that together with lower ones.
-            unacknowledgedStreamedBlocks.remove(newLastAcknowledgedBlockNumber);
+            unacknowledgedStreamedBlocks
+                    .headSet(newLastAcknowledgedBlockNumber, true)
+                    .clear();
             metrics.blockAcknowledgementsSent.increment(); // @todo(1415) add label
             LOGGER.log(
                     TRACE,
@@ -268,36 +268,26 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
         if (unacknowledgedStreamedBlocks.remove(blockNumber)) {
             // If the block number that failed verification was sent by this
             // handler, we need to send an EndOfStream with BAD_BLOCK_PROOF code.
-            try {
-                sendEndOfStream(Code.BAD_BLOCK_PROOF);
-                return true;
-            } finally {
-                scheduleShutdown();
-            }
+            endStreamWithCode(Code.BAD_BLOCK_PROOF, false);
+            return true;
         } else {
             return false;
         }
     }
 
-    /// This method must be called when persistence fails for a given block.
-    /// We will attempt to send an [EndOfStream] with a [Code#PERSISTENCE_FAILED] and
-    /// proceed to schedule the handler for shutdown.
-    void handleFailedPersistence() {
+    /// This method must be called when the handler needs to end with a code.
+    /// This includes ending successfully, ending for failed persistence,
+    /// ending a stalled publisher, or various other situations.
+    void endStreamWithCode(final Code codeToSend, boolean immediate) {
         try {
-            LOGGER.log(DEBUG, "[{0}] Handler {1} handling failed persistence", correlationIdPrefix, handlerId);
-            sendEndOfStream(Code.PERSISTENCE_FAILED);
+            LOGGER.log(DEBUG, "[{0}] Handler {1} ending with code {2}", correlationIdPrefix, handlerId, codeToSend);
+            sendEndOfStream(codeToSend);
         } finally {
-            scheduleShutdown();
-        }
-    }
-
-    /// This method is called when the manager is shutting down and needs
-    /// to force all handlers to close their publisher communication channels.
-    void closeCommunication() {
-        try {
-            sendEndOfStream(Code.SUCCESS);
-        } finally {
-            scheduleShutdown();
+            if (immediate) {
+                checkMidBlockAndShutdown(currentStreamingBlockNumber.get());
+            } else {
+                scheduleShutdown();
+            }
         }
     }
 
@@ -346,7 +336,6 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
     /// @return a [PublisherRequestResult] that we must then [PublisherRequestResult#handle()].
     private PublisherRequestResult handleBlockItemsRequest(
             final BlockItemSetUnparsed itemSetUnparsed, final List<BlockItemUnparsed> blockItems) {
-        final PublisherRequestResult result;
         long blockNumber = currentStreamingBlockNumber.get();
         final BlockItemUnparsed first = blockItems.getFirst();
         // every time we receive an item set, we need to check if we have
@@ -365,8 +354,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
                     LOGGER.log(DEBUG, "[{0}] Failed to parse BlockHeader due to {1}", correlationIdPrefix, e);
                     // if we have reached this block, this means that the
                     // request is invalid
-                    result = new SendEndAndShutdownResult(this, Code.INVALID_REQUEST, blockNumber);
-                    return result;
+                    return new SendEndAndShutdownResult(this, Code.INVALID_REQUEST, blockNumber);
                 }
             } else {
                 LOGGER.log(
@@ -375,8 +363,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
                         correlationIdPrefix,
                         handlerId);
                 // this should never happen
-                result = new SendEndAndShutdownResult(this, Code.ERROR, blockNumber);
-                return result;
+                return new SendEndAndShutdownResult(this, Code.ERROR, blockNumber);
             }
             if (isCurrentlyMidBlock(blockNumber) && blockNumber != header.number()) {
                 // If we are in the middle of streaming a block, and we have received a new header,
@@ -392,11 +379,13 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
             currentStreamingBlockNumber.set(blockNumber);
             // this means that we are starting a new block, so we can
             // update the current streaming block number
+            // Note: not surrounding correlationId={3} with [] intentionally as it will break Loki's parsing.
+            final String traceMessage =
+                    "metric-end-to-end-latency-by-block-start block={0,number,#} nsTimestamp={1,number,#} handlerId={2} correlationId={3}";
             currentStreamingBlockHeaderReceivedTime = System.nanoTime();
             LOGGER.log(
                     TRACE,
-                    // Note: not surrounding correlationId={3} with [] intentionally as it will break Loki's parsing.
-                    "metric-end-to-end-latency-by-block-start block={0,number,#} nsTimestamp={1,number,#} handlerId={2} correlationId={3}",
+                    traceMessage,
                     blockNumber,
                     currentStreamingBlockHeaderReceivedTime,
                     handlerId,
@@ -413,8 +402,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
                     "[{0}] Handler {1} dropping batch because first block item is not BlockHeader",
                     correlationIdPrefix,
                     handlerId);
-            result = new ContinueResult(this);
-            return result;
+            return new ContinueResult(this);
         }
         // now we need to query the manager with the block number currently
         // being streamed, we will receive a response that will tell us
@@ -427,7 +415,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
         final BlockAction actionFromPublisher =
                 publisherManager.getActionForBlock(blockNumber, blockAction.get(), handlerId);
         blockAction.set(actionFromPublisher);
-        result = switch (actionFromPublisher) {
+        return switch (actionFromPublisher) {
             case ACCEPT -> handleAccept(blockNumber, requestContainsHeader, itemSetUnparsed);
             case SKIP -> handleSkip(blockNumber);
             case RESEND -> {
@@ -443,7 +431,6 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
                 yield handleEndError(DEBUG, errorMessage, correlationIdPrefix, handlerId, actionFromPublisher);
             }
         };
-        return result;
     }
 
     /// todo(1420) add documentation
@@ -610,9 +597,10 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
             long start = System.nanoTime();
             replies.onNext(response);
             long duration = System.nanoTime() - start;
+            final String entryMessage = "[{0}] Handler {1} replies.onNext took {2,number,#} ns to send {3}";
             LOGGER.log(
                     DEBUG,
-                    "[{0}] Handler {1} replies.onNext took {2,number,#} ns to send {3}",
+                    entryMessage,
                     correlationIdPrefix,
                     handlerId,
                     duration,
@@ -623,9 +611,9 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
             // at debug rather than emitting noise in the logs.
             // Also, this confuses everyone, they all see this debug log and
             // assume the node crashed, so we must not print a stack trace.
+            final String messageFormat = "[%3$s] Publisher closed the connection unexpectedly for client %1$d: %2$s";
             final String exceptionMessage = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
-            final String message = "[%3$s] Publisher closed the connection unexpectedly for client %1$d: %2$s"
-                    .formatted(handlerId, exceptionMessage, correlationIdPrefix);
+            final String message = messageFormat.formatted(handlerId, exceptionMessage, correlationIdPrefix);
             LOGGER.log(DEBUG, message, e);
             metrics.sendResponseFailed.increment(); // @todo(1415) add label
             return false;
@@ -716,6 +704,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
         LOGGER.log(logLevel, errorMessage, errorMessageParams);
         // If the action is END_ERROR, we need to send an end of stream
         // response to the publisher and not propagate the items.
+        // SendEndAndShutdownResult sends the end of stream when handled.
         metrics.streamErrors.increment(); // @todo(1415) add label
         return new SendEndAndShutdownResult(this, Code.ERROR, currentStreamingBlockNumber.get());
     }
@@ -731,6 +720,12 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
     /// </pre>
     private PublisherRequestResult handleEndStream(final Level logLevel, final String message) {
         LOGGER.log(logLevel, "[{0}] {1}", correlationIdPrefix, message);
+        final long blockInProgress = currentStreamingBlockNumber.get();
+        if (isCurrentlyMidBlock(blockInProgress)) {
+            // This should generally not happen, we expect an end stream request
+            // from a publisher after it has completely streamed a full block.
+            publisherManager.blockIsEnding(blockInProgress, handlerId);
+        }
         metrics.endStreamsReceived.increment();
         return new ShutdownResult(this, currentStreamingBlockNumber.get());
     }
@@ -801,7 +796,8 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
     /// [#currentStreamingBlockNumber] value.
     private boolean isCurrentlyMidBlock(final long blockInProgress) {
         if (blockInProgress != currentStreamingBlockNumber.get()) {
-            LOGGER.log(DEBUG, "[{0}] Ending mid block, but block number does not match.", correlationIdPrefix);
+            final String message = "[{0}] Streaming check for mid block, but block number does not match.";
+            LOGGER.log(DEBUG, message, correlationIdPrefix);
         }
         return blockInProgress > UNKNOWN_BLOCK_NUMBER && currentBlockQueue.get() != null;
     }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
@@ -89,6 +89,8 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
     public static final MetricKey<LongGauge> METRIC_PUBLISHER_LATEST_BLOCK_NUMBER_ACKNOWLEDGED = MetricKey.of(
                     "publisher_latest_block_number_acknowledged", LongGauge.class)
             .addCategory(METRICS_CATEGORY);
+    public static final MetricKey<LongCounter> METRIC_PUBLISHER_STALL_TIMEOUTS_SENT =
+            MetricKey.of("publisher_stall_timeouts_sent", LongCounter.class).addCategory(METRICS_CATEGORY);
 
     /// The logger for this class.
     private static final System.Logger LOGGER = System.getLogger(StreamPublisherPlugin.class.getName());

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.endThisBlock;
+import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.sendHeaderOnly;
 
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
@@ -2123,7 +2124,7 @@ class LiveStreamPublisherManagerTest {
             }
         }
 
-        /// Tests for [LiveStreamPublisherManager#addHandler(PublisherHandler.MetricsHolder)].
+        /// Tests for [LiveStreamPublisherManager#addHandler].
         @Nested
         @DisplayName("addHandler() Tests")
         class AddHandlerTests {
@@ -2144,7 +2145,7 @@ class LiveStreamPublisherManagerTest {
             }
 
             /// This test aims to assert that registering a new handler
-            /// via [LiveStreamPublisherManager#addHandler(PublisherHandler.MetricsHolder)]
+            /// via [LiveStreamPublisherManager#addHandler]
             /// will fire a [PublisherStatusUpdateNotification]
             /// indicating that a new publisher has connected.
             @Test
@@ -2168,7 +2169,7 @@ class LiveStreamPublisherManagerTest {
             }
 
             /// This test aims to assert that registering a new handler
-            /// via [LiveStreamPublisherManager#addHandler(PublisherHandler.MetricsHolder)]
+            /// via [LiveStreamPublisherManager#addHandler]
             /// will update the current active publishers count metric.
             @Test
             @DisplayName("addHandler() updates the current active publishers count metric")
@@ -2308,6 +2309,257 @@ class LiveStreamPublisherManagerTest {
                 assertThat(actionForBlock)
                         .returns(BlockAction.RESEND, ActionForBlock::action)
                         .returns(blockThatFailsVerification.number(), ActionForBlock::blockNumber);
+            }
+        }
+
+        /// Tests for stall detection via [LiveStreamPublisherManager#checkForStalledHandlers].
+        @Nested
+        @DisplayName("StallDetection Tests")
+        class StallDetectionTests {
+
+            /// A handler holding ACCEPT for a block and completing it normally
+            /// (single handler) must never trigger stall detection.
+            @Test
+            @DisplayName("no stall detected when only one handler is connected")
+            void testNoStallWithSingleHandler() {
+                // Remove second handler so only handler 1 is connected.
+                toTest.removeHandler(publisherHandlerId2);
+                // Stream and complete blocks 0-3 via handler 1 alone.
+                for (long block = 0L; block <= 3L; block++) {
+                    final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
+                            .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
+                                    .asItemSetUnparsed())
+                            .build();
+                    publisherHandler.onNext(req);
+                    endThisBlock(publisherHandler, block);
+                }
+                // No EndStream(TIMEOUT) should have been sent.
+                assertThat(responsePipeline.getOnNextCalls())
+                        .as("single handler should never receive EndStream(TIMEOUT)")
+                        .noneMatch(r -> r.response().kind() == PublishStreamResponse.ResponseOneOfType.END_STREAM);
+                assertThat(responsePipeline.getOnCompleteCalls().get())
+                        .as("single handler should not be shut down by stall detection")
+                        .isZero();
+            }
+
+            /// Handler 2 completing block N+2 must NOT fire stall detection;
+            /// only completing a block strictly greater than N+2 fires it.
+            @Test
+            @DisplayName("no stall when completed block equals stalled + 2 (threshold boundary)")
+            void testNoStallWhenThresholdNotMet() {
+                // Handler 1 sends only the header for block 0 — goes silent.
+                sendHeaderOnly(publisherHandler, 0L);
+                // Handler 2 streams and completes block 1 (SKIP for 0, ACCEPT for 1).
+                final PublishStreamRequestUnparsed block1Req = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(TestBlockBuilder.generateBlockWithNumber(1L).asItemSetUnparsed())
+                        .build();
+                publisherHandler2.onNext(block1Req);
+                endThisBlock(publisherHandler2, 1L);
+                // Handler 2 completes block 2: 2 == 0+2, NOT strictly greater — no stall yet.
+                final PublishStreamRequestUnparsed block2Req = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(TestBlockBuilder.generateBlockWithNumber(2L).asItemSetUnparsed())
+                        .build();
+                publisherHandler2.onNext(block2Req);
+                endThisBlock(publisherHandler2, 2L);
+                assertThat(responsePipeline.getOnNextCalls())
+                        .as("completing block 2 (== 0+2) must not trigger stall detection")
+                        .noneMatch(r -> r.response().kind() == PublishStreamResponse.ResponseOneOfType.END_STREAM);
+                assertThat(responsePipeline.getOnCompleteCalls().get()).isZero();
+                // Handler 2 completes block 3: 3 > 0+2 — stall MUST fire now.
+                final PublishStreamRequestUnparsed block3Req = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(TestBlockBuilder.generateBlockWithNumber(3L).asItemSetUnparsed())
+                        .build();
+                publisherHandler2.onNext(block3Req);
+                endThisBlock(publisherHandler2, 3L);
+                assertThat(responsePipeline.getOnNextCalls())
+                        .as("completing block 3 (> 0+2) must trigger EndStream(TIMEOUT) on handler 1")
+                        .anySatisfy(r -> {
+                            assertThat(r.response().kind())
+                                    .isEqualTo(PublishStreamResponse.ResponseOneOfType.END_STREAM);
+                            assertThat(r.endStream().status())
+                                    .isEqualTo(PublishStreamResponse.EndOfStream.Code.TIMEOUT);
+                        });
+                assertThat(responsePipeline.getOnCompleteCalls().get())
+                        .as("stalled handler 1 must be shut down")
+                        .isEqualTo(1);
+            }
+
+            /// Basic stall detection: handler 1 sends only a header for block 0
+            /// then goes silent; handler 2 completes block 3.
+            @Test
+            @DisplayName("stall detected and EndStream(TIMEOUT) sent when ACCEPT winner goes silent")
+            void testStallDetectedAndEndStreamSent() {
+                // Handler 1 sends header only for block 0.
+                sendHeaderOnly(publisherHandler, 0L);
+                // Handler 2 is SKIPped for 0, then completes blocks 1, 2, 3.
+                for (long block = 1L; block <= 3L; block++) {
+                    final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
+                            .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
+                                    .asItemSetUnparsed())
+                            .build();
+                    publisherHandler2.onNext(req);
+                    endThisBlock(publisherHandler2, block);
+                }
+                // Handler 1 must have received EndStream(TIMEOUT) and been shut down.
+                assertThat(responsePipeline.getOnNextCalls())
+                        .as("stalled handler 1 must receive EndStream(TIMEOUT)")
+                        .anySatisfy(r -> {
+                            assertThat(r.response().kind())
+                                    .isEqualTo(PublishStreamResponse.ResponseOneOfType.END_STREAM);
+                            assertThat(r.endStream().status())
+                                    .isEqualTo(PublishStreamResponse.EndOfStream.Code.TIMEOUT);
+                        });
+                assertThat(responsePipeline.getOnCompleteCalls().get())
+                        .as("stalled handler 1 must be shut down after stall")
+                        .isEqualTo(1);
+            }
+
+            /// When the stalled handler disconnects before stall detection fires,
+            /// block-is-ending adds block 0 to blocksToResend via the drop path.
+            /// Stall detection should find no queue entry and be a no-op — no
+            /// double action, no extra metric increment.
+            @Test
+            @DisplayName("stall action is a no-op when ACCEPT winner already disconnected")
+            void testStalledHandlerAlreadyDisconnectedBeforeAction() {
+                // Handler 1 sends header only then disconnects (clientEndStreamReceived).
+                sendHeaderOnly(publisherHandler, 0L);
+                publisherHandler.clientEndStreamReceived();
+                // Clear pipeline noise from the disconnect itself.
+                responsePipeline.clear();
+                // Handler 2 completes blocks 1, 2, 3 — would trigger stall but block 0
+                // queue is already gone.
+                for (long block = 1L; block <= 3L; block++) {
+                    final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
+                            .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
+                                    .asItemSetUnparsed())
+                            .build();
+                    publisherHandler2.onNext(req);
+                    endThisBlock(publisherHandler2, block);
+                }
+                // No EndStream(TIMEOUT) should be sent (handler 1 already gone).
+                assertThat(responsePipeline.getOnNextCalls())
+                        .as("no extra EndStream(TIMEOUT) when handler already disconnected")
+                        .noneMatch(r -> r.response().kind() == PublishStreamResponse.ResponseOneOfType.END_STREAM);
+                // No additional shutdown on handler 1 pipeline.
+                assertThat(responsePipeline.getOnCompleteCalls().get())
+                        .as("no extra onComplete when handler already disconnected")
+                        .isZero();
+            }
+
+            /// If the ACCEPT winner finishes its block before stall detection fires,
+            /// the entry is already removed from acceptWinnerByBlock at endOfBlock time;
+            /// no EndStream(TIMEOUT) should be sent.
+            @Test
+            @DisplayName("no stall when ACCEPT winner completes block before threshold is reached")
+            void testStalledHandlerCompletesBeforeActionExecutes() {
+                // Handler 1 streams and fully completes block 0.
+                final PublishStreamRequestUnparsed block0Req = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(TestBlockBuilder.generateBlockWithNumber(0L).asItemSetUnparsed())
+                        .build();
+                publisherHandler.onNext(block0Req);
+                endThisBlock(publisherHandler, 0L);
+                // Handler 2 then completes blocks 1, 2, 3 — but block 0 is already done.
+                for (long block = 1L; block <= 3L; block++) {
+                    final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
+                            .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
+                                    .asItemSetUnparsed())
+                            .build();
+                    publisherHandler2.onNext(req);
+                    endThisBlock(publisherHandler2, block);
+                }
+                // Handler 1 must not have received EndStream(TIMEOUT).
+                assertThat(responsePipeline.getOnNextCalls())
+                        .as("completed handler 1 must not receive EndStream(TIMEOUT)")
+                        .noneMatch(r -> r.response().kind() == PublishStreamResponse.ResponseOneOfType.END_STREAM);
+                assertThat(responsePipeline.getOnCompleteCalls().get())
+                        .as("handler 1 should not be shut down by stall detection")
+                        .isZero();
+            }
+
+            /// When two handlers are simultaneously stalled, a single completing
+            /// handler that is far enough ahead must terminate both.
+            @Test
+            @DisplayName("all stalled handlers are terminated when multiple are stalled simultaneously")
+            void testMultipleStalledHandlersAllTerminated() {
+                // Add a third handler.
+                final TestResponsePipeline<PublishStreamResponse> responsePipeline3 = new TestResponsePipeline<>();
+                final PublisherHandler publisherHandler3 =
+                        toTest.addHandler(responsePipeline3, sharedHandlerMetrics, "testID");
+                // Handler 1 wins ACCEPT for block 0 — sends header only.
+                sendHeaderOnly(publisherHandler, 0L);
+                // Handler 2 wins ACCEPT for block 1 — sends header only.
+                sendHeaderOnly(publisherHandler2, 1L);
+                // Handler 3 completes block 4: 4 > 0+2 AND 4 > 1+2 — both stalled.
+                for (long block = 2L; block <= 4L; block++) {
+                    final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
+                            .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
+                                    .asItemSetUnparsed())
+                            .build();
+                    publisherHandler3.onNext(req);
+                    endThisBlock(publisherHandler3, block);
+                }
+                // Both handler 1 and handler 2 must have received EndStream(TIMEOUT).
+                assertThat(responsePipeline.getOnNextCalls())
+                        .as("stalled handler 1 must receive EndStream(TIMEOUT)")
+                        .anySatisfy(r -> {
+                            assertThat(r.response().kind())
+                                    .isEqualTo(PublishStreamResponse.ResponseOneOfType.END_STREAM);
+                            assertThat(r.endStream().status())
+                                    .isEqualTo(PublishStreamResponse.EndOfStream.Code.TIMEOUT);
+                        });
+                assertThat(responsePipeline.getOnCompleteCalls().get())
+                        .as("stalled handler 1 must be shut down")
+                        .isEqualTo(1);
+                assertThat(responsePipeline2.getOnNextCalls())
+                        .as("stalled handler 2 must receive EndStream(TIMEOUT)")
+                        .anySatisfy(r -> {
+                            assertThat(r.response().kind())
+                                    .isEqualTo(PublishStreamResponse.ResponseOneOfType.END_STREAM);
+                            assertThat(r.endStream().status())
+                                    .isEqualTo(PublishStreamResponse.EndOfStream.Code.TIMEOUT);
+                        });
+                assertThat(responsePipeline2.getOnCompleteCalls().get())
+                        .as("stalled handler 2 must be shut down")
+                        .isEqualTo(1);
+            }
+
+            /// After stall detection fires and block 0 is added to blocksToResend,
+            /// the next endOfBlock from handler 2 must deliver ResendBlock(0) back
+            /// to handler 2's publisher so it can take over.
+            @Test
+            @DisplayName("ResendBlock delivered at next endOfBlock after stall detection")
+            void testResendDeliveredAtNextEndOfBlock() {
+                // Handler 1 sends header only for block 0 — stalls.
+                sendHeaderOnly(publisherHandler, 0L);
+                // Handler 2 completes blocks 1, 2, 3 — triggers stall on block 3.
+                for (long block = 1L; block <= 3L; block++) {
+                    final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
+                            .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
+                                    .asItemSetUnparsed())
+                            .build();
+                    publisherHandler2.onNext(req);
+                    endThisBlock(publisherHandler2, block);
+                }
+                // Stall must have fired — handler 1 terminated.
+                assertThat(responsePipeline.getOnCompleteCalls().get())
+                        .as("handler 1 must be shut down by stall detection before checking resend")
+                        .isEqualTo(1);
+                // Clear pipeline 2 noise (SKIP responses for blocks 0-2).
+                responsePipeline2.clear();
+                // Handler 2 now streams block 4; its endOfBlock must return ResendBlock(0).
+                final PublishStreamRequestUnparsed block4Req = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(TestBlockBuilder.generateBlockWithNumber(4L).asItemSetUnparsed())
+                        .build();
+                publisherHandler2.onNext(block4Req);
+                endThisBlock(publisherHandler2, 4L);
+                // Handler 2 must have received a ResendBlock(0) response.
+                assertThat(responsePipeline2.getOnNextCalls())
+                        .as("handler 2 must receive ResendBlock(0) at next endOfBlock after stall")
+                        .anySatisfy(r -> {
+                            assertThat(r.response().kind())
+                                    .isEqualTo(PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK);
+                            assertThat(r.resendBlock().blockNumber()).isEqualTo(0L);
+                        });
             }
         }
     }

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherHandlerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherHandlerTest.java
@@ -218,8 +218,9 @@ class PublisherHandlerTest {
 
             // Triggers a DEBUG log: "Handler {0} handling failed verification for block {1}"
             handler.handleFailedVerification(10L);
-            // Triggers a DEBUG log: "Handler {0} handling failed persistence"
-            handler.handleFailedPersistence();
+            // FLAKEY WARNING - Tests that rely on log output are rarely reliable.
+            // Triggers a DEBUG log: "[{0}] Handler {1} ending with code {2}"
+            handler.endStreamWithCode(Code.PERSISTENCE_FAILED, false);
 
             final long prefixedCount = logHandler.getLogMessages().stream()
                     .filter(msg -> msg.startsWith("[" + TEST_CORRELATION_ID + "] "))


### PR DESCRIPTION
## Reviewer Notes
* Added detection based on "future" completed block count
   * This is a constant difference for now, will replace with configuration soon
* Added handler reset/end when its publisher is detected as stalled
* Added tests for the new functionality
* Added a new metric to track stall events

## Related Issue(s)
 Resolves #1841
