### PR TITLE
feat: `S3ArchivePlugin` Metrics

### DIFF
--- a/block-node/cloud-storage-archive/build.gradle.kts
+++ b/block-node/cloud-storage-archive/build.gradle.kts
@@ -17,9 +17,6 @@ testModuleInfo {
     requires("org.junit.jupiter.params")
     requires("org.assertj.core")
     requires("org.hiero.block.node.app.test.fixtures")
-    requires("org.hiero.metrics")
     requires("org.testcontainers")
     requires("io.minio")
-    requires("org.mockito")
-    runtimeOnly("org.mockito.junit.jupiter")
 }

--- a/block-node/cloud-storage-archive/src/main/java/module-info.java
+++ b/block-node/cloud-storage-archive/src/main/java/module-info.java
@@ -5,6 +5,7 @@ module org.hiero.block.node.cloud.storage.archive {
     requires transitive com.hedera.bucky;
     requires transitive com.swirlds.config.api;
     requires transitive org.hiero.block.node.spi;
+    requires transitive org.hiero.metrics;
     requires com.hedera.pbj.runtime;
     requires org.hiero.block.node.base;
     requires org.hiero.block.protobuf.pbj;

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTask.java
@@ -51,6 +51,8 @@ public class BlockUploadTask implements Callable<BlockUploadTask.UploadResult> {
     private final CloudStorageArchiveConfig config;
     /// Facility used to publish [PersistedNotification]s after each block is durably stored.
     private final BlockMessagingFacility blockMessaging;
+    /// Metrics holder for tracking upload statistics.
+    private final CloudStorageArchivePlugin.MetricsHolder metricsHolder;
 
     /// The block number of the first block in this batch.
     private final long firstBlock;
@@ -80,8 +82,9 @@ public class BlockUploadTask implements Callable<BlockUploadTask.UploadResult> {
             @NonNull BlockMessagingFacility blockMessaging,
             long firstBlock,
             long groupSize,
-            @NonNull BlockingQueue<BlockWithSource> blockQueue) {
-        this(config, blockMessaging, firstBlock, groupSize, blockQueue, null);
+            @NonNull BlockingQueue<BlockWithSource> blockQueue,
+            @NonNull CloudStorageArchivePlugin.MetricsHolder metricsHolder) {
+        this(config, blockMessaging, firstBlock, groupSize, blockQueue, null, metricsHolder);
     }
 
     /// Creates a task that resumes an existing upload prepared by [StartupRecoveryTask].
@@ -99,7 +102,8 @@ public class BlockUploadTask implements Callable<BlockUploadTask.UploadResult> {
             long firstBlock,
             long groupSize,
             @NonNull BlockingQueue<BlockWithSource> blockQueue,
-            RecoveryResult resumeState) {
+            RecoveryResult resumeState,
+            @NonNull CloudStorageArchivePlugin.MetricsHolder metricsHolder) {
         this.config = config;
         this.blockMessaging = blockMessaging;
         this.firstBlock = firstBlock;
@@ -107,6 +111,7 @@ public class BlockUploadTask implements Callable<BlockUploadTask.UploadResult> {
         this.partSizeBytes = config.partSizeMb() * 1024 * 1024;
         this.blockQueue = blockQueue;
         this.resumeState = resumeState;
+        this.metricsHolder = metricsHolder;
         this.key = ArchiveKey.format(firstBlock, config.groupingLevel());
     }
 
@@ -241,6 +246,8 @@ public class BlockUploadTask implements Callable<BlockUploadTask.UploadResult> {
                         blocksInBuffer.isEmpty() ? Map.entry(blockNum, blockSource) : blocksInBuffer.lastEntry();
                 blockMessaging.sendBlockPersisted(
                         new PersistedNotification(last.getKey(), true, 1_000, last.getValue()));
+                metricsHolder.blocksWritten().increment(blocksInBuffer.size());
+                metricsHolder.storedBytes().increment(partSizeBytes);
                 // Reset the map so the caller starts fresh for the next part's worth of blocks.
                 blocksInBuffer.clear();
             }
@@ -292,6 +299,8 @@ public class BlockUploadTask implements Callable<BlockUploadTask.UploadResult> {
         if (partResult == UploadResult.SUCCESS) {
             final Map.Entry<Long, BlockSource> last = blocksInBuffer.lastEntry();
             blockMessaging.sendBlockPersisted(new PersistedNotification(last.getKey(), true, 1_000, last.getValue()));
+            metricsHolder.blocksWritten().increment(blocksInBuffer.size());
+            metricsHolder.storedBytes().increment(buffer.length);
         }
         return partResult;
     }

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
@@ -23,6 +23,9 @@ import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.metrics.LongCounter;
+import org.hiero.metrics.core.MetricKey;
+import org.hiero.metrics.core.MetricRegistry;
 
 /// A block node plugin that stores verified blocks in cloud storage aggregated into `tar` archives.
 ///
@@ -43,6 +46,19 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     /// The logger for this class.
     private static final System.Logger LOGGER = System.getLogger(CloudStorageArchivePlugin.class.getName());
 
+    public static final MetricKey<LongCounter> METRIC_CLOUD_ARCHIVE_BLOCKS_WRITTEN = MetricKey.of(
+                    "cloud_storage_archive_blocks_written", LongCounter.class)
+            .addCategory(METRICS_CATEGORY);
+    public static final MetricKey<LongCounter> METRIC_CLOUD_ARCHIVE_FAILED_TASKS = MetricKey.of(
+                    "cloud_storage_archive_failed_tasks", LongCounter.class)
+            .addCategory(METRICS_CATEGORY);
+    public static final MetricKey<LongCounter> METRIC_CLOUD_ARCHIVE_SUCCESSFUL_TASKS = MetricKey.of(
+                    "cloud_storage_archive_successful_tasks", LongCounter.class)
+            .addCategory(METRICS_CATEGORY);
+    public static final MetricKey<LongCounter> METRIC_CLOUD_ARCHIVE_STORED_BYTES = MetricKey.of(
+                    "cloud_storage_archive_stored_bytes", LongCounter.class)
+            .addCategory(METRICS_CATEGORY);
+
     /// The block node context, set during [init].
     private BlockNodeContext context;
     /// The plugin configuration, set during [init].
@@ -52,6 +68,8 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     /// Whether the plugin configuration is valid.  Set during [init]; gates handler registration,
     /// startup recovery, and handler unregistration in [stop].
     private boolean configValid = false;
+    /// Holder for all cloud archive metrics, initialized during [init].
+    private MetricsHolder metricsHolder;
 
     /// The [Future] for the currently active [BlockUploadTask], or `null` when no upload is
     /// in progress.  Checked on every [handleVerification] call via [Future#isDone()] to detect
@@ -98,6 +116,7 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
         this.context = requireNonNull(context);
         this.config = context.configuration().getConfigData(CloudStorageArchiveConfig.class);
+        metricsHolder = MetricsHolder.createMetrics(context.metricRegistry());
         final List<String> violations = config.validate();
         if (!violations.isEmpty()) {
             // Should be reported to a health facility once we have it
@@ -153,6 +172,7 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
             Thread.currentThread().interrupt();
         } catch (ExecutionException e) {
             LOGGER.log(WARNING, "Could not complete uploading blocks to cloud archive storage", e);
+            metricsHolder.failedTasks().increment();
             // TODO(1166) Handle properly block upload task failure
         }
     }
@@ -169,7 +189,10 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                 final UploadResult uploadResult = currentUploadFuture.get();
                 if (uploadResult == UploadResult.FAILED) {
                     LOGGER.log(WARNING, "Block upload task failed");
+                    metricsHolder.failedTasks().increment();
                     // TODO(1166) Handle properly block upload task failure
+                } else {
+                    metricsHolder.successfulTasks().increment();
                 }
                 // Clear the future regardless of outcome so the next block starts a fresh task.
                 currentUploadFuture = null;
@@ -204,7 +227,8 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                         currentGroupStart,
                         currentGroupSize,
                         currentBlockQueue,
-                        result.uploadId() != null ? result : null));
+                        result.uploadId() != null ? result : null,
+                        metricsHolder));
                 tryReplayStash();
             }
             // No else: currentGroupStart == -1 means a fresh start with no prior S3 state.
@@ -241,7 +265,12 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
         // from the previous task, which still holds a reference to the old queue instance.
         currentBlockQueue = new LinkedBlockingQueue<>();
         currentUploadFuture = virtualThreadExecutor.submit(new BlockUploadTask(
-                config, context.blockMessaging(), currentGroupStart, currentGroupSize, currentBlockQueue));
+                config,
+                context.blockMessaging(),
+                currentGroupStart,
+                currentGroupSize,
+                currentBlockQueue,
+                metricsHolder));
         tryReplayStash();
     }
 
@@ -310,5 +339,34 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
             context.blockMessaging().unregisterBlockNotificationHandler(this);
         }
         LOGGER.log(TRACE, "Cloud storage archive plugin stopped");
+    }
+
+    /// Holder for all cloud storage archive metrics.
+    public record MetricsHolder(
+            LongCounter.Measurement blocksWritten,
+            LongCounter.Measurement failedTasks,
+            LongCounter.Measurement successfulTasks,
+            LongCounter.Measurement storedBytes) {
+
+        /// Factory method to create and register all cloud archive metrics.
+        public static MetricsHolder createMetrics(@NonNull final MetricRegistry metricRegistry) {
+            return new MetricsHolder(
+                    metricRegistry
+                            .register(LongCounter.builder(METRIC_CLOUD_ARCHIVE_BLOCKS_WRITTEN)
+                                    .setDescription("Number of blocks written to S3 cloud archive storage."))
+                            .getOrCreateNotLabeled(),
+                    metricRegistry
+                            .register(LongCounter.builder(METRIC_CLOUD_ARCHIVE_FAILED_TASKS)
+                                    .setDescription("Total number of failed cloud archive upload tasks."))
+                            .getOrCreateNotLabeled(),
+                    metricRegistry
+                            .register(LongCounter.builder(METRIC_CLOUD_ARCHIVE_SUCCESSFUL_TASKS)
+                                    .setDescription("Total number of successful cloud archive upload tasks."))
+                            .getOrCreateNotLabeled(),
+                    metricRegistry
+                            .register(LongCounter.builder(METRIC_CLOUD_ARCHIVE_STORED_BYTES)
+                                    .setDescription("Total number of bytes stored in S3 cloud archive storage."))
+                            .getOrCreateNotLabeled());
+        }
     }
 }

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTaskTest.java
@@ -27,10 +27,12 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.node.app.fixtures.TestMetricsExporter;
 import org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
+import org.hiero.metrics.core.MetricRegistry;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -119,6 +121,11 @@ class BlockUploadTaskTest {
                 "cloud.archive.secretKey", MINIO_PASSWORD);
     }
 
+    private CloudStorageArchivePlugin.MetricsHolder createMetricsHolder(TestMetricsExporter exporter) {
+        return CloudStorageArchivePlugin.MetricsHolder.createMetrics(
+                MetricRegistry.builder().setMetricsExporter(exporter).build());
+    }
+
     /// Verifies that when [BlockUploadTask#doUploadPart] throws during a mid-loop flush, all
     /// blocks whose tar bytes were in the buffer at the time of failure receive a failed
     /// [PersistedNotification], and [BlockUploadTask.UploadResult#FAILED] is returned.
@@ -133,7 +140,12 @@ class BlockUploadTaskTest {
                 ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);
         pluginConfig(GROUPING_LEVEL, PART_SIZE_MB).forEach(builder::withValue);
         final BlockUploadTask task = new FailingBlockUploadTask(
-                builder.build().getConfigData(CloudStorageArchiveConfig.class), messaging, 0, groupSize, queue);
+                builder.build().getConfigData(CloudStorageArchiveConfig.class),
+                messaging,
+                0,
+                groupSize,
+                queue,
+                createMetricsHolder(new TestMetricsExporter()));
 
         // Pre-fill the queue with enough large blocks to trigger at least one part flush
         final Random rng = new Random(0xDEADBEEFL);
@@ -174,7 +186,12 @@ class BlockUploadTaskTest {
                 ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);
         pluginConfig(groupingLevel, PART_SIZE_MB).forEach(builder::withValue);
         final BlockUploadTask task = new FailingBlockUploadTask(
-                builder.build().getConfigData(CloudStorageArchiveConfig.class), messaging, 0, groupSize, queue);
+                builder.build().getConfigData(CloudStorageArchiveConfig.class),
+                messaging,
+                0,
+                groupSize,
+                queue,
+                createMetricsHolder(new TestMetricsExporter()));
 
         // Small blocks (100 bytes each) so the total buffer stays well below PART_SIZE_MB,
         // meaning no mid-loop flush occurs and all blocks end up in the final partial buffer.
@@ -214,7 +231,12 @@ class BlockUploadTaskTest {
                 ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);
         pluginConfig(GROUPING_LEVEL, PART_SIZE_MB).forEach(builder::withValue);
         final BlockUploadTask task = new BlockUploadTask(
-                builder.build().getConfigData(CloudStorageArchiveConfig.class), messaging, 0, groupSize, queue);
+                builder.build().getConfigData(CloudStorageArchiveConfig.class),
+                messaging,
+                0,
+                groupSize,
+                queue,
+                createMetricsHolder(new TestMetricsExporter()));
 
         final Random rng = new Random(0xDEADBEEFL);
         for (int i = 0; i < groupSize; i++) {
@@ -253,7 +275,12 @@ class BlockUploadTaskTest {
                 ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);
         pluginConfig(groupingLevel, PART_SIZE_MB).forEach(builder::withValue);
         final BlockUploadTask task = new BlockUploadTask(
-                builder.build().getConfigData(CloudStorageArchiveConfig.class), messaging, 0, groupSize, queue);
+                builder.build().getConfigData(CloudStorageArchiveConfig.class),
+                messaging,
+                0,
+                groupSize,
+                queue,
+                createMetricsHolder(new TestMetricsExporter()));
 
         // Even blocks → PUBLISHER, odd blocks → BACKFILL
         final Random rng = new Random(0xDEADBEEFL);
@@ -291,7 +318,12 @@ class BlockUploadTaskTest {
                 ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);
         pluginConfig(groupingLevel, PART_SIZE_MB).forEach(builder::withValue);
         final BlockUploadTask task = new BlockUploadTask(
-                builder.build().getConfigData(CloudStorageArchiveConfig.class), messaging, 0, groupSize, queue);
+                builder.build().getConfigData(CloudStorageArchiveConfig.class),
+                messaging,
+                0,
+                groupSize,
+                queue,
+                createMetricsHolder(new TestMetricsExporter()));
 
         final Random rng = new Random(0xDEADBEEFL);
         for (int i = 0; i < groupSize; i++) {
@@ -314,6 +346,90 @@ class BlockUploadTaskTest {
         assertThat(notification.blockSource()).isEqualTo(BlockSource.UNKNOWN);
     }
 
+    /// Verifies that after a successful upload [blocksWritten] equals the group size and
+    /// [storedBytes] is positive, confirming metrics reflect what was durably stored.
+    @Test
+    @DisplayName("Successful upload tracks correct blocksWritten and storedBytes")
+    void testSuccessfulUploadTracksMetrics() throws Exception {
+        final int groupSize = (int) Math.pow(10, GROUPING_LEVEL);
+        final TestMetricsExporter exporter = new TestMetricsExporter();
+        final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
+        final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
+
+        final ConfigurationBuilder builder =
+                ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);
+        pluginConfig(GROUPING_LEVEL, PART_SIZE_MB).forEach(builder::withValue);
+        final BlockUploadTask task = new BlockUploadTask(
+                builder.build().getConfigData(CloudStorageArchiveConfig.class),
+                messaging,
+                0,
+                groupSize,
+                queue,
+                createMetricsHolder(exporter));
+
+        final Random rng = new Random(0xDEADBEEFL);
+        for (int i = 0; i < groupSize; i++) {
+            final byte[] data = new byte[BLOCK_DATA_BYTES];
+            rng.nextBytes(data);
+            final BlockItemUnparsed item = new BlockItemUnparsed(
+                    new OneOf<>(BlockItemUnparsed.ItemOneOfType.SIGNED_TRANSACTION, Bytes.wrap(data)));
+            queue.put(new BlockWithSource(
+                    BlockUnparsed.newBuilder()
+                            .blockItems(new BlockItemUnparsed[] {item})
+                            .build(),
+                    BlockSource.PUBLISHER));
+        }
+
+        assertThat(task.call()).isEqualTo(BlockUploadTask.UploadResult.SUCCESS);
+
+        assertThat(exporter.getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_BLOCKS_WRITTEN.name()))
+                .isEqualTo(groupSize);
+        assertThat(exporter.getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_STORED_BYTES.name()))
+                .isGreaterThan(0L);
+    }
+
+    /// Verifies that a failed upload leaves both [blocksWritten] and [storedBytes] at zero,
+    /// since no data was durably stored.
+    @Test
+    @DisplayName("Failed upload leaves blocksWritten and storedBytes at zero")
+    void testFailedUploadDoesNotTrackMetrics() throws Exception {
+        final int groupSize = (int) Math.pow(10, GROUPING_LEVEL);
+        final TestMetricsExporter exporter = new TestMetricsExporter();
+        final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
+        final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
+
+        final ConfigurationBuilder builder =
+                ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);
+        pluginConfig(GROUPING_LEVEL, PART_SIZE_MB).forEach(builder::withValue);
+        final BlockUploadTask task = new FailingBlockUploadTask(
+                builder.build().getConfigData(CloudStorageArchiveConfig.class),
+                messaging,
+                0,
+                groupSize,
+                queue,
+                createMetricsHolder(exporter));
+
+        final Random rng = new Random(0xDEADBEEFL);
+        for (int i = 0; i < groupSize; i++) {
+            final byte[] data = new byte[BLOCK_DATA_BYTES];
+            rng.nextBytes(data);
+            final BlockItemUnparsed item = new BlockItemUnparsed(
+                    new OneOf<>(BlockItemUnparsed.ItemOneOfType.SIGNED_TRANSACTION, Bytes.wrap(data)));
+            queue.put(new BlockWithSource(
+                    BlockUnparsed.newBuilder()
+                            .blockItems(new BlockItemUnparsed[] {item})
+                            .build(),
+                    BlockSource.PUBLISHER));
+        }
+
+        assertThat(task.call()).isEqualTo(BlockUploadTask.UploadResult.FAILED);
+
+        assertThat(exporter.getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_BLOCKS_WRITTEN.name()))
+                .isZero();
+        assertThat(exporter.getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_STORED_BYTES.name()))
+                .isZero();
+    }
+
     /// [BlockUploadTask] subclass that always throws from [doUploadPart] to simulate S3 failures.
     private static final class FailingBlockUploadTask extends BlockUploadTask {
 
@@ -322,8 +438,9 @@ class BlockUploadTaskTest {
                 BlockMessagingFacility blockMessaging,
                 long firstBlock,
                 int groupSize,
-                BlockingQueue<BlockWithSource> queue) {
-            super(config, blockMessaging, firstBlock, groupSize, queue);
+                BlockingQueue<BlockWithSource> queue,
+                CloudStorageArchivePlugin.MetricsHolder metricsHolder) {
+            super(config, blockMessaging, firstBlock, groupSize, queue, metricsHolder);
         }
 
         @Override

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 import com.hedera.bucky.S3Client;
 import com.hedera.pbj.runtime.OneOf;
@@ -38,6 +37,7 @@ import org.hiero.block.api.BlockNodeVersions;
 import org.hiero.block.api.TssData;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.node.app.fixtures.TestMetricsExporter;
 import org.hiero.block.node.app.fixtures.async.BlockingExecutor;
 import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
 import org.hiero.block.node.app.fixtures.blocks.TestBlock;
@@ -173,11 +173,10 @@ class CloudStorageArchivePluginTest {
                     .withConfigDataType(CloudStorageArchiveConfig.class)
                     .withValue("cloud.archive.endpointUrl", minioEndpoint)
                     .build();
-            final MetricRegistry metricsMock = mock(MetricRegistry.class);
             final HistoricalBlockFacility historicalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
             final BlockNodeContext testContext = new BlockNodeContext(
                     configuration,
-                    metricsMock,
+                    MetricRegistry.builder().build(),
                     new TestHealthFacility(),
                     new TestBlockMessagingFacility(),
                     historicalBlockFacility,
@@ -204,7 +203,7 @@ class CloudStorageArchivePluginTest {
             final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
             final BlockNodeContext testContext = new BlockNodeContext(
                     builder.build(),
-                    mock(MetricRegistry.class),
+                    MetricRegistry.builder().build(),
                     new TestHealthFacility(),
                     messaging,
                     new SimpleInMemoryHistoricalBlockFacility(),
@@ -265,7 +264,7 @@ class CloudStorageArchivePluginTest {
             final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
             final BlockNodeContext testContext = new BlockNodeContext(
                     configuration,
-                    mock(MetricRegistry.class),
+                    MetricRegistry.builder().build(),
                     new TestHealthFacility(),
                     messaging,
                     new SimpleInMemoryHistoricalBlockFacility(),
@@ -932,6 +931,148 @@ class CloudStorageArchivePluginTest {
                 baos.write(TarEntries.toTarEntry(blocks.get(i).blockUnparsed(), startBlockNum + i));
             }
             return baos.toByteArray();
+        }
+
+        private void sendVerifications(List<TestBlock> blocks) {
+            for (final TestBlock block : blocks) {
+                sendVerification(block);
+            }
+        }
+
+        private void sendVerification(TestBlock block) {
+            blockMessaging.sendBlockVerification(new VerificationNotification(
+                    true, null, block.number(), Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
+        }
+    }
+
+    /// Tests that verify plugin-level task metrics ([METRIC_CLOUD_ARCHIVE_SUCCESSFUL_TASKS] and
+    /// [METRIC_CLOUD_ARCHIVE_FAILED_TASKS]) are correctly incremented as upload tasks complete.
+    ///
+    /// The success tests use the correct MinIO credentials via [PluginTestBase].  The failure test
+    /// creates an independent [CloudStorageArchivePlugin] with wrong credentials that shares the
+    /// same [BlockingExecutor], so execution is still controlled deterministically from the test body.
+    @Nested
+    @DisplayName("Task Metrics Tests")
+    final class TaskMetricsTests
+            extends PluginTestBase<CloudStorageArchivePlugin, BlockingExecutor, ScheduledBlockingExecutor> {
+
+        private static final int GROUPING_LEVEL = 1;
+        private final BlockingExecutor pluginExecutor;
+
+        TaskMetricsTests() {
+            super(
+                    new BlockingExecutor(new LinkedBlockingQueue<>()),
+                    new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+            start(
+                    new CloudStorageArchivePlugin(),
+                    new SimpleInMemoryHistoricalBlockFacility(),
+                    pluginConfig(GROUPING_LEVEL, 10));
+            pluginExecutor = testThreadPoolManager.executor();
+        }
+
+        /// Drains the main plugin's startup recovery task before each test.
+        @BeforeEach
+        void drainRecovery() {
+            pluginExecutor.executeSerially();
+        }
+
+        /// Verifies that a successful upload task increments [METRIC_CLOUD_ARCHIVE_SUCCESSFUL_TASKS]
+        /// by one and leaves [METRIC_CLOUD_ARCHIVE_FAILED_TASKS] at zero.
+        ///
+        /// [checkCompletedUpload] is only called from [handleVerification], so the metric is not
+        /// updated until the next notification arrives after the task finishes.  A single trigger
+        /// block from the next group is sent after [executeSerially] to flush the counter.
+        @Test
+        @DisplayName("Successful upload task increments successfulTasks and leaves failedTasks at zero")
+        void testSuccessfulUploadIncrementsSuccessfulTasks() throws Exception {
+            final int groupSize = (int) Math.pow(10, GROUPING_LEVEL);
+            sendVerifications(TestBlockBuilder.generateBlocksInRange(0, groupSize - 1));
+            pluginExecutor.executeSerially();
+            // Trigger checkCompletedUpload() for the just-finished task.
+            sendVerification(
+                    TestBlockBuilder.generateBlocksInRange(groupSize, groupSize).getFirst());
+            assertThat(getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_SUCCESSFUL_TASKS))
+                    .isEqualTo(1L);
+            assertThat(getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_FAILED_TASKS))
+                    .isZero();
+        }
+
+        /// Verifies that two consecutive successful upload tasks increment
+        /// [METRIC_CLOUD_ARCHIVE_SUCCESSFUL_TASKS] by two.
+        ///
+        /// A trigger block is sent after each [executeSerially] so [checkCompletedUpload] detects
+        /// each completed task before the assertion.
+        @Test
+        @DisplayName("Two consecutive successful tasks increment successfulTasks by two")
+        void testTwoSuccessfulTasksIncrementSuccessfulTasksTwice() throws Exception {
+            final int groupSize = (int) Math.pow(10, GROUPING_LEVEL);
+            sendVerifications(TestBlockBuilder.generateBlocksInRange(0, groupSize - 1));
+            pluginExecutor.executeSerially();
+            sendVerifications(TestBlockBuilder.generateBlocksInRange(groupSize, groupSize * 2 - 1));
+            pluginExecutor.executeSerially();
+            // Trigger checkCompletedUpload() for the second completed task.
+            sendVerification(TestBlockBuilder.generateBlocksInRange(groupSize * 2, groupSize * 2)
+                    .getFirst());
+            assertThat(getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_SUCCESSFUL_TASKS))
+                    .isEqualTo(2L);
+            assertThat(getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_FAILED_TASKS))
+                    .isZero();
+        }
+
+        /// Verifies that a failed [StartupRecoveryTask] (due to invalid S3 credentials) causes
+        /// [METRIC_CLOUD_ARCHIVE_FAILED_TASKS] to increment by one when the next
+        /// [CloudStorageArchivePlugin#handleVerification] call detects the done-but-failed recovery
+        /// future and catches the resulting [ExecutionException].
+        ///
+        /// An independent plugin instance is created with wrong credentials but shares the same
+        /// [BlockingExecutor] as the main plugin, so recovery can be driven the same way.
+        @Test
+        @DisplayName("Failed recovery task increments failedTasks and leaves successfulTasks at zero")
+        void testFailedRecoveryIncrementsFailedTasks() {
+            final TestMetricsExporter exporter = new TestMetricsExporter();
+            final ConfigurationBuilder builder =
+                    ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);
+            Map.of(
+                            "cloud.archive.groupingLevel", "1",
+                            "cloud.archive.partSizeMb", "10",
+                            "cloud.archive.endpointUrl", minioEndpoint,
+                            "cloud.archive.regionName", "us-east-1",
+                            "cloud.archive.bucketName", BUCKET_NAME,
+                            "cloud.archive.accessKey", "wronguser",
+                            "cloud.archive.secretKey", "wrongpassword")
+                    .forEach(builder::withValue);
+            final TestBlockMessagingFacility failingMessaging = new TestBlockMessagingFacility();
+            final BlockNodeContext failingContext = new BlockNodeContext(
+                    builder.build(),
+                    MetricRegistry.builder().setMetricsExporter(exporter).build(),
+                    new TestHealthFacility(),
+                    failingMessaging,
+                    new SimpleInMemoryHistoricalBlockFacility(),
+                    null,
+                    null,
+                    testThreadPoolManager,
+                    BlockNodeVersions.DEFAULT,
+                    TssData.DEFAULT);
+            final CloudStorageArchivePlugin failingPlugin = new CloudStorageArchivePlugin();
+            failingPlugin.init(failingContext, null);
+            // start() submits the recovery task to the shared BlockingExecutor.
+            failingPlugin.start();
+            // Drain the failing recovery task.  BlockingExecutor re-wraps the S3ResponseException
+            // (403) as RuntimeException, so catch and ignore it here — the Future is still done.
+            try {
+                pluginExecutor.executeSerially();
+            } catch (RuntimeException ignored) {
+            }
+            // handleVerification() detects the done-but-failed recovery future, catches the
+            // resulting ExecutionException, and increments failedTasks.
+            final TestBlock block = TestBlockBuilder.generateBlocksInRange(0, 0).getFirst();
+            failingMessaging.sendBlockVerification(new VerificationNotification(
+                    true, null, block.number(), Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
+            assertThat(exporter.getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_FAILED_TASKS.name()))
+                    .isEqualTo(1L);
+            assertThat(exporter.getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_SUCCESSFUL_TASKS.name()))
+                    .isZero();
+            failingPlugin.stop();
         }
 
         private void sendVerifications(List<TestBlock> blocks) {


### PR DESCRIPTION
## Reviewer Notes

Adds four LongCounter metrics to CloudStorageArchivePlugin following the MetricsHolder pattern, and wires up increments at the appropriate points in the upload lifecycle.

`blocksWritten` and `storedBytes` are incremented inside `BlockUploadTask` at two sites — after each fixed-size part flush in `flushPartIfNeeded`, and after the final partial-buffer upload in `uploadFinalPart`. Both are incremented only on the success path, so a task that fails partway through does not over-count durable storage.

`successfulTasks` and `failedTasks` are incremented in `CloudStorageArchivePlugin.checkCompletedUpload()` when the task's `Future` is found done. `failedTasks` is also incremented in the `ExecutionException` catch in `handleVerification`.

`BlockUploadTaskTest` gains a `createMetricsHolder(TestMetricsExporter)` helper backed by a real `MetricRegistry` (no mocks).

## Related Issue(s)

Closes #1130
