### PR TITLE
chore: Update Solo Version to 0.71.0

### DIFF
--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew --no-daemon
-  SOLO_VERSION: "0.68.0"
+  SOLO_VERSION: "0.71.0"
 
 jobs:
   k6-tests:

--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -209,11 +209,11 @@ jobs:
             MN_VERSION="latest"
           fi
 
-          # Solo CLI version: use input if provided, otherwise default to 0.68.0 (as latest stable tested)
+          # Solo CLI version: use input if provided, otherwise default to 0.71.0 (as latest stable tested)
           if [[ -n "${{ inputs.solo-version }}" ]]; then
             SOLO_VERSION="${{ inputs.solo-version }}"
           else
-            SOLO_VERSION="0.68.0"
+            SOLO_VERSION="0.71.0"
           fi
 
           # Relay version: use input if provided, otherwise default to latest

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -32,7 +32,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         type: string
-        default: "0.68.0"
+        default: "0.71.0"
       tss-enabled:
         description: "Enable TSS/WRAPS on consensus nodes"
         type: boolean
@@ -116,7 +116,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         required: false
-        default: "0.68.0"
+        default: "0.71.0"
       tss-enabled:
         description: "Enable TSS (Threshold Signature Scheme) on consensus nodes"
         required: false


### PR DESCRIPTION
Updates Solo Version from 0.68.0 to 0.71.0.

Closes [#2642](https://github.com/issues?q=is%3Aopen+is%3Aissue+org%3Ahiero-ledger+archived%3Afalse+label%3A%22good+first+issue%22+&page=1&issue=hiero-ledger%7Chiero-block-node%7C2642).

