### PR TITLE
fix(solo-e2e): Fix the JS_SDK_VERSION Default on Scheduled runs

### DIFF
--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -230,7 +230,7 @@ jobs:
           TCK_VERSION="${TCK_VERSION:-latest}"
 
           # JS-SDK version: use input value (input has default v2.83.0)
-          JS_SDK_VERSION="${{ inputs.js-sdk-version }}"
+          JS_SDK_VERSION="${{ inputs.js-sdk-version || 'v2.83.0' }}"
 
           # TSS: use input value (defaults to true)
           TSS_ENABLED="${{ inputs.tss-enabled }}"

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -771,7 +771,7 @@ jobs:
         run: |
           cd sdk-tck/sdk-server
           git fetch --tags
-          JS_SDK_REQUESTED="${{ inputs.js-sdk-version }}"
+          JS_SDK_REQUESTED="${{ inputs.js-sdk-version || 'v2.83.0' }}"
           if [[ "${JS_SDK_REQUESTED}" == "latest" ]]; then
             JS_SDK_RESOLVED=$(git describe --tags --abbrev=0)
           else


### PR DESCRIPTION
## Reviewer Notes

fix: set default JS_SDK_VERSION to v2.83.0 in E2E test configurations

#2790 


Test run passed https://github.com/hiero-ledger/hiero-block-node/actions/runs/25760769815/job/75661195891 ✅ 