### PR TITLE
fix: Add logic to reduce incorrect acknowledgements.

### DIFF
--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -67,6 +67,8 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     private static final int DATA_READY_WAIT_MICROSECONDS = 5000;
     private static final String STALL_DETECTED_LOG_MESSAGE =
             "[{0}] Stall detected: handler {1} has not completed block {2}, another handler completed block {3}";
+    private static final String BLOCK_ABANDONED_LOG_MESSAGE =
+            "[{0}] Replacement persistence detected: handler {1} has not completed block {2}, but a different source persisted the same block {3}";
     private final System.Logger LOGGER = System.getLogger(LiveStreamPublisherManager.class.getName());
     private final MetricsHolder metrics;
     private final BlockNodeContext serverContext;
@@ -75,6 +77,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     private final ConcurrentNavigableMap<Long, PublisherHandler> handlers;
     private final AtomicLong nextHandlerId;
     private final ConcurrentNavigableMap<Long, Deque<BlockItemSetUnparsed>> queueByBlockMap;
+    // @todo Replace this with a metric, once metric values can be read.
     private final AtomicLong blocksClosedComplete;
     private final Condition dataReadyLatch;
     private final ReentrantLock dataReadyLock;
@@ -241,7 +244,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         // @todo(2344) we can further improve this
         LOGGER.log(INFO, "Handler {0} is ending mid-block {1}", handlerId, blockNumber);
         final Deque<BlockItemSetUnparsed> deque = queueByBlockMap.remove(blockNumber);
-        // Remove from the active resend set, if it's present
+        // Remove from the active resend set, if it's present (it should not be)
         activeResendBlocks.remove(blockNumber);
         // Remove this block from the ACCEPT winner tracking in all cases;
         // if the handler dropped mid-block there is no stall to detect here.
@@ -368,34 +371,78 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     @Override
     public void handlePersisted(@NonNull final PersistedNotification notification) {
         if (notification != null) {
-            final long newLastPersistedBlock = notification.blockNumber();
+            final long blockNumber = notification.blockNumber();
             if (notification.succeeded()) {
-                // If we are currently streaming any blocks < newLastPersistedBlock, then do not send acknowledgement
-                // There was a test, isBeforeEarliestActiveBlock(newLastPersistedBlock) here
-                // but this must be removed for now.
                 // @todo(#1841) reconsider this conditional in light of other changes.
-                if (newLastPersistedBlock > lastPersistedBlockNumber.get()) {
-                    // Update internal manager state before sending acknowledgement
-                    lastPersistedBlockNumber.set(newLastPersistedBlock);
-                    ensureNextGreaterThanPersisted(newLastPersistedBlock);
-                    clearObsoleteQueueItems(newLastPersistedBlock);
-                    handlers.values().parallelStream().unordered().forEach(handler -> {
-                        // _Important_, we only need the last persisted block number
-                        // all previous blocks are implicitly acknowledged.
-                        handler.sendAcknowledgement(newLastPersistedBlock);
-                    });
-                    metrics.latestBlockNumberAcknowledged.set(newLastPersistedBlock);
+                // Persistence success (as from backfill) can also detect stalled handlers...
+                checkForStalledHandlers(blockNumber);
+                if (blockNumber > lastPersistedBlockNumber.get()) {
+                    // Ensure we don't acknowledge past known gaps
+                    final long blockToAcknowledge = correctForResendAndStreaming(blockNumber);
+                    clearObsoleteQueueItems(blockToAcknowledge);
+                    // Don't update values or notify publishers if the block to be
+                    // acknowledged isn't greater than previous acknowledgement(s).
+                    if (blockToAcknowledge >= 0 && blockToAcknowledge > lastPersistedBlockNumber.get()) {
+                        // Update internal manager state before sending acknowledgement
+                        lastPersistedBlockNumber.set(blockToAcknowledge);
+                        handlers.values().parallelStream().unordered().forEach(handler -> {
+                            // _Important_, we only need the last persisted block number
+                            // all previous blocks are implicitly acknowledged.
+                            handler.sendAcknowledgement(lastPersistedBlockNumber.get());
+                        });
+                        metrics.latestBlockNumberAcknowledged.set(blockToAcknowledge);
+                    }
+                    // This needs to advance regardless, because we must handle that
+                    // backfill might be _ahead_ of the current blocks...
+                    // @todo We still need to work out a better way to handle this.
+                    //    We might need to look for and add any gaps created by
+                    //    this method call to the blocks to resend set.
+                    ensureNextGreaterThanPersisted(blockNumber);
                 }
             } else {
-                queueByBlockMap.clear();
-                final long blockNumber = notification.blockNumber();
-                // @todo(2198): We may have an extremely rare race condition here
-                nextUnstreamedBlockNumber.set(blockNumber);
+                if (blockNumber <= lastPersistedBlockNumber.get()) {
+                    // @todo(2198): We may have an extremely rare race condition here
+                    nextUnstreamedBlockNumber.set(blockNumber);
+                }
+                // Make sure to schedule resend for this failed persistence
+                // This is actually unnecessary, _for now_, add back in when
+                // we no longer end all handlers.
+                // blocksToResend.add(blockNumber);
+                // Notify the handlers that persistence failed.
                 handlers.values().parallelStream()
                         .unordered()
                         .forEach((handler) -> handler.endStreamWithCode(Code.PERSISTENCE_FAILED, false));
+                queueByBlockMap.clear();
             }
         }
+    }
+
+    /// Given a proposed block to acknowledge, adjust it to take into account any
+    /// blocks waiting to resend or currently resending, and any other necessary
+    /// conditions.
+    /// These adjustments ensure that we do not accidentally acknowledge a block
+    /// due to out-of-order persistence when there are earlier blocks that this
+    /// plugin _knows_ are not yet verified and persisted.
+    ///
+    /// @param blockNumber The block number that we are expecting to acknowledge.
+    ///
+    /// @return an adjusted (lower only) block number to actually acknowledge.
+    ///     This value is adjusted lower than any blocks we know are not yet
+    ///     stored successfully (including resends, active streams, etc...).
+    ///
+    private long correctForResendAndStreaming(final long blockNumber) {
+        // get the lowest block number resending or scheduled to resend
+        // Use block number + 1 as a default if something isn't set, because we'll reduce by one later.
+        final long defaultValue = blockNumber + 1;
+        final long earliestInFlight = queueByBlockMap.isEmpty() ? defaultValue : queueByBlockMap.firstKey();
+        final long activeResend = activeResendBlocks.isEmpty() ? defaultValue : activeResendBlocks.first();
+        final long scheduledResend = blocksToResend.isEmpty() ? defaultValue : blocksToResend.first();
+        final long earliestResend = Math.min(activeResend, scheduledResend);
+        final long earliestKnownGap = Math.min(earliestInFlight, earliestResend);
+        // Ensure we don't acknowledge blocks at or after the earliest block we
+        // still have not persisted. Note, this is not perfect, it cannot account
+        // for pre-existing gaps earlier than the last known persisted block.
+        return (earliestKnownGap <= blockNumber) ? earliestKnownGap - 1 : blockNumber;
     }
 
     /// Removes queue entries for blocks that are incomplete and
@@ -431,11 +478,14 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             final NavigableSet<Long> keysBeforeBlock = new TreeSet<>();
             keysBeforeBlock.addAll(queueByBlockMap.headMap(blockNumber, true).keySet());
             for (final Long candidate : keysBeforeBlock) {
-                if (!(blockProofs.containsKey(candidate) || hasBlockProof(queueByBlockMap.get(candidate)))) {
+                if (!(blockProofs.containsKey(candidate)
+                        || hasBlockProof(queueByBlockMap.get(candidate))
+                        || isResendingLive(candidate))) {
                     queueByBlockMap.remove(candidate);
                     // possibly remove a just collected block proof
                     blockProofs.remove(candidate);
                     // remove from stall-detection tracking; this block is now obsolete
+                    // This should not actually be needed, but it's here for a rare corner case
                     activeStreamHandlerByBlock.remove(candidate);
                 }
             }
@@ -490,11 +540,11 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     /// Checks whether any currently accepted block is stalled relative to the
     /// block that just completed. A handler is considered stalled when it holds
     /// ACCEPT for block N, has not yet called endOfBlock(N), and another handler
-    /// has just called endOfBlock(M) where M > N + 2.
+    /// has just called endOfBlock(M) where M > N + `K`.
     ///
-    /// The +2 threshold respects the protocol requirement that a publisher may
-    /// reasonably require up to 2 block times to complete a block due to
-    /// signature gathering.
+    /// The +`K` threshold respects the protocol requirement that a publisher may
+    /// reasonably require up to `K` block times to complete a block due to
+    /// signature gathering. The exact value, `K`, is configured.
     ///
     /// For each stalled block found:
     /// - Its queue and proof entries are removed so the forwarder can advance.
@@ -513,32 +563,47 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         for (final Map.Entry<Long, Long> entry : activeStreamHandlerByBlock.entrySet()) {
             final long candidateBlock = entry.getKey();
             final long handlerId = entry.getValue();
-            if (completedBlockNumber > candidateBlock + maxBlocksBeforeStalled
+            // Discard the block entirely if we just completed that exact block
+            // via another channel but do not discard _completed_ blocks.
+            // Include the CAS check here so we don't do this in multiple threads
+            if (completedBlockNumber == candidateBlock
+                    && !endBlocksReceived.contains(candidateBlock)
+                    && activeStreamHandlerByBlock.remove(candidateBlock, handlerId)) {
+                endStalledBlock(completedBlockNumber, handlerId, candidateBlock, BLOCK_ABANDONED_LOG_MESSAGE);
+                // Do not resend in this case.
+            } else if (completedBlockNumber > candidateBlock + maxBlocksBeforeStalled
                     && !endBlocksReceived.contains(candidateBlock)
                     && !isResendingLive(candidateBlock)
                     && activeStreamHandlerByBlock.remove(candidateBlock, handlerId)) {
                 // This thread won the CAS — execute the stall action.
-                // @todo: Add CorrelationID _for the handler that is stalled_
-                //        (not the thread that called this method).
-                //     This requires making correlation ID accessible in Handler.
-                PublisherHandler stalledHandler = handlers.get(handlerId);
-                String correlationId = stalledHandler != null ? stalledHandler.getCorrelationId() : "";
-                LOGGER.log(
-                        DEBUG,
-                        STALL_DETECTED_LOG_MESSAGE,
-                        correlationId,
-                        handlerId,
-                        candidateBlock,
-                        completedBlockNumber);
-                queueByBlockMap.remove(candidateBlock);
-                blockProofs.remove(candidateBlock);
+                endStalledBlock(completedBlockNumber, handlerId, candidateBlock, STALL_DETECTED_LOG_MESSAGE);
                 blocksToResend.add(candidateBlock);
-                if (stalledHandler != null) {
-                    stalledHandler.endStreamWithCode(TIMEOUT, true);
-                }
-                metrics.stallTimeoutsSent().increment();
             }
         }
+    }
+
+    /// Given a known-stalled block, log a stall, remove the block from queues
+    /// and tracking, end the stream for the responsible handler, and
+    /// increment a metric.
+    ///
+    /// @param completedBlock The block that was _completed_ and resulted
+    ///     in detecting the stall.
+    /// @param handlerId the Handler that is stalled
+    /// @param stalledBlock the block that is stalled
+    /// @param logMessage a log message to send, this message will be logged
+    ///     with correlation ID, handler ID, stalled block, and completed block,
+    ///     in that order.
+    private void endStalledBlock(
+            final long completedBlock, final long handlerId, final long stalledBlock, final String logMessage) {
+        PublisherHandler stalledHandler = handlers.get(handlerId);
+        String correlationId = stalledHandler != null ? stalledHandler.getCorrelationId() : "";
+        LOGGER.log(DEBUG, logMessage, correlationId, handlerId, stalledBlock, completedBlock);
+        queueByBlockMap.remove(stalledBlock);
+        blockProofs.remove(stalledBlock);
+        if (stalledHandler != null) {
+            stalledHandler.endStreamWithCode(TIMEOUT, true);
+        }
+        metrics.stallTimeoutsSent().increment();
     }
 
     /// Check if the candidate block is being resent and is newer than the last
@@ -553,18 +618,6 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     ///
     private boolean isResendingLive(final long candidateBlock) {
         return activeResendBlocks.contains(candidateBlock) && candidateBlock > lastPersistedBlockNumber.get();
-    }
-
-    /// Determine if the given block number is before the earliest active block.
-    /// @param blockNumber to check
-    /// @return `true` if, and only if, there are no blocks currently streaming or `blockNumber` is strictly less
-    ///     than the earliest block currently waiting to be sent to messaging
-    private boolean isBeforeEarliestActiveBlock(final long blockNumber) {
-        try {
-            return queueByBlockMap.isEmpty() || blockNumber < queueByBlockMap.firstKey();
-        } catch (final NoSuchElementException e) {
-            return true;
-        }
     }
 
     /// todo(1420) add documentation

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -1910,7 +1910,7 @@ class LiveStreamPublisherManagerTest {
                         .returns(block0.number(), acknowledgementBlockNumberExtractor);
                 // Now clear the pipeline so we can assert the duplicate below
                 responsePipeline.getOnNextCalls().clear();
-                // Now start streaming block 0 which is expected (by the manager) to be resent
+                // Now start streaming block 0 which is not expected (by the manager) to be resent
                 publisherHandler.onNext(requestBlock0);
                 // Give some time for the message forwarder to forward the items
                 LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(500L));

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherManagerRegressionTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherManagerRegressionTest.java
@@ -140,7 +140,7 @@ class PublisherManagerRegressionTest {
                         .kind());
 
         // Backfill persists blocks 0 through 2, covering and advancing past
-        // the stalled block.
+        // the stalled block. This won't free the stall, however, because
         final long lastBackfilledBlock = 2L;
         final SimpleBlockRangeSet availableBlocks = new SimpleBlockRangeSet();
         availableBlocks.add(stalledBlock, lastBackfilledBlock);
@@ -201,14 +201,6 @@ class PublisherManagerRegressionTest {
                 .returns(ResponseOneOfType.SKIP_BLOCK, response -> response.response()
                         .kind());
 
-        // Backfill persists block 5, advancing lastPersisted to 5.
-        // clearObsoleteQueueItems(5) uses headMap(5) which does NOT
-        // include block 5 — the stalled queue stays in the map.
-        final SimpleBlockRangeSet backfilledBlocks = new SimpleBlockRangeSet();
-        backfilledBlocks.add(0L, stalledBlock);
-        historicalBlockFacility.setTemporaryAvailableBlocks(backfilledBlocks);
-        toTest.handlePersisted(new PersistedNotification(stalledBlock, true, 0, BlockSource.BACKFILL));
-
         // Handler 2 sends a complete block 6.
         responsePipeline2.clear();
         final long nextLiveBlock = stalledBlock + 1;
@@ -216,14 +208,25 @@ class PublisherManagerRegressionTest {
         publisherHandler2.onNext(nextBlock.asPublishStreamRequestUnparsed());
         endThisBlock(publisherHandler2, nextLiveBlock);
 
+        // Backfill persists block 5, This must not advance last persisted (because block 5 is actively streaming).
+        // clearObsoleteQueueItems(5) uses headMap(5) which does NOT
+        // include block 5 — the stalled queue stays in the map.
+        // Except that persisted block == stalled block, so the stalled block is abandoned.
+        // This clears the blockage and block 6 will now proceed.
+        final SimpleBlockRangeSet backfilledBlocks = new SimpleBlockRangeSet();
+        backfilledBlocks.add(0L, stalledBlock);
+        historicalBlockFacility.setTemporaryAvailableBlocks(backfilledBlocks);
+        toTest.handlePersisted(new PersistedNotification(stalledBlock, true, 0, BlockSource.BACKFILL));
+
         // Run the forwarder. If the stalled block 5's queue is still
         // in queueByBlockMap, determineCurrentBlockNumber() returns 5
         // and the forwarder never reaches block 6.
         threadPoolManager.executor().executeAsync(1_000L, false);
 
-        // Block 6 must have been forwarded to the messaging facility.
         assertThat(messagingFacility.getSentBlockItems())
-                .as("block %d must be forwarded to messaging after backfill unblocked the pipeline", nextLiveBlock)
+                .as(
+                        "block %d must be forwarded to messaging after backfill unblocked the pipeline via stall detection",
+                        nextLiveBlock)
                 .anyMatch(items -> items.blockNumber() == nextLiveBlock);
     }
 

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
@@ -55,7 +55,7 @@ import org.junit.jupiter.api.Test;
 public class BlockNodeApiRegressionTest {
 
     private static final String BLOCKS_DATA_DIR_PATH = "build/tmp/data";
-    private static final Duration DEFAULT_AWAIT_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration DEFAULT_AWAIT_TIMEOUT = Duration.ofSeconds(60);
     private static final Options OPTIONS =
             new Options(Optional.empty(), ServiceInterface.RequestOptions.APPLICATION_GRPC);
 
@@ -87,7 +87,10 @@ public class BlockNodeApiRegressionTest {
         try {
             assertNotNull(app, "BlockNodeApp should be constructed");
             app.start();
-            Thread.sleep(200);
+            final long startupDeadline = System.currentTimeMillis() + 10_000;
+            while (app.blockNodeState() != State.RUNNING && System.currentTimeMillis() < startupDeadline) {
+                Thread.sleep(10);
+            }
             assertEquals(State.RUNNING, app.blockNodeState());
             publishBlockStreamPbjGrpcClient = createGrpcClient();
             getBlockPbjGrpcClient = createGrpcClient();
@@ -117,19 +120,25 @@ public class BlockNodeApiRegressionTest {
      * because {@code blocksToResend} contains 3. Publisher 2 responds by providing the full
      * block 3, filling the gap. Block 5 follows normally.
      *
+     * <p>ACK delivery: ACK(3) is always sent. ACK(4) may be suppressed when
+     * {@code handlePersisted(4)} fires before the forwarder removes block 4's key from
+     * {@code queueByBlockMap} — {@code correctForResendAndStreaming(4)} returns 3 in that case.
+     * ACK(5) is always sent because the forwarder removes block 5's key before dispatching
+     * to messaging. A newer ACK implicitly acknowledges all prior blocks.
+     *
      * <p>All three blocks must end up in storage. Without the fix, block 3's queue is never
      * forwarded to messaging and the gap persists silently.
      */
     @Test
     @DisplayName("publisher RESEND fills block gap left by severed connection")
-    void missingBlockGapWhenPublisherSeversConnectionBeforeEndOfBlock() throws InterruptedException {
+    void publisherResendFillsBlockGapLeftBySeveredConnection() throws InterruptedException {
         final Bytes hash0 = BlockItemBuilderUtils.computeBlockHash(0L, null);
         final Bytes hash1 = BlockItemBuilderUtils.computeBlockHash(1L, hash0);
         final Bytes hash2 = BlockItemBuilderUtils.computeBlockHash(2L, hash1);
         final Bytes hash3 = BlockItemBuilderUtils.computeBlockHash(3L, hash2);
         final Bytes hash4 = BlockItemBuilderUtils.computeBlockHash(4L, hash3);
 
-        // Publisher 1 — stream blocks 0–2 with proper hash chain, ACK for each.
+        // Publisher 1: stream blocks 0–2 with proper hash chain, ACK for each.
         final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisher1Client =
                 new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
                         publishBlockStreamPbjGrpcClient, OPTIONS);
@@ -148,8 +157,6 @@ public class BlockNodeApiRegressionTest {
         }
 
         // Publisher 1 sends only the header for block 3 (no proof), then severs via RESET.
-        // blockIsEnding(3) removes block 3's queue from queueByBlockMap and adds 3 to
-        // blocksToResend. No partial proof is stranded in blockProofs because no proof was sent.
         publisher1Stream.onNext(buildPublishRequest(new BlockItem[] {BlockItemBuilderUtils.sampleBlockHeader(3L)}));
         final AtomicReference<CountDownLatch> publisher1DisconnectLatch =
                 publisher1Observer.setAndGetConnectionEndedLatch(1);
@@ -160,24 +167,17 @@ public class BlockNodeApiRegressionTest {
                 .build());
         awaitLatch(publisher1DisconnectLatch, "publisher 1 disconnect after block 3 header");
 
-        // Publisher 2 — connect and send block 4, then block 3 (the gap), then block 5.
-        //
-        // Sequence on the server:
-        //   endOfBlock(4) -> RESEND(3): handler resets, block 4 stays in queueByBlockMap
-        //   block 3 header -> getActionForHeader(3) -> ACCEPT (removes 3 from blocksToResend)
-        //   endOfBlock(3) -> ACCEPT(3)
-        //   endOfBlock(5) -> ACCEPT(5)
-        //
-        // Forwarder persistence order: block 4 first, then block 3, then block 5.
-        // ACK(4) and ACK(5) are sent. Block 3 is persisted but implicit in ACK(4) (4 > 3).
+        // Publisher 2: send block 4, then block 3 (the gap), then block 5.
+        // endOfBlock(4) detects the gap and returns RESEND(3).
         final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisher2Client =
                 new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(createGrpcClient(), OPTIONS);
         final ResponsePipelineUtils<PublishStreamResponse> publisher2Observer = new ResponsePipelineUtils<>();
         final Pipeline<? super PublishStreamRequest> publisher2Stream =
                 publisher2Client.publishBlockStream(publisher2Observer);
 
-        // Expect 3 responses: RESEND(3), ACK(4), ACK(5).
-        final AtomicReference<CountDownLatch> publisher2Latch = publisher2Observer.setAndGetOnNextLatch(3);
+        final AtomicReference<CountDownLatch> publisher2Latch = publisher2Observer.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
+                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() == 5L);
 
         publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(4L, hash3)));
         endBlock(4L, publisher2Stream);
@@ -188,7 +188,7 @@ public class BlockNodeApiRegressionTest {
         publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(5L, hash4)));
         endBlock(5L, publisher2Stream);
 
-        awaitLatch(publisher2Latch, "RESEND(3) and ACKs for blocks 4 and 5");
+        awaitLatch(publisher2Latch, "RESEND(3) and ACK for block 5");
 
         final List<PublishStreamResponse> publisher2Responses = publisher2Observer.getOnNextCalls();
         assertThat(publisher2Responses)
@@ -197,36 +197,160 @@ public class BlockNodeApiRegressionTest {
                         .returns(PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK, responseKindExtractor)
                         .returns(3L, resendBlockNumberExtractor));
         assertThat(publisher2Responses)
-                .as("publisher 2 must receive ACK for block 4")
-                .anySatisfy(response -> assertThat(response)
-                        .returns(PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor)
-                        .returns(4L, acknowledgementBlockNumberExtractor));
-        assertThat(publisher2Responses)
-                .as("publisher 2 must receive ACK for block 5")
+                .as("publisher 2 must receive ACK for block 5 — all blocks through 5 are persisted")
                 .anySatisfy(response -> assertThat(response)
                         .returns(PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor)
                         .returns(5L, acknowledgementBlockNumberExtractor));
 
-        // All three blocks must be in storage — the gap at block 3 was filled by the RESEND.
-        // ACK(5) was received only after block 5 was persisted, so blocks 3 and 4 (persisted
-        // before block 5 in the forwarder's messaging order) are also present.
         final BlockAccessServiceInterface.BlockAccessServiceClient blockAccessClient =
                 new BlockAccessServiceInterface.BlockAccessServiceClient(getBlockPbjGrpcClient, OPTIONS);
-        assertThat(blockAccessClient
-                        .getBlock(BlockRequest.newBuilder().blockNumber(3L).build())
-                        .status())
-                .as("block 3 must be present in storage — gap was filled by RESEND mechanism")
-                .isEqualTo(BlockResponse.Code.SUCCESS);
-        assertThat(blockAccessClient
-                        .getBlock(BlockRequest.newBuilder().blockNumber(4L).build())
-                        .status())
-                .as("block 4 must be present in storage")
-                .isEqualTo(BlockResponse.Code.SUCCESS);
-        assertThat(blockAccessClient
-                        .getBlock(BlockRequest.newBuilder().blockNumber(5L).build())
-                        .status())
-                .as("block 5 must be present in storage")
-                .isEqualTo(BlockResponse.Code.SUCCESS);
+        for (long blockNum = 3L; blockNum <= 5L; blockNum++) {
+            assertThat(blockAccessClient
+                            .getBlock(BlockRequest.newBuilder()
+                                    .blockNumber(blockNum)
+                                    .build())
+                            .status())
+                    .as("block %d must be present in storage — gap was filled by RESEND", blockNum)
+                    .isEqualTo(BlockResponse.Code.SUCCESS);
+        }
+
+        publisher1Client.close();
+        publisher2Client.close();
+        blockAccessClient.close();
+    }
+
+    /**
+     * Reproduces the stall-detection regression where a stalled publisher's block is never
+     * acknowledged and later blocks are forwarded out of order.
+     *
+     * <p>Publisher 1 streams blocks 0–1 (fully ACKed), then sends only the header for block 2
+     * and goes silent. Publisher 2 streams blocks 3–6; when block 6 completes, stall detection
+     * fires (6 &gt; 2 + MaxFutureBlocksBeforeStalled = 5), removes block 2 from
+     * {@code queueByBlockMap}, adds 2 to {@code blocksToResend}, and returns
+     * {@code RESEND_BLOCK(2)} to publisher 2.
+     *
+     * <p>Publisher 2 responds to the RESEND by re-delivering the complete block 2, then
+     * continues with blocks 7–8.
+     *
+     * <p>With the fix, the forwarder respects sequential ordering: block 2 is forwarded before
+     * blocks 3–6, ACK(2) is sent before ACK(3), and all blocks reach storage without gaps.
+     *
+     * <p>Cross-connection synchronization: publisher 1's block 2 header and publisher 2's block 3
+     * are on different gRPC connections with no guaranteed ordering. Publisher 2 retries block 3
+     * until the server stops returning {@code NODE_BEHIND_PUBLISHER}, which proves publisher 1's
+     * header was processed and {@code nextUnstreamedBlockNumber >= 3}.
+     */
+    @Test
+    @DisplayName("stall-detected RESEND must persist stalled block and acknowledge in order")
+    void stallDetectedResendMustPersistStalledBlockAndAcknowledgeInOrder() throws InterruptedException {
+        final Bytes hash0 = BlockItemBuilderUtils.computeBlockHash(0L, null);
+        final Bytes hash1 = BlockItemBuilderUtils.computeBlockHash(1L, hash0);
+        final Bytes hash2 = BlockItemBuilderUtils.computeBlockHash(2L, hash1);
+        final Bytes hash3 = BlockItemBuilderUtils.computeBlockHash(3L, hash2);
+        final Bytes hash4 = BlockItemBuilderUtils.computeBlockHash(4L, hash3);
+        final Bytes hash5 = BlockItemBuilderUtils.computeBlockHash(5L, hash4);
+        final Bytes hash6 = BlockItemBuilderUtils.computeBlockHash(6L, hash5);
+        final Bytes hash7 = BlockItemBuilderUtils.computeBlockHash(7L, hash6);
+
+        // Publisher 1: blocks 0–1 fully ACKed, then header-only block 2 (stall).
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisher1Client =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
+                        publishBlockStreamPbjGrpcClient, OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> publisher1Observer = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> publisher1Stream =
+                publisher1Client.publishBlockStream(publisher1Observer);
+
+        final Bytes[] previousHashes = {null, hash0};
+        for (long blockNum = 0L; blockNum <= 1L; blockNum++) {
+            final AtomicReference<CountDownLatch> ackLatch = publisher1Observer.setAndGetOnNextLatch(1);
+            publisher1Stream.onNext(buildPublishRequest(
+                    BlockItemBuilderUtils.createSimpleBlockWithNumber(blockNum, previousHashes[(int) blockNum])));
+            endBlock(blockNum, publisher1Stream);
+            awaitLatch(ackLatch, "ACK for block " + blockNum + " from publisher 1");
+        }
+        publisher1Stream.onNext(buildPublishRequest(new BlockItem[] {BlockItemBuilderUtils.sampleBlockHeader(2L)}));
+
+        // Publisher 2: sync, trigger stall detection, fill gap via RESEND.
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisher2Client =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(createGrpcClient(), OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> publisher2Observer = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> publisher2Stream =
+                publisher2Client.publishBlockStream(publisher2Observer);
+
+        // Synchronize: ensure publisher 1's block 2 header was processed before
+        // sending blocks that depend on nextUnstreamedBlockNumber >= 3.
+        sendBlockUntilAccepted(
+                publisher2Stream, publisher2Observer, BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2), 3L);
+
+        // Blocks 4–6 trigger stall detection (6 > 2 + 3).
+        final AtomicReference<CountDownLatch> resendLatch = publisher2Observer.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK);
+
+        publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(4L, hash3)));
+        endBlock(4L, publisher2Stream);
+        publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(5L, hash4)));
+        endBlock(5L, publisher2Stream);
+        publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(6L, hash5)));
+        endBlock(6L, publisher2Stream);
+
+        awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection", publisher2Observer);
+
+        // Fill the gap: send complete block 2.
+        final AtomicReference<CountDownLatch> ack2Latch = publisher2Observer.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
+                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() >= 2L);
+
+        publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
+        endBlock(2L, publisher2Stream);
+
+        awaitLatch(ack2Latch, "ACK(>=2) — block 2 persisted after RESEND");
+
+        // Terminal signal: blocks 7–8 confirm the full chain is flowing.
+        final AtomicReference<CountDownLatch> terminalLatch = publisher2Observer.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
+                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() >= 7L);
+
+        publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));
+        endBlock(7L, publisher2Stream);
+        publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(8L, hash7)));
+        endBlock(8L, publisher2Stream);
+
+        awaitLatch(terminalLatch, "ACK(>=7) — terminal signal", publisher2Observer);
+
+        // Verify RESEND was issued for block 2.
+        assertThat(publisher2Observer.getOnNextCalls())
+                .as("publisher 2 must receive RESEND(2) — stall detection must request the gap block")
+                .anySatisfy(response -> assertThat(response)
+                        .returns(PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK, responseKindExtractor)
+                        .returns(2L, resendBlockNumberExtractor));
+
+        // Verify all blocks 2–6 are in storage (no gaps).
+        final BlockAccessServiceInterface.BlockAccessServiceClient blockAccessClient =
+                new BlockAccessServiceInterface.BlockAccessServiceClient(getBlockPbjGrpcClient, OPTIONS);
+        for (long blockNum = 2L; blockNum <= 6L; blockNum++) {
+            assertThat(blockAccessClient
+                            .getBlock(BlockRequest.newBuilder()
+                                    .blockNumber(blockNum)
+                                    .build())
+                            .status())
+                    .as("block %d must be in storage — stall RESEND sequence must leave no gaps", blockNum)
+                    .isEqualTo(BlockResponse.Code.SUCCESS);
+        }
+
+        // Verify ACK ordering: ACK(2) must arrive before any ACK for a higher block.
+        final List<Long> ackBlockNumbers = publisher2Observer.getOnNextCalls().stream()
+                .filter(response ->
+                        response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT)
+                .map(response ->
+                        Objects.requireNonNull(response.acknowledgement()).blockNumber())
+                .toList();
+
+        assertThat(ackBlockNumbers).as("ACK(2) must be present").contains(2L);
+
+        final int ack2Index = ackBlockNumbers.indexOf(2L);
+        assertThat(ackBlockNumbers.subList(0, ack2Index))
+                .as("no ACK for a block higher than 2 may arrive before ACK(2)")
+                .allSatisfy(blockNumber -> assertThat(blockNumber).isLessThanOrEqualTo(2L));
 
         publisher1Client.close();
         publisher2Client.close();
@@ -261,6 +385,91 @@ public class BlockNodeApiRegressionTest {
         requestStream.onNext(PublishStreamRequest.newBuilder()
                 .endOfBlock(BlockEnd.newBuilder().blockNumber(blockNumber).build())
                 .build());
+    }
+
+    /**
+     * Sends the given block repeatedly until the server accepts it (i.e. stops
+     * returning {@code NODE_BEHIND_PUBLISHER}). {@code NODE_BEHIND_PUBLISHER}
+     * is synchronous — if no response arrives within 500 ms the block was
+     * accepted. The handler resets after each {@code BEHIND}, so retrying is
+     * safe.
+     */
+    private void sendBlockUntilAccepted(
+            final Pipeline<? super PublishStreamRequest> stream,
+            final ResponsePipelineUtils<PublishStreamResponse> observer,
+            final BlockItem[] blockItems,
+            final long blockNumber)
+            throws InterruptedException {
+        boolean accepted = false;
+        while (!accepted) {
+            final int responsesBefore = observer.getOnNextCalls().size();
+            final AtomicReference<CountDownLatch> latch = observer.setAndGetOnNextLatch(1);
+            stream.onNext(buildPublishRequest(blockItems));
+            endBlock(blockNumber, stream);
+            final boolean responded = latch.get().await(500, TimeUnit.MILLISECONDS);
+            if (!responded) {
+                break;
+            }
+            final PublishStreamResponse response = observer.getOnNextCalls().get(responsesBefore);
+            accepted = response.response().kind() != PublishStreamResponse.ResponseOneOfType.NODE_BEHIND_PUBLISHER;
+        }
+    }
+
+    private void awaitLatch(
+            final AtomicReference<CountDownLatch> latch,
+            final String description,
+            final ResponsePipelineUtils<PublishStreamResponse> observer)
+            throws InterruptedException {
+        latch.get().await(DEFAULT_AWAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        if (latch.get().getCount() != 0) {
+            final StringBuilder diagnostics = new StringBuilder();
+            diagnostics.append("Timed out waiting for ").append(description).append('\n');
+            diagnostics
+                    .append("Responses received (")
+                    .append(observer.getOnNextCalls().size())
+                    .append("):\n");
+            for (int i = 0; i < observer.getOnNextCalls().size(); i++) {
+                final PublishStreamResponse response = observer.getOnNextCalls().get(i);
+                diagnostics
+                        .append("  [")
+                        .append(i)
+                        .append("] ")
+                        .append(response.response().kind());
+                if (response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT) {
+                    diagnostics
+                            .append(" block=")
+                            .append(Objects.requireNonNull(response.acknowledgement())
+                                    .blockNumber());
+                } else if (response.response().kind() == PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK) {
+                    diagnostics
+                            .append(" block=")
+                            .append(Objects.requireNonNull(response.resendBlock())
+                                    .blockNumber());
+                } else if (response.response().kind()
+                        == PublishStreamResponse.ResponseOneOfType.NODE_BEHIND_PUBLISHER) {
+                    diagnostics
+                            .append(" lastPersisted=")
+                            .append(Objects.requireNonNull(response.nodeBehindPublisher())
+                                    .blockNumber());
+                } else if (response.response().kind() == PublishStreamResponse.ResponseOneOfType.SKIP_BLOCK) {
+                    diagnostics
+                            .append(" block=")
+                            .append(Objects.requireNonNull(response.skipBlock()).blockNumber());
+                }
+                diagnostics.append('\n');
+            }
+            diagnostics
+                    .append("Errors: ")
+                    .append(observer.getOnErrorCalls().size())
+                    .append('\n');
+            for (final Throwable error : observer.getOnErrorCalls()) {
+                diagnostics.append("  ").append(error).append('\n');
+            }
+            diagnostics
+                    .append("onComplete calls: ")
+                    .append(observer.getOnCompleteCalls().get());
+            assertEquals(0, latch.get().getCount(), diagnostics.toString());
+        }
     }
 
     private void awaitLatch(final AtomicReference<CountDownLatch> latch, final String description)

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/utils/ResponsePipelineUtils.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/utils/ResponsePipelineUtils.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 
 /**
  * A simple test implementation of the {@link Pipeline} interface. It keeps
@@ -26,6 +27,9 @@ public class ResponsePipelineUtils<R> implements Pipeline<R> {
     private AtomicReference<CountDownLatch> onCompleteLatch = new AtomicReference<>();
     // Fires on either onComplete or onError — use when connection closure is the signal, not a specific response type
     private AtomicReference<CountDownLatch> connectionEndedLatch = new AtomicReference<>();
+    // Fires when any received item satisfies matchPredicate — use when a specific response is the terminal signal
+    private volatile Predicate<R> matchPredicate;
+    private final AtomicReference<CountDownLatch> matchLatch = new AtomicReference<>();
 
     @Override
     public void clientEndStreamReceived() {
@@ -37,6 +41,13 @@ public class ResponsePipelineUtils<R> implements Pipeline<R> {
         onNextCalls.add(Objects.requireNonNull(item));
         if (onNextLatch.get() != null) {
             onNextLatch.get().countDown();
+        }
+        final Predicate<R> pred = matchPredicate;
+        if (pred != null && pred.test(item)) {
+            final CountDownLatch latch = matchLatch.get();
+            if (latch != null) {
+                latch.countDown();
+            }
         }
     }
 
@@ -97,6 +108,14 @@ public class ResponsePipelineUtils<R> implements Pipeline<R> {
     public AtomicReference<CountDownLatch> setAndGetConnectionEndedLatch(int count) {
         connectionEndedLatch.set(new CountDownLatch(count));
         return connectionEndedLatch;
+    }
+
+    // Fires when the first item satisfying predicate is received.
+    // Set before sending items to avoid races.
+    public AtomicReference<CountDownLatch> setAndGetOnMatchLatch(final Predicate<R> predicate) {
+        matchLatch.set(new CountDownLatch(1));
+        matchPredicate = predicate;
+        return matchLatch;
     }
 
     /**


### PR DESCRIPTION
## Reviewer Notes
* Ensure no acknowledgement is _later_ than the earliest active resend.
* Ensure that no acknowledgement is _later_ than any known missing or in-flight block.
* Fix a small oversight in block queue cleanup.
* Removed an obsolete method.
