### PR TITLE
fix(publisher): prune stale `blocksToResend` entries beyond a configurable buffer (#2716)

### DIFF
--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -83,6 +83,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     private final ReentrantLock dataReadyLock;
     private final long earliestManagedBlock;
     private final int maxBlocksBeforeStalled;
+    private final long staleResendPruneBuffer;
     private final ScheduledExecutorService scheduledExecutor;
     private volatile ScheduledFuture<Boolean> publisherUnavailabilityTimeoutFuture;
 
@@ -134,6 +135,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 threadManager.createVirtualThreadScheduledExecutor(1, null, this::uncaughtScheduledExecutorException);
         publisherConfig = serverContext.configuration().getConfigData(PublisherConfig.class);
         maxBlocksBeforeStalled = publisherConfig.MaxFutureBlocksBeforeStalled();
+        staleResendPruneBuffer = publisherConfig.staleResendPruneBuffer();
         publisherUnavailabilityTimeoutFuture = schedulePublisherUnavailabilityTimeout();
         blockProofs = new ConcurrentSkipListMap<>();
         endBlocksReceived = new ConcurrentSkipListSet<>();
@@ -377,6 +379,14 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 // Persistence success (as from backfill) can also detect stalled handlers...
                 checkForStalledHandlers(blockNumber);
                 if (blockNumber > lastPersistedBlockNumber.get()) {
+                    // Drop stale resend entries that no publisher could realistically still
+                    // supply. Without this, an entry left behind by a TOCTOU race between
+                    // blockIsEnding and a concurrent BACKFILL handlePersisted would clamp
+                    // every future ack via correctForResendAndStreaming and force every
+                    // fresh publisher to receive RESEND for an already-persisted block —
+                    // killing the connection with TOO_FAR_BEHIND. The buffer keeps recent
+                    // (still-fillable) entries intact.
+                    pruneStaleResendEntries(blockNumber);
                     // Ensure we don't acknowledge past known gaps
                     final long blockToAcknowledge = correctForResendAndStreaming(blockNumber);
                     clearObsoleteQueueItems(blockToAcknowledge);
@@ -697,6 +707,40 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                     LOGGER.log(INFO, "Publisher unavailability timeout task completed exceptionally", e);
                 }
             }
+        }
+    }
+
+    /// Removes any entry in {@link #blocksToResend} whose block number is more than
+    /// {@link #staleResendPruneBuffer} behind {@code proposedPersistedBlock}. Such entries
+    /// cannot be filled by any current publisher (they would respond TOO_FAR_BEHIND and
+    /// disconnect), so leaving them in the set would force every subsequent {@code endOfBlock}
+    /// to ask publishers to resend a block they cannot supply.
+    ///
+    /// Entries within the buffer are intentionally preserved — they may still be fillable
+    /// by a publisher that happens to have the recent history.
+    private void pruneStaleResendEntries(final long proposedPersistedBlock) {
+        final long staleCutoff = proposedPersistedBlock - staleResendPruneBuffer;
+        if (staleCutoff < 0) {
+            return;
+        }
+        // headSet(toElement, true) is the inclusive prefix view; clearing it drops every
+        // entry <= staleCutoff in one shot. The view is backed by the set, so
+        // ConcurrentSkipListSet's weakly-consistent semantics apply.
+        final NavigableSet<Long> staleEntries = blocksToResend.headSet(staleCutoff, true);
+        if (!staleEntries.isEmpty()) {
+            // Snapshot before clear so the log message is meaningful. Pruning here is
+            // an abnormal recovery path — under healthy operation no entry should ever
+            // sit in blocksToResend long enough to fall this far behind lastPersistedBlockNumber.
+            // Surfacing the dropped block numbers helps operators correlate with upstream
+            // publisher / backfill timing issues.
+            final List<Long> droppedSnapshot = new ArrayList<>(staleEntries);
+            staleEntries.clear();
+            LOGGER.log(
+                    WARNING,
+                    "Pruned stale resend entries beyond {0}-block buffer: dropped={1} (lastPersistedBlockNumber advancing to {2}). These blocks can no longer be supplied by any live publisher and the gap is owned by backfill.",
+                    staleResendPruneBuffer,
+                    droppedSnapshot,
+                    proposedPersistedBlock);
         }
     }
 

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfig.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfig.java
@@ -14,11 +14,17 @@ import org.hiero.block.node.base.Loggable;
 /// @param publisherUnavailabilityTimeout The time in seconds to wait when we
 /// have no active publishers before sending a publisher unavailability timeout
 /// status update.
+/// @param staleResendPruneBuffer Number of blocks behind {@code lastPersistedBlockNumber}
+/// that a {@code blocksToResend} entry may sit before {@code handlePersisted} prunes it.
+/// Entries within the buffer remain fillable by a publisher that still has the block;
+/// entries older than the buffer are dropped to avoid asking publishers to resend a
+/// block they cannot supply (which kills the connection with TOO_FAR_BEHIND).
 @ConfigData("producer")
 public record PublisherConfig(
         // spotless:off
         @Loggable @ConfigProperty(defaultValue = "9_223_372_036_854_775_807") @Min(100_000L) long batchForwardLimit,
         @Loggable @ConfigProperty(defaultValue = "300") @Min(0L) long publisherUnavailabilityTimeout,
-        @Loggable @ConfigProperty(defaultValue = "3") @Min(3) @Max(50) int MaxFutureBlocksBeforeStalled) {
+        @Loggable @ConfigProperty(defaultValue = "3") @Min(3) @Max(50) int MaxFutureBlocksBeforeStalled,
+        @Loggable @ConfigProperty(defaultValue = "100") @Min(0L) @Max(200L) long staleResendPruneBuffer) {
         // spotless:on
 }

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherManagerRegressionTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherManagerRegressionTest.java
@@ -8,6 +8,7 @@ import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.s
 import com.swirlds.config.api.Configuration;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.hiero.block.api.BlockNodeVersions;
+import org.hiero.block.api.PublishStreamRequest.EndStream;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.api.PublishStreamResponse.EndOfStream.Code;
 import org.hiero.block.api.PublishStreamResponse.ResponseOneOfType;
@@ -297,6 +298,86 @@ class PublisherManagerRegressionTest {
                     assertThat(response.response().kind()).isEqualTo(ResponseOneOfType.RESEND_BLOCK);
                     assertThat(response.resendBlock().blockNumber()).isEqualTo(stalledBlock);
                 });
+    }
+
+    /// Reproduces the production stale-resend bug observed on release 0.33.0-rc3.
+    ///
+    /// In production, a TOCTOU race between {@link LiveStreamPublisherManager#blockIsEnding(long, long)}
+    /// and a concurrent BACKFILL-sourced {@link LiveStreamPublisherManager#handlePersisted} call
+    /// leaves a block number in {@code blocksToResend} after {@code lastPersistedBlockNumber}
+    /// has already advanced past it. From that point on, every fresh publisher's first
+    /// {@code endOfBlock} returns {@code RESEND(<stale block>)} and the publisher disconnects
+    /// with EndStream(TOO_FAR_BEHIND).
+    ///
+    /// We can't easily drive the race deterministically in a unit test, but the fix —
+    /// pruning stale entries during {@code handlePersisted} — has an observable invariant
+    /// that we can test with real publish-API operations:
+    ///
+    /// 1. A publisher sends only the header for block N then issues EndStream(RESET). The
+    ///    real {@code blockIsEnding(N)} path adds N to {@code blocksToResend}.
+    /// 2. Backfill persists block {@code N + buffer + delta} (well past the prune buffer).
+    /// 3. With the fix, {@code handlePersisted} prunes the now-stale entry for N before
+    ///    {@code correctForResendAndStreaming} can clamp the ack. {@code lastPersistedBlockNumber}
+    ///    advances and a fresh publisher's header for N is treated as
+    ///    {@code END_DUPLICATE} — not {@code ACCEPT} as if N were still expected.
+    ///
+    /// Without the fix the entry is never pruned, {@code lastPersistedBlockNumber} is
+    /// clamped at {@code N - 1}, and {@code getActionForBlock(N, ...)} pulls N out of
+    /// {@code blocksToResend} and returns {@code ACCEPT} — exactly the production symptom
+    /// where the BN keeps demanding the stale block from any publisher that connects.
+    ///
+    /// Note: the seed step uses only the publish API ({@code sendHeaderOnly} +
+    /// {@code EndStream}), so the entry is added by the same production code path
+    /// ({@code PublisherHandler.handleEndStream} → {@code LiveStreamPublisherManager.blockIsEnding})
+    /// the bug actually exercises — no internal state injection.
+    @Test
+    @DisplayName("handlePersisted must prune resend entries beyond the prune buffer")
+    void testStaleResendEntryPrunedWhenPersistenceMovesPastBuffer() {
+        // 1. Persist blocks up to 4 so the manager will accept a header for block 5
+        //    (nextUnstreamedBlockNumber == 5). Without this, sendHeaderOnly(5) returns
+        //    SEND_BEHIND and the handler never enters mid-block state.
+        final long lastPersistedBeforeStall = 4L;
+        final SimpleBlockRangeSet preStallBlocks = new SimpleBlockRangeSet();
+        preStallBlocks.add(0L, lastPersistedBeforeStall);
+        historicalBlockFacility.setTemporaryAvailableBlocks(preStallBlocks);
+        toTest.handlePersisted(new PersistedNotification(lastPersistedBeforeStall, true, 0, BlockSource.UNKNOWN));
+
+        // 2. Publisher A sends a header for block 5 then EndStream(RESET) mid-block.
+        //    handleEndStream invokes publisherManager.blockIsEnding(5, …), which adds 5
+        //    to blocksToResend through the same code path the production bug exercises.
+        //    No internal state is injected — we drive the same publish API that production uses.
+        final long staleResendBlock = 5L;
+        sendHeaderOnly(publisherHandler, staleResendBlock);
+
+        final EndStream endStream = EndStream.newBuilder()
+                .endCode(EndStream.Code.RESET)
+                .earliestBlockNumber(0L)
+                .latestBlockNumber(staleResendBlock)
+                .build();
+        publisherHandler.onNext(
+                PublishStreamRequestUnparsed.newBuilder().endStream(endStream).build());
+
+        // 3. Backfill persists a block far past the configured prune buffer (default 100).
+        //    handlePersisted's prune step must drop blocksToResend entries <= 200 - 100 = 100,
+        //    which includes block 5.
+        final long backfilledBlock = 200L;
+        final SimpleBlockRangeSet availableBlocks = new SimpleBlockRangeSet();
+        availableBlocks.add(0L, backfilledBlock);
+        historicalBlockFacility.setTemporaryAvailableBlocks(availableBlocks);
+        toTest.handlePersisted(new PersistedNotification(backfilledBlock, true, 0, BlockSource.BACKFILL));
+
+        // 4. A fresh publisher header for the previously-stale block must be treated as
+        //    END_DUPLICATE — not ACCEPT pulled out of blocksToResend, which would prove
+        //    the entry was never pruned. (END_DUPLICATE comes from blockNumber <= lastPersisted,
+        //    which only happens if both prune and ack-advancement succeeded.)
+        final BlockAction action = toTest.getActionForBlock(staleResendBlock, null, publisherHandlerId);
+        assertThat(action)
+                .describedAs(
+                        "block %d is already persisted (lastPersisted should be %d). The handler must see "
+                                + "END_DUPLICATE — not ACCEPT — which would only happen if the stale entry "
+                                + "had been pruned from blocksToResend by handlePersisted",
+                        staleResendBlock, backfilledBlock)
+                .isEqualTo(BlockAction.END_DUPLICATE);
     }
 
     @SuppressWarnings("all")

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -171,10 +171,11 @@ Currently, no specific options.
 
 ### Publisher Plugin Configuration
 
-| ENV Variable                              | Description                                                                                                                                 |                   Default |
-|:------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------|--------------------------:|
-| PRODUCER_BATCH_FORWARD_LIMIT              | Max number of blocks to forward in a batch. Must be ≥ 100,000.                                                                              | 9,223,372,036,854,775,807 |
-| PRODUCER_PUBLISHER_UNAVAILABILITY_TIMEOUT | The time in seconds to wait when we have no active publishers before sending a publisher unavailability timeout status update. Must be ≥ 0. |                       300 |
+| ENV Variable                              | Description                                                                                                                                                                                                                                                                                                                                           |                   Default |
+|:------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------:|
+| PRODUCER_BATCH_FORWARD_LIMIT              | Max number of blocks to forward in a batch. Must be ≥ 100,000.                                                                                                                                                                                                                                                                                        | 9,223,372,036,854,775,807 |
+| PRODUCER_PUBLISHER_UNAVAILABILITY_TIMEOUT | The time in seconds to wait when we have no active publishers before sending a publisher unavailability timeout status update. Must be ≥ 0.                                                                                                                                                                                                           |                       300 |
+| PRODUCER_STALE_RESEND_PRUNE_BUFFER        | Number of blocks behind `lastPersistedBlockNumber` that a `blocksToResend` entry may sit before `handlePersisted` prunes it. Entries within the buffer are still considered fillable by a publisher; entries older than the buffer are dropped (the gap is owned by backfill at that point). Set to ~CN block-history depth. Must be 0 ≤ value ≤ 200. |                       100 |
 
 ### Subscriber Plugin Configuration
 


### PR DESCRIPTION
Cherry-pick of #2716 into release branch `release/0.33`