### PR TITLE
fix: `CombinedBlockRangeSet#contains(long, long)` Checks Individual Internal Sets Without Combining Data

### DIFF
--- a/block-node/base/src/main/java/org/hiero/block/node/base/ranges/CombinedBlockRangeSet.java
+++ b/block-node/base/src/main/java/org/hiero/block/node/base/ranges/CombinedBlockRangeSet.java
@@ -3,6 +3,7 @@ package org.hiero.block.node.base.ranges;
 
 import static org.hiero.block.node.spi.BlockNodePlugin.UNKNOWN_BLOCK_NUMBER;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -48,12 +49,7 @@ public class CombinedBlockRangeSet implements BlockRangeSet {
      */
     @Override
     public boolean contains(long start, long end) {
-        for (BlockRangeSet set : blockRangeSets) {
-            if (set.contains(start, end)) {
-                return true;
-            }
-        }
-        return false;
+        return reduceRanges().contains(start, end);
     }
 
     /**
@@ -97,10 +93,7 @@ public class CombinedBlockRangeSet implements BlockRangeSet {
      */
     @Override
     public LongStream stream() {
-        return new ConcurrentLongRangeSet(Arrays.stream(blockRangeSets)
-                        .flatMap(BlockRangeSet::streamRanges)
-                        .toArray(LongRange[]::new))
-                .stream();
+        return reduceRanges().stream();
     }
 
     /**
@@ -108,9 +101,13 @@ public class CombinedBlockRangeSet implements BlockRangeSet {
      */
     @Override
     public Stream<LongRange> streamRanges() {
+        return reduceRanges().streamRanges();
+    }
+
+    @NonNull
+    private ConcurrentLongRangeSet reduceRanges() {
         return new ConcurrentLongRangeSet(Arrays.stream(blockRangeSets)
-                        .flatMap(BlockRangeSet::streamRanges)
-                        .toArray(LongRange[]::new))
-                .streamRanges();
+                .flatMap(BlockRangeSet::streamRanges)
+                .toArray(LongRange[]::new));
     }
 }

--- a/block-node/base/src/test/java/org/hiero/block/node/base/ranges/CombinedBlockRangeSetTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/ranges/CombinedBlockRangeSetTest.java
@@ -53,17 +53,37 @@ class CombinedBlockRangeSetTest {
     @Test
     @DisplayName("contains(start, end) returns true if any underlying set contains the range")
     void testContainsRange() {
-        final BlockRangeSet set1 = mock(BlockRangeSet.class);
-        final BlockRangeSet set2 = mock(BlockRangeSet.class);
-        when(set1.contains(10L, 20L)).thenReturn(false);
-        when(set2.contains(10L, 20L)).thenReturn(true);
-
+        final BlockRangeSet set1 = new ConcurrentLongRangeSet();
+        final BlockRangeSet set2 = new ConcurrentLongRangeSet(10L, 20L);
         final CombinedBlockRangeSet combinedSet = new CombinedBlockRangeSet(set1, set2);
         assertTrue(combinedSet.contains(10L, 20L));
+        assertFalse(combinedSet.contains(0L, 9L));
+        assertFalse(combinedSet.contains(0L, 20L));
         assertFalse(combinedSet.contains(30L, 40L));
+    }
 
-        verify(set1).contains(10L, 20L);
-        verify(set2).contains(10L, 20L);
+    @Test
+    @DisplayName("contains(start, end) returns true if range contained between multiple sets")
+    void testContainsRangeMultipleSets() {
+        final BlockRangeSet set1 = new ConcurrentLongRangeSet(10L, 15L);
+        final BlockRangeSet set2 = new ConcurrentLongRangeSet(16L, 20L);
+        final CombinedBlockRangeSet combinedSet = new CombinedBlockRangeSet(set1, set2);
+        assertTrue(combinedSet.contains(10L, 20L));
+        assertFalse(combinedSet.contains(0L, 9L));
+        assertFalse(combinedSet.contains(0L, 20L));
+        assertFalse(combinedSet.contains(30L, 40L));
+    }
+
+    @Test
+    @DisplayName("contains(start, end) returns true if range contained between multiple sets that overlap")
+    void testContainsRangeMultipleSetsOverlap() {
+        final BlockRangeSet set1 = new ConcurrentLongRangeSet(10L, 18L);
+        final BlockRangeSet set2 = new ConcurrentLongRangeSet(15L, 20L);
+        final CombinedBlockRangeSet combinedSet = new CombinedBlockRangeSet(set1, set2);
+        assertTrue(combinedSet.contains(10L, 20L));
+        assertFalse(combinedSet.contains(0L, 9L));
+        assertFalse(combinedSet.contains(0L, 20L));
+        assertFalse(combinedSet.contains(30L, 40L));
     }
 
     @Test


### PR DESCRIPTION
* Updated logic for the combined ranged set to consolidate all internal sets
* Additional tests to cover regressions

## Reviewer Notes

## Related Issue(s)

Fixes #2694 
