### PR TITLE
fix: update runner size for solo E2E test deployment

### DIFF
--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -52,9 +52,9 @@ on:
         type: string
         default: ""
       js-sdk-version:
-        description: "JS-SDK version (leave empty to use workflow default; 'latest' to use newest tag)"
+        description: "JS-SDK version ('latest' or tag like 'v2.83.0')"
         type: string
-        default: ""
+        default: "v2.83.0"
       solo-version:
         description: "Solo CLI version (leave empty to use run-type default)"
         type: string

--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -229,9 +229,8 @@ jobs:
           TCK_VERSION="${{ inputs.tck-version }}"
           TCK_VERSION="${TCK_VERSION:-latest}"
 
-          # JS-SDK version: use input if provided, otherwise default to last-known-good pinned version
+          # JS-SDK version: use input value (input has default v2.83.0)
           JS_SDK_VERSION="${{ inputs.js-sdk-version }}"
-          JS_SDK_VERSION="${JS_SDK_VERSION:-v2.83.0}"
 
           # TSS: use input value (defaults to true)
           TSS_ENABLED="${{ inputs.tss-enabled }}"

--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -51,6 +51,10 @@ on:
         description: "TCK-SDK version (leave empty for 'latest')"
         type: string
         default: ""
+      js-sdk-version:
+        description: "JS-SDK version (leave empty to use workflow default; 'latest' to use newest tag)"
+        type: string
+        default: ""
       solo-version:
         description: "Solo CLI version (leave empty to use run-type default)"
         type: string
@@ -95,6 +99,7 @@ jobs:
       solo-version: ${{ steps.config.outputs.solo_version }}
       relay-version: ${{ steps.config.outputs.relay_version }}
       tck-version: ${{ steps.config.outputs.tck_version }}
+      js-sdk-version: ${{ steps.config.outputs.js_sdk_version }}
       tss-enabled: ${{ steps.config.outputs.tss_enabled }}
       run-tck-regression-tests: ${{ steps.config.outputs.run_tck_regression_tests }}
       tck-test-file: ${{ steps.config.outputs.tck_test_file }}
@@ -224,6 +229,10 @@ jobs:
           TCK_VERSION="${{ inputs.tck-version }}"
           TCK_VERSION="${TCK_VERSION:-latest}"
 
+          # JS-SDK version: use input if provided, otherwise default to last-known-good pinned version
+          JS_SDK_VERSION="${{ inputs.js-sdk-version }}"
+          JS_SDK_VERSION="${JS_SDK_VERSION:-v2.83.0}"
+
           # TSS: use input value (defaults to true)
           TSS_ENABLED="${{ inputs.tss-enabled }}"
           TSS_ENABLED="${TSS_ENABLED:-true}"
@@ -247,6 +256,7 @@ jobs:
           echo "solo_version=${SOLO_VERSION}" >> "$GITHUB_OUTPUT"
           echo "relay_version=${RELAY_VERSION}" >> "$GITHUB_OUTPUT"
           echo "tck_version=${TCK_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "js_sdk_version=${JS_SDK_VERSION}" >> "$GITHUB_OUTPUT"
           echo "tss_enabled=${TSS_ENABLED}" >> "$GITHUB_OUTPUT"
           echo "run_tck_regression_tests=${RUN_TCK}" >> "$GITHUB_OUTPUT"
           echo "tck_test_file=${TCK_TEST_FILE}" >> "$GITHUB_OUTPUT"
@@ -265,6 +275,7 @@ jobs:
             echo "| Solo Version | ${SOLO_VERSION} |"
             echo "| Relay Version | ${RELAY_VERSION} |"
             echo "| TCK Version | ${TCK_VERSION} |"
+            echo "| JS-SDK Version | ${JS_SDK_VERSION} |"
             echo "| TSS Enabled | ${TSS_ENABLED} |"
             echo "| TCK Regression | ${RUN_TCK} |"
             echo "| Slack Notify | ${NOTIFY_SLACK} |"
@@ -337,6 +348,7 @@ jobs:
       solo-version: ${{ needs.configure.outputs.solo-version }}
       relay-version: ${{ needs.configure.outputs.relay-version }}
       tck-version: ${{ needs.configure.outputs.tck-version }}
+      js-sdk-version: ${{ needs.configure.outputs.js-sdk-version }}
       tss-enabled: ${{ needs.configure.outputs.tss-enabled == 'true' }}
       run-tck-regression-tests: ${{ needs.configure.outputs.run-tck-regression-tests == 'true' }}
       tck-test-file: ${{ needs.configure.outputs.tck-test-file }}

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -187,7 +187,7 @@ env:
 
 jobs:
   solo-test-deploy:
-    runs-on: hl-bn-lin-md
+    runs-on: hl-bn-lin-lg
     outputs:
       result: ${{ steps.result.outputs.status }}
       resolved-versions: ${{ steps.versions.outputs.cn_version }},${{ steps.versions.outputs.mn_version }},${{ steps.versions.outputs.bn_version }}

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -732,7 +732,10 @@ jobs:
       - name: Setup PNPM
         if: ${{ inputs.run-tck-regression-tests }}
         run: |
-          npm install -g pnpm
+          # Pin to pnpm 9.x: pnpm 10 enforces ERR_PNPM_IGNORED_BUILDS for native build
+          # scripts (chromedriver, esbuild, sharp, etc.) and requires explicit approval,
+          # which would fail unattended CI installs of the JS-SDK workspace.
+          npm install -g pnpm@9
 
       # Checkout TCK and checkout latest tag
       - name: Checkout TCK SDK

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -29,6 +29,10 @@ on:
         description: "TCK-SDK version ('latest' or tag like 'v1.2.3')"
         type: string
         default: "latest"
+      js-sdk-version:
+        description: "JS-SDK version ('latest' or tag like 'v2.83.0')"
+        type: string
+        default: "v2.83.0"
       solo-version:
         description: "Solo CLI Version"
         type: string
@@ -113,6 +117,10 @@ on:
         description: "TCK-SDK version ('latest' or tag like 'v1.2.3')"
         required: false
         default: "latest"
+      js-sdk-version:
+        description: "JS-SDK version ('latest' or tag like 'v2.83.0')"
+        required: false
+        default: "v2.83.0"
       solo-version:
         description: "Solo CLI Version"
         required: false
@@ -352,6 +360,7 @@ jobs:
             echo "| Block Node | \`${{ inputs.block-node-version || 'latest' }}\` | \`${{ steps.versions.outputs.bn_version }}\` |"
             echo "| Relay | \`${{ inputs.relay-version || 'latest' }}\` | \`${{ steps.versions.outputs.relay_version }}\` |"
             echo "| Solo CLI | \`${{ inputs.solo-version || 'latest' }}\` | \`${{ steps.solo.outputs.solo_version }}\` |"
+            echo "| JS-SDK | \`${{ inputs.js-sdk-version || 'v2.83.0' }}\` | |"
             echo "| TSS Enabled | | \`${{ inputs.tss-enabled }}\` |"
             echo ""
           } >> "${GITHUB_STEP_SUMMARY}"
@@ -754,14 +763,19 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Checkout Latest Tag (JS-SDK)
+      - name: Checkout JS-SDK Version
         if: ${{ inputs.run-tck-regression-tests }}
         run: |
           cd sdk-tck/sdk-server
           git fetch --tags
-          LATEST_TAG=$(git describe --tags --abbrev=0)
-          echo "Checking out JS-SDK latest tag: $LATEST_TAG"
-          git checkout "$LATEST_TAG"
+          JS_SDK_REQUESTED="${{ inputs.js-sdk-version }}"
+          if [[ "${JS_SDK_REQUESTED}" == "latest" ]]; then
+            JS_SDK_RESOLVED=$(git describe --tags --abbrev=0)
+          else
+            JS_SDK_RESOLVED="${JS_SDK_REQUESTED}"
+          fi
+          echo "Checking out JS-SDK version: ${JS_SDK_RESOLVED}"
+          git checkout "${JS_SDK_RESOLVED}"
 
       # Install TCK-SDK dependencies using shared script (versions extracted from source)
       - name: Install TCK-SDK Dependencies

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-tck-sdk-install.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-tck-sdk-install.sh
@@ -89,10 +89,12 @@ echo "  Long version: $LONG_VERSION"
 echo "  Proto version: $PROTO_VERSION"
 
 # First, install SDK workspace dependencies from root (builds @hiero-ledger/proto and @hiero-ledger/cryptography)
+# --no-frozen-lockfile: SDK source is fetched fresh at the latest tag; in CI pnpm defaults to frozen
+# mode, which fails when the upstream lockfile's overrides config drifts from package.json.
 echo ""
 echo "=== Installing SDK workspace dependencies ==="
 cd "${SDK_DIR}"
-pnpm install
+pnpm install --no-frozen-lockfile
 
 # Then install deps in SDK server's tck directory
 # Install both @hashgraph and @hiero-ledger packages (code imports from @hiero-ledger/*)


### PR DESCRIPTION
## Reviewer Notes

This PR upgrades the Solo-e2e-test runner to use a Large Box so it can successfully run larger topologies and in the future we can also use it for longer testing with more load.

Also fixes an issue with the TCK-SDK installation that is happening on daily and weekly runs.

Finally it makes the TCK-SDK Version parametrized and pinned by default to "v2.83.0" and pnpm to version 9.

Main:
https://github.com/hiero-ledger/hiero-block-node/actions/runs/25541303143/job/74967658444

This branch:
https://github.com/hiero-ledger/hiero-block-node/actions/runs/25685466309

Fixes #2790