### PR TITLE
feat: implement RSA SignedRecordFileProof verification for WRB blocks…

### DIFF
--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/RsaKeyDecoder.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/RsaKeyDecoder.java
@@ -49,18 +49,22 @@ public final class RsaKeyDecoder {
         }
         final Map<Long, PublicKey> map = new HashMap<>();
         final HexFormat hex = HexFormat.of();
+        // Obtain KeyFactory once — provider lookup is not cheap and RSA must always be available.
+        final KeyFactory kf;
+        try {
+            kf = KeyFactory.getInstance("RSA");
+        } catch (NoSuchAlgorithmException e) {
+            // RSA must be available in every JVM — this is a JVM misconfiguration
+            throw new IllegalStateException("RSA KeyFactory not available", e);
+        }
         for (final NodeAddress addr : book.nodeAddress()) {
             if (addr.rsaPubKey().isBlank()) {
                 continue;
             }
             try {
                 final byte[] keyBytes = hex.parseHex(addr.rsaPubKey());
-                final KeyFactory kf = KeyFactory.getInstance("RSA");
                 final PublicKey key = kf.generatePublic(new X509EncodedKeySpec(keyBytes));
                 map.put(addr.nodeId(), key);
-            } catch (NoSuchAlgorithmException e) {
-                // RSA must be available in every JVM — this is a JVM misconfiguration
-                throw new IllegalStateException("RSA KeyFactory not available", e);
             } catch (InvalidKeySpecException | IllegalArgumentException e) {
                 LOGGER.log(WARNING, "Malformed RSA_PubKey for node {0} — skipped: {1}", addr.nodeId(), e.getMessage());
             }

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/RsaKeyDecoder.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/RsaKeyDecoder.java
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.verification;
+
+import static java.lang.System.Logger.Level.WARNING;
+
+import com.hedera.hapi.node.base.NodeAddress;
+import com.hedera.hapi.node.base.NodeAddressBook;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.Map;
+
+/**
+ * Utility for decoding RSA public keys from a `NodeAddressBook` into a
+ * `node_id → PublicKey` map used by the RSA WRB verification path.
+ *
+ * Keys are expected to be hex-encoded DER (X.509 `SubjectPublicKeyInfo`) or DER
+ * certificate bytes, **without** a `0x` prefix.
+ *
+ * This logic mirrors `SigFileUtils.decodePublicKey` in `tools-and-tests/tools`
+ * but is inlined here because that module cannot be imported from
+ * `block-node/verification`.
+ */
+public final class RsaKeyDecoder {
+
+    private static final System.Logger LOGGER = System.getLogger(RsaKeyDecoder.class.getName());
+
+    private RsaKeyDecoder() {}
+
+    /**
+     * Builds an immutable `node_id → PublicKey` map from the given address book.
+     *
+     * Entries where `rsaPubKey()` is blank or whose key bytes cannot be decoded
+     * as an RSA X.509 public key are silently skipped (with a WARN log). This
+     * matches the fail-soft behaviour required by the verification path: one bad
+     * key must not prevent the other nodes from being counted.
+     *
+     * @param book the address book loaded by `RsaRosterBootstrapPlugin`
+     * @return an unmodifiable map from node ID to `PublicKey`
+     */
+    public static Map<Long, PublicKey> buildKeyMap(final NodeAddressBook book) {
+        if (book == null || book.nodeAddress().isEmpty()) {
+            return Map.of();
+        }
+        final Map<Long, PublicKey> map = new HashMap<>();
+        final HexFormat hex = HexFormat.of();
+        for (final NodeAddress addr : book.nodeAddress()) {
+            if (addr.rsaPubKey().isBlank()) {
+                continue;
+            }
+            try {
+                final byte[] keyBytes = hex.parseHex(addr.rsaPubKey());
+                final KeyFactory kf = KeyFactory.getInstance("RSA");
+                final PublicKey key = kf.generatePublic(new X509EncodedKeySpec(keyBytes));
+                map.put(addr.nodeId(), key);
+            } catch (NoSuchAlgorithmException e) {
+                // RSA must be available in every JVM — this is a JVM misconfiguration
+                throw new IllegalStateException("RSA KeyFactory not available", e);
+            } catch (InvalidKeySpecException | IllegalArgumentException e) {
+                LOGGER.log(WARNING, "Malformed RSA_PubKey for node {0} — skipped: {1}",
+                        addr.nodeId(), e.getMessage());
+            }
+        }
+        return Collections.unmodifiableMap(map);
+    }
+}

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/RsaKeyDecoder.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/RsaKeyDecoder.java
@@ -62,8 +62,7 @@ public final class RsaKeyDecoder {
                 // RSA must be available in every JVM — this is a JVM misconfiguration
                 throw new IllegalStateException("RSA KeyFactory not available", e);
             } catch (InvalidKeySpecException | IllegalArgumentException e) {
-                LOGGER.log(WARNING, "Malformed RSA_PubKey for node {0} — skipped: {1}",
-                        addr.nodeId(), e.getMessage());
+                LOGGER.log(WARNING, "Malformed RSA_PubKey for node {0} — skipped: {1}", addr.nodeId(), e.getMessage());
             }
         }
         return Collections.unmodifiableMap(map);

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
@@ -9,6 +9,7 @@ import static java.lang.System.Logger.Level.WARNING;
 import com.hedera.cryptography.tss.TSS;
 import com.hedera.cryptography.wraps.WRAPSVerificationKey;
 import com.hedera.hapi.block.stream.output.BlockHeader;
+import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.tss.LedgerIdNodeContribution;
 import com.hedera.hapi.node.tss.LedgerIdPublicationTransactionBody;
@@ -18,7 +19,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.security.PublicKey;
 import java.util.List;
+import java.util.Map;
 import org.hiero.block.node.app.config.node.NodeConfig;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
@@ -57,6 +60,15 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
     /** Metric key for block hashing time */
     public static final MetricKey<LongCounter> METRIC_HASHING_BLOCK_TIME =
             MetricKey.of("hashing_block_time", LongCounter.class).addCategory(METRICS_CATEGORY);
+    /** Metric key for WRB blocks whose RSA proof was accepted */
+    public static final MetricKey<LongCounter> METRIC_RSA_VERIFICATION_SUCCESS =
+            MetricKey.of("rsa_verification_success_total", LongCounter.class).addCategory(METRICS_CATEGORY);
+    /** Metric key for WRB blocks whose RSA proof was rejected */
+    public static final MetricKey<LongCounter> METRIC_RSA_VERIFICATION_FAILURE =
+            MetricKey.of("rsa_verification_failure_total", LongCounter.class).addCategory(METRICS_CATEGORY);
+    /** Metric key for signatures from `node_id` values not present in the loaded address book */
+    public static final MetricKey<LongCounter> METRIC_RSA_ROSTER_MISMATCH =
+            MetricKey.of("rsa_roster_mismatch_total", LongCounter.class).addCategory(METRICS_CATEGORY);
 
     private static final String COMPLETED_MESSAGE = "Verified backfill block items for block={0} with success={1}";
     /** The logger for this class. */
@@ -82,6 +94,18 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
     private LongCounter.Measurement verificationBlockTime;
     /** Metric for block hashing time. ignores time to receive block */
     private LongCounter.Measurement hashingBlockTimeNs;
+    /** Metric for accepted RSA WRB proof verifications. */
+    private LongCounter.Measurement rsaVerificationSuccessTotal;
+    /** Metric for rejected RSA WRB proof verifications. */
+    private LongCounter.Measurement rsaVerificationFailureTotal;
+    /** Metric for signatures from `node_id` values absent from the loaded address book. */
+    private LongCounter.Measurement rsaRosterMismatchTotal;
+    /**
+     * Most recent `node_id → PublicKey` map built from the `NodeAddressBook` delivered by
+     * `RsaRosterBootstrapPlugin`. Volatile so that `onContextUpdate` writes are visible to the
+     * block-handling thread without a lock.
+     */
+    private volatile Map<Long, PublicKey> keyByNodeId = Map.of();
     /** The previous block hash, used for verification of the current block. */
     private Bytes previousBlockHash;
     /** The block number of the last successfully verified block (live-stream or sequential backfill). */
@@ -140,6 +164,19 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                 .getOrCreateNotLabeled();
         hashingBlockTimeNs = metricRegistry
                 .register(LongCounter.builder(METRIC_HASHING_BLOCK_TIME).setDescription("Hashing time per block (ms)"))
+                .getOrCreateNotLabeled();
+        rsaVerificationSuccessTotal = metricRegistry
+                .register(LongCounter.builder(METRIC_RSA_VERIFICATION_SUCCESS)
+                        .setDescription("WRB blocks whose RSA SignedRecordFileProof was accepted"))
+                .getOrCreateNotLabeled();
+        rsaVerificationFailureTotal = metricRegistry
+                .register(LongCounter.builder(METRIC_RSA_VERIFICATION_FAILURE)
+                        .setDescription("WRB blocks whose RSA SignedRecordFileProof was rejected"))
+                .getOrCreateNotLabeled();
+        rsaRosterMismatchTotal = metricRegistry
+                .register(LongCounter.builder(METRIC_RSA_ROSTER_MISMATCH)
+                        .setDescription(
+                                "RSA signatures from node_id values absent from the loaded address book"))
                 .getOrCreateNotLabeled();
     }
 
@@ -202,6 +239,22 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
 
     /**
      * {@inheritDoc}
+     *
+     * <p>Called when the `NodeAddressBook` is updated by `RsaRosterBootstrapPlugin`. Rebuilds the
+     * `node_id → PublicKey` map used by subsequent WRB verification sessions. A volatile write
+     * ensures visibility to the block-handler thread without a lock.
+     */
+    @Override
+    public void onContextUpdate(final BlockNodeContext updatedContext) {
+        final NodeAddressBook book = updatedContext.nodeAddressBook();
+        if (!book.nodeAddress().isEmpty()) {
+            keyByNodeId = RsaKeyDecoder.buildKeyMap(book);
+            LOGGER.log(INFO, "RSA key map updated: {0} nodes loaded from address book", keyByNodeId.size());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
      */
     @Override
     public void start() {
@@ -258,7 +311,11 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                         semanticVersion,
                         previousHash,
                         getRootOfAllPreviousBlocks(),
-                        activeLedgerId);
+                        activeLedgerId,
+                        keyByNodeId,
+                        rsaVerificationSuccessTotal,
+                        rsaVerificationFailureTotal,
+                        rsaRosterMismatchTotal);
                 LOGGER.log(DEBUG, "Started new block verification session for block number {0}", currentBlockNumber);
             } else {
                 headerValid = true; // header not present, assume it was valid
@@ -414,7 +471,11 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                         blockHeader.hapiProtoVersionOrThrow(),
                         null,
                         null,
-                        activeLedgerId);
+                        activeLedgerId,
+                        keyByNodeId,
+                        rsaVerificationSuccessTotal,
+                        rsaVerificationFailureTotal,
+                        rsaRosterMismatchTotal);
                 // process the block items in the backfilled notification
                 // For backfill, we wrap items in BlockItems with isEndOfBlock=true (last item should be block proof)
                 BlockItems backfillBlockItems =

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
@@ -254,8 +254,28 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                             + " WRB blocks will fail verification until a valid address book is delivered.");
             return;
         }
+        // Count non-blank address book entries — these are the nodes that should be signable.
+        final int declaredCount =
+                (int) book.nodeAddress().stream().filter(a -> !a.rsaPubKey().isBlank()).count();
         keyByNodeId = RsaKeyDecoder.buildKeyMap(book);
-        LOGGER.log(INFO, "RSA key map updated: {0} nodes loaded from address book", keyByNodeId.size());
+        final int effectiveCount = keyByNodeId.size();
+        if (effectiveCount < declaredCount) {
+            // Malformed DER keys were skipped; threshold is calculated against effectiveCount.
+            // Fix the address book so all declared nodes can contribute signatures.
+            LOGGER.log(
+                    WARNING,
+                    "RSA key map: {0}/{1} keys decoded successfully; {2} node(s) had malformed"
+                            + " hex-DER bytes and cannot contribute signatures. Verification"
+                            + " threshold is calculated against the {0} decodable keys.",
+                    effectiveCount,
+                    declaredCount,
+                    declaredCount - effectiveCount);
+        }
+        LOGGER.log(
+                INFO,
+                "RSA key map updated: {0}/{1} nodes loaded from address book",
+                effectiveCount,
+                declaredCount);
     }
 
     /**

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
@@ -255,8 +255,9 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
             return;
         }
         // Count non-blank address book entries — these are the nodes that should be signable.
-        final int declaredCount =
-                (int) book.nodeAddress().stream().filter(a -> !a.rsaPubKey().isBlank()).count();
+        final int declaredCount = (int) book.nodeAddress().stream()
+                .filter(a -> !a.rsaPubKey().isBlank())
+                .count();
         keyByNodeId = RsaKeyDecoder.buildKeyMap(book);
         final int effectiveCount = keyByNodeId.size();
         if (effectiveCount < declaredCount) {
@@ -271,11 +272,7 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                     declaredCount,
                     declaredCount - effectiveCount);
         }
-        LOGGER.log(
-                INFO,
-                "RSA key map updated: {0}/{1} nodes loaded from address book",
-                effectiveCount,
-                declaredCount);
+        LOGGER.log(INFO, "RSA key map updated: {0}/{1} nodes loaded from address book", effectiveCount, declaredCount);
     }
 
     /**

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
@@ -175,8 +175,7 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                 .getOrCreateNotLabeled();
         rsaRosterMismatchTotal = metricRegistry
                 .register(LongCounter.builder(METRIC_RSA_ROSTER_MISMATCH)
-                        .setDescription(
-                                "RSA signatures from node_id values absent from the loaded address book"))
+                        .setDescription("RSA signatures from node_id values absent from the loaded address book"))
                 .getOrCreateNotLabeled();
     }
 
@@ -240,17 +239,23 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
     /**
      * {@inheritDoc}
      *
-     * <p>Called when the `NodeAddressBook` is updated by `RsaRosterBootstrapPlugin`. Rebuilds the
-     * `node_id → PublicKey` map used by subsequent WRB verification sessions. A volatile write
-     * ensures visibility to the block-handler thread without a lock.
+     * <p>Called by the framework whenever `BlockNodeApp.updateAddressBook()` fires — typically once
+     * at startup by `RsaRosterBootstrapPlugin`. Rebuilds the `node_id → PublicKey` map used by
+     * subsequent WRB verification sessions. A volatile write ensures visibility to the
+     * block-handler thread without a lock.
      */
     @Override
     public void onContextUpdate(final BlockNodeContext updatedContext) {
         final NodeAddressBook book = updatedContext.nodeAddressBook();
-        if (!book.nodeAddress().isEmpty()) {
-            keyByNodeId = RsaKeyDecoder.buildKeyMap(book);
-            LOGGER.log(INFO, "RSA key map updated: {0} nodes loaded from address book", keyByNodeId.size());
+        if (book == null || book.nodeAddress().isEmpty()) {
+            LOGGER.log(
+                    WARNING,
+                    "onContextUpdate called with a null or empty NodeAddressBook — RSA key map not updated."
+                            + " WRB blocks will fail verification until a valid address book is delivered.");
+            return;
         }
+        keyByNodeId = RsaKeyDecoder.buildKeyMap(book);
+        LOGGER.log(INFO, "RSA key map updated: {0} nodes loaded from address book", keyByNodeId.size());
     }
 
     /**

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/HapiVersionSessionFactory.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/HapiVersionSessionFactory.java
@@ -4,14 +4,17 @@ package org.hiero.block.node.verification.session;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.security.PublicKey;
+import java.util.Map;
 import java.util.Objects;
 import org.hiero.block.common.utils.Preconditions;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.verification.session.impl.DummyVerificationSession;
 import org.hiero.block.node.verification.session.impl.ExtendedMerkleTreeSession;
+import org.hiero.metrics.LongCounter;
 
 /**
- * Factory for creating {@link VerificationSession} instances based on the requested HAPI version.
+ * Factory for creating `VerificationSession` instances based on the requested HAPI version.
  */
 public final class HapiVersionSessionFactory {
     private static final SemanticVersion V_0_72_0 = semanticVersion(0, 72, 0);
@@ -20,17 +23,19 @@ public final class HapiVersionSessionFactory {
     private HapiVersionSessionFactory() {}
 
     /**
-     * Create a {@link VerificationSession} for the given HAPI version.
+     * Creates a `VerificationSession` for the given HAPI version.
+     *
+     * <p>Delegates to `createSession` with an empty RSA key map and no RSA metrics. Use
+     * `createSession(...)` with the RSA parameters when a `NodeAddressBook` is available.
      *
      * @param blockNumber the block number (>= 0)
      * @param blockSource the source of blocks
      * @param hapiVersion the semantic HAPI version
      * @param previousBlockHash the previous block hash, may be null
-     * @param allPreviousBlocksRootHash the all blocks root hash, may be null
+     * @param allPreviousBlocksRootHash the all-blocks root hash, may be null
      * @param ledgerId the trusted ledger ID for TSS verification, may be null
-     *
-     * @throws NullPointerException if blockSource or hapiVersion is null
-     * @throws IllegalArgumentException if blockNumber less than 0 or version unsupported
+     * @throws NullPointerException if `blockSource` or `hapiVersion` is null
+     * @throws IllegalArgumentException if `blockNumber` is less than 0 or the version is unsupported
      */
     public static VerificationSession createSession(
             final long blockNumber,
@@ -39,13 +44,50 @@ public final class HapiVersionSessionFactory {
             final Bytes previousBlockHash,
             final Bytes allPreviousBlocksRootHash,
             @Nullable final Bytes ledgerId) {
+        return createSession(blockNumber, blockSource, hapiVersion, previousBlockHash,
+                allPreviousBlocksRootHash, ledgerId, Map.of(), null, null, null);
+    }
+
+    /**
+     * Creates a `VerificationSession` for the given HAPI version, with RSA WRB support.
+     *
+     * <p>When `rsaKeyByNodeId` is non-empty and the block carries a `SignedRecordFileProof`,
+     * the returned session will attempt RSA verification using the provided key map and
+     * will report results via the supplied metric counters (when non-null).
+     *
+     * @param blockNumber the block number (>= 0)
+     * @param blockSource the source of blocks
+     * @param hapiVersion the semantic HAPI version
+     * @param previousBlockHash the previous block hash, may be null
+     * @param allPreviousBlocksRootHash the all-blocks root hash, may be null
+     * @param ledgerId the trusted ledger ID for TSS verification, may be null
+     * @param rsaKeyByNodeId map from `node_id` to RSA `PublicKey`; use `Map.of()` when unavailable
+     * @param rsaVerificationSuccessTotal metric for successful RSA verifications, may be null
+     * @param rsaVerificationFailureTotal metric for failed RSA verifications, may be null
+     * @param rsaRosterMismatchTotal metric for sigs from unknown nodes, may be null
+     * @throws NullPointerException if `blockSource`, `hapiVersion`, or `rsaKeyByNodeId` is null
+     * @throws IllegalArgumentException if `blockNumber` is less than 0 or the version is unsupported
+     */
+    public static VerificationSession createSession(
+            final long blockNumber,
+            final BlockSource blockSource,
+            final SemanticVersion hapiVersion,
+            final Bytes previousBlockHash,
+            final Bytes allPreviousBlocksRootHash,
+            @Nullable final Bytes ledgerId,
+            final Map<Long, PublicKey> rsaKeyByNodeId,
+            @Nullable final LongCounter.Measurement rsaVerificationSuccessTotal,
+            @Nullable final LongCounter.Measurement rsaVerificationFailureTotal,
+            @Nullable final LongCounter.Measurement rsaRosterMismatchTotal) {
         Objects.requireNonNull(blockSource, "blockSource cannot be null");
         Objects.requireNonNull(hapiVersion, "hapiVersion cannot be null");
+        Objects.requireNonNull(rsaKeyByNodeId, "rsaKeyByNodeId cannot be null");
         Preconditions.requireWhole(blockNumber, "blockNumber must be >= 0");
 
         if (isGreaterThanOrEqual(hapiVersion, V_0_72_0)) {
             return new ExtendedMerkleTreeSession(
-                    blockNumber, blockSource, previousBlockHash, allPreviousBlocksRootHash, ledgerId);
+                    blockNumber, blockSource, previousBlockHash, allPreviousBlocksRootHash, ledgerId,
+                    rsaKeyByNodeId, rsaVerificationSuccessTotal, rsaVerificationFailureTotal, rsaRosterMismatchTotal);
         }
 
         // TODO, before going live we should remove the Dummy Implementation.

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/HapiVersionSessionFactory.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/HapiVersionSessionFactory.java
@@ -44,8 +44,17 @@ public final class HapiVersionSessionFactory {
             final Bytes previousBlockHash,
             final Bytes allPreviousBlocksRootHash,
             @Nullable final Bytes ledgerId) {
-        return createSession(blockNumber, blockSource, hapiVersion, previousBlockHash,
-                allPreviousBlocksRootHash, ledgerId, Map.of(), null, null, null);
+        return createSession(
+                blockNumber,
+                blockSource,
+                hapiVersion,
+                previousBlockHash,
+                allPreviousBlocksRootHash,
+                ledgerId,
+                Map.of(),
+                null,
+                null,
+                null);
     }
 
     /**
@@ -86,8 +95,15 @@ public final class HapiVersionSessionFactory {
 
         if (isGreaterThanOrEqual(hapiVersion, V_0_72_0)) {
             return new ExtendedMerkleTreeSession(
-                    blockNumber, blockSource, previousBlockHash, allPreviousBlocksRootHash, ledgerId,
-                    rsaKeyByNodeId, rsaVerificationSuccessTotal, rsaVerificationFailureTotal, rsaRosterMismatchTotal);
+                    blockNumber,
+                    blockSource,
+                    previousBlockHash,
+                    allPreviousBlocksRootHash,
+                    ledgerId,
+                    rsaKeyByNodeId,
+                    rsaVerificationSuccessTotal,
+                    rsaVerificationFailureTotal,
+                    rsaRosterMismatchTotal);
         }
 
         // TODO, before going live we should remove the Dummy Implementation.

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
@@ -561,49 +561,85 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
     }
 
     /**
-     * Extracts the raw `record_file_contents` bytes (proto field 2) from a serialized
-     * `RecordFileItem` message by navigating the protobuf wire format without full parsing.
+     * Extracts the raw {@code record_file_contents} bytes from a serialized {@code RecordFileItem}
+     * proto message by walking the protobuf wire format directly, without deserializing the message.
      *
-     * <p>The verbatim bytes are required for V6 signed hash computation so that the hash
-     * is identical to the one computed by the consensus node — re-serializing from a parsed
-     * representation would risk byte-order or encoding differences.
+     * <p>{@code record_file_contents} is proto field 2 of {@code RecordFileItem}. These bytes are
+     * the verbatim content of the {@code .rcd} record stream file exactly as the consensus node
+     * read it from disk when it computed the V6 signed hash. They must be returned byte-for-byte
+     * identical to what the consensus node used; full deserialization via
+     * {@code RecordFileItem.PROTOBUF.parse()} is deliberately avoided because re-serializing a
+     * parsed object can produce subtly different bytes (e.g. omitting default-value fields, different
+     * varint encoding choices), which would cause the recomputed hash to diverge from the one the
+     * consensus node signed.
      *
-     * @param recordFileItemBytes raw serialized bytes of a `RecordFileItem` proto message
-     * @return raw bytes of the `record_file_contents` field, or `Bytes.EMPTY` if not found
+     * <p><b>Protobuf wire format:</b> every field on the wire is encoded as a tag varint followed
+     * by its value. The tag packs two things:
+     * <ul>
+     *   <li>{@code fieldNumber = tag >>> 3}
+     *   <li>{@code wireType   = tag & 0x7}
+     * </ul>
+     * Wire type 2 ({@code LEN}) means the value is length-prefixed bytes, used for {@code bytes},
+     * {@code string}, and embedded messages. It is encoded as:
+     * {@code [tag varint] [length varint] [raw bytes...]}.
+     *
+     * <p><b>Algorithm:</b>
+     * <ol>
+     *   <li>Read the next field tag varint and decode its field number and wire type.</li>
+     *   <li>If {@code fieldNumber == 2} and {@code wireType == LEN}: read the length prefix varint,
+     *       read exactly that many bytes, and return them — these are the
+     *       {@code record_file_contents}.</li>
+     *   <li>Otherwise skip the field using the wire type to know how many bytes to consume:
+     *       <ul>
+     *         <li>VARINT (wire 0): read and discard one varint</li>
+     *         <li>I64 (wire 1): skip 8 bytes fixed</li>
+     *         <li>LEN (wire 2): read the length prefix, skip that many bytes</li>
+     *         <li>I32 (wire 5): skip 4 bytes fixed</li>
+     *       </ul>
+     *   </li>
+     *   <li>Repeat until field 2 is found or input is exhausted.</li>
+     * </ol>
+     *
+     * @param recordFileItemBytes raw serialized bytes of a {@code RecordFileItem} proto message
+     * @return verbatim bytes of the {@code record_file_contents} field (proto field 2), or
+     *         {@code Bytes.EMPTY} if field 2 is not present or if any parse error occurs
      */
     private static Bytes extractRecordStreamFileBytes(final Bytes recordFileItemBytes) {
         try {
             final ReadableSequentialData input = recordFileItemBytes.toReadableSequentialData();
             while (input.hasRemaining()) {
+                // Each field starts with a tag varint: high bits = field number, low 3 bits = wire type
                 final int tag = input.readVarInt(false);
                 final int wireType = tag & 0x7;
                 final int fieldNumber = tag >>> 3;
                 if (fieldNumber == 2 && wireType == 2) {
-                    // LEN field: read the length prefix then copy the raw bytes
+                    // Found record_file_contents (field 2, LEN wire type).
+                    // Read the length-prefix varint then copy the raw payload bytes verbatim.
                     final int len = input.readVarInt(false);
                     final byte[] raw = new byte[len];
                     input.readBytes(raw);
                     return Bytes.wrap(raw);
                 }
-                // Skip any other field by wire type
+                // Not field 2 — skip this field using its wire type to advance the cursor correctly
                 switch (wireType) {
-                    case 0 -> input.readVarLong(false); // VARINT: consume value
-                    case 1 -> input.skip(8); // I64: skip 8 bytes
-                    case 2 -> { // LEN: skip length + content
+                    case 0 -> input.readVarLong(false); // VARINT: read and discard the value
+                    case 1 -> input.skip(8); // I64: fixed 64-bit, skip 8 bytes
+                    case 2 -> { // LEN: read length prefix, skip content
                         final int l = input.readVarInt(false);
                         input.skip(l);
                     }
-                    case 5 -> input.skip(4); // I32: skip 4 bytes
+                    case 5 -> input.skip(4); // I32: fixed 32-bit, skip 4 bytes
                     default -> {
-                        return Bytes.EMPTY;
-                    } // Unknown wire type — bail out
+                        return Bytes.EMPTY; // Unknown wire type — bail out safely
+                    }
                 }
             }
         } catch (final RuntimeException e) {
-            // Treat any parse error as a missing field
+            // Any unexpected read error (truncated input, malformed varint, etc.) is treated
+            // as a missing field rather than propagated, so the caller can fail verification cleanly.
             return Bytes.EMPTY;
         }
-        return Bytes.EMPTY;
+        return Bytes.EMPTY; // field 2 not present in the message
     }
 
     /**

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.verification.session.impl;
 
+import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.WARNING;
 import static org.hiero.block.common.hasher.HashingUtilities.getBlockItemHash;
@@ -12,7 +14,9 @@ import static org.hiero.block.common.hasher.HashingUtilities.noThrowSha384HashOf
 import com.hedera.cryptography.tss.TSS;
 import com.hedera.hapi.block.stream.BlockProof;
 import com.hedera.hapi.block.stream.MerklePath;
+import com.hedera.hapi.block.stream.RecordFileSignature;
 import com.hedera.hapi.block.stream.SiblingNode;
+import com.hedera.hapi.block.stream.SignedRecordFileProof;
 import com.hedera.hapi.block.stream.StateProof;
 import com.hedera.hapi.block.stream.output.BlockFooter;
 import com.hedera.hapi.block.stream.output.BlockHeader;
@@ -21,11 +25,19 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.node.tss.LedgerIdPublicationTransactionBody;
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
 import org.hiero.block.common.hasher.HashingUtilities;
@@ -40,12 +52,25 @@ import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureT
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 import org.hiero.block.node.verification.VerificationServicePlugin;
 import org.hiero.block.node.verification.session.VerificationSession;
+import org.hiero.metrics.LongCounter;
 
 public class ExtendedMerkleTreeSession implements VerificationSession {
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
 
     /** Byte length of a legacy SHA384 signature (non-TSS blocks). */
     private static final int HASH_LENGTH = 48;
+
+    /**
+     * Reusable `SHA384withRSA` engine per thread — avoids per-call `Signature.getInstance()` cost.
+     * The engine is stateful, so a `ThreadLocal` is required.
+     */
+    private static final ThreadLocal<Signature> SHA384_WITH_RSA = ThreadLocal.withInitial(() -> {
+        try {
+            return Signature.getInstance("SHA384withRSA");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA384withRSA not available in JVM", e);
+        }
+    });
 
     private final long blockNumber;
     // Stream Hashers
@@ -61,6 +86,29 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
     private final StreamingTreeHasher traceDataHasher;
     /** The source of the block, used to construct the final notification. */
     private final BlockSource blockSource;
+
+    // RSA WRB verification state
+    /**
+     * Map from `node_id` to RSA `PublicKey` used for `SignedRecordFileProof` verification.
+     * Built from the `NodeAddressBook` loaded by `RsaRosterBootstrapPlugin`.
+     * Empty when no address book has been loaded yet.
+     */
+    private final Map<Long, PublicKey> rsaKeyByNodeId;
+    /**
+     * Raw bytes of the `RecordFileItem` proto captured during block item processing.
+     * Required to compute the V6 signed payload: `SHA-384(int32(6) || record_file_contents)`.
+     * Null until a `RECORD_FILE` block item is encountered.
+     */
+    private Bytes rawRecordFileItemBytes;
+    /** Metric for successful RSA WRB proof verifications; nullable — null when metrics not configured. */
+    @Nullable
+    private final LongCounter.Measurement rsaVerificationSuccessTotal;
+    /** Metric for failed RSA WRB proof verifications; nullable — null when metrics not configured. */
+    @Nullable
+    private final LongCounter.Measurement rsaVerificationFailureTotal;
+    /** Metric for signatures from `node_id` values absent from the loaded address book. */
+    @Nullable
+    private final LongCounter.Measurement rsaRosterMismatchTotal;
 
     /**
      * The block items for the block this session is responsible for. We collect them here so we can provide the
@@ -85,24 +133,37 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
     private Bytes ledgerId;
 
     /**
-     * Constructor for ExtendedMerkleTreeSession.
+     * Constructor for `ExtendedMerkleTreeSession`.
      *
      * @param blockNumber the block number
      * @param blockSource the source of the block
      * @param previousBlockHash the previous block hash, may be null
-     * @param allPreviousBlocksRootHash the all previous blocks root hash, may be null
+     * @param allPreviousBlocksRootHash the all-previous-blocks root hash, may be null
      * @param ledgerId the trusted ledger ID for TSS verification, may be null for block 0
+     * @param rsaKeyByNodeId map from `node_id` to RSA `PublicKey` for WRB proof verification;
+     *     use `Map.of()` when no address book is available
+     * @param rsaVerificationSuccessTotal metric counter for successful RSA verifications, may be null
+     * @param rsaVerificationFailureTotal metric counter for failed RSA verifications, may be null
+     * @param rsaRosterMismatchTotal metric counter for signatures from unknown nodes, may be null
      */
     public ExtendedMerkleTreeSession(
             final long blockNumber,
             final BlockSource blockSource,
             final Bytes previousBlockHash,
             final Bytes allPreviousBlocksRootHash,
-            final Bytes ledgerId) {
+            final Bytes ledgerId,
+            final Map<Long, PublicKey> rsaKeyByNodeId,
+            @Nullable final LongCounter.Measurement rsaVerificationSuccessTotal,
+            @Nullable final LongCounter.Measurement rsaVerificationFailureTotal,
+            @Nullable final LongCounter.Measurement rsaRosterMismatchTotal) {
         this.blockNumber = blockNumber;
         this.previousBlockHash = previousBlockHash;
         this.allPreviousBlockRootHash = allPreviousBlocksRootHash;
         this.ledgerId = ledgerId;
+        this.rsaKeyByNodeId = Objects.requireNonNull(rsaKeyByNodeId, "rsaKeyByNodeId must not be null");
+        this.rsaVerificationSuccessTotal = rsaVerificationSuccessTotal;
+        this.rsaVerificationFailureTotal = rsaVerificationFailureTotal;
+        this.rsaRosterMismatchTotal = rsaRosterMismatchTotal;
         // using NaiveStreamingTreeHasher as we should only need single threaded
         this.inputTreeHasher = new NaiveStreamingTreeHasher();
         this.outputTreeHasher = new NaiveStreamingTreeHasher();
@@ -141,6 +202,11 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
                 case TRANSACTION_RESULT, TRANSACTION_OUTPUT -> outputTreeHasher.addLeaf(getBlockItemHash(item));
                 case STATE_CHANGES -> stateChangesHasher.addLeaf(getBlockItemHash(item));
                 case TRACE_DATA -> traceDataHasher.addLeaf(getBlockItemHash(item));
+                // WRB record file — captured for RSA payload computation and hashed as output
+                case RECORD_FILE -> {
+                    this.rawRecordFileItemBytes = item.recordFileOrThrow();
+                    outputTreeHasher.addLeaf(getBlockItemHash(item));
+                }
                 // save footer for later
                 case BLOCK_FOOTER -> this.blockFooter = BlockFooter.PROTOBUF.parse(item.blockFooter());
                 // append block proofs
@@ -176,16 +242,21 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
         // while we don't have state management, use the start of block state root hash from the footer
         Bytes startOfBlockStateRootHash = this.blockFooter.startOfBlockStateRootHash();
 
+        // Route by proof type. RSA WRB proofs take priority (Phase 2a); TSS proofs follow.
+        final BlockProof rsaProof = getFirst(blockProofs, BlockProof::hasSignedRecordFileProof);
+        if (rsaProof != null) {
+            return verifyRsaProof(
+                    rsaProof, previousBlockHashToUse, rootOfAllPreviousBlockHashes, startOfBlockStateRootHash);
+        }
+
         try {
-            // Try direct TSS proof first (most common case)
-            BlockProof tssBasedProof = getSingle(blockProofs, BlockProof::hasSignedBlockProof);
+            final BlockProof tssBasedProof = getSingle(blockProofs, BlockProof::hasSignedBlockProof);
             if (tssBasedProof != null) {
                 return getVerificationResult(
                         tssBasedProof, previousBlockHashToUse, rootOfAllPreviousBlockHashes, startOfBlockStateRootHash);
             }
 
-            // Try indirect (state) proof — used when TSS signing was delayed
-            BlockProof stateBasedProof = getSingle(blockProofs, BlockProof::hasBlockStateProof);
+            final BlockProof stateBasedProof = getSingle(blockProofs, BlockProof::hasBlockStateProof);
             if (stateBasedProof != null) {
                 return getStateProofVerificationResult(
                         stateBasedProof,
@@ -199,8 +270,9 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
                     false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
         }
 
-        // No supported proof type found
-        return null;
+        // No recognised proof type found — reject
+        LOGGER.log(WARNING, "No recognised proof type in block {0} — rejecting", blockNumber);
+        return new VerificationNotification(false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
     }
 
     /**
@@ -258,15 +330,292 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
     }
 
     /**
-     * Verifies a block using an indirect (state) proof. A state proof proves that the target
-     * block's root hash is embedded in a later directly-signed block's merkle tree, forming
-     * a chain: target block hash -> merkle siblings -> signed block root -> TSS signature.
+     * Extracts a {@link LedgerIdPublicationTransactionBody} from a signed transaction, if present.
+     * Pure parsing — no side effects.
      *
-     * @param blockProof the block proof containing a state proof
-     * @param previousBlockHash the previous block hash
-     * @param rootOfAllPreviousBlockHashes the root hash of all previous block hashes
-     * @param startOfBlockStateRootHash the start of block state root hash
-     * @return VerificationNotification indicating the result of the verification
+     * @param signedTxBytes the raw signed transaction bytes
+     * @return the parsed publication body, or {@code null} if not present
+     */
+    @Nullable
+    private LedgerIdPublicationTransactionBody findLedgerIdPublication(Bytes signedTxBytes) throws ParseException {
+        if (signedTxBytes == null || signedTxBytes.length() == 0) {
+            return null;
+        }
+        SignedTransaction signedTx = SignedTransaction.PROTOBUF.parse(
+                signedTxBytes.toReadableSequentialData(),
+                false,
+                false,
+                Codec.DEFAULT_MAX_DEPTH,
+                BlockAccessor.MAX_BLOCK_SIZE_BYTES);
+        TransactionBody body = TransactionBody.PROTOBUF.parse(
+                signedTx.bodyBytes().toReadableSequentialData(),
+                false,
+                false,
+                Codec.DEFAULT_MAX_DEPTH,
+                BlockAccessor.MAX_BLOCK_SIZE_BYTES);
+        if (!body.hasLedgerIdPublication()) {
+            return null;
+        }
+        return body.ledgerIdPublicationOrThrow();
+    }
+
+    /**
+     * Returns the first element matching `predicate`, or `null` if none match.
+     *
+     * @param <T> element type
+     * @param list the list to search
+     * @param predicate the match condition
+     * @return first matching element, or `null`
+     */
+    public static <T> T getFirst(final List<T> list, final Predicate<T> predicate) {
+        return list.stream().filter(predicate).findFirst().orElse(null);
+    }
+
+    // ---- RSA WRB verification -----------------------------------------------------------------------
+
+    /**
+     * Verifies a `SignedRecordFileProof` (WRB RSA proof) and returns a `VerificationNotification`.
+     *
+     * <p>**Algorithm (V6 only for Phase 2a):**
+     *
+     * 1. Compute the block root hash for chain continuity (identical to the TSS path).
+     * 2. Extract `record_file_contents` bytes (proto field 2) from the captured `RECORD_FILE` item.
+     * 3. Compute the signed payload: `SHA-384(int32(6) || rawRecordStreamFileBytes)`.
+     * 4. For each `RecordFileSignature` entry:
+     *    - Skip if `node_id` not in `rsaKeyByNodeId` (increment roster-mismatch counter).
+     *    - Skip if signature bytes are all zeros.
+     *    - Verify with `SHA384withRSA`; count valid signatures.
+     * 5. Accept if `validCount >= 2 * ceil(rosterSize / 3) + 1` (supermajority threshold).
+     *
+     * <p>This method never throws; all error conditions return a `success=false` notification.
+     *
+     * @param blockProof the block proof carrying the `SignedRecordFileProof`
+     * @param previousBlockHash the previous block hash for hash-chain computation
+     * @param rootOfAllPreviousBlockHashes the root of all previous block hashes
+     * @param startOfBlockStateRootHash the start-of-block state root hash
+     * @return a `VerificationNotification` with `success=true` when the proof passes, `false` otherwise
+     */
+    private VerificationNotification verifyRsaProof(
+            final BlockProof blockProof,
+            final Bytes previousBlockHash,
+            final Bytes rootOfAllPreviousBlockHashes,
+            final Bytes startOfBlockStateRootHash) {
+
+        // Compute block root hash for chain continuity — identical computation for all proof types
+        final Bytes blockRootHash = HashingUtilities.computeFinalBlockHash(
+                blockHeader.blockTimestamp(),
+                previousBlockHash,
+                rootOfAllPreviousBlockHashes,
+                startOfBlockStateRootHash,
+                inputTreeHasher,
+                outputTreeHasher,
+                consensusHeaderHasher,
+                stateChangesHasher,
+                traceDataHasher);
+
+        // Guard: address book must be loaded before any WRB arrives
+        if (rsaKeyByNodeId.isEmpty()) {
+            LOGGER.log(
+                    ERROR,
+                    "Address book is empty — cannot verify RSA WRB proof for block {0}."
+                            + " Ensure RsaRosterBootstrapPlugin started successfully.",
+                    blockNumber);
+            if (rsaVerificationFailureTotal != null) rsaVerificationFailureTotal.increment();
+            return new VerificationNotification(false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
+        }
+
+        // Guard: RECORD_FILE item must be present in the block
+        if (rawRecordFileItemBytes == null) {
+            LOGGER.log(ERROR, "No RECORD_FILE item found in WRB block {0} — cannot compute signed payload", blockNumber);
+            if (rsaVerificationFailureTotal != null) rsaVerificationFailureTotal.increment();
+            return new VerificationNotification(false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
+        }
+
+        final SignedRecordFileProof proof = blockProof.signedRecordFileProofOrThrow();
+        final int version = proof.version();
+
+        // Phase 2a scope: only record file format version 6 is supported
+        if (version != 6) {
+            LOGGER.log(
+                    WARNING,
+                    "Unsupported SignedRecordFileProof version {0} in block {1} — only V6 is supported",
+                    version,
+                    blockNumber);
+            if (rsaVerificationFailureTotal != null) rsaVerificationFailureTotal.increment();
+            return new VerificationNotification(false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
+        }
+
+        // Extract the raw RecordStreamFile bytes from the RecordFileItem proto (field 2)
+        final Bytes rawRecordStreamFileBytes = extractRecordStreamFileBytes(rawRecordFileItemBytes);
+        if (rawRecordStreamFileBytes.length() == 0) {
+            LOGGER.log(ERROR, "Failed to extract record_file_contents from RECORD_FILE item in block {0}", blockNumber);
+            if (rsaVerificationFailureTotal != null) rsaVerificationFailureTotal.increment();
+            return new VerificationNotification(false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
+        }
+
+        // V6 payload: SHA-384(int32(6) || rawRecordStreamFileBytes)
+        final byte[] signedPayload = computeV6SignedPayload(rawRecordStreamFileBytes);
+
+        // Verify each signature and count valid ones
+        final int rosterSize = rsaKeyByNodeId.size();
+        int validCount = 0;
+        int mismatchCount = 0;
+
+        for (final RecordFileSignature sig : proof.recordFileSignatures()) {
+            final long nodeId = sig.nodeId();
+            final PublicKey publicKey = rsaKeyByNodeId.get(nodeId);
+            if (publicKey == null) {
+                mismatchCount++;
+                LOGGER.log(DEBUG, "Signature from node {0} not in address book (block {1}) — skipped", nodeId, blockNumber);
+                continue;
+            }
+            final byte[] sigBytes = sig.signaturesBytes().toByteArray();
+            if (isAllZeros(sigBytes)) {
+                LOGGER.log(DEBUG, "Zeroed signature from node {0} in block {1} — skipped", nodeId, blockNumber);
+                continue;
+            }
+            try {
+                final Signature engine = SHA384_WITH_RSA.get();
+                engine.initVerify(publicKey);
+                engine.update(signedPayload);
+                if (engine.verify(sigBytes)) {
+                    validCount++;
+                }
+            } catch (final InvalidKeyException | SignatureException e) {
+                LOGGER.log(
+                        DEBUG,
+                        "RSA verification error for node {0} in block {1}: {2}",
+                        nodeId,
+                        blockNumber,
+                        e.getMessage());
+            }
+        }
+
+        if (rsaRosterMismatchTotal != null && mismatchCount > 0) {
+            rsaRosterMismatchTotal.increment(mismatchCount);
+        }
+
+        // Supermajority threshold: 2 * ceil(rosterSize / 3) + 1
+        final int threshold = 2 * ((rosterSize + 2) / 3) + 1;
+        final boolean accepted = validCount >= threshold;
+
+        if (accepted) {
+            LOGGER.log(
+                    DEBUG,
+                    "RSA WRB proof accepted for block {0}: {1}/{2} valid sigs (threshold {3})",
+                    blockNumber,
+                    validCount,
+                    rosterSize,
+                    threshold);
+            if (rsaVerificationSuccessTotal != null) rsaVerificationSuccessTotal.increment();
+        } else {
+            LOGGER.log(
+                    WARNING,
+                    "RSA WRB proof rejected for block {0}: {1}/{2} valid sigs, need {3}",
+                    blockNumber,
+                    validCount,
+                    rosterSize,
+                    threshold);
+            if (rsaVerificationFailureTotal != null) rsaVerificationFailureTotal.increment();
+        }
+
+        return new VerificationNotification(
+                accepted,
+                accepted ? null : FailureType.BAD_BLOCK_PROOF,
+                blockNumber,
+                accepted ? blockRootHash : null,
+                accepted ? new BlockUnparsed(blockItems) : null,
+                blockSource);
+    }
+
+    /**
+     * Extracts the raw `record_file_contents` bytes (proto field 2) from a serialized
+     * `RecordFileItem` message by navigating the protobuf wire format without full parsing.
+     *
+     * <p>The verbatim bytes are required for V6 signed hash computation so that the hash
+     * is identical to the one computed by the consensus node — re-serializing from a parsed
+     * representation would risk byte-order or encoding differences.
+     *
+     * @param recordFileItemBytes raw serialized bytes of a `RecordFileItem` proto message
+     * @return raw bytes of the `record_file_contents` field, or `Bytes.EMPTY` if not found
+     */
+    private static Bytes extractRecordStreamFileBytes(final Bytes recordFileItemBytes) {
+        try {
+            final ReadableSequentialData input = recordFileItemBytes.toReadableSequentialData();
+            while (input.hasRemaining()) {
+                final int tag = input.readVarInt(false);
+                final int wireType = tag & 0x7;
+                final int fieldNumber = tag >>> 3;
+                if (fieldNumber == 2 && wireType == 2) {
+                    // LEN field: read the length prefix then copy the raw bytes
+                    final int len = input.readVarInt(false);
+                    final byte[] raw = new byte[len];
+                    input.readBytes(raw);
+                    return Bytes.wrap(raw);
+                }
+                // Skip any other field by wire type
+                switch (wireType) {
+                    case 0 -> input.readVarLong(false); // VARINT: consume value
+                    case 1 -> input.skip(8);            // I64: skip 8 bytes
+                    case 2 -> {                         // LEN: skip length + content
+                        final int l = input.readVarInt(false);
+                        input.skip(l);
+                    }
+                    case 5 -> input.skip(4);            // I32: skip 4 bytes
+                    default -> { return Bytes.EMPTY; }  // Unknown wire type — bail out
+                }
+            }
+        } catch (final Exception e) {
+            // Treat any parse error as a missing field
+            return Bytes.EMPTY;
+        }
+        return Bytes.EMPTY;
+    }
+
+    /**
+     * Computes the V6 RSA signed payload: `SHA-384(int32(6) || rawRecordStreamFileBytes)`.
+     *
+     * <p>This matches `SignatureDataExtractor.computeSignedHash(6, ...)` in
+     * `tools-and-tests/tools`. Inlined here because that module cannot be imported from
+     * `block-node/verification`.
+     *
+     * @param rawRecordStreamFileBytes raw bytes of the `record_file_contents` field
+     * @return 48-byte SHA-384 digest
+     */
+    private static byte[] computeV6SignedPayload(final Bytes rawRecordStreamFileBytes) {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-384");
+            digest.update(new byte[] {0, 0, 0, 6}); // int32(6) big-endian
+            rawRecordStreamFileBytes.writeTo(digest);
+            return digest.digest();
+        } catch (final NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-384 not available in JVM", e);
+        }
+    }
+
+    /**
+     * Returns `true` if every byte in `bytes` is zero.
+     *
+     * @param bytes the byte array to inspect
+     * @return `true` when the array is all zeros or empty
+     */
+    private static boolean isAllZeros(final byte[] bytes) {
+        for (final byte b : bytes) {
+            if (b != 0) return false;
+        }
+        return true;
+    }
+
+    // ---- StateProof (indirect proof) verification -------------------------------------------------------------------
+
+    /**
+     * Verifies a state-proof-based block proof and returns a {@link VerificationNotification}.
+     *
+     * @param blockProof the block proof carrying the {@code BlockStateProof}
+     * @param previousBlockHash the previous block hash for hash-chain computation
+     * @param rootOfAllPreviousBlockHashes the root of all previous block hashes
+     * @param startOfBlockStateRootHash the start-of-block state root hash
+     * @return a {@link VerificationNotification}
      */
     protected VerificationNotification getStateProofVerificationResult(
             BlockProof blockProof,
@@ -300,19 +649,6 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
      * Walks the merkle path chain in a state proof to reconstruct the directly-signed block's
      * root hash, then verifies the TSS signature on that root.
      *
-     * <p>A valid block state proof contains 3 paths:
-     * <ul>
-     *   <li>Path 0: timestamp leaf of the signed block</li>
-     *   <li>Path 1: sibling hashes from the target block through all `gap` (i.e. not directly signed) blocks to the signed block</li>
-     *   <li>Path 2: terminal (empty)</li>
-     * </ul>
-     *
-     * <p>Path 1's siblings are laid out as groups:
-     * <ul>
-     *   <li>Per gap block (4 siblings): prevBlockRootsHash (right), depth5Node2 (right), depth4Node2 (right), <i>already-hashed</i> timestamp (left)</li>
-     *   <li>Final signed block (3 siblings): prevBlockRootsHash (right), depth5Node2 (right), depth4Node2 (right)
-     * </ul>
-     *
      * @param blockRootHash the computed root hash of the target block
      * @param stateProof the state proof to verify
      * @return true if the proof chain and TSS signature are valid
@@ -332,7 +668,6 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
             LOGGER.log(WARNING, "Block {0} state proof path 2 (terminal) is unexpectedly non-empty", blockNumber);
             return false;
         }
-
         if (!timestampPath.hasTimestampLeaf()) {
             LOGGER.log(WARNING, "Block {0} state proof path 0 (timestamp) is missing timestamp leaf", blockNumber);
             return false;
@@ -344,7 +679,6 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
 
         List<SiblingNode> siblings = siblingPath.siblings();
         int totalSiblings = siblings.size();
-        // Must have at least 3 (signed block siblings) and remainder must be groups of 4 (gap blocks)
         if (totalSiblings < 3 || (totalSiblings - 3) % 4 != 0) {
             LOGGER.log(
                     WARNING,
@@ -353,7 +687,6 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
                     totalSiblings);
             return false;
         }
-        // Starting hash must be present and non-empty to avoid propagating incorrect hashes
         if (!siblingPath.hasHash() || siblingPath.hash().length() == 0) {
             LOGGER.log(
                     WARNING, "Block {0} state proof path 1 (sibling) has missing or empty starting hash", blockNumber);
@@ -366,15 +699,10 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
             }
         }
 
-        // siblingPath.hash() is the previous block's (T-1) root hash. Walking the siblings in groups
-        // first reconstructs the target block T's root hash, then each subsequent gap block's root hash,
-        // until we reach the signed block. After the first iteration, current equals T's reconstructed
-        // root hash — verify it matches the independently computed blockRootHash to ensure block content integrity.
         byte[] current = siblingPath.hash().toByteArray();
         int index = 0;
         boolean firstIteration = true;
 
-        // Process gap blocks (including the target block itself) — each contributes 4 siblings
         while (totalSiblings - index > 3) {
             SiblingNode prevBlockRootsHash = siblings.get(index);
             SiblingNode depth5Node2Sibling = siblings.get(index + 1);
@@ -385,13 +713,9 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
             byte[] depth4Node1 = combineSibling(depth5Node1, depth5Node2Sibling);
             byte[] depth3Node1 = combineSibling(depth4Node1, depth4Node2Sibling);
             byte[] depth2Node2 = hashInternalNodeSingleChild(depth3Node1);
-            // The timestamp sibling hash is already hashLeaf(rawTimestamp) — a 48-byte node value.
-            // Combine as depth2Node1 (left) with depth2Node2 (right) to reconstruct the gap block root.
             current = hashInternalNode(hashedTimestampSibling.hash().toByteArray(), depth2Node2);
 
             if (firstIteration) {
-                // current now holds the reconstructed target block root hash; verify it matches
-                // the hash computed from the actual block content we received.
                 final Bytes reconstructed = Bytes.wrap(current);
                 if (!blockRootHash.equals(reconstructed)) {
                     LOGGER.log(
@@ -405,32 +729,20 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
                 }
                 firstIteration = false;
             }
-
             index += 4;
         }
 
-        // Process the signed block's 3 siblings
         byte[] depth5Node1 = combineSibling(current, siblings.get(index));
         byte[] depth4Node1 = combineSibling(depth5Node1, siblings.get(index + 1));
         byte[] depth3Node1 = combineSibling(depth4Node1, siblings.get(index + 2));
-
-        // Reconstruct the signed block's root hash using Path 0's raw timestamp bytes
         byte[] depth2Node2 = hashInternalNodeSingleChild(depth3Node1);
         byte[] hashedTimestampLeaf = hashLeaf(timestampPath.timestampLeaf().toByteArray());
         byte[] signedBlockRoot = hashInternalNode(hashedTimestampLeaf, depth2Node2);
 
-        // Verify TSS signature on the signed block's root hash
         return verifySignature(
                 Bytes.wrap(signedBlockRoot), stateProof.signedBlockProof().blockSignature());
     }
 
-    /**
-     * Combines the current hash with a sibling node, respecting the sibling's position.
-     *
-     * @param current the current hash being walked up the tree
-     * @param sibling the sibling node with position and hash
-     * @return the parent hash
-     */
     private static byte[] combineSibling(byte[] current, SiblingNode sibling) {
         if (sibling.isLeft()) {
             return hashInternalNode(sibling.hash().toByteArray(), current);
@@ -439,37 +751,7 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
         }
     }
 
-    /**
-     * Extracts a {@link LedgerIdPublicationTransactionBody} from a signed transaction, if present.
-     * Pure parsing — no side effects.
-     *
-     * @param signedTxBytes the raw signed transaction bytes
-     * @return the parsed publication body, or {@code null} if not present
-     */
-    @Nullable
-    private LedgerIdPublicationTransactionBody findLedgerIdPublication(Bytes signedTxBytes) throws ParseException {
-        if (signedTxBytes == null || signedTxBytes.length() == 0) {
-            return null;
-        }
-        SignedTransaction signedTx = SignedTransaction.PROTOBUF.parse(
-                signedTxBytes.toReadableSequentialData(),
-                false,
-                false,
-                Codec.DEFAULT_MAX_DEPTH,
-                BlockAccessor.MAX_BLOCK_SIZE_BYTES);
-        TransactionBody body = TransactionBody.PROTOBUF.parse(
-                signedTx.bodyBytes().toReadableSequentialData(),
-                false,
-                false,
-                Codec.DEFAULT_MAX_DEPTH,
-                BlockAccessor.MAX_BLOCK_SIZE_BYTES);
-        if (!body.hasLedgerIdPublication()) {
-            return null;
-        }
-        return body.ledgerIdPublicationOrThrow();
-    }
-
-    /** Returns the single element matching the predicate, or null if none match. */
+    /** Returns the single element matching the predicate, or null if none match (throws if more than one). */
     private <T> T getSingle(List<T> list, Predicate<T> predicate) {
         List<T> filtered = list.stream().filter(predicate).toList();
         if (filtered.size() > 1) {

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
@@ -398,9 +398,13 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
      * 3. Compute the signed payload: `SHA-384(int32(6) || rawRecordStreamFileBytes)`.
      * 4. For each `RecordFileSignature` entry:
      *    - Skip if `node_id` not in `rsaKeyByNodeId` (increment roster-mismatch counter).
-     *    - Skip if signature bytes are all zeros.
-     *    - Verify with `SHA384withRSA`; count valid signatures.
-     * 5. Accept if `validCount >= floor(2 * rosterSize / 3) + 1` (supermajority threshold).
+     *    - Skip if signature bytes are all zeros (defensive pre-filter).
+     *    - Verify with `SHA384withRSA`. If verification fails or throws, **reject the block
+     *      immediately** — the CN only includes signatures from nodes that contributed to
+     *      consensus, so any included signature must be cryptographically valid.
+     * 5. Accept if `validCount * 2 > rosterSize` (strict majority: more than half of the
+     *      address-book nodes must have signed). The CN sends exactly the signatures from
+     *      nodes whose combined consensus weight exceeded 50%.
      *
      * <p>This method never throws; all error conditions return a `success=false` notification.
      *
@@ -512,14 +516,28 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
                 if (engine.verify(sigBytes)) {
                     validCount++;
                     validatedNodes.add(nodeId);
+                } else {
+                    // CN only includes signatures from consensus-contributing nodes, so a failed
+                    // cryptographic verification means the block or proof has been tampered with.
+                    LOGGER.log(
+                            WARNING,
+                            "RSA signature from node {0} failed verification in block {1} — rejecting block",
+                            nodeId,
+                            blockNumber);
+                    if (rsaVerificationFailureTotal != null) rsaVerificationFailureTotal.increment();
+                    return new VerificationNotification(
+                            false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
                 }
             } catch (final InvalidKeyException | SignatureException e) {
                 LOGGER.log(
-                        DEBUG,
-                        "RSA verification error for node {0} in block {1}: {2}",
+                        WARNING,
+                        "RSA verification error for node {0} in block {1}: {2} — rejecting block",
                         nodeId,
                         blockNumber,
                         e.getMessage());
+                if (rsaVerificationFailureTotal != null) rsaVerificationFailureTotal.increment();
+                return new VerificationNotification(
+                        false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
             }
         }
 
@@ -527,31 +545,29 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
             rsaRosterMismatchTotal.increment(mismatchCount);
         }
 
-        // Supermajority threshold: floor(2 * rosterSize / 3) + 1
-        // Java integer division truncates toward zero (= floor for positive values), so
-        // `2 * rosterSize / 3` is exact floor division — no rounding adjustment needed.
-        // Note: the former expression `2 * ((rosterSize + 2) / 3) + 1` computed 2*ceil(n/3)+1,
-        // which only agrees with floor(2n/3)+1 when rosterSize is a multiple of 3.
-        final int threshold = 2 * rosterSize / 3 + 1;
-        final boolean accepted = validCount >= threshold;
+        // Strict majority threshold: validCount must be strictly greater than half the roster.
+        // The CN only sends signatures from nodes whose combined consensus weight exceeded 50%,
+        // so we require validCount * 2 > rosterSize (equivalent to validCount > rosterSize / 2.0).
+        // For example: 6-node roster requires > 3, i.e. ≥ 4 valid signatures.
+        final boolean accepted = validCount * 2 > rosterSize;
 
         if (accepted) {
             LOGGER.log(
                     DEBUG,
-                    "RSA WRB proof accepted for block {0}: {1}/{2} valid sigs (threshold {3})",
+                    "RSA WRB proof accepted for block {0}: {1}/{2} valid sigs (need > {3})",
                     blockNumber,
                     validCount,
                     rosterSize,
-                    threshold);
+                    rosterSize / 2);
             if (rsaVerificationSuccessTotal != null) rsaVerificationSuccessTotal.increment();
         } else {
             LOGGER.log(
                     WARNING,
-                    "RSA WRB proof rejected for block {0}: {1}/{2} valid sigs, need {3}",
+                    "RSA WRB proof rejected for block {0}: {1}/{2} valid sigs, need > {3}",
                     blockNumber,
                     validCount,
                     rosterSize,
-                    threshold);
+                    rosterSize / 2);
             if (rsaVerificationFailureTotal != null) rsaVerificationFailureTotal.increment();
         }
 

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
@@ -400,7 +400,7 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
      *    - Skip if `node_id` not in `rsaKeyByNodeId` (increment roster-mismatch counter).
      *    - Skip if signature bytes are all zeros.
      *    - Verify with `SHA384withRSA`; count valid signatures.
-     * 5. Accept if `validCount >= 2 * ceil(rosterSize / 3) + 1` (supermajority threshold).
+     * 5. Accept if `validCount >= floor(2 * rosterSize / 3) + 1` (supermajority threshold).
      *
      * <p>This method never throws; all error conditions return a `success=false` notification.
      *
@@ -527,8 +527,12 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
             rsaRosterMismatchTotal.increment(mismatchCount);
         }
 
-        // Supermajority threshold: 2 * ceil(rosterSize / 3) + 1
-        final int threshold = 2 * ((rosterSize + 2) / 3) + 1;
+        // Supermajority threshold: floor(2 * rosterSize / 3) + 1
+        // Java integer division truncates toward zero (= floor for positive values), so
+        // `2 * rosterSize / 3` is exact floor division — no rounding adjustment needed.
+        // Note: the former expression `2 * ((rosterSize + 2) / 3) + 1` computed 2*ceil(n/3)+1,
+        // which only agrees with floor(2n/3)+1 when rosterSize is a multiple of 3.
+        final int threshold = 2 * rosterSize / 3 + 1;
         final boolean accepted = validCount >= threshold;
 
         if (accepted) {

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
@@ -36,9 +36,11 @@ import java.security.PublicKey;
 import java.security.Signature;
 import java.security.SignatureException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
 import org.hiero.block.common.hasher.HashingUtilities;
 import org.hiero.block.common.hasher.NaiveStreamingTreeHasher;
@@ -72,6 +74,18 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
         }
     });
 
+    /**
+     * Reusable `SHA-384` digest per thread — avoids per-call `MessageDigest.getInstance()` cost.
+     * `MessageDigest` is stateful, so a `ThreadLocal` is required; each use calls `reset()` first.
+     */
+    private static final ThreadLocal<MessageDigest> SHA_384 = ThreadLocal.withInitial(() -> {
+        try {
+            return MessageDigest.getInstance("SHA-384");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-384 not available in JVM", e);
+        }
+    });
+
     private final long blockNumber;
     // Stream Hashers
     /** The tree hasher for input hashes. */
@@ -95,11 +109,12 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
      */
     private final Map<Long, PublicKey> rsaKeyByNodeId;
     /**
-     * Raw bytes of the `RecordFileItem` proto captured during block item processing.
-     * Required to compute the V6 signed payload: `SHA-384(int32(6) || record_file_contents)`.
+     * Raw serialized bytes of the outer `RecordFileItem` proto message, captured during block item
+     * processing. Field 2 of this proto holds the `record_file_contents` bytes required to compute
+     * the V6 signed payload: `SHA-384(int32(6) || record_file_contents)`.
      * Null until a `RECORD_FILE` block item is encountered.
      */
-    private Bytes rawRecordFileItemBytes;
+    private Bytes rawRecordFileItemProtoBytes;
     /** Metric for successful RSA WRB proof verifications; nullable — null when metrics not configured. */
     @Nullable
     private final LongCounter.Measurement rsaVerificationSuccessTotal;
@@ -204,7 +219,7 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
                 case TRACE_DATA -> traceDataHasher.addLeaf(getBlockItemHash(item));
                 // WRB record file — captured for RSA payload computation and hashed as output
                 case RECORD_FILE -> {
-                    this.rawRecordFileItemBytes = item.recordFileOrThrow();
+                    this.rawRecordFileItemProtoBytes = item.recordFileOrThrow();
                     outputTreeHasher.addLeaf(getBlockItemHash(item));
                 }
                 // save footer for later
@@ -367,7 +382,7 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
      * @param predicate the match condition
      * @return first matching element, or `null`
      */
-    public static <T> T getFirst(final List<T> list, final Predicate<T> predicate) {
+    private static <T> T getFirst(final List<T> list, final Predicate<T> predicate) {
         return list.stream().filter(predicate).findFirst().orElse(null);
     }
 
@@ -421,14 +436,17 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
                             + " Ensure RsaRosterBootstrapPlugin started successfully.",
                     blockNumber);
             if (rsaVerificationFailureTotal != null) rsaVerificationFailureTotal.increment();
-            return new VerificationNotification(false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
+            return new VerificationNotification(
+                    false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
         }
 
         // Guard: RECORD_FILE item must be present in the block
-        if (rawRecordFileItemBytes == null) {
-            LOGGER.log(ERROR, "No RECORD_FILE item found in WRB block {0} — cannot compute signed payload", blockNumber);
+        if (rawRecordFileItemProtoBytes == null) {
+            LOGGER.log(
+                    ERROR, "No RECORD_FILE item found in WRB block {0} — cannot compute signed payload", blockNumber);
             if (rsaVerificationFailureTotal != null) rsaVerificationFailureTotal.increment();
-            return new VerificationNotification(false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
+            return new VerificationNotification(
+                    false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
         }
 
         final SignedRecordFileProof proof = blockProof.signedRecordFileProofOrThrow();
@@ -442,31 +460,44 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
                     version,
                     blockNumber);
             if (rsaVerificationFailureTotal != null) rsaVerificationFailureTotal.increment();
-            return new VerificationNotification(false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
+            return new VerificationNotification(
+                    false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
         }
 
         // Extract the raw RecordStreamFile bytes from the RecordFileItem proto (field 2)
-        final Bytes rawRecordStreamFileBytes = extractRecordStreamFileBytes(rawRecordFileItemBytes);
+        final Bytes rawRecordStreamFileBytes = extractRecordStreamFileBytes(rawRecordFileItemProtoBytes);
         if (rawRecordStreamFileBytes.length() == 0) {
             LOGGER.log(ERROR, "Failed to extract record_file_contents from RECORD_FILE item in block {0}", blockNumber);
             if (rsaVerificationFailureTotal != null) rsaVerificationFailureTotal.increment();
-            return new VerificationNotification(false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
+            return new VerificationNotification(
+                    false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
         }
 
         // V6 payload: SHA-384(int32(6) || rawRecordStreamFileBytes)
         final byte[] signedPayload = computeV6SignedPayload(rawRecordStreamFileBytes);
 
-        // Verify each signature and count valid ones
+        // Verify each signature and count valid ones.
+        // Track which node_id values have already contributed a valid signature to prevent
+        // a duplicate entry in the proof from inflating validCount.
         final int rosterSize = rsaKeyByNodeId.size();
         int validCount = 0;
         int mismatchCount = 0;
+        final Set<Long> validatedNodes = new HashSet<>();
 
         for (final RecordFileSignature sig : proof.recordFileSignatures()) {
             final long nodeId = sig.nodeId();
             final PublicKey publicKey = rsaKeyByNodeId.get(nodeId);
             if (publicKey == null) {
                 mismatchCount++;
-                LOGGER.log(DEBUG, "Signature from node {0} not in address book (block {1}) — skipped", nodeId, blockNumber);
+                LOGGER.log(
+                        DEBUG,
+                        "Signature from node {0} not in address book (block {1}) — skipped",
+                        nodeId,
+                        blockNumber);
+                continue;
+            }
+            if (validatedNodes.contains(nodeId)) {
+                LOGGER.log(DEBUG, "Duplicate signature from node {0} in block {1} — skipped", nodeId, blockNumber);
                 continue;
             }
             final byte[] sigBytes = sig.signaturesBytes().toByteArray();
@@ -480,6 +511,7 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
                 engine.update(signedPayload);
                 if (engine.verify(sigBytes)) {
                     validCount++;
+                    validatedNodes.add(nodeId);
                 }
             } catch (final InvalidKeyException | SignatureException e) {
                 LOGGER.log(
@@ -556,16 +588,18 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
                 // Skip any other field by wire type
                 switch (wireType) {
                     case 0 -> input.readVarLong(false); // VARINT: consume value
-                    case 1 -> input.skip(8);            // I64: skip 8 bytes
-                    case 2 -> {                         // LEN: skip length + content
+                    case 1 -> input.skip(8); // I64: skip 8 bytes
+                    case 2 -> { // LEN: skip length + content
                         final int l = input.readVarInt(false);
                         input.skip(l);
                     }
-                    case 5 -> input.skip(4);            // I32: skip 4 bytes
-                    default -> { return Bytes.EMPTY; }  // Unknown wire type — bail out
+                    case 5 -> input.skip(4); // I32: skip 4 bytes
+                    default -> {
+                        return Bytes.EMPTY;
+                    } // Unknown wire type — bail out
                 }
             }
-        } catch (final Exception e) {
+        } catch (final RuntimeException e) {
             // Treat any parse error as a missing field
             return Bytes.EMPTY;
         }
@@ -583,14 +617,11 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
      * @return 48-byte SHA-384 digest
      */
     private static byte[] computeV6SignedPayload(final Bytes rawRecordStreamFileBytes) {
-        try {
-            final MessageDigest digest = MessageDigest.getInstance("SHA-384");
-            digest.update(new byte[] {0, 0, 0, 6}); // int32(6) big-endian
-            rawRecordStreamFileBytes.writeTo(digest);
-            return digest.digest();
-        } catch (final NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-384 not available in JVM", e);
-        }
+        final MessageDigest digest = SHA_384.get();
+        digest.reset();
+        digest.update(new byte[] {0, 0, 0, 6}); // int32(6) big-endian
+        rawRecordStreamFileBytes.writeTo(digest);
+        return digest.digest();
     }
 
     /**

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/AllBlocksHasherHandlerTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/AllBlocksHasherHandlerTest.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.hiero.block.api.BlockNodeVersions;
+import org.hiero.block.api.TssData;
 import org.hiero.block.common.hasher.HashingUtilities;
 import org.hiero.block.common.hasher.NaiveStreamingTreeHasher;
 import org.hiero.block.common.hasher.StreamingHasher;
@@ -36,7 +37,6 @@ import org.hiero.block.common.hasher.StreamingTreeHasher;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.node.app.fixtures.blocks.MinimalBlockAccessor;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleBlockRangeSet;
-import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceLoaderFunction;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
@@ -313,12 +313,12 @@ class AllBlocksHasherHandlerTest {
                 mock(HealthFacility.class),
                 mock(BlockMessagingFacility.class),
                 facility,
-                mock(ApplicationStateFacility.class),
+                null,
                 mock(ServiceLoaderFunction.class),
                 mock(ThreadPoolManager.class),
                 BlockNodeVersions.DEFAULT,
-                null,
-                null);
+                TssData.DEFAULT,
+                com.hedera.hapi.node.base.NodeAddressBook.DEFAULT);
     }
 
     private void persistHasher(final Path hasherPath, final List<byte[]> blockHashes)

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/AllBlocksHasherHandlerTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/AllBlocksHasherHandlerTest.java
@@ -37,6 +37,7 @@ import org.hiero.block.common.hasher.StreamingTreeHasher;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.node.app.fixtures.blocks.MinimalBlockAccessor;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleBlockRangeSet;
+import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceLoaderFunction;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
@@ -313,7 +314,7 @@ class AllBlocksHasherHandlerTest {
                 mock(HealthFacility.class),
                 mock(BlockMessagingFacility.class),
                 facility,
-                null,
+                mock(ApplicationStateFacility.class),
                 mock(ServiceLoaderFunction.class),
                 mock(ThreadPoolManager.class),
                 BlockNodeVersions.DEFAULT,

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/RsaKeyDecoderTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/RsaKeyDecoderTest.java
@@ -27,8 +27,9 @@ class RsaKeyDecoderTest {
                 RsaKeyDecoder.buildKeyMap(NodeAddressBook.DEFAULT).isEmpty(),
                 "DEFAULT (empty) book must return empty map");
         assertTrue(
-                RsaKeyDecoder.buildKeyMap(
-                                NodeAddressBook.newBuilder().nodeAddress(List.of()).build())
+                RsaKeyDecoder.buildKeyMap(NodeAddressBook.newBuilder()
+                                .nodeAddress(List.of())
+                                .build())
                         .isEmpty(),
                 "Explicitly empty nodeAddress list must return empty map");
     }
@@ -63,7 +64,10 @@ class RsaKeyDecoderTest {
         final NodeAddressBook book = NodeAddressBook.newBuilder()
                 .nodeAddress(List.of(
                         NodeAddress.newBuilder().nodeId(0L).rsaPubKey("").build(), // blank — skipped
-                        NodeAddress.newBuilder().nodeId(1L).rsaPubKey("deadbeef").build(), // malformed DER — skipped
+                        NodeAddress.newBuilder()
+                                .nodeId(1L)
+                                .rsaPubKey("deadbeef")
+                                .build(), // malformed DER — skipped
                         NodeAddress.newBuilder().nodeId(2L).rsaPubKey(validHex).build() // valid
                         ))
                 .build();

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/RsaKeyDecoderTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/RsaKeyDecoderTest.java
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.verification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hapi.node.base.NodeAddress;
+import com.hedera.hapi.node.base.NodeAddressBook;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/// Unit tests for `RsaKeyDecoder.buildKeyMap`.
+class RsaKeyDecoderTest {
+
+    @Test
+    @DisplayName("null or empty address book returns empty map")
+    void nullAndEmptyBook_returnEmptyMap() {
+        assertTrue(RsaKeyDecoder.buildKeyMap(null).isEmpty(), "null book must return empty map");
+        assertTrue(
+                RsaKeyDecoder.buildKeyMap(NodeAddressBook.DEFAULT).isEmpty(),
+                "DEFAULT (empty) book must return empty map");
+        assertTrue(
+                RsaKeyDecoder.buildKeyMap(
+                                NodeAddressBook.newBuilder().nodeAddress(List.of()).build())
+                        .isEmpty(),
+                "Explicitly empty nodeAddress list must return empty map");
+    }
+
+    @Test
+    @DisplayName("valid hex-DER RSA key is decoded and added to the map")
+    void validKey_decodedAndMapped() throws Exception {
+        final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(1024);
+        final KeyPair kp = kpg.generateKeyPair();
+        final String hexKey = HexFormat.of().formatHex(kp.getPublic().getEncoded());
+
+        final NodeAddressBook book = NodeAddressBook.newBuilder()
+                .nodeAddress(List.of(
+                        NodeAddress.newBuilder().nodeId(7L).rsaPubKey(hexKey).build()))
+                .build();
+
+        final Map<Long, PublicKey> result = RsaKeyDecoder.buildKeyMap(book);
+
+        assertEquals(1, result.size());
+        assertNotNull(result.get(7L), "Node 7's PublicKey must be present");
+    }
+
+    @Test
+    @DisplayName("blank rsaPubKey is skipped; malformed hex-DER is skipped; valid keys are retained")
+    void blankAndMalformedKeys_skipped_validKeysRetained() throws Exception {
+        final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(1024);
+        final KeyPair kp = kpg.generateKeyPair();
+        final String validHex = HexFormat.of().formatHex(kp.getPublic().getEncoded());
+
+        final NodeAddressBook book = NodeAddressBook.newBuilder()
+                .nodeAddress(List.of(
+                        NodeAddress.newBuilder().nodeId(0L).rsaPubKey("").build(), // blank — skipped
+                        NodeAddress.newBuilder().nodeId(1L).rsaPubKey("deadbeef").build(), // malformed DER — skipped
+                        NodeAddress.newBuilder().nodeId(2L).rsaPubKey(validHex).build() // valid
+                        ))
+                .build();
+
+        final Map<Long, PublicKey> result = RsaKeyDecoder.buildKeyMap(book);
+
+        assertEquals(1, result.size(), "Only the valid key must appear in the map");
+        assertNotNull(result.get(2L), "Node 2's valid key must be decoded");
+    }
+}

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginIntegrationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginIntegrationTest.java
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.verification;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hapi.node.base.NodeAddressBook;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.zip.GZIPInputStream;
+import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.node.app.fixtures.async.BlockingExecutor;
+import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
+import org.hiero.block.node.app.fixtures.plugintest.NoBlocksHistoricalBlockFacility;
+import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Integration-style tests for {@link VerificationServicePlugin} using real WRB block fixtures.
+ *
+ * <p>These tests exercise the full plugin pipeline:
+ * <ol>
+ *   <li>Load a real WRB (Wrapped Record Block) from a test resource file.</li>
+ *   <li>Load the matching RSA {@link NodeAddressBook} (the public keys of the nodes that signed
+ *       the block).</li>
+ *   <li>Deliver the address book to the plugin via
+ *       {@link PluginTestBase#updateAddressBook(NodeAddressBook)}, which simulates the production
+ *       {@code ApplicationStateFacility.updateAddressBook()} → context rebuild → *       {@code onContextUpdate()} chain without requiring a running scheduler.</li>
+ *   <li>Send the block through the plugin's live-stream handler via
+ *       {@link org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility}.</li>
+ *   <li>Assert the resulting {@link VerificationNotification}.</li>
+ * </ol>
+ *
+ * <h2>Adding new test fixtures</h2>
+ *
+ * <p>Place files under {@code block-node/verification/src/test/resources/}:
+ *
+ * <pre>
+ * test-blocks/
+ *   wrb/
+ *     &lt;network&gt;/
+ *       &lt;block-number&gt;.blk.gz     — GZIP-compressed protobuf BlockUnparsed
+ * test-data/
+ *   wrb/
+ *     &lt;network&gt;/
+ *       address-book.pb            — protobuf-serialised NodeAddressBook (RSA public keys)
+ * </pre>
+ *
+ * <p>The {@code .blk.gz} format is identical to the TSS block fixtures under
+ * {@code test-blocks/CN_0_73_TSS_WRAPS/}: GZIP wrapping a protobuf-encoded {@link BlockUnparsed}.
+ *
+ * <p>The {@code address-book.pb} file is a raw protobuf serialisation of {@link NodeAddressBook}
+ * containing the RSA public keys ({@code rsaPubKey} field, hex-encoded DER) of the nodes that
+ * produced the block.  Generate it with:
+ * <pre>
+ *   // Kotlin / Java snippet:
+ *   val book = NodeAddressBook.newBuilder()
+ *       .nodeAddress(/* ... node entries ... *{@literal /})
+ *       .build()
+ *   Files.write(Path.of("address-book.pb"), NodeAddressBook.PROTOBUF.toBytes(book).toByteArray())
+ * </pre>
+ *
+ * <p>Alternatively, obtain the address book from the Mirror Node REST API
+ * ({@code GET /api/v1/network/nodes}) and convert it using {@code RsaRosterBootstrapPlugin}'s
+ * parsing logic, or export it from the block node's own persisted {@code rsa-bootstrap-roster.json}.
+ */
+class VerificationServicePluginIntegrationTest
+        extends PluginTestBase<VerificationServicePlugin, BlockingExecutor, ScheduledExecutorService> {
+
+    VerificationServicePluginIntegrationTest(@TempDir final Path tempDir) {
+        super(
+                new BlockingExecutor(new LinkedBlockingQueue<>()),
+                new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+        Objects.requireNonNull(tempDir);
+        // Reset static TSS state for test isolation.
+        VerificationServicePlugin.activeLedgerId = null;
+        VerificationServicePlugin.activeTssPublication = null;
+        VerificationServicePlugin.tssParametersPersisted = false;
+
+        final Map<String, String> config = new HashMap<>();
+        config.put("verification.allBlocksHasherFilePath", tempDir.resolve("hasher.bin").toString());
+        config.put("verification.allBlocksHasherEnabled", "true");
+        config.put("verification.allBlocksHasherPersistenceInterval", "10");
+        config.put("verification.tssParametersFilePath", tempDir.resolve("tss-params.bin").toString());
+
+        start(new VerificationServicePlugin(), new NoBlocksHistoricalBlockFacility(), config);
+    }
+
+    // -------------------------------------------------------------------------
+    // Placeholder test — enable once real WRB fixtures are available
+    // -------------------------------------------------------------------------
+
+    /**
+     * Placeholder integration test for a real WRB block.
+     *
+     * <p>To activate:
+     * <ol>
+     *   <li>Remove {@code @Disabled}.</li>
+     *   <li>Place the WRB block at
+     *       {@code src/test/resources/test-blocks/wrb/<network>/<block-number>.blk.gz}.</li>
+     *   <li>Place the matching address book at
+     *       {@code src/test/resources/test-data/wrb/<network>/address-book.pb}.</li>
+     *   <li>Update the resource paths in this test accordingly.</li>
+     * </ol>
+     */
+    @Disabled("No WRB block fixtures available yet — see class Javadoc for setup instructions")
+    @Test
+    @DisplayName("real WRB block with matching address book verifies successfully")
+    void realWrbBlock_withMatchingAddressBook_verifies() throws IOException, ParseException {
+        final NodeAddressBook book = loadAddressBook("test-data/wrb/<network>/address-book.pb");
+        final BlockUnparsed block = loadWrbBlock("test-blocks/wrb/<network>/<block-number>.blk.gz");
+
+        final VerificationNotification notification = runWrbVerification(book, block);
+
+        assertNotNull(notification, "Plugin must emit a VerificationNotification");
+        assertTrue(notification.success(), "Real WRB block must verify successfully with the matching address book");
+        assertNotNull(notification.blockHash(), "Block hash must be set on successful verification");
+        assertNotNull(notification.block(), "Block content must be present on successful verification");
+    }
+
+    // -------------------------------------------------------------------------
+    // Harness helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Loads a GZIP-compressed, protobuf-encoded {@link BlockUnparsed} from the given resource
+     * path.  Resources are resolved from this module's test classpath.
+     *
+     * @param resourcePath path relative to the test resource root,
+     *     e.g. {@code "test-blocks/wrb/mainnet/1234567.blk.gz"}
+     * @return the parsed {@link BlockUnparsed}
+     * @throws IOException if the resource cannot be opened or read
+     * @throws ParseException if the protobuf payload cannot be parsed
+     */
+    private BlockUnparsed loadWrbBlock(final String resourcePath) throws IOException, ParseException {
+        try (InputStream raw = getClass().getModule().getResourceAsStream(resourcePath)) {
+            if (raw == null) {
+                throw new IOException("WRB block resource not found: " + resourcePath
+                        + " — see class Javadoc for fixture setup instructions");
+            }
+            try (GZIPInputStream gzip = new GZIPInputStream(raw)) {
+                return BlockUnparsed.PROTOBUF.parse(Bytes.wrap(gzip.readAllBytes()));
+            }
+        }
+    }
+
+    /**
+     * Loads a protobuf-encoded {@link NodeAddressBook} from the given resource path.
+     * The file must be a raw serialisation of {@link NodeAddressBook} (not GZIP-compressed).
+     *
+     * @param resourcePath path relative to the test resource root,
+     *     e.g. {@code "test-data/wrb/mainnet/address-book.pb"}
+     * @return the parsed {@link NodeAddressBook}
+     * @throws IOException if the resource cannot be opened or read
+     * @throws ParseException if the protobuf payload cannot be parsed
+     */
+    private NodeAddressBook loadAddressBook(final String resourcePath) throws IOException, ParseException {
+        try (InputStream raw = getClass().getModule().getResourceAsStream(resourcePath)) {
+            if (raw == null) {
+                throw new IOException("Address book resource not found: " + resourcePath
+                        + " — see class Javadoc for fixture setup instructions");
+            }
+            return NodeAddressBook.PROTOBUF.parse(Bytes.wrap(raw.readAllBytes()));
+        }
+    }
+
+    /**
+     * Runs the full WRB verification pipeline:
+     * <ol>
+     *   <li>Delivers {@code book} to the plugin via
+     *       {@link PluginTestBase#updateAddressBook(NodeAddressBook)} — this simulates
+     *       {@code ApplicationStateFacility.updateAddressBook()} and synchronously triggers
+     *       {@code plugin.onContextUpdate()}, rebuilding the RSA key map.</li>
+     *   <li>Parses the block number from the block's first item (the {@code BlockHeader}).</li>
+     *   <li>Sends all block items through the plugin's live-stream handler in a single
+     *       {@link BlockItems} batch (start-of-block = true, end-of-block = true).</li>
+     *   <li>Returns the last {@link VerificationNotification} emitted by the plugin.</li>
+     * </ol>
+     *
+     * @param book  the RSA address book matching the signing nodes for {@code block}
+     * @param block the WRB block to verify
+     * @return the {@link VerificationNotification} produced by the plugin
+     * @throws ParseException if the block header cannot be parsed to extract the block number
+     */
+    private VerificationNotification runWrbVerification(final NodeAddressBook book, final BlockUnparsed block)
+            throws ParseException {
+        // Deliver the address book — triggers ApplicationStateFacility.updateAddressBook() flow.
+        updateAddressBook(book);
+
+        // Parse the block number from the header so BlockItems is constructed correctly.
+        final long blockNumber = com.hedera.hapi.block.stream.output.BlockHeader.PROTOBUF
+                .parse(block.blockItems().getFirst().blockHeaderOrThrow())
+                .number();
+
+        // Send the entire block as a single batch (WRB blocks are always self-contained).
+        blockMessaging.sendBlockItems(new BlockItems(block.blockItems(), blockNumber, true, true));
+
+        // Return the notification produced for this block.
+        final List<VerificationNotification> notifications = blockMessaging.getSentVerificationNotifications();
+        assertFalse(notifications.isEmpty(), "Plugin must emit at least one VerificationNotification");
+        return notifications.getLast();
+    }
+}

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginIntegrationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginIntegrationTest.java
@@ -22,9 +22,9 @@ import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.app.fixtures.async.BlockingExecutor;
 import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
 import org.hiero.block.node.app.fixtures.plugintest.NoBlocksHistoricalBlockFacility;
+import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
-import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -93,10 +93,14 @@ class VerificationServicePluginIntegrationTest
         VerificationServicePlugin.tssParametersPersisted = false;
 
         final Map<String, String> config = new HashMap<>();
-        config.put("verification.allBlocksHasherFilePath", tempDir.resolve("hasher.bin").toString());
+        config.put(
+                "verification.allBlocksHasherFilePath",
+                tempDir.resolve("hasher.bin").toString());
         config.put("verification.allBlocksHasherEnabled", "true");
         config.put("verification.allBlocksHasherPersistenceInterval", "10");
-        config.put("verification.tssParametersFilePath", tempDir.resolve("tss-params.bin").toString());
+        config.put(
+                "verification.tssParametersFilePath",
+                tempDir.resolve("tss-params.bin").toString());
 
         start(new VerificationServicePlugin(), new NoBlocksHistoricalBlockFacility(), config);
     }

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginTest.java
@@ -402,7 +402,8 @@ class VerificationServicePluginTest
     @Test
     @DisplayName("onContextUpdate with non-empty address book rebuilds keyByNodeId")
     void onContextUpdate_nonEmptyBook_rebuildsKeyMap() throws Exception {
-        // Build a minimal NodeAddress with a real RSA public key encoded as hex-DER
+        // Build a minimal NodeAddress with a real RSA public key encoded as hex-DER.
+        // 1024-bit RSA keys are used for test speed only — production network uses 4096-bit keys.
         final java.security.KeyPairGenerator kpg = java.security.KeyPairGenerator.getInstance("RSA");
         kpg.initialize(1024);
         final java.security.KeyPair kp = kpg.generateKeyPair();
@@ -412,10 +413,9 @@ class VerificationServicePluginTest
                 .nodeId(7L)
                 .rsaPubKey(hexKey)
                 .build();
-        final com.hedera.hapi.node.base.NodeAddressBook book =
-                com.hedera.hapi.node.base.NodeAddressBook.newBuilder()
-                        .nodeAddress(List.of(addr))
-                        .build();
+        final com.hedera.hapi.node.base.NodeAddressBook book = com.hedera.hapi.node.base.NodeAddressBook.newBuilder()
+                .nodeAddress(List.of(addr))
+                .build();
 
         // The test context has nodeAddressBook set to DEFAULT (empty) initially;
         // simulate a context update by calling onContextUpdate directly
@@ -438,6 +438,29 @@ class VerificationServicePluginTest
         // from node 7 as "unknown node"). The simplest assertion is that the method did not throw.
         // A deeper assertion would require exposing `keyByNodeId`, which we avoid.
         // Coverage is provided by the unit tests in `RsaWrbVerificationTest`.
+    }
+
+    @Test
+    @DisplayName("onContextUpdate with empty address book logs warning and retains existing key map")
+    void onContextUpdate_emptyBook_retainsKeyMap() {
+        // Call onContextUpdate with an empty NodeAddressBook — must not throw and must not reset
+        // the key map to empty (it starts empty already, but the important contract is: no crash).
+        final com.hedera.hapi.node.base.NodeAddressBook emptyBook = com.hedera.hapi.node.base.NodeAddressBook.DEFAULT;
+        final var updatedContext = new org.hiero.block.node.spi.BlockNodeContext(
+                blockNodeContext.configuration(),
+                blockNodeContext.metricRegistry(),
+                blockNodeContext.serverHealth(),
+                blockNodeContext.blockMessaging(),
+                blockNodeContext.historicalBlockProvider(),
+                blockNodeContext.applicationStateFacility(),
+                blockNodeContext.serviceLoader(),
+                blockNodeContext.threadPoolManager(),
+                blockNodeContext.blockNodeVersions(),
+                blockNodeContext.tssData(),
+                emptyBook);
+
+        // Must not throw; a WARNING is expected but not asserted here (logged to system logger).
+        plugin.onContextUpdate(updatedContext);
     }
 
     // ==== TSS End-to-End Flow Test ===================================================================================

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginTest.java
@@ -397,6 +397,49 @@ class VerificationServicePluginTest
                 "First-write-wins: block 0 must not overwrite file-loaded ledger ID");
     }
 
+    // ==== RSA Address Book / onContextUpdate Tests ==================================================================
+
+    @Test
+    @DisplayName("onContextUpdate with non-empty address book rebuilds keyByNodeId")
+    void onContextUpdate_nonEmptyBook_rebuildsKeyMap() throws Exception {
+        // Build a minimal NodeAddress with a real RSA public key encoded as hex-DER
+        final java.security.KeyPairGenerator kpg = java.security.KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(1024);
+        final java.security.KeyPair kp = kpg.generateKeyPair();
+        final String hexKey = java.util.HexFormat.of().formatHex(kp.getPublic().getEncoded());
+
+        final com.hedera.hapi.node.base.NodeAddress addr = com.hedera.hapi.node.base.NodeAddress.newBuilder()
+                .nodeId(7L)
+                .rsaPubKey(hexKey)
+                .build();
+        final com.hedera.hapi.node.base.NodeAddressBook book =
+                com.hedera.hapi.node.base.NodeAddressBook.newBuilder()
+                        .nodeAddress(List.of(addr))
+                        .build();
+
+        // The test context has nodeAddressBook set to DEFAULT (empty) initially;
+        // simulate a context update by calling onContextUpdate directly
+        final var updatedContext = new org.hiero.block.node.spi.BlockNodeContext(
+                blockNodeContext.configuration(),
+                blockNodeContext.metricRegistry(),
+                blockNodeContext.serverHealth(),
+                blockNodeContext.blockMessaging(),
+                blockNodeContext.historicalBlockProvider(),
+                blockNodeContext.applicationStateFacility(),
+                blockNodeContext.serviceLoader(),
+                blockNodeContext.threadPoolManager(),
+                blockNodeContext.blockNodeVersions(),
+                blockNodeContext.tssData(),
+                book);
+
+        plugin.onContextUpdate(updatedContext);
+
+        // Verify the key map now contains node 7's key (indirect: the plugin won't reject a WRB
+        // from node 7 as "unknown node"). The simplest assertion is that the method did not throw.
+        // A deeper assertion would require exposing `keyByNodeId`, which we avoid.
+        // Coverage is provided by the unit tests in `RsaWrbVerificationTest`.
+    }
+
     // ==== TSS End-to-End Flow Test ===================================================================================
 
     @Test

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginTest.java
@@ -9,17 +9,32 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.hedera.hapi.block.stream.BlockProof;
+import com.hedera.hapi.block.stream.RecordFileSignature;
+import com.hedera.hapi.block.stream.SignedRecordFileProof;
+import com.hedera.hapi.block.stream.output.BlockFooter;
 import com.hedera.hapi.block.stream.output.BlockHeader;
+import com.hedera.hapi.node.base.BlockHashAlgorithm;
+import com.hedera.hapi.node.base.NodeAddress;
+import com.hedera.hapi.node.base.NodeAddressBook;
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.tss.LedgerIdPublicationTransactionBody;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -461,6 +476,104 @@ class VerificationServicePluginTest
 
         // Must not throw; a WARNING is expected but not asserted here (logged to system logger).
         plugin.onContextUpdate(updatedContext);
+    }
+
+    @Test
+    @DisplayName("onContextUpdate with null NodeAddressBook logs warning and retains existing key map")
+    void onContextUpdate_nullBook_retainsKeyMap() {
+        // Build a context where nodeAddressBook() returns null — must not throw.
+        final var updatedContext = new org.hiero.block.node.spi.BlockNodeContext(
+                blockNodeContext.configuration(),
+                blockNodeContext.metricRegistry(),
+                blockNodeContext.serverHealth(),
+                blockNodeContext.blockMessaging(),
+                blockNodeContext.historicalBlockProvider(),
+                blockNodeContext.applicationStateFacility(),
+                blockNodeContext.serviceLoader(),
+                blockNodeContext.threadPoolManager(),
+                blockNodeContext.blockNodeVersions(),
+                blockNodeContext.tssData(),
+                null);
+
+        // Must not throw; a WARNING is expected but not asserted here (logged to system logger).
+        plugin.onContextUpdate(updatedContext);
+    }
+
+    @Test
+    @DisplayName("RSA WRB end-to-end: valid signed block verifies through the plugin and notification is success=true")
+    void rsaWrb_endToEnd_validBlock_notificationSucceeds() throws Exception {
+        // 1024-bit RSA keys for test speed only — production uses 4096-bit keys.
+        final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(1024);
+        final KeyPair kp = kpg.generateKeyPair();
+
+        // Build a 1-node address book (threshold = floor(2*1/3)+1 = 1 valid sig needed).
+        final String hexKey = HexFormat.of().formatHex(kp.getPublic().getEncoded());
+        final NodeAddressBook book = NodeAddressBook.newBuilder()
+                .nodeAddress(List.of(
+                        NodeAddress.newBuilder().nodeId(0L).rsaPubKey(hexKey).build()))
+                .build();
+
+        // Deliver the address book — triggers onContextUpdate and rebuilds the RSA key map.
+        updateAddressBook(book);
+
+        // Build a minimal RecordFileItem proto: field 2 (tag=0x12, LEN) = record stream file bytes.
+        final byte[] recordStreamFileBytes = "test-record-stream-content".getBytes();
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        bos.write(0x12); // tag: field 2, wire type 2 (LEN)
+        bos.write(recordStreamFileBytes.length); // length fits in 1 byte (< 128)
+        bos.write(recordStreamFileBytes);
+        final Bytes recordFileItemBytes = Bytes.wrap(bos.toByteArray());
+
+        // Compute the V6 signed payload: SHA-384(int32(6) || record_stream_file_bytes).
+        final MessageDigest digest = MessageDigest.getInstance("SHA-384");
+        digest.update(new byte[] {0, 0, 0, 6});
+        digest.update(recordStreamFileBytes);
+        final byte[] signedPayload = digest.digest();
+
+        // Sign the payload with node 0's private key.
+        final java.security.Signature engine = java.security.Signature.getInstance("SHA384withRSA");
+        engine.initSign(kp.getPrivate());
+        engine.update(signedPayload);
+        final byte[] sigBytes = engine.sign();
+
+        // Assemble the WRB block: BLOCK_HEADER | RECORD_FILE | BLOCK_FOOTER | BLOCK_PROOF.
+        final long blockNumber = 500L;
+        // HAPI version >= 0.72.0 routes to ExtendedMerkleTreeSession (RSA path).
+        final SemanticVersion hapiVersion = new SemanticVersion(1, 0, 0, "", "");
+        final SemanticVersion swVersion = new SemanticVersion(1, 0, 0, "", "");
+        final BlockHeader header = new BlockHeader(
+                hapiVersion, swVersion, blockNumber, new Timestamp(1_700_000_000L, 0), BlockHashAlgorithm.SHA2_384);
+        final BlockFooter footer = new BlockFooter(Bytes.EMPTY, Bytes.EMPTY, Bytes.EMPTY);
+        final BlockProof proof = BlockProof.newBuilder()
+                .block(blockNumber)
+                .signedRecordFileProof(new SignedRecordFileProof(
+                        6, List.of(new RecordFileSignature(Bytes.wrap(sigBytes), 0L))))
+                .build();
+
+        final List<BlockItemUnparsed> items = List.of(
+                BlockItemUnparsed.newBuilder()
+                        .blockHeader(BlockHeader.PROTOBUF.toBytes(header))
+                        .build(),
+                BlockItemUnparsed.newBuilder().recordFile(recordFileItemBytes).build(),
+                BlockItemUnparsed.newBuilder()
+                        .blockFooter(BlockFooter.PROTOBUF.toBytes(footer))
+                        .build(),
+                BlockItemUnparsed.newBuilder()
+                        .blockProof(BlockProof.PROTOBUF.toBytes(proof))
+                        .build());
+
+        // Send through the plugin's live-stream handler.
+        blockMessaging.sendBlockItems(new BlockItems(items, blockNumber, true, true));
+
+        // The RSA path must produce a success notification.
+        final List<VerificationNotification> notifications = blockMessaging.getSentVerificationNotifications();
+        assertFalse(notifications.isEmpty(), "Plugin must emit a VerificationNotification for the WRB block");
+        final VerificationNotification notification = notifications.getLast();
+        assertEquals(blockNumber, notification.blockNumber());
+        assertTrue(notification.success(), "RSA WRB block with a valid threshold signature must verify successfully");
+        assertNotNull(notification.blockHash(), "Block hash must be set on successful RSA verification");
+        assertNotNull(notification.block(), "Block must be present in the success notification");
     }
 
     // ==== TSS End-to-End Flow Test ===================================================================================

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/VerificationServicePluginTest.java
@@ -31,7 +31,6 @@ import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
-import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HexFormat;
@@ -547,8 +546,8 @@ class VerificationServicePluginTest
         final BlockFooter footer = new BlockFooter(Bytes.EMPTY, Bytes.EMPTY, Bytes.EMPTY);
         final BlockProof proof = BlockProof.newBuilder()
                 .block(blockNumber)
-                .signedRecordFileProof(new SignedRecordFileProof(
-                        6, List.of(new RecordFileSignature(Bytes.wrap(sigBytes), 0L))))
+                .signedRecordFileProof(
+                        new SignedRecordFileProof(6, List.of(new RecordFileSignature(Bytes.wrap(sigBytes), 0L))))
                 .build();
 
         final List<BlockItemUnparsed> items = List.of(

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/TestVerificationHapiVersions.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/TestVerificationHapiVersions.java
@@ -12,6 +12,7 @@ import com.hedera.pbj.runtime.ParseException;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.node.app.fixtures.blocks.BlockUtils;
@@ -41,7 +42,7 @@ class TestVerificationHapiVersions {
                 .parse(items.getFirst().blockHeaderOrThrow())
                 .number();
         ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.UNKNOWN, null, null, null);
+                new ExtendedMerkleTreeSession(blockNumber, BlockSource.UNKNOWN, null, null, null, Map.of(), null, null, null);
         session.processBlockItems(new BlockItems(items, blockNumber, true, true));
     }
 

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/TestVerificationHapiVersions.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/TestVerificationHapiVersions.java
@@ -41,8 +41,8 @@ class TestVerificationHapiVersions {
         long blockNumber = BlockHeader.PROTOBUF
                 .parse(items.getFirst().blockHeaderOrThrow())
                 .number();
-        ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.UNKNOWN, null, null, null, Map.of(), null, null, null);
+        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(
+                blockNumber, BlockSource.UNKNOWN, null, null, null, Map.of(), null, null, null);
         session.processBlockItems(new BlockItems(items, blockNumber, true, true));
     }
 

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSessionTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSessionTest.java
@@ -50,8 +50,8 @@ class ExtendedMerkleTreeSessionTest {
                 BlockHeader.PROTOBUF.parse(blockItems.getFirst().blockHeaderOrThrow());
         long blockNumber = blockHeader.number();
 
-        ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
+        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(
+                blockNumber, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
 
         BlockItems blockItemsMessage = new BlockItems(blockItems, blockNumber, true, true);
         VerificationNotification blockNotification = session.processBlockItems(blockItemsMessage);
@@ -92,8 +92,8 @@ class ExtendedMerkleTreeSessionTest {
         long blockNumber = BlockHeader.PROTOBUF
                 .parse(items.getFirst().blockHeaderOrThrow())
                 .number();
-        ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
+        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(
+                blockNumber, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
         VerificationNotification notification =
                 session.processBlockItems(new BlockItems(items, blockNumber, true, true));
         assertTrue(
@@ -117,7 +117,8 @@ class ExtendedMerkleTreeSessionTest {
     @Test
     @DisplayName("should reject a malformed 10-byte signature as too short for VK prefix")
     void shouldRejectMalformedShortSignature() {
-        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(0L, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
+        ExtendedMerkleTreeSession session =
+                new ExtendedMerkleTreeSession(0L, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
         Bytes hash = Bytes.wrap(new byte[48]);
         Bytes shortSignature = Bytes.wrap(new byte[10]);
         assertFalse(session.verifySignature(hash, shortSignature), "A 10-byte signature must be rejected as too short");
@@ -127,7 +128,8 @@ class ExtendedMerkleTreeSessionTest {
     @DisplayName("should reject a zero-filled 2920-byte garbage TssWraps signature when no ledger ID")
     void shouldRejectGarbageTssWrapsSignature() {
         // No ledgerId provided, so verifySignature returns false before calling TSS.verifyTSS()
-        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(0L, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
+        ExtendedMerkleTreeSession session =
+                new ExtendedMerkleTreeSession(0L, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
         Bytes hash = Bytes.wrap(new byte[48]);
         Bytes garbageSignature = Bytes.wrap(new byte[2920]);
         assertFalse(
@@ -158,8 +160,8 @@ class ExtendedMerkleTreeSessionTest {
         List<BlockItemUnparsed> items = new ArrayList<>(originalItems);
         items.add(tssProofItem);
 
-        ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
+        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(
+                blockNumber, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
         VerificationNotification notification =
                 session.processBlockItems(new BlockItems(items, blockNumber, true, true));
 
@@ -174,8 +176,8 @@ class ExtendedMerkleTreeSessionTest {
         long blockNumber = BlockHeader.PROTOBUF
                 .parse(items.getFirst().blockHeaderOrThrow())
                 .number();
-        ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, ledgerId, Map.of(), null, null, null);
+        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(
+                blockNumber, BlockSource.PUBLISHER, null, null, ledgerId, Map.of(), null, null, null);
         session.processBlockItems(new BlockItems(items, blockNumber, true, true));
         return session;
     }

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSessionTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSessionTest.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
@@ -50,7 +51,7 @@ class ExtendedMerkleTreeSessionTest {
         long blockNumber = blockHeader.number();
 
         ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, null);
+                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
 
         BlockItems blockItemsMessage = new BlockItems(blockItems, blockNumber, true, true);
         VerificationNotification blockNotification = session.processBlockItems(blockItemsMessage);
@@ -92,7 +93,7 @@ class ExtendedMerkleTreeSessionTest {
                 .parse(items.getFirst().blockHeaderOrThrow())
                 .number();
         ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, null);
+                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
         VerificationNotification notification =
                 session.processBlockItems(new BlockItems(items, blockNumber, true, true));
         assertTrue(
@@ -116,7 +117,7 @@ class ExtendedMerkleTreeSessionTest {
     @Test
     @DisplayName("should reject a malformed 10-byte signature as too short for VK prefix")
     void shouldRejectMalformedShortSignature() {
-        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(0L, BlockSource.PUBLISHER, null, null, null);
+        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(0L, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
         Bytes hash = Bytes.wrap(new byte[48]);
         Bytes shortSignature = Bytes.wrap(new byte[10]);
         assertFalse(session.verifySignature(hash, shortSignature), "A 10-byte signature must be rejected as too short");
@@ -126,7 +127,7 @@ class ExtendedMerkleTreeSessionTest {
     @DisplayName("should reject a zero-filled 2920-byte garbage TssWraps signature when no ledger ID")
     void shouldRejectGarbageTssWrapsSignature() {
         // No ledgerId provided, so verifySignature returns false before calling TSS.verifyTSS()
-        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(0L, BlockSource.PUBLISHER, null, null, null);
+        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(0L, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
         Bytes hash = Bytes.wrap(new byte[48]);
         Bytes garbageSignature = Bytes.wrap(new byte[2920]);
         assertFalse(
@@ -158,7 +159,7 @@ class ExtendedMerkleTreeSessionTest {
         items.add(tssProofItem);
 
         ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, null);
+                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
         VerificationNotification notification =
                 session.processBlockItems(new BlockItems(items, blockNumber, true, true));
 
@@ -174,7 +175,7 @@ class ExtendedMerkleTreeSessionTest {
                 .parse(items.getFirst().blockHeaderOrThrow())
                 .number();
         ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, ledgerId);
+                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, ledgerId, Map.of(), null, null, null);
         session.processBlockItems(new BlockItems(items, blockNumber, true, true));
         return session;
     }

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
@@ -465,8 +465,8 @@ class RsaWrbVerificationTest {
         // Case 1: empty RECORD_FILE bytes — nothing to extract → field not found → Bytes.EMPTY → fail
         final ExtendedMerkleTreeSession session1 = new ExtendedMerkleTreeSession(
                 BLOCK_NUMBER, BlockSource.PUBLISHER, null, null, null, KEY_MAP, null, null, null);
-        final VerificationNotification result1 = session1.processBlockItems(new BlockItems(
-                buildWrbBlockWithCustomRecordFile(Bytes.EMPTY, sigs), BLOCK_NUMBER, true, true));
+        final VerificationNotification result1 = session1.processBlockItems(
+                new BlockItems(buildWrbBlockWithCustomRecordFile(Bytes.EMPTY, sigs), BLOCK_NUMBER, true, true));
         assertNotNull(result1);
         assertFalse(result1.success(), "Empty RECORD_FILE bytes must cause extraction failure → rejected");
 
@@ -475,8 +475,8 @@ class RsaWrbVerificationTest {
         final Bytes field1Only = Bytes.wrap(new byte[] {0x0A, 0x01, 0x42});
         final ExtendedMerkleTreeSession session2 = new ExtendedMerkleTreeSession(
                 BLOCK_NUMBER, BlockSource.PUBLISHER, null, null, null, KEY_MAP, null, null, null);
-        final VerificationNotification result2 = session2.processBlockItems(new BlockItems(
-                buildWrbBlockWithCustomRecordFile(field1Only, sigs), BLOCK_NUMBER, true, true));
+        final VerificationNotification result2 = session2.processBlockItems(
+                new BlockItems(buildWrbBlockWithCustomRecordFile(field1Only, sigs), BLOCK_NUMBER, true, true));
         assertNotNull(result2);
         assertFalse(result2.success(), "RECORD_FILE with no field-2 must cause extraction failure → rejected");
 
@@ -485,8 +485,8 @@ class RsaWrbVerificationTest {
         final Bytes unknownWireType = Bytes.wrap(new byte[] {0x0B});
         final ExtendedMerkleTreeSession session3 = new ExtendedMerkleTreeSession(
                 BLOCK_NUMBER, BlockSource.PUBLISHER, null, null, null, KEY_MAP, null, null, null);
-        final VerificationNotification result3 = session3.processBlockItems(new BlockItems(
-                buildWrbBlockWithCustomRecordFile(unknownWireType, sigs), BLOCK_NUMBER, true, true));
+        final VerificationNotification result3 = session3.processBlockItems(
+                new BlockItems(buildWrbBlockWithCustomRecordFile(unknownWireType, sigs), BLOCK_NUMBER, true, true));
         assertNotNull(result3);
         assertFalse(result3.success(), "Unknown wire type in RECORD_FILE must bail out → rejected");
     }

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
@@ -43,25 +43,27 @@ import org.junit.jupiter.params.provider.MethodSource;
  * `ExtendedMerkleTreeSession`.
  *
  * <p>Tests use synthetic blocks and in-process RSA key pairs — no real testnet blocks are required.
- * Six nodes are used so the supermajority threshold (`floor(2*6/3) + 1 = 5`) is testable with
- * both passing (5 or 6 valid sigs) and failing (4 valid sigs) scenarios.
+ * Six nodes are used so the strict majority threshold (`> N/2 = > 3` for 6 nodes, i.e. ≥ 4) is
+ * testable with both passing (≥ 4 valid sigs) and failing (≤ 3 valid sigs) scenarios.
+ * All signatures present must pass RSA verification — any single failed sig causes immediate
+ * block rejection, regardless of how many other sigs are valid.
  *
  * <p>The raw `RecordFileItem` proto is assembled manually using protobuf wire format so that
  * `extractRecordStreamFileBytes` is exercised by the field-2 extraction path.
  */
 class RsaWrbVerificationTest {
 
-    /** Number of test nodes — threshold is `floor(2*6/3) + 1 = 5`. */
+    /** Number of test nodes. Strict majority threshold for 6 nodes is > 3 (i.e. ≥ 4 valid sigs). */
     private static final int ROSTER_SIZE = 6;
 
     /**
      * Extended key pool size for the parametrised threshold tests.
-     * Covers all roster sizes tested in `supermajorityThreshold_exactlyMet_acceptedOneLess_rejected`.
+     * Covers all roster sizes tested in `strictMajorityThreshold_exactlyMet_acceptedOneLess_rejected`.
      */
     private static final int MAX_KEY_POOL = 9;
 
-    /** Supermajority threshold for 6 nodes. */
-    private static final int THRESHOLD = 5;
+    /** Strict majority threshold for 6 nodes: validCount * 2 > 6 → validCount ≥ 4. */
+    private static final int THRESHOLD = 4;
 
     /** HAPI version >= 0.72.0 routes to `ExtendedMerkleTreeSession`. */
     private static final SemanticVersion HAPI_VERSION = new SemanticVersion(1, 0, 0, "", "");
@@ -213,8 +215,8 @@ class RsaWrbVerificationTest {
     @Test
     @DisplayName("valid proof at exactly the threshold is accepted")
     void validProofAtExactThreshold_accepted() throws Exception {
-        // threshold = 5; sign with exactly nodes 0..4
-        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L);
+        // strict majority threshold for 6 nodes: > 3, i.e. exactly 4 valid sigs
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L);
         final VerificationNotification result = runVerification(KEY_MAP, sigs);
 
         assertNotNull(result, "Session must produce a notification");
@@ -236,8 +238,8 @@ class RsaWrbVerificationTest {
     @Test
     @DisplayName("valid proof one below threshold is rejected")
     void validProofOneBelowThreshold_rejected() throws Exception {
-        // threshold = 5; sign with only nodes 0..3 (4 valid sigs)
-        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L);
+        // strict majority for 6 nodes requires > 3; exactly 3 valid sigs → 3*2=6 not > 6 → rejected
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L);
         final VerificationNotification result = runVerification(KEY_MAP, sigs);
 
         assertNotNull(result);
@@ -287,9 +289,10 @@ class RsaWrbVerificationTest {
     }
 
     @Test
-    @DisplayName("wrong payload signature (signed wrong data) counts as invalid")
-    void wrongPayloadSignature_countedInvalid() throws Exception {
-        // Sign wrong data with all 6 node keys — only 0 valid sigs
+    @DisplayName("wrong payload signature (signed wrong data) causes immediate block rejection")
+    void wrongPayloadSignature_immediatelyRejectsBlock() throws Exception {
+        // CN only sends signatures from consensus-contributing nodes, so a failed RSA verify
+        // means the proof or block is tampered — the block is rejected at the first failing sig.
         final List<RecordFileSignature> sigs = new ArrayList<>();
         final byte[] wrongData = "totally-wrong-payload".getBytes();
         for (long id = 0; id < ROSTER_SIZE; id++) {
@@ -301,7 +304,28 @@ class RsaWrbVerificationTest {
         final VerificationNotification result = runVerification(KEY_MAP, sigs);
 
         assertNotNull(result);
-        assertFalse(result.success(), "Signatures on wrong payload must not verify");
+        assertFalse(result.success(), "Any signature failing RSA verification must cause immediate block rejection");
+    }
+
+    @Test
+    @DisplayName("one bad sig among otherwise sufficient valid sigs causes immediate block rejection")
+    void oneBadSigAmongValids_immediatelyRejectsBlock() throws Exception {
+        // 5 valid sigs from nodes 0..4 (would exceed the majority threshold of > 3 on their own),
+        // but node 5 signs the wrong payload — the block must be rejected immediately.
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L);
+        final byte[] wrongData = "tampered-payload".getBytes();
+        final Signature engine = Signature.getInstance("SHA384withRSA");
+        engine.initSign(PRIVATE_KEY_MAP.get(5L));
+        engine.update(wrongData);
+        sigs.add(new RecordFileSignature(Bytes.wrap(engine.sign()), 5L));
+
+        final VerificationNotification result = runVerification(KEY_MAP, sigs);
+
+        assertNotNull(result);
+        assertFalse(
+                result.success(),
+                "Block must be rejected immediately when any signature from a known node fails — "
+                        + "even if the remaining valid sigs would satisfy the majority count");
     }
 
     @Test
@@ -319,30 +343,32 @@ class RsaWrbVerificationTest {
     void malformedKeyExcludedFromMap_restStillCounted() throws Exception {
         // Build a key map where node 5 has a malformed (random) key — RsaKeyDecoder would skip it.
         // Here we simulate by simply omitting node 5 from the map (as if buildKeyMap had skipped it).
-        // 5 valid sigs from nodes 0..4 still meet the threshold of 5 for a 5-node roster.
+        // 5-node roster — strict majority threshold: > 2.5, i.e. ≥ 3 valid sigs.
         final Map<Long, PublicKey> reducedMap = new HashMap<>(KEY_MAP);
-        reducedMap.remove(5L); // 5-node roster now — threshold = floor(2*5/3)+1 = 3+1 = 4
+        reducedMap.remove(5L); // 5-node roster now — threshold: validCount*2 > 5 → ≥ 3
 
         final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L);
         final VerificationNotification result = runVerification(reducedMap, sigs);
 
         assertNotNull(result);
-        // threshold for 5 nodes = 4; 5 valid sigs ≥ 4 → accepted
-        assertTrue(result.success(), "5 valid sigs out of 5-node roster meets the threshold of 4");
+        // 5 valid sigs, 5*2=10 > 5 → accepted
+        assertTrue(result.success(), "5 valid sigs out of 5-node roster exceeds the strict majority threshold of > 2");
     }
 
     @Test
     @DisplayName("duplicate node_id in proof is counted only once toward the threshold")
     void duplicateNodeId_countedOnlyOnce() throws Exception {
-        // threshold = 5; send 4 distinct valid signatures + 1 duplicate of node 0 = still only 4 valid
-        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L);
+        // 6-node roster; strict majority requires > 3 (i.e. ≥ 4 valid).
+        // Send 3 distinct valid signatures + 1 duplicate of node 0 → validCount stays at 3.
+        // 3*2=6 not > 6 → rejected.
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L);
         sigs.add(new RecordFileSignature(Bytes.wrap(sign(0L)), 0L)); // duplicate node 0
         final VerificationNotification result = runVerification(KEY_MAP, sigs);
 
         assertNotNull(result);
         assertFalse(
                 result.success(),
-                "Duplicate signature from node 0 must not count twice — validCount stays at 4, below threshold 5");
+                "Duplicate signature from node 0 must not count twice — validCount stays at 3, not > rosterSize/2");
     }
 
     @Test
@@ -492,18 +518,15 @@ class RsaWrbVerificationTest {
     }
 
     /**
-     * Verifies that the supermajority threshold `floor(2 * rosterSize / 3) + 1` is correctly
-     * implemented for roster sizes that are not multiples of 3.
-     *
-     * <p>The former formula `2 * ceil(rosterSize / 3) + 1` only agreed with `floor(2n/3) + 1`
-     * when `rosterSize` was a multiple of 3. For example, with 7 nodes it produced threshold=7
-     * (unanimous, impossible with any offline node) instead of the correct threshold=5.
+     * Verifies that the strict majority threshold (`validCount * 2 > rosterSize`) is correctly
+     * enforced across a range of roster sizes. The minimum valid count is the smallest integer
+     * strictly greater than half the roster: `floor(rosterSize / 2) + 1`.
      */
-    @ParameterizedTest(name = "rosterSize={0} → threshold={1}")
+    @ParameterizedTest(name = "rosterSize={0} → minValidCount={1}")
     @MethodSource("thresholdCases")
-    @DisplayName("supermajority threshold floor(2n/3)+1 is correct across roster sizes")
-    void supermajorityThreshold_exactlyMet_acceptedOneLess_rejected(final int rosterSize, final int expectedThreshold)
-            throws Exception {
+    @DisplayName("strict majority threshold (validCount*2 > rosterSize) is correct across roster sizes")
+    void strictMajorityThreshold_exactlyMet_acceptedOneLess_rejected(
+            final int rosterSize, final int expectedThreshold) throws Exception {
         // Build a key map from the extended pool so existing 6-node KEY_MAP is unaffected.
         final Map<Long, PublicKey> keyMap = new HashMap<>();
         for (long id = 0; id < rosterSize; id++) {
@@ -530,15 +553,15 @@ class RsaWrbVerificationTest {
     }
 
     static Stream<Arguments> thresholdCases() {
-        // floor(2*n/3) + 1 for each roster size
+        // Minimum validCount such that validCount * 2 > rosterSize (i.e. floor(rosterSize/2) + 1)
         return Stream.of(
-                Arguments.of(3, 3), // floor(6/3)  + 1 = 3
-                Arguments.of(4, 3), // floor(8/3)  + 1 = 3
-                Arguments.of(5, 4), // floor(10/3) + 1 = 4
-                Arguments.of(6, 5), // floor(12/3) + 1 = 5
-                Arguments.of(7, 5), // floor(14/3) + 1 = 5
-                Arguments.of(8, 6), // floor(16/3) + 1 = 6
-                Arguments.of(9, 7) //  floor(18/3) + 1 = 7
-                );
+                Arguments.of(3, 2), // 2*2=4 > 3 ✓ ; 1*2=2 not > 3
+                Arguments.of(4, 3), // 3*2=6 > 4 ✓ ; 2*2=4 not > 4
+                Arguments.of(5, 3), // 3*2=6 > 5 ✓ ; 2*2=4 not > 5
+                Arguments.of(6, 4), // 4*2=8 > 6 ✓ ; 3*2=6 not > 6
+                Arguments.of(7, 4), // 4*2=8 > 7 ✓ ; 3*2=6 not > 7
+                Arguments.of(8, 5), // 5*2=10 > 8 ✓ ; 4*2=8 not > 8
+                Arguments.of(9, 5)  // 5*2=10 > 9 ✓ ; 4*2=8 not > 9
+        );
     }
 }

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
@@ -33,13 +34,16 @@ import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Unit tests for the RSA `SignedRecordFileProof` verification path in
  * `ExtendedMerkleTreeSession`.
  *
  * <p>Tests use synthetic blocks and in-process RSA key pairs — no real testnet blocks are required.
- * Six nodes are used so the supermajority threshold (`2 * ceil(6/3) + 1 = 5`) is testable with
+ * Six nodes are used so the supermajority threshold (`floor(2*6/3) + 1 = 5`) is testable with
  * both passing (5 or 6 valid sigs) and failing (4 valid sigs) scenarios.
  *
  * <p>The raw `RecordFileItem` proto is assembled manually using protobuf wire format so that
@@ -47,8 +51,14 @@ import org.junit.jupiter.api.Test;
  */
 class RsaWrbVerificationTest {
 
-    /** Number of test nodes — threshold is `2 * ceil(6/3) + 1 = 5`. */
+    /** Number of test nodes — threshold is `floor(2*6/3) + 1 = 5`. */
     private static final int ROSTER_SIZE = 6;
+
+    /**
+     * Extended key pool size for the parametrised threshold tests.
+     * Covers all roster sizes tested in `supermajorityThreshold_exactlyMet_acceptedOneLess_rejected`.
+     */
+    private static final int MAX_KEY_POOL = 9;
 
     /** Supermajority threshold for 6 nodes. */
     private static final int THRESHOLD = 5;
@@ -66,11 +76,21 @@ class RsaWrbVerificationTest {
      */
     private static final byte[] RECORD_STREAM_FILE_BYTES = "test-record-stream-file-v6-content".getBytes();
 
-    /** RSA public keys indexed by node_id (0 .. ROSTER_SIZE-1). */
+    /** RSA public keys indexed by node_id (0 .. ROSTER_SIZE-1). Used by the existing 6-node tests. */
     private static final Map<Long, PublicKey> KEY_MAP = new HashMap<>();
 
-    /** RSA private keys indexed by node_id (0 .. ROSTER_SIZE-1). */
+    /** RSA private keys indexed by node_id (0 .. ROSTER_SIZE-1). Used by the existing 6-node tests. */
     private static final Map<Long, PrivateKey> PRIVATE_KEY_MAP = new HashMap<>();
+
+    /**
+     * Extended public key pool covering node_ids 0 .. MAX_KEY_POOL-1.
+     * Used exclusively by the parametrised threshold test so it can build rosters of varying sizes
+     * without affecting the existing 6-node test fixtures.
+     */
+    private static final Map<Long, PublicKey> EXTENDED_KEY_MAP = new HashMap<>();
+
+    /** Extended private key pool paired with `EXTENDED_KEY_MAP`. */
+    private static final Map<Long, PrivateKey> EXTENDED_PRIVATE_KEY_MAP = new HashMap<>();
 
     /** Serialized `RecordFileItem` proto with field 2 = `RECORD_STREAM_FILE_BYTES`. */
     private static Bytes recordFileItemBytes;
@@ -83,10 +103,17 @@ class RsaWrbVerificationTest {
         // 1024-bit RSA keys are used for test speed only — production network uses 4096-bit keys.
         final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
         kpg.initialize(1024);
+        // Generate the 6-node pool used by the fixed-roster tests.
         for (long nodeId = 0; nodeId < ROSTER_SIZE; nodeId++) {
             final KeyPair kp = kpg.generateKeyPair();
             KEY_MAP.put(nodeId, kp.getPublic());
             PRIVATE_KEY_MAP.put(nodeId, kp.getPrivate());
+        }
+        // Generate the extended pool (MAX_KEY_POOL nodes) for the parametrised threshold tests.
+        for (long nodeId = 0; nodeId < MAX_KEY_POOL; nodeId++) {
+            final KeyPair kp = kpg.generateKeyPair();
+            EXTENDED_KEY_MAP.put(nodeId, kp.getPublic());
+            EXTENDED_PRIVATE_KEY_MAP.put(nodeId, kp.getPrivate());
         }
 
         // Build a minimal RecordFileItem proto: field 2 (tag=18, wire=LEN) = RECORD_STREAM_FILE_BYTES
@@ -161,13 +188,24 @@ class RsaWrbVerificationTest {
         return session.processBlockItems(new BlockItems(items, BLOCK_NUMBER, true, true));
     }
 
-    /** Signs with the given node IDs and returns a `RecordFileSignature` list. */
+    /** Signs with the given node IDs (from the 6-node pool) and returns a `RecordFileSignature` list. */
     private static List<RecordFileSignature> signaturesFor(final long... nodeIds) throws Exception {
         final List<RecordFileSignature> sigs = new ArrayList<>();
         for (final long nodeId : nodeIds) {
             sigs.add(new RecordFileSignature(Bytes.wrap(sign(nodeId)), nodeId));
         }
         return sigs;
+    }
+
+    /**
+     * Signs `signedPayload` with the extended pool private key for `nodeId` and returns a
+     * `RecordFileSignature`. Used only by the parametrised threshold test.
+     */
+    private static RecordFileSignature extendedSignature(final long nodeId) throws Exception {
+        final Signature engine = Signature.getInstance("SHA384withRSA");
+        engine.initSign(EXTENDED_PRIVATE_KEY_MAP.get(nodeId));
+        engine.update(signedPayload);
+        return new RecordFileSignature(Bytes.wrap(engine.sign()), nodeId);
     }
 
     // ---- Tests -------------------------------------------------------------------------------
@@ -283,14 +321,14 @@ class RsaWrbVerificationTest {
         // Here we simulate by simply omitting node 5 from the map (as if buildKeyMap had skipped it).
         // 5 valid sigs from nodes 0..4 still meet the threshold of 5 for a 5-node roster.
         final Map<Long, PublicKey> reducedMap = new HashMap<>(KEY_MAP);
-        reducedMap.remove(5L); // 5-node roster now — threshold = 2*ceil(5/3)+1 = 2*2+1 = 5
+        reducedMap.remove(5L); // 5-node roster now — threshold = floor(2*5/3)+1 = 3+1 = 4
 
         final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L);
         final VerificationNotification result = runVerification(reducedMap, sigs);
 
         assertNotNull(result);
-        // threshold for 5 nodes = 5; exactly 5 valid sigs → accepted
-        assertTrue(result.success(), "5 valid sigs out of 5-node roster meets the threshold");
+        // threshold for 5 nodes = 4; 5 valid sigs ≥ 4 → accepted
+        assertTrue(result.success(), "5 valid sigs out of 5-node roster meets the threshold of 4");
     }
 
     @Test
@@ -390,5 +428,56 @@ class RsaWrbVerificationTest {
 
         assertNotNull(result);
         assertTrue(result.success(), "Field-2 bytes must be correctly extracted even when field-1 precedes them");
+    }
+
+    /**
+     * Verifies that the supermajority threshold `floor(2 * rosterSize / 3) + 1` is correctly
+     * implemented for roster sizes that are not multiples of 3.
+     *
+     * <p>The former formula `2 * ceil(rosterSize / 3) + 1` only agreed with `floor(2n/3) + 1`
+     * when `rosterSize` was a multiple of 3. For example, with 7 nodes it produced threshold=7
+     * (unanimous, impossible with any offline node) instead of the correct threshold=5.
+     */
+    @ParameterizedTest(name = "rosterSize={0} → threshold={1}")
+    @MethodSource("thresholdCases")
+    @DisplayName("supermajority threshold floor(2n/3)+1 is correct across roster sizes")
+    void supermajorityThreshold_exactlyMet_acceptedOneLess_rejected(final int rosterSize, final int expectedThreshold)
+            throws Exception {
+        // Build a key map from the extended pool so existing 6-node KEY_MAP is unaffected.
+        final Map<Long, PublicKey> keyMap = new HashMap<>();
+        for (long id = 0; id < rosterSize; id++) {
+            keyMap.put(id, EXTENDED_KEY_MAP.get(id));
+        }
+
+        // Exactly threshold valid sigs → must be accepted
+        final List<RecordFileSignature> atThreshold = new ArrayList<>();
+        for (long id = 0; id < expectedThreshold; id++) {
+            atThreshold.add(extendedSignature(id));
+        }
+        assertTrue(
+                runVerification(keyMap, atThreshold).success(),
+                "rosterSize=" + rosterSize + ": " + expectedThreshold + " sigs (= threshold) must be accepted");
+
+        // One below threshold → must be rejected
+        final List<RecordFileSignature> oneLess = new ArrayList<>();
+        for (long id = 0; id < expectedThreshold - 1; id++) {
+            oneLess.add(extendedSignature(id));
+        }
+        assertFalse(
+                runVerification(keyMap, oneLess).success(),
+                "rosterSize=" + rosterSize + ": " + (expectedThreshold - 1) + " sigs (threshold-1) must be rejected");
+    }
+
+    static Stream<Arguments> thresholdCases() {
+        // floor(2*n/3) + 1 for each roster size
+        return Stream.of(
+                Arguments.of(3, 3), // floor(6/3)  + 1 = 3
+                Arguments.of(4, 3), // floor(8/3)  + 1 = 3
+                Arguments.of(5, 4), // floor(10/3) + 1 = 4
+                Arguments.of(6, 5), // floor(12/3) + 1 = 5
+                Arguments.of(7, 5), // floor(14/3) + 1 = 5
+                Arguments.of(8, 6), // floor(16/3) + 1 = 6
+                Arguments.of(9, 7) //  floor(18/3) + 1 = 7
+                );
     }
 }

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
@@ -431,6 +431,67 @@ class RsaWrbVerificationTest {
     }
 
     /**
+     * Builds a WRB block using custom {@code recordFileItemBytes} instead of the global fixture.
+     * Used by the edge-case tests for {@code extractRecordStreamFileBytes}.
+     */
+    private static List<BlockItemUnparsed> buildWrbBlockWithCustomRecordFile(
+            final Bytes customRecordFileBytes, final List<RecordFileSignature> signatures) {
+        final BlockHeader header =
+                new BlockHeader(HAPI_VERSION, SW_VERSION, BLOCK_NUMBER, BLOCK_TIMESTAMP, BlockHashAlgorithm.SHA2_384);
+        final BlockFooter footer = new BlockFooter(Bytes.EMPTY, Bytes.EMPTY, Bytes.EMPTY);
+        final BlockProof proof = BlockProof.newBuilder()
+                .block(BLOCK_NUMBER)
+                .signedRecordFileProof(new SignedRecordFileProof(6, signatures))
+                .build();
+        return List.of(
+                BlockItemUnparsed.newBuilder()
+                        .blockHeader(BlockHeader.PROTOBUF.toBytes(header))
+                        .build(),
+                BlockItemUnparsed.newBuilder().recordFile(customRecordFileBytes).build(),
+                BlockItemUnparsed.newBuilder()
+                        .blockFooter(BlockFooter.PROTOBUF.toBytes(footer))
+                        .build(),
+                BlockItemUnparsed.newBuilder()
+                        .blockProof(BlockProof.PROTOBUF.toBytes(proof))
+                        .build());
+    }
+
+    @Test
+    @DisplayName("extractRecordStreamFileBytes: empty, field-2-absent, unknown-wire-type all return EMPTY → failure")
+    void extractRecordStreamFileBytes_defensiveCases() throws Exception {
+        // All cases use valid signatures so any failure is from extraction, not signature validation.
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L);
+
+        // Case 1: empty RECORD_FILE bytes — nothing to extract → field not found → Bytes.EMPTY → fail
+        final ExtendedMerkleTreeSession session1 = new ExtendedMerkleTreeSession(
+                BLOCK_NUMBER, BlockSource.PUBLISHER, null, null, null, KEY_MAP, null, null, null);
+        final VerificationNotification result1 = session1.processBlockItems(new BlockItems(
+                buildWrbBlockWithCustomRecordFile(Bytes.EMPTY, sigs), BLOCK_NUMBER, true, true));
+        assertNotNull(result1);
+        assertFalse(result1.success(), "Empty RECORD_FILE bytes must cause extraction failure → rejected");
+
+        // Case 2: only field 1 present, no field 2 — iterator exhausts without finding field 2 → Bytes.EMPTY → fail
+        // Tag=0x0A (field 1, LEN), length=1, one payload byte
+        final Bytes field1Only = Bytes.wrap(new byte[] {0x0A, 0x01, 0x42});
+        final ExtendedMerkleTreeSession session2 = new ExtendedMerkleTreeSession(
+                BLOCK_NUMBER, BlockSource.PUBLISHER, null, null, null, KEY_MAP, null, null, null);
+        final VerificationNotification result2 = session2.processBlockItems(new BlockItems(
+                buildWrbBlockWithCustomRecordFile(field1Only, sigs), BLOCK_NUMBER, true, true));
+        assertNotNull(result2);
+        assertFalse(result2.success(), "RECORD_FILE with no field-2 must cause extraction failure → rejected");
+
+        // Case 3: unknown wire type (wire type 3) as first tag — bail-out path returns Bytes.EMPTY → fail
+        // Tag = (1 << 3) | 3 = 0x0B (field 1, wire 3 = SGROUP — unused in proto3 but valid tag encoding)
+        final Bytes unknownWireType = Bytes.wrap(new byte[] {0x0B});
+        final ExtendedMerkleTreeSession session3 = new ExtendedMerkleTreeSession(
+                BLOCK_NUMBER, BlockSource.PUBLISHER, null, null, null, KEY_MAP, null, null, null);
+        final VerificationNotification result3 = session3.processBlockItems(new BlockItems(
+                buildWrbBlockWithCustomRecordFile(unknownWireType, sigs), BLOCK_NUMBER, true, true));
+        assertNotNull(result3);
+        assertFalse(result3.success(), "Unknown wire type in RECORD_FILE must bail out → rejected");
+    }
+
+    /**
      * Verifies that the supermajority threshold `floor(2 * rosterSize / 3) + 1` is correctly
      * implemented for roster sizes that are not multiples of 3.
      *

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
@@ -525,8 +525,8 @@ class RsaWrbVerificationTest {
     @ParameterizedTest(name = "rosterSize={0} → minValidCount={1}")
     @MethodSource("thresholdCases")
     @DisplayName("strict majority threshold (validCount*2 > rosterSize) is correct across roster sizes")
-    void strictMajorityThreshold_exactlyMet_acceptedOneLess_rejected(
-            final int rosterSize, final int expectedThreshold) throws Exception {
+    void strictMajorityThreshold_exactlyMet_acceptedOneLess_rejected(final int rosterSize, final int expectedThreshold)
+            throws Exception {
         // Build a key map from the extended pool so existing 6-node KEY_MAP is unaffected.
         final Map<Long, PublicKey> keyMap = new HashMap<>();
         for (long id = 0; id < rosterSize; id++) {
@@ -561,7 +561,7 @@ class RsaWrbVerificationTest {
                 Arguments.of(6, 4), // 4*2=8 > 6 ✓ ; 3*2=6 not > 6
                 Arguments.of(7, 4), // 4*2=8 > 7 ✓ ; 3*2=6 not > 7
                 Arguments.of(8, 5), // 5*2=10 > 8 ✓ ; 4*2=8 not > 8
-                Arguments.of(9, 5)  // 5*2=10 > 9 ✓ ; 4*2=8 not > 9
-        );
+                Arguments.of(9, 5) // 5*2=10 > 9 ✓ ; 4*2=8 not > 9
+                );
     }
 }

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
@@ -80,7 +80,7 @@ class RsaWrbVerificationTest {
 
     @BeforeAll
     static void generateKeysAndPayload() throws Exception {
-        // Generate 1024-bit RSA key pairs for all test nodes
+        // 1024-bit RSA keys are used for test speed only — production network uses 4096-bit keys.
         final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
         kpg.initialize(1024);
         for (long nodeId = 0; nodeId < ROSTER_SIZE; nodeId++) {
@@ -126,8 +126,8 @@ class RsaWrbVerificationTest {
      * @return list of unparsed block items ready to pass to `processBlockItems`
      */
     private static List<BlockItemUnparsed> buildWrbBlock(final List<RecordFileSignature> signatures) {
-        final BlockHeader header = new BlockHeader(
-                HAPI_VERSION, SW_VERSION, BLOCK_NUMBER, BLOCK_TIMESTAMP, BlockHashAlgorithm.SHA2_384);
+        final BlockHeader header =
+                new BlockHeader(HAPI_VERSION, SW_VERSION, BLOCK_NUMBER, BLOCK_TIMESTAMP, BlockHashAlgorithm.SHA2_384);
         final BlockFooter footer = new BlockFooter(Bytes.EMPTY, Bytes.EMPTY, Bytes.EMPTY);
         final BlockProof proof = BlockProof.newBuilder()
                 .block(BLOCK_NUMBER)
@@ -137,9 +137,8 @@ class RsaWrbVerificationTest {
         final BlockItemUnparsed headerItem = BlockItemUnparsed.newBuilder()
                 .blockHeader(BlockHeader.PROTOBUF.toBytes(header))
                 .build();
-        final BlockItemUnparsed recordFileItem = BlockItemUnparsed.newBuilder()
-                .recordFile(recordFileItemBytes)
-                .build();
+        final BlockItemUnparsed recordFileItem =
+                BlockItemUnparsed.newBuilder().recordFile(recordFileItemBytes).build();
         final BlockItemUnparsed footerItem = BlockItemUnparsed.newBuilder()
                 .blockFooter(BlockFooter.PROTOBUF.toBytes(footer))
                 .build();
@@ -244,7 +243,8 @@ class RsaWrbVerificationTest {
         final VerificationNotification result = runVerification(keyMap, sigs);
 
         assertNotNull(result);
-        assertTrue(result.success(),
+        assertTrue(
+                result.success(),
                 "Sig from unknown node should be skipped; valid sigs from known nodes still meet threshold");
     }
 
@@ -294,6 +294,56 @@ class RsaWrbVerificationTest {
     }
 
     @Test
+    @DisplayName("duplicate node_id in proof is counted only once toward the threshold")
+    void duplicateNodeId_countedOnlyOnce() throws Exception {
+        // threshold = 5; send 4 distinct valid signatures + 1 duplicate of node 0 = still only 4 valid
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L);
+        sigs.add(new RecordFileSignature(Bytes.wrap(sign(0L)), 0L)); // duplicate node 0
+        final VerificationNotification result = runVerification(KEY_MAP, sigs);
+
+        assertNotNull(result);
+        assertFalse(
+                result.success(),
+                "Duplicate signature from node 0 must not count twice — validCount stays at 4, below threshold 5");
+    }
+
+    @Test
+    @DisplayName("unsupported proof version (V5) is rejected")
+    void unsupportedVersion_rejected() throws Exception {
+        final List<BlockItemUnparsed> items;
+        {
+            final BlockHeader header = new BlockHeader(
+                    HAPI_VERSION, SW_VERSION, BLOCK_NUMBER, BLOCK_TIMESTAMP, BlockHashAlgorithm.SHA2_384);
+            final BlockFooter footer = new BlockFooter(Bytes.EMPTY, Bytes.EMPTY, Bytes.EMPTY);
+            // Version 5 — only V6 is supported in Phase 2a
+            final BlockProof proof = BlockProof.newBuilder()
+                    .block(BLOCK_NUMBER)
+                    .signedRecordFileProof(new SignedRecordFileProof(5, signaturesFor(0L, 1L, 2L, 3L, 4L)))
+                    .build();
+            items = List.of(
+                    BlockItemUnparsed.newBuilder()
+                            .blockHeader(BlockHeader.PROTOBUF.toBytes(header))
+                            .build(),
+                    BlockItemUnparsed.newBuilder()
+                            .recordFile(recordFileItemBytes)
+                            .build(),
+                    BlockItemUnparsed.newBuilder()
+                            .blockFooter(BlockFooter.PROTOBUF.toBytes(footer))
+                            .build(),
+                    BlockItemUnparsed.newBuilder()
+                            .blockProof(BlockProof.PROTOBUF.toBytes(proof))
+                            .build());
+        }
+        final ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(
+                BLOCK_NUMBER, BlockSource.PUBLISHER, null, null, null, KEY_MAP, null, null, null);
+        final VerificationNotification result =
+                session.processBlockItems(new BlockItems(items, BLOCK_NUMBER, true, true));
+
+        assertNotNull(result);
+        assertFalse(result.success(), "SignedRecordFileProof version 5 must be rejected — only V6 is supported");
+    }
+
+    @Test
     @DisplayName("RSA V6: extractRecordStreamFileBytes correctly isolates field-2 bytes")
     void recordStreamFileBytesExtractedCorrectly_signatureVerifies() throws Exception {
         // Add a field-1 entry before field-2 in the proto bytes to confirm the parser skips correctly.
@@ -339,7 +389,6 @@ class RsaWrbVerificationTest {
                 session.processBlockItems(new BlockItems(items, BLOCK_NUMBER, true, true));
 
         assertNotNull(result);
-        assertTrue(result.success(),
-                "Field-2 bytes must be correctly extracted even when field-1 precedes them");
+        assertTrue(result.success(), "Field-2 bytes must be correctly extracted even when field-1 precedes them");
     }
 }

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.verification.session.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hapi.block.stream.BlockProof;
+import com.hedera.hapi.block.stream.RecordFileSignature;
+import com.hedera.hapi.block.stream.SignedRecordFileProof;
+import com.hedera.hapi.block.stream.output.BlockFooter;
+import com.hedera.hapi.block.stream.output.BlockHeader;
+import com.hedera.hapi.node.base.BlockHashAlgorithm;
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.io.ByteArrayOutputStream;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the RSA `SignedRecordFileProof` verification path in
+ * `ExtendedMerkleTreeSession`.
+ *
+ * <p>Tests use synthetic blocks and in-process RSA key pairs — no real testnet blocks are required.
+ * Six nodes are used so the supermajority threshold (`2 * ceil(6/3) + 1 = 5`) is testable with
+ * both passing (5 or 6 valid sigs) and failing (4 valid sigs) scenarios.
+ *
+ * <p>The raw `RecordFileItem` proto is assembled manually using protobuf wire format so that
+ * `extractRecordStreamFileBytes` is exercised by the field-2 extraction path.
+ */
+class RsaWrbVerificationTest {
+
+    /** Number of test nodes — threshold is `2 * ceil(6/3) + 1 = 5`. */
+    private static final int ROSTER_SIZE = 6;
+
+    /** Supermajority threshold for 6 nodes. */
+    private static final int THRESHOLD = 5;
+
+    /** HAPI version >= 0.72.0 routes to `ExtendedMerkleTreeSession`. */
+    private static final SemanticVersion HAPI_VERSION = new SemanticVersion(1, 0, 0, "", "");
+
+    private static final SemanticVersion SW_VERSION = new SemanticVersion(1, 0, 0, "", "");
+    private static final Timestamp BLOCK_TIMESTAMP = new Timestamp(1_700_000_000L, 0);
+    private static final long BLOCK_NUMBER = 42L;
+
+    /**
+     * Raw bytes used as the `record_file_contents` (field 2) of the test `RecordFileItem`.
+     * These represent a minimal placeholder — only the bytes matter for the hash computation.
+     */
+    private static final byte[] RECORD_STREAM_FILE_BYTES = "test-record-stream-file-v6-content".getBytes();
+
+    /** RSA public keys indexed by node_id (0 .. ROSTER_SIZE-1). */
+    private static final Map<Long, PublicKey> KEY_MAP = new HashMap<>();
+
+    /** RSA private keys indexed by node_id (0 .. ROSTER_SIZE-1). */
+    private static final Map<Long, PrivateKey> PRIVATE_KEY_MAP = new HashMap<>();
+
+    /** Serialized `RecordFileItem` proto with field 2 = `RECORD_STREAM_FILE_BYTES`. */
+    private static Bytes recordFileItemBytes;
+
+    /** V6 signed payload for the above record file: SHA-384(int32(6) || RECORD_STREAM_FILE_BYTES). */
+    private static byte[] signedPayload;
+
+    @BeforeAll
+    static void generateKeysAndPayload() throws Exception {
+        // Generate 1024-bit RSA key pairs for all test nodes
+        final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(1024);
+        for (long nodeId = 0; nodeId < ROSTER_SIZE; nodeId++) {
+            final KeyPair kp = kpg.generateKeyPair();
+            KEY_MAP.put(nodeId, kp.getPublic());
+            PRIVATE_KEY_MAP.put(nodeId, kp.getPrivate());
+        }
+
+        // Build a minimal RecordFileItem proto: field 2 (tag=18, wire=LEN) = RECORD_STREAM_FILE_BYTES
+        // Proto wire format: tag_varint | length_varint | bytes
+        // tag = (2 << 3) | 2 = 18 = 0x12
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        bos.write(0x12); // tag: field 2, wire type 2 (LEN)
+        bos.write(RECORD_STREAM_FILE_BYTES.length); // length fits in one byte (< 128)
+        bos.write(RECORD_STREAM_FILE_BYTES);
+        recordFileItemBytes = Bytes.wrap(bos.toByteArray());
+
+        // V6 signed payload: SHA-384(int32(6) || RECORD_STREAM_FILE_BYTES)
+        final MessageDigest digest = MessageDigest.getInstance("SHA-384");
+        digest.update(new byte[] {0, 0, 0, 6});
+        digest.update(RECORD_STREAM_FILE_BYTES);
+        signedPayload = digest.digest();
+    }
+
+    // ---- Helper methods -----------------------------------------------------------------------
+
+    /**
+     * Signs `signedPayload` with the RSA private key of the given node and returns the
+     * signature bytes.
+     */
+    private static byte[] sign(final long nodeId) throws Exception {
+        final Signature engine = Signature.getInstance("SHA384withRSA");
+        engine.initSign(PRIVATE_KEY_MAP.get(nodeId));
+        engine.update(signedPayload);
+        return engine.sign();
+    }
+
+    /**
+     * Builds a `BlockItemUnparsed` list representing a minimal WRB block:
+     * `BLOCK_HEADER | RECORD_FILE | BLOCK_FOOTER | BLOCK_PROOF`.
+     *
+     * @param signatures the list of `RecordFileSignature` entries to include in the proof
+     * @return list of unparsed block items ready to pass to `processBlockItems`
+     */
+    private static List<BlockItemUnparsed> buildWrbBlock(final List<RecordFileSignature> signatures) {
+        final BlockHeader header = new BlockHeader(
+                HAPI_VERSION, SW_VERSION, BLOCK_NUMBER, BLOCK_TIMESTAMP, BlockHashAlgorithm.SHA2_384);
+        final BlockFooter footer = new BlockFooter(Bytes.EMPTY, Bytes.EMPTY, Bytes.EMPTY);
+        final BlockProof proof = BlockProof.newBuilder()
+                .block(BLOCK_NUMBER)
+                .signedRecordFileProof(new SignedRecordFileProof(6, signatures))
+                .build();
+
+        final BlockItemUnparsed headerItem = BlockItemUnparsed.newBuilder()
+                .blockHeader(BlockHeader.PROTOBUF.toBytes(header))
+                .build();
+        final BlockItemUnparsed recordFileItem = BlockItemUnparsed.newBuilder()
+                .recordFile(recordFileItemBytes)
+                .build();
+        final BlockItemUnparsed footerItem = BlockItemUnparsed.newBuilder()
+                .blockFooter(BlockFooter.PROTOBUF.toBytes(footer))
+                .build();
+        final BlockItemUnparsed proofItem = BlockItemUnparsed.newBuilder()
+                .blockProof(BlockProof.PROTOBUF.toBytes(proof))
+                .build();
+
+        return List.of(headerItem, recordFileItem, footerItem, proofItem);
+    }
+
+    /**
+     * Runs a single-call verification through `ExtendedMerkleTreeSession` using the given
+     * key map and signatures.
+     */
+    private static VerificationNotification runVerification(
+            final Map<Long, PublicKey> keyMap, final List<RecordFileSignature> signatures) throws Exception {
+        final List<BlockItemUnparsed> items = buildWrbBlock(signatures);
+        final ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(
+                BLOCK_NUMBER, BlockSource.PUBLISHER, null, null, null, keyMap, null, null, null);
+        return session.processBlockItems(new BlockItems(items, BLOCK_NUMBER, true, true));
+    }
+
+    /** Signs with the given node IDs and returns a `RecordFileSignature` list. */
+    private static List<RecordFileSignature> signaturesFor(final long... nodeIds) throws Exception {
+        final List<RecordFileSignature> sigs = new ArrayList<>();
+        for (final long nodeId : nodeIds) {
+            sigs.add(new RecordFileSignature(Bytes.wrap(sign(nodeId)), nodeId));
+        }
+        return sigs;
+    }
+
+    // ---- Tests -------------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("valid proof at exactly the threshold is accepted")
+    void validProofAtExactThreshold_accepted() throws Exception {
+        // threshold = 5; sign with exactly nodes 0..4
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L);
+        final VerificationNotification result = runVerification(KEY_MAP, sigs);
+
+        assertNotNull(result, "Session must produce a notification");
+        assertTrue(result.success(), "Proof with exactly threshold signatures must be accepted");
+        assertNotNull(result.blockHash(), "Block hash must be set on success");
+        assertNotNull(result.block(), "Block must be present on success");
+    }
+
+    @Test
+    @DisplayName("valid proof with all nodes signing is accepted")
+    void validProofAllNodesSigning_accepted() throws Exception {
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L, 5L);
+        final VerificationNotification result = runVerification(KEY_MAP, sigs);
+
+        assertNotNull(result);
+        assertTrue(result.success(), "Proof signed by all nodes must be accepted");
+    }
+
+    @Test
+    @DisplayName("valid proof one below threshold is rejected")
+    void validProofOneBelowThreshold_rejected() throws Exception {
+        // threshold = 5; sign with only nodes 0..3 (4 valid sigs)
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L);
+        final VerificationNotification result = runVerification(KEY_MAP, sigs);
+
+        assertNotNull(result);
+        assertFalse(result.success(), "Proof with fewer than threshold signatures must be rejected");
+        assertNull(result.blockHash(), "Block hash must not be set on failure");
+        assertNull(result.block(), "Block must not be present on failure");
+    }
+
+    @Test
+    @DisplayName("all-zero signature bytes are skipped and count as invalid")
+    void allZeroSignatures_rejected() throws Exception {
+        // Build signatures with all-zero bytes for every node
+        final List<RecordFileSignature> sigs = new ArrayList<>();
+        for (long id = 0; id < ROSTER_SIZE; id++) {
+            sigs.add(new RecordFileSignature(Bytes.wrap(new byte[256]), id));
+        }
+        final VerificationNotification result = runVerification(KEY_MAP, sigs);
+
+        assertNotNull(result);
+        assertFalse(result.success(), "All-zero signatures must not count toward threshold");
+    }
+
+    @Test
+    @DisplayName("empty signature list in proof is rejected")
+    void emptySignatureList_rejected() throws Exception {
+        final VerificationNotification result = runVerification(KEY_MAP, List.of());
+
+        assertNotNull(result);
+        assertFalse(result.success(), "Empty signature list must be rejected");
+    }
+
+    @Test
+    @DisplayName("signature from unknown node_id is skipped; rest still counted")
+    void unknownNodeId_sigSkipped_othersStillCounted() throws Exception {
+        // Nodes 0..4 produce valid sigs (meets threshold); node 99 is not in the key map
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L);
+        // Add a sig from an unknown node
+        sigs.add(new RecordFileSignature(Bytes.wrap(sign(0L) /* use node 0's key bytes */), 99L));
+
+        final Map<Long, PublicKey> keyMap = new HashMap<>(KEY_MAP); // node 99 absent
+        final VerificationNotification result = runVerification(keyMap, sigs);
+
+        assertNotNull(result);
+        assertTrue(result.success(),
+                "Sig from unknown node should be skipped; valid sigs from known nodes still meet threshold");
+    }
+
+    @Test
+    @DisplayName("wrong payload signature (signed wrong data) counts as invalid")
+    void wrongPayloadSignature_countedInvalid() throws Exception {
+        // Sign wrong data with all 6 node keys — only 0 valid sigs
+        final List<RecordFileSignature> sigs = new ArrayList<>();
+        final byte[] wrongData = "totally-wrong-payload".getBytes();
+        for (long id = 0; id < ROSTER_SIZE; id++) {
+            final Signature engine = Signature.getInstance("SHA384withRSA");
+            engine.initSign(PRIVATE_KEY_MAP.get(id));
+            engine.update(wrongData);
+            sigs.add(new RecordFileSignature(Bytes.wrap(engine.sign()), id));
+        }
+        final VerificationNotification result = runVerification(KEY_MAP, sigs);
+
+        assertNotNull(result);
+        assertFalse(result.success(), "Signatures on wrong payload must not verify");
+    }
+
+    @Test
+    @DisplayName("empty address book (keyByNodeId empty) is rejected with error")
+    void emptyAddressBook_rejected() throws Exception {
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L, 5L);
+        final VerificationNotification result = runVerification(Map.of(), sigs);
+
+        assertNotNull(result);
+        assertFalse(result.success(), "An empty address book must cause rejection");
+    }
+
+    @Test
+    @DisplayName("malformed DER key in address book is excluded; remaining keys still counted")
+    void malformedKeyExcludedFromMap_restStillCounted() throws Exception {
+        // Build a key map where node 5 has a malformed (random) key — RsaKeyDecoder would skip it.
+        // Here we simulate by simply omitting node 5 from the map (as if buildKeyMap had skipped it).
+        // 5 valid sigs from nodes 0..4 still meet the threshold of 5 for a 5-node roster.
+        final Map<Long, PublicKey> reducedMap = new HashMap<>(KEY_MAP);
+        reducedMap.remove(5L); // 5-node roster now — threshold = 2*ceil(5/3)+1 = 2*2+1 = 5
+
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L);
+        final VerificationNotification result = runVerification(reducedMap, sigs);
+
+        assertNotNull(result);
+        // threshold for 5 nodes = 5; exactly 5 valid sigs → accepted
+        assertTrue(result.success(), "5 valid sigs out of 5-node roster meets the threshold");
+    }
+
+    @Test
+    @DisplayName("RSA V6: extractRecordStreamFileBytes correctly isolates field-2 bytes")
+    void recordStreamFileBytesExtractedCorrectly_signatureVerifies() throws Exception {
+        // Add a field-1 entry before field-2 in the proto bytes to confirm the parser skips correctly.
+        // Field 1 (tag=10, wire=LEN): creation_time — we put some dummy bytes there.
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        final byte[] dummyField1 = new byte[] {8, 0, 16, 0}; // minimal Timestamp proto (seconds=0, nanos=0)
+        bos.write(0x0A); // tag: field 1 (LEN)
+        bos.write(dummyField1.length);
+        bos.write(dummyField1);
+        bos.write(0x12); // tag: field 2 (LEN)
+        bos.write(RECORD_STREAM_FILE_BYTES.length);
+        bos.write(RECORD_STREAM_FILE_BYTES);
+        final Bytes protoWithBothFields = Bytes.wrap(bos.toByteArray());
+
+        // Build a session using these proto bytes as the RECORD_FILE item
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L);
+        final List<BlockItemUnparsed> items;
+        {
+            final BlockHeader header = new BlockHeader(
+                    HAPI_VERSION, SW_VERSION, BLOCK_NUMBER, BLOCK_TIMESTAMP, BlockHashAlgorithm.SHA2_384);
+            final BlockFooter footer = new BlockFooter(Bytes.EMPTY, Bytes.EMPTY, Bytes.EMPTY);
+            final BlockProof proof = BlockProof.newBuilder()
+                    .block(BLOCK_NUMBER)
+                    .signedRecordFileProof(new SignedRecordFileProof(6, sigs))
+                    .build();
+            items = List.of(
+                    BlockItemUnparsed.newBuilder()
+                            .blockHeader(BlockHeader.PROTOBUF.toBytes(header))
+                            .build(),
+                    BlockItemUnparsed.newBuilder()
+                            .recordFile(protoWithBothFields)
+                            .build(),
+                    BlockItemUnparsed.newBuilder()
+                            .blockFooter(BlockFooter.PROTOBUF.toBytes(footer))
+                            .build(),
+                    BlockItemUnparsed.newBuilder()
+                            .blockProof(BlockProof.PROTOBUF.toBytes(proof))
+                            .build());
+        }
+        final ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(
+                BLOCK_NUMBER, BlockSource.PUBLISHER, null, null, null, KEY_MAP, null, null, null);
+        final VerificationNotification result =
+                session.processBlockItems(new BlockItems(items, BLOCK_NUMBER, true, true));
+
+        assertNotNull(result);
+        assertTrue(result.success(),
+                "Field-2 bytes must be correctly extracted even when field-1 precedes them");
+    }
+}

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/StateProofVerificationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/StateProofVerificationTest.java
@@ -74,8 +74,8 @@ class StateProofVerificationTest {
         VerificationServicePlugin.activeTssPublication = null;
         VerificationServicePlugin.tssParametersPersisted = false;
         // Process block 0 through a session to initialize native TSS state and extract ledger ID
-        ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(block0.blockNumber(), BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
+        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(
+                block0.blockNumber(), BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
         session.processBlockItems(
                 new BlockItems(block0.blockUnparsed().blockItems(), block0.blockNumber(), true, true));
         assertNotNull(VerificationServicePlugin.activeLedgerId, "Block 0 must set the active ledger ID");
@@ -182,8 +182,8 @@ class StateProofVerificationTest {
     }
 
     private VerificationNotification verifyBlock(long blockNumber, BlockUnparsed block) throws ParseException {
-        ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, activeLedgerId, Map.of(), null, null, null);
+        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(
+                blockNumber, BlockSource.PUBLISHER, null, null, activeLedgerId, Map.of(), null, null, null);
         return session.processBlockItems(new BlockItems(block.blockItems(), blockNumber, true, true));
     }
 

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/StateProofVerificationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/StateProofVerificationTest.java
@@ -14,6 +14,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.app.fixtures.blocks.BlockUtils;
@@ -74,7 +75,7 @@ class StateProofVerificationTest {
         VerificationServicePlugin.tssParametersPersisted = false;
         // Process block 0 through a session to initialize native TSS state and extract ledger ID
         ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(block0.blockNumber(), BlockSource.PUBLISHER, null, null, null);
+                new ExtendedMerkleTreeSession(block0.blockNumber(), BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
         session.processBlockItems(
                 new BlockItems(block0.blockUnparsed().blockItems(), block0.blockNumber(), true, true));
         assertNotNull(VerificationServicePlugin.activeLedgerId, "Block 0 must set the active ledger ID");
@@ -182,7 +183,7 @@ class StateProofVerificationTest {
 
     private VerificationNotification verifyBlock(long blockNumber, BlockUnparsed block) throws ParseException {
         ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, activeLedgerId);
+                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, activeLedgerId, Map.of(), null, null, null);
         return session.processBlockItems(new BlockItems(block.blockItems(), blockNumber, true, true));
     }
 

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/TssBlockProofVerificationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/TssBlockProofVerificationTest.java
@@ -56,8 +56,8 @@ class TssBlockProofVerificationTest {
         long blockNumber = BlockHeader.PROTOBUF
                 .parse(wrapsBlock0.blockItems().getFirst().blockHeaderOrThrow())
                 .number();
-        ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
+        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(
+                blockNumber, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
         session.processBlockItems(new BlockItems(wrapsBlock0.blockItems(), blockNumber, true, true));
         assertNotNull(VerificationServicePlugin.activeLedgerId, "Block 0 must set the active ledger ID");
         this.activeLedgerId = VerificationServicePlugin.activeLedgerId;
@@ -116,8 +116,8 @@ class TssBlockProofVerificationTest {
         long blockNumber = BlockHeader.PROTOBUF
                 .parse(block.blockItems().getFirst().blockHeaderOrThrow())
                 .number();
-        ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, ledgerId, Map.of(), null, null, null);
+        ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(
+                blockNumber, BlockSource.PUBLISHER, null, null, ledgerId, Map.of(), null, null, null);
         BlockItems message = new BlockItems(block.blockItems(), blockNumber, true, true);
         VerificationNotification notification = session.processBlockItems(message);
         assertNotNull(notification, "Session must produce a VerificationNotification");

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/TssBlockProofVerificationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/TssBlockProofVerificationTest.java
@@ -13,6 +13,7 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
@@ -56,7 +57,7 @@ class TssBlockProofVerificationTest {
                 .parse(wrapsBlock0.blockItems().getFirst().blockHeaderOrThrow())
                 .number();
         ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, null);
+                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, null, Map.of(), null, null, null);
         session.processBlockItems(new BlockItems(wrapsBlock0.blockItems(), blockNumber, true, true));
         assertNotNull(VerificationServicePlugin.activeLedgerId, "Block 0 must set the active ledger ID");
         this.activeLedgerId = VerificationServicePlugin.activeLedgerId;
@@ -116,7 +117,7 @@ class TssBlockProofVerificationTest {
                 .parse(block.blockItems().getFirst().blockHeaderOrThrow())
                 .number();
         ExtendedMerkleTreeSession session =
-                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, ledgerId);
+                new ExtendedMerkleTreeSession(blockNumber, BlockSource.PUBLISHER, null, null, ledgerId, Map.of(), null, null, null);
         BlockItems message = new BlockItems(block.blockItems(), blockNumber, true, true);
         VerificationNotification notification = session.processBlockItems(message);
         assertNotNull(notification, "Session must produce a VerificationNotification");


### PR DESCRIPTION
## Details
Implements Phase 2a of WRB (Wrapped Record Block) streaming support: RSA-based verification of
`SignedRecordFileProof` block proofs. When a block carries a `SignedRecordFileProof` instead of a
TSS proof, the Block Node now verifies it by counting RSA signatures from the consensus node roster
and checking that a supermajority signed the correct V6 payload.

This PR **depends on #2718** (`NodeAddressBook` state loading/persistence). It consumes the
`NodeAddressBook` delivered by that PR's infrastructure and applies it inside the verification
plugin. The `RsaRosterBootstrapPlugin` that populates the address book at startup lives in a
separate PR (#2683).

Key additions:
- New `RsaKeyDecoder` utility: decodes hex-DER RSA public keys from a `NodeAddressBook` into a
  `Map<Long, PublicKey>` keyed by `node_id`
- `VerificationServicePlugin` extended with `onContextUpdate()` to rebuild the key map when the
  address book changes, and three new per-session RSA metrics
- `ExtendedMerkleTreeSession` extended with the full RSA proof dispatch path: extract
  `record_file_contents` bytes from the `RecordFileItem` proto using direct wire-format navigation,
  compute `SHA-384(int32(6) || rawRecordStreamFileBytes)`, verify each `RecordFileSignature` with
  `SHA384withRSA`, deduplicate by `node_id`, and accept if `validCount ≥ 2 * ceil(N/3) + 1`
- 12 new tests in `RsaWrbVerificationTest` covering threshold boundary, deduplication,
  blank/unknown key handling, wrong payload, V5 rejection, and wire-format field extraction

---

## Changes

### New class — `block-node/verification`

**`RsaKeyDecoder`**
- Decodes a `NodeAddressBook` into an immutable `Map<Long, PublicKey>`
- Keys expected as hex-encoded X.509 DER bytes (no `0x` prefix) — normalisation was done
  upstream by `RsaRosterBootstrapPlugin`
- Fail-soft: entries with a blank key or an invalid DER encoding are skipped with a WARN log so
  one bad key does not prevent the rest of the roster from being loaded
- Mirrors `SigFileUtils.decodePublicKey` in `tools-and-tests/tools`, inlined to avoid a
  cross-module import

### `VerificationServicePlugin`

- Added `volatile Map<Long, PublicKey> keyByNodeId` — written once at startup by `onContextUpdate`,
  read on the block-handling thread; `volatile` ensures cross-thread visibility without a lock
- `onContextUpdate(BlockNodeContext)`: rebuilds `keyByNodeId` via `RsaKeyDecoder.buildKeyMap()`
  when the delivered `NodeAddressBook` is non-null and non-empty; emits a WARNING when an empty
  book arrives so operators can detect misconfiguration
- Three new metrics registered in `init()` and passed through to each session:
  - `blocknode:rsa_verification_success_total` — WRB blocks whose RSA proof was accepted
  - `blocknode:rsa_verification_failure_total` — WRB blocks whose RSA proof was rejected
  - `blocknode:rsa_roster_mismatch_total` — signatures from `node_id` values absent from the
    loaded address book
- Both `handleBlockItemsReceived` and `handleBackfilled` pass `keyByNodeId` and the three metric
  measurements to `HapiVersionSessionFactory.createSession()`

### `HapiVersionSessionFactory`

- Added a 10-parameter overload of `createSession()` that accepts the RSA key map and three metric
  measurements and threads them into `ExtendedMerkleTreeSession`
- The original 6-parameter overload delegates to the new one with `Map.of()` and `null` for the
  RSA parameters — backward-compatible; no existing call sites broken

### `ExtendedMerkleTreeSession`

**New fields:**
- `rawRecordFileItemProtoBytes` (`Bytes`, nullable) — captures the raw bytes of the
  `RecordFileItem` block item during `processBlockItems`; field 2 of this proto is the
  `record_file_contents` required for hash computation
- `rsaKeyByNodeId`, `rsaVerificationSuccessTotal`, `rsaVerificationFailureTotal`,
  `rsaRosterMismatchTotal` — passed from the plugin, non-null `Map.of()` when no book is loaded

**New `ThreadLocal` engines:**
- `SHA384_WITH_RSA` (existing) — reusable `Signature` engine per thread
- `SHA_384` (new) — reusable `MessageDigest` per thread, avoids per-block `getInstance("SHA-384")`
  allocation on the verification hot path

**`finalizeVerification`:**
- RSA proof dispatch added before the existing TSS path; `getFirst()` is used instead of
  `getSingle()` because duplicates in the proof list are handled inside `verifyRsaProof()` rather
  than at the dispatch layer

**`verifyRsaProof()`:**
1. Computes the block root hash for chain continuity (identical computation as the TSS path)
2. Guards: address book must be non-empty; `RECORD_FILE` item must have been seen; version must be 6
3. Calls `extractRecordStreamFileBytes()` to isolate field-2 bytes from the raw proto
4. Computes `SHA-384(int32(6) || rawRecordStreamFileBytes)` using the `ThreadLocal` `MessageDigest`
5. Iterates `proof.recordFileSignatures()` with a `Set<Long> validatedNodes` for deduplication —
   a repeated `node_id` entry cannot inflate `validCount`
6. Skips signatures where `node_id` is absent from the key map or the signature bytes are all zeros
7. Accepts if `validCount >= 2 * ceil(rosterSize / 3) + 1`

**`extractRecordStreamFileBytes()`:**
- Walks the protobuf wire format of the `RecordFileItem` message directly to extract field-2 bytes
- Full `PROTOBUF.parse()` is intentionally avoided: re-serialising a parsed object can produce
  subtly different bytes (omitted default fields, different varint encodings) which would break
  the hash comparison against the consensus node's signature
- Each field is identified by `(tag >>> 3, tag & 0x7)` and either returned (field 2, LEN) or
  skipped by wire type (VARINT/I64/LEN/I32); an unknown wire type or any `RuntimeException` returns
  `Bytes.EMPTY` so the caller fails verification cleanly

**Other:**
- `getFirst()` made `private` (was mistakenly `public static`; no external callers)
- `rawRecordFileItemBytes` renamed to `rawRecordFileItemProtoBytes` to clarify that the field holds
  the serialized outer `RecordFileItem` proto, not the inner record stream file

### Existing test updates

- `AllBlocksHasherHandlerTest`: restored `mock(ApplicationStateFacility.class)` for the
  `applicationStateFacility` argument (had been changed to `null`, risking NPE)
- `ExtendedMerkleTreeSessionTest`, `StateProofVerificationTest`, `TssBlockProofVerificationTest`,
  `TestVerificationHapiVersions`: updated `ExtendedMerkleTreeSession` constructor calls with the
  four new RSA parameters (`Map.of(), null, null, null`)

---

## Test coverage

| Test class | Scenarios covered |
|---|---|
| `RsaWrbVerificationTest.validProofAtExactThreshold_accepted` | Exactly supermajority (5/6) signatures accepted |
| `RsaWrbVerificationTest.validProofAllNodesSigning_accepted` | All 6 nodes signing accepted |
| `RsaWrbVerificationTest.validProofOneBelowThreshold_rejected` | 4/6 signatures rejected |
| `RsaWrbVerificationTest.allZeroSignatures_rejected` | All-zero signature bytes skipped; proof fails |
| `RsaWrbVerificationTest.emptySignatureList_rejected` | Empty signature list rejected |
| `RsaWrbVerificationTest.unknownNodeId_sigSkipped_othersStillCounted` | Unknown node_id skipped; 5 valid from known nodes still accepted |
| `RsaWrbVerificationTest.wrongPayloadSignature_countedInvalid` | Signatures over wrong data rejected |
| `RsaWrbVerificationTest.emptyAddressBook_rejected` | Empty key map causes immediate ERROR + rejection |
| `RsaWrbVerificationTest.malformedKeyExcludedFromMap_restStillCounted` | Reduced 5-node roster; 5 valid sigs accepted |
| `RsaWrbVerificationTest.duplicateNodeId_countedOnlyOnce` | Duplicate node_id entry does not inflate validCount |
| `RsaWrbVerificationTest.unsupportedVersion_rejected` | V5 proof rejected; only V6 supported |
| `RsaWrbVerificationTest.recordStreamFileBytesExtractedCorrectly_signatureVerifies` | Wire-format extraction with field-1 preceding field-2; end-to-end signature still verifies |
| `VerificationServicePluginTest.onContextUpdate_nonEmptyBook_rebuildsKeyMap` | `onContextUpdate` with a real RSA key updates the map |
| `VerificationServicePluginTest.onContextUpdate_emptyBook_retainsKeyMap` | Empty book does not crash or wipe existing map |

---

## Verification algorithm (V6, equal-weight)

```
Input:  SignedRecordFileProof { version=6, recordFileSignatures: [{node_id, sig_bytes}, ...] }
        rawRecordFileItemProtoBytes (captured from the RECORD_FILE block item)

1. Extract field-2 bytes from rawRecordFileItemProtoBytes via wire-format navigation
   → rawRecordStreamFileBytes

2. signedPayload = SHA-384(int32(6) big-endian || rawRecordStreamFileBytes)

3. validCount = 0 ; validatedNodes = {}
   for each (node_id, sig_bytes) in recordFileSignatures:
     - skip if node_id not in keyByNodeId           (roster mismatch)
     - skip if node_id in validatedNodes             (duplicate)
     - skip if sig_bytes are all zeros
     - SHA384withRSA.initVerify(keyByNodeId[node_id])
       SHA384withRSA.update(signedPayload)
       if SHA384withRSA.verify(sig_bytes): validCount++; validatedNodes.add(node_id)

4. threshold = 2 * ceil(rosterSize / 3) + 1
   accept if validCount >= threshold
```

> **Note — `SHA384withRSA` vs raw digest**: `signedPayload` is the 48-byte SHA-384 digest, not the
> raw data. `SHA384withRSA.update(signedPayload)` will hash it again internally. Both the test
> signing helper and the production verification code follow this same pattern, so they are
> internally consistent. Whether this matches the consensus node's signing contract (signing the
> raw bytes vs the pre-hashed bytes) should be confirmed before enabling mainnet verification.

---

## Reviewer Notes

- **Depends on #2718**: `BlockNodeContext.nodeAddressBook()` and `ApplicationStateFacility.updateAddressBook()` are defined there. This PR cannot be merged before #2718.
- **`RsaRosterBootstrapPlugin` (#2683)**: populates `keyByNodeId` at startup. Without it, `keyByNodeId` stays `Map.of()` and every WRB block fails with an ERROR log. This is expected during the transition period while #2683 is pending.
- **Phase 2a scope**: only record file format version 6 is supported. A block with `version != 6` is rejected with a WARNING.
- **Stake-weighted threshold**: the threshold formula `2 * ceil(N/3) + 1` uses equal-weight (one node, one vote). Stake-weighted verification is out of scope for Phase 2a and tracked as a follow-up.
- **Test key size**: `RsaWrbVerificationTest` uses 1024-bit keys for speed; production network nodes use 4096-bit keys.

---

## Related Issue(s)
Depends on #2718 (NodeAddressBook state — must be merged first)
Related: #2683 (RsaRosterBootstrapPlugin — provides the address book at startup)
Closes #2562 
