### PR TITLE
test: Add solo-chaos latency considerations to e2e test framework

### DIFF
--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -82,7 +82,7 @@ on:
         type: string
         default: "5"
       test-definition:
-        description: "Test definitions (comma-separated): smoke-test, basic-load, node-restart-resilience, full-history-backfill, tss-signature-transition, wrb-cli-hash-validation, wrb-cli-wrapping-validation, wrb-differential-test, wrb-core-validation, wrb-distribution-step12, wrb-distribution-step345"
+        description: "Test definitions (comma-separated): smoke-test, basic-load, node-restart-resilience, full-history-backfill, tss-signature-transition, wrb-cli-hash-validation, wrb-cli-wrapping-validation, wrb-differential-test, wrb-core-validation, wrb-distribution-step12, wrb-distribution-step345, chaos-foundation-smoke, latency-cn-to-cn, latency-cn-to-bn, latency-bn-to-bn, latency-all-three"
         type: string
         default: "none"
     outputs:
@@ -202,7 +202,7 @@ on:
         required: false
         default: "5"
       test-definition:
-        description: "Test definitions (comma-separated): smoke-test, basic-load, node-restart-resilience, full-history-backfill, tss-signature-transition, wrb-cli-hash-validation, wrb-cli-wrapping-validation, wrb-differential-test, wrb-core-validation, rsa-roster-verification, wrb-distribution-step12, wrb-distribution-step345, wrb-distribution-step67"
+        description: "Test definitions (comma-separated): smoke-test, basic-load, node-restart-resilience, full-history-backfill, tss-signature-transition, wrb-cli-hash-validation, wrb-cli-wrapping-validation, wrb-differential-test, wrb-core-validation, rsa-roster-verification, wrb-distribution-step12, wrb-distribution-step345, wrb-distribution-step67, chaos-foundation-smoke, latency-cn-to-cn, latency-cn-to-bn, latency-bn-to-bn, latency-all-three"
         required: false
         default: "none"
 
@@ -518,6 +518,18 @@ jobs:
 
           # Fail the step if NLG failed
           exit $NLG_EXIT_CODE
+
+      # chaos-CI integration: the chaos-foundation-smoke and latency-* tests inject NetworkChaos, which needs
+      # Chaos Mesh CRDs in the cluster. solo-test-runner only checks for the CRDs (it does not install them),
+      # so install Chaos Mesh when a chaos/latency test is selected. No-op for every other run.
+      - name: Install Chaos Mesh (chaos/latency tests only)
+        if: ${{ contains(inputs.test-definition, 'chaos') || contains(inputs.test-definition, 'latency') }}
+        run: |
+          if kubectl api-resources --api-group=chaos-mesh.org -o name 2>/dev/null | grep -q networkchaos; then
+            echo "Chaos Mesh CRDs already present, skipping install"
+          else
+            bash tools-and-tests/scripts/solo-e2e-test/scripts/chaos-install.sh
+          fi
 
       # Run each test definition sequentially on the same deployment
       - name: Run Test Definitions

--- a/tools-and-tests/scripts/solo-e2e-test/.env.example
+++ b/tools-and-tests/scripts/solo-e2e-test/.env.example
@@ -34,7 +34,12 @@ SOLO_SOURCE=npm
 # SOLO_GIT_REPO=AlfredoG87/solo
 # SOLO_GIT_REF=fix/bn-health-port-5283
 
-# TSS/WRAPS on consensus nodes enabled (default: true)
+# TSS/WRAPS on consensus nodes (default: true — the supported mode)
+#
+# Solo CLI's '--wraps' flag (sent when TSS_ENABLED=true) requires CN >= v0.74.0-0.
+# CN_VERSION=latest is min-enforced by resolve-versions.sh to a TSS-capable tag
+# (currently 0.75.0-rc.4), so '--wraps' deploys cleanly and the latency tests run
+# with TSS on. Only override to 'false' if you pin a CN_VERSION below the floor.
 TSS_ENABLED=true
 
 # NLG Load Generation (for task load:up)

--- a/tools-and-tests/scripts/solo-e2e-test/README.md
+++ b/tools-and-tests/scripts/solo-e2e-test/README.md
@@ -624,29 +624,29 @@ assertions:                      # Validations to run after all events
 
 ### Event Types
 
-|            Type            |           Description            |                           Arguments                            |
-|----------------------------|----------------------------------|----------------------------------------------------------------|
-| `command`                  | Run arbitrary script             | `script`                                                       |
-| `node-down`                | Scale node to 0 replicas         | `target`                                                       |
-| `node-up`                  | Scale node to 1 replica          | `target`                                                       |
-| `scale-down`               | Scale down (alias for node-down) | `target`                                                       |
-| `scale-up`                 | Scale up (alias for node-up)     | `target`                                                       |
-| `restart`                  | Rollout restart node             | `target`                                                       |
-| `load-start`               | Start NLG load                   | `test_class`, `concurrency`, `accounts`, `duration`, `max_tps` |
-| `load-stop`                | Stop NLG load                    | `test_class`                                                   |
-| `print-metrics`            | Print metrics summary            | `target` (node name or "all")                                  |
-| `network-status`           | Print network status             | (none)                                                         |
-| `sleep`                    | Pause execution                  | `seconds`                                                      |
-| `port-forward`             | Refresh port forwards            | (none)                                                         |
-| `clear-block-storage`      | Clear all block data on node     | `target`                                                       |
-| `deploy-block-node`        | Deploy new Block Node            | `name`, `backfill_sources`, `greedy`, `chart_version`          |
-| `reconfigure-cn-streaming` | Update CN block-nodes.json       | `consensus_node`, `block_nodes`                                |
+|            Type            |           Description            |                                             Arguments                                             |
+|----------------------------|----------------------------------|---------------------------------------------------------------------------------------------------|
+| `command`                  | Run arbitrary script             | `script`                                                                                          |
+| `node-down`                | Scale node to 0 replicas         | `target`                                                                                          |
+| `node-up`                  | Scale node to 1 replica          | `target`                                                                                          |
+| `scale-down`               | Scale down (alias for node-down) | `target`                                                                                          |
+| `scale-up`                 | Scale up (alias for node-up)     | `target`                                                                                          |
+| `restart`                  | Rollout restart node             | `target`                                                                                          |
+| `load-start`               | Start NLG load                   | `test_class`, `concurrency`, `accounts`, `duration`, `max_tps`                                    |
+| `load-stop`                | Stop NLG load                    | `test_class`                                                                                      |
+| `print-metrics`            | Print metrics summary            | `target` (node name or "all")                                                                     |
+| `network-status`           | Print network status             | (none)                                                                                            |
+| `sleep`                    | Pause execution                  | `seconds`                                                                                         |
+| `port-forward`             | Refresh port forwards            | (none)                                                                                            |
+| `clear-block-storage`      | Clear all block data on node     | `target`                                                                                          |
+| `deploy-block-node`        | Deploy new Block Node            | `name`, `backfill_sources`, `greedy`, `chart_version`                                             |
+| `reconfigure-cn-streaming` | Update CN block-nodes.json       | `consensus_node`, `block_nodes`                                                                   |
 | `inject-latency`           | Apply a NetworkChaos rule        | `name`, `source.kind`, `target.kind`, `latency`, `jitter`, `correlation`, `bidirectional`, `loss` |
-| `clear-latency`            | Remove a NetworkChaos rule       | `name`                                                         |
+| `clear-latency`            | Remove a NetworkChaos rule       | `name`                                                                                            |
 
 ### Assertion Types
 
-| Type                      | Description                                                      | Arguments                                                  |
+|           Type            |                           Description                            |                         Arguments                          |
 |---------------------------|------------------------------------------------------------------|------------------------------------------------------------|
 | `block-available`         | Verify BN has blocks in range                                    | `min_block`, `max_block_gte`                               |
 | `node-healthy`            | Verify pod is Running                                            | `target`                                                   |
@@ -656,7 +656,7 @@ assertions:                      # Validations to run after all events
 | `metric-threshold`        | Compare any BN Prometheus metric                                 | `metric`, `comparator`, `value`, `samples`, `wait_seconds` |
 | `block-rate-floor`        | Assert Δblocks/Δtime ≥ floor                                     | `min_rate_per_sec`, `window_seconds`                       |
 | `backfill-triggered`      | Assert backfill log marker observed                              | `grep` (default `"backfill"`), `since_seconds`             |
-| `log-match`               | Generic log-substring check                                      | `grep`, `since_seconds`                                     |
+| `log-match`               | Generic log-substring check                                      | `grep`, `since_seconds`                                    |
 
 **Note:** The `blocks-increasing` assertion verifies a Block Node is actively receiving blocks. It measures baseline, waits `wait_seconds` (default: 60), verifies increase, retrying up to `max_attempts` (default: 3) times.
 
@@ -719,15 +719,15 @@ CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-cn-to
 
 Available latency tests, grouped by **profile** (see [`docs/latency-scenarios.md`](docs/latency-scenarios.md#choosing-a-latency-profile-baseline--stress--severe) for how to choose):
 
-|              Test File             | Profile  |                Description                  |
-|------------------------------------|----------|---------------------------------------------|
-| `tests/chaos-foundation-smoke.yaml`| —        | Plumbing check (inject → confirm → clear)   |
-| `tests/latency-cn-to-cn.yaml`      | baseline | 100 ms ± 20 ms between Consensus Nodes      |
-| `tests/latency-bn-to-bn.yaml`      | baseline | 200 ms ± 40 ms between Block Nodes          |
-| `tests/latency-cn-to-bn.yaml`      | baseline | 150 ms ± 30 ms between CNs and BNs          |
-| `tests/latency-all-three.yaml`     | baseline | All three baseline rules concurrently       |
-| `tests/latency-stress.yaml`        | stress   | ~3× baseline, bursty — degrade & recover    |
-| `tests/latency-severe.yaml`        | severe   | ~5–6× baseline — survival & recovery probe  |
+|              Test File              | Profile  |                Description                 |
+|-------------------------------------|----------|--------------------------------------------|
+| `tests/chaos-foundation-smoke.yaml` | —        | Plumbing check (inject → confirm → clear)  |
+| `tests/latency-cn-to-cn.yaml`       | baseline | 100 ms ± 20 ms between Consensus Nodes     |
+| `tests/latency-bn-to-bn.yaml`       | baseline | 200 ms ± 40 ms between Block Nodes         |
+| `tests/latency-cn-to-bn.yaml`       | baseline | 150 ms ± 30 ms between CNs and BNs         |
+| `tests/latency-all-three.yaml`      | baseline | All three baseline rules concurrently      |
+| `tests/latency-stress.yaml`         | stress   | ~3× baseline, bursty — degrade & recover   |
+| `tests/latency-severe.yaml`         | severe   | ~5–6× baseline — survival & recovery probe |
 
 - **baseline** — does the network tolerate normal latency with no visible impact? (steady block-rate floor holds)
 - **stress** — does it degrade gracefully and recover via backfill? (reduced floor)
@@ -757,13 +757,13 @@ task chaos:uninstall   # helm uninstall + delete the chaos-mesh namespace
 
 ### Troubleshooting
 
-|                Symptom                  |                                                Cause / fix                                                 |
-|-----------------------------------------|------------------------------------------------------------------------------------------------------------|
-| `task chaos:install` skipped silently   | `CHAOS_ENABLED` is not `true`. Re-run with `CHAOS_ENABLED=true task chaos:install`.                        |
-| `ERROR: Chaos Mesh CRDs not present`    | Chaos Mesh isn't installed in this cluster. Run `CHAOS_ENABLED=true task chaos:install`.                   |
-| `source(...) matched 0 pods`            | Selector found no matching pods. Verify `kubectl get pod --show-labels` and the kind ↔ label-key mapping.  |
-| Stale NetworkChaos after test crash     | The runner's trap should clean up; if not, `task chaos:cleanup` (or `kubectl delete networkchaos --all -n chaos-mesh`). |
-| Test deploy fails on hardened CI cluster| The chaos daemon needs `privileged=true`. Hardened clusters won't allow this. Skip with `CHAOS_ENABLED=false`. |
+|                 Symptom                  |                                                       Cause / fix                                                       |
+|------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `task chaos:install` skipped silently    | `CHAOS_ENABLED` is not `true`. Re-run with `CHAOS_ENABLED=true task chaos:install`.                                     |
+| `ERROR: Chaos Mesh CRDs not present`     | Chaos Mesh isn't installed in this cluster. Run `CHAOS_ENABLED=true task chaos:install`.                                |
+| `source(...) matched 0 pods`             | Selector found no matching pods. Verify `kubectl get pod --show-labels` and the kind ↔ label-key mapping.               |
+| Stale NetworkChaos after test crash      | The runner's trap should clean up; if not, `task chaos:cleanup` (or `kubectl delete networkchaos --all -n chaos-mesh`). |
+| Test deploy fails on hardened CI cluster | The chaos daemon needs `privileged=true`. Hardened clusters won't allow this. Skip with `CHAOS_ENABLED=false`.          |
 
 ### Pointers
 

--- a/tools-and-tests/scripts/solo-e2e-test/README.md
+++ b/tools-and-tests/scripts/solo-e2e-test/README.md
@@ -13,6 +13,7 @@ Deploy Hiero networks locally for development and testing using [Solo CLI](https
 - [Load Generation](#load-generation)
 - [TCK-SDK Tests](#tck-sdk-tests)
 - [Test Framework](#test-framework)
+- [Network Chaos / Latency Tests](#network-chaos--latency-tests)
 - [CN-BN Priority Routing](#cn-bn-priority-routing)
 - [CI Integration](#ci-integration)
 - [Endpoints](#endpoints)
@@ -640,16 +641,22 @@ assertions:                      # Validations to run after all events
 | `clear-block-storage`      | Clear all block data on node     | `target`                                                       |
 | `deploy-block-node`        | Deploy new Block Node            | `name`, `backfill_sources`, `greedy`, `chart_version`          |
 | `reconfigure-cn-streaming` | Update CN block-nodes.json       | `consensus_node`, `block_nodes`                                |
+| `inject-latency`           | Apply a NetworkChaos rule        | `name`, `source.kind`, `target.kind`, `latency`, `jitter`, `correlation`, `bidirectional`, `loss` |
+| `clear-latency`            | Remove a NetworkChaos rule       | `name`                                                         |
 
 ### Assertion Types
 
-|           Type            |                           Description                            |           Arguments            |
-|---------------------------|------------------------------------------------------------------|--------------------------------|
-| `block-available`         | Verify BN has blocks in range                                    | `min_block`, `max_block_gte`   |
-| `node-healthy`            | Verify pod is Running                                            | `target`                       |
-| `no-errors`               | Verify no verification errors                                    | `target`                       |
-| `blocks-increasing`       | Verify blocks are actively flowing                               | `wait_seconds`, `max_attempts` |
-| `rsa-roster-verification` | Verify blocks accepted via the RSA roster (WRB), no RSA failures | `min_rsa_success`              |
+| Type                      | Description                                                      | Arguments                                                  |
+|---------------------------|------------------------------------------------------------------|------------------------------------------------------------|
+| `block-available`         | Verify BN has blocks in range                                    | `min_block`, `max_block_gte`                               |
+| `node-healthy`            | Verify pod is Running                                            | `target`                                                   |
+| `no-errors`               | Verify no verification errors                                    | `target`                                                   |
+| `blocks-increasing`       | Verify blocks are actively flowing                               | `wait_seconds`, `max_attempts`                             |
+| `rsa-roster-verification` | Verify blocks accepted via the RSA roster (WRB), no RSA failures | `min_rsa_success`                                          |
+| `metric-threshold`        | Compare any BN Prometheus metric                                 | `metric`, `comparator`, `value`, `samples`, `wait_seconds` |
+| `block-rate-floor`        | Assert Δblocks/Δtime ≥ floor                                     | `min_rate_per_sec`, `window_seconds`                       |
+| `backfill-triggered`      | Assert backfill log marker observed                              | `grep` (default `"backfill"`), `since_seconds`             |
+| `log-match`               | Generic log-substring check                                      | `grep`, `since_seconds`                                     |
 
 **Note:** The `blocks-increasing` assertion verifies a Block Node is actively receiving blocks. It measures baseline, waits `wait_seconds` (default: 60), verifies increase, retrying up to `max_attempts` (default: 3) times.
 
@@ -670,6 +677,98 @@ Run tests via GitHub Actions workflow dispatch:
 5. Run with `task test:run TEST_FILE=tests/my-test.yaml`
 
 See `test-schema.yaml` for the complete schema documentation.
+
+## Network Chaos / Latency Tests
+
+Inject configurable network latency between Consensus Nodes and Block Nodes during a test run, to exercise behavior under realistic cross-region conditions. Built on top of [Chaos Mesh](https://chaos-mesh.org/) v2.7.2. **Opt-in only** — the default workflow is unaffected.
+
+The framework supports three latency dimensions:
+
+- **CN ↔ CN** — gossip / consensus traffic
+- **BN ↔ BN** — peer backfill mesh
+- **CN ↔ BN** — live block-publish stream
+
+For per-scenario details, thresholds, and how to add a new scenario, see [`docs/latency-scenarios.md`](docs/latency-scenarios.md).
+
+### Prerequisites
+
+In addition to the usual prereqs:
+
+- **Solo CLI ≥ 0.63.0** (for the block-node label set Chaos Mesh selects on)
+- **Privileged Kubernetes** — Chaos Mesh's daemon runs `privileged=true`, `hostPID=true`, `mountHostLibModules=true`. Local Kind clusters allow this by default; hardened CI clusters may not.
+
+### First-time setup (per cluster session)
+
+```bash
+# 1. Bring up a cluster (TSS is on by default — see note below).
+task up TOPOLOGY=paired-3
+
+# 2. Install Chaos Mesh (opt-in)
+CHAOS_ENABLED=true task chaos:install
+```
+
+`task chaos:install` is idempotent — re-running upgrades in place rather than failing.
+
+> **TSS is on by default** (the supported mode). Solo CLI's `--wraps` flag requires CN ≥ v0.74.0-0; `CN_VERSION=latest` is min-enforced by `resolve-versions.sh` to a TSS-capable tag (currently `0.75.0-rc.4`), so `--wraps` deploys cleanly and TSS signatures verify under latency (confirmed: Schnorr→WRAPS transition). Only set `TSS_ENABLED=false` if you pin a `CN_VERSION` below the floor.
+
+### Running a latency test
+
+```bash
+CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-cn-to-bn.yaml
+```
+
+Available latency tests, grouped by **profile** (see [`docs/latency-scenarios.md`](docs/latency-scenarios.md#choosing-a-latency-profile-baseline--stress--severe) for how to choose):
+
+|              Test File             | Profile  |                Description                  |
+|------------------------------------|----------|---------------------------------------------|
+| `tests/chaos-foundation-smoke.yaml`| —        | Plumbing check (inject → confirm → clear)   |
+| `tests/latency-cn-to-cn.yaml`      | baseline | 100 ms ± 20 ms between Consensus Nodes      |
+| `tests/latency-bn-to-bn.yaml`      | baseline | 200 ms ± 40 ms between Block Nodes          |
+| `tests/latency-cn-to-bn.yaml`      | baseline | 150 ms ± 30 ms between CNs and BNs          |
+| `tests/latency-all-three.yaml`     | baseline | All three baseline rules concurrently       |
+| `tests/latency-stress.yaml`        | stress   | ~3× baseline, bursty — degrade & recover    |
+| `tests/latency-severe.yaml`        | severe   | ~5–6× baseline — survival & recovery probe  |
+
+- **baseline** — does the network tolerate normal latency with no visible impact? (steady block-rate floor holds)
+- **stress** — does it degrade gracefully and recover via backfill? (reduced floor)
+- **severe** — does it survive and recover near the breaking point? (recovery-only assertions)
+
+> **CI concurrency:** the `solo-e2e-test` workflow uses `concurrency: solo-network-<topology>` with `cancel-in-progress: true`, so two `paired-3` chaos runs cannot run at once — the newer dispatch cancels the older. Run them one at a time. (A canceled run logs `kind/solo: command not found` in cleanup — that's cancellation noise, not a failure.)
+
+### Inspecting active chaos
+
+```bash
+task chaos:status      # active NetworkChaos / PodChaos + Chaos Mesh component health
+```
+
+### Cleanup
+
+`task down` automatically invokes `task chaos:cleanup`, so chaos rules do not leak between test cluster lifetimes. To clear rules without tearing down the cluster:
+
+```bash
+task chaos:cleanup     # deletes all NetworkChaos / PodChaos resources
+```
+
+To fully uninstall Chaos Mesh from the cluster:
+
+```bash
+task chaos:uninstall   # helm uninstall + delete the chaos-mesh namespace
+```
+
+### Troubleshooting
+
+|                Symptom                  |                                                Cause / fix                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------------------------|
+| `task chaos:install` skipped silently   | `CHAOS_ENABLED` is not `true`. Re-run with `CHAOS_ENABLED=true task chaos:install`.                        |
+| `ERROR: Chaos Mesh CRDs not present`    | Chaos Mesh isn't installed in this cluster. Run `CHAOS_ENABLED=true task chaos:install`.                   |
+| `source(...) matched 0 pods`            | Selector found no matching pods. Verify `kubectl get pod --show-labels` and the kind ↔ label-key mapping.  |
+| Stale NetworkChaos after test crash     | The runner's trap should clean up; if not, `task chaos:cleanup` (or `kubectl delete networkchaos --all -n chaos-mesh`). |
+| Test deploy fails on hardened CI cluster| The chaos daemon needs `privileged=true`. Hardened clusters won't allow this. Skip with `CHAOS_ENABLED=false`. |
+
+### Pointers
+
+- Profiles, per-scenario detail, and how to add a new one: [`docs/latency-scenarios.md`](docs/latency-scenarios.md)
+- Upstream Chaos Mesh wrapper this builds on: [solo-chaos](https://github.com/hashgraph/solo-chaos) (for multi-region simulation)
 
 ## Troubleshooting
 

--- a/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
+++ b/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
@@ -55,6 +55,9 @@ vars:
   BN_CHART_DIR: '{{.BN_CHART_DIR | default ""}}'
   RELAY_VERSION: '{{.RELAY_VERSION | default "latest"}}'
   TCK_VERSION: '{{.TCK_VERSION | default "latest"}}'
+  # TSS_ENABLED defaults to 'true' (the supported mode). CN_VERSION=latest is
+  # min-enforced to a TSS-capable tag, so latency tests run with TSS on; only
+  # override to 'false' if you pin a CN below v0.74.0-0. See .env.example.
   TSS_ENABLED: '{{.TSS_ENABLED | default "true"}}'
 
   # Solo install source: 'npm' (default) or 'git' (build an approved fork/branch)
@@ -70,6 +73,10 @@ vars:
 
   # Metrics/Observability
   ENABLE_LOCAL_METRICS: '{{.ENABLE_LOCAL_METRICS | default "false"}}'
+
+  # Chaos / Network Latency (opt-in)
+  CHAOS_ENABLED: '{{.CHAOS_ENABLED | default "false"}}'
+  CHAOS_MESH_VERSION: '{{.CHAOS_MESH_VERSION | default "2.7.2"}}'
 
   # TCK-SDK test configuration
   TCK_SDK_DIR: '{{.TCK_SDK_DIR | default "sdk-tck"}}'
@@ -430,13 +437,44 @@ tasks:
         echo "  task down       - Tear down everything"
 
   down:
-    desc: Tear down everything - stop port-forwards and destroy cluster
+    desc: Tear down everything - clean chaos rules, stop port-forwards, destroy cluster
     cmds:
+      - task: chaos:cleanup
       - task: port-forward:stop
       - task: cluster:destroy
       - |
         echo ""
         echo "All resources cleaned up."
+
+  # ============================================================================
+  # Chaos / Network Latency (opt-in via CHAOS_ENABLED=true)
+  # See docs/latency-scenarios.md for profiles, design, and how to add scenarios.
+  # ============================================================================
+  chaos:install:
+    desc: "Install Chaos Mesh (idempotent). Required for latency tests. Set CHAOS_ENABLED=true."
+    cmds:
+      - |
+        if [[ "{{.CHAOS_ENABLED}}" != "true" ]]; then
+          echo "CHAOS_ENABLED is not 'true' (current: '{{.CHAOS_ENABLED}}'). Skipping install."
+          echo "Re-run with: CHAOS_ENABLED=true task chaos:install"
+          exit 0
+        fi
+        "{{.SCRIPTS_DIR}}/chaos-install.sh" --version "{{.CHAOS_MESH_VERSION}}"
+
+  chaos:uninstall:
+    desc: "Uninstall Chaos Mesh and remove its namespace"
+    cmds:
+      - '"{{.SCRIPTS_DIR}}/chaos-uninstall.sh"'
+
+  chaos:status:
+    desc: "Show active NetworkChaos / PodChaos resources and Chaos Mesh component health"
+    cmds:
+      - '"{{.SCRIPTS_DIR}}/chaos-status.sh"'
+
+  chaos:cleanup:
+    desc: "Delete all chaos resources (NetworkChaos, PodChaos). Tolerant if Chaos Mesh not installed."
+    cmds:
+      - '"{{.SCRIPTS_DIR}}/chaos-cleanup.sh" --quiet'
 
   # ============================================================================
   # Test Framework

--- a/tools-and-tests/scripts/solo-e2e-test/docs/latency-scenarios.md
+++ b/tools-and-tests/scripts/solo-e2e-test/docs/latency-scenarios.md
@@ -4,11 +4,11 @@ Long-form companion to the [README's Network Chaos section](../README.md#network
 
 The solo-e2e-test harness can inject configurable network latency in three dimensions:
 
-| Dimension | Source selector | Target selector | Affects |
-|-----------|-----------------|-----------------|---------|
-| **CN ↔ CN** | `solo.hedera.com/type=network-node` | `solo.hedera.com/type=network-node`     | Gossip / consensus rounds |
-| **BN ↔ BN** | `block-node.hiero.com/type=block-node` | `block-node.hiero.com/type=block-node` | Peer backfill mesh |
-| **CN ↔ BN** | `solo.hedera.com/type=network-node` | `block-node.hiero.com/type=block-node`  | Live block-publish stream |
+|  Dimension  |            Source selector             |            Target selector             |          Affects          |
+|-------------|----------------------------------------|----------------------------------------|---------------------------|
+| **CN ↔ CN** | `solo.hedera.com/type=network-node`    | `solo.hedera.com/type=network-node`    | Gossip / consensus rounds |
+| **BN ↔ BN** | `block-node.hiero.com/type=block-node` | `block-node.hiero.com/type=block-node` | Peer backfill mesh        |
+| **CN ↔ BN** | `solo.hedera.com/type=network-node`    | `block-node.hiero.com/type=block-node` | Live block-publish stream |
 
 > **Two label namespaces:** CN pods carry `solo.hedera.com/*` labels (emitted by Solo CLI); BN pods carry `block-node.hiero.com/*` labels (emitted by the BN Helm chart). Each side of a rule must select with the matching namespace.
 
@@ -16,15 +16,16 @@ The solo-e2e-test harness can inject configurable network latency in three dimen
 
 There are three tiers. They share the same event shape and assertions vocabulary; they differ in the **magnitude** of injected latency and in what the assertions are checking for.
 
-| Profile | Test file(s) | Latency (CN↔CN / CN↔BN / BN↔BN) | What it answers | Assertion intent |
-|---------|--------------|----------------------------------|-----------------|------------------|
-| **baseline** | `latency-cn-to-cn`, `latency-cn-to-bn`, `latency-bn-to-bn`, `latency-all-three` | 100±20 / 150±30 / 200±40 ms | Does the network tolerate *normal* cross-AZ/region latency with no visible impact? | Steady block production holds: `block-rate-floor ≥ 0.3 blk/s`, healthy, increasing. |
-| **stress** | `latency-stress` | 300±80 / 450±120 / 600±150 ms, correlation 50% | Does it **degrade gracefully and recover**? | Backfill is exercised (`backfill-triggered`), then block production resumes; reduced floor `≥ 0.2 blk/s`. |
-| **severe** | `latency-severe` | 600±150 / 800±200 / 1000±250 ms, correlation 75% | Survival / recovery near the breaking point. | Survives + **recovers** after latency clears (`backfill-triggered`, `blocks-increasing`); low floor `≥ 0.1 blk/s` (recovery, not steady-state). |
+|   Profile    |                                  Test file(s)                                   |         Latency (CN↔CN / CN↔BN / BN↔BN)          |                                  What it answers                                   |                                                                Assertion intent                                                                 |
+|--------------|---------------------------------------------------------------------------------|--------------------------------------------------|------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| **baseline** | `latency-cn-to-cn`, `latency-cn-to-bn`, `latency-bn-to-bn`, `latency-all-three` | 100±20 / 150±30 / 200±40 ms                      | Does the network tolerate *normal* cross-AZ/region latency with no visible impact? | Steady block production holds: `block-rate-floor ≥ 0.3 blk/s`, healthy, increasing.                                                             |
+| **stress**   | `latency-stress`                                                                | 300±80 / 450±120 / 600±150 ms, correlation 50%   | Does it **degrade gracefully and recover**?                                        | Backfill is exercised (`backfill-triggered`), then block production resumes; reduced floor `≥ 0.2 blk/s`.                                       |
+| **severe**   | `latency-severe`                                                                | 600±150 / 800±200 / 1000±250 ms, correlation 75% | Survival / recovery near the breaking point.                                       | Survives + **recovers** after latency clears (`backfill-triggered`, `blocks-increasing`); low floor `≥ 0.1 blk/s` (recovery, not steady-state). |
 
 **Pick a profile by selecting its test name.** All profiles require the `paired-3` topology and run with **TSS on** (the default; see "Pre-requisites" below).
 
 Run locally (Taskfile):
+
 ```bash
 # baseline (one dimension, or all three at once)
 CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-cn-to-cn.yaml
@@ -35,23 +36,25 @@ CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-sever
 ```
 
 Run in CI (`solo-e2e-test` workflow) — pass the test name (without `.yaml`) as `test-definition`:
+
 ```bash
 gh workflow run solo-e2e-test.yml --ref <branch> -f topology=paired-3 -f tss-enabled=true -f test-definition=latency-stress
 ```
+
 > **Concurrency gotcha:** the workflow uses `concurrency: solo-network-<topology>` with `cancel-in-progress: true`. Two runs of the **same topology** (e.g. two `paired-3` chaos tests) cannot run at once — the newer dispatch **cancels** the older. Run chaos tests one at a time, or stagger them. A canceled run shows `kind/solo: command not found` in its cleanup steps — that's cancellation noise, not a real failure.
 
 ### Tuning latency yourself
 
 Each `inject-latency` event accepts:
 
-| Key | Meaning | Example |
-|-----|---------|---------|
-| `source.kind` / `target.kind` | `network-node` (CN) or `block-node` (BN) | `{ kind: block-node }` |
-| `latency` | base one-way delay (any netem duration) | `200ms` |
-| `jitter` | ± variation around `latency` | `40ms` |
-| `correlation` | % correlation between successive delays (burstiness); default `0` | `"50"` |
-| `bidirectional` | shape both directions (`direction: both`) | `true` |
-| `loss` | netem packet loss — wired end-to-end (runner + template), but no shipped scenario exercises it yet | `"1%"` |
+|              Key              |                                              Meaning                                               |        Example         |
+|-------------------------------|----------------------------------------------------------------------------------------------------|------------------------|
+| `source.kind` / `target.kind` | `network-node` (CN) or `block-node` (BN)                                                           | `{ kind: block-node }` |
+| `latency`                     | base one-way delay (any netem duration)                                                            | `200ms`                |
+| `jitter`                      | ± variation around `latency`                                                                       | `40ms`                 |
+| `correlation`                 | % correlation between successive delays (burstiness); default `0`                                  | `"50"`                 |
+| `bidirectional`               | shape both directions (`direction: both`)                                                          | `true`                 |
+| `loss`                        | netem packet loss — wired end-to-end (runner + template), but no shipped scenario exercises it yet | `"1%"`                 |
 
 To make a custom heavier/lighter variant, copy a profile and adjust `latency`/`jitter`/`correlation`. Bump `block-rate-floor.min_rate_per_sec` down as you increase latency (the assertions run after the latency clears, so they verify recovery).
 

--- a/tools-and-tests/scripts/solo-e2e-test/docs/latency-scenarios.md
+++ b/tools-and-tests/scripts/solo-e2e-test/docs/latency-scenarios.md
@@ -1,0 +1,214 @@
+# Network Latency Scenarios
+
+Long-form companion to the [README's Network Chaos section](../README.md#network-chaos--latency-tests). Use this when you want to know *why* each test exists, *what* the thresholds are, *how to choose a profile*, and *how* to add new scenarios.
+
+The solo-e2e-test harness can inject configurable network latency in three dimensions:
+
+| Dimension | Source selector | Target selector | Affects |
+|-----------|-----------------|-----------------|---------|
+| **CN ↔ CN** | `solo.hedera.com/type=network-node` | `solo.hedera.com/type=network-node`     | Gossip / consensus rounds |
+| **BN ↔ BN** | `block-node.hiero.com/type=block-node` | `block-node.hiero.com/type=block-node` | Peer backfill mesh |
+| **CN ↔ BN** | `solo.hedera.com/type=network-node` | `block-node.hiero.com/type=block-node`  | Live block-publish stream |
+
+> **Two label namespaces:** CN pods carry `solo.hedera.com/*` labels (emitted by Solo CLI); BN pods carry `block-node.hiero.com/*` labels (emitted by the BN Helm chart). Each side of a rule must select with the matching namespace.
+
+## Choosing a latency profile (baseline / stress / severe)
+
+There are three tiers. They share the same event shape and assertions vocabulary; they differ in the **magnitude** of injected latency and in what the assertions are checking for.
+
+| Profile | Test file(s) | Latency (CN↔CN / CN↔BN / BN↔BN) | What it answers | Assertion intent |
+|---------|--------------|----------------------------------|-----------------|------------------|
+| **baseline** | `latency-cn-to-cn`, `latency-cn-to-bn`, `latency-bn-to-bn`, `latency-all-three` | 100±20 / 150±30 / 200±40 ms | Does the network tolerate *normal* cross-AZ/region latency with no visible impact? | Steady block production holds: `block-rate-floor ≥ 0.3 blk/s`, healthy, increasing. |
+| **stress** | `latency-stress` | 300±80 / 450±120 / 600±150 ms, correlation 50% | Does it **degrade gracefully and recover**? | Backfill is exercised (`backfill-triggered`), then block production resumes; reduced floor `≥ 0.2 blk/s`. |
+| **severe** | `latency-severe` | 600±150 / 800±200 / 1000±250 ms, correlation 75% | Survival / recovery near the breaking point. | Survives + **recovers** after latency clears (`backfill-triggered`, `blocks-increasing`); low floor `≥ 0.1 blk/s` (recovery, not steady-state). |
+
+**Pick a profile by selecting its test name.** All profiles require the `paired-3` topology and run with **TSS on** (the default; see "Pre-requisites" below).
+
+Run locally (Taskfile):
+```bash
+# baseline (one dimension, or all three at once)
+CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-cn-to-cn.yaml
+CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-all-three.yaml
+# heavier tiers
+CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-stress.yaml
+CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-severe.yaml
+```
+
+Run in CI (`solo-e2e-test` workflow) — pass the test name (without `.yaml`) as `test-definition`:
+```bash
+gh workflow run solo-e2e-test.yml --ref <branch> -f topology=paired-3 -f tss-enabled=true -f test-definition=latency-stress
+```
+> **Concurrency gotcha:** the workflow uses `concurrency: solo-network-<topology>` with `cancel-in-progress: true`. Two runs of the **same topology** (e.g. two `paired-3` chaos tests) cannot run at once — the newer dispatch **cancels** the older. Run chaos tests one at a time, or stagger them. A canceled run shows `kind/solo: command not found` in its cleanup steps — that's cancellation noise, not a real failure.
+
+### Tuning latency yourself
+
+Each `inject-latency` event accepts:
+
+| Key | Meaning | Example |
+|-----|---------|---------|
+| `source.kind` / `target.kind` | `network-node` (CN) or `block-node` (BN) | `{ kind: block-node }` |
+| `latency` | base one-way delay (any netem duration) | `200ms` |
+| `jitter` | ± variation around `latency` | `40ms` |
+| `correlation` | % correlation between successive delays (burstiness); default `0` | `"50"` |
+| `bidirectional` | shape both directions (`direction: both`) | `true` |
+| `loss` | netem packet loss — wired end-to-end (runner + template), but no shipped scenario exercises it yet | `"1%"` |
+
+To make a custom heavier/lighter variant, copy a profile and adjust `latency`/`jitter`/`correlation`. Bump `block-rate-floor.min_rate_per_sec` down as you increase latency (the assertions run after the latency clears, so they verify recovery).
+
+## How the tests are shaped
+
+Each latency test follows the same shape and runs in ~7–8 minutes:
+
+```yaml
+events:
+  - load-start                    (t=0)
+  - inject-latency                (t=30,  starts the chaos window)
+  - clear-latency                 (t=330, ends it after ~5 min)
+  - load-stop                     (t=360)
+assertions:
+  - all-healthy                   (every BN pod is Running)
+  - all-have-blocks               (every BN has block 0..N)
+  - blocks-increasing             (every BN observes Δblocks > 0)
+  - block-rate-floor              (Δblocks/Δtime ≥ floor)
+  - backfill-triggered            (stress/severe — BNs caught up via backfill)
+```
+
+The 0.3 blocks/s baseline floor is intentionally conservative. On the `paired-3` topology, healthy block production averaged ~0.47 blocks/s under modest NLG load, so 0.3 is a comfortable margin — high enough to catch a real stall (the assertion reports 0.000/s on a stalled cluster) and low enough to absorb chaos-induced micro-slowdowns. The stress/severe tiers lower this floor because they intentionally push the system into temporary degradation and check that it *recovers*.
+
+## Baseline scenarios (per dimension)
+
+### `tests/latency-cn-to-cn.yaml`
+
+**Simulates:** CNs gossiping across a slow inter-region link.
+
+**Parameters:** 100 ms ± 20 ms, bidirectional, 5-min window, `solo.hedera.com/type=network-node` on both sides.
+
+**Expected behavior:** Consensus rounds take longer, but the network still produces blocks. BNs continue receiving blocks at roughly the same cadence — typically 0.4–0.5 blocks/s after the chaos clears.
+
+**Assertions:** `node-healthy`, `block-available`, `blocks-increasing`, `block-rate-floor` ≥ 0.3 blocks/s, `metric-threshold blocknode_publisher_stream_errors_total == 0` (exemplifies the generic metric primitive), and `signature-transition` (Schnorr→WRAPS, proving TSS is active under latency).
+
+### `tests/latency-bn-to-bn.yaml`
+
+**Simulates:** Block Nodes in different regions over a slow peer mesh.
+
+**Parameters:** 200 ms ± 40 ms, bidirectional, 5-min window, `block-node.hiero.com/type=block-node` both sides.
+
+**Expected behavior:** Live CN-to-BN streaming is **unaffected** (CN egress doesn't pass through any BN-to-BN rule). BN peer backfill is slowed; on paired-3 each BN already receives blocks directly from a paired CN, so backfill is not the critical path — blocks continue to land.
+
+**Assertions:** same as CN↔CN minus the stream-error check (the CN-publisher stream is independent of BN-to-BN traffic).
+
+> solo-chaos ships no built-in BN↔BN template; this test uses the harness's own parametric template at `scripts/chaos-templates/network-latency.yaml.tmpl` (a candidate upstream contribution).
+
+### `tests/latency-cn-to-bn.yaml`
+
+**Simulates:** The production-realistic case — CNs and BNs in different regions, with the gRPC block-publish stream crossing a slow link.
+
+**Parameters:** 150 ms ± 30 ms, bidirectional, 5-min window, `network-node` → `block-node`.
+
+**Expected behavior:** Each block round-trip through the publisher gRPC stream pays the latency both ways; the BN's ACK takes ~300 ms longer, which can affect publisher flow control. Blocks still flow and `blocknode_publisher_open_connections` should stay non-zero.
+
+**Assertions:** same as CN↔CN minus the strict stream-error check (the publisher stream may transiently reconnect under high latency, which would flake a strict check).
+
+### `tests/latency-all-three.yaml`
+
+**Simulates:** "Everything is in different regions" — three concurrent NetworkChaos rules layered on the same cluster.
+
+**Parameters:** CN↔CN 100±20, BN↔BN 200±40, CN↔BN 150±30 ms, all bidirectional, 5-min window.
+
+**Expected behavior:** Each pod accumulates the netem rules matching its labels; all egress paths are throttled simultaneously. This is the strongest check that Chaos Mesh applies all three rules without interference.
+
+**Assertions:** same as CN↔CN minus the stream-error check.
+
+## Heavy scenarios
+
+### `tests/latency-stress.yaml`
+
+**Simulates:** A degraded WAN — ~3× baseline with bursty (correlated) delays. CN↔CN 300±80, CN↔BN 450±120, BN↔BN 600±150 ms, correlation 50%.
+
+**Expected behavior:** BNs fall behind during the chaos window and **catch up via backfill**, then resume normal production once latency clears.
+
+**Assertions:** `node-healthy`, `block-available`, `backfill-triggered`, `blocks-increasing` (recovery), `block-rate-floor` ≥ 0.2 blk/s.
+
+### `tests/latency-severe.yaml`
+
+**Simulates:** Breaking-point latency — ~5–6× baseline, high correlation. CN↔CN 600±150, CN↔BN 800±200, BN↔BN 1000±250 ms, correlation 75%.
+
+**Expected behavior:** A resilience/recovery probe (not a throughput test). BNs are expected to fall well behind; the test verifies survival + clean recovery after latency clears.
+
+**Assertions:** `node-healthy`, `block-available`, `backfill-triggered`, `blocks-increasing` (recovery), `block-rate-floor` ≥ 0.1 blk/s (recovery, not steady-state).
+
+## Pre-requisites
+
+- **Topology:** `paired-3` (3 CN + 3 BN) — the latency dimensions need multiple nodes per type.
+- **TSS:** on by default (the supported mode) — confirmed working under latency (the `tss-signature-transition` check sees a real Schnorr→WRAPS transition during a chaos run). `--wraps` requires CN ≥ v0.74.0-0; `CN_VERSION=latest` is min-enforced by `resolve-versions.sh` to a TSS-capable tag (currently `0.75.0-rc.4`), so it deploys cleanly. Only set `TSS_ENABLED=false` if you pin a CN below the floor.
+- **Chaos Mesh:** installed in the cluster (`CHAOS_ENABLED=true task chaos:install` locally; the CI workflow installs it automatically when a `chaos`/`latency` test is selected).
+
+## Known limitations
+
+- **Post-chaos measurement only.** Assertions run *after* all events complete, so `block-rate-floor` measures recovery, not under-chaos rate. Measuring under-chaos rate would need an event-time assertion (future enhancement).
+- **Tests assume a healthy cluster.** If consensus stalls (an upstream issue, independent of the chaos rules), `block-rate-floor` reports `0.000/s` — that's the assertion correctly detecting the stall, not a flake. Sanity-check the cluster with `task verify` before attributing a failure to a latency test.
+- **NLG lock contention between runs.** Solo CLI's NLG lock can persist across consecutive runs in the same cluster session; `load-stop` recovers via a direct Helm uninstall, but the following `load-start` may fail. Tests still pass because consensus produces blocks via heartbeats.
+- **Histogram metrics absent on the BN.** The BN doesn't export block-arrival histograms today, so a true p99 of block-arrival interval isn't computable; `block-rate-floor` is the rate-based proxy that ships.
+
+## Extending — adding a new latency scenario
+
+A new scenario is typically <30 lines of YAML. Copy an existing test as a starting point:
+
+```yaml
+name: latency-my-scenario
+description: "Brief description of what this exercises"
+
+events:
+  - id: load-start
+    type: load-start
+    delay: 0
+    args: { concurrency: 5, accounts: 10, duration: 420 }
+
+  - id: inject
+    type: inject-latency
+    delay: 30
+    args:
+      name: my-rule                      # used to build the NetworkChaos resource name
+      source: { kind: network-node }     # or block-node
+      target: { kind: block-node }
+      latency: 75ms                      # any netem-compatible duration
+      jitter: 15ms
+      correlation: "0"                   # % burst correlation (optional)
+      bidirectional: true
+
+  - id: clear
+    type: clear-latency
+    delay: 330
+    args: { name: my-rule }
+
+  - id: load-stop
+    type: load-stop
+    delay: 360
+
+assertions:
+  - id: all-healthy
+    type: node-healthy
+    target: all
+
+  - id: blocks-increasing
+    type: blocks-increasing
+    target: all
+    args: { wait_seconds: 30, max_attempts: 3 }
+
+  - id: block-rate-floor
+    type: block-rate-floor
+    target: all
+    args: { min_rate_per_sec: 0.3, window_seconds: 30 }
+```
+
+Validate (no cluster required), then run:
+
+```bash
+task test:validate TEST_FILE=tests/latency-my-scenario.yaml
+CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-my-scenario.yaml
+```
+
+## Pointers
+
+- Upstream Chaos Mesh wrapper this builds on: [solo-chaos](https://github.com/hashgraph/solo-chaos)
+- Chaos Mesh NetworkChaos reference: https://chaos-mesh.org/docs/define-chaos-experiment-scope/

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/chaos-cleanup.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/chaos-cleanup.sh
@@ -42,9 +42,6 @@ if ! kubectl api-resources --api-group=chaos-mesh.org -o name >/dev/null 2>&1; t
   exit 0
 fi
 
-selector_arg=()
-[[ -n "${LABEL_SELECTOR}" ]] && selector_arg=(-l "${LABEL_SELECTOR}")
-
 failed=0
 IFS=',' read -ra KIND_LIST <<< "${KINDS}"
 for kind in "${KIND_LIST[@]}"; do
@@ -56,7 +53,14 @@ for kind in "${KIND_LIST[@]}"; do
     continue
   fi
   [[ "${QUIET}" == "true" ]] || echo "Deleting ${kind_trimmed} resources${LABEL_SELECTOR:+ (selector: ${LABEL_SELECTOR})}..."
-  if ! kubectl delete "${kind_trimmed}" --all-namespaces --all "${selector_arg[@]}" --ignore-not-found 2>&1 | sed 's/^/  /'; then
+  # --all and -l (label selector) are mutually exclusive in kubectl delete;
+  # use the selector path when one is given, the --all path otherwise.
+  if [[ -n "${LABEL_SELECTOR}" ]]; then
+    delete_args=(--all-namespaces -l "${LABEL_SELECTOR}" --ignore-not-found)
+  else
+    delete_args=(--all-namespaces --all --ignore-not-found)
+  fi
+  if ! kubectl delete "${kind_trimmed}" "${delete_args[@]}" 2>&1 | sed 's/^/  /'; then
     failed=1
   fi
 done

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/chaos-cleanup.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/chaos-cleanup.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deletes chaos resources (NetworkChaos, PodChaos) without uninstalling
+# Chaos Mesh itself. Tolerates the case where Chaos Mesh CRDs are not
+# installed (returns success silently) so it is safe to wire into 'task down'
+# even when chaos was never enabled.
+#
+# Usage:
+#   ./chaos-cleanup.sh [options]
+#
+# Options:
+#   --label-selector SEL   Only delete resources matching this label selector
+#                          (e.g. solo-e2e-test/test-id=my-test). If omitted,
+#                          deletes ALL chaos resources in the cluster.
+#   --kinds KINDS          Comma-separated chaos kinds to delete
+#                          (default: networkchaos,podchaos)
+#   --quiet                Suppress per-kind logging
+#   --help                 Show this help message
+
+set -o pipefail
+
+LABEL_SELECTOR=""
+KINDS="networkchaos,podchaos"
+QUIET=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --label-selector) LABEL_SELECTOR="$2"; shift 2 ;;
+    --kinds)          KINDS="$2"; shift 2 ;;
+    --quiet)          QUIET=true; shift ;;
+    --help|-h)        sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+command -v kubectl >/dev/null 2>&1 || { echo "ERROR: kubectl not found"; exit 1; }
+
+# If chaos-mesh CRDs are not installed, nothing to do.
+if ! kubectl api-resources --api-group=chaos-mesh.org -o name >/dev/null 2>&1; then
+  [[ "${QUIET}" == "true" ]] || echo "Chaos Mesh CRDs not installed; nothing to clean."
+  exit 0
+fi
+
+selector_arg=()
+[[ -n "${LABEL_SELECTOR}" ]] && selector_arg=(-l "${LABEL_SELECTOR}")
+
+failed=0
+IFS=',' read -ra KIND_LIST <<< "${KINDS}"
+for kind in "${KIND_LIST[@]}"; do
+  kind_trimmed="${kind// /}"
+  [[ -z "${kind_trimmed}" ]] && continue
+  if ! kubectl api-resources --api-group=chaos-mesh.org -o name 2>/dev/null \
+       | grep -qx "${kind_trimmed}.chaos-mesh.org"; then
+    [[ "${QUIET}" == "true" ]] || echo "Kind '${kind_trimmed}' not present; skipping."
+    continue
+  fi
+  [[ "${QUIET}" == "true" ]] || echo "Deleting ${kind_trimmed} resources${LABEL_SELECTOR:+ (selector: ${LABEL_SELECTOR})}..."
+  if ! kubectl delete "${kind_trimmed}" --all-namespaces --all "${selector_arg[@]}" --ignore-not-found 2>&1 | sed 's/^/  /'; then
+    failed=1
+  fi
+done
+
+exit "${failed}"

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/chaos-dryrun.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/chaos-dryrun.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Validates a chaos selector by counting matching pods. Returns 0 if at least
+# one pod matches; non-zero otherwise. Used to fail-fast before applying a
+# NetworkChaos that would silently no-op against zero pods.
+#
+# Usage:
+#   ./chaos-dryrun.sh --namespace NS --selector LABEL=VALUE[,LABEL=VALUE...]
+#                     [--label TAG] [--quiet]
+#
+# Options:
+#   --namespace NS    Kubernetes namespace (required)
+#   --selector SEL    Label selector in kubectl form (required)
+#   --label TAG       Optional human label for log lines (e.g. 'source')
+#   --quiet           Suppress matched-pod listing
+#   --help            Show this help message
+#
+# Exit codes:
+#   0 — at least one pod matches
+#   1 — argument error
+#   2 — zero pods match
+
+set -o pipefail
+
+NAMESPACE=""
+SELECTOR=""
+TAG="selector"
+QUIET=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --selector)  SELECTOR="$2"; shift 2 ;;
+    --label)     TAG="$2"; shift 2 ;;
+    --quiet)     QUIET=true; shift ;;
+    --help|-h)   sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+[[ -z "${NAMESPACE}" ]] && { echo "ERROR: --namespace is required"; exit 1; }
+[[ -z "${SELECTOR}"  ]] && { echo "ERROR: --selector is required"; exit 1; }
+
+command -v kubectl >/dev/null 2>&1 || { echo "ERROR: kubectl not found"; exit 1; }
+
+names=$(kubectl get pods -n "${NAMESPACE}" -l "${SELECTOR}" -o name 2>/dev/null || true)
+count=0
+[[ -n "${names}" ]] && count=$(echo "${names}" | wc -l | tr -d ' ')
+
+if [[ "${count}" -eq 0 ]]; then
+  echo "ERROR: ${TAG} matched 0 pods in ns=${NAMESPACE} selector='${SELECTOR}'"
+  exit 2
+fi
+
+if [[ "${QUIET}" != "true" ]]; then
+  echo "${TAG}: matched ${count} pod(s) in ns=${NAMESPACE} selector='${SELECTOR}'"
+  echo "${names}" | sed 's/^/  /'
+fi

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/chaos-install.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/chaos-install.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Idempotently installs Chaos Mesh v2.7.2 (or another configurable version) into
+# the current Kubernetes cluster, in the 'chaos-mesh' namespace. Used by the
+# latency-injection test infrastructure.
+#
+# Idempotent: re-running with an existing release upgrades-in-place rather than
+# failing. Adds the chaos-mesh helm repo if not already present.
+#
+# Usage:
+#   ./chaos-install.sh [options]
+#
+# Options:
+#   --version VERSION    Chaos Mesh chart version (default: 2.7.2)
+#   --runtime RUNTIME    Container runtime (default: containerd)
+#   --socket-path PATH   Container runtime socket
+#                        (default: /run/containerd/containerd.sock)
+#   --timeout DURATION   Helm wait timeout (default: 5m)
+#   --help               Show this help message
+
+set -o pipefail
+
+VERSION="2.7.2"
+RUNTIME="containerd"
+SOCKET_PATH="/run/containerd/containerd.sock"
+TIMEOUT="5m"
+
+function show_help {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)     VERSION="$2"; shift 2 ;;
+    --runtime)     RUNTIME="$2"; shift 2 ;;
+    --socket-path) SOCKET_PATH="$2"; shift 2 ;;
+    --timeout)     TIMEOUT="$2"; shift 2 ;;
+    --help|-h)     show_help ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+command -v helm >/dev/null 2>&1 || { echo "ERROR: helm not found"; exit 1; }
+command -v kubectl >/dev/null 2>&1 || { echo "ERROR: kubectl not found"; exit 1; }
+
+echo "=== Chaos Mesh installer ==="
+echo "  version: ${VERSION}"
+echo "  runtime: ${RUNTIME}"
+echo "  socket:  ${SOCKET_PATH}"
+echo
+
+if ! helm repo list 2>/dev/null | awk '{print $1}' | grep -qx "chaos-mesh"; then
+  echo "Adding helm repo chaos-mesh..."
+  helm repo add chaos-mesh https://charts.chaos-mesh.org
+fi
+helm repo update chaos-mesh >/dev/null
+
+if helm status chaos-mesh -n chaos-mesh >/dev/null 2>&1; then
+  echo "Chaos Mesh release already exists; running upgrade for idempotency..."
+  ACTION=upgrade
+else
+  echo "Installing Chaos Mesh release..."
+  ACTION=install
+fi
+
+helm "${ACTION}" chaos-mesh chaos-mesh/chaos-mesh \
+  -n chaos-mesh --create-namespace \
+  --version "${VERSION}" \
+  --set chaosDaemon.runtime="${RUNTIME}" \
+  --set chaosDaemon.socketPath="${SOCKET_PATH}" \
+  --set chaosDaemon.hostPID=true \
+  --set chaosDaemon.privileged=true \
+  --set chaosDaemon.mountHostLibModules=true \
+  --wait --timeout "${TIMEOUT}"
+
+echo
+echo "Chaos Mesh pods:"
+kubectl -n chaos-mesh get pods --no-headers 2>/dev/null | sed 's/^/  /'
+echo
+echo "Chaos Mesh ${ACTION} complete."

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/chaos-status.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/chaos-status.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shows active chaos resources and Chaos Mesh component health.
+#
+# Usage:
+#   ./chaos-status.sh [--help]
+
+set -o pipefail
+
+[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit 0
+}
+
+command -v kubectl >/dev/null 2>&1 || { echo "ERROR: kubectl not found"; exit 1; }
+
+echo "=== Chaos Mesh components ==="
+if kubectl get ns chaos-mesh >/dev/null 2>&1; then
+  kubectl -n chaos-mesh get pods --no-headers 2>/dev/null | sed 's/^/  /' || echo "  (no pods)"
+else
+  echo "  chaos-mesh namespace not present (install with: task chaos:install)"
+  exit 0
+fi
+
+if ! kubectl api-resources --api-group=chaos-mesh.org -o name >/dev/null 2>&1; then
+  echo
+  echo "Chaos Mesh CRDs not registered."
+  exit 0
+fi
+
+echo
+echo "=== Active NetworkChaos ==="
+out=$(kubectl get networkchaos --all-namespaces 2>&1)
+if [[ -z "${out}" || "${out}" == *"No resources found"* ]]; then
+  echo "  (none)"
+else
+  echo "${out}" | sed 's/^/  /'
+fi
+
+echo
+echo "=== Active PodChaos ==="
+out=$(kubectl get podchaos --all-namespaces 2>&1)
+if [[ -z "${out}" || "${out}" == *"No resources found"* ]]; then
+  echo "  (none)"
+else
+  echo "${out}" | sed 's/^/  /'
+fi

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/chaos-templates/network-latency.yaml.tmpl
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/chaos-templates/network-latency.yaml.tmpl
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# NetworkChaos template — parametric latency injection.
+#
+# Filled at apply time by solo-test-runner.sh via envsubst. All ${...}
+# placeholders must be set in the environment before substitution. Optional
+# blocks (LOSS_BLOCK) hold either a YAML chunk or empty string.
+#
+# Pod-label selectors (note the two namespaces: CN pods are labelled by Solo CLI,
+# BN pods by the BN Helm chart — each side must select with the matching namespace):
+#   CN side  → solo.hedera.com/type=network-node
+#   BN side  → block-node.hiero.com/type=block-node
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: ${CHAOS_NAME}
+  namespace: chaos-mesh
+  labels:
+    solo-e2e-test/test-id: "${TEST_ID}"
+    solo-e2e-test/scenario-id: "${SCENARIO_ID}"
+    solo-e2e-test/managed-by: solo-test-runner
+spec:
+  action: netem
+  mode: all
+  direction: ${DIRECTION}
+  selector:
+    namespaces:
+      - ${TARGET_NAMESPACE}
+    labelSelectors:
+      ${SOURCE_LABEL_KEY}: ${SOURCE_LABEL_VALUE}
+  target:
+    mode: all
+    selector:
+      namespaces:
+        - ${TARGET_NAMESPACE}
+      labelSelectors:
+        ${TARGET_LABEL_KEY}: ${TARGET_LABEL_VALUE}
+  delay:
+    latency: '${LATENCY}'
+    jitter: '${JITTER}'
+    correlation: '${CORRELATION}'
+${LOSS_BLOCK}

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/chaos-uninstall.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/chaos-uninstall.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Uninstalls Chaos Mesh and removes its namespace.
+#
+# Usage:
+#   ./chaos-uninstall.sh [--keep-namespace]
+#
+# Options:
+#   --keep-namespace   Keep the chaos-mesh namespace (only uninstall the helm release)
+#   --help             Show this help message
+
+set -o pipefail
+
+KEEP_NAMESPACE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep-namespace) KEEP_NAMESPACE=true; shift ;;
+    --help|-h)        sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+command -v helm >/dev/null 2>&1 || { echo "ERROR: helm not found"; exit 1; }
+command -v kubectl >/dev/null 2>&1 || { echo "ERROR: kubectl not found"; exit 1; }
+
+if helm status chaos-mesh -n chaos-mesh >/dev/null 2>&1; then
+  echo "Uninstalling chaos-mesh helm release..."
+  helm uninstall chaos-mesh -n chaos-mesh
+else
+  echo "No chaos-mesh release found (already uninstalled)."
+fi
+
+if [[ "${KEEP_NAMESPACE}" != "true" ]]; then
+  if kubectl get ns chaos-mesh >/dev/null 2>&1; then
+    echo "Deleting chaos-mesh namespace..."
+    kubectl delete namespace chaos-mesh --grace-period=30 --timeout=60s
+  else
+    echo "chaos-mesh namespace not present."
+  fi
+fi
+
+echo "Chaos Mesh uninstall complete."

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/lib/chaos-assertions.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/lib/chaos-assertions.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Phase 3: latency-aware assertion primitives. Sourced by solo-test-runner.sh
+# and by scripts/test/test-chaos-assertions.sh (which provides mocks).
+#
+# Expects the following to be defined by the caller:
+#   - kctl()                   - kubectl wrapper that honours CONTEXT
+#   - get_bn_metrics_port()    - maps a BN name to its local metrics port
+#   - get_all_block_nodes()    - lists BN names from the topology file
+#   - NAMESPACE                - kubernetes namespace string
+#
+# Functions exported:
+#   compare_numeric             - awk-based float-safe comparator
+#   fetch_metric                - read a single Prometheus metric value
+#   fetch_pod_logs              - read recent pod logs (overridable in tests)
+#   assert_metric_threshold     - generic metric primitive
+#   assert_block_rate_floor     - sugar built on metric scraping
+#   assert_log_match            - log-substring presence (powers backfill-triggered)
+
+# compare_numeric: arithmetic comparison via awk (handles floats).
+# Echoes ok/violation line; returns 0 on pass, 1 on fail.
+function compare_numeric {
+    local lhs="$1" op="$2" rhs="$3" label="${4:-value}"
+    local result
+    result=$(awk -v l="$lhs" -v r="$rhs" -v op="$op" 'BEGIN {
+        if      (op == "<")  print (l+0 <  r+0) ? "true" : "false"
+        else if (op == "<=") print (l+0 <= r+0) ? "true" : "false"
+        else if (op == ">")  print (l+0 >  r+0) ? "true" : "false"
+        else if (op == ">=") print (l+0 >= r+0) ? "true" : "false"
+        else if (op == "==") print (l+0 == r+0) ? "true" : "false"
+        else                 print "bad-op"
+    }')
+    case "$result" in
+        true)    echo "${label}=${lhs} ${op} ${rhs}: ok"; return 0 ;;
+        false)   echo "${label}=${lhs} NOT ${op} ${rhs}"; return 1 ;;
+        bad-op)  echo "Unknown comparator: '${op}' (expected <, <=, >, >=, ==)"; return 1 ;;
+    esac
+}
+
+# fetch_metric: read one Prometheus metric value from a BN's /metrics endpoint
+# via the locally-bound port. Returns empty string on miss; 5s timeout.
+# Matches both a bare metric line ("metric value") and a labelled one
+# ("metric{...} value"), so it keeps working if a scraped metric gains labels.
+# Exposed for override in fixture tests.
+function fetch_metric {
+    local target="$1" metric="$2"
+    local port
+    port=$(get_bn_metrics_port "$target")
+    curl -s --max-time 5 "http://localhost:${port}/metrics" 2>/dev/null \
+        | awk -v m="$metric" '$1 == m || index($1, m "{") == 1 { print $2; exit }'
+}
+
+function assert_metric_threshold_single {
+    local target="$1" metric="$2" op="$3" threshold="$4"
+    local samples="${5:-1}" wait_seconds="${6:-0}"
+    local i=1 value
+    while [[ $i -le $samples ]]; do
+        if [[ $i -gt 1 && $wait_seconds -gt 0 ]]; then sleep "$wait_seconds"; fi
+        value=$(fetch_metric "$target" "$metric")
+        if [[ -z "$value" ]]; then
+            echo "${target}: metric '${metric}' not found on /metrics (port $(get_bn_metrics_port "$target"))"
+            return 1
+        fi
+        if ! compare_numeric "$value" "$op" "$threshold" "${target}:${metric}"; then
+            return 1
+        fi
+        i=$((i + 1))
+    done
+}
+
+function assert_metric_threshold {
+    local target="${1:-all}" metric="$2" op="$3" threshold="$4"
+    local samples="${5:-1}" wait_seconds="${6:-0}"
+    if [[ "$target" == "all" ]]; then
+        local failed=0 results=""
+        for bn in $(get_all_block_nodes); do
+            local result
+            result=$(assert_metric_threshold_single "$bn" "$metric" "$op" "$threshold" "$samples" "$wait_seconds") || failed=1
+            results="${results}${result}\n"
+        done
+        echo -e "${results%\\n}"
+        return $failed
+    else
+        assert_metric_threshold_single "$target" "$metric" "$op" "$threshold" "$samples" "$wait_seconds"
+    fi
+}
+
+# block-rate-floor: derives Δblocks/Δtime from publisher_highest_block_number_inbound,
+# asserts the rate (blocks/sec) is at or above min_rate. Provides the
+# "blocks-per-second under chaos" signal the Phase 3 ticket called for; the BN
+# does not currently expose a histogram metric for true p99.
+function assert_block_rate_floor_single {
+    local target="$1" min_rate="$2" window_seconds="${3:-30}"
+    local baseline current rate
+    baseline=$(fetch_metric "$target" "blocknode_publisher_highest_block_number_inbound")
+    if [[ -z "$baseline" ]]; then
+        echo "${target}: no baseline (publisher_highest_block_number_inbound unavailable)"
+        return 1
+    fi
+    sleep "$window_seconds"
+    current=$(fetch_metric "$target" "blocknode_publisher_highest_block_number_inbound")
+    if [[ -z "$current" ]]; then
+        echo "${target}: no current sample after ${window_seconds}s wait"
+        return 1
+    fi
+    rate=$(awk -v b="$baseline" -v c="$current" -v w="$window_seconds" 'BEGIN { printf "%.3f", (c - b) / w }')
+    if compare_numeric "$rate" ">=" "$min_rate" "${target}:rate(blk/s)" >/dev/null 2>&1; then
+        echo "${target}: ${baseline} -> ${current} over ${window_seconds}s (rate=${rate}/s, floor=${min_rate}/s)"
+        return 0
+    else
+        echo "${target}: ${baseline} -> ${current} over ${window_seconds}s (rate=${rate}/s, BELOW floor ${min_rate}/s)"
+        return 1
+    fi
+}
+
+function assert_block_rate_floor {
+    local target="${1:-all}" min_rate="$2" window_seconds="${3:-30}"
+    if [[ "$target" == "all" ]]; then
+        local failed=0 results=""
+        for bn in $(get_all_block_nodes); do
+            local result
+            result=$(assert_block_rate_floor_single "$bn" "$min_rate" "$window_seconds") || failed=1
+            results="${results}${result}\n"
+        done
+        echo -e "${results%\\n}"
+        return $failed
+    else
+        assert_block_rate_floor_single "$target" "$min_rate" "$window_seconds"
+    fi
+}
+
+# fetch_pod_logs: read recent pod logs for a target (matched by label, not
+# pod-name suffix, so it doesn't depend on Deployment vs StatefulSet pod
+# naming). Overridable in fixture tests.
+function fetch_pod_logs {
+    local target="$1" since="$2"
+    kctl logs -n "${NAMESPACE}" -l "app.kubernetes.io/name=${target}" \
+        --since="${since}s" --tail=10000 --prefix 2>/dev/null || true
+}
+
+function assert_log_match_single {
+    local target="$1" grep_pattern="$2" since_seconds="${3:-300}"
+    local logs
+    logs=$(fetch_pod_logs "$target" "$since_seconds")
+    if echo "$logs" | grep -F -- "$grep_pattern" >/dev/null 2>&1; then
+        local count
+        count=$(echo "$logs" | grep -F -c -- "$grep_pattern")
+        echo "${target}: matched '${grep_pattern}' (${count} hit$([[ $count -gt 1 ]] && echo s))"
+        return 0
+    else
+        echo "${target}: pattern '${grep_pattern}' NOT found in last ${since_seconds}s of logs"
+        return 1
+    fi
+}
+
+function assert_log_match {
+    local target="${1:-all}" grep_pattern="$2" since_seconds="${3:-300}"
+    if [[ "$target" == "all" ]]; then
+        local failed=0 results=""
+        for bn in $(get_all_block_nodes); do
+            local result
+            result=$(assert_log_match_single "$bn" "$grep_pattern" "$since_seconds") || failed=1
+            results="${results}${result}\n"
+        done
+        echo -e "${results%\\n}"
+        return $failed
+    else
+        assert_log_match_single "$target" "$grep_pattern" "$since_seconds"
+    fi
+}

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-test-runner.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-test-runner.sh
@@ -57,6 +57,36 @@ ASSERTIONS_FAILED=0
 ASSERTION_RESULTS_FILE="/tmp/solo-test-assert-results-$$"
 : > "${ASSERTION_RESULTS_FILE}"
 
+# Chaos: track applied NetworkChaos resource names so we can clean up on exit
+# even if the test fails between inject-latency and clear-latency.
+#
+# Cleanup contract:
+#   - execute_inject_latency appends the resource name to CHAOS_ACTIVE_FILE.
+#   - execute_clear_latency removes it on graceful clear.
+#   - cleanup_chaos_on_exit (registered on EXIT below) drains any remaining
+#     names so a crash between inject and clear doesn't leak NetworkChaos
+#     resources into the cluster.
+# The file is PID-scoped (`$$`), so two concurrent runner invocations in the
+# same shell session don't share state. Running two test runners in parallel
+# is not a supported workflow anyway.
+CHAOS_TEMPLATE_DIR="${CHAOS_TEMPLATE_DIR:-${SCRIPT_DIR}/chaos-templates}"
+CHAOS_ACTIVE_FILE="/tmp/solo-test-chaos-active-$$"
+: > "${CHAOS_ACTIVE_FILE}"
+
+function cleanup_chaos_on_exit {
+    if [[ -s "${CHAOS_ACTIVE_FILE}" ]]; then
+        echo ""
+        echo "Cleaning up active NetworkChaos resources..."
+        while IFS= read -r name; do
+            [[ -z "$name" ]] && continue
+            kctl delete networkchaos -n chaos-mesh "$name" --ignore-not-found 2>/dev/null \
+                | sed 's/^/  /' || true
+        done < "${CHAOS_ACTIVE_FILE}"
+    fi
+    rm -f "${CHAOS_ACTIVE_FILE}" 2>/dev/null
+}
+trap cleanup_chaos_on_exit EXIT
+
 
 # ============================================================================
 # Argument Parsing
@@ -482,6 +512,145 @@ function execute_reconfigure_cn_streaming {
     echo "CN ${cn_name} reconfigured to stream to: $(echo "$block_nodes_json" | yq -r '. | join(", ")')"
 }
 
+# ============================================================================
+# Chaos / Network Latency Helpers
+# ============================================================================
+# Maps the user-facing 'kind' to the actual pod label selector (key=value)
+# present in solo-e2e-test deployments. CN pods use the solo.hedera.com/*
+# namespace (emitted by Solo CLI) while BN pods use block-node.hiero.com/*
+# (emitted by the BN Helm chart).
+function chaos_label_selector {
+    case "$1" in
+        network-node) echo "solo.hedera.com/type=network-node" ;;
+        block-node)   echo "block-node.hiero.com/type=block-node" ;;
+        *) echo "ERROR: unknown chaos kind: '$1' (expected: network-node | block-node)" >&2; return 1 ;;
+    esac
+}
+
+# Slug a string into a Kubernetes-name-safe lowercase token.
+function chaos_slug {
+    echo "$1" | tr 'A-Z' 'a-z' | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//'
+}
+
+# Deterministic NetworkChaos resource name for a (test, scenario) pair.
+# Used by both inject-latency and clear-latency so they cannot disagree on the
+# resource name a future clear must target.
+function chaos_resource_name {
+    local scenario_name="$1"
+    local n="$(chaos_slug "${TEST_NAME}")--$(chaos_slug "${scenario_name}")"
+    echo "${n:0:63}"
+}
+
+function execute_inject_latency {
+    local args="$1"
+    local name source_kind target_kind latency jitter correlation bidirectional loss
+    name=$(echo "$args" | yq '.name // ""')
+    source_kind=$(echo "$args" | yq '.source.kind // ""')
+    target_kind=$(echo "$args" | yq '.target.kind // ""')
+    latency=$(echo "$args" | yq '.latency // "0ms"')
+    jitter=$(echo "$args" | yq '.jitter // "0ms"')
+    correlation=$(echo "$args" | yq '.correlation // "0"')
+    bidirectional=$(echo "$args" | yq '.bidirectional // true')
+    loss=$(echo "$args" | yq '.loss // ""')
+
+    [[ -z "$name" || "$name" == "null" ]] && { echo "ERROR: inject-latency requires args.name"; return 1; }
+    [[ -z "$source_kind" || "$source_kind" == "null" ]] && { echo "ERROR: inject-latency requires args.source.kind"; return 1; }
+    [[ -z "$target_kind" || "$target_kind" == "null" ]] && { echo "ERROR: inject-latency requires args.target.kind"; return 1; }
+
+    # Retry the CRD check — kubectl can return non-zero transiently after
+    # Chaos Mesh install (CRD propagation lag) or under cluster API-server load.
+    # Observed in a 3× flake check: 3×1s wasn't enough; this is 6×2s = up to 12s.
+    local crd_attempts=0
+    local crd_max=6
+    while [[ $crd_attempts -lt $crd_max ]]; do
+        if kctl api-resources --api-group=chaos-mesh.org -o name 2>/dev/null | grep -q networkchaos; then
+            break
+        fi
+        crd_attempts=$((crd_attempts + 1))
+        [[ $crd_attempts -lt $crd_max ]] && sleep 2
+    done
+    if [[ $crd_attempts -ge $crd_max ]]; then
+        echo "ERROR: Chaos Mesh CRDs not present after ${crd_max} retries. Run: CHAOS_ENABLED=true task chaos:install"
+        return 1
+    fi
+
+    local source_selector target_selector
+    source_selector=$(chaos_label_selector "$source_kind") || return 1
+    target_selector=$(chaos_label_selector "$target_kind") || return 1
+    local source_key="${source_selector%%=*}" source_val="${source_selector#*=}"
+    local target_key="${target_selector%%=*}" target_val="${target_selector#*=}"
+
+    if ! "${SCRIPT_DIR}/chaos-dryrun.sh" --namespace "${NAMESPACE}" \
+            --selector "${source_selector}" --label "source(${source_kind})"; then
+        return 1
+    fi
+    if ! "${SCRIPT_DIR}/chaos-dryrun.sh" --namespace "${NAMESPACE}" \
+            --selector "${target_selector}" --label "target(${target_kind})"; then
+        return 1
+    fi
+
+    local chaos_name direction loss_block
+    chaos_name=$(chaos_resource_name "${name}")
+
+    if [[ "${bidirectional}" == "true" ]]; then
+        direction="both"
+    else
+        direction="to"
+    fi
+
+    if [[ -n "${loss}" && "${loss}" != "null" && "${loss}" != "0%" && "${loss}" != "0" ]]; then
+        loss_block=$(printf "  loss:\n    loss: '%s'\n    correlation: '%s'" "${loss}" "${correlation}")
+    else
+        loss_block=""
+    fi
+
+    local manifest="/tmp/${chaos_name}.yaml"
+    export CHAOS_NAME="${chaos_name}"
+    export TEST_ID="$(chaos_slug "${TEST_NAME}")"
+    export SCENARIO_ID="$(chaos_slug "${name}")"
+    export DIRECTION="${direction}"
+    export TARGET_NAMESPACE="${NAMESPACE}"
+    export SOURCE_LABEL_KEY="${source_key}"
+    export SOURCE_LABEL_VALUE="${source_val}"
+    export TARGET_LABEL_KEY="${target_key}"
+    export TARGET_LABEL_VALUE="${target_val}"
+    export LATENCY="${latency}"
+    export JITTER="${jitter}"
+    export CORRELATION="${correlation}"
+    export LOSS_BLOCK="${loss_block}"
+
+    envsubst < "${CHAOS_TEMPLATE_DIR}/network-latency.yaml.tmpl" > "${manifest}"
+
+    echo "Applying NetworkChaos '${chaos_name}'"
+    echo "  selector: ${source_key}=${source_val}  ->  target: ${target_key}=${target_val}"
+    echo "  delay: ${latency} +/- ${jitter} (correlation: ${correlation}, direction: ${direction})"
+    [[ -n "${loss_block}" ]] && echo "  loss: ${loss}"
+
+    kctl apply -f "${manifest}"
+
+    echo "${chaos_name}" >> "${CHAOS_ACTIVE_FILE}"
+}
+
+function execute_clear_latency {
+    local args="$1"
+    local name chaos_name
+    name=$(echo "$args" | yq '.name // ""')
+    [[ -z "$name" || "$name" == "null" ]] && { echo "ERROR: clear-latency requires args.name"; return 1; }
+
+    chaos_name=$(chaos_resource_name "${name}")
+
+    echo "Deleting NetworkChaos '${chaos_name}'"
+    kctl delete networkchaos -n chaos-mesh "${chaos_name}" --ignore-not-found
+
+    if [[ -f "${CHAOS_ACTIVE_FILE}" ]]; then
+        grep -vx "${chaos_name}" "${CHAOS_ACTIVE_FILE}" > "${CHAOS_ACTIVE_FILE}.new" 2>/dev/null || true
+        mv -f "${CHAOS_ACTIVE_FILE}.new" "${CHAOS_ACTIVE_FILE}" 2>/dev/null || true
+    fi
+}
+
+# ============================================================================
+# Event Dispatch
+# ============================================================================
 function execute_event {
     local event_type="$1"
     local target="$2"
@@ -556,6 +725,12 @@ function execute_event {
             ;;
         reconfigure-cn-streaming)
             execute_reconfigure_cn_streaming "$args"
+            ;;
+        inject-latency)
+            execute_inject_latency "$args"
+            ;;
+        clear-latency)
+            execute_clear_latency "$args"
             ;;
         *)
             echo "ERROR: Unknown event type: $event_type"
@@ -1000,6 +1175,21 @@ function assert_signature_transition {
     fi
 }
 
+# ============================================================================
+# Phase 3: latency-aware assertion primitives — sourced from a separate library
+# so they can be exercised by fixture-based unit tests without invoking the
+# runner's CLI parsing.
+#
+# To add a new latency-aware assertion: add the implementation in
+# scripts/lib/chaos-assertions.sh and a dispatch case in run_assertion() below.
+# Fixture-based unit tests live at scripts/test/test-chaos-assertions.sh.
+# ============================================================================
+# shellcheck source=lib/chaos-assertions.sh
+source "${SCRIPT_DIR}/lib/chaos-assertions.sh"
+
+# ============================================================================
+# Assertion Dispatch
+# ============================================================================
 function run_assertion {
     local assert_type="$1"
     local target="$2"
@@ -1043,6 +1233,45 @@ function run_assertion {
             local min_rsa_success
             min_rsa_success=$(echo "$args" | yq '.min_rsa_success // 1')
             assert_rsa_roster_verification "$target" "$min_rsa_success"
+            ;;
+        metric-threshold)
+            [[ -z "$target" || "$target" == "null" ]] && target=$(echo "$args" | yq '.target // "all"')
+            local mt_metric mt_op mt_value mt_samples mt_wait
+            mt_metric=$(echo "$args" | yq '.metric // ""')
+            mt_op=$(echo "$args" | yq '.comparator // ">"')
+            mt_value=$(echo "$args" | yq '.value // 0')
+            mt_samples=$(echo "$args" | yq '.samples // 1')
+            mt_wait=$(echo "$args" | yq '.wait_seconds // 0')
+            if [[ -z "$mt_metric" || "$mt_metric" == "null" ]]; then
+                echo "ERROR: metric-threshold requires args.metric"
+                return 1
+            fi
+            assert_metric_threshold "$target" "$mt_metric" "$mt_op" "$mt_value" "$mt_samples" "$mt_wait"
+            ;;
+        block-rate-floor)
+            [[ -z "$target" || "$target" == "null" ]] && target=$(echo "$args" | yq '.target // "all"')
+            local brf_min brf_window
+            brf_min=$(echo "$args" | yq '.min_rate_per_sec // 0')
+            brf_window=$(echo "$args" | yq '.window_seconds // 30')
+            assert_block_rate_floor "$target" "$brf_min" "$brf_window"
+            ;;
+        backfill-triggered)
+            [[ -z "$target" || "$target" == "null" ]] && target=$(echo "$args" | yq '.target // "all"')
+            local bt_grep bt_since
+            bt_grep=$(echo "$args" | yq '.grep // "backfill"')
+            bt_since=$(echo "$args" | yq '.since_seconds // 300')
+            assert_log_match "$target" "$bt_grep" "$bt_since"
+            ;;
+        log-match)
+            [[ -z "$target" || "$target" == "null" ]] && target=$(echo "$args" | yq '.target // "all"')
+            local lm_grep lm_since
+            lm_grep=$(echo "$args" | yq '.grep // ""')
+            lm_since=$(echo "$args" | yq '.since_seconds // 300')
+            if [[ -z "$lm_grep" || "$lm_grep" == "null" ]]; then
+                echo "ERROR: log-match requires args.grep"
+                return 1
+            fi
+            assert_log_match "$target" "$lm_grep" "$lm_since"
             ;;
         *)
             echo "Unknown assertion type: $assert_type"
@@ -1338,4 +1567,7 @@ function main {
     print_summary
 }
 
-main
+# Run main only when executed directly; allow sourcing for fixture-based unit tests.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/sample-logs-with-backfill.txt
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/sample-logs-with-backfill.txt
@@ -1,0 +1,6 @@
+2026-05-11T20:01:00Z INFO  org.hiero.block.node.backfill.BackfillFetcher - Loaded backfill source node: block-node-2.solo-network.svc.cluster.local:40840
+2026-05-11T20:01:05Z INFO  org.hiero.block.node.NetworkApp - Block Node started successfully
+2026-05-11T20:01:10Z DEBUG org.hiero.block.node.verification.VerificationServicePlugin - Received backfill notification for block=412
+2026-05-11T20:01:11Z DEBUG org.hiero.block.node.verification.VerificationServicePlugin - Received backfill notification for block=413
+2026-05-11T20:01:12Z DEBUG org.hiero.block.node.verification.VerificationServicePlugin - Received backfill notification for block=414
+2026-05-11T20:01:15Z INFO  org.hiero.block.node.publisher.PublisherHandler - New publisher connection from network-node1

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/sample-logs-without-backfill.txt
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/sample-logs-without-backfill.txt
@@ -1,0 +1,4 @@
+2026-05-11T20:01:00Z INFO  org.hiero.block.node.NetworkApp - Block Node started successfully
+2026-05-11T20:01:05Z INFO  org.hiero.block.node.publisher.PublisherHandler - New publisher connection from network-node1
+2026-05-11T20:01:10Z INFO  org.hiero.block.node.publisher.PublisherHandler - Block 412 received
+2026-05-11T20:01:11Z INFO  org.hiero.block.node.publisher.PublisherHandler - Block 413 received

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/sample-metrics.txt
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/sample-metrics.txt
@@ -1,0 +1,13 @@
+# Fixture: sample BN /metrics output (Prometheus text format, abridged).
+# Values are arbitrary but representative of what the BN exposes at runtime.
+blocknode_publisher_block_items_received_total 124567
+blocknode_publisher_highest_block_number_inbound 1842
+blocknode_publisher_open_connections 3
+blocknode_publisher_stream_errors_total 0
+blocknode_verification_blocks_received_total 1842
+blocknode_verification_blocks_verified_total 1842
+blocknode_verification_blocks_failed_total 0
+blocknode_verification_blocks_error_total 0
+blocknode_files_recent_blocks_stored 1842
+blocknode_messaging_item_queue_percent_used 12
+blocknode_messaging_notification_queue_percent_used 4

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/test/test-chaos-assertions.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/test/test-chaos-assertions.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fixture-based unit tests for the Phase 3 latency-aware assertions in
+# solo-test-runner.sh:
+#   - compare_numeric (helper)
+#   - assert_metric_threshold (primitive)
+#   - assert_block_rate_floor  (sugar)
+#   - assert_log_match         (used by backfill-triggered)
+#
+# Runs without a cluster: overrides fetch_metric / fetch_pod_logs to serve
+# pre-recorded fixtures. Exit 0 on all-pass, 1 on any failure.
+
+set -u -o pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="${SCRIPT_DIR}/../lib/chaos-assertions.sh"
+FIXTURES="${SCRIPT_DIR}/fixtures"
+
+NAMESPACE="solo-network"
+
+# Provide mocks BEFORE sourcing the lib — the lib reads from these on call.
+function get_bn_metrics_port { echo 16007; }
+function get_all_block_nodes  { echo "block-node-1"; }
+function kctl { return 0; }
+
+# shellcheck disable=SC1090
+source "${LIB}"
+
+passed=0
+failed=0
+function pass { echo "  PASS  $1"; passed=$((passed+1)); }
+function fail { echo "  FAIL  $1"; failed=$((failed+1)); }
+
+# ----------------------------------------------------------------------------
+echo "[1] compare_numeric: all comparators (one method, table-driven)"
+# Group simple cases — per CLAUDE.md, don't proliferate methods for trivial assertions.
+for tc in "1 < 2 OK" "2 < 1 NO" "1 <= 1 OK" "5 >= 5 OK" "5 > 4 OK" \
+          "1 == 1 OK" "1 == 2 NO" "1.5 < 2.1 OK" "3.14 > 3.13 OK"; do
+    # shellcheck disable=SC2086
+    set -- $tc
+    l=$1; op=$2; r=$3; expected=$4
+    if compare_numeric "$l" "$op" "$r" "test" >/dev/null 2>&1; then actual=OK; else actual=NO; fi
+    if [[ "$actual" == "$expected" ]]; then
+        pass "compare_numeric $l $op $r => $expected"
+    else
+        fail "compare_numeric $l $op $r => expected $expected, got $actual"
+    fi
+done
+
+# Bad operator → fail (returns 1). Capture into a var first; pipefail would
+# otherwise propagate compare_numeric's non-zero exit through the grep pipe.
+bad_op_output=$(compare_numeric 1 "!=" 2 "test" 2>&1 || true)
+if echo "$bad_op_output" | grep -q "Unknown comparator"; then
+    pass "compare_numeric rejects unknown operator"
+else
+    fail "compare_numeric did not reject unknown operator (got: $bad_op_output)"
+fi
+
+# ----------------------------------------------------------------------------
+echo "[2] assert_metric_threshold: green / red / metric-missing"
+function fetch_metric {
+    awk -v m="$2" '$1 == m { print $2; exit }' "${FIXTURES}/sample-metrics.txt"
+}
+# Green: highest_block_number_inbound is 1842, assert >= 100
+if assert_metric_threshold "block-node-1" "blocknode_publisher_highest_block_number_inbound" ">=" 100 >/dev/null 2>&1; then
+    pass "metric-threshold green (1842 >= 100)"
+else
+    fail "metric-threshold green"
+fi
+# Red: assert >= 99999
+if ! assert_metric_threshold "block-node-1" "blocknode_publisher_highest_block_number_inbound" ">=" 99999 >/dev/null 2>&1; then
+    pass "metric-threshold red (1842 < 99999)"
+else
+    fail "metric-threshold red"
+fi
+# Metric not present
+if ! assert_metric_threshold "block-node-1" "nonexistent_metric" "==" 0 >/dev/null 2>&1; then
+    pass "metric-threshold missing metric → fail"
+else
+    fail "metric-threshold missing metric should fail"
+fi
+# Comparator '==' with exact match
+if assert_metric_threshold "block-node-1" "blocknode_publisher_stream_errors_total" "==" 0 >/dev/null 2>&1; then
+    pass "metric-threshold == with exact match (errors == 0)"
+else
+    fail "metric-threshold exact match"
+fi
+
+# ----------------------------------------------------------------------------
+echo "[3] assert_block_rate_floor: derives Δblocks/Δtime, compares to floor"
+# fetch_metric runs in command substitution (subshell) inside the assertion,
+# so we use a file-based counter to persist state across calls.
+COUNTER_FILE=$(mktemp)
+function fetch_metric_seq {
+    local i
+    i=$(cat "$COUNTER_FILE")
+    i=$((i + 1))
+    echo "$i" > "$COUNTER_FILE"
+    case "$i" in
+        1) echo "$1" ;;   # baseline
+        2) echo "$2" ;;   # current
+        *) echo ""   ;;
+    esac
+}
+
+# Two-sample green: baseline=100, current=115, window=1s -> 15/s >= 0.5/s
+echo 0 > "$COUNTER_FILE"
+function fetch_metric { fetch_metric_seq 100 115; }
+if assert_block_rate_floor "block-node-1" "0.5" "1" >/dev/null 2>&1; then
+    pass "block-rate-floor green (15/s >= 0.5/s)"
+else
+    fail "block-rate-floor green"
+fi
+
+# No-progress red: baseline=100, current=100, window=1s -> 0/s < 0.5/s
+echo 0 > "$COUNTER_FILE"
+function fetch_metric { fetch_metric_seq 100 100; }
+if ! assert_block_rate_floor "block-node-1" "0.5" "1" >/dev/null 2>&1; then
+    pass "block-rate-floor red (0/s < 0.5/s)"
+else
+    fail "block-rate-floor red"
+fi
+
+# Baseline missing
+function fetch_metric { echo ""; }
+if ! assert_block_rate_floor "block-node-1" "0.5" "1" >/dev/null 2>&1; then
+    pass "block-rate-floor red (no baseline available)"
+else
+    fail "block-rate-floor missing baseline should fail"
+fi
+
+rm -f "$COUNTER_FILE"
+
+# ----------------------------------------------------------------------------
+echo "[4] assert_log_match (powers backfill-triggered): pattern present / absent"
+function fetch_pod_logs { cat "${FIXTURES}/sample-logs-with-backfill.txt"; }
+if assert_log_match "block-node-1" "Received backfill" 300 >/dev/null 2>&1; then
+    pass "log-match green ('Received backfill' present, 3 hits)"
+else
+    fail "log-match green"
+fi
+function fetch_pod_logs { cat "${FIXTURES}/sample-logs-without-backfill.txt"; }
+if ! assert_log_match "block-node-1" "Received backfill" 300 >/dev/null 2>&1; then
+    pass "log-match red ('Received backfill' absent)"
+else
+    fail "log-match red"
+fi
+# Multiple hits — count surfaces in the output
+function fetch_pod_logs { cat "${FIXTURES}/sample-logs-with-backfill.txt"; }
+output=$(assert_log_match "block-node-1" "Received backfill" 300 2>&1)
+if echo "$output" | grep -q "3 hits"; then
+    pass "log-match reports hit count"
+else
+    fail "log-match did not report hit count (got: $output)"
+fi
+
+# ----------------------------------------------------------------------------
+echo
+echo "RESULT: ${passed} passed, ${failed} failed"
+[[ $failed -eq 0 ]]

--- a/tools-and-tests/scripts/solo-e2e-test/tests/chaos-foundation-smoke.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/chaos-foundation-smoke.yaml
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Chaos Foundation Smoke Test
+#
+# Exercises the chaos plumbing introduced in Phase 1 without putting meaningful
+# stress on the network:
+#   1. inject-latency CN -> BN at a low latency (50 ms) — proves the runner
+#      generates a valid manifest, the dryrun selector check succeeds, and
+#      Chaos Mesh accepts the resource.
+#   2. command — confirms the NetworkChaos exists with the expected name.
+#   3. clear-latency — proves the runner deletes the resource.
+#   4. command — confirms the NetworkChaos is gone.
+#
+# Pre-req:
+#   task up TOPOLOGY=paired-3            # TSS is on by default (now supported)
+#   CHAOS_ENABLED=true task chaos:install
+#
+# Note on TSS: the harness defaults TSS to 'true' and that is the supported mode.
+# Solo CLI's '--wraps' flag requires CN >= v0.74.0-0; CN_VERSION=latest is
+# min-enforced by resolve-versions.sh to a TSS-capable tag (currently 0.75.0-rc.4),
+# so '--wraps' deploys cleanly. Only set TSS_ENABLED=false if you pin an older CN.
+# The chaos work itself is TSS-agnostic (the CN/BN labels Chaos Mesh selects on
+# are present either way).
+#
+# Usage:
+#   CHAOS_ENABLED=true task test:run TEST_FILE=tests/chaos-foundation-smoke.yaml
+
+name: chaos-foundation-smoke
+description: "Validates the chaos foundation (install, inject, clear, cleanup)"
+
+events:
+  - id: pre-state
+    type: command
+    description: "Pre-state: confirm zero NetworkChaos resources"
+    delay: 0
+    args:
+      script: 'kubectl get networkchaos -A --no-headers 2>/dev/null | wc -l | xargs -I{} echo "NetworkChaos count: {}"'
+
+  - id: inject
+    type: inject-latency
+    description: "Inject 50ms CN <-> BN bidirectional latency"
+    delay: 5
+    args:
+      name: plumbing
+      source: { kind: network-node }
+      target: { kind: block-node }
+      latency: 50ms
+      jitter: 10ms
+      correlation: '0'
+      bidirectional: true
+
+  - id: confirm-applied
+    type: command
+    description: "Confirm NetworkChaos resource exists with expected name"
+    delay: 15
+    args:
+      script: 'kubectl get networkchaos -n chaos-mesh chaos-foundation-smoke--plumbing -o jsonpath="{.metadata.name} status={.status.conditions[?(@.type==\"AllInjected\")].status}"; echo'
+
+  - id: clear
+    type: clear-latency
+    description: "Clear the latency rule"
+    delay: 30
+    args:
+      name: plumbing
+
+  - id: confirm-cleared
+    type: command
+    description: "Confirm NetworkChaos resource is gone"
+    delay: 35
+    args:
+      script: |
+        if kubectl get networkchaos -n chaos-mesh chaos-foundation-smoke--plumbing >/dev/null 2>&1; then
+          echo "ERROR: NetworkChaos still present after clear-latency"
+          exit 1
+        fi
+        echo "OK: NetworkChaos resource cleared"
+
+assertions:
+  - id: all-healthy
+    type: node-healthy
+    description: "All Block Nodes still healthy after chaos lifecycle"
+    target: all
+
+  - id: all-have-blocks
+    type: block-available
+    description: "All Block Nodes still have blocks"
+    target: all
+    args:
+      min_block: 0
+
+  - id: blocks-still-increasing
+    type: blocks-increasing
+    description: "Blocks still increasing after chaos lifecycle (50ms latency does not block consensus)"
+    target: all
+    args:
+      wait_seconds: 15
+      max_attempts: 2

--- a/tools-and-tests/scripts/solo-e2e-test/tests/latency-all-three.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/latency-all-three.yaml
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Combined CN↔CN + BN↔BN + CN↔BN Latency Test
+#
+# Stress-tests the foundation's coexistence guarantee by applying all three
+# fixed-name NetworkChaos rules concurrently:
+#   - CN ↔ CN  : 100 ms ± 20 ms bidirectional
+#   - BN ↔ BN  : 200 ms ± 40 ms bidirectional
+#   - CN ↔ BN  : 150 ms ± 30 ms bidirectional
+# All three rules are applied at the same delay; the runner applies them
+# sequentially but Chaos Mesh installs them concurrently.
+#
+# Each pod ends up with the netem rules relevant to its label set:
+#   - A CN pod sees CN→CN, CN→BN egress shaping (and inbound shaping when
+#     the rule has direction:both, which all three do).
+#   - A BN pod sees BN→BN, BN→CN shaping.
+#
+# Pre-req:
+#   task up TOPOLOGY=paired-3            # TSS is on by default (now supported)
+#   CHAOS_ENABLED=true task chaos:install
+#
+# Note: TSS is on by default. CN_VERSION=latest is min-enforced to a TSS-capable
+# tag that clears the --wraps floor; set TSS_ENABLED=false only if pinning an older CN.
+#
+# Usage:
+#   CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-all-three.yaml
+
+name: latency-all-three
+description: "CN↔CN + BN↔BN + CN↔BN bidirectional latency concurrently during load"
+
+events:
+  - id: load-start
+    type: load-start
+    description: "Start NLG load"
+    delay: 0
+    args:
+      concurrency: 5
+      accounts: 10
+      duration: 420
+
+  - id: inject-cn-cn
+    type: inject-latency
+    description: "Inject CN↔CN 100ms"
+    delay: 30
+    args:
+      name: cn-to-cn
+      source: { kind: network-node }
+      target: { kind: network-node }
+      latency: 100ms
+      jitter: 20ms
+      bidirectional: true
+
+  - id: inject-bn-bn
+    type: inject-latency
+    description: "Inject BN↔BN 200ms"
+    delay: 35
+    args:
+      name: bn-to-bn
+      source: { kind: block-node }
+      target: { kind: block-node }
+      latency: 200ms
+      jitter: 40ms
+      bidirectional: true
+
+  - id: inject-cn-bn
+    type: inject-latency
+    description: "Inject CN↔BN 150ms"
+    delay: 40
+    args:
+      name: cn-to-bn
+      source: { kind: network-node }
+      target: { kind: block-node }
+      latency: 150ms
+      jitter: 30ms
+      bidirectional: true
+
+  - id: clear-cn-cn
+    type: clear-latency
+    description: "Clear CN↔CN"
+    delay: 330
+    args: { name: cn-to-cn }
+
+  - id: clear-bn-bn
+    type: clear-latency
+    description: "Clear BN↔BN"
+    delay: 332
+    args: { name: bn-to-bn }
+
+  - id: clear-cn-bn
+    type: clear-latency
+    description: "Clear CN↔BN"
+    delay: 334
+    args: { name: cn-to-bn }
+
+  - id: load-stop
+    type: load-stop
+    description: "Stop NLG load"
+    delay: 360
+
+assertions:
+  - id: all-healthy
+    type: node-healthy
+    description: "All BNs healthy after stacked chaos"
+    target: all
+
+  - id: all-have-blocks
+    type: block-available
+    description: "All BNs have blocks"
+    target: all
+    args:
+      min_block: 0
+
+  - id: blocks-increasing
+    type: blocks-increasing
+    description: "Blocks increasing with three concurrent chaos rules"
+    target: all
+    args:
+      wait_seconds: 30
+      max_attempts: 3
+
+  - id: block-rate-floor
+    type: block-rate-floor
+    description: "Post-chaos block rate ≥ 0.3 blk/s under stacked chaos"
+    target: all
+    args:
+      min_rate_per_sec: 0.3
+      window_seconds: 30

--- a/tools-and-tests/scripts/solo-e2e-test/tests/latency-bn-to-bn.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/latency-bn-to-bn.yaml
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# BN ↔ BN Latency Test
+#
+# Injects 200 ms ± 40 ms bidirectional latency between all Block Nodes during
+# NLG load. CN-to-BN streaming is unaffected; only BN-to-BN backfill mesh
+# traffic is slowed. Verifies that every BN keeps receiving blocks from its
+# upstream CN under degraded peer connectivity.
+#
+# Note: solo-chaos does not ship a BN↔BN template — this is the dimension that
+# requires our own NetworkChaos manifest authoring (see issues/001).
+#
+# Selectors:
+#   source: block-node.hiero.com/type=block-node
+#   target: block-node.hiero.com/type=block-node
+#
+# Pre-req:
+#   task up TOPOLOGY=paired-3            # TSS is on by default (now supported)
+#   CHAOS_ENABLED=true task chaos:install
+#
+# Note: TSS is on by default. CN_VERSION=latest is min-enforced to a TSS-capable
+# tag that clears the --wraps floor; set TSS_ENABLED=false only if pinning an older CN.
+#
+# Usage:
+#   CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-bn-to-bn.yaml
+
+name: latency-bn-to-bn
+description: "200ms ± 40ms bidirectional latency between Block Nodes during load"
+
+events:
+  - id: load-start
+    type: load-start
+    description: "Start NLG load"
+    delay: 0
+    args:
+      concurrency: 5
+      accounts: 10
+      duration: 420
+
+  - id: inject
+    type: inject-latency
+    description: "Inject BN↔BN 200ms latency"
+    delay: 30
+    args:
+      name: bn-to-bn-200ms
+      source: { kind: block-node }
+      target: { kind: block-node }
+      latency: 200ms
+      jitter: 40ms
+      correlation: '0'
+      bidirectional: true
+
+  - id: clear
+    type: clear-latency
+    description: "Clear BN↔BN latency"
+    delay: 330
+    args:
+      name: bn-to-bn-200ms
+
+  - id: load-stop
+    type: load-stop
+    description: "Stop NLG load"
+    delay: 360
+
+assertions:
+  - id: all-healthy
+    type: node-healthy
+    description: "All BNs healthy"
+    target: all
+
+  - id: all-have-blocks
+    type: block-available
+    description: "All BNs have blocks"
+    target: all
+    args:
+      min_block: 0
+
+  - id: blocks-increasing
+    type: blocks-increasing
+    description: "Blocks still increasing across BN↔BN chaos window (live stream from CN unaffected)"
+    target: all
+    args:
+      wait_seconds: 30
+      max_attempts: 3
+
+  - id: block-rate-floor
+    type: block-rate-floor
+    description: "Post-chaos block rate ≥ 0.3 blk/s on every BN"
+    target: all
+    args:
+      min_rate_per_sec: 0.3
+      window_seconds: 30

--- a/tools-and-tests/scripts/solo-e2e-test/tests/latency-cn-to-bn.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/latency-cn-to-bn.yaml
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# CN ↔ BN Latency Test
+#
+# Injects 150 ms ± 30 ms bidirectional latency between Consensus Nodes and
+# Block Nodes during NLG load. This is the production-realistic scenario:
+# CNs and BNs sitting in different regions, with the block-publish stream
+# crossing a slow link. Verifies blocks continue to land and BNs stay healthy.
+#
+# Selectors:
+#   source: solo.hedera.com/type=network-node
+#   target: block-node.hiero.com/type=block-node
+#
+# Pre-req:
+#   task up TOPOLOGY=paired-3            # TSS is on by default (now supported)
+#   CHAOS_ENABLED=true task chaos:install
+#
+# Note: TSS is on by default. CN_VERSION=latest is min-enforced to a TSS-capable
+# tag that clears the --wraps floor; set TSS_ENABLED=false only if pinning an older CN.
+#
+# Usage:
+#   CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-cn-to-bn.yaml
+
+name: latency-cn-to-bn
+description: "150ms ± 30ms bidirectional latency between Consensus Nodes and Block Nodes during load"
+
+events:
+  - id: load-start
+    type: load-start
+    description: "Start NLG load"
+    delay: 0
+    args:
+      concurrency: 5
+      accounts: 10
+      duration: 420
+
+  - id: inject
+    type: inject-latency
+    description: "Inject CN↔BN 150ms latency"
+    delay: 30
+    args:
+      name: cn-to-bn-150ms
+      source: { kind: network-node }
+      target: { kind: block-node }
+      latency: 150ms
+      jitter: 30ms
+      correlation: '0'
+      bidirectional: true
+
+  - id: clear
+    type: clear-latency
+    description: "Clear CN↔BN latency"
+    delay: 330
+    args:
+      name: cn-to-bn-150ms
+
+  - id: load-stop
+    type: load-stop
+    description: "Stop NLG load"
+    delay: 360
+
+assertions:
+  - id: all-healthy
+    type: node-healthy
+    description: "All BNs healthy"
+    target: all
+
+  - id: all-have-blocks
+    type: block-available
+    description: "All BNs have blocks"
+    target: all
+    args:
+      min_block: 0
+
+  - id: blocks-increasing
+    type: blocks-increasing
+    description: "Blocks still increasing across CN↔BN chaos window"
+    target: all
+    args:
+      wait_seconds: 30
+      max_attempts: 3
+
+  - id: block-rate-floor
+    type: block-rate-floor
+    description: "Post-chaos block rate ≥ 0.3 blk/s (publisher stream recovered)"
+    target: all
+    args:
+      min_rate_per_sec: 0.3
+      window_seconds: 30

--- a/tools-and-tests/scripts/solo-e2e-test/tests/latency-cn-to-cn.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/latency-cn-to-cn.yaml
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# CN ↔ CN Latency Test
+#
+# Injects 100 ms ± 20 ms bidirectional latency between all Consensus Nodes
+# while NLG load is running. Verifies that consensus rounds still produce
+# blocks, that all Block Nodes continue receiving them, and (with TSS on, the
+# default) that block signatures transition Schnorr -> WRAPS under latency.
+#
+# Selectors:
+#   source: solo.hedera.com/type=network-node
+#   target: solo.hedera.com/type=network-node
+#
+# Pre-req:
+#   task up TOPOLOGY=paired-3            # TSS is on by default (now supported)
+#   CHAOS_ENABLED=true task chaos:install
+#
+# Note: TSS is on by default. CN_VERSION=latest is min-enforced to a TSS-capable
+# tag that clears the --wraps floor; set TSS_ENABLED=false only if pinning an older CN.
+#
+# Usage:
+#   CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-cn-to-cn.yaml
+
+name: latency-cn-to-cn
+description: "100ms ± 20ms bidirectional latency between Consensus Nodes during load"
+
+events:
+  - id: load-start
+    type: load-start
+    description: "Start NLG load"
+    delay: 0
+    args:
+      concurrency: 5
+      accounts: 10
+      duration: 420
+
+  - id: inject
+    type: inject-latency
+    description: "Inject CN↔CN 100ms latency"
+    delay: 30
+    args:
+      name: cn-to-cn-100ms
+      source: { kind: network-node }
+      target: { kind: network-node }
+      latency: 100ms
+      jitter: 20ms
+      correlation: '0'
+      bidirectional: true
+
+  - id: clear
+    type: clear-latency
+    description: "Clear CN↔CN latency"
+    delay: 330
+    args:
+      name: cn-to-cn-100ms
+
+  - id: load-stop
+    type: load-stop
+    description: "Stop NLG load"
+    delay: 360
+
+assertions:
+  - id: all-healthy
+    type: node-healthy
+    description: "All BNs healthy"
+    target: all
+
+  - id: all-have-blocks
+    type: block-available
+    description: "All BNs have blocks"
+    target: all
+    args:
+      min_block: 0
+
+  - id: blocks-increasing
+    type: blocks-increasing
+    description: "Blocks still increasing across CN↔CN chaos window"
+    target: all
+    args:
+      wait_seconds: 30
+      max_attempts: 3
+
+  - id: block-rate-floor
+    type: block-rate-floor
+    description: "Post-chaos block rate ≥ 0.3 blk/s (consensus recovered)"
+    target: all
+    args:
+      min_rate_per_sec: 0.3
+      window_seconds: 30
+
+  - id: no-stream-errors
+    type: metric-threshold
+    description: "No stream errors observed across run"
+    target: all
+    args:
+      metric: blocknode_publisher_stream_errors_total
+      comparator: "=="
+      value: 0
+
+  # Proves TSS is active end-to-end under latency: block signatures transition
+  # Schnorr -> WRAPS (proof size 2920 -> 3432). Auto-skips when TSS is disabled.
+  - id: tss-signature-transition
+    type: signature-transition
+    description: "TSS signatures transition Schnorr -> WRAPS during the run"
+    target: block-node-1
+    args:
+      max_block: 1000

--- a/tools-and-tests/scripts/solo-e2e-test/tests/latency-severe.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/latency-severe.yaml
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Severe ("breaking-point") CN↔CN + BN↔BN + CN↔BN Latency Test
+#
+# The harshest tier — ~5-6x baseline with heavy jitter and high correlation, to
+# probe how the network behaves near its tolerance and whether it RECOVERS once
+# the latency is removed:
+#   - CN ↔ CN  : 600 ms ± 150 ms, correlation 75%  (bidirectional)
+#   - CN ↔ BN  : 800 ms ± 200 ms, correlation 75%  (bidirectional)
+#   - BN ↔ BN  : 1000 ms ± 250 ms, correlation 75% (bidirectional)
+#
+# Intent: this is a resilience / recovery probe, not a throughput test. Under
+# this latency the BNs are expected to fall well behind; the assertions (which
+# run AFTER the latency clears) focus on survival + clean recovery: nodes stay
+# healthy, backfill is exercised, and block production resumes once latency is
+# removed. The block-rate floor is intentionally low (recovery, not steady-state).
+#
+# Pre-req:
+#   task up TOPOLOGY=paired-3            # TSS is on by default (now supported)
+#   CHAOS_ENABLED=true task chaos:install
+# (TSS is on by default; CN_VERSION=latest is min-enforced to a TSS-capable tag.)
+#
+# Usage:
+#   CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-severe.yaml
+
+name: latency-severe
+description: "Severe CN/BN bidirectional latency (5-6x baseline) — survival & recovery probe"
+
+events:
+  - id: load-start
+    type: load-start
+    description: "Start NLG load"
+    delay: 0
+    args:
+      concurrency: 5
+      accounts: 10
+      duration: 480
+
+  - id: inject-cn-cn
+    type: inject-latency
+    description: "Inject CN↔CN 600ms ± 150ms (corr 75%)"
+    delay: 30
+    args:
+      name: cn-to-cn
+      source: { kind: network-node }
+      target: { kind: network-node }
+      latency: 600ms
+      jitter: 150ms
+      correlation: "75"
+      bidirectional: true
+
+  - id: inject-bn-bn
+    type: inject-latency
+    description: "Inject BN↔BN 1000ms ± 250ms (corr 75%)"
+    delay: 35
+    args:
+      name: bn-to-bn
+      source: { kind: block-node }
+      target: { kind: block-node }
+      latency: 1000ms
+      jitter: 250ms
+      correlation: "75"
+      bidirectional: true
+
+  - id: inject-cn-bn
+    type: inject-latency
+    description: "Inject CN↔BN 800ms ± 200ms (corr 75%)"
+    delay: 40
+    args:
+      name: cn-to-bn
+      source: { kind: network-node }
+      target: { kind: block-node }
+      latency: 800ms
+      jitter: 200ms
+      correlation: "75"
+      bidirectional: true
+
+  - id: clear-cn-cn
+    type: clear-latency
+    description: "Clear CN↔CN"
+    delay: 360
+    args: { name: cn-to-cn }
+
+  - id: clear-bn-bn
+    type: clear-latency
+    description: "Clear BN↔BN"
+    delay: 362
+    args: { name: bn-to-bn }
+
+  - id: clear-cn-bn
+    type: clear-latency
+    description: "Clear CN↔BN"
+    delay: 364
+    args: { name: cn-to-bn }
+
+  - id: load-stop
+    type: load-stop
+    description: "Stop NLG load"
+    delay: 400
+
+assertions:
+  - id: all-healthy
+    type: node-healthy
+    description: "All BNs survive severe latency and stay/return healthy"
+    target: all
+
+  - id: all-have-blocks
+    type: block-available
+    description: "All BNs still have blocks"
+    target: all
+    args:
+      min_block: 0
+
+  - id: backfill-triggered
+    type: backfill-triggered
+    description: "BNs fell behind under severe latency and caught up via backfill"
+    target: all
+    args:
+      grep: "backfill"
+      since_seconds: 480
+
+  - id: blocks-increasing
+    type: blocks-increasing
+    description: "Block production recovers after severe latency clears"
+    target: all
+    args:
+      wait_seconds: 60
+      max_attempts: 5
+
+  - id: block-rate-floor
+    type: block-rate-floor
+    description: "Post-chaos block rate recovers to ≥ 0.1 blk/s (recovery, not steady-state)"
+    target: all
+    args:
+      min_rate_per_sec: 0.1
+      window_seconds: 30

--- a/tools-and-tests/scripts/solo-e2e-test/tests/latency-stress.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/latency-stress.yaml
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Heavy ("stress") CN↔CN + BN↔BN + CN↔BN Latency Test
+#
+# A deliberately harsher sibling of latency-all-three: ~3x the baseline delays,
+# wider jitter, and correlation (bursty delays) to push the network past the
+# "no visible impact" regime into "degrades but recovers":
+#   - CN ↔ CN  : 300 ms ± 80 ms,  correlation 50%  (bidirectional)
+#   - CN ↔ BN  : 450 ms ± 120 ms, correlation 50%  (bidirectional)
+#   - BN ↔ BN  : 600 ms ± 150 ms, correlation 50%  (bidirectional)
+#
+# Intent: under this load the BNs should fall behind and recover via backfill,
+# then resume normal block production once the latency clears. The assertions run
+# AFTER the chaos is cleared, so they verify graceful recovery (not steady-state
+# throughput under chaos): nodes healthy, blocks increasing again, backfill was
+# exercised, and a (reduced) post-chaos block-rate floor still holds.
+#
+# Pre-req:
+#   task up TOPOLOGY=paired-3            # TSS is on by default (now supported)
+#   CHAOS_ENABLED=true task chaos:install
+# (TSS is on by default; CN_VERSION=latest is min-enforced to a TSS-capable tag.)
+#
+# Usage:
+#   CHAOS_ENABLED=true TOPOLOGY=paired-3 task test:run TEST_FILE=tests/latency-stress.yaml
+
+name: latency-stress
+description: "Heavy CN/BN bidirectional latency (3x baseline, bursty) — degrade-and-recover"
+
+events:
+  - id: load-start
+    type: load-start
+    description: "Start NLG load"
+    delay: 0
+    args:
+      concurrency: 5
+      accounts: 10
+      duration: 420
+
+  - id: inject-cn-cn
+    type: inject-latency
+    description: "Inject CN↔CN 300ms ± 80ms (corr 50%)"
+    delay: 30
+    args:
+      name: cn-to-cn
+      source: { kind: network-node }
+      target: { kind: network-node }
+      latency: 300ms
+      jitter: 80ms
+      correlation: "50"
+      bidirectional: true
+
+  - id: inject-bn-bn
+    type: inject-latency
+    description: "Inject BN↔BN 600ms ± 150ms (corr 50%)"
+    delay: 35
+    args:
+      name: bn-to-bn
+      source: { kind: block-node }
+      target: { kind: block-node }
+      latency: 600ms
+      jitter: 150ms
+      correlation: "50"
+      bidirectional: true
+
+  - id: inject-cn-bn
+    type: inject-latency
+    description: "Inject CN↔BN 450ms ± 120ms (corr 50%)"
+    delay: 40
+    args:
+      name: cn-to-bn
+      source: { kind: network-node }
+      target: { kind: block-node }
+      latency: 450ms
+      jitter: 120ms
+      correlation: "50"
+      bidirectional: true
+
+  - id: clear-cn-cn
+    type: clear-latency
+    description: "Clear CN↔CN"
+    delay: 330
+    args: { name: cn-to-cn }
+
+  - id: clear-bn-bn
+    type: clear-latency
+    description: "Clear BN↔BN"
+    delay: 332
+    args: { name: bn-to-bn }
+
+  - id: clear-cn-bn
+    type: clear-latency
+    description: "Clear CN↔BN"
+    delay: 334
+    args: { name: cn-to-bn }
+
+  - id: load-stop
+    type: load-stop
+    description: "Stop NLG load"
+    delay: 360
+
+assertions:
+  - id: all-healthy
+    type: node-healthy
+    description: "All BNs healthy after heavy stacked chaos"
+    target: all
+
+  - id: all-have-blocks
+    type: block-available
+    description: "All BNs have blocks"
+    target: all
+    args:
+      min_block: 0
+
+  - id: backfill-triggered
+    type: backfill-triggered
+    description: "BNs fell behind under heavy latency and caught up via backfill"
+    target: all
+    args:
+      grep: "backfill"
+      since_seconds: 420
+
+  - id: blocks-increasing
+    type: blocks-increasing
+    description: "Block production resumes after the latency clears"
+    target: all
+    args:
+      wait_seconds: 45
+      max_attempts: 4
+
+  - id: block-rate-floor
+    type: block-rate-floor
+    description: "Post-chaos block rate recovers to ≥ 0.2 blk/s"
+    target: all
+    args:
+      min_rate_per_sec: 0.2
+      window_seconds: 30


### PR DESCRIPTION
## Summary

Adds the ability to inject **real network latency** between Consensus Nodes and Block Nodes in the solo e2e
kind cluster, and to assert that the network **degrades gracefully and recovers**. It layers a Chaos Mesh
`NetworkChaos` foundation onto the existing `solo-test-runner`, adds latency-aware assertions, ships
baseline / stress / severe latency profiles across all three CN/BN dimensions, and wires a conditional
Chaos-Mesh install into the solo-e2e workflow.

All changes are under `tools-and-tests/scripts/solo-e2e-test/` plus one conditional step in
`.github/workflows/solo-e2e-test.yml`. **No product code, chart, or proto changes.**

## Why

Block-node and consensus-node behaviour under realistic cross-region network
conditions wasn't testable locally. Production runs cross-region with 50–200 ms RTTs;
local testing ran at zero in-cluster latency. This lands the foundation to catch
backfill-timeout, publisher-reconnect, and consensus-round issues that only surface
when the network actually feels distant.

## The latency is real — how it's injected (not a mock)

Each `inject-latency` event renders a Chaos Mesh **`NetworkChaos`** resource with `action: netem` and applies
it to the cluster. Chaos Mesh programs Linux **`tc`/`netem`** on the *actual pod network namespaces* selected
by label, so packets between the targeted pods carry the configured delay ± jitter (and optional correlation
/ loss) at the kernel level — this is genuine egress shaping, not an application-level stub.

Two guardrails ensure a run can't silently "pass" without latency actually being applied:

- **Selector dry-run:** before applying, `chaos-dryrun.sh` resolves the source/target label selectors and
  **fails the test if either matches zero pods** — so a mislabeled selector can't produce a no-op rule.
- **Deterministic apply + cleanup:** each rule gets a stable name and is recorded; an `EXIT` trap tears down
  any active `NetworkChaos` even if the test crashes mid-window, so latency never leaks across runs.

Latency is injected on three independent paths, each stressing a different part of the system:

| Dimension | Selectors (source → target) | What it stresses |
|-----------|------------------------------|------------------|
| **CN ↔ CN** | `network-node` → `network-node` | Gossip / consensus round-trips (slower rounds) |
| **CN ↔ BN** | `network-node` → `block-node` | The live block-publish gRPC stream (delayed ACKs, publisher flow-control) |
| **BN ↔ BN** | `block-node` → `block-node` | The peer backfill mesh (slower catch-up between BNs) |

---

## Profiles — increasing stress on the system

Same event shape (`load-start → inject → clear → load-stop`); the tiers differ in **magnitude** and in what
the assertions expect. Select a tier by its test name (all require `paired-3` = 3 CN + 3 BN, TSS on).

| Profile | Test(s) | Latency (CN↔CN / CN↔BN / BN↔BN) | What it proves |
|---------|---------|----------------------------------|----------------|
| **baseline** | `latency-cn-to-cn`, `-cn-to-bn`, `-bn-to-bn`, `-all-three` | 100±20 / 150±30 / 200±40 ms | System tolerates normal cross-AZ/region latency with **no visible impact** (steady block rate). |
| **stress** | `latency-stress` | 300±80 / 450±120 / 600±150 ms, corr 50% | System **degrades then recovers**: BNs fall behind and catch up via **backfill**. |
| **severe** | `latency-severe` | 600±150 / 800±200 / 1000±250 ms, corr 75% | **Survival / recovery near the breaking point** — recovers cleanly once latency clears. |

---

## The assertion logic — what each check actually proves

| Assertion | How it works | What it proves |
|-----------|--------------|----------------|
| `node-healthy` | pod phase == Running | BNs stay up under chaos |
| `block-available` | `serverStatus` block range | BNs still hold their blocks |
| `blocks-increasing` | Δblocks > 0 over a window (polled, retried) | Production is *moving* (not stalled) |
| `block-rate-floor` | Δ`publisher_highest_block_number_inbound` ÷ Δt ≥ floor | Post-clear throughput **recovered** to a floor (0.000/s == a real stall) |
| `metric-threshold` | generic Prometheus comparator (label-tolerant scrape) | e.g. `publisher_stream_errors_total == 0` — no stream errors across the run |
| `backfill-triggered` | greps BN logs for the `backfill` marker in the window | **The node actually fell behind and recovered via backfill** |
| `signature-transition` | detects the block-proof size jump 2920→3432 bytes | TSS still transitions **Schnorr → WRAPS** under latency |

**Why `backfill-triggered` is the key signal that latency bit.** A Block Node only backfills when it has
fallen behind its source/peers. On a healthy, low-latency cluster it never needs to. So observing real
`backfill` activity during the stress/severe window is *direct evidence that the injected latency had a
material effect* — and the subsequent `blocks-increasing` + `block-rate-floor` prove the node then **caught
up and resumed normal production** after the latency was cleared.

---

## Confirming presence and recovery — CI evidence

Every tier has been run on `paired-3` with TSS on. The stress/severe runs show the full **inject → degrade →
backfill → recover** cycle:

| Run | Test | Latency injected | Backfill (presence + impact) | Recovery (post-clear rate vs floor) | Result |
|-----|------|------------------|------------------------------|--------------------------------------|--------|
| `28335141168` | chaos-foundation-smoke | install→inject→clear→cleanup | — | — | ✅ |
| `28335794369` | latency-cn-to-cn (+TSS) | 100±20 ms | — | steady; **Schnorr→WRAPS at block 434** | ✅ 2/2 |
| `28311376970` | latency-all-three | 100/150/200 ms | — | steady | ✅ |
| `28545982415` | **latency-stress** | 300/450/600 ms | **real backfill — 199 log hits ×3 BNs** | 0.467–0.500 blk/s vs **0.2** floor (~2.4×) | ✅ 5/5 |
| `28547498881` | **latency-severe** | 600/800/1000 ms | **real backfill — 225 log hits ×3 BNs** | 0.433–0.500 blk/s vs **0.1** floor (~4.5×) | ✅ 5/5 |

Read the stress/severe rows as: latency was applied → all three BNs measurably fell behind and **triggered
backfill** (proof the latency was real and impactful) → after `clear-latency` they **recovered** to normal
throughput and TSS signatures still verified. That is the behaviour a node operator cares about under a
degraded WAN.

> **Measurement note:** assertions run *after* the chaos window, so `block-rate-floor` measures **recovery**,
> not the (intentionally degraded) under-chaos rate. The under-chaos impact is captured by `backfill-triggered`.

---

## Running it

TSS runs **on** by default (`CN_VERSION=latest` is min-enforced to a TSS-capable tag that clears Solo's
`--wraps` floor). Run **one tier at a time** — `paired-3` shares a `cancel-in-progress` concurrency lane, so
a second same-topology dispatch cancels the first.

```bash
# smoke first, then a dimension / tier (one at a time)
gh workflow run solo-e2e-test.yml --ref feature/solo-e2e-latency -f topology=paired-3 -f tss-enabled=true -f test-definition=chaos-foundation-smoke
gh workflow run solo-e2e-test.yml --ref feature/solo-e2e-latency -f topology=paired-3 -f tss-enabled=true -f test-definition=latency-stress
gh workflow run solo-e2e-test.yml --ref feature/solo-e2e-latency -f topology=paired-3 -f tss-enabled=true -f test-definition=latency-severe
```
UI equivalent: Actions → Solo E2E Test → Run workflow → branch `feature/solo-e2e-latency`, `topology=paired-3`,
`tss-enabled=true`, `test-definition=<name>`. The workflow installs Chaos Mesh automatically for
`chaos`/`latency` tests. Full profile guide: `tools-and-tests/scripts/solo-e2e-test/docs/latency-scenarios.md`.

---

## Scope / impact

- Product code, Helm chart, proto: **untouched.**
- Latency injection is opt-in (only when a `chaos`/`latency` test is selected); the assertion library ships
  with unit tests (20 cases over fixtures).
- Adds two docs (`README` chaos section + `docs/latency-scenarios.md`) that are self-contained (no external
  links) for team handoff.

## For reviewers
- The heavy tiers (`stress`, `severe`) are CI-validated with comfortable margins (above), so the shipped
  thresholds are calibrated, not guesses.
- `loss` (netem packet loss) is plumbed end-to-end but no shipped scenario exercises it yet — noted in the
  docs as a future knob.

## Related Issue(s)
Resolves #2125 