### PR TITLE
feat: S3 Cloud Archive Plugin to update store blocks (#2703)

### DIFF
--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -43,6 +43,7 @@ import org.hiero.block.node.app.config.WebServerHttp2Config;
 import org.hiero.block.node.app.config.node.NodeConfig;
 import org.hiero.block.node.app.logging.CleanColorfulFormatter;
 import org.hiero.block.node.app.logging.ConfigLogger;
+import org.hiero.block.node.base.ranges.ConcurrentLongRangeSet;
 import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
@@ -66,6 +67,12 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     /** Metric key for the newest historical block available */
     public static final MetricKey<ObservableGauge> METRIC_APP_HISTORICAL_NEWEST_BLOCK =
             MetricKey.of("app_historical_newest_block", ObservableGauge.class).addCategory(METRICS_CATEGORY);
+    /** Metric key for the oldest stored block */
+    public static final MetricKey<ObservableGauge> METRIC_APP_STORED_OLDEST_BLOCK =
+            MetricKey.of("app_stored_oldest_block", ObservableGauge.class).addCategory(METRICS_CATEGORY);
+    /** Metric key for the newest stored block */
+    public static final MetricKey<ObservableGauge> METRIC_APP_STORED_NEWEST_BLOCK =
+            MetricKey.of("app_stored_newest_block", ObservableGauge.class).addCategory(METRICS_CATEGORY);
     /** Metric key for the current state status of the app */
     public static final MetricKey<ObservableGauge> METRIC_APP_STATE_STATUS =
             MetricKey.of("app_state_status", ObservableGauge.class).addCategory(METRICS_CATEGORY);
@@ -85,6 +92,9 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     BlockNodeContext blockNodeContext;
     /** list of all loaded plugins. Package so accessible for testing. */
     final List<BlockNodePlugin> loadedPlugins = new ArrayList<>();
+
+    /** The set of blocks stored in the cloud archive. */
+    private final ConcurrentLongRangeSet storedBlocks = new ConcurrentLongRangeSet();
 
     /** Create a ConcurrentLinkedQueue to hold TssData updates */
     private final ConcurrentLinkedQueue<TssData> tssDataUpdates = new ConcurrentLinkedQueue<>();
@@ -254,6 +264,12 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         metricRegistry.register(ObservableGauge.builder(METRIC_APP_STATE_STATUS)
                 .setDescription("The current state of the BlockNode App")
                 .observe(() -> state.get().ordinal()));
+        metricRegistry.register(ObservableGauge.builder(METRIC_APP_STORED_OLDEST_BLOCK)
+                .setDescription("The oldest block archived in S3")
+                .observe(() -> storedBlocks.min()));
+        metricRegistry.register(ObservableGauge.builder(METRIC_APP_STORED_NEWEST_BLOCK)
+                .setDescription("The newest block archived in S3")
+                .observe(() -> storedBlocks.max()));
     }
 
     /**
@@ -374,6 +390,14 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     @Override
     public void updateTssData(TssData tssData) {
         if (tssData != null) tssDataUpdates.add(tssData);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void updateStoredBlocks(long startBlock, long endBlock) {
+        storedBlocks.add(startBlock, endBlock);
     }
 
     /**

--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppStoredBlocksTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppStoredBlocksTest.java
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.app;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.hiero.block.node.spi.ServiceLoaderFunction;
+import org.junit.jupiter.api.Test;
+import java.io.IOException;
+
+public class BlockNodeAppStoredBlocksTest {
+
+    @Test
+    public void testUpdateStoredBlocks() throws IOException {
+        ServiceLoaderFunction serviceLoader = mock(ServiceLoaderFunction.class);
+        BlockNodeApp app = new BlockNodeApp(serviceLoader, false);
+        
+        app.updateStoredBlocks(10, 20);
+        app.updateStoredBlocks(30, 40);
+        
+        // We don't have a public getter for storedBlocks, but we can check metrics if we want.
+        // For now, this just verifies that the method exists and doesn't crash.
+    }
+}

--- a/block-node/base/src/main/java/org/hiero/block/node/base/s3/S3Client.java
+++ b/block-node/base/src/main/java/org/hiero/block/node/base/s3/S3Client.java
@@ -287,7 +287,8 @@ public final class S3Client implements AutoCloseable {
             @NonNull final String objectKey,
             @NonNull final String storageClass,
             @NonNull final Iterator<byte[]> contentIterable,
-            @NonNull final String contentType)
+            @NonNull final String contentType,
+            @NonNull final Runnable partUploadedCallback)
             throws S3ResponseException, IOException {
         // start the multipart upload
         final String uploadId = createMultipartUpload(objectKey, storageClass, contentType);
@@ -310,6 +311,8 @@ public final class S3Client implements AutoCloseable {
                     remainingContent -= length;
                     // we now have a full chunk so need to upload the chunk to S3
                     eTags.add(multipartUploadPart(objectKey, uploadId, eTags.size() + 1, chunk));
+                    // notify that a part was uploaded
+                    partUploadedCallback.run();
                     // reset the offset in the chunk
                     offsetInChunk = 0;
                 } else {
@@ -327,6 +330,8 @@ public final class S3Client implements AutoCloseable {
             System.arraycopy(chunk, 0, lastChunk, 0, offsetInChunk);
             // we have a partial chunk so need to upload it to S3
             eTags.add(multipartUploadPart(objectKey, uploadId, eTags.size() + 1, lastChunk));
+            // notify that a part was uploaded
+            partUploadedCallback.run();
         }
         // Complete the multipart upload
         completeMultipartUpload(objectKey, uploadId, eTags);

--- a/block-node/base/src/test/java/org/hiero/block/node/base/s3/S3ClientTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/s3/S3ClientTest.java
@@ -230,7 +230,7 @@ public class S3ClientTest {
         }
         // upload parts
         try (final S3Client s3Client = client()) {
-            s3Client.uploadFile(key, "STANDARD", parts.iterator(), "plain/text");
+            s3Client.uploadFile(key, "STANDARD", parts.iterator(), "plain/text", () -> {});
         }
         // download with a minio client
         final byte[] actual = minioClient

--- a/block-node/s3-archive/src/main/java/org/hiero/block/node/archive/s3/S3ArchivePlugin.java
+++ b/block-node/s3-archive/src/main/java/org/hiero/block/node/archive/s3/S3ArchivePlugin.java
@@ -136,6 +136,9 @@ public class S3ArchivePlugin implements BlockNodePlugin, BlockNotificationHandle
                 if (lastArchivedBlockNumberString != null && !lastArchivedBlockNumberString.isEmpty()) {
                     lastArchivedBlockNumber.set(Long.parseLong(lastArchivedBlockNumberString));
                 }
+                if (lastArchivedBlockNumber.get() != UNKNOWN_BLOCK_NUMBER) {
+                    context.applicationStateFacility().updateStoredBlocks(0, lastArchivedBlockNumber.get());
+                }
                 LOGGER.log(INFO, "Last S3 archived block number: " + lastArchivedBlockNumber);
             } catch (final Exception e) {
                 LOGGER.log(ERROR, "Failed to read latest archived block file: " + e.getMessage(), e);
@@ -329,8 +332,9 @@ public class S3ArchivePlugin implements BlockNodePlugin, BlockNotificationHandle
                 if (blockAccessorBatch.isEmpty()) {
                     return false;
                 } else {
+                    final BlockRangeTracker tracker = new BlockRangeTracker(blockAccessorBatch.iterator());
                     final Iterator<byte[]> tarBlocks =
-                            new TaredBlockIterator(Format.ZSTD_PROTOBUF, blockAccessorBatch.iterator());
+                            new TaredBlockIterator(Format.ZSTD_PROTOBUF, tracker);
                     // fetch the first blocks consensus time so that we can place the file in a directory based on year
                     // and
                     // month
@@ -366,7 +370,14 @@ public class S3ArchivePlugin implements BlockNodePlugin, BlockNotificationHandle
                                     startBlockNumberFormatted,
                                     endBlockNumberFormatted);
                     // Upload the blocks to S3
-                    s3Client.uploadFile(objectKey, archiveConfig.storageClass(), tarBlocks, "application/x-tar");
+                    s3Client.uploadFile(
+                            objectKey, archiveConfig.storageClass(), tarBlocks, "application/x-tar", () -> {
+                                if (tracker.getMin() <= tracker.getMax()) {
+                                    context.applicationStateFacility()
+                                            .updateStoredBlocks(tracker.getMin(), tracker.getMax());
+                                    tracker.reset();
+                                }
+                            });
                     return true;
                 }
             } catch (final ParseException e) {
@@ -409,6 +420,46 @@ public class S3ArchivePlugin implements BlockNodePlugin, BlockNotificationHandle
                 accessors.close();
             }
             return accessors;
+        }
+    }
+
+    /**
+     * A block range tracker. This class tracks the block numbers of the blocks
+     * that have been read from the delegate iterator.
+     */
+    private static final class BlockRangeTracker implements Iterator<BlockAccessor> {
+        private final Iterator<BlockAccessor> delegate;
+        private long min = Long.MAX_VALUE;
+        private long max = Long.MIN_VALUE;
+
+        private BlockRangeTracker(Iterator<BlockAccessor> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return delegate.hasNext();
+        }
+
+        @Override
+        public BlockAccessor next() {
+            BlockAccessor acc = delegate.next();
+            min = Math.min(min, acc.blockNumber());
+            max = Math.max(max, acc.blockNumber());
+            return acc;
+        }
+
+        public long getMin() {
+            return min;
+        }
+
+        public long getMax() {
+            return max;
+        }
+
+        public void reset() {
+            min = Long.MAX_VALUE;
+            max = Long.MIN_VALUE;
         }
     }
 }

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/ApplicationStateFacility.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/ApplicationStateFacility.java
@@ -15,4 +15,12 @@ public interface ApplicationStateFacility {
      * @param tssData - The TssData to be updated on the `BlockNodeContext`
      * */
     void updateTssData(TssData tssData);
+
+    /**
+     * Used by plugins to update the stored blocks range for this application. i.e. `S3ArchivePlugin`
+     *
+     * @param startBlock - The start block number of the range
+     * @param endBlock - The end block number of the range
+     * */
+    void updateStoredBlocks(long startBlock, long endBlock);
 }


### PR DESCRIPTION
I've updated the S3 Archive plugin to keep the application state in the loop about what's actually been stored in the cloud. Instead of waiting for a massive upload to finish, the plugin now reports back every time a 5MB part is successfully hit S3. This gives us much better real-time visibility.

I also made sure that when the node starts up, it checks S3 for the last archived block and populates the application state right away, so we don't start with a blank slate after a restart.

On the technical side:

Added a simple callback to S3Client so we can hook into the multipart upload loop.
Created a BlockRangeTracker to keep tabs on which block numbers are passing through the stream.
Added a couple of new metrics (app_stored_oldest_block and app_stored_newest_block) so we can easily monitor the archive status.
Related Issue(s)
Resolves #2703