### PR TITLE
Feature/issue 2660 rsa roster script

### DIFF
--- a/docs/runbooks/rsa-roster-bootstrap.md
+++ b/docs/runbooks/rsa-roster-bootstrap.md
@@ -1,0 +1,27 @@
+# Runbook: Generating RSA Roster Bootstrap File
+
+## Overview
+As per Issue #2660, Block Nodes (BN) need an address book roster ready at deployment time so they don't have to query the Mirror Node (MN) API dynamically to verify Wrapped Record Blocks (WRBs). 
+
+This runbook explains how to use the `generate-rsa-roster-bootstrap.sh` script to pre-fetch this data.
+
+## Prerequisites
+- `curl` installed
+- `jq` installed (Command-line JSON processor)
+
+## Execution Steps
+
+1. Navigate to the root of the repository.
+2. Run the script. You can pass the Mirror Node URL and Output File path as optional arguments.
+
+**Default execution (Mainnet):**
+```bash
+./scripts/generate-rsa-roster-bootstrap.sh
+```
+
+**Custom execution (e.g., Testnet):**
+```bash
+./scripts/generate-rsa-roster-bootstrap.sh "https://testnet.mirrornode.hedera.com" "testnet-roster.json"
+```
+
+3. Take the generated JSON file and mount/place it into your Block Node's deployment configuration directory as required by the `roster-bootstrap-rsa` plugin.

--- a/scripts/generate-rsa-roster-bootstrap.sh
+++ b/scripts/generate-rsa-roster-bootstrap.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Script to generate an RSA roster bootstrap file by querying a Mirror Node API.
+# Resolves Issue #2660 for hiero-block-node.
+
+set -e
+
+# Default configurations
+MIRROR_NODE_URL="${1:-https://mainnet-public.mirrornode.hedera.com}"
+OUTPUT_FILE="${2:-bootstrap-roster.json}"
+NEXT_LINK="/api/v1/network/nodes"
+
+echo "🔍 Fetching network nodes from Mirror Node: ${MIRROR_NODE_URL}"
+
+# Check if jq is installed
+if ! command -v jq &> /dev/null; then
+    echo "❌ Error: 'jq' is not installed. Please install jq to run this script."
+    exit 1
+fi
+
+# Initialize an empty JSON array to hold all nodes
+ALL_NODES="[]"
+
+# Loop through paginated API responses
+while [ "${NEXT_LINK}" != "null" ] && [ -n "${NEXT_LINK}" ]; do
+    echo "➡️ Fetching page: ${NEXT_LINK}..."
+    
+    RESPONSE=$(curl -s --fail "${MIRROR_NODE_URL}${NEXT_LINK}") || {
+        echo "❌ Error: Failed to reach Mirror Node API."
+        exit 1
+    }
+    
+    # Extract nodes from the current page and append to the master array
+    PAGE_NODES=$(echo "${RESPONSE}" | jq '.nodes')
+    ALL_NODES=$(jq -s '.[0] + .[1]' <(echo "${ALL_NODES}") <(echo "${PAGE_NODES}"))
+    
+    # Get the next page link, if it exists
+    NEXT_LINK=$(echo "${RESPONSE}" | jq -r '.links.next // empty')
+done
+
+echo "✅ Successfully retrieved all nodes. Parsing RSA keys..."
+
+# Parse the accumulated JSON array to extract the required fields
+echo "${ALL_NODES}" | jq '{
+    "roster": [
+        .[] | {
+            "node_id": .node_id,
+            "account_id": .node_account_id,
+            "rsa_public_key": .rsa_public_key
+        }
+    ],
+    "generated_at": (now | todateiso8601)
+}' > "${OUTPUT_FILE}"
+
+echo "🎉 Roster bootstrap file successfully generated at: ${OUTPUT_FILE}"


### PR DESCRIPTION
This PR introduces a standalone operator bash script (`generate-rsa-roster-bootstrap.sh`) to pre-fetch and build the RSA bootstrap address book roster prior to Block Node deployment.

Key implementations include:

1. Mirror Node Integration:Queries the `/api/v1/network/nodes` endpoint to dynamically build the roster.
2. Pagination Handling:Implements a `while` loop to follow `links.next` pagination until all nodes are retrieved, ensuring no nodes are missed on larger networks like Mainnet.
3. JSON Parsing: Utilizes `jq` to safely extract `node_id`, `node_account_id`, and `rsa_public_key`, formatting them into the expected `bootstrap-roster.json` structure.
4. Documentation: Adds a comprehensive runbook (`docs/runbooks/rsa-roster-bootstrap.md`) detailing prerequisites and execution steps for both Mainnet and Testnet environments.

Related Issue(s)
Closes #2660