### PR TITLE
feat: AddressBook Roster Load/Persist Improvements

### DIFF
--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/state/ApplicationStateConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/state/ApplicationStateConfig.java
@@ -20,8 +20,6 @@ import org.hiero.block.node.base.Loggable;
  *     Defaults to {@code /opt/hiero/block-node/node/rsa-bootstrap-roster.json}.
  * @param updateScanInterval The amount of milliseconds that the {@code ApplicationStateFacility} waits between
  *     checking to see if there are any {@code TssData} updates to process.
- * @param updateInitialDelay The amount of milliseconds that the {@code ApplicationStateFacility} waits before
- *     starting the scan interval.
  */
 @ConfigData("app.state")
 public record ApplicationStateConfig(
@@ -32,7 +30,4 @@ public record ApplicationStateConfig(
         Path rsaBootstrapFilePath,
 
         @Loggable @ConfigProperty(defaultValue = "500") @Min(100)
-        long updateScanInterval,
-
-        @Loggable @ConfigProperty(defaultValue = "100") @Min(100)
-        int updateInitialDelay) {}
+        long updateScanInterval) {}

--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/state/ApplicationStateConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/state/ApplicationStateConfig.java
@@ -25,7 +25,7 @@ import org.hiero.block.node.base.Loggable;
  */
 @ConfigData("app.state")
 public record ApplicationStateConfig(
-        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/node/app-state-data.bin")
+        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/node/app-state-data.json")
         Path dataFilePath,
 
         @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/node/rsa-bootstrap-roster.json")

--- a/block-node/app/build.gradle.kts
+++ b/block-node/app/build.gradle.kts
@@ -223,7 +223,9 @@ testModuleInfo {
 val copyRsaTestFixture =
     tasks.register<Copy>("copyRsaTestFixture") {
         description = "Copies the RSA bootstrap test fixture into build/tmp/data/config/"
-        from(layout.projectDirectory.file("src/test/resources/data/config/rsa-bootstrap-roster.pb"))
+        from(
+            layout.projectDirectory.file("src/test/resources/data/config/rsa-bootstrap-roster.json")
+        )
         into(layout.buildDirectory.dir("tmp/data/config"))
     }
 

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -452,10 +452,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
 
         // Schedule periodic check for live updates from running plugins.
         applicationStateExecutor.scheduleAtFixedRate(
-                this::checkForApplicationStateUpdates,
-                appStateConfig.updateInitialDelay(),
-                appStateConfig.updateScanInterval(),
-                TimeUnit.MILLISECONDS);
+                this::checkForApplicationStateUpdates, 0, appStateConfig.updateScanInterval(), TimeUnit.MILLISECONDS);
     }
 
     private void checkForApplicationStateUpdates() {

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -31,7 +31,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
-import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 import java.time.Duration;
@@ -689,7 +688,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             }
             try {
                 final byte[] keyBytes = hex.parseHex(addr.rsaPubKey());
-                final PublicKey key = kf.generatePublic(new X509EncodedKeySpec(keyBytes));
+                kf.generatePublic(new X509EncodedKeySpec(keyBytes));
                 usable++;
             } catch (InvalidKeySpecException | IllegalArgumentException e) {
                 LOGGER.log(WARNING, "Malformed RSA_PubKey for node {0} — skipped: {1}", addr.nodeId(), e.getMessage());

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -49,6 +49,7 @@ import org.hiero.block.node.app.logging.CleanColorfulFormatter;
 import org.hiero.block.node.app.logging.ConfigLogger;
 import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
+import org.hiero.block.node.spi.BlockNodeContext.Builder;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceLoaderFunction;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
@@ -85,7 +86,11 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     private final HistoricalBlockFacilityImpl historicalBlockFacility;
     /** Should the shutdown() method exit the JVM. */
     private final boolean shouldExitJvmOnShutdown;
-    /** The block node context. Volatile: written by the scheduled scanner thread, read by plugin threads. */
+
+    /** The block node context. It is marked as volatile for thread safety.
+     * It is written by the scheduled scanner thread, read by plugin threads.
+     * Plugins should take care to make a copy of the BlockNodeContext before they use it so that they get a consistent
+     * BlockNodeContext */
     volatile BlockNodeContext blockNodeContext;
     /** list of all loaded plugins. Package so accessible for testing. */
     final List<BlockNodePlugin> loadedPlugins = new ArrayList<>();
@@ -376,7 +381,9 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     }
 
     /**
-     * Allow plugins to update the TssData for this BlockNodeApp
+     * Allow plugins to update the TssData for this BlockNodeApp. Uses a concurrentList to capture all TssData
+     * updates between scans. The ApplicationStateFacility scans for updates on a separate thread and will process any
+     * TssData updates that are newer than the current TssData.
      *
      * @param tssData - The TssData to be updated on the `BlockNodeContext`
      */
@@ -389,20 +396,22 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
      * Allow plugins to update the NodeAddressBook for this BlockNodeApp. The address book is staged
      * in a last-write-wins reference; if {@code updateAddressBook} is called more than once before
      * the next {@code checkForApplicationStateUpdates} scan tick, only the most recent book is used.
-     * Null, empty, or all-blank-key books are silently rejected.
+     * Null, empty, or all-blank-key books will ```return false;```
      *
      * @param nodeAddressBook the NodeAddressBook to store in BlockNodeContext
+     * @return true if the address book is queued for update, false if it was not
      */
     @Override
-    public void updateAddressBook(NodeAddressBook nodeAddressBook) {
-        if (nodeAddressBook == null) return;
+    public boolean updateAddressBook(NodeAddressBook nodeAddressBook) {
+        if (nodeAddressBook == null) return false;
         try {
             validateAddressBook(nodeAddressBook, "runtime update");
         } catch (IllegalStateException e) {
             LOGGER.log(WARNING, "Rejecting invalid address book update: {0}", e.getMessage());
-            return;
+            return false;
         }
         pendingAddressBook.set(nodeAddressBook);
+        return true;
     }
 
     /**
@@ -444,33 +453,23 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     }
 
     private void checkForApplicationStateUpdates() {
-        boolean tssUpdated = false;
-        TssData tssData = tssDataUpdates.poll();
-        while (tssData != null) {
-            // Because we only update TssData for the most recent blockNumber,
-            // |= will let us know if any TssData were updated.
-            tssUpdated |= updateBlockNodeContext(tssData, null);
-            tssData = tssDataUpdates.poll();
+
+        // get any TssData update
+        TssData tssData = getPendingTssData();
+        if (tssData != null) {
+            persistTssData(tssData);
+            LOGGER.log(INFO, "ApplicationStateFacility persisted TssData");
         }
 
-        // Consume any address book cached at startup (one-shot).
-        boolean addressBookUpdated = false;
         final NodeAddressBook addressBook = pendingAddressBook.getAndSet(null);
         if (addressBook != null) {
-            addressBookUpdated = updateBlockNodeContext(null, addressBook);
+            persistNodeAddressBook(addressBook);
+            LOGGER.log(INFO, "ApplicationStateFacility persisted NodeAddressBook");
         }
 
-        if (tssUpdated || addressBookUpdated) {
+        if (updateBlockNodeContext(tssData, addressBook)) {
             loadedPlugins.parallelStream().forEach(plugin -> plugin.onContextUpdate(blockNodeContext));
             LOGGER.log(INFO, "ApplicationStateFacility called plugin.onContextUpdate for all plugins");
-            if (tssUpdated) {
-                persistTssData(blockNodeContext.tssData());
-                LOGGER.log(INFO, "ApplicationStateFacility persisted TssData");
-            }
-            if (addressBookUpdated) {
-                persistNodeAddressBook(blockNodeContext.nodeAddressBook());
-                LOGGER.log(INFO, "ApplicationStateFacility persisted NodeAddressBook");
-            }
         }
     }
 
@@ -489,6 +488,25 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     }
 
     /**
+     * Get the latest TssData to update.
+     *
+     * @return The TssData to update or null if no updates pending.
+     */
+    private TssData getPendingTssData() {
+        boolean updated = false;
+        TssData currTssData = blockNodeContext.tssData();
+        TssData tssData = tssDataUpdates.poll();
+        while (tssData != null) {
+            if (currTssData == null || tssData.validFromBlock() > currTssData.validFromBlock()) {
+                updated = true;
+                currTssData = tssData;
+            }
+            tssData = tssDataUpdates.poll();
+        }
+        return updated ? currTssData : null;
+    }
+
+    /**
      * Update the BlockNodeContext if either the provided TssData or NodeAddressBook is valid.
      * TssData is considered valid if it is non-null and its {@code validFromBlock} is greater than
      * the current context value. NodeAddressBook is considered valid if it is non-null.
@@ -498,35 +516,23 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
      * @return {@code true} if the BlockNodeContext was updated
      */
     private boolean updateBlockNodeContext(TssData tssData, NodeAddressBook addressBook) {
-        TssData newTss = blockNodeContext.tssData();
-        NodeAddressBook newBook = blockNodeContext.nodeAddressBook();
-        boolean updated = false;
-
-        if (tssData != null && (newTss == null || newTss.validFromBlock() < tssData.validFromBlock())) {
-            newTss = tssData;
-            updated = true;
+        if (tssData == null && addressBook == null) {
+            return false;
         }
+
+        BlockNodeContext.Builder builder = new Builder(blockNodeContext);
+        if (tssData != null) {
+            builder.tssData(tssData);
+        }
+
         if (addressBook != null) {
-            newBook = addressBook;
-            updated = true;
+            builder.nodeAddressBook(addressBook);
         }
+        LOGGER.log(INFO, "BlockNodeContext updated");
 
-        if (updated) {
-            blockNodeContext = new BlockNodeContext(
-                    blockNodeContext.configuration(),
-                    blockNodeContext.metricRegistry(),
-                    blockNodeContext.serverHealth(),
-                    blockNodeContext.blockMessaging(),
-                    blockNodeContext.historicalBlockProvider(),
-                    blockNodeContext.applicationStateFacility(),
-                    blockNodeContext.serviceLoader(),
-                    blockNodeContext.threadPoolManager(),
-                    blockNodeContext.blockNodeVersions(),
-                    newTss,
-                    newBook);
-            LOGGER.log(INFO, "BlockNodeContext updated");
-        }
-        return updated;
+        // update the BlockNodeContext
+        blockNodeContext = builder.build();
+        return true;
     }
 
     /**
@@ -541,7 +547,6 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 .getConfigData(ApplicationStateConfig.class)
                 .dataFilePath();
         try {
-            Files.createDirectories(appStateDataFilePath.getParent());
             Bytes serialized = TssData.JSON.toBytes(tssData);
             Files.write(appStateDataFilePath, serialized.toByteArray());
             LOGGER.log(INFO, "Persisted Application State Data to file: {0}", appStateDataFilePath);
@@ -559,7 +564,6 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 .getConfigData(ApplicationStateConfig.class)
                 .rsaBootstrapFilePath();
         try {
-            Files.createDirectories(filePath.getParent());
             final Path tmp = filePath.resolveSibling(filePath.getFileName() + ".tmp");
             final Bytes encoded = NodeAddressBook.JSON.toBytes(nodeAddressBook);
             Files.write(tmp, encoded.toByteArray());
@@ -601,6 +605,14 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             } catch (ParseException | IOException e) {
                 LOGGER.log(ERROR, "Failed to read Application State Data file: " + tssDataJsonPath, e);
             }
+        } else {
+            // make sure the directory is created for the writes
+            Path parent = tssDataJsonPath.getParent();
+            try {
+                Files.createDirectories(tssDataJsonPath.getParent());
+            } catch (IOException e) {
+                LOGGER.log(ERROR, "Failed to create Application State Data directory: " + parent, e);
+            }
         }
 
         // Load RSA NodeAddressBook (JSON format) — cached for processing on the next scanner tick.
@@ -623,6 +635,14 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                         "Corrupt RSA bootstrap file at " + rsaFilePath
                                 + " — delete and restart to re-fetch from Mirror Node",
                         e);
+            }
+        } else {
+            // make sure the directory is created for the writes
+            Path parent = rsaFilePath.getParent();
+            try {
+                Files.createDirectories(tssDataJsonPath.getParent());
+            } catch (IOException e) {
+                LOGGER.log(ERROR, "Failed to create Application State Data directory: " + parent, e);
             }
         }
     }

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -409,7 +409,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
      */
     @Override
     public boolean updateAddressBook(NodeAddressBook nodeAddressBook) {
-        if (nodeAddressBook == null) return false;
+        if (nodeAddressBook == null || nodeAddressBook.equals(blockNodeContext.nodeAddressBook())) return false;
         try {
             validateAddressBook(nodeAddressBook, "runtime update");
         } catch (IllegalStateException e) {
@@ -461,13 +461,11 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         TssData tssData = getPendingTssData();
         if (tssData != null) {
             persistTssData(tssData);
-            LOGGER.log(INFO, "ApplicationStateFacility persisted TssData");
         }
 
         final NodeAddressBook addressBook = pendingAddressBook.getAndSet(null);
         if (addressBook != null) {
             persistNodeAddressBook(addressBook);
-            LOGGER.log(INFO, "ApplicationStateFacility persisted NodeAddressBook");
         }
 
         if (updateBlockNodeContext(tssData, addressBook)) {
@@ -552,12 +550,9 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         try {
             Bytes serialized = TssData.JSON.toBytes(tssData);
             Files.write(appStateDataFilePath, serialized.toByteArray());
-            LOGGER.log(INFO, "Persisted Application State Data to file: {0}", appStateDataFilePath);
+            LOGGER.log(INFO, "Persisted TssData to file: {0}", appStateDataFilePath);
         } catch (IOException e) {
-            LOGGER.log(
-                    WARNING,
-                    "Failed to persist Application State Data to %s: %s".formatted(appStateDataFilePath, e),
-                    e);
+            LOGGER.log(WARNING, "Failed to persist TssData to %s: %s".formatted(appStateDataFilePath, e), e);
         }
     }
 
@@ -604,17 +599,17 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             try {
                 TssData tssData = TssData.JSON.parse(Bytes.wrap(Files.readAllBytes(tssDataJsonPath)));
                 updateTssData(tssData);
-                LOGGER.log(INFO, "Loaded Application State Data from file: {0}", tssDataJsonPath);
+                LOGGER.log(INFO, "Loaded TssData from file: {0}", tssDataJsonPath);
             } catch (ParseException | IOException e) {
-                LOGGER.log(ERROR, "Failed to read Application State Data file: " + tssDataJsonPath, e);
+                LOGGER.log(ERROR, "Failed to read TssData file: " + tssDataJsonPath, e);
             }
         } else {
             // make sure the directory is created for the writes
             Path parent = tssDataJsonPath.getParent();
             try {
-                Files.createDirectories(tssDataJsonPath.getParent());
+                Files.createDirectories(parent);
             } catch (IOException e) {
-                LOGGER.log(ERROR, "Failed to create Application State Data directory: " + parent, e);
+                LOGGER.log(ERROR, "Failed to create TssData directory: " + parent, e);
             }
         }
 
@@ -643,9 +638,9 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             // make sure the directory is created for the writes
             Path parent = rsaFilePath.getParent();
             try {
-                Files.createDirectories(tssDataJsonPath.getParent());
+                Files.createDirectories(parent);
             } catch (IOException e) {
-                LOGGER.log(ERROR, "Failed to create Application State Data directory: " + parent, e);
+                LOGGER.log(ERROR, "Failed to create RSA bootstrap directory: " + parent, e);
             }
         }
     }

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -11,6 +11,7 @@ import static org.hiero.block.common.constants.StringsConstants.APPLICATION_TEST
 import static org.hiero.block.node.spi.BlockNodePlugin.METRICS_CATEGORY;
 
 import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.node.base.NodeAddress;
 import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.pbj.grpc.helidon.config.PbjConfig;
 import com.hedera.pbj.runtime.ParseException;
@@ -28,8 +29,14 @@ import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ScheduledExecutorService;
@@ -659,12 +666,38 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             throw new IllegalStateException(
                     "RSA address book from " + source + " contains no entries — cannot verify WRB proofs");
         }
-        final long usable = book.nodeAddress().stream()
+        final long declared = book.nodeAddress().stream()
                 .filter(a -> !a.rsaPubKey().isBlank())
                 .count();
-        if (usable == 0) {
+        if (declared == 0) {
             throw new IllegalStateException("RSA address book from " + source + " has "
                     + book.nodeAddress().size() + " entries but none have a non-blank RSA_PubKey");
+        }
+        long usable = 0;
+        final HexFormat hex = HexFormat.of();
+        // Obtain KeyFactory once — provider lookup is not cheap and RSA must always be available.
+        final KeyFactory kf;
+        try {
+            kf = KeyFactory.getInstance("RSA");
+        } catch (NoSuchAlgorithmException e) {
+            // RSA must be available in every JVM — this is a JVM misconfiguration
+            throw new IllegalStateException("RSA KeyFactory not available", e);
+        }
+        for (final NodeAddress addr : book.nodeAddress()) {
+            if (addr.rsaPubKey().isBlank()) {
+                continue;
+            }
+            try {
+                final byte[] keyBytes = hex.parseHex(addr.rsaPubKey());
+                final PublicKey key = kf.generatePublic(new X509EncodedKeySpec(keyBytes));
+                usable++;
+            } catch (InvalidKeySpecException | IllegalArgumentException e) {
+                LOGGER.log(WARNING, "Malformed RSA_PubKey for node {0} — skipped: {1}", addr.nodeId(), e.getMessage());
+            }
+        }
+        if (usable == 0) {
+            throw new IllegalStateException("RSA address book from " + source + " has "
+                    + book.nodeAddress().size() + " entries but none have a valid RSA_PubKey");
         }
     }
 }

--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
@@ -112,7 +112,7 @@ class BlockNodeAppTest {
     @AfterEach
     void cleanup() {
         try {
-            Files.deleteIfExists(Path.of("build/tmp/data/block/node/app-state-data.bin"));
+            Files.deleteIfExists(Path.of("build/tmp/data/block/node/app-state-data.json"));
         } catch (Exception e) {
             // ignore
         }

--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
@@ -21,8 +21,12 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -464,10 +468,14 @@ class BlockNodeAppTest {
      */
     @Test
     @DisplayName("validateAddressBook accepts book with at least one non-blank RSA key")
-    void validateAddressBookAcceptsValidBook() {
+    void validateAddressBookAcceptsValidBook() throws NoSuchAlgorithmException {
+        final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(1024);
+        final KeyPair kp = kpg.generateKeyPair();
+        final String hexKey = HexFormat.of().formatHex(kp.getPublic().getEncoded());
         final NodeAddressBook valid = NodeAddressBook.newBuilder()
                 .nodeAddress(
-                        NodeAddress.newBuilder().nodeId(0).rsaPubKey("deadbeef").build())
+                        NodeAddress.newBuilder().nodeId(0).rsaPubKey(hexKey).build())
                 .build();
         assertDoesNotThrow(() -> BlockNodeApp.validateAddressBook(valid, "test-valid"));
     }
@@ -559,7 +567,7 @@ class BlockNodeAppTest {
      */
     @Test
     @DisplayName("updateAddressBook queues book; scanner picks it up and notifies plugins")
-    void updateAddressBookQueuesForScanner() throws IOException, InterruptedException {
+    void updateAddressBookQueuesForScanner() throws IOException, InterruptedException, NoSuchAlgorithmException {
         final ServiceLoaderFunction serviceLoaderFunction = new ServiceLoaderFunction();
         final BlockNodeApp app = new BlockNodeApp(serviceLoaderFunction, false);
         final TestPlugin testPlugin = new TestPlugin();
@@ -569,9 +577,13 @@ class BlockNodeAppTest {
         final int updatesBeforeCall = testPlugin.getContextUpdated();
         testPlugin.expectContextUpdates(1);
 
+        final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(1024);
+        final KeyPair kp = kpg.generateKeyPair();
+        final String hexKey = HexFormat.of().formatHex(kp.getPublic().getEncoded());
         final NodeAddressBook book = NodeAddressBook.newBuilder()
                 .nodeAddress(
-                        NodeAddress.newBuilder().nodeId(1).rsaPubKey("aabbcc").build())
+                        NodeAddress.newBuilder().nodeId(1).rsaPubKey(hexKey).build())
                 .build();
         app.updateAddressBook(book);
 
@@ -585,7 +597,7 @@ class BlockNodeAppTest {
         assertNotNull(app.blockNodeContext.nodeAddressBook());
         assertEquals(1, app.blockNodeContext.nodeAddressBook().nodeAddress().size());
         assertEquals(
-                "aabbcc",
+                hexKey,
                 app.blockNodeContext.nodeAddressBook().nodeAddress().getFirst().rsaPubKey());
 
         app.stopApplicationStateFacility();
@@ -596,7 +608,7 @@ class BlockNodeAppTest {
      */
     @Test
     @DisplayName("address book is persisted and reloaded on next startup")
-    void addressBookPersistenceRoundTrip() throws IOException, InterruptedException {
+    void addressBookPersistenceRoundTrip() throws IOException, InterruptedException, NoSuchAlgorithmException {
         final ServiceLoaderFunction serviceLoaderFunction = new ServiceLoaderFunction();
         final BlockNodeApp app = new BlockNodeApp(serviceLoaderFunction, false);
         final Path rsaPath = app.blockNodeContext
@@ -609,9 +621,14 @@ class BlockNodeAppTest {
         app.loadedPlugins.add(testPlugin);
         testPlugin.expectContextUpdates(1);
 
+        final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(1024);
+        final KeyPair kp = kpg.generateKeyPair();
+        final String hexKey = HexFormat.of().formatHex(kp.getPublic().getEncoded());
+
         final NodeAddressBook book = NodeAddressBook.newBuilder()
                 .nodeAddress(
-                        NodeAddress.newBuilder().nodeId(7).rsaPubKey("cafebabe").build())
+                        NodeAddress.newBuilder().nodeId(7).rsaPubKey(hexKey).build())
                 .build();
         app.updateAddressBook(book);
         // wait for scanner to process and persist the address book
@@ -627,7 +644,7 @@ class BlockNodeAppTest {
         final NodeAddressBook loaded = app2.blockNodeContext.nodeAddressBook();
         assertNotNull(loaded, "Persisted address book must be loaded on restart");
         assertEquals(1, loaded.nodeAddress().size());
-        assertEquals("cafebabe", loaded.nodeAddress().getFirst().rsaPubKey());
+        assertEquals(hexKey, loaded.nodeAddress().getFirst().rsaPubKey());
 
         app2.stopApplicationStateFacility();
     }

--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
@@ -470,7 +470,7 @@ class BlockNodeAppTest {
     @DisplayName("validateAddressBook accepts book with at least one non-blank RSA key")
     void validateAddressBookAcceptsValidBook() throws NoSuchAlgorithmException {
         final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(1024);
+        kpg.initialize(2048);
         final KeyPair kp = kpg.generateKeyPair();
         final String hexKey = HexFormat.of().formatHex(kp.getPublic().getEncoded());
         final NodeAddressBook valid = NodeAddressBook.newBuilder()

--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
@@ -578,7 +578,7 @@ class BlockNodeAppTest {
         testPlugin.expectContextUpdates(1);
 
         final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(1024);
+        kpg.initialize(2048);
         final KeyPair kp = kpg.generateKeyPair();
         final String hexKey = HexFormat.of().formatHex(kp.getPublic().getEncoded());
         final NodeAddressBook book = NodeAddressBook.newBuilder()
@@ -622,7 +622,7 @@ class BlockNodeAppTest {
         testPlugin.expectContextUpdates(1);
 
         final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(1024);
+        kpg.initialize(2048);
         final KeyPair kp = kpg.generateKeyPair();
         final String hexKey = HexFormat.of().formatHex(kp.getPublic().getEncoded());
 

--- a/block-node/app/src/test/resources/app-test.properties
+++ b/block-node/app/src/test/resources/app-test.properties
@@ -5,5 +5,5 @@ mediator.ringBufferSize=1024
 notifier.ringBufferSize=1024
 files.recent.liveRootPath=build/tmp/data/liveRootPath
 files.historic.rootPath=build/tmp/data/historic
-app.state.dataFilePath=build/tmp/data/block/node/app-state-data.bin
+app.state.dataFilePath=build/tmp/data/block/node/app-state-data.json
 app.state.rsaBootstrapFilePath=build/resources/test/data/config/rsa-bootstrap-roster.json

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
@@ -322,7 +322,7 @@ public abstract class PluginTestBase<
     }
 
     @Override
-    public void updateAddressBook(NodeAddressBook nodeAddressBook) {
+    public boolean updateAddressBook(NodeAddressBook nodeAddressBook) {
         blockNodeContext = new BlockNodeContext(
                 blockNodeContext.configuration(),
                 blockNodeContext.metricRegistry(),
@@ -336,5 +336,6 @@ public abstract class PluginTestBase<
                 blockNodeContext.tssData(),
                 nodeAddressBook);
         plugin.onContextUpdate(blockNodeContext);
+        return true;
     }
 }

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/ApplicationStateFacility.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/ApplicationStateFacility.java
@@ -23,6 +23,7 @@ public interface ApplicationStateFacility {
      * {@link BlockNodePlugin#onContextUpdate(BlockNodeContext)}.
      *
      * @param nodeAddressBook The NodeAddressBook to be stored in the BlockNodeContext.
+     * @return true if the addressbook is queued for update, false if it was not
      */
-    void updateAddressBook(NodeAddressBook nodeAddressBook);
+    boolean updateAddressBook(NodeAddressBook nodeAddressBook);
 }

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/BlockNodeContext.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/BlockNodeContext.java
@@ -49,4 +49,59 @@ public record BlockNodeContext(
         ThreadPoolManager threadPoolManager,
         BlockNodeVersions blockNodeVersions,
         TssData tssData,
-        NodeAddressBook nodeAddressBook) {}
+        NodeAddressBook nodeAddressBook) {
+
+    // Static inner Builder class
+    public static class Builder {
+        Configuration configuration;
+        MetricRegistry metricRegistry;
+        HealthFacility serverHealth;
+        BlockMessagingFacility blockMessaging;
+        HistoricalBlockFacility historicalBlockProvider;
+        ApplicationStateFacility applicationStateFacility;
+        ServiceLoaderFunction serviceLoader;
+        ThreadPoolManager threadPoolManager;
+        BlockNodeVersions blockNodeVersions;
+        TssData tssData;
+        NodeAddressBook nodeAddressBook;
+
+        public Builder(BlockNodeContext context) {
+            this.configuration = context.configuration;
+            this.metricRegistry = context.metricRegistry;
+            this.serverHealth = context.serverHealth;
+            this.blockMessaging = context.blockMessaging;
+            this.historicalBlockProvider = context.historicalBlockProvider;
+            this.applicationStateFacility = context.applicationStateFacility;
+            this.serviceLoader = context.serviceLoader;
+            this.threadPoolManager = context.threadPoolManager;
+            this.blockNodeVersions = context.blockNodeVersions;
+            this.tssData = context.tssData;
+            this.nodeAddressBook = context.nodeAddressBook;
+        }
+
+        public Builder tssData(TssData tssData) {
+            this.tssData = tssData;
+            return this; // Returns the builder for chaining
+        }
+
+        public Builder nodeAddressBook(NodeAddressBook nodeAddressBook) {
+            this.nodeAddressBook = nodeAddressBook;
+            return this; // Returns the builder for chaining
+        }
+
+        public BlockNodeContext build() {
+            return new BlockNodeContext(
+                    this.configuration,
+                    this.metricRegistry,
+                    this.serverHealth,
+                    this.blockMessaging,
+                    this.historicalBlockProvider,
+                    this.applicationStateFacility,
+                    this.serviceLoader,
+                    this.threadPoolManager,
+                    this.blockNodeVersions,
+                    this.tssData,
+                    this.nodeAddressBook);
+        }
+    }
+}

--- a/block-node/spi-plugins/src/test/java/org/hiero/block/node/spi/BlockNodePluginTest.java
+++ b/block-node/spi-plugins/src/test/java/org/hiero/block/node/spi/BlockNodePluginTest.java
@@ -58,8 +58,9 @@ public class BlockNodePluginTest {
         }
 
         @Override
-        public void updateAddressBook(NodeAddressBook nodeAddressBook) {
+        public boolean updateAddressBook(NodeAddressBook nodeAddressBook) {
             // do nothing
+            return false;
         }
     }
 
@@ -84,8 +85,9 @@ public class BlockNodePluginTest {
         }
 
         @Override
-        public void updateAddressBook(NodeAddressBook nodeAddressBook) {
+        public boolean updateAddressBook(NodeAddressBook nodeAddressBook) {
             // do nothing
+            return false;
         }
     }
 


### PR DESCRIPTION
## Reviewer Notes
- [x] **[File path should reference JSON, not binary](https://github.com/hiero-ledger/hiero-block-node/pull/2718#discussion_r3204988762)** — `block-node/app/build.gradle.kts`: resource path referenced in config may need to point to the `.json` file rather than the current value.

- [x] **[Add startup check that parent directory is writable](https://github.com/hiero-ledger/hiero-block-node/pull/2718#discussion_r3204994417)** — `ApplicationStateConfig`: validate that the parent directory of the persistence file path is writable at startup, so permission issues surface early rather than at first persist attempt.

- [x] **[`updateAddressBook` should signal success/failure to callers](https://github.com/hiero-ledger/hiero-block-node/pull/2718#discussion_r3205007062)** — `BlockNodeApp`: method currently swallows errors silently. Return a `boolean` (or a result object) so plugins know whether the update succeeded.

- [x] **[Document thread-safety contract of `updateAddressBook`](https://github.com/hiero-ledger/hiero-block-node/pull/2718#discussion_r3205010718)** — `BlockNodeApp`: add Javadoc stating the thread-safety guarantees (or lack thereof) for this method.

- [x] **[Fail-fast on malformed RSA key format at address-book update time](https://github.com/hiero-ledger/hiero-block-node/pull/2718#discussion_r3205015626)** — `BlockNodeApp`: validate that each `rsaPubKey` value is parseable DER when the address book is ingested, rather than waiting for proof-verification time.

- [x] **[Avoid calling `updateBlockNodeContext` twice with partial state](https://github.com/hiero-ledger/hiero-block-node/pull/2718#discussion_r3205024477)** — `BlockNodeApp`: the current logic triggers a context rebuild once per updated field, which is confusing and potentially races. Batch state updates and trigger a single `updateBlockNodeContext` call.

- [x] **[Consider coalescing context updates with a short debounce window](https://github.com/hiero-ledger/hiero-block-node/pull/2718#discussion_r3205430786)** — `BlockNodeApp` (jsync suggestion): queue updates, let them accumulate for ~100 ms, then fire a single context rebuild. Keep `BlockNodeContext` as a record to avoid needing multiple global locks.


## Related Issue(s)
 Closes: #2756
 Closes: #2757