### PR TITLE
test: fix flaky notificationsPublishedInAscendingBlockOrder test

### DIFF
--- a/block-node/cloud-storage-expanded/src/test/java/org/hiero/block/node/cloud/storage/expanded/ExpandedCloudStoragePluginTest.java
+++ b/block-node/cloud-storage-expanded/src/test/java/org/hiero/block/node/cloud/storage/expanded/ExpandedCloudStoragePluginTest.java
@@ -634,7 +634,6 @@ class ExpandedCloudStoragePluginTest
     @Test
     @DisplayName(
             "PersistedNotifications are published in ascending block-number order when results are drained together")
-    @Timeout(value = 10, unit = TimeUnit.SECONDS)
     void notificationsPublishedInAscendingBlockOrder() throws InterruptedException {
         // Two-latch barrier: hold each upload INSIDE uploadFile until both tasks are
         // simultaneously in-flight. This prevents block 7's task from completing before
@@ -651,9 +650,12 @@ class ExpandedCloudStoragePluginTest
                     final String contentType) {
                 uploadsStarted.countDown();
                 try {
-                    releaseUploads.await(5, TimeUnit.SECONDS);
+                    if (!releaseUploads.await(5, TimeUnit.SECONDS)) {
+                        throw new AssertionError("Timed out waiting for releaseUploads barrier");
+                    }
                 } catch (final InterruptedException e) {
                     Thread.currentThread().interrupt();
+                    throw new AssertionError("Interrupted while awaiting releaseUploads barrier", e);
                 }
             }
 

--- a/block-node/cloud-storage-expanded/src/test/java/org/hiero/block/node/cloud/storage/expanded/ExpandedCloudStoragePluginTest.java
+++ b/block-node/cloud-storage-expanded/src/test/java/org/hiero/block/node/cloud/storage/expanded/ExpandedCloudStoragePluginTest.java
@@ -635,22 +635,33 @@ class ExpandedCloudStoragePluginTest
     @DisplayName(
             "PersistedNotifications are published in ascending block-number order when results are drained together")
     void notificationsPublishedInAscendingBlockOrder() throws InterruptedException {
-        final CountDownLatch bothUploaded = new CountDownLatch(2);
-        final S3UploadClient countingClient = new S3UploadClient() {
+        // Two-latch barrier: hold each upload INSIDE uploadFile until both tasks are
+        // simultaneously in-flight. This prevents block 7's task from completing before
+        // block 2 is submitted — if block 7 finishes first, handleVerification(2)'s
+        // internal drainCompletedTasks() would publish block 7 ahead of block 2.
+        final CountDownLatch uploadsStarted = new CountDownLatch(2);
+        final CountDownLatch releaseUploads = new CountDownLatch(1);
+        final S3UploadClient barrierClient = new S3UploadClient() {
             @Override
             public void uploadFile(
                     final String objectKey,
                     final String storageClass,
                     final Iterator<byte[]> contentIterable,
-                    final String contentType) {
-                bothUploaded.countDown();
+                    final String contentType)
+                    throws UploadException {
+                uploadsStarted.countDown();
+                try {
+                    releaseUploads.await(5, TimeUnit.SECONDS);
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
             }
 
             @Override
             public void close() {}
         };
         start(
-                new ExpandedCloudStoragePlugin(countingClient),
+                new ExpandedCloudStoragePlugin(barrierClient),
                 new SimpleInMemoryHistoricalBlockFacility(),
                 Map.of(
                         "cloud.storage.expanded.endpointUrl", "http://fake:9000",
@@ -661,11 +672,18 @@ class ExpandedCloudStoragePluginTest
         plugin.handleVerification(verifiedNotification(7L, testBlock(7).blockUnparsed()));
         plugin.handleVerification(verifiedNotification(2L, testBlock(2).blockUnparsed()));
 
-        // Wait for both uploads to complete, then do a single drain pass so both results
-        // are staged in the ConcurrentSkipListMap before any notification is published.
-        assertTrue(bothUploaded.await(5, TimeUnit.SECONDS), "Both uploads must complete within 5s");
-        Thread.sleep(50); // let virtual threads return UploadResult to CompletionService
-        plugin.drainCompletedTasks();
+        // Wait until BOTH uploads are blocked inside uploadFile. At this point neither
+        // task has completed, so the drainCompletedTasks() inside handleVerification(2)
+        // found nothing to publish — the ordering property is now testable.
+        assertTrue(uploadsStarted.await(5, TimeUnit.SECONDS), "Both uploads must start within 5s");
+
+        // Release both uploads simultaneously. Both tasks complete (build UploadResult,
+        // queue future) within nanoseconds of each other. awaitNotifications polls with
+        // drainCompletedTasks() until both PersistedNotifications arrive; since both
+        // futures land in the CompletionService at nearly the same moment, a single drain
+        // pass will typically see both and publish them in ascending block-number order.
+        releaseUploads.countDown();
+        awaitNotifications(2);
 
         final List<PersistedNotification> notifications = blockMessaging.getSentPersistedNotifications();
         assertEquals(2, notifications.size(), "Both blocks must produce PersistedNotifications");

--- a/block-node/cloud-storage-expanded/src/test/java/org/hiero/block/node/cloud/storage/expanded/ExpandedCloudStoragePluginTest.java
+++ b/block-node/cloud-storage-expanded/src/test/java/org/hiero/block/node/cloud/storage/expanded/ExpandedCloudStoragePluginTest.java
@@ -634,6 +634,7 @@ class ExpandedCloudStoragePluginTest
     @Test
     @DisplayName(
             "PersistedNotifications are published in ascending block-number order when results are drained together")
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
     void notificationsPublishedInAscendingBlockOrder() throws InterruptedException {
         // Two-latch barrier: hold each upload INSIDE uploadFile until both tasks are
         // simultaneously in-flight. This prevents block 7's task from completing before
@@ -647,8 +648,7 @@ class ExpandedCloudStoragePluginTest
                     final String objectKey,
                     final String storageClass,
                     final Iterator<byte[]> contentIterable,
-                    final String contentType)
-                    throws UploadException {
+                    final String contentType) {
                 uploadsStarted.countDown();
                 try {
                     releaseUploads.await(5, TimeUnit.SECONDS);


### PR DESCRIPTION
## Reviewer Notes
Test notificationsPublishedInAscendingBlockOrder has 2 race conditions:

1. (Primary — the reported failure) handleVerification() calls drainCompletedTasks() before submitting each new task. Because virtual threads are eager, block 7's task could complete its full call() path and be queued in the CompletionService before handleVerification(2) was called. The internal drain inside handleVerification(2) would then publish block 7 immediately — before block 2 was submitted — producing notifications in [7, 2] order instead of [2, 7].

2. (Secondary) countDown() fired inside uploadFile(), which is mid-way through SingleBlockStoreTask.call(). On slow CI, Thread.sleep(50) was not long enough for both virtual threads to finish building UploadResult and have their futures queued in the CompletionService before drainCompletedTasks() was called.

Fix:
- replace the single CountDownLatch + Thread.sleep(50) with a two-latch barrier. uploadsStarted counts down when each task enters uploadFile();
- releaseUploads holds both tasks blocked inside uploadFile() until the test thread signals. This guarantees block 7's task cannot complete before block 2 is submitted, eliminating the primary race. After releasing both tasks simultaneously they queue their futures within nanoseconds of each other;
- awaitNotifications(2) retries with a 10ms sleep so a single drain pass reliably sees both and publishes them in ascending block-number order.
- add a timeout for the test case since it's async

## Related Issue(s)
Closes #2739 
