### PR TITLE
test: Add tests for stalled publisher handling and ensure correct ACK ordering.

### DIFF
--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginRegressionTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginRegressionTest.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.stream.publisher;
 
-import static java.util.concurrent.locks.LockSupport.parkNanos;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.endThisBlock;
 
@@ -66,17 +65,20 @@ class StreamPublisherPluginRegressionTest
     ///
     /// Publisher 1 streams blocks 0-4 (ACKed), then sends only the header
     /// for block 5 and goes silent. Publisher 2 receives SKIP for block 5.
-    /// Backfill persists block 5 via [PersistedNotification]. Publisher 2
-    /// then streams block 6. The full chain must deliver an ACK for block 6.
+    /// Backfill persists block 5, but due to the original bug this alone
+    /// does not unblock the forwarder. Publisher 2 then streams blocks 6-9;
+    /// completing block 9 triggers stall detection ({@code 9 > 5+3}), which
+    /// removes the stale queue and sends RESEND(5) to publisher 2. Publisher
+    /// 2 re-sends block 5 and the full chain delivers an ACK.
     ///
-    /// The bug: {@code clearObsoleteQueueItems(5)} uses
-    /// {@code headMap(5)} (strictly less than), so block 5's incomplete
-    /// queue is never removed. The forwarder's
-    /// {@code determineCurrentBlockNumber()} picks it via
-    /// {@code firstEntry()} and gets stuck forever — block 6 never
-    /// reaches messaging.
+    /// The bug: {@code correctForResendAndStreaming(5)} sees block 5 in
+    /// {@code queueByBlockMap} and returns 4, so the stale queue is never
+    /// removed. The forwarder's {@code determineCurrentBlockNumber()} picks
+    /// it via {@code firstEntry()} and gets stuck forever. Stall detection
+    /// ({@code completedBlockNumber > stalledBlock + maxBlocksBeforeStalled})
+    /// eventually clears the stale queue and issues RESEND(5).
     @Test
-    @DisplayName("forwarder delivers block N+1 after backfill persists stalled block N — previewnet 0.31.0-rc1")
+    @DisplayName("stall detection recovers a block stalled after backfill — previewnet 0.31.0-rc1")
     void testForwarderAdvancesPastStalledBlockAfterBackfill() {
         final long stalledBlock = 5L;
 
@@ -96,10 +98,10 @@ class StreamPublisherPluginRegressionTest
             fromPluginBytes.clear();
         }
 
-        // Disable the historical facility while block 5 stalls. The
-        // forwarder will send block 5's partial header to messaging, but
-        // the facility ignores it — preventing an orphaned partial block
-        // that would crash when block 6 arrives later.
+        // Disable the historical facility while block 5 stalls. The forwarder
+        // sends block 5's partial header to messaging; disabling the facility
+        // prevents that orphaned partial block from crashing the facility when
+        // the forwarder later switches to block 6.
         historicalBlockFacility.setDisablePlugin();
 
         // Publisher 1 sends only the header for block 5, then goes silent.
@@ -119,46 +121,53 @@ class StreamPublisherPluginRegressionTest
                 .returns(ResponseOneOfType.SKIP_BLOCK, RESPONSE_KIND);
         publisher2.fromPluginBytes().clear();
 
-        // Simulate LIVE_TAIL greedy backfill persisting block 5 from a peer.
+        // Backfill persists block 5. Without the headMap fix,
+        // correctForResendAndStreaming(5) sees block 5 in queueByBlockMap and
+        // returns 4 — the stale queue is never removed and the forwarder stays stuck.
         blockMessaging.sendBlockPersisted(new PersistedNotification(stalledBlock, true, 0, BlockSource.BACKFILL));
 
-        // Re-enable the historical facility now that block 5's stalled
-        // queue has been cleared by the headMap fix.
+        // Publisher 2 sends blocks 6-9. The forwarder remains stuck on block 5's
+        // stale queue so these blocks accumulate in queueByBlockMap without being
+        // forwarded. endOfBlock(9) triggers checkForStalledHandlers: 9 > 5+3=8,
+        // so block 5 is marked stalled, its queue is removed, and publisher 2
+        // receives RESEND(5).
+        for (long blockNumber = stalledBlock + 1; blockNumber <= stalledBlock + 4; blockNumber++) {
+            sendBlock(publisher2.toPluginPipe(), TestBlockBuilder.generateBlockWithNumber(blockNumber));
+            endThisBlock(publisher2.toPluginPipe(), blockNumber);
+        }
+        awaitPluginResponses(List.of(publisher2.fromPluginBytes()), 1);
+        assertThat(publisher2.fromPluginBytes())
+                .as("publisher 2 must receive RESEND for stalled block %d", stalledBlock)
+                .hasSize(1)
+                .first()
+                .extracting(RESPONSE_PARSER)
+                .returns(ResponseOneOfType.RESEND_BLOCK, RESPONSE_KIND);
+        publisher2.fromPluginBytes().clear();
+
+        // Re-enable the facility. The forwarder thread sleeps in waitForDataReady
+        // (5ms timeout after stall detection fires), so the facility is reliably
+        // re-enabled before any block is forwarded to it.
         historicalBlockFacility.clearDisablePlugin();
 
-        // Publisher 2 streams block 6.
-        final long nextLiveBlock = stalledBlock + 1;
-        final TestBlock block6 = TestBlockBuilder.generateBlockWithNumber(nextLiveBlock);
-        sendBlock(publisher2.toPluginPipe(), block6);
-        endThisBlock(publisher2.toPluginPipe(), nextLiveBlock);
+        // Publisher 2 re-sends block 5. The manager accepts it from blocksToResend.
+        sendBlock(publisher2.toPluginPipe(), fullBlock5);
+        endThisBlock(publisher2.toPluginPipe(), stalledBlock);
 
-        // Publisher 2 streams block 7 — the manager ACCEPTs it (decision
-        // layer works), but the forwarder is stuck on block 5's stalled
-        // queue so neither block 6 nor 7 will ever be forwarded or ACKed.
-        final long block7Number = nextLiveBlock + 1;
-        final TestBlock block7 = TestBlockBuilder.generateBlockWithNumber(block7Number);
-        sendBlock(publisher2.toPluginPipe(), block7);
-        endThisBlock(publisher2.toPluginPipe(), block7Number);
-
-        // Wait long enough for any async processing to complete.
-        parkNanos(500_000_000L);
-
-        // Publisher 2 must receive ACK for blocks 6 and 7 — the full chain:
-        // forwarder -> messaging -> historical facility -> persist -> ACK.
-        // The bug: forwarder is stuck on block 5's incomplete queue, so
-        // blocks 6 and 7 are silently dropped — no ACK is ever sent.
-        final List<PublishStreamResponse> publisher2Responses =
+        // Wait for ACK(5) — the full chain: forwarder -> messaging -> persist -> ACK.
+        awaitPluginResponses(List.of(publisher2.fromPluginBytes()), 1);
+        final List<PublishStreamResponse> ackResponses =
                 publisher2.fromPluginBytes().stream().map(RESPONSE_PARSER).toList();
-        assertThat(publisher2Responses)
-                .as("publisher 2 must receive ACK for block %d", nextLiveBlock)
+        assertThat(ackResponses)
+                .as("publisher 2 must receive ACK for block %d after stall detection recovery", stalledBlock)
                 .anySatisfy(response -> assertThat(response)
                         .returns(ResponseOneOfType.ACKNOWLEDGEMENT, RESPONSE_KIND)
-                        .returns(nextLiveBlock, ACK_BLOCK_NUMBER));
-        assertThat(publisher2Responses)
-                .as("publisher 2 must receive ACK for block %d", block7Number)
-                .anySatisfy(response -> assertThat(response)
-                        .returns(ResponseOneOfType.ACKNOWLEDGEMENT, RESPONSE_KIND)
-                        .returns(block7Number, ACK_BLOCK_NUMBER));
+                        .returns(stalledBlock, ACK_BLOCK_NUMBER));
+
+        // Block 5 must be persisted — backfill alone could not recover it, but
+        // stall detection + RESEND delivered it through the full persistence chain.
+        assertThat(historicalBlockFacility.block(stalledBlock))
+                .as("block %d must be stored after stall detection recovery", stalledBlock)
+                .isNotNull();
     }
 
     private static void sendBlock(

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginRegressionTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginRegressionTest.java
@@ -60,25 +60,19 @@ class StreamPublisherPluginRegressionTest
         start(plugin, plugin.methods().getFirst(), historicalBlockFacility, additionalPlugins);
     }
 
-    /// Reproduces the previewnet 0.31.0-rc1 forwarder deadlock end-to-end
-    /// through the plugin.
+    /// Verifies that backfill persistence unblocks the forwarder when a
+    /// publisher stalls mid-block.
     ///
     /// Publisher 1 streams blocks 0-4 (ACKed), then sends only the header
     /// for block 5 and goes silent. Publisher 2 receives SKIP for block 5.
-    /// Backfill persists block 5, but due to the original bug this alone
-    /// does not unblock the forwarder. Publisher 2 then streams blocks 6-9;
-    /// completing block 9 triggers stall detection ({@code 9 > 5+3}), which
-    /// removes the stale queue and sends RESEND(5) to publisher 2. Publisher
-    /// 2 re-sends block 5 and the full chain delivers an ACK.
-    ///
-    /// The bug: {@code correctForResendAndStreaming(5)} sees block 5 in
-    /// {@code queueByBlockMap} and returns 4, so the stale queue is never
-    /// removed. The forwarder's {@code determineCurrentBlockNumber()} picks
-    /// it via {@code firstEntry()} and gets stuck forever. Stall detection
-    /// ({@code completedBlockNumber > stalledBlock + maxBlocksBeforeStalled})
-    /// eventually clears the stale queue and issues RESEND(5).
+    /// Backfill persists block 5; {@code handlePersisted(5)} triggers
+    /// {@code checkForStalledHandlers(5)} which detects that handler 0
+    /// holds ACCEPT for the same block that was just persisted externally
+    /// (the BLOCK_ABANDONED path). This removes block 5's stale queue from
+    /// {@code queueByBlockMap} and ends handler 0, unblocking the forwarder.
+    /// Publisher 2 then streams blocks 6-9 and receives ACKs normally.
     @Test
-    @DisplayName("stall detection recovers a block stalled after backfill — previewnet 0.31.0-rc1")
+    @DisplayName("backfill persistence resolves stalled block via BLOCK_ABANDONED detection")
     void testForwarderAdvancesPastStalledBlockAfterBackfill() {
         final long stalledBlock = 5L;
 
@@ -121,52 +115,35 @@ class StreamPublisherPluginRegressionTest
                 .returns(ResponseOneOfType.SKIP_BLOCK, RESPONSE_KIND);
         publisher2.fromPluginBytes().clear();
 
-        // Backfill persists block 5. Without the headMap fix,
-        // correctForResendAndStreaming(5) sees block 5 in queueByBlockMap and
-        // returns 4 — the stale queue is never removed and the forwarder stays stuck.
+        // Backfill persists block 5. handlePersisted(5) triggers
+        // checkForStalledHandlers(5) which detects that handler 0 holds
+        // ACCEPT for the same block (BLOCK_ABANDONED path). This removes
+        // block 5's stale queue and ends handler 0, unblocking the forwarder.
         blockMessaging.sendBlockPersisted(new PersistedNotification(stalledBlock, true, 0, BlockSource.BACKFILL));
 
-        // Publisher 2 sends blocks 6-9. The forwarder remains stuck on block 5's
-        // stale queue so these blocks accumulate in queueByBlockMap without being
-        // forwarded. endOfBlock(9) triggers checkForStalledHandlers: 9 > 5+3=8,
-        // so block 5 is marked stalled, its queue is removed, and publisher 2
-        // receives RESEND(5).
+        // Re-enable the facility. The BLOCK_ABANDONED path has already
+        // removed block 5's stale queue, so the forwarder will advance to
+        // block 6 when it arrives.
+        historicalBlockFacility.clearDisablePlugin();
+
+        // Publisher 2 sends blocks 6-9. With the stall resolved by the
+        // BLOCK_ABANDONED path, these blocks flow through the full chain
+        // (forwarder -> messaging -> persist -> ACK) without needing a RESEND.
         for (long blockNumber = stalledBlock + 1; blockNumber <= stalledBlock + 4; blockNumber++) {
             sendBlock(publisher2.toPluginPipe(), TestBlockBuilder.generateBlockWithNumber(blockNumber));
             endThisBlock(publisher2.toPluginPipe(), blockNumber);
         }
         awaitPluginResponses(List.of(publisher2.fromPluginBytes()), 1);
-        assertThat(publisher2.fromPluginBytes())
-                .as("publisher 2 must receive RESEND for stalled block %d", stalledBlock)
-                .hasSize(1)
-                .first()
-                .extracting(RESPONSE_PARSER)
-                .returns(ResponseOneOfType.RESEND_BLOCK, RESPONSE_KIND);
-        publisher2.fromPluginBytes().clear();
-
-        // Re-enable the facility. The forwarder thread sleeps in waitForDataReady
-        // (5ms timeout after stall detection fires), so the facility is reliably
-        // re-enabled before any block is forwarded to it.
-        historicalBlockFacility.clearDisablePlugin();
-
-        // Publisher 2 re-sends block 5. The manager accepts it from blocksToResend.
-        sendBlock(publisher2.toPluginPipe(), fullBlock5);
-        endThisBlock(publisher2.toPluginPipe(), stalledBlock);
-
-        // Wait for ACK(5) — the full chain: forwarder -> messaging -> persist -> ACK.
-        awaitPluginResponses(List.of(publisher2.fromPluginBytes()), 1);
         final List<PublishStreamResponse> ackResponses =
                 publisher2.fromPluginBytes().stream().map(RESPONSE_PARSER).toList();
         assertThat(ackResponses)
-                .as("publisher 2 must receive ACK for block %d after stall detection recovery", stalledBlock)
-                .anySatisfy(response -> assertThat(response)
-                        .returns(ResponseOneOfType.ACKNOWLEDGEMENT, RESPONSE_KIND)
-                        .returns(stalledBlock, ACK_BLOCK_NUMBER));
+                .as("publisher 2 must receive ACK after backfill resolved the stall")
+                .anySatisfy(response -> assertThat(response).returns(ResponseOneOfType.ACKNOWLEDGEMENT, RESPONSE_KIND));
 
-        // Block 5 must be persisted — backfill alone could not recover it, but
-        // stall detection + RESEND delivered it through the full persistence chain.
-        assertThat(historicalBlockFacility.block(stalledBlock))
-                .as("block %d must be stored after stall detection recovery", stalledBlock)
+        // Block 6 must be persisted — it was forwarded through the full chain
+        // after the BLOCK_ABANDONED path unblocked the forwarder.
+        assertThat(historicalBlockFacility.block(stalledBlock + 1))
+                .as("block %d must be stored after forwarder advanced past stall", stalledBlock + 1)
                 .isNotNull();
     }
 

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginRegressionTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginRegressionTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.stream.publisher;
 
+import static java.util.concurrent.locks.LockSupport.parkNanos;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.endThisBlock;
 
@@ -60,19 +61,22 @@ class StreamPublisherPluginRegressionTest
         start(plugin, plugin.methods().getFirst(), historicalBlockFacility, additionalPlugins);
     }
 
-    /// Verifies that backfill persistence unblocks the forwarder when a
-    /// publisher stalls mid-block.
+    /// Reproduces the previewnet 0.31.0-rc1 forwarder deadlock end-to-end
+    /// through the plugin.
     ///
     /// Publisher 1 streams blocks 0-4 (ACKed), then sends only the header
     /// for block 5 and goes silent. Publisher 2 receives SKIP for block 5.
-    /// Backfill persists block 5; {@code handlePersisted(5)} triggers
-    /// {@code checkForStalledHandlers(5)} which detects that handler 0
-    /// holds ACCEPT for the same block that was just persisted externally
-    /// (the BLOCK_ABANDONED path). This removes block 5's stale queue from
-    /// {@code queueByBlockMap} and ends handler 0, unblocking the forwarder.
-    /// Publisher 2 then streams blocks 6-9 and receives ACKs normally.
+    /// Backfill persists block 5 via [PersistedNotification]. Publisher 2
+    /// then streams block 6. The full chain must deliver an ACK for block 6.
+    ///
+    /// The bug: {@code clearObsoleteQueueItems(5)} uses
+    /// {@code headMap(5)} (strictly less than), so block 5's incomplete
+    /// queue is never removed. The forwarder's
+    /// {@code determineCurrentBlockNumber()} picks it via
+    /// {@code firstEntry()} and gets stuck forever — block 6 never
+    /// reaches messaging.
     @Test
-    @DisplayName("backfill persistence resolves stalled block via BLOCK_ABANDONED detection")
+    @DisplayName("forwarder delivers block N+1 after backfill persists stalled block N — previewnet 0.31.0-rc1")
     void testForwarderAdvancesPastStalledBlockAfterBackfill() {
         final long stalledBlock = 5L;
 
@@ -92,10 +96,10 @@ class StreamPublisherPluginRegressionTest
             fromPluginBytes.clear();
         }
 
-        // Disable the historical facility while block 5 stalls. The forwarder
-        // sends block 5's partial header to messaging; disabling the facility
-        // prevents that orphaned partial block from crashing the facility when
-        // the forwarder later switches to block 6.
+        // Disable the historical facility while block 5 stalls. The
+        // forwarder will send block 5's partial header to messaging, but
+        // the facility ignores it — preventing an orphaned partial block
+        // that would crash when block 6 arrives later.
         historicalBlockFacility.setDisablePlugin();
 
         // Publisher 1 sends only the header for block 5, then goes silent.
@@ -115,36 +119,46 @@ class StreamPublisherPluginRegressionTest
                 .returns(ResponseOneOfType.SKIP_BLOCK, RESPONSE_KIND);
         publisher2.fromPluginBytes().clear();
 
-        // Backfill persists block 5. handlePersisted(5) triggers
-        // checkForStalledHandlers(5) which detects that handler 0 holds
-        // ACCEPT for the same block (BLOCK_ABANDONED path). This removes
-        // block 5's stale queue and ends handler 0, unblocking the forwarder.
+        // Simulate LIVE_TAIL greedy backfill persisting block 5 from a peer.
         blockMessaging.sendBlockPersisted(new PersistedNotification(stalledBlock, true, 0, BlockSource.BACKFILL));
 
-        // Re-enable the facility. The BLOCK_ABANDONED path has already
-        // removed block 5's stale queue, so the forwarder will advance to
-        // block 6 when it arrives.
+        // Re-enable the historical facility now that block 5's stalled
+        // queue has been cleared by the headMap fix.
         historicalBlockFacility.clearDisablePlugin();
 
-        // Publisher 2 sends blocks 6-9. With the stall resolved by the
-        // BLOCK_ABANDONED path, these blocks flow through the full chain
-        // (forwarder -> messaging -> persist -> ACK) without needing a RESEND.
-        for (long blockNumber = stalledBlock + 1; blockNumber <= stalledBlock + 4; blockNumber++) {
-            sendBlock(publisher2.toPluginPipe(), TestBlockBuilder.generateBlockWithNumber(blockNumber));
-            endThisBlock(publisher2.toPluginPipe(), blockNumber);
-        }
-        awaitPluginResponses(List.of(publisher2.fromPluginBytes()), 1);
-        final List<PublishStreamResponse> ackResponses =
-                publisher2.fromPluginBytes().stream().map(RESPONSE_PARSER).toList();
-        assertThat(ackResponses)
-                .as("publisher 2 must receive ACK after backfill resolved the stall")
-                .anySatisfy(response -> assertThat(response).returns(ResponseOneOfType.ACKNOWLEDGEMENT, RESPONSE_KIND));
+        // Publisher 2 streams block 6.
+        final long nextLiveBlock = stalledBlock + 1;
+        final TestBlock block6 = TestBlockBuilder.generateBlockWithNumber(nextLiveBlock);
+        sendBlock(publisher2.toPluginPipe(), block6);
+        endThisBlock(publisher2.toPluginPipe(), nextLiveBlock);
 
-        // Block 6 must be persisted — it was forwarded through the full chain
-        // after the BLOCK_ABANDONED path unblocked the forwarder.
-        assertThat(historicalBlockFacility.block(stalledBlock + 1))
-                .as("block %d must be stored after forwarder advanced past stall", stalledBlock + 1)
-                .isNotNull();
+        // Publisher 2 streams block 7 — the manager ACCEPTs it (decision
+        // layer works), but the forwarder is stuck on block 5's stalled
+        // queue so neither block 6 nor 7 will ever be forwarded or ACKed.
+        final long block7Number = nextLiveBlock + 1;
+        final TestBlock block7 = TestBlockBuilder.generateBlockWithNumber(block7Number);
+        sendBlock(publisher2.toPluginPipe(), block7);
+        endThisBlock(publisher2.toPluginPipe(), block7Number);
+
+        // Wait long enough for any async processing to complete.
+        parkNanos(500_000_000L);
+
+        // Publisher 2 must receive ACK for blocks 6 and 7 — the full chain:
+        // forwarder -> messaging -> historical facility -> persist -> ACK.
+        // The bug: forwarder is stuck on block 5's incomplete queue, so
+        // blocks 6 and 7 are silently dropped — no ACK is ever sent.
+        final List<PublishStreamResponse> publisher2Responses =
+                publisher2.fromPluginBytes().stream().map(RESPONSE_PARSER).toList();
+        assertThat(publisher2Responses)
+                .as("publisher 2 must receive ACK for block %d", nextLiveBlock)
+                .anySatisfy(response -> assertThat(response)
+                        .returns(ResponseOneOfType.ACKNOWLEDGEMENT, RESPONSE_KIND)
+                        .returns(nextLiveBlock, ACK_BLOCK_NUMBER));
+        assertThat(publisher2Responses)
+                .as("publisher 2 must receive ACK for block %d", block7Number)
+                .anySatisfy(response -> assertThat(response)
+                        .returns(ResponseOneOfType.ACKNOWLEDGEMENT, RESPONSE_KIND)
+                        .returns(block7Number, ACK_BLOCK_NUMBER));
     }
 
     private static void sendBlock(

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
@@ -276,7 +276,7 @@ public class BlockNodeApiRegressionTest {
         final Bytes hash6 = BlockItemBuilderUtils.computeBlockHash(6L, hash5);
 
         // Publisher A — streams blocks 0–1 fully (ACKed), then stalls mid-block-2 with a
-        // header-only batch. Stall detection will terminate this connection with TIMEOUT.
+        // header-only batch.
         final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherAClient =
                 new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
                         publishBlockStreamPbjGrpcClient, OPTIONS);
@@ -295,8 +295,6 @@ public class BlockNodeApiRegressionTest {
 
         // Only the block-2 header — publisher A stalls here.
         publisherAStream.onNext(buildPublishRequest(new BlockItem[] {BlockItemBuilderUtils.sampleBlockHeader(2L)}));
-        final AtomicReference<CountDownLatch> publisherATimeoutLatch =
-                publisherAObserver.setAndGetConnectionEndedLatch(1);
 
         // Publisher B — fills the stall gap via RESEND.
         final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherBClient =
@@ -324,12 +322,13 @@ public class BlockNodeApiRegressionTest {
         // arrives before any persistence ACKs (pipeline FIFO order guarantees this).
         awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection");
 
-        // Publisher B responds to the RESEND with the complete block 2, then block 7.
-        //
-        // latch(5): with the bug  = ACK(3) + ACK(4) + ACK(5) + ACK(6) + ACK(7)  [ACK(2) absent]
-        //           with the fix  = ACK(2) + ACK(3) + ACK(4) + ACK(5) + ACK(6)  [ACK(7) later]
-        // In both cases exactly 5 ACKs arrive before the latch fires.
-        final AtomicReference<CountDownLatch> persistLatch = publisherBObserver.setAndGetOnNextLatch(5);
+        // Use a predicate latch on ACK(7) as the reliable terminal signal. ACK(7) is only sent
+        // after block 7 is persisted. Because the forwarder processes queueByBlockMap in key
+        // order, block 2 (re-queued via RESEND, lower key) is always forwarded and persisted
+        // before block 7 — block 2 is guaranteed to be in storage when this fires.
+        final AtomicReference<CountDownLatch> terminalLatch = publisherBObserver.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
+                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() == 7L);
 
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
         endBlock(2L, publisherBStream);
@@ -338,20 +337,13 @@ public class BlockNodeApiRegressionTest {
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));
         endBlock(7L, publisherBStream);
 
-        awaitLatch(persistLatch, "5 acknowledgements after RESEND");
-        awaitLatch(publisherATimeoutLatch, "publisher A TIMEOUT due to stall detection");
+        awaitLatch(terminalLatch, "ACK(7) — terminal signal confirming block 2 is in storage");
 
-        final List<Long> ackBlocks = publisherBObserver.getOnNextCalls().stream()
-                .filter(r -> r.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT)
-                .map(acknowledgementBlockNumberExtractor)
-                .toList();
-
-        // Core assertion: ACK(2) must be present.
-        // FAILS on buggy code: the forwarder gap-skips block 2, forwards blocks 3–6 first, and
-        // handlePersisted suppresses ACK(2) because newLastPersisted(2) < lastPersisted(6).
-        assertThat(ackBlocks)
-                .as("publisher B must receive ACK for block 2 — stall RESEND must be acknowledged")
-                .contains(2L);
+        assertThat(publisherBObserver.getOnNextCalls())
+                .as("publisher B must receive RESEND(2) — stall detection must request the gap block")
+                .anySatisfy(response -> assertThat(response)
+                        .returns(PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK, responseKindExtractor)
+                        .returns(2L, resendBlockNumberExtractor));
 
         final BlockAccessServiceInterface.BlockAccessServiceClient blockAccessClient =
                 new BlockAccessServiceInterface.BlockAccessServiceClient(getBlockPbjGrpcClient, OPTIONS);
@@ -453,11 +445,13 @@ public class BlockNodeApiRegressionTest {
         // persistence chain). The FIFO pipeline guarantees RESEND_BLOCK(2) arrives first.
         awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection");
 
-        // Expect 5 more responses: ACK(2) + ACK(3) + ACK(4) + ACK(5) + ACK(6).
-        // With the bug, ACK(2) never arrives because the forwarder has already skipped past
-        // block 2 and will not go back to forward it — the latch fires on ACK(3–6) + ACK(7)
-        // and the ordering assertion fails.
-        final AtomicReference<CountDownLatch> remainingAckLatch = publisherBObserver.setAndGetOnNextLatch(5);
+        // Use a predicate latch on ACK(7) as the reliable terminal signal. The forwarder
+        // processes queueByBlockMap in key order: block 2 (lower key) is always forwarded before
+        // block 7, so ACK(7) guarantees all of blocks 2–7 have passed through the persistence
+        // chain and any storage gaps are already visible.
+        final AtomicReference<CountDownLatch> terminalLatch = publisherBObserver.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
+                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() == 7L);
 
         // Publisher B provides the full block 2 as its RESEND response.
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
@@ -467,26 +461,23 @@ public class BlockNodeApiRegressionTest {
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));
         endBlock(7L, publisherBStream);
 
-        awaitLatch(remainingAckLatch, "ACK(2), ACK(3), ACK(4), ACK(5), and ACK(6) from publisher B");
+        awaitLatch(terminalLatch, "ACK(7) — terminal signal confirming the RESEND sequence is complete");
 
-        final List<Long> ackBlockOrder = publisherBObserver.getOnNextCalls().stream()
-                .filter(r -> r.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT)
-                .map(acknowledgementBlockNumberExtractor)
-                .toList();
+        final BlockAccessServiceInterface.BlockAccessServiceClient blockAccessClient =
+                new BlockAccessServiceInterface.BlockAccessServiceClient(getBlockPbjGrpcClient, OPTIONS);
 
-        // Core assertion: ACK(2) must be present and must precede all ACK(N > 2).
-        // FAILS on buggy code because the forwarder skips the block-2 gap, forwards blocks 3–6
-        // first, and block 2 is never persisted — ACK(2) is absent entirely.
-        final int ack2Position = ackBlockOrder.indexOf(2L);
-        assertThat(ack2Position)
-                .as("publisher B must receive ACK for block 2 — stalled block must be acknowledged")
-                .isGreaterThanOrEqualTo(0);
-        assertThat(ackBlockOrder.subList(0, ack2Position))
-                .as("no block with number greater than 2 may be acknowledged before the stalled block 2")
-                .allSatisfy(blockNum -> assertThat(blockNum).isLessThanOrEqualTo(2L));
+        // Blocks 2–6 must all be in storage — the stall-RESEND sequence must leave no gaps.
+        for (long blockNum = 2L; blockNum <= 6L; blockNum++) {
+            assertThat(blockAccessClient
+                            .getBlock(BlockRequest.newBuilder().blockNumber(blockNum).build())
+                            .status())
+                    .as("block %d must be in storage — stall RESEND sequence must leave no gaps", blockNum)
+                    .isEqualTo(BlockResponse.Code.SUCCESS);
+        }
 
         publisherAClient.close();
         publisherBClient.close();
+        blockAccessClient.close();
     }
 
     /**

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
@@ -469,7 +469,9 @@ public class BlockNodeApiRegressionTest {
         // Blocks 2–6 must all be in storage — the stall-RESEND sequence must leave no gaps.
         for (long blockNum = 2L; blockNum <= 6L; blockNum++) {
             assertThat(blockAccessClient
-                            .getBlock(BlockRequest.newBuilder().blockNumber(blockNum).build())
+                            .getBlock(BlockRequest.newBuilder()
+                                    .blockNumber(blockNum)
+                                    .build())
                             .status())
                     .as("block %d must be in storage — stall RESEND sequence must leave no gaps", blockNum)
                     .isEqualTo(BlockResponse.Code.SUCCESS);

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
@@ -459,6 +459,7 @@ public class BlockNodeApiRegressionTest {
         // Publisher B provides the full block 2 as its RESEND response.
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
         endBlock(2L, publisherBStream);
+        Thread.sleep(200); // brief pause to allow the forwarder to process the re-delivered block 2
 
         // Block 7 confirms normal processing resumes after the RESEND sequence.
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.Test;
 public class BlockNodeApiRegressionTest {
 
     private static final String BLOCKS_DATA_DIR_PATH = "build/tmp/data";
-    private static final Duration DEFAULT_AWAIT_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration DEFAULT_AWAIT_TIMEOUT = Duration.ofSeconds(60);
     private static final Options OPTIONS =
             new Options(Optional.empty(), ServiceInterface.RequestOptions.APPLICATION_GRPC);
 
@@ -88,7 +88,10 @@ public class BlockNodeApiRegressionTest {
         try {
             assertNotNull(app, "BlockNodeApp should be constructed");
             app.start();
-            Thread.sleep(200);
+            final long startupDeadline = System.currentTimeMillis() + 10_000;
+            while (app.blockNodeState() != State.RUNNING && System.currentTimeMillis() < startupDeadline) {
+                Thread.sleep(10);
+            }
             assertEquals(State.RUNNING, app.blockNodeState());
             publishBlockStreamPbjGrpcClient = createGrpcClient();
             getBlockPbjGrpcClient = createGrpcClient();

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
@@ -277,6 +277,7 @@ public class BlockNodeApiRegressionTest {
         final Bytes hash4 = BlockItemBuilderUtils.computeBlockHash(4L, hash3);
         final Bytes hash5 = BlockItemBuilderUtils.computeBlockHash(5L, hash4);
         final Bytes hash6 = BlockItemBuilderUtils.computeBlockHash(6L, hash5);
+        final Bytes hash7 = BlockItemBuilderUtils.computeBlockHash(7L, hash6);
 
         // Publisher A — streams blocks 0–1 fully (ACKed), then stalls mid-block-2 with a
         // header-only batch.
@@ -334,15 +335,19 @@ public class BlockNodeApiRegressionTest {
 
         awaitLatch(ack2Latch, "ACK(2) — block 2 persisted after RESEND");
 
+        // Send blocks 7–8 and wait for any ACK >= 7. Sending two blocks
+        // provides resilience against correctForResendAndStreaming suppressing
+        // a single block's ACK due to transient queue-map state.
         final AtomicReference<CountDownLatch> terminalLatch = publisherBObserver.setAndGetOnMatchLatch(
                 response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
-                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() == 7L);
+                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() >= 7L);
 
-        // Block 7 — confirms normal processing continues after the RESEND sequence.
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));
         endBlock(7L, publisherBStream);
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(8L, hash7)));
+        endBlock(8L, publisherBStream);
 
-        awaitLatch(terminalLatch, "ACK(7) — terminal signal confirming block 2 is in storage");
+        awaitLatch(terminalLatch, "ACK(>=7) — terminal signal confirming block 2 is in storage", publisherBObserver);
 
         assertThat(publisherBObserver.getOnNextCalls())
                 .as("publisher B must receive RESEND(2) — stall detection must request the gap block")
@@ -405,6 +410,7 @@ public class BlockNodeApiRegressionTest {
         final Bytes hash4 = BlockItemBuilderUtils.computeBlockHash(4L, hash3);
         final Bytes hash5 = BlockItemBuilderUtils.computeBlockHash(5L, hash4);
         final Bytes hash6 = BlockItemBuilderUtils.computeBlockHash(6L, hash5);
+        final Bytes hash7 = BlockItemBuilderUtils.computeBlockHash(7L, hash6);
 
         // Publisher A — streams blocks 0–1 (ACKed), then stalls mid-block-2 (header only).
         final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherAClient =
@@ -460,15 +466,22 @@ public class BlockNodeApiRegressionTest {
 
         awaitLatch(ack2Latch, "ACK(2) — block 2 persisted after RESEND");
 
+        // Send blocks 7–8 and wait for any ACK >= 7. Sending two blocks
+        // provides resilience against correctForResendAndStreaming suppressing
+        // a single block's ACK due to transient queue-map state.
         final AtomicReference<CountDownLatch> terminalLatch = publisherBObserver.setAndGetOnMatchLatch(
                 response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
-                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() == 7L);
+                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() >= 7L);
 
-        // Block 7 confirms normal processing resumes after the RESEND sequence.
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));
         endBlock(7L, publisherBStream);
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(8L, hash7)));
+        endBlock(8L, publisherBStream);
 
-        awaitLatch(terminalLatch, "ACK(7) — terminal signal confirming the RESEND sequence is complete");
+        awaitLatch(
+                terminalLatch,
+                "ACK(>=7) — terminal signal confirming the RESEND sequence is complete",
+                publisherBObserver);
 
         final BlockAccessServiceInterface.BlockAccessServiceClient blockAccessClient =
                 new BlockAccessServiceInterface.BlockAccessServiceClient(getBlockPbjGrpcClient, OPTIONS);
@@ -623,6 +636,53 @@ public class BlockNodeApiRegressionTest {
         requestStream.onNext(PublishStreamRequest.newBuilder()
                 .endOfBlock(BlockEnd.newBuilder().blockNumber(blockNumber).build())
                 .build());
+    }
+
+    private void awaitLatch(
+            final AtomicReference<CountDownLatch> latch,
+            final String description,
+            final ResponsePipelineUtils<PublishStreamResponse> observer)
+            throws InterruptedException {
+        latch.get().await(DEFAULT_AWAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        if (latch.get().getCount() != 0) {
+            final StringBuilder diagnostics = new StringBuilder();
+            diagnostics.append("Timed out waiting for ").append(description).append('\n');
+            diagnostics
+                    .append("Responses received (")
+                    .append(observer.getOnNextCalls().size())
+                    .append("):\n");
+            for (int i = 0; i < observer.getOnNextCalls().size(); i++) {
+                final PublishStreamResponse response = observer.getOnNextCalls().get(i);
+                diagnostics
+                        .append("  [")
+                        .append(i)
+                        .append("] ")
+                        .append(response.response().kind());
+                if (response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT) {
+                    diagnostics
+                            .append(" block=")
+                            .append(Objects.requireNonNull(response.acknowledgement())
+                                    .blockNumber());
+                } else if (response.response().kind() == PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK) {
+                    diagnostics
+                            .append(" block=")
+                            .append(Objects.requireNonNull(response.resendBlock())
+                                    .blockNumber());
+                }
+                diagnostics.append('\n');
+            }
+            diagnostics
+                    .append("Errors: ")
+                    .append(observer.getOnErrorCalls().size())
+                    .append('\n');
+            for (final Throwable error : observer.getOnErrorCalls()) {
+                diagnostics.append("  ").append(error).append('\n');
+            }
+            diagnostics
+                    .append("onComplete calls: ")
+                    .append(observer.getOnCompleteCalls().get());
+            assertEquals(0, latch.get().getCount(), diagnostics.toString());
+        }
     }
 
     private void awaitLatch(final AtomicReference<CountDownLatch> latch, final String description)

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
@@ -325,16 +325,18 @@ public class BlockNodeApiRegressionTest {
         // arrives before any persistence ACKs (pipeline FIFO order guarantees this).
         awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection");
 
-        // Use a predicate latch on ACK(7) as the reliable terminal signal. ACK(7) is only sent
-        // after block 7 is persisted. Because the forwarder processes queueByBlockMap in key
-        // order, block 2 (re-queued via RESEND, lower key) is always forwarded and persisted
-        // before block 7 — block 2 is guaranteed to be in storage when this fires.
-        final AtomicReference<CountDownLatch> terminalLatch = publisherBObserver.setAndGetOnMatchLatch(
+        final AtomicReference<CountDownLatch> ack2Latch = publisherBObserver.setAndGetOnMatchLatch(
                 response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
-                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() == 7L);
+                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() >= 2L);
 
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
         endBlock(2L, publisherBStream);
+
+        awaitLatch(ack2Latch, "ACK(2) — block 2 persisted after RESEND");
+
+        final AtomicReference<CountDownLatch> terminalLatch = publisherBObserver.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
+                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() == 7L);
 
         // Block 7 — confirms normal processing continues after the RESEND sequence.
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));
@@ -448,18 +450,19 @@ public class BlockNodeApiRegressionTest {
         // persistence chain). The FIFO pipeline guarantees RESEND_BLOCK(2) arrives first.
         awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection");
 
-        // Use a predicate latch on ACK(7) as the reliable terminal signal. The forwarder
-        // processes queueByBlockMap in key order: block 2 (lower key) is always forwarded before
-        // block 7, so ACK(7) guarantees all of blocks 2–7 have passed through the persistence
-        // chain and any storage gaps are already visible.
-        final AtomicReference<CountDownLatch> terminalLatch = publisherBObserver.setAndGetOnMatchLatch(
+        final AtomicReference<CountDownLatch> ack2Latch = publisherBObserver.setAndGetOnMatchLatch(
                 response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
-                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() == 7L);
+                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() >= 2L);
 
         // Publisher B provides the full block 2 as its RESEND response.
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
         endBlock(2L, publisherBStream);
-        Thread.sleep(200); // brief pause to allow the forwarder to process the re-delivered block 2
+
+        awaitLatch(ack2Latch, "ACK(2) — block 2 persisted after RESEND");
+
+        final AtomicReference<CountDownLatch> terminalLatch = publisherBObserver.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
+                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() == 7L);
 
         // Block 7 confirms normal processing resumes after the RESEND sequence.
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
@@ -307,17 +307,23 @@ public class BlockNodeApiRegressionTest {
         final Pipeline<? super PublishStreamRequest> publisherBStream =
                 publisherBClient.publishBlockStream(publisherBObserver);
 
-        // Synchronization probe: publisher B sends block 2 and waits for
-        // SKIP_BLOCK. This round-trip guarantees the server has processed
-        // publisher A's block 2 header (advancing nextUnstreamedBlockNumber
-        // to 3) before publisher B sends blocks 3-6. Without this, on slow
-        // CI machines publisher B's blocks can arrive before publisher A's
-        // header is processed, causing NODE_BEHIND_PUBLISHER instead of the
-        // expected stall-detection path.
-        final AtomicReference<CountDownLatch> probeLatch = publisherBObserver.setAndGetOnNextLatch(1);
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
-        endBlock(2L, publisherBStream);
-        awaitLatch(probeLatch, "SKIP_BLOCK(2) — sync probe confirming publisher A holds block 2");
+        // Synchronization: retry block 3 until it gets a non-BEHIND
+        // response. NODE_BEHIND_PUBLISHER means publisher A's block 2 header
+        // hasn't been processed yet (nextUnstreamedBlockNumber < 3). The
+        // handler resets after each BEHIND, so retrying is safe. Once block 3
+        // gets through, publisher A's block 2 header must have been accepted.
+        boolean block3Accepted = false;
+        while (!block3Accepted) {
+            final int responsesBefore = publisherBObserver.getOnNextCalls().size();
+            final AtomicReference<CountDownLatch> probeLatch = publisherBObserver.setAndGetOnNextLatch(1);
+            publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2)));
+            endBlock(3L, publisherBStream);
+            awaitLatch(probeLatch, "response for block 3 sync probe");
+            final PublishStreamResponse probeResponse =
+                    publisherBObserver.getOnNextCalls().get(responsesBefore);
+            block3Accepted =
+                    probeResponse.response().kind() != PublishStreamResponse.ResponseOneOfType.NODE_BEHIND_PUBLISHER;
+        }
 
         // Set latch for RESEND_BLOCK before sending so it cannot be missed.
         // Stall threshold is MaxFutureBlocksBeforeStalled=3: stall fires when
@@ -325,9 +331,8 @@ public class BlockNodeApiRegressionTest {
         final AtomicReference<CountDownLatch> resendLatch = publisherBObserver.setAndGetOnMatchLatch(
                 response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK);
 
-        // Blocks 3–6: stall fires when endOfBlock(6) is processed (6 > 2+3).
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2)));
-        endBlock(3L, publisherBStream);
+        // Blocks 4–6: stall fires when endOfBlock(6) is processed (6 > 2+3).
+        // Block 3 was already sent in the sync probe above.
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(4L, hash3)));
         endBlock(4L, publisherBStream);
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(5L, hash4)));
@@ -449,17 +454,23 @@ public class BlockNodeApiRegressionTest {
         final Pipeline<? super PublishStreamRequest> publisherBStream =
                 publisherBClient.publishBlockStream(publisherBObserver);
 
-        // Synchronization probe: publisher B sends block 2 and waits for
-        // SKIP_BLOCK. This round-trip guarantees the server has processed
-        // publisher A's block 2 header (advancing nextUnstreamedBlockNumber
-        // to 3) before publisher B sends blocks 3-6. Without this, on slow
-        // CI machines publisher B's blocks can arrive before publisher A's
-        // header is processed, causing NODE_BEHIND_PUBLISHER instead of the
-        // expected stall-detection path.
-        final AtomicReference<CountDownLatch> probeLatch = publisherBObserver.setAndGetOnNextLatch(1);
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
-        endBlock(2L, publisherBStream);
-        awaitLatch(probeLatch, "SKIP_BLOCK(2) — sync probe confirming publisher A holds block 2");
+        // Synchronization: retry block 3 until it gets a non-BEHIND
+        // response. NODE_BEHIND_PUBLISHER means publisher A's block 2 header
+        // hasn't been processed yet (nextUnstreamedBlockNumber < 3). The
+        // handler resets after each BEHIND, so retrying is safe. Once block 3
+        // gets through, publisher A's block 2 header must have been accepted.
+        boolean block3Accepted = false;
+        while (!block3Accepted) {
+            final int responsesBefore = publisherBObserver.getOnNextCalls().size();
+            final AtomicReference<CountDownLatch> probeLatch = publisherBObserver.setAndGetOnNextLatch(1);
+            publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2)));
+            endBlock(3L, publisherBStream);
+            awaitLatch(probeLatch, "response for block 3 sync probe");
+            final PublishStreamResponse probeResponse =
+                    publisherBObserver.getOnNextCalls().get(responsesBefore);
+            block3Accepted =
+                    probeResponse.response().kind() != PublishStreamResponse.ResponseOneOfType.NODE_BEHIND_PUBLISHER;
+        }
 
         // Set latch for RESEND_BLOCK before sending so it cannot be missed.
         // Stall threshold is MaxFutureBlocksBeforeStalled=3: stall fires when
@@ -467,8 +478,8 @@ public class BlockNodeApiRegressionTest {
         final AtomicReference<CountDownLatch> resendLatch = publisherBObserver.setAndGetOnMatchLatch(
                 response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK);
 
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2)));
-        endBlock(3L, publisherBStream);
+        // Blocks 4–6: stall fires when endOfBlock(6) is processed (6 > 2+3).
+        // Block 3 was already sent in the sync probe above.
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(4L, hash3)));
         endBlock(4L, publisherBStream);
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(5L, hash4)));

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
@@ -310,15 +310,19 @@ public class BlockNodeApiRegressionTest {
         // Synchronization: retry block 3 until it gets a non-BEHIND
         // response. NODE_BEHIND_PUBLISHER means publisher A's block 2 header
         // hasn't been processed yet (nextUnstreamedBlockNumber < 3). The
-        // handler resets after each BEHIND, so retrying is safe. Once block 3
-        // gets through, publisher A's block 2 header must have been accepted.
+        // handler resets after each BEHIND, so retrying is safe. ACCEPT sends
+        // no immediate response (ACK is stuck behind stalled block 2 in the
+        // forwarder), so a short timeout with no response means ACCEPT.
         boolean block3Accepted = false;
         while (!block3Accepted) {
             final int responsesBefore = publisherBObserver.getOnNextCalls().size();
             final AtomicReference<CountDownLatch> probeLatch = publisherBObserver.setAndGetOnNextLatch(1);
             publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2)));
             endBlock(3L, publisherBStream);
-            awaitLatch(probeLatch, "response for block 3 sync probe");
+            final boolean responded = probeLatch.get().await(500, TimeUnit.MILLISECONDS);
+            if (!responded) {
+                break;
+            }
             final PublishStreamResponse probeResponse =
                     publisherBObserver.getOnNextCalls().get(responsesBefore);
             block3Accepted =
@@ -457,15 +461,19 @@ public class BlockNodeApiRegressionTest {
         // Synchronization: retry block 3 until it gets a non-BEHIND
         // response. NODE_BEHIND_PUBLISHER means publisher A's block 2 header
         // hasn't been processed yet (nextUnstreamedBlockNumber < 3). The
-        // handler resets after each BEHIND, so retrying is safe. Once block 3
-        // gets through, publisher A's block 2 header must have been accepted.
+        // handler resets after each BEHIND, so retrying is safe. ACCEPT sends
+        // no immediate response (ACK is stuck behind stalled block 2 in the
+        // forwarder), so a short timeout with no response means ACCEPT.
         boolean block3Accepted = false;
         while (!block3Accepted) {
             final int responsesBefore = publisherBObserver.getOnNextCalls().size();
             final AtomicReference<CountDownLatch> probeLatch = publisherBObserver.setAndGetOnNextLatch(1);
             publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2)));
             endBlock(3L, publisherBStream);
-            awaitLatch(probeLatch, "response for block 3 sync probe");
+            final boolean responded = probeLatch.get().await(500, TimeUnit.MILLISECONDS);
+            if (!responded) {
+                break;
+            }
             final PublishStreamResponse probeResponse =
                     publisherBObserver.getOnNextCalls().get(responsesBefore);
             block3Accepted =

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
@@ -42,6 +42,7 @@ import org.hiero.block.suites.utils.BlockItemBuilderUtils;
 import org.hiero.block.suites.utils.ResponsePipelineUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -117,6 +118,12 @@ public class BlockNodeApiRegressionTest {
      * because {@code blocksToResend} contains 3. Publisher 2 responds by providing the full
      * block 3, filling the gap. Block 5 follows normally.
      *
+     * <p>ACK delivery: ACK(3) is always sent. ACK(4) may be suppressed when
+     * {@code handlePersisted(4)} fires before the forwarder removes block 4's key from
+     * {@code queueByBlockMap} — {@code correctForResendAndStreaming(4)} returns 3 in that case.
+     * ACK(5) is always sent because the forwarder removes block 5's key before dispatching
+     * to messaging. A newer ACK implicitly acknowledges all prior blocks.
+     *
      * <p>All three blocks must end up in storage. Without the fix, block 3's queue is never
      * forwarded to messaging and the gap persists silently.
      */
@@ -163,21 +170,27 @@ public class BlockNodeApiRegressionTest {
         // Publisher 2 — connect and send block 4, then block 3 (the gap), then block 5.
         //
         // Sequence on the server:
-        //   endOfBlock(4) -> RESEND(3): handler resets, block 4 stays in queueByBlockMap
+        //   endOfBlock(4) -> RESEND(3): handler detects gap, publisher asked to fill it
         //   block 3 header -> getActionForHeader(3) -> ACCEPT (removes 3 from blocksToResend)
         //   endOfBlock(3) -> ACCEPT(3)
         //   endOfBlock(5) -> ACCEPT(5)
         //
-        // Forwarder persistence order: block 4 first, then block 3, then block 5.
-        // ACK(4) and ACK(5) are sent. Block 3 is persisted but implicit in ACK(4) (4 > 3).
+        // ACK delivery: ACK(3) is always sent. ACK(4) may be suppressed when
+        // handlePersisted(4) fires before the forwarder removes block 4's key from
+        // queueByBlockMap — correctForResendAndStreaming(4) sees firstKey=4 and returns 3.
+        // ACK(5) is always sent because the forwarder removes block 5's key before
+        // dispatching to messaging. A newer ACK implicitly acknowledges all prior blocks.
         final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisher2Client =
                 new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(createGrpcClient(), OPTIONS);
         final ResponsePipelineUtils<PublishStreamResponse> publisher2Observer = new ResponsePipelineUtils<>();
         final Pipeline<? super PublishStreamRequest> publisher2Stream =
                 publisher2Client.publishBlockStream(publisher2Observer);
 
-        // Expect 3 responses: RESEND(3), ACK(4), ACK(5).
-        final AtomicReference<CountDownLatch> publisher2Latch = publisher2Observer.setAndGetOnNextLatch(3);
+        // Use a predicate latch on ACK(5) — the reliable terminal signal — rather than
+        // a fixed-count latch. ACK(4) is non-deterministic and would cause flakiness.
+        final AtomicReference<CountDownLatch> publisher2Latch = publisher2Observer.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
+                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() == 5L);
 
         publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(4L, hash3)));
         endBlock(4L, publisher2Stream);
@@ -188,7 +201,7 @@ public class BlockNodeApiRegressionTest {
         publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(5L, hash4)));
         endBlock(5L, publisher2Stream);
 
-        awaitLatch(publisher2Latch, "RESEND(3) and ACKs for blocks 4 and 5");
+        awaitLatch(publisher2Latch, "RESEND(3) and ACK for block 5");
 
         final List<PublishStreamResponse> publisher2Responses = publisher2Observer.getOnNextCalls();
         assertThat(publisher2Responses)
@@ -197,19 +210,13 @@ public class BlockNodeApiRegressionTest {
                         .returns(PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK, responseKindExtractor)
                         .returns(3L, resendBlockNumberExtractor));
         assertThat(publisher2Responses)
-                .as("publisher 2 must receive ACK for block 4")
-                .anySatisfy(response -> assertThat(response)
-                        .returns(PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor)
-                        .returns(4L, acknowledgementBlockNumberExtractor));
-        assertThat(publisher2Responses)
-                .as("publisher 2 must receive ACK for block 5")
+                .as("publisher 2 must receive ACK for block 5 — all blocks through 5 are persisted")
                 .anySatisfy(response -> assertThat(response)
                         .returns(PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor)
                         .returns(5L, acknowledgementBlockNumberExtractor));
 
         // All three blocks must be in storage — the gap at block 3 was filled by the RESEND.
-        // ACK(5) was received only after block 5 was persisted, so blocks 3 and 4 (persisted
-        // before block 5 in the forwarder's messaging order) are also present.
+        // Blocks are persisted in sequential order (3, 4, 5); ACK(5) confirms all are present.
         final BlockAccessServiceInterface.BlockAccessServiceClient blockAccessClient =
                 new BlockAccessServiceInterface.BlockAccessServiceClient(getBlockPbjGrpcClient, OPTIONS);
         assertThat(blockAccessClient
@@ -231,6 +238,361 @@ public class BlockNodeApiRegressionTest {
         publisher1Client.close();
         publisher2Client.close();
         blockAccessClient.close();
+    }
+
+    /**
+     * Reproduces the block gap where a stalled publisher's block is never acknowledged after
+     * stall detection triggers a RESEND.
+     *
+     * <p>Publisher A streams blocks 0–1 (fully ACKed), then sends only the header for block 2
+     * and stalls. Publisher B streams blocks 3–6; when block 6 completes, stall detection fires
+     * (6 &gt; 2 + MAX_ADVANCE = 5), removes block 2 from {@code queueByBlockMap}, adds 2 to
+     * {@code blocksToResend}, and returns {@code RESEND_BLOCK(2)} to publisher B.
+     *
+     * <p>Publisher B responds to the RESEND by re-delivering the complete block 2, then
+     * continues with block 7. With the bug, {@code MessagingForwarderTask} skips the block-2
+     * gap by using {@code firstEntry()} after the stall removes block 2 from the queue — it
+     * immediately forwards blocks 3–6 without waiting for the RESEND response. Block 2 is
+     * eventually stored out of order, but {@code handlePersisted} suppresses ACK(2) because
+     * {@code 2 < lastPersistedBlockNumber(6)}. Additionally, {@code clearObsoleteQueueItems}
+     * may evict the re-queued block-2 entry before its proof arrives.
+     *
+     * <p>With the fix the forwarder respects sequential ordering, ACK(2) is sent before
+     * ACK(3)–ACK(6), and block 2 reaches storage in the correct order.
+     *
+     * <p>The ACK(2) assertion FAILS on buggy code because the forwarder skipped block 2 and
+     * the out-of-order persistence guard in {@code handlePersisted} never emits ACK(2).
+     * The storage assertions on blocks 2 and 6 confirm end-to-end persistence integrity.
+     */
+    @Test
+    @DisplayName("stall-detected RESEND must result in the stalled block being acknowledged and persisted")
+    void stalledPublisherResendQueueEvictedByObsoleteCleanupLeavesBlockGap() throws InterruptedException {
+        final Bytes hash0 = BlockItemBuilderUtils.computeBlockHash(0L, null);
+        final Bytes hash1 = BlockItemBuilderUtils.computeBlockHash(1L, hash0);
+        final Bytes hash2 = BlockItemBuilderUtils.computeBlockHash(2L, hash1);
+        final Bytes hash3 = BlockItemBuilderUtils.computeBlockHash(3L, hash2);
+        final Bytes hash4 = BlockItemBuilderUtils.computeBlockHash(4L, hash3);
+        final Bytes hash5 = BlockItemBuilderUtils.computeBlockHash(5L, hash4);
+        final Bytes hash6 = BlockItemBuilderUtils.computeBlockHash(6L, hash5);
+
+        // Publisher A — streams blocks 0–1 fully (ACKed), then stalls mid-block-2 with a
+        // header-only batch. Stall detection will terminate this connection with TIMEOUT.
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherAClient =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
+                        publishBlockStreamPbjGrpcClient, OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> publisherAObserver = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> publisherAStream =
+                publisherAClient.publishBlockStream(publisherAObserver);
+
+        final Bytes[] prevHashesForA = {null, hash0};
+        for (long blockNum = 0L; blockNum <= 1L; blockNum++) {
+            final AtomicReference<CountDownLatch> ackLatch = publisherAObserver.setAndGetOnNextLatch(1);
+            publisherAStream.onNext(buildPublishRequest(
+                    BlockItemBuilderUtils.createSimpleBlockWithNumber(blockNum, prevHashesForA[(int) blockNum])));
+            endBlock(blockNum, publisherAStream);
+            awaitLatch(ackLatch, "ACK for block " + blockNum + " from publisher A");
+        }
+
+        // Only the block-2 header — publisher A stalls here.
+        publisherAStream.onNext(buildPublishRequest(new BlockItem[] {BlockItemBuilderUtils.sampleBlockHeader(2L)}));
+        final AtomicReference<CountDownLatch> publisherATimeoutLatch =
+                publisherAObserver.setAndGetConnectionEndedLatch(1);
+
+        // Publisher B — fills the stall gap via RESEND.
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherBClient =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(createGrpcClient(), OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> publisherBObserver = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> publisherBStream =
+                publisherBClient.publishBlockStream(publisherBObserver);
+
+        // Set latch(1) before sending so RESEND_BLOCK(2) cannot be missed.
+        // Stall threshold is MaxFutureBlocksBeforeStalled=3: stall fires when
+        // completedBlock > stalledBlock + 3, i.e. block 6 > 2 + 3.
+        final AtomicReference<CountDownLatch> resendLatch = publisherBObserver.setAndGetOnNextLatch(1);
+
+        // Blocks 3–6: stall fires when endOfBlock(6) is processed (6 > 2+3).
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2)));
+        endBlock(3L, publisherBStream);
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(4L, hash3)));
+        endBlock(4L, publisherBStream);
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(5L, hash4)));
+        endBlock(5L, publisherBStream);
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(6L, hash5)));
+        endBlock(6L, publisherBStream);
+
+        // RESEND_BLOCK(2) is sent synchronously in the handler thread during endOfBlock(6) and
+        // arrives before any persistence ACKs (pipeline FIFO order guarantees this).
+        awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection");
+
+        // Publisher B responds to the RESEND with the complete block 2, then block 7.
+        //
+        // latch(5): with the bug  = ACK(3) + ACK(4) + ACK(5) + ACK(6) + ACK(7)  [ACK(2) absent]
+        //           with the fix  = ACK(2) + ACK(3) + ACK(4) + ACK(5) + ACK(6)  [ACK(7) later]
+        // In both cases exactly 5 ACKs arrive before the latch fires.
+        final AtomicReference<CountDownLatch> persistLatch = publisherBObserver.setAndGetOnNextLatch(5);
+
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
+        endBlock(2L, publisherBStream);
+
+        // Block 7 — confirms normal processing continues after the RESEND sequence.
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));
+        endBlock(7L, publisherBStream);
+
+        awaitLatch(persistLatch, "5 acknowledgements after RESEND");
+        awaitLatch(publisherATimeoutLatch, "publisher A TIMEOUT due to stall detection");
+
+        final List<Long> ackBlocks = publisherBObserver.getOnNextCalls().stream()
+                .filter(r -> r.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT)
+                .map(acknowledgementBlockNumberExtractor)
+                .toList();
+
+        // Core assertion: ACK(2) must be present.
+        // FAILS on buggy code: the forwarder gap-skips block 2, forwards blocks 3–6 first, and
+        // handlePersisted suppresses ACK(2) because newLastPersisted(2) < lastPersisted(6).
+        assertThat(ackBlocks)
+                .as("publisher B must receive ACK for block 2 — stall RESEND must be acknowledged")
+                .contains(2L);
+
+        final BlockAccessServiceInterface.BlockAccessServiceClient blockAccessClient =
+                new BlockAccessServiceInterface.BlockAccessServiceClient(getBlockPbjGrpcClient, OPTIONS);
+
+        // Block 2 must be retrievable from storage after the RESEND completes.
+        assertThat(blockAccessClient
+                        .getBlock(BlockRequest.newBuilder().blockNumber(2L).build())
+                        .status())
+                .as("block 2 must be in storage — stall RESEND must fill the gap")
+                .isEqualTo(BlockResponse.Code.SUCCESS);
+
+        // Block 6 is the collateral-damage block: received complete while block 2 was stalled.
+        // It must also reach storage; the gap at block 2 must not leave it permanently lost.
+        assertThat(blockAccessClient
+                        .getBlock(BlockRequest.newBuilder().blockNumber(6L).build())
+                        .status())
+                .as("block 6 must be in storage — collateral complete block must not be lost")
+                .isEqualTo(BlockResponse.Code.SUCCESS);
+
+        publisherAClient.close();
+        publisherBClient.close();
+        blockAccessClient.close();
+    }
+
+    /**
+     * Reproduces the protocol ordering violation where the publisher manager forwards blocks 3–5
+     * to messaging before the stalled block 2 is re-delivered.
+     *
+     * <p>Protocol requirement (HIP-1081): a Block-Node MUST NOT acknowledge block M before it has
+     * verified, persisted, and acknowledged block M-1.
+     *
+     * <p>Publisher A streams blocks 0–1 (ACKed), then sends only the header for block 2 and
+     * stalls. Publisher B streams blocks 3–6; when block 6 completes, stall detection fires: block
+     * 2 is removed from {@code queueByBlockMap}, added to {@code blocksToResend}, and
+     * RESEND_BLOCK(2) is returned to publisher B.
+     *
+     * <p>With the bug, after the stall the {@code MessagingForwarderTask} skips the block-2 gap
+     * by calling {@code firstEntry()} and immediately forwards blocks 3–6. Those blocks are
+     * persisted and ACK(3)–ACK(6) are sent to publisher B before block 2 has been re-delivered.
+     * Publisher B then sends the full block 2 as its RESEND response, but the forwarder has
+     * already moved past it — block 2 is never persisted and ACK(2) never arrives.
+     *
+     * <p>With the fix, the forwarder respects sequential ordering and waits for block 2 before
+     * forwarding blocks 3–6. After publisher B delivers block 2, all five blocks (2, 3, 4, 5, 6)
+     * are persisted in order, and ACK(2) is sent before ACK(3).
+     */
+    @Test
+    @DisplayName("stall RESEND must not cause acknowledgements for later blocks before the stalled block")
+    void stalledPublisherMustNotAcknowledgeLaterBlocksBeforeStalledBlock() throws InterruptedException {
+        final Bytes hash0 = BlockItemBuilderUtils.computeBlockHash(0L, null);
+        final Bytes hash1 = BlockItemBuilderUtils.computeBlockHash(1L, hash0);
+        final Bytes hash2 = BlockItemBuilderUtils.computeBlockHash(2L, hash1);
+        final Bytes hash3 = BlockItemBuilderUtils.computeBlockHash(3L, hash2);
+        final Bytes hash4 = BlockItemBuilderUtils.computeBlockHash(4L, hash3);
+        final Bytes hash5 = BlockItemBuilderUtils.computeBlockHash(5L, hash4);
+        final Bytes hash6 = BlockItemBuilderUtils.computeBlockHash(6L, hash5);
+
+        // Publisher A — streams blocks 0–1 (ACKed), then stalls mid-block-2 (header only).
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherAClient =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
+                        publishBlockStreamPbjGrpcClient, OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> publisherAObserver = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> publisherAStream =
+                publisherAClient.publishBlockStream(publisherAObserver);
+
+        final Bytes[] prevHashesForA = {null, hash0};
+        for (long blockNum = 0L; blockNum <= 1L; blockNum++) {
+            final AtomicReference<CountDownLatch> ackLatch = publisherAObserver.setAndGetOnNextLatch(1);
+            publisherAStream.onNext(buildPublishRequest(
+                    BlockItemBuilderUtils.createSimpleBlockWithNumber(blockNum, prevHashesForA[(int) blockNum])));
+            endBlock(blockNum, publisherAStream);
+            awaitLatch(ackLatch, "ACK for block " + blockNum + " from publisher A");
+        }
+        // Publisher A stalls here — only the block-2 header is sent, no proof.
+        publisherAStream.onNext(buildPublishRequest(new BlockItem[] {BlockItemBuilderUtils.sampleBlockHeader(2L)}));
+
+        // Publisher B — streams blocks 3–6 to trigger stall detection (threshold=3: 6 > 2+3).
+        // Set latch(1) before sending so no response is missed.
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherBClient =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(createGrpcClient(), OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> publisherBObserver = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> publisherBStream =
+                publisherBClient.publishBlockStream(publisherBObserver);
+
+        final AtomicReference<CountDownLatch> resendLatch = publisherBObserver.setAndGetOnNextLatch(1);
+
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2)));
+        endBlock(3L, publisherBStream);
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(4L, hash3)));
+        endBlock(4L, publisherBStream);
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(5L, hash4)));
+        endBlock(5L, publisherBStream);
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(6L, hash5)));
+        endBlock(6L, publisherBStream);
+
+        // Wait until stall fires. RESEND_BLOCK(2) is sent synchronously in the handler thread
+        // as part of endOfBlock(6) processing and is enqueued into the response pipeline before
+        // any persistence ACKs (which travel through the asynchronous forwarder → disruptor →
+        // persistence chain). The FIFO pipeline guarantees RESEND_BLOCK(2) arrives first.
+        awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection");
+
+        // Expect 5 more responses: ACK(2) + ACK(3) + ACK(4) + ACK(5) + ACK(6).
+        // With the bug, ACK(2) never arrives because the forwarder has already skipped past
+        // block 2 and will not go back to forward it — the latch fires on ACK(3–6) + ACK(7)
+        // and the ordering assertion fails.
+        final AtomicReference<CountDownLatch> remainingAckLatch = publisherBObserver.setAndGetOnNextLatch(5);
+
+        // Publisher B provides the full block 2 as its RESEND response.
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
+        endBlock(2L, publisherBStream);
+
+        // Block 7 confirms normal processing resumes after the RESEND sequence.
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));
+        endBlock(7L, publisherBStream);
+
+        awaitLatch(remainingAckLatch, "ACK(2), ACK(3), ACK(4), ACK(5), and ACK(6) from publisher B");
+
+        final List<Long> ackBlockOrder = publisherBObserver.getOnNextCalls().stream()
+                .filter(r -> r.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT)
+                .map(acknowledgementBlockNumberExtractor)
+                .toList();
+
+        // Core assertion: ACK(2) must be present and must precede all ACK(N > 2).
+        // FAILS on buggy code because the forwarder skips the block-2 gap, forwards blocks 3–6
+        // first, and block 2 is never persisted — ACK(2) is absent entirely.
+        final int ack2Position = ackBlockOrder.indexOf(2L);
+        assertThat(ack2Position)
+                .as("publisher B must receive ACK for block 2 — stalled block must be acknowledged")
+                .isGreaterThanOrEqualTo(0);
+        assertThat(ackBlockOrder.subList(0, ack2Position))
+                .as("no block with number greater than 2 may be acknowledged before the stalled block 2")
+                .allSatisfy(blockNum -> assertThat(blockNum).isLessThanOrEqualTo(2L));
+
+        publisherAClient.close();
+        publisherBClient.close();
+    }
+
+    /**
+     * Bug reproduction: asserts the out-of-order acknowledgement behaviour produced by
+     * {@code MessagingForwarderTask} skipping the stalled block-2 gap.
+     *
+     * <p><b>This test documented the bug and was expected to PASS on buggy code. It is disabled
+     * because the bug is now fixed — the assertions below fail correctly with the fix in
+     * place.</b> Delete this test once the fix has soaked in production.
+     *
+     * <p>After stall detection removes block 2 from {@code queueByBlockMap}, the forwarder calls
+     * {@code firstEntry()} and immediately forwards blocks 3–6, producing ACK(3), ACK(4), ACK(5),
+     * ACK(6) before block 2 is re-delivered. Publisher B then sends block 2 as the RESEND
+     * response, but the forwarder has already advanced its {@code lastForwardedBlockNumber} past
+     * block 2 — it will never forward block 2. ACK(2) is therefore absent from publisher B's
+     * responses, while ACK(3) and later are present — a direct protocol ordering violation.
+     *
+     * <p>With the fix the forwarder waits for block 2 before forwarding blocks 3–6, ACK(2)
+     * arrives before ACK(3), and the {@code doesNotContain(2L)} assertion below fails.
+     */
+    @Test
+    @Disabled("Bug is fixed — assertions document the violation and now fail correctly; delete when soaked")
+    @DisplayName("[BUG] stalled forwarder skips block-2 gap and acknowledges later blocks out of order")
+    void bugRepro_stalledForwarderSkipsGapAndAcknowledgesLaterBlocksOutOfOrder() throws InterruptedException {
+        final Bytes hash0 = BlockItemBuilderUtils.computeBlockHash(0L, null);
+        final Bytes hash1 = BlockItemBuilderUtils.computeBlockHash(1L, hash0);
+        final Bytes hash2 = BlockItemBuilderUtils.computeBlockHash(2L, hash1);
+        final Bytes hash3 = BlockItemBuilderUtils.computeBlockHash(3L, hash2);
+        final Bytes hash4 = BlockItemBuilderUtils.computeBlockHash(4L, hash3);
+        final Bytes hash5 = BlockItemBuilderUtils.computeBlockHash(5L, hash4);
+        final Bytes hash6 = BlockItemBuilderUtils.computeBlockHash(6L, hash5);
+
+        // Publisher A — streams blocks 0–1 (ACKed), then stalls mid-block-2 (header only).
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherAClient =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
+                        publishBlockStreamPbjGrpcClient, OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> publisherAObserver = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> publisherAStream =
+                publisherAClient.publishBlockStream(publisherAObserver);
+
+        final Bytes[] prevHashesForA = {null, hash0};
+        for (long blockNum = 0L; blockNum <= 1L; blockNum++) {
+            final AtomicReference<CountDownLatch> ackLatch = publisherAObserver.setAndGetOnNextLatch(1);
+            publisherAStream.onNext(buildPublishRequest(
+                    BlockItemBuilderUtils.createSimpleBlockWithNumber(blockNum, prevHashesForA[(int) blockNum])));
+            endBlock(blockNum, publisherAStream);
+            awaitLatch(ackLatch, "ACK for block " + blockNum + " from publisher A");
+        }
+        publisherAStream.onNext(buildPublishRequest(new BlockItem[] {BlockItemBuilderUtils.sampleBlockHeader(2L)}));
+
+        // Publisher B — streams blocks 3–6 to trigger stall detection (threshold=3: 6 > 2+3),
+        // then sends block 2 RESEND.
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherBClient =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(createGrpcClient(), OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> publisherBObserver = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> publisherBStream =
+                publisherBClient.publishBlockStream(publisherBObserver);
+
+        final AtomicReference<CountDownLatch> resendLatch = publisherBObserver.setAndGetOnNextLatch(1);
+
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2)));
+        endBlock(3L, publisherBStream);
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(4L, hash3)));
+        endBlock(4L, publisherBStream);
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(5L, hash4)));
+        endBlock(5L, publisherBStream);
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(6L, hash5)));
+        endBlock(6L, publisherBStream);
+
+        awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection");
+
+        // With the bug the forwarder has begun forwarding blocks 3–6 asynchronously. Publisher B
+        // now sends block 2 (full) and block 7. Block 2 is never forwarded (forwarder is past it);
+        // block 7 is forwarded normally. Expect 5 responses: ACK(3) + ACK(4) + ACK(5) + ACK(6) + ACK(7).
+        //
+        // With the fix the forwarder waited: publisher B's block 2 fills the gap, the forwarder
+        // then forwards 2 → 3 → 4 → 5 → 6 in order, and ACK(2) arrives as the first of the 5
+        // responses — which causes the assertion below to fail.
+        final AtomicReference<CountDownLatch> postResendLatch = publisherBObserver.setAndGetOnNextLatch(5);
+
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
+        endBlock(2L, publisherBStream);
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));
+        endBlock(7L, publisherBStream);
+
+        awaitLatch(postResendLatch, "ACK(3), ACK(4), ACK(5), ACK(6), and ACK(7) from publisher B");
+
+        final List<Long> ackBlockOrder = publisherBObserver.getOnNextCalls().stream()
+                .filter(r -> r.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT)
+                .map(acknowledgementBlockNumberExtractor)
+                .toList();
+
+        // BUG: block 2 is never forwarded — the forwarder skipped it and will not go back.
+        // PASSES on buggy code (ACK(2) absent); FAILS when fixed (ACK(2) present).
+        assertThat(ackBlockOrder)
+                .as("BUG: block 2 must not be acknowledged — forwarder skipped the gap and moved past it")
+                .doesNotContain(2L);
+
+        // BUG: later blocks were acknowledged despite the unsatisfied gap at block 2.
+        // PASSES on buggy code (ACK(3–6) present); FAILS when fixed (reordering prevented).
+        assertThat(ackBlockOrder)
+                .as("BUG: blocks later than 2 must be acknowledged before block 2 is delivered — ordering violation")
+                .containsAnyOf(3L, 4L, 5L, 6L);
+
+        publisherAClient.close();
+        publisherBClient.close();
     }
 
     private PbjGrpcClient createGrpcClient() {

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
@@ -307,10 +307,23 @@ public class BlockNodeApiRegressionTest {
         final Pipeline<? super PublishStreamRequest> publisherBStream =
                 publisherBClient.publishBlockStream(publisherBObserver);
 
-        // Set latch(1) before sending so RESEND_BLOCK(2) cannot be missed.
+        // Synchronization probe: publisher B sends block 2 and waits for
+        // SKIP_BLOCK. This round-trip guarantees the server has processed
+        // publisher A's block 2 header (advancing nextUnstreamedBlockNumber
+        // to 3) before publisher B sends blocks 3-6. Without this, on slow
+        // CI machines publisher B's blocks can arrive before publisher A's
+        // header is processed, causing NODE_BEHIND_PUBLISHER instead of the
+        // expected stall-detection path.
+        final AtomicReference<CountDownLatch> probeLatch = publisherBObserver.setAndGetOnNextLatch(1);
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
+        endBlock(2L, publisherBStream);
+        awaitLatch(probeLatch, "SKIP_BLOCK(2) — sync probe confirming publisher A holds block 2");
+
+        // Set latch for RESEND_BLOCK before sending so it cannot be missed.
         // Stall threshold is MaxFutureBlocksBeforeStalled=3: stall fires when
         // completedBlock > stalledBlock + 3, i.e. block 6 > 2 + 3.
-        final AtomicReference<CountDownLatch> resendLatch = publisherBObserver.setAndGetOnNextLatch(1);
+        final AtomicReference<CountDownLatch> resendLatch = publisherBObserver.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK);
 
         // Blocks 3–6: stall fires when endOfBlock(6) is processed (6 > 2+3).
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2)));
@@ -322,9 +335,7 @@ public class BlockNodeApiRegressionTest {
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(6L, hash5)));
         endBlock(6L, publisherBStream);
 
-        // RESEND_BLOCK(2) is sent synchronously in the handler thread during endOfBlock(6) and
-        // arrives before any persistence ACKs (pipeline FIFO order guarantees this).
-        awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection");
+        awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection", publisherBObserver);
 
         final AtomicReference<CountDownLatch> ack2Latch = publisherBObserver.setAndGetOnMatchLatch(
                 response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
@@ -431,15 +442,30 @@ public class BlockNodeApiRegressionTest {
         // Publisher A stalls here — only the block-2 header is sent, no proof.
         publisherAStream.onNext(buildPublishRequest(new BlockItem[] {BlockItemBuilderUtils.sampleBlockHeader(2L)}));
 
-        // Publisher B — streams blocks 3–6 to trigger stall detection (threshold=3: 6 > 2+3).
-        // Set latch(1) before sending so no response is missed.
+        // Publisher B — triggers stall detection via blocks 3–6.
         final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherBClient =
                 new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(createGrpcClient(), OPTIONS);
         final ResponsePipelineUtils<PublishStreamResponse> publisherBObserver = new ResponsePipelineUtils<>();
         final Pipeline<? super PublishStreamRequest> publisherBStream =
                 publisherBClient.publishBlockStream(publisherBObserver);
 
-        final AtomicReference<CountDownLatch> resendLatch = publisherBObserver.setAndGetOnNextLatch(1);
+        // Synchronization probe: publisher B sends block 2 and waits for
+        // SKIP_BLOCK. This round-trip guarantees the server has processed
+        // publisher A's block 2 header (advancing nextUnstreamedBlockNumber
+        // to 3) before publisher B sends blocks 3-6. Without this, on slow
+        // CI machines publisher B's blocks can arrive before publisher A's
+        // header is processed, causing NODE_BEHIND_PUBLISHER instead of the
+        // expected stall-detection path.
+        final AtomicReference<CountDownLatch> probeLatch = publisherBObserver.setAndGetOnNextLatch(1);
+        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
+        endBlock(2L, publisherBStream);
+        awaitLatch(probeLatch, "SKIP_BLOCK(2) — sync probe confirming publisher A holds block 2");
+
+        // Set latch for RESEND_BLOCK before sending so it cannot be missed.
+        // Stall threshold is MaxFutureBlocksBeforeStalled=3: stall fires when
+        // completedBlock > stalledBlock + 3, i.e. block 6 > 2 + 3.
+        final AtomicReference<CountDownLatch> resendLatch = publisherBObserver.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK);
 
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2)));
         endBlock(3L, publisherBStream);
@@ -450,11 +476,7 @@ public class BlockNodeApiRegressionTest {
         publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(6L, hash5)));
         endBlock(6L, publisherBStream);
 
-        // Wait until stall fires. RESEND_BLOCK(2) is sent synchronously in the handler thread
-        // as part of endOfBlock(6) processing and is enqueued into the response pipeline before
-        // any persistence ACKs (which travel through the asynchronous forwarder → disruptor →
-        // persistence chain). The FIFO pipeline guarantees RESEND_BLOCK(2) arrives first.
-        awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection");
+        awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection", publisherBObserver);
 
         final AtomicReference<CountDownLatch> ack2Latch = publisherBObserver.setAndGetOnMatchLatch(
                 response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
@@ -668,6 +690,16 @@ public class BlockNodeApiRegressionTest {
                             .append(" block=")
                             .append(Objects.requireNonNull(response.resendBlock())
                                     .blockNumber());
+                } else if (response.response().kind()
+                        == PublishStreamResponse.ResponseOneOfType.NODE_BEHIND_PUBLISHER) {
+                    diagnostics
+                            .append(" lastPersisted=")
+                            .append(Objects.requireNonNull(response.nodeBehindPublisher())
+                                    .blockNumber());
+                } else if (response.response().kind() == PublishStreamResponse.ResponseOneOfType.SKIP_BLOCK) {
+                    diagnostics
+                            .append(" block=")
+                            .append(Objects.requireNonNull(response.skipBlock()).blockNumber());
                 }
                 diagnostics.append('\n');
             }

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
@@ -42,7 +42,6 @@ import org.hiero.block.suites.utils.BlockItemBuilderUtils;
 import org.hiero.block.suites.utils.ResponsePipelineUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -132,14 +131,14 @@ public class BlockNodeApiRegressionTest {
      */
     @Test
     @DisplayName("publisher RESEND fills block gap left by severed connection")
-    void missingBlockGapWhenPublisherSeversConnectionBeforeEndOfBlock() throws InterruptedException {
+    void publisherResendFillsBlockGapLeftBySeveredConnection() throws InterruptedException {
         final Bytes hash0 = BlockItemBuilderUtils.computeBlockHash(0L, null);
         final Bytes hash1 = BlockItemBuilderUtils.computeBlockHash(1L, hash0);
         final Bytes hash2 = BlockItemBuilderUtils.computeBlockHash(2L, hash1);
         final Bytes hash3 = BlockItemBuilderUtils.computeBlockHash(3L, hash2);
         final Bytes hash4 = BlockItemBuilderUtils.computeBlockHash(4L, hash3);
 
-        // Publisher 1 — stream blocks 0–2 with proper hash chain, ACK for each.
+        // Publisher 1: stream blocks 0–2 with proper hash chain, ACK for each.
         final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisher1Client =
                 new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
                         publishBlockStreamPbjGrpcClient, OPTIONS);
@@ -158,8 +157,6 @@ public class BlockNodeApiRegressionTest {
         }
 
         // Publisher 1 sends only the header for block 3 (no proof), then severs via RESET.
-        // blockIsEnding(3) removes block 3's queue from queueByBlockMap and adds 3 to
-        // blocksToResend. No partial proof is stranded in blockProofs because no proof was sent.
         publisher1Stream.onNext(buildPublishRequest(new BlockItem[] {BlockItemBuilderUtils.sampleBlockHeader(3L)}));
         final AtomicReference<CountDownLatch> publisher1DisconnectLatch =
                 publisher1Observer.setAndGetConnectionEndedLatch(1);
@@ -170,27 +167,14 @@ public class BlockNodeApiRegressionTest {
                 .build());
         awaitLatch(publisher1DisconnectLatch, "publisher 1 disconnect after block 3 header");
 
-        // Publisher 2 — connect and send block 4, then block 3 (the gap), then block 5.
-        //
-        // Sequence on the server:
-        //   endOfBlock(4) -> RESEND(3): handler detects gap, publisher asked to fill it
-        //   block 3 header -> getActionForHeader(3) -> ACCEPT (removes 3 from blocksToResend)
-        //   endOfBlock(3) -> ACCEPT(3)
-        //   endOfBlock(5) -> ACCEPT(5)
-        //
-        // ACK delivery: ACK(3) is always sent. ACK(4) may be suppressed when
-        // handlePersisted(4) fires before the forwarder removes block 4's key from
-        // queueByBlockMap — correctForResendAndStreaming(4) sees firstKey=4 and returns 3.
-        // ACK(5) is always sent because the forwarder removes block 5's key before
-        // dispatching to messaging. A newer ACK implicitly acknowledges all prior blocks.
+        // Publisher 2: send block 4, then block 3 (the gap), then block 5.
+        // endOfBlock(4) detects the gap and returns RESEND(3).
         final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisher2Client =
                 new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(createGrpcClient(), OPTIONS);
         final ResponsePipelineUtils<PublishStreamResponse> publisher2Observer = new ResponsePipelineUtils<>();
         final Pipeline<? super PublishStreamRequest> publisher2Stream =
                 publisher2Client.publishBlockStream(publisher2Observer);
 
-        // Use a predicate latch on ACK(5) — the reliable terminal signal — rather than
-        // a fixed-count latch. ACK(4) is non-deterministic and would cause flakiness.
         final AtomicReference<CountDownLatch> publisher2Latch = publisher2Observer.setAndGetOnMatchLatch(
                 response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
                         && Objects.requireNonNull(response.acknowledgement()).blockNumber() == 5L);
@@ -218,25 +202,17 @@ public class BlockNodeApiRegressionTest {
                         .returns(PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor)
                         .returns(5L, acknowledgementBlockNumberExtractor));
 
-        // All three blocks must be in storage — the gap at block 3 was filled by the RESEND.
-        // Blocks are persisted in sequential order (3, 4, 5); ACK(5) confirms all are present.
         final BlockAccessServiceInterface.BlockAccessServiceClient blockAccessClient =
                 new BlockAccessServiceInterface.BlockAccessServiceClient(getBlockPbjGrpcClient, OPTIONS);
-        assertThat(blockAccessClient
-                        .getBlock(BlockRequest.newBuilder().blockNumber(3L).build())
-                        .status())
-                .as("block 3 must be present in storage — gap was filled by RESEND mechanism")
-                .isEqualTo(BlockResponse.Code.SUCCESS);
-        assertThat(blockAccessClient
-                        .getBlock(BlockRequest.newBuilder().blockNumber(4L).build())
-                        .status())
-                .as("block 4 must be present in storage")
-                .isEqualTo(BlockResponse.Code.SUCCESS);
-        assertThat(blockAccessClient
-                        .getBlock(BlockRequest.newBuilder().blockNumber(5L).build())
-                        .status())
-                .as("block 5 must be present in storage")
-                .isEqualTo(BlockResponse.Code.SUCCESS);
+        for (long blockNum = 3L; blockNum <= 5L; blockNum++) {
+            assertThat(blockAccessClient
+                            .getBlock(BlockRequest.newBuilder()
+                                    .blockNumber(blockNum)
+                                    .build())
+                            .status())
+                    .as("block %d must be present in storage — gap was filled by RESEND", blockNum)
+                    .isEqualTo(BlockResponse.Code.SUCCESS);
+        }
 
         publisher1Client.close();
         publisher2Client.close();
@@ -244,32 +220,29 @@ public class BlockNodeApiRegressionTest {
     }
 
     /**
-     * Reproduces the block gap where a stalled publisher's block is never acknowledged after
-     * stall detection triggers a RESEND.
+     * Reproduces the stall-detection regression where a stalled publisher's block is never
+     * acknowledged and later blocks are forwarded out of order.
      *
-     * <p>Publisher A streams blocks 0–1 (fully ACKed), then sends only the header for block 2
-     * and stalls. Publisher B streams blocks 3–6; when block 6 completes, stall detection fires
-     * (6 &gt; 2 + MAX_ADVANCE = 5), removes block 2 from {@code queueByBlockMap}, adds 2 to
-     * {@code blocksToResend}, and returns {@code RESEND_BLOCK(2)} to publisher B.
+     * <p>Publisher 1 streams blocks 0–1 (fully ACKed), then sends only the header for block 2
+     * and goes silent. Publisher 2 streams blocks 3–6; when block 6 completes, stall detection
+     * fires (6 &gt; 2 + MaxFutureBlocksBeforeStalled = 5), removes block 2 from
+     * {@code queueByBlockMap}, adds 2 to {@code blocksToResend}, and returns
+     * {@code RESEND_BLOCK(2)} to publisher 2.
      *
-     * <p>Publisher B responds to the RESEND by re-delivering the complete block 2, then
-     * continues with block 7. With the bug, {@code MessagingForwarderTask} skips the block-2
-     * gap by using {@code firstEntry()} after the stall removes block 2 from the queue — it
-     * immediately forwards blocks 3–6 without waiting for the RESEND response. Block 2 is
-     * eventually stored out of order, but {@code handlePersisted} suppresses ACK(2) because
-     * {@code 2 < lastPersistedBlockNumber(6)}. Additionally, {@code clearObsoleteQueueItems}
-     * may evict the re-queued block-2 entry before its proof arrives.
+     * <p>Publisher 2 responds to the RESEND by re-delivering the complete block 2, then
+     * continues with blocks 7–8.
      *
-     * <p>With the fix the forwarder respects sequential ordering, ACK(2) is sent before
-     * ACK(3)–ACK(6), and block 2 reaches storage in the correct order.
+     * <p>With the fix, the forwarder respects sequential ordering: block 2 is forwarded before
+     * blocks 3–6, ACK(2) is sent before ACK(3), and all blocks reach storage without gaps.
      *
-     * <p>The ACK(2) assertion FAILS on buggy code because the forwarder skipped block 2 and
-     * the out-of-order persistence guard in {@code handlePersisted} never emits ACK(2).
-     * The storage assertions on blocks 2 and 6 confirm end-to-end persistence integrity.
+     * <p>Cross-connection synchronization: publisher 1's block 2 header and publisher 2's block 3
+     * are on different gRPC connections with no guaranteed ordering. Publisher 2 retries block 3
+     * until the server stops returning {@code NODE_BEHIND_PUBLISHER}, which proves publisher 1's
+     * header was processed and {@code nextUnstreamedBlockNumber >= 3}.
      */
     @Test
-    @DisplayName("stall-detected RESEND must result in the stalled block being acknowledged and persisted")
-    void stalledPublisherResendQueueEvictedByObsoleteCleanupLeavesBlockGap() throws InterruptedException {
+    @DisplayName("stall-detected RESEND must persist stalled block and acknowledge in order")
+    void stallDetectedResendMustPersistStalledBlockAndAcknowledgeInOrder() throws InterruptedException {
         final Bytes hash0 = BlockItemBuilderUtils.computeBlockHash(0L, null);
         final Bytes hash1 = BlockItemBuilderUtils.computeBlockHash(1L, hash0);
         final Bytes hash2 = BlockItemBuilderUtils.computeBlockHash(2L, hash1);
@@ -279,255 +252,81 @@ public class BlockNodeApiRegressionTest {
         final Bytes hash6 = BlockItemBuilderUtils.computeBlockHash(6L, hash5);
         final Bytes hash7 = BlockItemBuilderUtils.computeBlockHash(7L, hash6);
 
-        // Publisher A — streams blocks 0–1 fully (ACKed), then stalls mid-block-2 with a
-        // header-only batch.
-        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherAClient =
+        // Publisher 1: blocks 0–1 fully ACKed, then header-only block 2 (stall).
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisher1Client =
                 new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
                         publishBlockStreamPbjGrpcClient, OPTIONS);
-        final ResponsePipelineUtils<PublishStreamResponse> publisherAObserver = new ResponsePipelineUtils<>();
-        final Pipeline<? super PublishStreamRequest> publisherAStream =
-                publisherAClient.publishBlockStream(publisherAObserver);
+        final ResponsePipelineUtils<PublishStreamResponse> publisher1Observer = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> publisher1Stream =
+                publisher1Client.publishBlockStream(publisher1Observer);
 
-        final Bytes[] prevHashesForA = {null, hash0};
+        final Bytes[] previousHashes = {null, hash0};
         for (long blockNum = 0L; blockNum <= 1L; blockNum++) {
-            final AtomicReference<CountDownLatch> ackLatch = publisherAObserver.setAndGetOnNextLatch(1);
-            publisherAStream.onNext(buildPublishRequest(
-                    BlockItemBuilderUtils.createSimpleBlockWithNumber(blockNum, prevHashesForA[(int) blockNum])));
-            endBlock(blockNum, publisherAStream);
-            awaitLatch(ackLatch, "ACK for block " + blockNum + " from publisher A");
+            final AtomicReference<CountDownLatch> ackLatch = publisher1Observer.setAndGetOnNextLatch(1);
+            publisher1Stream.onNext(buildPublishRequest(
+                    BlockItemBuilderUtils.createSimpleBlockWithNumber(blockNum, previousHashes[(int) blockNum])));
+            endBlock(blockNum, publisher1Stream);
+            awaitLatch(ackLatch, "ACK for block " + blockNum + " from publisher 1");
         }
+        publisher1Stream.onNext(buildPublishRequest(new BlockItem[] {BlockItemBuilderUtils.sampleBlockHeader(2L)}));
 
-        // Only the block-2 header — publisher A stalls here.
-        publisherAStream.onNext(buildPublishRequest(new BlockItem[] {BlockItemBuilderUtils.sampleBlockHeader(2L)}));
-
-        // Publisher B — fills the stall gap via RESEND.
-        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherBClient =
+        // Publisher 2: sync, trigger stall detection, fill gap via RESEND.
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisher2Client =
                 new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(createGrpcClient(), OPTIONS);
-        final ResponsePipelineUtils<PublishStreamResponse> publisherBObserver = new ResponsePipelineUtils<>();
-        final Pipeline<? super PublishStreamRequest> publisherBStream =
-                publisherBClient.publishBlockStream(publisherBObserver);
+        final ResponsePipelineUtils<PublishStreamResponse> publisher2Observer = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> publisher2Stream =
+                publisher2Client.publishBlockStream(publisher2Observer);
 
-        // Synchronization: retry block 3 until it gets a non-BEHIND
-        // response. NODE_BEHIND_PUBLISHER means publisher A's block 2 header
-        // hasn't been processed yet (nextUnstreamedBlockNumber < 3). The
-        // handler resets after each BEHIND, so retrying is safe. ACCEPT sends
-        // no immediate response (ACK is stuck behind stalled block 2 in the
-        // forwarder), so a short timeout with no response means ACCEPT.
-        boolean block3Accepted = false;
-        while (!block3Accepted) {
-            final int responsesBefore = publisherBObserver.getOnNextCalls().size();
-            final AtomicReference<CountDownLatch> probeLatch = publisherBObserver.setAndGetOnNextLatch(1);
-            publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2)));
-            endBlock(3L, publisherBStream);
-            final boolean responded = probeLatch.get().await(500, TimeUnit.MILLISECONDS);
-            if (!responded) {
-                break;
-            }
-            final PublishStreamResponse probeResponse =
-                    publisherBObserver.getOnNextCalls().get(responsesBefore);
-            block3Accepted =
-                    probeResponse.response().kind() != PublishStreamResponse.ResponseOneOfType.NODE_BEHIND_PUBLISHER;
-        }
+        // Synchronize: ensure publisher 1's block 2 header was processed before
+        // sending blocks that depend on nextUnstreamedBlockNumber >= 3.
+        sendBlockUntilAccepted(
+                publisher2Stream, publisher2Observer, BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2), 3L);
 
-        // Set latch for RESEND_BLOCK before sending so it cannot be missed.
-        // Stall threshold is MaxFutureBlocksBeforeStalled=3: stall fires when
-        // completedBlock > stalledBlock + 3, i.e. block 6 > 2 + 3.
-        final AtomicReference<CountDownLatch> resendLatch = publisherBObserver.setAndGetOnMatchLatch(
+        // Blocks 4–6 trigger stall detection (6 > 2 + 3).
+        final AtomicReference<CountDownLatch> resendLatch = publisher2Observer.setAndGetOnMatchLatch(
                 response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK);
 
-        // Blocks 4–6: stall fires when endOfBlock(6) is processed (6 > 2+3).
-        // Block 3 was already sent in the sync probe above.
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(4L, hash3)));
-        endBlock(4L, publisherBStream);
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(5L, hash4)));
-        endBlock(5L, publisherBStream);
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(6L, hash5)));
-        endBlock(6L, publisherBStream);
+        publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(4L, hash3)));
+        endBlock(4L, publisher2Stream);
+        publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(5L, hash4)));
+        endBlock(5L, publisher2Stream);
+        publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(6L, hash5)));
+        endBlock(6L, publisher2Stream);
 
-        awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection", publisherBObserver);
+        awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection", publisher2Observer);
 
-        final AtomicReference<CountDownLatch> ack2Latch = publisherBObserver.setAndGetOnMatchLatch(
+        // Fill the gap: send complete block 2.
+        final AtomicReference<CountDownLatch> ack2Latch = publisher2Observer.setAndGetOnMatchLatch(
                 response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
                         && Objects.requireNonNull(response.acknowledgement()).blockNumber() >= 2L);
 
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
-        endBlock(2L, publisherBStream);
+        publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
+        endBlock(2L, publisher2Stream);
 
-        awaitLatch(ack2Latch, "ACK(2) — block 2 persisted after RESEND");
+        awaitLatch(ack2Latch, "ACK(>=2) — block 2 persisted after RESEND");
 
-        // Send blocks 7–8 and wait for any ACK >= 7. Sending two blocks
-        // provides resilience against correctForResendAndStreaming suppressing
-        // a single block's ACK due to transient queue-map state.
-        final AtomicReference<CountDownLatch> terminalLatch = publisherBObserver.setAndGetOnMatchLatch(
+        // Terminal signal: blocks 7–8 confirm the full chain is flowing.
+        final AtomicReference<CountDownLatch> terminalLatch = publisher2Observer.setAndGetOnMatchLatch(
                 response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
                         && Objects.requireNonNull(response.acknowledgement()).blockNumber() >= 7L);
 
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));
-        endBlock(7L, publisherBStream);
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(8L, hash7)));
-        endBlock(8L, publisherBStream);
+        publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));
+        endBlock(7L, publisher2Stream);
+        publisher2Stream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(8L, hash7)));
+        endBlock(8L, publisher2Stream);
 
-        awaitLatch(terminalLatch, "ACK(>=7) — terminal signal confirming block 2 is in storage", publisherBObserver);
+        awaitLatch(terminalLatch, "ACK(>=7) — terminal signal", publisher2Observer);
 
-        assertThat(publisherBObserver.getOnNextCalls())
-                .as("publisher B must receive RESEND(2) — stall detection must request the gap block")
+        // Verify RESEND was issued for block 2.
+        assertThat(publisher2Observer.getOnNextCalls())
+                .as("publisher 2 must receive RESEND(2) — stall detection must request the gap block")
                 .anySatisfy(response -> assertThat(response)
                         .returns(PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK, responseKindExtractor)
                         .returns(2L, resendBlockNumberExtractor));
 
+        // Verify all blocks 2–6 are in storage (no gaps).
         final BlockAccessServiceInterface.BlockAccessServiceClient blockAccessClient =
                 new BlockAccessServiceInterface.BlockAccessServiceClient(getBlockPbjGrpcClient, OPTIONS);
-
-        // Block 2 must be retrievable from storage after the RESEND completes.
-        assertThat(blockAccessClient
-                        .getBlock(BlockRequest.newBuilder().blockNumber(2L).build())
-                        .status())
-                .as("block 2 must be in storage — stall RESEND must fill the gap")
-                .isEqualTo(BlockResponse.Code.SUCCESS);
-
-        // Block 6 is the collateral-damage block: received complete while block 2 was stalled.
-        // It must also reach storage; the gap at block 2 must not leave it permanently lost.
-        assertThat(blockAccessClient
-                        .getBlock(BlockRequest.newBuilder().blockNumber(6L).build())
-                        .status())
-                .as("block 6 must be in storage — collateral complete block must not be lost")
-                .isEqualTo(BlockResponse.Code.SUCCESS);
-
-        publisherAClient.close();
-        publisherBClient.close();
-        blockAccessClient.close();
-    }
-
-    /**
-     * Reproduces the protocol ordering violation where the publisher manager forwards blocks 3–5
-     * to messaging before the stalled block 2 is re-delivered.
-     *
-     * <p>Protocol requirement (HIP-1081): a Block-Node MUST NOT acknowledge block M before it has
-     * verified, persisted, and acknowledged block M-1.
-     *
-     * <p>Publisher A streams blocks 0–1 (ACKed), then sends only the header for block 2 and
-     * stalls. Publisher B streams blocks 3–6; when block 6 completes, stall detection fires: block
-     * 2 is removed from {@code queueByBlockMap}, added to {@code blocksToResend}, and
-     * RESEND_BLOCK(2) is returned to publisher B.
-     *
-     * <p>With the bug, after the stall the {@code MessagingForwarderTask} skips the block-2 gap
-     * by calling {@code firstEntry()} and immediately forwards blocks 3–6. Those blocks are
-     * persisted and ACK(3)–ACK(6) are sent to publisher B before block 2 has been re-delivered.
-     * Publisher B then sends the full block 2 as its RESEND response, but the forwarder has
-     * already moved past it — block 2 is never persisted and ACK(2) never arrives.
-     *
-     * <p>With the fix, the forwarder respects sequential ordering and waits for block 2 before
-     * forwarding blocks 3–6. After publisher B delivers block 2, all five blocks (2, 3, 4, 5, 6)
-     * are persisted in order, and ACK(2) is sent before ACK(3).
-     */
-    @Test
-    @DisplayName("stall RESEND must not cause acknowledgements for later blocks before the stalled block")
-    void stalledPublisherMustNotAcknowledgeLaterBlocksBeforeStalledBlock() throws InterruptedException {
-        final Bytes hash0 = BlockItemBuilderUtils.computeBlockHash(0L, null);
-        final Bytes hash1 = BlockItemBuilderUtils.computeBlockHash(1L, hash0);
-        final Bytes hash2 = BlockItemBuilderUtils.computeBlockHash(2L, hash1);
-        final Bytes hash3 = BlockItemBuilderUtils.computeBlockHash(3L, hash2);
-        final Bytes hash4 = BlockItemBuilderUtils.computeBlockHash(4L, hash3);
-        final Bytes hash5 = BlockItemBuilderUtils.computeBlockHash(5L, hash4);
-        final Bytes hash6 = BlockItemBuilderUtils.computeBlockHash(6L, hash5);
-        final Bytes hash7 = BlockItemBuilderUtils.computeBlockHash(7L, hash6);
-
-        // Publisher A — streams blocks 0–1 (ACKed), then stalls mid-block-2 (header only).
-        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherAClient =
-                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
-                        publishBlockStreamPbjGrpcClient, OPTIONS);
-        final ResponsePipelineUtils<PublishStreamResponse> publisherAObserver = new ResponsePipelineUtils<>();
-        final Pipeline<? super PublishStreamRequest> publisherAStream =
-                publisherAClient.publishBlockStream(publisherAObserver);
-
-        final Bytes[] prevHashesForA = {null, hash0};
-        for (long blockNum = 0L; blockNum <= 1L; blockNum++) {
-            final AtomicReference<CountDownLatch> ackLatch = publisherAObserver.setAndGetOnNextLatch(1);
-            publisherAStream.onNext(buildPublishRequest(
-                    BlockItemBuilderUtils.createSimpleBlockWithNumber(blockNum, prevHashesForA[(int) blockNum])));
-            endBlock(blockNum, publisherAStream);
-            awaitLatch(ackLatch, "ACK for block " + blockNum + " from publisher A");
-        }
-        // Publisher A stalls here — only the block-2 header is sent, no proof.
-        publisherAStream.onNext(buildPublishRequest(new BlockItem[] {BlockItemBuilderUtils.sampleBlockHeader(2L)}));
-
-        // Publisher B — triggers stall detection via blocks 3–6.
-        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherBClient =
-                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(createGrpcClient(), OPTIONS);
-        final ResponsePipelineUtils<PublishStreamResponse> publisherBObserver = new ResponsePipelineUtils<>();
-        final Pipeline<? super PublishStreamRequest> publisherBStream =
-                publisherBClient.publishBlockStream(publisherBObserver);
-
-        // Synchronization: retry block 3 until it gets a non-BEHIND
-        // response. NODE_BEHIND_PUBLISHER means publisher A's block 2 header
-        // hasn't been processed yet (nextUnstreamedBlockNumber < 3). The
-        // handler resets after each BEHIND, so retrying is safe. ACCEPT sends
-        // no immediate response (ACK is stuck behind stalled block 2 in the
-        // forwarder), so a short timeout with no response means ACCEPT.
-        boolean block3Accepted = false;
-        while (!block3Accepted) {
-            final int responsesBefore = publisherBObserver.getOnNextCalls().size();
-            final AtomicReference<CountDownLatch> probeLatch = publisherBObserver.setAndGetOnNextLatch(1);
-            publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2)));
-            endBlock(3L, publisherBStream);
-            final boolean responded = probeLatch.get().await(500, TimeUnit.MILLISECONDS);
-            if (!responded) {
-                break;
-            }
-            final PublishStreamResponse probeResponse =
-                    publisherBObserver.getOnNextCalls().get(responsesBefore);
-            block3Accepted =
-                    probeResponse.response().kind() != PublishStreamResponse.ResponseOneOfType.NODE_BEHIND_PUBLISHER;
-        }
-
-        // Set latch for RESEND_BLOCK before sending so it cannot be missed.
-        // Stall threshold is MaxFutureBlocksBeforeStalled=3: stall fires when
-        // completedBlock > stalledBlock + 3, i.e. block 6 > 2 + 3.
-        final AtomicReference<CountDownLatch> resendLatch = publisherBObserver.setAndGetOnMatchLatch(
-                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK);
-
-        // Blocks 4–6: stall fires when endOfBlock(6) is processed (6 > 2+3).
-        // Block 3 was already sent in the sync probe above.
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(4L, hash3)));
-        endBlock(4L, publisherBStream);
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(5L, hash4)));
-        endBlock(5L, publisherBStream);
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(6L, hash5)));
-        endBlock(6L, publisherBStream);
-
-        awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection", publisherBObserver);
-
-        final AtomicReference<CountDownLatch> ack2Latch = publisherBObserver.setAndGetOnMatchLatch(
-                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
-                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() >= 2L);
-
-        // Publisher B provides the full block 2 as its RESEND response.
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
-        endBlock(2L, publisherBStream);
-
-        awaitLatch(ack2Latch, "ACK(2) — block 2 persisted after RESEND");
-
-        // Send blocks 7–8 and wait for any ACK >= 7. Sending two blocks
-        // provides resilience against correctForResendAndStreaming suppressing
-        // a single block's ACK due to transient queue-map state.
-        final AtomicReference<CountDownLatch> terminalLatch = publisherBObserver.setAndGetOnMatchLatch(
-                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
-                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() >= 7L);
-
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));
-        endBlock(7L, publisherBStream);
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(8L, hash7)));
-        endBlock(8L, publisherBStream);
-
-        awaitLatch(
-                terminalLatch,
-                "ACK(>=7) — terminal signal confirming the RESEND sequence is complete",
-                publisherBObserver);
-
-        final BlockAccessServiceInterface.BlockAccessServiceClient blockAccessClient =
-                new BlockAccessServiceInterface.BlockAccessServiceClient(getBlockPbjGrpcClient, OPTIONS);
-
-        // Blocks 2–6 must all be in storage — the stall-RESEND sequence must leave no gaps.
         for (long blockNum = 2L; blockNum <= 6L; blockNum++) {
             assertThat(blockAccessClient
                             .getBlock(BlockRequest.newBuilder()
@@ -538,115 +337,24 @@ public class BlockNodeApiRegressionTest {
                     .isEqualTo(BlockResponse.Code.SUCCESS);
         }
 
-        publisherAClient.close();
-        publisherBClient.close();
-        blockAccessClient.close();
-    }
-
-    /**
-     * Bug reproduction: asserts the out-of-order acknowledgement behaviour produced by
-     * {@code MessagingForwarderTask} skipping the stalled block-2 gap.
-     *
-     * <p><b>This test documented the bug and was expected to PASS on buggy code. It is disabled
-     * because the bug is now fixed — the assertions below fail correctly with the fix in
-     * place.</b> Delete this test once the fix has soaked in production.
-     *
-     * <p>After stall detection removes block 2 from {@code queueByBlockMap}, the forwarder calls
-     * {@code firstEntry()} and immediately forwards blocks 3–6, producing ACK(3), ACK(4), ACK(5),
-     * ACK(6) before block 2 is re-delivered. Publisher B then sends block 2 as the RESEND
-     * response, but the forwarder has already advanced its {@code lastForwardedBlockNumber} past
-     * block 2 — it will never forward block 2. ACK(2) is therefore absent from publisher B's
-     * responses, while ACK(3) and later are present — a direct protocol ordering violation.
-     *
-     * <p>With the fix the forwarder waits for block 2 before forwarding blocks 3–6, ACK(2)
-     * arrives before ACK(3), and the {@code doesNotContain(2L)} assertion below fails.
-     */
-    @Test
-    @Disabled("Bug is fixed — assertions document the violation and now fail correctly; delete when soaked")
-    @DisplayName("[BUG] stalled forwarder skips block-2 gap and acknowledges later blocks out of order")
-    void bugRepro_stalledForwarderSkipsGapAndAcknowledgesLaterBlocksOutOfOrder() throws InterruptedException {
-        final Bytes hash0 = BlockItemBuilderUtils.computeBlockHash(0L, null);
-        final Bytes hash1 = BlockItemBuilderUtils.computeBlockHash(1L, hash0);
-        final Bytes hash2 = BlockItemBuilderUtils.computeBlockHash(2L, hash1);
-        final Bytes hash3 = BlockItemBuilderUtils.computeBlockHash(3L, hash2);
-        final Bytes hash4 = BlockItemBuilderUtils.computeBlockHash(4L, hash3);
-        final Bytes hash5 = BlockItemBuilderUtils.computeBlockHash(5L, hash4);
-        final Bytes hash6 = BlockItemBuilderUtils.computeBlockHash(6L, hash5);
-
-        // Publisher A — streams blocks 0–1 (ACKed), then stalls mid-block-2 (header only).
-        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherAClient =
-                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
-                        publishBlockStreamPbjGrpcClient, OPTIONS);
-        final ResponsePipelineUtils<PublishStreamResponse> publisherAObserver = new ResponsePipelineUtils<>();
-        final Pipeline<? super PublishStreamRequest> publisherAStream =
-                publisherAClient.publishBlockStream(publisherAObserver);
-
-        final Bytes[] prevHashesForA = {null, hash0};
-        for (long blockNum = 0L; blockNum <= 1L; blockNum++) {
-            final AtomicReference<CountDownLatch> ackLatch = publisherAObserver.setAndGetOnNextLatch(1);
-            publisherAStream.onNext(buildPublishRequest(
-                    BlockItemBuilderUtils.createSimpleBlockWithNumber(blockNum, prevHashesForA[(int) blockNum])));
-            endBlock(blockNum, publisherAStream);
-            awaitLatch(ackLatch, "ACK for block " + blockNum + " from publisher A");
-        }
-        publisherAStream.onNext(buildPublishRequest(new BlockItem[] {BlockItemBuilderUtils.sampleBlockHeader(2L)}));
-
-        // Publisher B — streams blocks 3–6 to trigger stall detection (threshold=3: 6 > 2+3),
-        // then sends block 2 RESEND.
-        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherBClient =
-                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(createGrpcClient(), OPTIONS);
-        final ResponsePipelineUtils<PublishStreamResponse> publisherBObserver = new ResponsePipelineUtils<>();
-        final Pipeline<? super PublishStreamRequest> publisherBStream =
-                publisherBClient.publishBlockStream(publisherBObserver);
-
-        final AtomicReference<CountDownLatch> resendLatch = publisherBObserver.setAndGetOnNextLatch(1);
-
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(3L, hash2)));
-        endBlock(3L, publisherBStream);
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(4L, hash3)));
-        endBlock(4L, publisherBStream);
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(5L, hash4)));
-        endBlock(5L, publisherBStream);
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(6L, hash5)));
-        endBlock(6L, publisherBStream);
-
-        awaitLatch(resendLatch, "RESEND_BLOCK(2) from stall detection");
-
-        // With the bug the forwarder has begun forwarding blocks 3–6 asynchronously. Publisher B
-        // now sends block 2 (full) and block 7. Block 2 is never forwarded (forwarder is past it);
-        // block 7 is forwarded normally. Expect 5 responses: ACK(3) + ACK(4) + ACK(5) + ACK(6) + ACK(7).
-        //
-        // With the fix the forwarder waited: publisher B's block 2 fills the gap, the forwarder
-        // then forwards 2 → 3 → 4 → 5 → 6 in order, and ACK(2) arrives as the first of the 5
-        // responses — which causes the assertion below to fail.
-        final AtomicReference<CountDownLatch> postResendLatch = publisherBObserver.setAndGetOnNextLatch(5);
-
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1)));
-        endBlock(2L, publisherBStream);
-        publisherBStream.onNext(buildPublishRequest(BlockItemBuilderUtils.createSimpleBlockWithNumber(7L, hash6)));
-        endBlock(7L, publisherBStream);
-
-        awaitLatch(postResendLatch, "ACK(3), ACK(4), ACK(5), ACK(6), and ACK(7) from publisher B");
-
-        final List<Long> ackBlockOrder = publisherBObserver.getOnNextCalls().stream()
-                .filter(r -> r.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT)
-                .map(acknowledgementBlockNumberExtractor)
+        // Verify ACK ordering: ACK(2) must arrive before any ACK for a higher block.
+        final List<Long> ackBlockNumbers = publisher2Observer.getOnNextCalls().stream()
+                .filter(response ->
+                        response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT)
+                .map(response ->
+                        Objects.requireNonNull(response.acknowledgement()).blockNumber())
                 .toList();
 
-        // BUG: block 2 is never forwarded — the forwarder skipped it and will not go back.
-        // PASSES on buggy code (ACK(2) absent); FAILS when fixed (ACK(2) present).
-        assertThat(ackBlockOrder)
-                .as("BUG: block 2 must not be acknowledged — forwarder skipped the gap and moved past it")
-                .doesNotContain(2L);
+        assertThat(ackBlockNumbers).as("ACK(2) must be present").contains(2L);
 
-        // BUG: later blocks were acknowledged despite the unsatisfied gap at block 2.
-        // PASSES on buggy code (ACK(3–6) present); FAILS when fixed (reordering prevented).
-        assertThat(ackBlockOrder)
-                .as("BUG: blocks later than 2 must be acknowledged before block 2 is delivered — ordering violation")
-                .containsAnyOf(3L, 4L, 5L, 6L);
+        final int ack2Index = ackBlockNumbers.indexOf(2L);
+        assertThat(ackBlockNumbers.subList(0, ack2Index))
+                .as("no ACK for a block higher than 2 may arrive before ACK(2)")
+                .allSatisfy(blockNumber -> assertThat(blockNumber).isLessThanOrEqualTo(2L));
 
-        publisherAClient.close();
-        publisherBClient.close();
+        publisher1Client.close();
+        publisher2Client.close();
+        blockAccessClient.close();
     }
 
     private PbjGrpcClient createGrpcClient() {
@@ -677,6 +385,34 @@ public class BlockNodeApiRegressionTest {
         requestStream.onNext(PublishStreamRequest.newBuilder()
                 .endOfBlock(BlockEnd.newBuilder().blockNumber(blockNumber).build())
                 .build());
+    }
+
+    /**
+     * Sends the given block repeatedly until the server accepts it (i.e. stops
+     * returning {@code NODE_BEHIND_PUBLISHER}). {@code NODE_BEHIND_PUBLISHER}
+     * is synchronous — if no response arrives within 500 ms the block was
+     * accepted. The handler resets after each {@code BEHIND}, so retrying is
+     * safe.
+     */
+    private void sendBlockUntilAccepted(
+            final Pipeline<? super PublishStreamRequest> stream,
+            final ResponsePipelineUtils<PublishStreamResponse> observer,
+            final BlockItem[] blockItems,
+            final long blockNumber)
+            throws InterruptedException {
+        boolean accepted = false;
+        while (!accepted) {
+            final int responsesBefore = observer.getOnNextCalls().size();
+            final AtomicReference<CountDownLatch> latch = observer.setAndGetOnNextLatch(1);
+            stream.onNext(buildPublishRequest(blockItems));
+            endBlock(blockNumber, stream);
+            final boolean responded = latch.get().await(500, TimeUnit.MILLISECONDS);
+            if (!responded) {
+                break;
+            }
+            final PublishStreamResponse response = observer.getOnNextCalls().get(responsesBefore);
+            accepted = response.response().kind() != PublishStreamResponse.ResponseOneOfType.NODE_BEHIND_PUBLISHER;
+        }
     }
 
     private void awaitLatch(

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/utils/ResponsePipelineUtils.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/utils/ResponsePipelineUtils.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 
 /**
  * A simple test implementation of the {@link Pipeline} interface. It keeps
@@ -26,6 +27,9 @@ public class ResponsePipelineUtils<R> implements Pipeline<R> {
     private AtomicReference<CountDownLatch> onCompleteLatch = new AtomicReference<>();
     // Fires on either onComplete or onError — use when connection closure is the signal, not a specific response type
     private AtomicReference<CountDownLatch> connectionEndedLatch = new AtomicReference<>();
+    // Fires when any received item satisfies matchPredicate — use when a specific response is the terminal signal
+    private volatile Predicate<R> matchPredicate;
+    private final AtomicReference<CountDownLatch> matchLatch = new AtomicReference<>();
 
     @Override
     public void clientEndStreamReceived() {
@@ -37,6 +41,13 @@ public class ResponsePipelineUtils<R> implements Pipeline<R> {
         onNextCalls.add(Objects.requireNonNull(item));
         if (onNextLatch.get() != null) {
             onNextLatch.get().countDown();
+        }
+        final Predicate<R> pred = matchPredicate;
+        if (pred != null && pred.test(item)) {
+            final CountDownLatch latch = matchLatch.get();
+            if (latch != null) {
+                latch.countDown();
+            }
         }
     }
 
@@ -97,6 +108,14 @@ public class ResponsePipelineUtils<R> implements Pipeline<R> {
     public AtomicReference<CountDownLatch> setAndGetConnectionEndedLatch(int count) {
         connectionEndedLatch.set(new CountDownLatch(count));
         return connectionEndedLatch;
+    }
+
+    // Fires when the first item satisfying predicate is received.
+    // Set before sending items to avoid races.
+    public AtomicReference<CountDownLatch> setAndGetOnMatchLatch(final Predicate<R> predicate) {
+        matchLatch.set(new CountDownLatch(1));
+        matchPredicate = predicate;
+        return matchLatch;
     }
 
     /**


### PR DESCRIPTION
## Summary

E2E regression tests for the stalled-publisher bugs fixed in `reduce-out-of-order-acknowledgements` (#2699). Two tests verify that stall detection and RESEND produce correct behavior through the full stack (gRPC → forwarder → messaging → persistence → ACK).

- **Severed-connection RESEND test** — publisher 1 disconnects mid-block, publisher 2 fills the gap via RESEND(3), blocks 3-5 all reach storage
- **Stall-detection RESEND test** — publisher 1 stalls on block 2 (header only), publisher 2 advances past the stall threshold triggering RESEND(2), then fills the gap. Asserts blocks 2-6 in storage with no gaps AND ACK(2) arrives before any higher ACK (HIP-1081 ordering requirement)
- **`ResponsePipelineUtils.setAndGetOnMatchLatch`** — predicate-based latch that fires on a specific response type instead of any response, eliminating flakiness from non-deterministic ACK suppression
- **`sendBlockUntilAccepted` helper** — handles cross-connection gRPC ordering: retries a block until the server stops returning `NODE_BEHIND_PUBLISHER`, synchronizing two publishers without arbitrary sleeps
- **CI reliability** — `DEFAULT_AWAIT_TIMEOUT` 30s → 60s, `Thread.sleep(200)` replaced with readiness poll on `blockNodeState()`

## Test plan

- [x] Both E2E regression tests pass on CI (`runAPISuites`)
- [x] Existing tests unaffected (full `check` passes)

## Related Issue(s)

Related #2694

