### PR TITLE
Test/issue 2657 junit tempdir

### DIFF
--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
@@ -36,10 +36,10 @@ import org.hiero.block.node.spi.ServiceLoaderFunction;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
 import org.hiero.block.node.spi.health.HealthFacility.State;
 import org.hiero.block.node.spi.historicalblocks.BlockProviderPlugin;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockitoAnnotations;
 
 /**
@@ -50,6 +50,9 @@ class BlockNodeAppTest {
     BlockNodePlugin plugin2;
     BlockProviderPlugin providerPlugin1;
     BlockProviderPlugin providerPlugin2;
+
+    @TempDir
+    Path tempDir;
 
     private BlockNodeApp blockNodeApp;
     private TestBlockMessagingFacility mockBlockMessagingFacility;
@@ -72,6 +75,7 @@ class BlockNodeAppTest {
 
     @BeforeEach
     void setUp() throws IOException, ClassNotFoundException, InstantiationException, IllegalAccessException {
+        System.setProperty("block.node.appStateDataFilePath", tempDir.resolve("app-state-data.bin").toString());
         MockitoAnnotations.openMocks(this);
         // minimal plugin mocks
         plugin1 = createMockedPlugin(1, BlockNodePlugin.class);
@@ -103,14 +107,6 @@ class BlockNodeAppTest {
         blockNodeApp = spy(new BlockNodeApp(serviceLoaderFunction, false));
     }
 
-    @AfterEach
-    void cleanup() {
-        try {
-            Files.deleteIfExists(Path.of("build/tmp/data/block/node/app-state-data.bin"));
-        } catch (Exception e) {
-            // ignore the exception
-        }
-    }
 
     @Test
     @DisplayName("Test BlockNodeApp Initialization")


### PR DESCRIPTION
This PR refactors BlockNodeAppTest.java to use JUnit 5's @TempDir for managing temporary state data files, replacing the previous hardcoded path approach.

Key Changes:
Injected @TempDir: Added a JUnit-managed temporary directory field in BlockNodeAppTest.
Dynamic Configuration: Updated the setUp() method to dynamically set the block.node.appStateDataFilePath system property to a path within the temporary directory. This ensures the BlockNodeApp instance uses a fresh, isolated directory for each test run.
Removed Manual Cleanup: Deleted the @AfterEach cleanup method as JUnit's @TempDir automatically handles the deletion of the directory and its contents after tests complete.
Improved Test Reliability: By removing hardcoded paths in the build/ directory, the tests are now more robust and less prone to side effects from previous runs or shared file access.
Reviewer Notes
The refactor ensures that the tests no longer rely on a hardcoded path (build/tmp/data/block/node/app-state-data.bin), which simplifies the maintenance and improves the isolation of the unit tests.

Related Issue(s)
Resolves #2657