### PR TITLE
feat(verification): Temporary bypass for 1-path StateBlock Proofs in order to troubleshoot and potentially unblock.

### DIFF
--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
@@ -295,7 +295,12 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                         allBlocksHasherHandler.appendLatestHashToAllPreviousBlocksStreamingHasher(
                                 this.previousBlockHash.toByteArray());
                     } else {
-                        LOGGER.log(INFO, "Verification failed for block={0}", currentBlockNumber);
+                        LOGGER.log(
+                                WARNING,
+                                "Verification failed for block={0} failureType={1} source={2}",
+                                currentBlockNumber,
+                                notification.failureType(),
+                                BlockSource.PUBLISHER);
                         sendFailureNotification(currentBlockNumber, BlockSource.PUBLISHER);
                     }
 
@@ -438,6 +443,13 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                             allBlocksHasherHandler.appendLatestHashToAllPreviousBlocksStreamingHasher(
                                     backfillNotification.blockHash().toByteArray());
                         }
+                    } else {
+                        LOGGER.log(
+                                WARNING,
+                                "Verification failed for block={0} failureType={1} source={2}",
+                                notification.blockNumber(),
+                                backfillNotification.failureType(),
+                                BlockSource.BACKFILL);
                     }
                     // send the verification notification for the backfilled block
                     context.blockMessaging().sendBlockVerification(backfillNotification);

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
@@ -321,6 +321,15 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
         List<MerklePath> paths = stateProof.paths();
         if (paths.size() != 3) {
             LOGGER.log(WARNING, "Block {0} state proof has {1} paths, expected 3", blockNumber, paths.size());
+            // TODO: TEMPORARY DEBUG WORKAROUND — REMOVE BEFORE PROD.
+            //   CN has been observed emitting state proofs with 1 path. Treat that shape as
+            //   verified so the live stream keeps draining; the block is persisted normally and
+            //   can be retrieved from storage for offline analysis. Delete this branch once the
+            //   CN/BN proof-shape mismatch is fixed.
+            if (paths.size() == 1) {
+                LOGGER.log(WARNING, "Block {0} accepted via 1-path state-proof bypass.", blockNumber);
+                return true;
+            }
             return false;
         }
 

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/StateProofVerificationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/StateProofVerificationTest.java
@@ -161,6 +161,15 @@ class StateProofVerificationTest {
     }
 
     @Test
+    void shouldAcceptSinglePathStateProof() throws ParseException {
+        // TODO: TEMPORARY DEBUG WORKAROUND — 1-path state proof is unconditionally accepted.
+        BlockUnparsed singlePathBlock = withSinglePathStateProof(block3.blockUnparsed());
+        VerificationNotification notification = verifyBlock(block3.blockNumber(), singlePathBlock);
+        assertNotNull(notification);
+        assertTrue(notification.success(), "1-path state proof must pass under the bypass workaround");
+    }
+
+    @Test
     void shouldVerifyDirectTssProofStillWorks() throws ParseException {
         // Block 0 and block 4 have direct TSS proofs — ensure the existing path still works
         VerificationNotification notification0 = verifyBlock(block0);
@@ -245,6 +254,38 @@ class StateProofVerificationTest {
             break;
         }
         return new BlockUnparsed(items);
+    }
+
+    /**
+     * Creates a copy of the block whose state proof has only path 0 (1 path total). Mirrors the
+     * shape that triggered the 2026-05-07 incident.
+     */
+    private static BlockUnparsed withSinglePathStateProof(BlockUnparsed block) throws ParseException {
+        List<BlockItemUnparsed> items = new ArrayList<>(block.blockItems());
+        for (int i = items.size() - 1; i >= 0; i--) {
+            BlockItemUnparsed item = items.get(i);
+            if (item.item().kind() != BlockItemUnparsed.ItemOneOfType.BLOCK_PROOF) {
+                continue;
+            }
+            BlockProof proof = BlockProof.PROTOBUF.parse(item.blockProofOrThrow());
+            if (!proof.hasBlockStateProof()) {
+                continue;
+            }
+            StateProof stateProof = proof.blockStateProof();
+            StateProof shrunkStateProof = stateProof
+                    .copyBuilder()
+                    .paths(List.of(stateProof.paths().get(0)))
+                    .build();
+            BlockProof shrunkProof =
+                    proof.copyBuilder().blockStateProof(shrunkStateProof).build();
+            items.set(
+                    i,
+                    BlockItemUnparsed.newBuilder()
+                            .blockProof(BlockProof.PROTOBUF.toBytes(shrunkProof))
+                            .build());
+            return new BlockUnparsed(items);
+        }
+        throw new IllegalStateException("No state proof found in block");
     }
 
     /**


### PR DESCRIPTION
In the 2026-05-07 incident the CN emitted state proofs with 1 path while the BN expects 3, stalling the live stream. As a temporary debug workaround, `ExtendedMerkleTreeSession.verifyStateProof` now treats a 1-path state proof as verified (instead of failing) and logs a WARN with the block number. The block is persisted via the normal storage path and can be retrieved from disk for offline analysis.

Independent improvement: the verification-failure log is upgraded from INFO to WARN and now includes `failureType`.

## TODO before production

This is **not a fix**. Once the CN/BN proof-shape mismatch is resolved, delete the bypass branch in `ExtendedMerkleTreeSession.verifyStateProof`. The site is marked `TODO: TEMPORARY DEBUG WORKAROUND`.

