### PR TITLE
refactor: extract ApplicationStateConfig from NodeConfig (#2652)

### DIFF
--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/node/NodeConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/node/NodeConfig.java
@@ -4,7 +4,6 @@ package org.hiero.block.node.app.config.node;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 import com.swirlds.config.api.validation.annotation.Min;
-import java.nio.file.Path;
 import org.hiero.block.node.base.Loggable;
 
 /**
@@ -16,16 +15,9 @@ import org.hiero.block.node.base.Loggable;
  * @param earliestManagedBlock the block number for the earliest block managed
  *     by this node. Blocks earlier than this might be present, but the node
  *     should not make any particular effort to obtain or store them.
- * @param appStateDataFilePath path where application state, like TSS data (ledger ID, address book, WRAPS VK),
- *     are persisted across restarts as a serialized {@code TssData}.
- * @param appStateUpdateScanInterval The amount of milliseconds that the {@code ApplicationStateFacility} waits between
- *     checking to see if there are any {@code TssData} updates to process.
  */
 // spotless:off
 @ConfigData("block.node")
 public record NodeConfig(
-        @Loggable @ConfigProperty(defaultValue = "0") @Min(0) long earliestManagedBlock,
-        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/node/app-state-data.bin") Path appStateDataFilePath,
-        @Loggable @ConfigProperty(defaultValue = "500") @Min(100) long appStateUpdateScanInterval,
-        @Loggable @ConfigProperty(defaultValue = "100") @Min(100) int appStateUpdateInitialDelay) {}
+        @Loggable @ConfigProperty(defaultValue = "0") @Min(0) long earliestManagedBlock) {}
 // spotless:on

--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/state/ApplicationStateConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/state/ApplicationStateConfig.java
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.app.config.state;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import com.swirlds.config.api.validation.annotation.Min;
+import java.nio.file.Path;
+import org.hiero.block.node.base.Loggable;
+
+/**
+ * Configuration for the Application State.
+ *
+ * @param appStateDataFilePath path where application state, like TSS data (ledger ID, address book, WRAPS VK),
+ *     are persisted across restarts as a serialized {@code TssData}.
+ * @param appStateUpdateScanInterval The amount of milliseconds that the {@code ApplicationStateFacility} waits between
+ *     checking to see if there are any {@code TssData} updates to process.
+ * @param appStateUpdateInitialDelay The amount of milliseconds that the {@code ApplicationStateFacility} waits before
+ *     checking for the first time if there are any {@code TssData} updates to process.
+ */
+@ConfigData("appState")
+public record ApplicationStateConfig(
+        @Loggable
+                @ConfigProperty(defaultValue = "/opt/hiero/block-node/node/app-state-data.bin")
+                Path appStateDataFilePath,
+        @Loggable @ConfigProperty(defaultValue = "500") @Min(100) long appStateUpdateScanInterval,
+        @Loggable @ConfigProperty(defaultValue = "100") @Min(100) int appStateUpdateInitialDelay) {}

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -41,6 +41,7 @@ import org.hiero.block.node.app.config.AutomaticEnvironmentVariableConfigSource;
 import org.hiero.block.node.app.config.ServerConfig;
 import org.hiero.block.node.app.config.WebServerHttp2Config;
 import org.hiero.block.node.app.config.node.NodeConfig;
+import org.hiero.block.node.app.config.state.ApplicationStateConfig;
 import org.hiero.block.node.app.logging.CleanColorfulFormatter;
 import org.hiero.block.node.app.logging.ConfigLogger;
 import org.hiero.block.node.spi.ApplicationStateFacility;
@@ -156,6 +157,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         allConfigDataTypes.add(ServerConfig.class);
         allConfigDataTypes.add(WebServerHttp2Config.class);
         allConfigDataTypes.add(NodeConfig.class);
+        allConfigDataTypes.add(ApplicationStateConfig.class);
         loadedPlugins.forEach(plugin -> allConfigDataTypes.addAll(plugin.configDataTypes()));
         // Init BlockNode Configuration
         String appProperties = getClass().getClassLoader().getResource(APPLICATION_TEST_PROPERTIES) != null
@@ -399,13 +401,14 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 .createVirtualThreadScheduledExecutor(
                         1, "ApplicationStateScanner", BlockNodeApp::uncaughtExceptionHandler);
 
-        NodeConfig nodeConfig = blockNodeContext.configuration().getConfigData(NodeConfig.class);
+        ApplicationStateConfig appStateConfig =
+                blockNodeContext.configuration().getConfigData(ApplicationStateConfig.class);
 
         // Schedule periodic gap detection task using autonomous executor
         applicationStateExecutor.scheduleAtFixedRate(
                 this::checkForApplicationStateUpdates,
-                nodeConfig.appStateUpdateInitialDelay(),
-                nodeConfig.appStateUpdateScanInterval(),
+                appStateConfig.appStateUpdateInitialDelay(),
+                appStateConfig.appStateUpdateScanInterval(),
                 TimeUnit.MILLISECONDS);
     }
 
@@ -475,8 +478,10 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
      * @param tssData The TssData to persist
      */
     private void persistTssData(TssData tssData) {
-        final Path appStateDataFilePath =
-                blockNodeContext.configuration().getConfigData(NodeConfig.class).appStateDataFilePath();
+        final Path appStateDataFilePath = blockNodeContext
+                .configuration()
+                .getConfigData(ApplicationStateConfig.class)
+                .appStateDataFilePath();
         try {
             Files.createDirectories(appStateDataFilePath.getParent());
             Bytes serialized = TssData.JSON.toBytes(tssData);
@@ -499,7 +504,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
      */
     private void loadApplicationState(Configuration configuration) {
         final Path tssDataJsonPath =
-                configuration.getConfigData(NodeConfig.class).appStateDataFilePath();
+                configuration.getConfigData(ApplicationStateConfig.class).appStateDataFilePath();
         if (Files.exists(tssDataJsonPath)) {
             try {
                 TssData tssData = TssData.JSON.parse(Bytes.wrap(Files.readAllBytes(tssDataJsonPath)));

--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
@@ -28,6 +28,7 @@ import org.hiero.block.api.RosterEntry;
 import org.hiero.block.api.TssData;
 import org.hiero.block.api.TssRoster;
 import org.hiero.block.node.app.config.node.NodeConfig;
+import org.hiero.block.node.app.config.state.ApplicationStateConfig;
 import org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility;
 import org.hiero.block.node.base.ranges.ConcurrentLongRangeSet;
 import org.hiero.block.node.spi.BlockNodeContext;
@@ -72,6 +73,7 @@ class BlockNodeAppTest {
 
     @BeforeEach
     void setUp() throws IOException, ClassNotFoundException, InstantiationException, IllegalAccessException {
+        System.setProperty("appState.appStateDataFilePath", "build/tmp/data/block/node/app-state-data.bin");
         MockitoAnnotations.openMocks(this);
         // minimal plugin mocks
         plugin1 = createMockedPlugin(1, BlockNodePlugin.class);
@@ -344,7 +346,7 @@ class BlockNodeAppTest {
         final Path appStateDataFilePath = blockNodeApp
                 .blockNodeContext
                 .configuration()
-                .getConfigData(NodeConfig.class)
+                .getConfigData(ApplicationStateConfig.class)
                 .appStateDataFilePath();
 
         Files.deleteIfExists(appStateDataFilePath);

--- a/block-node/app/src/test/resources/app-test.properties
+++ b/block-node/app/src/test/resources/app-test.properties
@@ -5,4 +5,4 @@ mediator.ringBufferSize=1024
 notifier.ringBufferSize=1024
 files.recent.liveRootPath=build/tmp/data/liveRootPath
 files.historic.rootPath=build/tmp/data/historic
-block.node.appStateDataFilePath=build/tmp/data/block/node/app-state-data.bin
+appState.appStateDataFilePath=build/tmp/data/block/node/app-state-data.bin


### PR DESCRIPTION
Refactor the application state configurations by isolating them from the general NodeConfig into a dedicated ApplicationStateConfig record. This improves modularity and ensures that state-related settings are managed independently.

Create ApplicationStateConfig record in the state config package
Remove application state properties from NodeConfig to reduce coupling
Register ApplicationStateConfig in BlockNodeApp and update internal retrieval logic
Update BlockNodeAppTest and resources to use the new appState configuration namespace

Related Issue(s): Fixes #2652