### PR TITLE
fix: raise signature threshold to 1/2 of nodes for live-sequential

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -1332,7 +1332,7 @@ public class LiveSequential implements Runnable {
                                         .getCurrentAddressBook()
                                         .nodeAddress()
                                         .size()
-                                / 3
+                                / 2
                         + 1;
                 if (!hasRecord || sigFiles < minSigs) {
                     break;
@@ -1471,13 +1471,13 @@ public class LiveSequential implements Runnable {
             return resetPrefetchAndRetry(state, nextBlockNumber);
         }
 
-        // Verify sufficient signature files (need at least ceil(N/3) for stake-weighted validation)
+        // Verify sufficient signature files (need majority N/2 + 1 to prevent partition ambiguity)
         long sigCount = inMemoryFiles.stream()
                 .filter(f -> f.path().getFileName().toString().contains("_sig"))
                 .count();
         long maxExpectedSigs =
                 addressBookRegistry.getCurrentAddressBook().nodeAddress().size();
-        long minSigs = (maxExpectedSigs / 3) + 1;
+        long minSigs = (maxExpectedSigs / 2) + 1;
         if (sigCount < minSigs) {
             System.out.println("[live-sequential] Insufficient signatures for block " + nextBlockNumber + " ("
                     + sigCount + "/" + maxExpectedSigs + ", need " + minSigs + "), waiting for GCS uploads...");
@@ -1509,8 +1509,8 @@ public class LiveSequential implements Runnable {
             return false;
         }
 
-        // If we already have enough signatures for stake-weighted validation, proceed immediately
-        long minSigs = (maxExpectedSigs / 3) + 1;
+        // If we already have enough signatures for majority validation, proceed immediately
+        long minSigs = (maxExpectedSigs / 2) + 1;
         if (sigCount >= minSigs) {
             System.out.printf(
                     "[live-sequential] Block %d has sufficient signatures (%d/%d, need %d), proceeding%n",

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -138,7 +138,7 @@ public class LiveSequential implements Runnable {
     /** How close to wall-clock time a block must be to count as "live edge". */
     private static final Duration LIVE_EDGE_THRESHOLD = Duration.ofMinutes(5);
     /** Maximum time to wait for all signatures at the live edge before proceeding with what we have. */
-    private static final Duration MAX_SIG_WAIT = Duration.ofMinutes(2);
+    private static final Duration MAX_SIG_WAIT = Duration.ofMinutes(5);
 
     /** Maximum number of 15-minute retries when waiting for GCS listings for a new day. */
     private static final int MAX_LISTING_WAIT_ATTEMPTS = 10;
@@ -585,7 +585,7 @@ public class LiveSequential implements Runnable {
                 loadOrRefreshListings(blockDay, blockTime, netConfig, state);
 
                 // Step 4: Fill the prefetch window
-                fillPrefetchWindow(nextBlockNumber, netConfig, downloadManager, state);
+                fillPrefetchWindow(nextBlockNumber, netConfig, downloadManager, state, addressBookRegistry);
 
                 // Step 5: Get downloads for current block (from window or fresh)
                 BlockDownloadInfo downloads =
@@ -1306,7 +1306,8 @@ public class LiveSequential implements Runnable {
             long nextBlockNumber,
             NetworkConfig netConfig,
             ConcurrentDownloadManagerVirtualThreadsV3 downloadManager,
-            DownloadLoopState state) {
+            DownloadLoopState state,
+            AddressBookRegistry addressBookRegistry) {
         while (state.prefetchWindow.size() < PREFETCH_WINDOW) {
             long target = state.nextPrefetchBlock;
             if (target < nextBlockNumber) {
@@ -1327,7 +1328,13 @@ public class LiveSequential implements Runnable {
                 long sigFiles = group.stream()
                         .filter(f -> f.type() == ListingRecordFile.Type.RECORD_SIG)
                         .count();
-                if (!hasRecord || sigFiles < 3) {
+                long minSigs = addressBookRegistry
+                                        .getCurrentAddressBook()
+                                        .nodeAddress()
+                                        .size()
+                                / 3
+                        + 1;
+                if (!hasRecord || sigFiles < minSigs) {
                     break;
                 }
                 List<ListingRecordFile> ordered = resolveOrderedFiles(group);
@@ -1464,15 +1471,16 @@ public class LiveSequential implements Runnable {
             return resetPrefetchAndRetry(state, nextBlockNumber);
         }
 
-        // Verify sufficient signature files (need at least 3/N for consensus)
+        // Verify sufficient signature files (need at least ceil(N/3) for stake-weighted validation)
         long sigCount = inMemoryFiles.stream()
                 .filter(f -> f.path().getFileName().toString().contains("_sig"))
                 .count();
         long maxExpectedSigs =
                 addressBookRegistry.getCurrentAddressBook().nodeAddress().size();
-        if (sigCount < 3) {
+        long minSigs = (maxExpectedSigs / 3) + 1;
+        if (sigCount < minSigs) {
             System.out.println("[live-sequential] Insufficient signatures for block " + nextBlockNumber + " ("
-                    + sigCount + "/" + maxExpectedSigs + "), waiting for GCS uploads...");
+                    + sigCount + "/" + maxExpectedSigs + ", need " + minSigs + "), waiting for GCS uploads...");
             refreshAndReloadListings(blockDay, blockTime, netConfig, state);
             return resetPrefetchAndRetry(state, nextBlockNumber);
         }
@@ -1498,6 +1506,15 @@ public class LiveSequential implements Runnable {
         Instant blockInstantUtc = blockTime.atZone(ZoneOffset.UTC).toInstant();
         boolean isLiveEdge = Duration.between(blockInstantUtc, Instant.now()).compareTo(LIVE_EDGE_THRESHOLD) < 0;
         if (!isLiveEdge) {
+            return false;
+        }
+
+        // If we already have enough signatures for stake-weighted validation, proceed immediately
+        long minSigs = (maxExpectedSigs / 3) + 1;
+        if (sigCount >= minSigs) {
+            System.out.printf(
+                    "[live-sequential] Block %d has sufficient signatures (%d/%d, need %d), proceeding%n",
+                    nextBlockNumber, sigCount, maxExpectedSigs, minSigs);
             return false;
         }
 


### PR DESCRIPTION
## Summary
- Raised minimum signature threshold from hardcoded `3` to `(N/2)+1` in `fillPrefetchWindow()`, `waitForSufficientSignatures()`, and `checkLiveEdgeSignatures()`
- Added early-proceed check in `checkLiveEdgeSignatures()` — proceeds immediately when `sigCount >= minSigs` instead of waiting for ALL signatures
- Increased `MAX_SIG_WAIT` from 2 minutes to 5 minutes for live-edge signature collection

## Context
At the live edge, only a few nodes may have published signatures. With 33 mainnet nodes, 3 sigs is ~9% of nodes — far below the 1/3 stake threshold required by `SignatureValidation`. This caused the wrap thread to crash:
```
Validation 'Signatures' failed at block 94398862:
Insufficient validated stake: 176209106600000000/1401578583100000000 (4 nodes),
need 467192861033333334/1401578583100000000
```

closes #2664
