### PR TITLE
chore: Address outstanding feedback on PR 2631

### DIFF
--- a/block-node/roster-bootstrap-rsa/README.md
+++ b/block-node/roster-bootstrap-rsa/README.md
@@ -23,25 +23,24 @@ the roster cannot be loaded.
 
 ## How it works
 
-1. **File-first:** On startup the application state facility checks for a local bootstrap file at the configured path
-   (default `data/config/rsa-bootstrap-roster.pb`). If found, the roster is loaded from that file.
-2. **Mirror Node fallback:** If no local file is present, the roster is fetched from the Hedera
-   Mirror Node REST API (`GET /api/v1/network/nodes`, paginated). The result is written to the
-   bootstrap file for future restarts.
-3. **Fail fast:** If neither source succeeds startup is aborted with a clear error message.
+1. **File-first:** On startup `BlockNodeApp.loadApplicationState()` checks for a local bootstrap file at
+   `app.state.rsaBootstrapFilePath` (default `/opt/hiero/block-node/node/rsa-bootstrap-roster.json`). If found,
+   the roster is parsed and made available in `BlockNodeContext` before any plugin is started.
+2. **Mirror Node fallback:** If no local file is present, the plugin queries the Hedera Mirror Node REST API
+   (`GET /api/v1/network/nodes`, paginated, `order=desc`). The result is written to the bootstrap file via
+   `ApplicationStateFacility.updateAddressBook()` for future restarts.
+3. **Fail fast on Mirror Node error:** If `roster.bootstrap.rsa.mirrorNodeBaseUrl` is configured but the Mirror Node
+   is unreachable after 3 retries, startup is aborted with a clear error log. If `mirrorNodeBaseUrl` is left blank
+   and no file is present, a WARNING is logged and the plugin exits without failing startup.
 4. **No runtime reload:** The roster is loaded once and does not change for the lifetime of the
    BN instance. An address-book change requires a restart with a refreshed bootstrap file.
-5. **Status endpoint exposure:** The loaded `NodeAddressBook` is included in `ServerStatusDetailResponse` returned by
-   `BlockNodeService.serverStatusDetail()` (field 4). Callers can retrieve the full list of node ID + RSA public key
-   entries without restarting the BN.
 
 ---
 
 ## Bootstrap file format
 
-The bootstrap file is a **binary protobuf serialization** of the `NodeAddressBook` message from
-`basic_types.proto` (`hiero-consensus-node`). This reuses the on-chain address book format used for
-Hedera file `0.0.102`, avoiding a bespoke schema.
+The bootstrap file is a **JSON serialization** of the `NodeAddressBook` protobuf message from
+`basic_types.proto` (`hiero-consensus-node`), written and read via `NodeAddressBook.JSON`.
 
 Only two fields from each `NodeAddress` entry are populated:
 
@@ -50,32 +49,38 @@ Only two fields from each `NodeAddress` entry are populated:
 | `nodeId`     | 5             | `int64`  | Numeric node identifier                                       |
 | `RSA_PubKey` | 4             | `string` | Raw hex-encoded DER X.509 RSA public key — **no** `0x` prefix |
 
-No metadata fields (network name, generation timestamp, schema version) are embedded; the file is
-a direct binary protobuf of `NodeAddressBook`. Operators wishing to annotate the file should
-maintain a separate sidecar.
+No metadata fields (network name, generation timestamp, schema version) are embedded.
+Operators wishing to annotate the file should maintain a separate sidecar.
 
-**Default file path:** `data/config/rsa-bootstrap-roster.pb`
+**Default file path:** `/opt/hiero/block-node/node/rsa-bootstrap-roster.json`
+(Configured via `app.state.rsaBootstrapFilePath`.)
 
 Generate this file before Phase 2a cutover using the operator script:
 
 ```bash
 tools-and-tests/scripts/node-operations/generate-roster-bootstrap.sh \
   --network mainnet \
-  --output data/config/rsa-bootstrap-roster.pb
+  --output /opt/hiero/block-node/node/rsa-bootstrap-roster.json
 ```
 
 ---
 
 ## Configuration
 
-|                      Property                       |                    Default                     |                        Description                        |
-|-----------------------------------------------------|------------------------------------------------|-----------------------------------------------------------|
-| `roster.bootstrap.enabled`                          | `true`                                         | Enable/disable the plugin.                                |
-| `roster.bootstrap.filePath`                         | `data/config/rsa-bootstrap-rosterp.pb`         | Path to the local bootstrap file (binary protobuf).       |
-| `roster.bootstrap.mirrorNode.baseUrl`               | `https://testnet-public.mirrornode.hedera.com` | Mirror Node base URL.                                     |
-| `roster.bootstrap.mirrorNode.connectTimeoutSeconds` | `5`                                            | Connect timeout for Mirror Node calls.                    |
-| `roster.bootstrap.mirrorNode.readTimeoutSeconds`    | `10`                                           | Read timeout for Mirror Node calls.                       |
-| `roster.bootstrap.mirrorNode.pageSize`              | `100`                                          | Nodes per page for paginated Mirror Node calls (max 100). |
+Bootstrap file path is configured in the `app.state` namespace (shared with other application state):
+
+|                Property                 |                           Default                            |                                     Description                                      |
+|-----------------------------------------|--------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| `app.state.rsaBootstrapFilePath`        | `/opt/hiero/block-node/node/rsa-bootstrap-roster.json`       | Path to the local bootstrap file (JSON-serialized `NodeAddressBook`).                |
+
+Mirror Node fallback is configured in the `roster.bootstrap.rsa` namespace:
+
+|                         Property                          | Default |                        Description                        |
+|-----------------------------------------------------------|---------|-----------------------------------------------------------|
+| `roster.bootstrap.rsa.mirrorNodeBaseUrl`                  | *(blank)* | Mirror Node base URL. Leave blank to disable MN fallback. |
+| `roster.bootstrap.rsa.mirrorNodeConnectTimeoutSeconds`    | `5`     | TCP connect timeout for Mirror Node calls.                |
+| `roster.bootstrap.rsa.mirrorNodeReadTimeoutSeconds`       | `10`    | Read timeout per Mirror Node request.                     |
+| `roster.bootstrap.rsa.mirrorNodePageSize`                 | `100`   | Nodes per page for paginated Mirror Node calls (max 100). |
 
 ---
 
@@ -83,8 +88,8 @@ tools-and-tests/scripts/node-operations/generate-roster-bootstrap.sh \
 
 This plugin parallels `RosterBootstrapTssPlugin` in structure. Both plugins:
 
-- Implement `BlockNodePlugin` and perform all work in `init()`.
-- Use a binary protobuf bootstrap file in `data/config/` managed by Application State Facility.
+- Implement `BlockNodePlugin` and perform all work in `start()`.
+- Use a JSON bootstrap file under the path configured in `app.state` managed by Application State Facility.
 - Populate a field on `BlockNodeContext` for downstream consumers.
 
 The RSA roster plugin handles Phase 2a verification. The TSS bootstrap plugin handles Phase 2b
@@ -97,6 +102,6 @@ transition window.
 
 |                                Ticket                                 |                                                                   Work                                                                   |
 |-----------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
-| [#2561](https://github.com/hiero-ledger/hiero-block-node/issues/2561) | Implement `RsaRosterBootstrapPlugin`, `MirrorNodeRosterSource`, `BootstrapRosterConfig`, and extend `BlockNodeContext` with `RsaRoster`. |
+| [#2561](https://github.com/hiero-ledger/hiero-block-node/issues/2561) | Implement `RsaRosterBootstrapPlugin` and `RsaRosterBootstrapConfig`; extend `ApplicationStateFacility` with `updateAddressBook()` and `BlockNodeContext` with `nodeAddressBook()`. |
 | [#2562](https://github.com/hiero-ledger/hiero-block-node/issues/2562) | Implement RSA `SignedRecordFileProof` verification in `BlockVerificationService`.                                                        |
 | [#2660](https://github.com/hiero-ledger/hiero-block-node/issues/2660) | Implement `generate-roster-bootstrap.sh` operator script and Phase 2a cutover runbook.                                                   |

--- a/block-node/roster-bootstrap-rsa/README.md
+++ b/block-node/roster-bootstrap-rsa/README.md
@@ -69,18 +69,18 @@ tools-and-tests/scripts/node-operations/generate-roster-bootstrap.sh \
 
 Bootstrap file path is configured in the `app.state` namespace (shared with other application state):
 
-|                Property                 |                           Default                            |                                     Description                                      |
-|-----------------------------------------|--------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| `app.state.rsaBootstrapFilePath`        | `/opt/hiero/block-node/node/rsa-bootstrap-roster.json`       | Path to the local bootstrap file (JSON-serialized `NodeAddressBook`).                |
+|             Property             |                        Default                         |                              Description                              |
+|----------------------------------|--------------------------------------------------------|-----------------------------------------------------------------------|
+| `app.state.rsaBootstrapFilePath` | `/opt/hiero/block-node/node/rsa-bootstrap-roster.json` | Path to the local bootstrap file (JSON-serialized `NodeAddressBook`). |
 
 Mirror Node fallback is configured in the `roster.bootstrap.rsa` namespace:
 
-|                         Property                          | Default |                        Description                        |
-|-----------------------------------------------------------|---------|-----------------------------------------------------------|
-| `roster.bootstrap.rsa.mirrorNodeBaseUrl`                  | *(blank)* | Mirror Node base URL. Leave blank to disable MN fallback. |
-| `roster.bootstrap.rsa.mirrorNodeConnectTimeoutSeconds`    | `5`     | TCP connect timeout for Mirror Node calls.                |
-| `roster.bootstrap.rsa.mirrorNodeReadTimeoutSeconds`       | `10`    | Read timeout per Mirror Node request.                     |
-| `roster.bootstrap.rsa.mirrorNodePageSize`                 | `100`   | Nodes per page for paginated Mirror Node calls (max 100). |
+|                        Property                        |  Default  |                        Description                        |
+|--------------------------------------------------------|-----------|-----------------------------------------------------------|
+| `roster.bootstrap.rsa.mirrorNodeBaseUrl`               | *(blank)* | Mirror Node base URL. Leave blank to disable MN fallback. |
+| `roster.bootstrap.rsa.mirrorNodeConnectTimeoutSeconds` | `5`       | TCP connect timeout for Mirror Node calls.                |
+| `roster.bootstrap.rsa.mirrorNodeReadTimeoutSeconds`    | `10`      | Read timeout per Mirror Node request.                     |
+| `roster.bootstrap.rsa.mirrorNodePageSize`              | `100`     | Nodes per page for paginated Mirror Node calls (max 100). |
 
 ---
 
@@ -100,8 +100,8 @@ transition window.
 
 ## Follow-on tickets
 
-|                                Ticket                                 |                                                                   Work                                                                   |
-|-----------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+|                                Ticket                                 |                                                                                        Work                                                                                        |
+|-----------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [#2561](https://github.com/hiero-ledger/hiero-block-node/issues/2561) | Implement `RsaRosterBootstrapPlugin` and `RsaRosterBootstrapConfig`; extend `ApplicationStateFacility` with `updateAddressBook()` and `BlockNodeContext` with `nodeAddressBook()`. |
-| [#2562](https://github.com/hiero-ledger/hiero-block-node/issues/2562) | Implement RSA `SignedRecordFileProof` verification in `BlockVerificationService`.                                                        |
-| [#2660](https://github.com/hiero-ledger/hiero-block-node/issues/2660) | Implement `generate-roster-bootstrap.sh` operator script and Phase 2a cutover runbook.                                                   |
+| [#2562](https://github.com/hiero-ledger/hiero-block-node/issues/2562) | Implement RSA `SignedRecordFileProof` verification in `BlockVerificationService`.                                                                                                  |
+| [#2660](https://github.com/hiero-ledger/hiero-block-node/issues/2660) | Implement `generate-roster-bootstrap.sh` operator script and Phase 2a cutover runbook.                                                                                             |

--- a/block-node/roster-bootstrap-rsa/README.md
+++ b/block-node/roster-bootstrap-rsa/README.md
@@ -23,7 +23,7 @@ the roster cannot be loaded.
 
 ## How it works
 
-1. **File-first:** On startup the plugin checks for a local bootstrap file at the configured path
+1. **File-first:** On startup the application state facility checks for a local bootstrap file at the configured path
    (default `data/config/rsa-bootstrap-roster.pb`). If found, the roster is loaded from that file.
 2. **Mirror Node fallback:** If no local file is present, the roster is fetched from the Hedera
    Mirror Node REST API (`GET /api/v1/network/nodes`, paginated). The result is written to the
@@ -31,14 +31,17 @@ the roster cannot be loaded.
 3. **Fail fast:** If neither source succeeds startup is aborted with a clear error message.
 4. **No runtime reload:** The roster is loaded once and does not change for the lifetime of the
    BN instance. An address-book change requires a restart with a refreshed bootstrap file.
+5. **Status endpoint exposure:** The loaded `NodeAddressBook` is included in `ServerStatusDetailResponse` returned by
+   `BlockNodeService.serverStatusDetail()` (field 4). Callers can retrieve the full list of node ID + RSA public key
+   entries without restarting the BN.
 
 ---
 
 ## Bootstrap file format
 
 The bootstrap file is a **binary protobuf serialization** of the `NodeAddressBook` message from
-`basic_types.proto` (`hiero-consensus-node`). This reuses the on-chain address book format stored
-at Hedera file `0.0.102`, avoiding a bespoke schema.
+`basic_types.proto` (`hiero-consensus-node`). This reuses the on-chain address book format used for
+Hedera file `0.0.102`, avoiding a bespoke schema.
 
 Only two fields from each `NodeAddress` entry are populated:
 
@@ -76,12 +79,12 @@ tools-and-tests/scripts/node-operations/generate-roster-bootstrap.sh \
 
 ---
 
-## Relationship to `TssBootstrapPlugin`
+## Relationship to `RosterBootstrapTssPlugin`
 
-This plugin parallels `TssBootstrapPlugin` in structure. Both plugins:
+This plugin parallels `RosterBootstrapTssPlugin` in structure. Both plugins:
 
 - Implement `BlockNodePlugin` and perform all work in `init()`.
-- Use a binary protobuf bootstrap file in `data/config/`.
+- Use a binary protobuf bootstrap file in `data/config/` managed by Application State Facility.
 - Populate a field on `BlockNodeContext` for downstream consumers.
 
 The RSA roster plugin handles Phase 2a verification. The TSS bootstrap plugin handles Phase 2b

--- a/block-node/roster-bootstrap-rsa/build.gradle.kts
+++ b/block-node/roster-bootstrap-rsa/build.gradle.kts
@@ -3,10 +3,6 @@ plugins { id("org.hiero.gradle.module.library") }
 
 description = "Hiero Block Node RSA Roster Bootstrap Plugin"
 
-// Remove the following line to enable all 'javac' lint checks that we have turned on by default
-// and then fix the reported issues.
-tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
-
 mainModuleInfo { runtimeOnly("com.swirlds.config.impl") }
 
 testModuleInfo {

--- a/docs/design/wrb-streaming/bootstrap-roster-plugin.md
+++ b/docs/design/wrb-streaming/bootstrap-roster-plugin.md
@@ -173,14 +173,18 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
     @Override
     public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
         this.applicationStateFacility = Objects.requireNonNull(context.applicationStateFacility());
-        this.config = context.configuration().getConfigData(BootstrapRosterConfig.class);
+        this.config = context.configuration().getConfigData(RsaRosterBootstrapConfig.class);
     }
 
     @Override
     public void start() {
-        final NodeAddressBook book = loadOrFetchAddressBook(config);
-        // ApplicationStateFacility handles file persistence and onContextUpdate broadcast
-        applicationStateFacility.updateAddressBook(book);
+        NodeAddressBook book = context.nodeAddressBook();
+        if (book == null) {
+            // No bootstrap file was loaded by BlockNodeApp.loadApplicationState()
+            book = fetchFromMirrorNode();
+            // ApplicationStateFacility handles file persistence and onContextUpdate broadcast
+            applicationStateFacility.updateAddressBook(book);
+        }
     }
 }
 ```
@@ -220,9 +224,9 @@ exist).
 
 ### 4.2 Bootstrap File Format
 
-The bootstrap file is a **binary protobuf serialization** of the `NodeAddressBook` message from `basic_types.proto`.
-This reuses a well-known, stable message definition from the Hedera services API rather than introducing a bespoke
-schema, and it is directly compatible with the on-chain address book format stored at file `0.0.102`.
+The bootstrap file is a **JSON serialization** of the `NodeAddressBook` protobuf message from `basic_types.proto`,
+written and read via PBJ's `NodeAddressBook.JSON` codec. This reuses a well-known, stable message definition from
+the Hedera services API rather than introducing a bespoke schema.
 
 **Proto definition (from `hiero-consensus-nodehapi/hedera-protobuf-java-api/src/main/proto/services/basic_types.proto`):**
 
@@ -267,23 +271,25 @@ All other `NodeAddress` fields (`ipAddress`, `portno`, `memo`, `nodeAccountId`, 
 **Serialization and deserialization (PBJ):**
 
 ```java
-// Write
-final Bytes encoded = NodeAddressBook.PROTOBUF.toBytes(nodeAddressBook);
+// Write (via BlockNodeApp.persistNodeAddressBook)
+final Bytes encoded = NodeAddressBook.JSON.toBytes(nodeAddressBook);
 Files.write(filePath, encoded.toByteArray());
 
-// Read
+// Read (via BlockNodeApp.loadApplicationState)
 final byte[] raw = Files.readAllBytes(filePath);
 final NodeAddressBook nodeAddressBook =
-        NodeAddressBook.PROTOBUF.parse(BufferedData.wrap(raw));
+        NodeAddressBook.JSON.parse(Bytes.wrap(raw));
 ```
 
-**Default file path:** `data/config/rsa-bootstrap-roster.pb`
+**Default file path:** `/opt/hiero/block-node/node/rsa-bootstrap-roster.json`
+(Configured via `app.state.rsaBootstrapFilePath`.)
 
 **Notes:**
 - The `RSA_PubKey` string in `NodeAddress` is the raw hex-encoded DER bytes without an `0x` prefix. Mirror Node
 returns the key with a leading `0x` which must be stripped before storing.
 - The file does not embed metadata such as network name or generation timestamp. Operators wishing to annotate the
 file should maintain a separate sidecar file or rely on filesystem timestamps.
+- Writes use an atomic `.tmp`-then-move strategy to avoid corrupt files on process crash.
 
 ---
 
@@ -311,33 +317,46 @@ it is `null` to collect all nodes.
 **Filtering:** Only include nodes where `public_key` is non-null and non-empty. Nodes without a public key are not
 eligible for RSA verification and must be excluded from the `NodeAddressBook`.
 
+**Active-entry filtering:** The API is queried with `order=desc` so the most-recently-active entries
+(`timestamp.to == null`) arrive first. Pagination stops on the first entry with a non-null `timestamp.to`, since
+all remaining entries in descending order are also historical.
+
 **Pseudo-implementation:**
 
 ```java
-private NodeAddressBook fetchFromMirrorNode(BootstrapRosterConfig config) {
+private NodeAddressBook fetchFromMirrorNode(RsaRosterBootstrapConfig config) {
     final List<NodeAddress> entries = new ArrayList<>();
-    String nextPath = "/api/v1/network/nodes?limit=100&order=asc";
+    // Use order=desc so active entries (timestamp.to == null) arrive first.
+    String nextUrl = config.mirrorNodeBaseUrl()
+            + "/api/v1/network/nodes?limit=" + config.mirrorNodePageSize() + "&order=desc";
 
-    while (nextPath != null) {
-        final JsonNode page = httpGet(config.mirrorNodeBaseUrl() + nextPath);
-        for (JsonNode node : page.get("nodes")) {
-            final String pubKey = node.path("public_key").asText(null);
-            if (pubKey == null || pubKey.isBlank()) continue;
+    outer:
+    while (nextUrl != null) {
+        final MirrorNodeNodesResponse page = fetchAndParseWithRetry(client, nextUrl);
+        for (MirrorNodeNodesResponse.NodeEntry entry : page.nodes()) {
+            // A non-null timestamp.to means this entry has been superseded — stop.
+            if (entry.timestamp() != null && entry.timestamp().to() != null) break outer;
+
+            if (entry.publicKey() == null || entry.publicKey().isBlank()) continue;
 
             // Strip the 0x prefix that Mirror Node includes
-            final String rsaPubKeyHex = pubKey.replaceFirst("^0x", "");
+            final String hexKey = entry.publicKey().startsWith("0x")
+                    ? entry.publicKey().substring(2) : entry.publicKey();
 
             entries.add(NodeAddress.newBuilder()
-                    .nodeId(node.get("node_id").asLong())
-                    .rsaPubKey(rsaPubKeyHex)
+                    .nodeId(entry.nodeId())
+                    .rsaPubKey(hexKey)
                     .build());
         }
-        nextPath = page.path("links").path("next").asText(null);
+        // Mirror Node may return a relative path; resolve against the base URL.
+        final String rawNext = page.nextLink();
+        nextUrl = (rawNext == null) ? null
+                : rawNext.startsWith("http") ? rawNext : config.mirrorNodeBaseUrl() + rawNext;
     }
 
     if (entries.isEmpty()) {
-        throw new RosterFetchException(
-                "Mirror Node returned zero nodes with RSA public keys");
+        throw new IllegalStateException(
+                "Mirror Node returned zero nodes with a non-blank public_key");
     }
     return NodeAddressBook.newBuilder().nodeAddress(entries).build();
 }
@@ -355,29 +374,38 @@ The plugin follows a **file-first** strategy consistent with `TssBootstrapPlugin
 happen in `start()`, after `init()` has stored the facility reference.
 
 ```
-start() called
+BlockNodeApp.loadApplicationState() [before any plugin is started]
    │
-   ├─ Bootstrap file exists at config path (rsa-bootstrap-roster.pb)?
+   ├─ rsa-bootstrap-roster.json exists at app.state.rsaBootstrapFilePath?
    │       │
-   │       YES ──► Read bytes → NodeAddressBook.PROTOBUF.parse() → validate (≥1 entry)
+   │       YES ──► NodeAddressBook.JSON.parse() → validate (≥1 entry)
    │       │        │
-   │       │        ├─ On parse error or empty book: LOG ERROR → FAIL FAST (throw)
+   │       │        ├─ On parse error or empty book: FAIL FAST (throw IllegalStateException)
    │       │        │
-   │       │        └─ applicationStateFacility.updateAddressBook(book)
-   │       │              └─ BlockNodeApp notifies all plugins via onContextUpdate
+   │       │        └─ pendingAddressBook.set(book) [flushed to context before plugins start]
    │       │
-   │       NO ──► Query Mirror Node API (paginated GET /api/v1/network/nodes)
+   │       NO ──► (no-op; context.nodeAddressBook() will be null when plugins start)
+   │
+RsaRosterBootstrapPlugin.start() called
+   │
+   ├─ context.nodeAddressBook() != null?
+   │       │
+   │       YES ──► record metrics, log success, return
+   │       │
+   │       NO ──► mirrorNodeBaseUrl blank?
    │               │
-   │               ├─ SUCCESS: build NodeAddressBook (nodeId + RSA_PubKey per entry)
-   │               │     └─ applicationStateFacility.updateAddressBook(book)
-   │               │           ├─ BlockNodeApp writes rsa-bootstrap-roster.pb
-   │               │           └─ BlockNodeApp notifies all plugins via onContextUpdate
+   │               YES ──► LOG WARNING → return (no fail-fast)
    │               │
-   │               └─ FAILURE (API unreachable / timeout / empty response):
-   │                     LOG ERROR: "RSA address book could not be created — Mirror Node
-   │                                 API unavailable. BN cannot verify WRB proofs."
-   │                     FAIL FAST → shutdown BN
-   │                     (see Open Question #1 below)
+   │               NO ──► Query Mirror Node API (paginated GET /api/v1/network/nodes, order=desc)
+   │                       │
+   │                       ├─ SUCCESS: build NodeAddressBook (nodeId + RSA_PubKey per entry)
+   │                       │     └─ applicationStateFacility.updateAddressBook(book)
+   │                       │           ├─ BlockNodeApp writes rsa-bootstrap-roster.json (atomic)
+   │                       │           └─ BlockNodeApp notifies all plugins via onContextUpdate [async]
+   │                       │
+   │                       └─ FAILURE after MAX_RETRIES (API unreachable / timeout / empty response):
+   │                             LOG ERROR: "RSA address book could not be created"
+   │                             FAIL FAST → throw IllegalStateException → shutdown BN
    │
    └─ Startup complete
 ```
@@ -536,27 +564,33 @@ sequenceDiagram
     participant MN as Mirror Node API
     participant Plugins as All Loaded Plugins
 
+    App->>File: loadApplicationState() — exists(rsa-bootstrap-roster.json)?
+    alt file found
+        File-->>App: raw bytes
+        App->>App: NodeAddressBook.JSON.parse(bytes), validate ≥1 entry
+        App->>App: pendingAddressBook.set(book)
+        App->>App: checkForApplicationStateUpdates() [flush to context before plugins start]
+    end
     App->>Plugin: init(context, serviceBuilder)
     Plugin->>Plugin: store applicationStateFacility, config
     App->>Plugin: start()
-    Plugin->>File: exists(rsa-bootstrap-roster.pb)?
-    alt file found
-        File-->>Plugin: raw bytes
-        Plugin->>Plugin: NodeAddressBook.PROTOBUF.parse(bytes)
-        Plugin->>Plugin: validate ≥1 entry with RSA_PubKey + nodeId
-        Plugin->>Facility: updateAddressBook(book)
-        Facility->>Plugins: onContextUpdate(updatedContext) [async]
-    else no file
-        Plugin->>MN: GET /api/v1/network/nodes (paginated)
-        alt MN reachable
-            MN-->>Plugin: node list (node_id, public_key)
-            Plugin->>Plugin: build NodeAddressBook (nodeId + RSA_PubKey per entry)
-            Plugin->>Facility: updateAddressBook(book)
-            Facility->>File: NodeAddressBook.PROTOBUF.toBytes() → write
-            Facility->>Plugins: onContextUpdate(updatedContext) [async]
-        else MN unreachable
-            Plugin->>Plugin: LOG ERROR: address book not created
-            Plugin->>App: FAIL FAST → shutdown
+    alt context.nodeAddressBook() != null (file was loaded)
+        Plugin->>Plugin: record metrics, log success, return
+    else context.nodeAddressBook() == null
+        alt mirrorNodeBaseUrl is blank
+            Plugin->>Plugin: LOG WARNING → return (no fail-fast)
+        else mirrorNodeBaseUrl configured
+            Plugin->>MN: GET /api/v1/network/nodes (paginated, order=desc)
+            alt MN reachable
+                MN-->>Plugin: node list (node_id, public_key, timestamp)
+                Plugin->>Plugin: build NodeAddressBook (active entries only)
+                Plugin->>Facility: updateAddressBook(book)
+                Facility->>File: NodeAddressBook.JSON.toBytes() → atomic write
+                Facility->>Plugins: onContextUpdate(updatedContext) [async]
+            else MN unreachable after retries
+                Plugin->>Plugin: LOG ERROR: address book not created
+                Plugin->>App: FAIL FAST → throw → shutdown
+            end
         end
     end
     App->>App: continue startup (if not shut down)
@@ -604,20 +638,25 @@ sequenceDiagram
 
 ## 6. Configuration
 
-All properties are under the `roster.bootstrap.rsa` namespace.
+Bootstrap file path is in the `app.state` namespace (shared application state config):
 
-|                        Property                         |  Type   |                    Default                     |                                      Description                                       |
-|---------------------------------------------------------|---------|------------------------------------------------|----------------------------------------------------------------------------------------|
-| `roster.bootstrap.rsa.filePath`                         | string  | `data/config/rsa-bootstrap-roster.pb`          | Path to the local bootstrap file (binary protobuf). Relative to BN working directory.  |
-| `roster.bootstrap.rsa.mirrorNode.baseUrl`               | string  | `https://testnet-public.mirrornode.hedera.com` | Base URL for Mirror Node REST API calls. Used when no local bootstrap file is present. |
-| `roster.bootstrap.rsa.mirrorNode.connectTimeoutSeconds` | integer | `5`                                            | TCP connect timeout for Mirror Node HTTP calls.                                        |
-| `roster.bootstrap.rsa.mirrorNode.readTimeoutSeconds`    | integer | `10`                                           | Read timeout for Mirror Node HTTP calls.                                               |
-| `roster.bootstrap.rsa.mirrorNode.pageSize`              | integer | `100`                                          | Items per page for paginated Mirror Node calls. Max 100.                               |
+|           Property            |  Type  |                           Default                            |                          Description                           |
+|-------------------------------|--------|--------------------------------------------------------------|----------------------------------------------------------------|
+| `app.state.rsaBootstrapFilePath` | string | `/opt/hiero/block-node/node/rsa-bootstrap-roster.json` | Path to the JSON-serialized `NodeAddressBook` bootstrap file. |
+
+Mirror Node fallback is in the `roster.bootstrap.rsa` namespace:
+
+|                           Property                            |  Type   | Default  |                                      Description                                       |
+|---------------------------------------------------------------|---------|----------|----------------------------------------------------------------------------------------|
+| `roster.bootstrap.rsa.mirrorNodeBaseUrl`                      | string  | *(blank)* | Base URL for Mirror Node REST API calls. Blank disables Mirror Node fallback.          |
+| `roster.bootstrap.rsa.mirrorNodeConnectTimeoutSeconds`        | integer | `5`      | TCP connect timeout for Mirror Node HTTP calls.                                        |
+| `roster.bootstrap.rsa.mirrorNodeReadTimeoutSeconds`           | integer | `10`     | Read timeout for Mirror Node HTTP calls.                                               |
+| `roster.bootstrap.rsa.mirrorNodePageSize`                     | integer | `100`    | Items per page for paginated Mirror Node calls. Max 100.                               |
 
 **Environment variable overrides** follow the standard Swirlds Config pattern (uppercase, `_` for `.` and `-`). For example:
 
 ```
-ROSTER_BOOTSTRAP_MIRROR_NODE_BASE_URL=https://testnet.mirrornode.hedera.com
+ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL=https://testnet.mirrornode.hedera.com
 ```
 
 ---
@@ -626,14 +665,21 @@ ROSTER_BOOTSTRAP_MIRROR_NODE_BASE_URL=https://testnet.mirrornode.hedera.com
 
 All metrics use the BN-standard category `blocknode` and must follow existing naming conventions.
 
-|                 Metric name                  |   Type    |                             Labels                             |                                          Description                                          |
-|----------------------------------------------|-----------|----------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
-| `blocknode_verification_proof_total`         | Counter   | `proof_type={rsa,state_proof,tss}`, `result={success,failure}` | Count of block proof verifications, broken down by proof type and result.                     |
-| `blocknode_rsa_verification_latency_seconds` | Histogram | —                                                              | Latency of the full RSA verification step per block (p50, p95, p99 buckets).                  |
-| `blocknode_rsa_roster_entries_loaded`        | Gauge     | `source={file,mirror_node}`                                    | Number of `NodeAddress` entries loaded at startup, labelled by source.                        |
-| `blocknode_rsa_roster_mismatch_total`        | Counter   | —                                                              | Count of signatures where the signing node ID was not found in the loaded `NodeAddressBook`.  |
-| `blocknode_rsa_roster_load_duration_seconds` | Gauge     | `source={file,mirror_node}`                                    | Time taken to load the roster at startup (for alerting on slow Mirror Node calls).            |
-| `blocknode_rsa_roster_creation_failed`       | Counter   | —                                                              | Incremented each time the roster cannot be created (file corrupt or Mirror Node unreachable). |
+**Plugin metrics** (`RsaRosterBootstrapPlugin` — category `blocknode`):
+
+|             Metric name              |  Type  | Labels |                                 Description                                  |
+|--------------------------------------|--------|--------|------------------------------------------------------------------------------|
+| `blocknode_roster_entries_loaded`    | Gauge  | —      | Number of `NodeAddress` entries loaded at startup.                           |
+| `blocknode_roster_load_duration_ms`  | Gauge  | —      | Time to load the RSA roster at startup in milliseconds.                      |
+| `blocknode_rsa_roster_creation_failed` | Counter | —  | Incremented each time the roster cannot be created (file corrupt or Mirror Node unreachable). |
+
+**Verification service metrics** (`BlockVerificationService` — category `blocknode`):
+
+|                 Metric name                  |   Type    |                             Labels                             |                                         Description                                          |
+|----------------------------------------------|-----------|----------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| `blocknode_verification_proof_total`         | Counter   | `proof_type={rsa,state_proof,tss}`, `result={success,failure}` | Count of block proof verifications, broken down by proof type and result.                    |
+| `blocknode_rsa_verification_latency_seconds` | Histogram | —                                                              | Latency of the full RSA verification step per block (p50, p95, p99 buckets).                 |
+| `blocknode_rsa_roster_mismatch_total`        | Counter   | —                                                              | Count of signatures where the signing node ID was not found in the loaded `NodeAddressBook`. |
 
 
 ---
@@ -668,30 +714,25 @@ A script `tools-and-tests/scripts/node-operations/generate-roster-rsa-bootstrap.
 1. Accept `--network <mainnet|testnet|previewnet>` and optionally `--mirror-node-url <url>`.
 2. Query `GET /api/v1/network/nodes` (with pagination) to collect all nodes with non-empty `public_key`.
 3. Build a `NodeAddressBook` protobuf, setting only `nodeId` and `RSA_PubKey` (stripped of `0x` prefix) per `NodeAddress` entry.
-4. Serialize with `NodeAddressBook.PROTOBUF.toBytes()` and write to `rsa-bootstrap-roster.pb`.
+4. Serialize with `NodeAddressBook.JSON.toBytes()` and write to `rsa-bootstrap-roster.json`.
 5. Print a summary: number of entries written, file path, file size.
 
 **Expected usage before a Phase 2a cutover:**
 
 ```bash
-generate-rsa-roster-bootstrap.sh --network mainnet --output /opt/blocknode/data/config/rsa-bootstrap-roster.pb
+generate-rsa-roster-bootstrap.sh --network mainnet --output /opt/hiero/block-node/node/rsa-bootstrap-roster.json
 ```
 
 Operators must regenerate and restart the BN if the address book changes (new nodes added, nodes removed).
 The `blocknode_roster_entries_loaded` gauge metric provides a quick sanity check that the expected number of nodes was
 loaded at startup.
 
-**Fallback — public NodeAddressBook snapshot:** If the Mirror Node API is unavailable at the time of the pre-cutover
-setup, operators can obtain a copy of the on-chain `NodeAddressBook` (file `0.0.102`) from a publicly available
-snapshot of Hedera state (e.g., a Mirror Node state snapshot or community-maintained archive). The binary contents of
-`0.0.102` are directly compatible with the binary protobuf format expected by the plugin.
-
 **Inspecting the generated file:**
 
-The binary protobuf can be inspected using `protoc` with the `NodeAddressBook` proto definition:
+The JSON file is human-readable and can be inspected directly:
 
 ```bash
-protoc --decode=NodeAddressBook basic_types.proto < rsa-bootstrap-roster.pb
+cat /opt/hiero/block-node/node/rsa-bootstrap-roster.json | python3 -m json.tool | head -40
 ```
 
 ---

--- a/docs/design/wrb-streaming/bootstrap-roster-plugin.md
+++ b/docs/design/wrb-streaming/bootstrap-roster-plugin.md
@@ -185,6 +185,25 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
 }
 ```
 
+**Node details status endpoint:** Once the `NodeAddressBook` is loaded it must be included in the
+`ServerStatusDetailResponse` returned by `BlockNodeService.serverStatusDetail()`. The `node_service.proto` response
+message will carry the full address book as field 4:
+
+```protobuf
+message ServerStatusDetailResponse {
+    // ... existing fields ...
+
+    /**
+     * RSA Node Address Book Data from the block node server.
+     * Node Id, rsa public key information
+     */
+    NodeAddressBook node_address_book = 4;
+}
+```
+
+This allows any caller of `serverStatusDetail` to inspect the full set of loaded `NodeAddress` entries (node ID and
+RSA public key per entry) without restarting the BN.
+
 **`ApplicationStateFacility` extension:** A new `updateAddressBook(NodeAddressBook)` method must be added:
 - `BlockNodeApp` implements the method.
 - The method updates the `nodeAddressBook` field in `BlockNodeContext`.
@@ -607,13 +626,15 @@ ROSTER_BOOTSTRAP_MIRROR_NODE_BASE_URL=https://testnet.mirrornode.hedera.com
 
 All metrics use the BN-standard category `blocknode` and must follow existing naming conventions.
 
-|                 Metric name                  |   Type    |                             Labels                             |                                         Description                                          |
-|----------------------------------------------|-----------|----------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| `blocknode_verification_proof_total`         | Counter   | `proof_type={rsa,state_proof,tss}`, `result={success,failure}` | Count of block proof verifications, broken down by proof type and result.                    |
-| `blocknode_rsa_verification_latency_seconds` | Histogram | —                                                              | Latency of the full RSA verification step per block (p50, p95, p99 buckets).                 |
-| `blocknode_rsa_roster_entries_loaded`        | Gauge     | `source={file,mirror_node}`                                    | Number of `NodeAddress` entries loaded at startup, labelled by source.                       |
-| `blocknode_rsa_roster_mismatch_total`        | Counter   | —                                                              | Count of signatures where the signing node ID was not found in the loaded `NodeAddressBook`. |
-| `blocknode_rsa_roster_load_duration_seconds` | Gauge     | `source={file,mirror_node}`                                    | Time taken to load the roster at startup (for alerting on slow Mirror Node calls).           |
+|                 Metric name                  |   Type    |                             Labels                             |                                          Description                                          |
+|----------------------------------------------|-----------|----------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| `blocknode_verification_proof_total`         | Counter   | `proof_type={rsa,state_proof,tss}`, `result={success,failure}` | Count of block proof verifications, broken down by proof type and result.                     |
+| `blocknode_rsa_verification_latency_seconds` | Histogram | —                                                              | Latency of the full RSA verification step per block (p50, p95, p99 buckets).                  |
+| `blocknode_rsa_roster_entries_loaded`        | Gauge     | `source={file,mirror_node}`                                    | Number of `NodeAddress` entries loaded at startup, labelled by source.                        |
+| `blocknode_rsa_roster_mismatch_total`        | Counter   | —                                                              | Count of signatures where the signing node ID was not found in the loaded `NodeAddressBook`.  |
+| `blocknode_rsa_roster_load_duration_seconds` | Gauge     | `source={file,mirror_node}`                                    | Time taken to load the roster at startup (for alerting on slow Mirror Node calls).            |
+| `blocknode_rsa_roster_creation_failed`       | Counter   | —                                                              | Incremented each time the roster cannot be created (file corrupt or Mirror Node unreachable). |
+
 
 ---
 

--- a/docs/design/wrb-streaming/bootstrap-roster-plugin.md
+++ b/docs/design/wrb-streaming/bootstrap-roster-plugin.md
@@ -640,18 +640,18 @@ sequenceDiagram
 
 Bootstrap file path is in the `app.state` namespace (shared application state config):
 
-|           Property            |  Type  |                           Default                            |                          Description                           |
-|-------------------------------|--------|--------------------------------------------------------------|----------------------------------------------------------------|
+|             Property             |  Type  |                        Default                         |                          Description                          |
+|----------------------------------|--------|--------------------------------------------------------|---------------------------------------------------------------|
 | `app.state.rsaBootstrapFilePath` | string | `/opt/hiero/block-node/node/rsa-bootstrap-roster.json` | Path to the JSON-serialized `NodeAddressBook` bootstrap file. |
 
 Mirror Node fallback is in the `roster.bootstrap.rsa` namespace:
 
-|                           Property                            |  Type   | Default  |                                      Description                                       |
-|---------------------------------------------------------------|---------|----------|----------------------------------------------------------------------------------------|
-| `roster.bootstrap.rsa.mirrorNodeBaseUrl`                      | string  | *(blank)* | Base URL for Mirror Node REST API calls. Blank disables Mirror Node fallback.          |
-| `roster.bootstrap.rsa.mirrorNodeConnectTimeoutSeconds`        | integer | `5`      | TCP connect timeout for Mirror Node HTTP calls.                                        |
-| `roster.bootstrap.rsa.mirrorNodeReadTimeoutSeconds`           | integer | `10`     | Read timeout for Mirror Node HTTP calls.                                               |
-| `roster.bootstrap.rsa.mirrorNodePageSize`                     | integer | `100`    | Items per page for paginated Mirror Node calls. Max 100.                               |
+|                        Property                        |  Type   |  Default  |                                  Description                                  |
+|--------------------------------------------------------|---------|-----------|-------------------------------------------------------------------------------|
+| `roster.bootstrap.rsa.mirrorNodeBaseUrl`               | string  | *(blank)* | Base URL for Mirror Node REST API calls. Blank disables Mirror Node fallback. |
+| `roster.bootstrap.rsa.mirrorNodeConnectTimeoutSeconds` | integer | `5`       | TCP connect timeout for Mirror Node HTTP calls.                               |
+| `roster.bootstrap.rsa.mirrorNodeReadTimeoutSeconds`    | integer | `10`      | Read timeout for Mirror Node HTTP calls.                                      |
+| `roster.bootstrap.rsa.mirrorNodePageSize`              | integer | `100`     | Items per page for paginated Mirror Node calls. Max 100.                      |
 
 **Environment variable overrides** follow the standard Swirlds Config pattern (uppercase, `_` for `.` and `-`). For example:
 
@@ -667,11 +667,11 @@ All metrics use the BN-standard category `blocknode` and must follow existing na
 
 **Plugin metrics** (`RsaRosterBootstrapPlugin` — category `blocknode`):
 
-|             Metric name              |  Type  | Labels |                                 Description                                  |
-|--------------------------------------|--------|--------|------------------------------------------------------------------------------|
-| `blocknode_roster_entries_loaded`    | Gauge  | —      | Number of `NodeAddress` entries loaded at startup.                           |
-| `blocknode_roster_load_duration_ms`  | Gauge  | —      | Time to load the RSA roster at startup in milliseconds.                      |
-| `blocknode_rsa_roster_creation_failed` | Counter | —  | Incremented each time the roster cannot be created (file corrupt or Mirror Node unreachable). |
+|              Metric name               |  Type   | Labels |                                          Description                                          |
+|----------------------------------------|---------|--------|-----------------------------------------------------------------------------------------------|
+| `blocknode_roster_entries_loaded`      | Gauge   | —      | Number of `NodeAddress` entries loaded at startup.                                            |
+| `blocknode_roster_load_duration_ms`    | Gauge   | —      | Time to load the RSA roster at startup in milliseconds.                                       |
+| `blocknode_rsa_roster_creation_failed` | Counter | —      | Incremented each time the roster cannot be created (file corrupt or Mirror Node unreachable). |
 
 **Verification service metrics** (`BlockVerificationService` — category `blocknode`):
 
@@ -680,7 +680,6 @@ All metrics use the BN-standard category `blocknode` and must follow existing na
 | `blocknode_verification_proof_total`         | Counter   | `proof_type={rsa,state_proof,tss}`, `result={success,failure}` | Count of block proof verifications, broken down by proof type and result.                    |
 | `blocknode_rsa_verification_latency_seconds` | Histogram | —                                                              | Latency of the full RSA verification step per block (p50, p95, p99 buckets).                 |
 | `blocknode_rsa_roster_mismatch_total`        | Counter   | —                                                              | Count of signatures where the signing node ID was not found in the loaded `NodeAddressBook`. |
-
 
 ---
 


### PR DESCRIPTION
## Reviewer Notes

Addresses reviewer feedback on the original `roster-bootstrap-rsa` scaffold and aligns the README and design document with the full implementation that landed in PR #2789.

The implementation (`RsaRosterBootstrapPlugin`, `RsaRosterBootstrapConfig`, `MirrorNodeNodesResponse`, `ApplicationStateFacility.updateAddressBook()`) is now on `main` via #2789. This PR makes the documentation reflect what was actually built rather than what was originally sketched.

---

## What changed

### `block-node/roster-bootstrap-rsa/build.gradle.kts`

- Removed the `-Xlint:-exports` javac lint suppression. The full implementation no longer triggers the export warning, so the suppression is no longer needed.

### `block-node/roster-bootstrap-rsa/README.md`

| Area | Before | After |
|---|---|---|
| File format | Binary protobuf (`.pb`) | JSON via `NodeAddressBook.JSON` (`.json`) |
| Default file path | `data/config/rsa-bootstrap-roster.pb` | `/opt/hiero/block-node/node/rsa-bootstrap-roster.json` (from `app.state.rsaBootstrapFilePath`) |
| File-first step | "application state facility checks..." | Correctly attributes the file load to `BlockNodeApp.loadApplicationState()` before any plugin starts |
| Fail-fast behaviour | "If neither source succeeds, startup is aborted" | Accurate: blank `mirrorNodeBaseUrl` + no file → WARNING + early return (no abort); fail-fast only when MN is configured but unreachable |
| Configuration table | Wrong property names (`roster.bootstrap.enabled`, `roster.bootstrap.filePath`, `roster.bootstrap.mirrorNode.*`) with wrong defaults | Split into `app.state.rsaBootstrapFilePath` (file path) and `roster.bootstrap.rsa.*` (MN fallback); `mirrorNodeBaseUrl` default is blank, not a testnet URL |
| Status endpoint step | Described as implemented (step 5) | Removed — not in the current implementation |
| Relationship section | "perform all work in `init()`" | Corrected to `start()` |

### `docs/design/wrb-streaming/bootstrap-roster-plugin.md`

| Section | Correction |
|---|---|
| §4.1 Plugin skeleton | `BootstrapRosterConfig` → `RsaRosterBootstrapConfig`; `start()` body updated to check `context.nodeAddressBook()` then call `fetchFromMirrorNode()` |
| §4.2 Bootstrap file format | Serialization changed from `NodeAddressBook.PROTOBUF` to `NodeAddressBook.JSON`; default path updated; atomic `.tmp`-then-move write strategy noted |
| §4.3 Mirror Node fetch | Pseudo-code changed from `order=asc` to `order=desc`; added `timestamp.to != null` early-termination logic for active-entry filtering (matches actual implementation) |
| §4.4 Startup sequence | ASCII flow diagram restructured: `BlockNodeApp.loadApplicationState()` runs before plugins are started; plugin's `start()` checks `context.nodeAddressBook()`; blank `mirrorNodeBaseUrl` path added |
| §5 Mermaid diagram | Updated to match the two-phase startup (`BlockNodeApp` loads file → plugins init → plugin `start()` checks context) |
| §6 Configuration | Split into `app.state` and `roster.bootstrap.rsa` namespaces; `mirrorNodeBaseUrl` default corrected to blank; removed non-existent `roster.bootstrap.rsa.filePath` property |
| §7 Metrics | Separated plugin metrics from verification-service metrics; corrected names to match implementation (`blocknode_roster_entries_loaded`, `blocknode_roster_load_duration_ms` — no `rsa_` prefix, ms not seconds, no `source` label); added `blocknode_rsa_roster_creation_failed` |
| §9 Operator tooling | Updated codec reference to JSON; corrected example output path |


## Related Issue(s)
Related to #2631 