### PR TITLE
fix: cherry-pick stalled publisher handling fix into release/0.33

### DIFF
--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -4,6 +4,7 @@ package org.hiero.block.node.stream.publisher;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.TRACE;
+import static java.lang.System.Logger.Level.WARNING;
 import static org.hiero.block.api.PublishStreamResponse.EndOfStream.Code.TIMEOUT;
 import static org.hiero.block.node.spi.BlockNodePlugin.UNKNOWN_BLOCK_NUMBER;
 import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_BLOCKS_CLOSED_COMPLETE;
@@ -64,9 +65,8 @@ import org.hiero.metrics.core.MetricRegistry;
 /// todo(1420) add documentation
 public final class LiveStreamPublisherManager implements StreamPublisherManager {
     private static final int DATA_READY_WAIT_MICROSECONDS = 5000;
-    private static final int MAX_ADVANCE_FOR_STALL_DETECTION = 2;
     private static final String STALL_DETECTED_LOG_MESSAGE =
-            "Stall detected: handler {0} has not completed block {1}, another handler completed block {2}";
+            "[{0}] Stall detected: handler {1} has not completed block {2}, another handler completed block {3}";
     private final System.Logger LOGGER = System.getLogger(LiveStreamPublisherManager.class.getName());
     private final MetricsHolder metrics;
     private final BlockNodeContext serverContext;
@@ -79,11 +79,12 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     private final Condition dataReadyLatch;
     private final ReentrantLock dataReadyLock;
     private final long earliestManagedBlock;
+    private final int maxBlocksBeforeStalled;
     private final ScheduledExecutorService scheduledExecutor;
     private volatile ScheduledFuture<Boolean> publisherUnavailabilityTimeoutFuture;
 
     /// Future tracking the queue forwarder task.
-    ///
+    ///MaxFutureBlocksBeforeStalled
     /// This will run until it encounters an exception or reaches a reasonable
     /// run time limit. When handlers encounter a block proof, a method is called
     /// to check and restart the task if it is not yet running or has completed.
@@ -97,9 +98,12 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     private final AtomicLong nextUnstreamedBlockNumber;
     private final AtomicLong lastPersistedBlockNumber;
 
-    private final ConcurrentNavigableMap<Long, BlockItemUnparsed> blockProofs;
-    private final NavigableSet<Long> endBlocksReceived;
-    private final NavigableSet<Long> blocksToResend;
+    // Note, using concrete definitions here to avoid unnecessary virtual calls
+    //    for these frequently accessed collections.
+    private final ConcurrentSkipListMap<Long, BlockItemUnparsed> blockProofs;
+    private final ConcurrentSkipListSet<Long> endBlocksReceived;
+    private final ConcurrentSkipListSet<Long> blocksToResend;
+    private final ConcurrentSkipListSet<Long> activeResendBlocks;
     /// Maps block number to the ID of the handler that currently holds ACCEPT for that block.
     /// An entry is added when a handler wins ACCEPT via registerQueueForBlock().
     /// An entry is removed when endOfBlock() is called for that block, when blockIsEnding()
@@ -123,16 +127,15 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         dataReadyLatch = dataReadyLock.newCondition();
         NodeConfig nodeConfiguration = serverContext.configuration().getConfigData(NodeConfig.class);
         earliestManagedBlock = nodeConfiguration.earliestManagedBlock();
-        scheduledExecutor = threadManager.createVirtualThreadScheduledExecutor(
-                1,
-                null,
-                (t, e) -> LOGGER.log(
-                        INFO, "Scheduled task thread exception occurred in Live Stream Publisher Manager", e));
+        scheduledExecutor =
+                threadManager.createVirtualThreadScheduledExecutor(1, null, this::uncaughtScheduledExecutorException);
         publisherConfig = serverContext.configuration().getConfigData(PublisherConfig.class);
+        maxBlocksBeforeStalled = publisherConfig.MaxFutureBlocksBeforeStalled();
         publisherUnavailabilityTimeoutFuture = schedulePublisherUnavailabilityTimeout();
         blockProofs = new ConcurrentSkipListMap<>();
         endBlocksReceived = new ConcurrentSkipListSet<>();
         blocksToResend = new ConcurrentSkipListSet<>();
+        activeResendBlocks = new ConcurrentSkipListSet<>();
         activeStreamHandlerByBlock = new ConcurrentSkipListMap<>();
         initializeBlockNumbers(serverContext);
     }
@@ -216,11 +219,15 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             // Remove a proof in case it is collected
             blockProofs.remove(blockNumber);
         }
+        // Remove from the active resend set, if it's present
+        activeResendBlocks.remove(blockNumber);
         // The completing block is no longer an ACCEPT candidate for stall detection.
         activeStreamHandlerByBlock.remove(blockNumber);
         // After removing the completing block, check whether any remaining
         // ACCEPT holders are stalled relative to this completion.
         checkForStalledHandlers(blockNumber);
+        // Check for new blocks to resend (previous method might have added one)
+        // and send a resend response if there are blocks needing to resend.
         final long blockToResend = nextBlockToResend();
         if (blockToResend != UNKNOWN_BLOCK_NUMBER) {
             return new ActionForBlock(BlockAction.RESEND, blockToResend);
@@ -234,6 +241,8 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         // @todo(2344) we can further improve this
         LOGGER.log(INFO, "Handler {0} is ending mid-block {1}", handlerId, blockNumber);
         final Deque<BlockItemSetUnparsed> deque = queueByBlockMap.remove(blockNumber);
+        // Remove from the active resend set, if it's present
+        activeResendBlocks.remove(blockNumber);
         // Remove this block from the ACCEPT winner tracking in all cases;
         // if the handler dropped mid-block there is no stall to detect here.
         activeStreamHandlerByBlock.remove(blockNumber);
@@ -396,12 +405,15 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     /// is strictly less than `blockNumber` and removes any that are confirmed
     /// incomplete — meaning the block has not yet streamed a block proof.
     ///
-    /// An entry is considered safe to remove only when _both_ conditions hold:
+    /// An entry is considered safe to remove only when _all_ conditions hold:
     /// - The block number is **not** present as a key in [#blockProofs], which
     ///    would indicate that the block is complete and awaiting dispatch
     /// - The last [BlockItemSetUnparsed] batch in the queue does **not** end
     ///   with a `BlockProof` item, which would indicate the proof arrived but
     ///   the block is not yet completed (this should be quite rare).
+    /// - The block number is **not** present in current blocks being resent.
+    ///   Blocks being actively resent would otherwise always be removed,
+    ///   resulting in broken blocks and handler failures.
     ///
     /// Entries that fail either check are left in the map so that in-flight
     /// complete blocks are not lost before they can be forwarded to the
@@ -499,28 +511,48 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     /// @param completedBlockNumber the block number that just finished via endOfBlock()
     private void checkForStalledHandlers(final long completedBlockNumber) {
         for (final Map.Entry<Long, Long> entry : activeStreamHandlerByBlock.entrySet()) {
-            final long stalledBlock = entry.getKey();
+            final long candidateBlock = entry.getKey();
             final long handlerId = entry.getValue();
-            if (completedBlockNumber > stalledBlock + MAX_ADVANCE_FOR_STALL_DETECTION
-                    && !endBlocksReceived.contains(stalledBlock)
-                    // TODO: Blocks to resend isn't enough here, need a better check...
-                    && !blocksToResend.contains(stalledBlock)
-                    && activeStreamHandlerByBlock.remove(stalledBlock, handlerId)) {
+            if (completedBlockNumber > candidateBlock + maxBlocksBeforeStalled
+                    && !endBlocksReceived.contains(candidateBlock)
+                    && !isResendingLive(candidateBlock)
+                    && activeStreamHandlerByBlock.remove(candidateBlock, handlerId)) {
                 // This thread won the CAS — execute the stall action.
                 // @todo: Add CorrelationID _for the handler that is stalled_
                 //        (not the thread that called this method).
                 //     This requires making correlation ID accessible in Handler.
-                LOGGER.log(DEBUG, STALL_DETECTED_LOG_MESSAGE, handlerId, stalledBlock, completedBlockNumber);
-                queueByBlockMap.remove(stalledBlock);
-                blockProofs.remove(stalledBlock);
-                blocksToResend.add(stalledBlock);
-                final PublisherHandler stalledHandler = handlers.get(handlerId);
+                PublisherHandler stalledHandler = handlers.get(handlerId);
+                String correlationId = stalledHandler != null ? stalledHandler.getCorrelationId() : "";
+                LOGGER.log(
+                        DEBUG,
+                        STALL_DETECTED_LOG_MESSAGE,
+                        correlationId,
+                        handlerId,
+                        candidateBlock,
+                        completedBlockNumber);
+                queueByBlockMap.remove(candidateBlock);
+                blockProofs.remove(candidateBlock);
+                blocksToResend.add(candidateBlock);
                 if (stalledHandler != null) {
                     stalledHandler.endStreamWithCode(TIMEOUT, true);
                 }
                 metrics.stallTimeoutsSent().increment();
             }
         }
+    }
+
+    /// Check if the candidate block is being resent and is newer than the last
+    /// persisted block. If both conditions are true, then this block should
+    /// be considered a "live" resend and not eligible for stall detection.
+    ///
+    /// @param candidateBlock the block number to test
+    ///
+    /// @return true if, and only if, the candidate block is currently
+    ///     streaming as a result of a resend request and is still needed by
+    ///     this block node.
+    ///
+    private boolean isResendingLive(final long candidateBlock) {
+        return activeResendBlocks.contains(candidateBlock) && candidateBlock > lastPersistedBlockNumber.get();
     }
 
     /// Determine if the given block number is before the earliest active block.
@@ -790,6 +822,11 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     /// @return a Future representing pending completion of the task
     private Future<Long> launchQueueForwarder() {
         return threadManager.getVirtualThreadExecutor().submit(new MessagingForwarderTask(this));
+    }
+
+    private void uncaughtScheduledExecutorException(Thread t, Throwable e) {
+        final String message = "Scheduled task thread exception occurred in Live Stream Publisher Manager";
+        LOGGER.log(WARNING, message, e);
     }
 
     /// todo(1420) add documentation

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfig.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfig.java
@@ -3,6 +3,7 @@ package org.hiero.block.node.stream.publisher;
 
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
+import com.swirlds.config.api.validation.annotation.Max;
 import com.swirlds.config.api.validation.annotation.Min;
 import org.hiero.block.node.base.Loggable;
 
@@ -17,6 +18,7 @@ import org.hiero.block.node.base.Loggable;
 public record PublisherConfig(
         // spotless:off
         @Loggable @ConfigProperty(defaultValue = "9_223_372_036_854_775_807") @Min(100_000L) long batchForwardLimit,
-        @Loggable @ConfigProperty(defaultValue = "300") @Min(0L) long publisherUnavailabilityTimeout) {
+        @Loggable @ConfigProperty(defaultValue = "300") @Min(0L) long publisherUnavailabilityTimeout,
+        @Loggable @ConfigProperty(defaultValue = "3") @Min(3) @Max(50) int MaxFutureBlocksBeforeStalled) {
         // spotless:on
 }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -121,12 +121,17 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
         replies = Objects.requireNonNull(replyPipeline);
         metrics = Objects.requireNonNull(handlerMetrics);
         publisherManager = Objects.requireNonNull(manager);
-        this.correlationIdPrefix = (correlationId == null || correlationId.isEmpty()) ? "" : correlationId;
+        correlationIdPrefix = (correlationId == null || correlationId.isEmpty()) ? "" : correlationId;
         currentStreamingBlockNumber = new AtomicLong(UNKNOWN_BLOCK_NUMBER);
         currentBlockQueue = new AtomicReference<>();
         blockAction = new AtomicReference<>();
         unacknowledgedStreamedBlocks = new ConcurrentSkipListSet<>();
         isActive = new AtomicBoolean(true);
+    }
+
+    // A package-private method for accessing correlation ID for tracing support.
+    String getCorrelationId() {
+        return correlationIdPrefix;
     }
 
     // ==== Flow Methods =======================================================
@@ -176,7 +181,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
                 final PublisherRequestResult result = processNextRequestUnparsed(request);
                 result.handle();
                 LOGGER.log(TRACE, "[{0}] Handler {1} finished processing request", correlationIdPrefix, handlerId);
-            } catch (final InterruptedException | RuntimeException e) {
+            } catch (final RuntimeException e) {
                 // If we reach here, it means that the handler was interrupted or
                 // an unexpected error occurred. We should log the error and shut down.
                 try {
@@ -278,6 +283,9 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
     /// This method must be called when the handler needs to end with a code.
     /// This includes ending successfully, ending for failed persistence,
     /// ending a stalled publisher, or various other situations.
+    ///
+    /// @param codeToSend the end of stream code to send.
+    /// @param immediate whether to schedule the shutdown or shut down immediately.
     void endStreamWithCode(final Code codeToSend, boolean immediate) {
         try {
             LOGGER.log(DEBUG, "[{0}] Handler {1} ending with code {2}", correlationIdPrefix, handlerId, codeToSend);
@@ -291,6 +299,8 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
         }
     }
 
+    /// Set this handler to shut down at the next efficient opportunity.
+    /// This is generally after the next end-of-block message is received.
     void scheduleShutdown() {
         isActive.set(false);
     }
@@ -307,11 +317,10 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
     }
 
     /// todo(1420) add documentation
-    private PublisherRequestResult processNextRequestUnparsed(final PublishStreamRequestUnparsed request)
-            throws InterruptedException {
+    private PublisherRequestResult processNextRequestUnparsed(final PublishStreamRequestUnparsed request) {
         final PublisherRequestResult result;
         if (request.hasBlockItems()) {
-            final BlockItemSetUnparsed itemSetUnparsed = Objects.requireNonNull(request.blockItems());
+            final BlockItemSetUnparsed itemSetUnparsed = request.blockItems();
             final List<BlockItemUnparsed> blockItems = itemSetUnparsed.blockItems();
             if (blockItems.isEmpty()) {
                 result = new SendEndAndShutdownResult(this, Code.INVALID_REQUEST, currentStreamingBlockNumber.get());
@@ -319,9 +328,9 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
                 result = handleBlockItemsRequest(itemSetUnparsed, blockItems);
             }
         } else if (request.hasEndStream()) {
-            result = handleEndStreamRequest(Objects.requireNonNull(request.endStream()));
+            result = handleEndStreamRequest(request.endStream());
         } else if (request.hasEndOfBlock()) {
-            result = handleEndOfBlock(Objects.requireNonNull(request.endOfBlock()));
+            result = handleEndOfBlock(request.endOfBlock());
         } else {
             // this should never happen
             result = new SendEndAndShutdownResult(this, Code.ERROR, currentStreamingBlockNumber.get());
@@ -556,11 +565,11 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
             case TIMEOUT -> {
                 final String message = "Handler %d received EndStream with TIMEOUT. %s"
                         .formatted(handlerId, earliestAndLatestBlockNumbers);
-                yield handleEndStream(DEBUG, message);
+                yield handleEndStream(INFO, message);
             }
             case ERROR -> {
                 final String message = "Handler %d received EndStream with ERROR.".formatted(handlerId);
-                yield handleEndStream(DEBUG, message);
+                yield handleEndStream(INFO, message);
             }
             case TOO_FAR_BEHIND -> {
                 final String message = "Handler %d received EndStream with TOO_FAR_BEHIND. %s"

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -2355,24 +2355,29 @@ class LiveStreamPublisherManagerTest {
                         .build();
                 publisherHandler2.onNext(block1Req);
                 endThisBlock(publisherHandler2, 1L);
-                // Handler 2 completes block 2: 2 == 0+2, NOT strictly greater — no stall yet.
+                // Handler 2 completes block 2, 3: 3 == 0+3, NOT strictly greater — no stall yet.
                 final PublishStreamRequestUnparsed block2Req = PublishStreamRequestUnparsed.newBuilder()
                         .blockItems(TestBlockBuilder.generateBlockWithNumber(2L).asItemSetUnparsed())
                         .build();
                 publisherHandler2.onNext(block2Req);
-                endThisBlock(publisherHandler2, 2L);
-                assertThat(responsePipeline.getOnNextCalls())
-                        .as("completing block 2 (== 0+2) must not trigger stall detection")
-                        .noneMatch(r -> r.response().kind() == PublishStreamResponse.ResponseOneOfType.END_STREAM);
-                assertThat(responsePipeline.getOnCompleteCalls().get()).isZero();
-                // Handler 2 completes block 3: 3 > 0+2 — stall MUST fire now.
+                // Handler 2 completes block 2, 3: 3 == 0+3, NOT strictly greater — no stall yet.
                 final PublishStreamRequestUnparsed block3Req = PublishStreamRequestUnparsed.newBuilder()
                         .blockItems(TestBlockBuilder.generateBlockWithNumber(3L).asItemSetUnparsed())
                         .build();
                 publisherHandler2.onNext(block3Req);
                 endThisBlock(publisherHandler2, 3L);
                 assertThat(responsePipeline.getOnNextCalls())
-                        .as("completing block 3 (> 0+2) must trigger EndStream(TIMEOUT) on handler 1")
+                        .as("completing block 3 (== 0+3) must not trigger stall detection")
+                        .noneMatch(r -> r.response().kind() == PublishStreamResponse.ResponseOneOfType.END_STREAM);
+                assertThat(responsePipeline.getOnCompleteCalls().get()).isZero();
+                // Handler 2 completes block 4: 4 > 0+3 — stall MUST fire now.
+                final PublishStreamRequestUnparsed block4Req = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(TestBlockBuilder.generateBlockWithNumber(4L).asItemSetUnparsed())
+                        .build();
+                publisherHandler2.onNext(block4Req);
+                endThisBlock(publisherHandler2, 4L);
+                assertThat(responsePipeline.getOnNextCalls())
+                        .as("completing block 4 (> 0+3) must trigger EndStream(TIMEOUT) on handler 1")
                         .anySatisfy(r -> {
                             assertThat(r.response().kind())
                                     .isEqualTo(PublishStreamResponse.ResponseOneOfType.END_STREAM);
@@ -2391,8 +2396,8 @@ class LiveStreamPublisherManagerTest {
             void testStallDetectedAndEndStreamSent() {
                 // Handler 1 sends header only for block 0.
                 sendHeaderOnly(publisherHandler, 0L);
-                // Handler 2 is SKIPped for 0, then completes blocks 1, 2, 3.
-                for (long block = 1L; block <= 3L; block++) {
+                // Handler 2 is SKIPped for 0, then completes blocks 1, 2, 3, 4.
+                for (long block = 1L; block <= 4L; block++) {
                     final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
                             .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
                                     .asItemSetUnparsed())
@@ -2489,8 +2494,8 @@ class LiveStreamPublisherManagerTest {
                 sendHeaderOnly(publisherHandler, 0L);
                 // Handler 2 wins ACCEPT for block 1 — sends header only.
                 sendHeaderOnly(publisherHandler2, 1L);
-                // Handler 3 completes block 4: 4 > 0+2 AND 4 > 1+2 — both stalled.
-                for (long block = 2L; block <= 4L; block++) {
+                // Handler 3 completes block 5: 4 > 0+3 AND 5 > 1+3 — both stalled.
+                for (long block = 2L; block <= 5L; block++) {
                     final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
                             .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
                                     .asItemSetUnparsed())
@@ -2531,8 +2536,8 @@ class LiveStreamPublisherManagerTest {
             void testResendDeliveredAtNextEndOfBlock() {
                 // Handler 1 sends header only for block 0 — stalls.
                 sendHeaderOnly(publisherHandler, 0L);
-                // Handler 2 completes blocks 1, 2, 3 — triggers stall on block 3.
-                for (long block = 1L; block <= 3L; block++) {
+                // Handler 2 completes blocks 1, 2, 3, 4 — triggers stall on block 4.
+                for (long block = 1L; block <= 4L; block++) {
                     final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
                             .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
                                     .asItemSetUnparsed())
@@ -2544,14 +2549,14 @@ class LiveStreamPublisherManagerTest {
                 assertThat(responsePipeline.getOnCompleteCalls().get())
                         .as("handler 1 must be shut down by stall detection before checking resend")
                         .isEqualTo(1);
-                // Clear pipeline 2 noise (SKIP responses for blocks 0-2).
+                // Clear pipeline 2 noise (SKIP responses for blocks 0-4).
                 responsePipeline2.clear();
-                // Handler 2 now streams block 4; its endOfBlock must return ResendBlock(0).
-                final PublishStreamRequestUnparsed block4Req = PublishStreamRequestUnparsed.newBuilder()
-                        .blockItems(TestBlockBuilder.generateBlockWithNumber(4L).asItemSetUnparsed())
+                // Handler 2 now streams block 5; its endOfBlock must return ResendBlock(0).
+                final PublishStreamRequestUnparsed block5Req = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(TestBlockBuilder.generateBlockWithNumber(5L).asItemSetUnparsed())
                         .build();
-                publisherHandler2.onNext(block4Req);
-                endThisBlock(publisherHandler2, 4L);
+                publisherHandler2.onNext(block5Req);
+                endThisBlock(publisherHandler2, 5L);
                 // Handler 2 must have received a ResendBlock(0) response.
                 assertThat(responsePipeline2.getOnNextCalls())
                         .as("handler 2 must receive ResendBlock(0) at next endOfBlock after stall")


### PR DESCRIPTION
## Summary

Cherry-pick of #2675 into `release/0.33`.

- Addresses additional items for stalled publisher handling

Original PR: https://github.com/hiero-ledger/hiero-block-node/pull/2675