### PR TITLE
fix(verification): disable allBlocksHasher by default and add missing docs for VerificationPlugin.

### DIFF
--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationConfig.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationConfig.java
@@ -21,7 +21,7 @@ import org.hiero.block.node.base.Loggable;
 @ConfigData("verification")
 public record VerificationConfig(
         @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/verification/rootHashOfAllPreviousBlocks.bin") Path allBlocksHasherFilePath,
-        @Loggable @ConfigProperty(defaultValue = "true") boolean allBlocksHasherEnabled,
+        @Loggable @ConfigProperty(defaultValue = "false") boolean allBlocksHasherEnabled,
         @Loggable @ConfigProperty(defaultValue = "10") int allBlocksHasherPersistenceInterval,
         @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/verification/tss-parameters.bin") Path tssParametersFilePath) {}
 

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -186,12 +186,12 @@ Currently, no specific options.
 
 ### Verification Plugin Configuration
 
-| ENV Variable                                    | Description                                                            |                                                           Default |
-|:------------------------------------------------|:-----------------------------------------------------------------------|------------------------------------------------------------------:|
-| VERIFICATION_ALL_BLOCKS_HASHER_ENABLED          | Enable the all-blocks hasher to compute and verify a rolling root hash. |                                                             false |
-| VERIFICATION_ALL_BLOCKS_HASHER_FILE_PATH        | Path to the persisted root hash file for all previous blocks.          | /opt/hiero/block-node/verification/rootHashOfAllPreviousBlocks.bin |
-| VERIFICATION_ALL_BLOCKS_HASHER_PERSISTENCE_INTERVAL | How often (in blocks) the hasher persists its state to disk.       |                                                                10 |
-| VERIFICATION_TSS_PARAMETERS_FILE_PATH           | Path to the persisted TSS parameters file (ledger ID, address book, WRAPS VK). | /opt/hiero/block-node/verification/tss-parameters.bin |
+| ENV Variable                                        | Description                                                                    |                                                            Default |
+|:----------------------------------------------------|:-------------------------------------------------------------------------------|-------------------------------------------------------------------:|
+| VERIFICATION_ALL_BLOCKS_HASHER_ENABLED              | Enable the all-blocks hasher to compute and verify a rolling root hash.        |                                                              false |
+| VERIFICATION_ALL_BLOCKS_HASHER_FILE_PATH            | Path to the persisted root hash file for all previous blocks.                  | /opt/hiero/block-node/verification/rootHashOfAllPreviousBlocks.bin |
+| VERIFICATION_ALL_BLOCKS_HASHER_PERSISTENCE_INTERVAL | How often (in blocks) the hasher persists its state to disk.                   |                                                                 10 |
+| VERIFICATION_TSS_PARAMETERS_FILE_PATH               | Path to the persisted TSS parameters file (ledger ID, address book, WRAPS VK). |              /opt/hiero/block-node/verification/tss-parameters.bin |
 
 > **Note:** `VERIFICATION_ALL_BLOCKS_HASHER_ENABLED` must remain `false` (the default).
 > The all-blocks hasher requires a strictly sequential block stream; out-of-order or

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -186,4 +186,13 @@ Currently, no specific options.
 
 ### Verification Plugin Configuration
 
-Currently, no specific options.
+| ENV Variable                                    | Description                                                            |                                                           Default |
+|:------------------------------------------------|:-----------------------------------------------------------------------|------------------------------------------------------------------:|
+| VERIFICATION_ALL_BLOCKS_HASHER_ENABLED          | Enable the all-blocks hasher to compute and verify a rolling root hash. |                                                             false |
+| VERIFICATION_ALL_BLOCKS_HASHER_FILE_PATH        | Path to the persisted root hash file for all previous blocks.          | /opt/hiero/block-node/verification/rootHashOfAllPreviousBlocks.bin |
+| VERIFICATION_ALL_BLOCKS_HASHER_PERSISTENCE_INTERVAL | How often (in blocks) the hasher persists its state to disk.       |                                                                10 |
+| VERIFICATION_TSS_PARAMETERS_FILE_PATH           | Path to the persisted TSS parameters file (ledger ID, address book, WRAPS VK). | /opt/hiero/block-node/verification/tss-parameters.bin |
+
+> **Note:** `VERIFICATION_ALL_BLOCKS_HASHER_ENABLED` must remain `false` (the default).
+> The all-blocks hasher requires a strictly sequential block stream; out-of-order or
+> forward-arriving blocks will cause it to fall out of sync and produce incorrect root hashes.


### PR DESCRIPTION
## Summary

- Change `allBlocksHasherEnabled` default from `true` to `false` — the hasher requires a strictly sequential block stream, and out-of-order or forward-arriving blocks cause it to fall out of sync and produce incorrect root hashes
- Add Verification Plugin Configuration section to `configuration.md` documenting all four `VERIFICATION_*` env vars with a note explaining why the hasher must remain disabled

Fixes #2628 