### PR TITLE
refactor: relax RSA WRB acceptance to at-least-one-valid signature

### DIFF
--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
@@ -397,9 +397,10 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
      *    - Verify with `SHA384withRSA`. If verification fails or throws, **reject the block
      *      immediately** — the CN only includes signatures from nodes that contributed to
      *      consensus, so any included signature must be cryptographically valid.
-     * 5. Accept if `validCount * 2 > rosterSize` (strict majority: more than half of the
-     *      address-book nodes must have signed). The CN sends exactly the signatures from
-     *      nodes whose combined consensus weight exceeded 50%.
+     * 5. Accept if at least one signature in the proof verified. Step 4 already rejects
+     *      the block on any failed verification, so reaching this step means every
+     *      signature we were able to verify did pass; we only need to confirm at least
+     *      one such verification occurred.
      *
      * <p>This method never throws; all error conditions return a `success=false` notification.
      *
@@ -529,20 +530,18 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
             metrics.incrementRsaRosterMismatch(mismatchCount);
         }
 
-        // Strict majority threshold: validCount must be strictly greater than half the roster.
-        // The CN only sends signatures from nodes whose combined consensus weight exceeded 50%,
-        // so we require validCount * 2 > rosterSize (equivalent to validCount > rosterSize / 2.0).
-        // For example: 6-node roster requires > 3, i.e. ≥ 4 valid signatures.
-        final boolean accepted = validCount * 2 > rosterSize;
+        // Acceptance threshold: at least one valid signature from a roster node.
+        // Every signature present in the proof that failed cryptographic verification already
+        // rejected the block in the loop above, so reaching this point with validCount >= 1
+        // means all signatures we attempted to verify did pass.
+        final boolean accepted = validCount >= 1;
 
         if (!accepted) {
             LOGGER.log(
                     WARNING,
-                    "RSA WRB proof rejected for block {0}: {1}/{2} valid sigs, need > {3}",
+                    "RSA WRB proof rejected for block {0}: 0 valid signatures (roster size {1})",
                     blockNumber,
-                    validCount,
-                    rosterSize,
-                    rosterSize / 2);
+                    rosterSize);
             metrics.incrementRsaFailure();
             return new VerificationNotification(
                     false, FailureType.BAD_BLOCK_PROOF, blockNumber, null, null, blockSource);
@@ -564,11 +563,10 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
 
         LOGGER.log(
                 DEBUG,
-                "RSA WRB proof accepted for block {0}: {1}/{2} valid sigs (need > {3})",
+                "RSA WRB proof accepted for block {0}: {1} valid signature(s) (roster size {2})",
                 blockNumber,
                 validCount,
-                rosterSize,
-                rosterSize / 2);
+                rosterSize);
         metrics.incrementRsaSuccess();
         return new VerificationNotification(
                 true, null, blockNumber, blockRootHash, new BlockUnparsed(blockItems), blockSource);

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
@@ -397,10 +397,11 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
      *    - Verify with `SHA384withRSA`. If verification fails or throws, **reject the block
      *      immediately** — the CN only includes signatures from nodes that contributed to
      *      consensus, so any included signature must be cryptographically valid.
-     * 5. Accept if at least one signature in the proof verified. Step 4 already rejects
-     *      the block on any failed verification, so reaching this step means every
-     *      signature we were able to verify did pass; we only need to confirm at least
-     *      one such verification occurred.
+     * 5. Accept if all signatures in the proof verified. Signatures from nodes not in
+     *      the local roster are skipped (see TODO(2808)); step 4 already rejects
+     *      the block on any failed signature from a known node, so reaching this step
+     *      means every verifiable signature passed; we only need to confirm at least
+     *      one such signature exists.
      *
      * <p>This method never throws; all error conditions return a `success=false` notification.
      *
@@ -475,6 +476,9 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
 
         for (final RecordFileSignature sig : proof.recordFileSignatures()) {
             final long nodeId = sig.nodeId();
+            // TODO(2808): long-term, use a historical roster keyed by block number so signatures
+            //   from nodes that were valid at the time the block was produced are verified correctly
+            //   across address-book transitions, rather than skipping unknown node IDs.
             final PublicKey publicKey = rsaKeyByNodeId.get(nodeId);
             if (publicKey == null) {
                 mismatchCount++;
@@ -530,17 +534,18 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
             metrics.incrementRsaRosterMismatch(mismatchCount);
         }
 
-        // Acceptance threshold: at least one valid signature from a roster node.
-        // Every signature present in the proof that failed cryptographic verification already
-        // rejected the block in the loop above, so reaching this point with validCount >= 1
-        // means all signatures we attempted to verify did pass.
-        final boolean accepted = validCount >= 1;
+        // Acceptance threshold: every signature present in the proof passes validation,
+        // and at least one such signature exists. Signatures from nodes not in the local
+        // roster are skipped (see TODO(2808)). Because we fail fast on any failed
+        // verification, reaching this point means all verifiable signatures passed.
+        final boolean accepted = validCount > 0;
 
         if (!accepted) {
             LOGGER.log(
                     WARNING,
-                    "RSA WRB proof rejected for block {0}: 0 valid signatures (roster size {1})",
+                    "RSA WRB proof rejected for block {0}: {1} valid signatures (roster size {2})",
                     blockNumber,
+                    validCount,
                     rosterSize);
             metrics.incrementRsaFailure();
             return new VerificationNotification(
@@ -563,7 +568,7 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
 
         LOGGER.log(
                 DEBUG,
-                "RSA WRB proof accepted for block {0}: {1} valid signature(s) (roster size {2})",
+                "RSA WRB proof accepted for block {0}: {1} valid signatures (roster size {2})",
                 blockNumber,
                 validCount,
                 rosterSize);

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
@@ -44,27 +44,23 @@ import org.junit.jupiter.params.provider.MethodSource;
  * `ExtendedMerkleTreeSession`.
  *
  * <p>Tests use synthetic blocks and in-process RSA key pairs — no real testnet blocks are required.
- * Six nodes are used so the strict majority threshold (`> N/2 = > 3` for 6 nodes, i.e. ≥ 4) is
- * testable with both passing (≥ 4 valid sigs) and failing (≤ 3 valid sigs) scenarios.
- * All signatures present must pass RSA verification — any single failed sig causes immediate
- * block rejection, regardless of how many other sigs are valid.
+ * The acceptance rule is: at least one signature in the proof must verify, AND every signature
+ * present that we are able to verify must succeed — any single failed cryptographic verification
+ * causes immediate block rejection regardless of how many other sigs are valid.
  *
  * <p>The raw `RecordFileItem` proto is assembled manually using protobuf wire format so that
  * `extractRecordStreamFileBytes` is exercised by the field-2 extraction path.
  */
 class RsaWrbVerificationTest {
 
-    /** Number of test nodes. Strict majority threshold for 6 nodes is > 3 (i.e. ≥ 4 valid sigs). */
+    /** Number of nodes in the fixed roster used by most tests. */
     private static final int ROSTER_SIZE = 6;
 
     /**
-     * Extended key pool size for the parametrised threshold tests.
-     * Covers all roster sizes tested in `strictMajorityThreshold_exactlyMet_acceptedOneLess_rejected`.
+     * Extended key pool size for the parametrised roster-size test.
+     * Covers all roster sizes exercised in `oneValidSignatureSuffices_zeroRejected`.
      */
     private static final int MAX_KEY_POOL = 9;
-
-    /** Strict majority threshold for 6 nodes: validCount * 2 > 6 → validCount ≥ 4. */
-    private static final int THRESHOLD = 4;
 
     /** HAPI version >= 0.72.0 routes to `ExtendedMerkleTreeSession`. */
     private static final SemanticVersion HAPI_VERSION = new SemanticVersion(1, 0, 0, "", "");
@@ -87,7 +83,7 @@ class RsaWrbVerificationTest {
 
     /**
      * Extended public key pool covering node_ids 0 .. MAX_KEY_POOL-1.
-     * Used exclusively by the parametrised threshold test so it can build rosters of varying sizes
+     * Used exclusively by the parametrised roster-size test so it can build rosters of varying sizes
      * without affecting the existing 6-node test fixtures.
      */
     private static final Map<Long, PublicKey> EXTENDED_KEY_MAP = new HashMap<>();
@@ -113,7 +109,7 @@ class RsaWrbVerificationTest {
             KEY_MAP.put(nodeId, kp.getPublic());
             PRIVATE_KEY_MAP.put(nodeId, kp.getPrivate());
         }
-        // Generate the extended pool (MAX_KEY_POOL nodes) for the parametrised threshold tests.
+        // Generate the extended pool (MAX_KEY_POOL nodes) for the parametrised roster-size tests.
         for (long nodeId = 0; nodeId < MAX_KEY_POOL; nodeId++) {
             final KeyPair kp = kpg.generateKeyPair();
             EXTENDED_KEY_MAP.put(nodeId, kp.getPublic());
@@ -236,7 +232,7 @@ class RsaWrbVerificationTest {
 
     /**
      * Signs `signedPayload` with the extended pool private key for `nodeId` and returns a
-     * `RecordFileSignature`. Used only by the parametrised threshold test.
+     * `RecordFileSignature`. Used only by the parametrised roster-size test.
      */
     private static RecordFileSignature extendedSignature(final long nodeId) throws Exception {
         final Signature engine = Signature.getInstance("SHA384withRSA");
@@ -248,14 +244,26 @@ class RsaWrbVerificationTest {
     // ---- Tests -------------------------------------------------------------------------------
 
     @Test
-    @DisplayName("valid proof at exactly the threshold is accepted")
-    void validProofAtExactThreshold_accepted() throws Exception {
-        // strict majority threshold for 6 nodes: > 3, i.e. exactly 4 valid sigs
+    @DisplayName("valid proof with a single signature is accepted")
+    void validProofSingleSignature_accepted() throws Exception {
+        // Under the at-least-one-valid rule, a single valid signature accepts the block.
+        final List<RecordFileSignature> sigs = signaturesFor(0L);
+        final VerificationNotification result = runVerification(KEY_MAP, sigs);
+
+        assertNotNull(result, "Session must produce a notification");
+        assertTrue(result.success(), "Proof with one valid signature must be accepted");
+        assertNotNull(result.blockHash(), "Block hash must be set on success");
+        assertNotNull(result.block(), "Block must be present on success");
+    }
+
+    @Test
+    @DisplayName("valid proof with multiple signatures is accepted")
+    void validProofMultipleSignatures_accepted() throws Exception {
         final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L);
         final VerificationNotification result = runVerification(KEY_MAP, sigs);
 
         assertNotNull(result, "Session must produce a notification");
-        assertTrue(result.success(), "Proof with exactly threshold signatures must be accepted");
+        assertTrue(result.success(), "Proof with multiple valid signatures must be accepted");
         assertNotNull(result.blockHash(), "Block hash must be set on success");
         assertNotNull(result.block(), "Block must be present on success");
     }
@@ -271,22 +279,24 @@ class RsaWrbVerificationTest {
     }
 
     @Test
-    @DisplayName("valid proof one below threshold is rejected")
-    void validProofOneBelowThreshold_rejected() throws Exception {
-        // strict majority for 6 nodes requires > 3; exactly 3 valid sigs → 3*2=6 not > 6 → rejected
+    @DisplayName("valid proof with three signatures in a six-node roster is accepted")
+    void validProofMinoritySignatures_accepted() throws Exception {
+        // Under the at-least-one-valid rule a small number of valid signatures (well below half
+        // the roster) still accepts the block, provided every signature present verifies.
         final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L);
         final VerificationNotification result = runVerification(KEY_MAP, sigs);
 
         assertNotNull(result);
-        assertFalse(result.success(), "Proof with fewer than threshold signatures must be rejected");
-        assertNull(result.blockHash(), "Block hash must not be set on failure");
-        assertNull(result.block(), "Block must not be present on failure");
+        assertTrue(result.success(), "3 valid sigs of 6 must be accepted under the at-least-one rule");
+        assertNotNull(result.blockHash(), "Block hash must be set on success");
+        assertNotNull(result.block(), "Block must be present on success");
     }
 
     @Test
-    @DisplayName("all-zero signature bytes are skipped and count as invalid")
+    @DisplayName("all-zero signature bytes are skipped, leaving zero valid sigs → rejected")
     void allZeroSignatures_rejected() throws Exception {
-        // Build signatures with all-zero bytes for every node
+        // Every entry is all-zero — the defensive pre-filter skips each, validCount stays at 0,
+        // and the at-least-one-valid rule rejects the block.
         final List<RecordFileSignature> sigs = new ArrayList<>();
         for (long id = 0; id < ROSTER_SIZE; id++) {
             sigs.add(new RecordFileSignature(Bytes.wrap(new byte[256]), id));
@@ -294,7 +304,7 @@ class RsaWrbVerificationTest {
         final VerificationNotification result = runVerification(KEY_MAP, sigs);
 
         assertNotNull(result);
-        assertFalse(result.success(), "All-zero signatures must not count toward threshold");
+        assertFalse(result.success(), "All-zero signatures yield zero valid sigs and must be rejected");
     }
 
     @Test
@@ -309,7 +319,7 @@ class RsaWrbVerificationTest {
     @Test
     @DisplayName("signature from unknown node_id is skipped; rest still counted")
     void unknownNodeId_sigSkipped_othersStillCounted() throws Exception {
-        // Nodes 0..4 produce valid sigs (meets threshold); node 99 is not in the key map
+        // Nodes 0..4 produce valid sigs; node 99 is not in the key map and is skipped.
         final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L);
         // Add a sig from an unknown node
         sigs.add(new RecordFileSignature(Bytes.wrap(sign(0L) /* use node 0's key bytes */), 99L));
@@ -320,7 +330,7 @@ class RsaWrbVerificationTest {
         assertNotNull(result);
         assertTrue(
                 result.success(),
-                "Sig from unknown node should be skipped; valid sigs from known nodes still meet threshold");
+                "Sig from unknown node is skipped (no key to verify); valid sigs from known nodes still accept");
     }
 
     @Test
@@ -343,10 +353,11 @@ class RsaWrbVerificationTest {
     }
 
     @Test
-    @DisplayName("one bad sig among otherwise sufficient valid sigs causes immediate block rejection")
+    @DisplayName("one bad sig among otherwise valid sigs causes immediate block rejection")
     void oneBadSigAmongValids_immediatelyRejectsBlock() throws Exception {
-        // 5 valid sigs from nodes 0..4 (would exceed the majority threshold of > 3 on their own),
-        // but node 5 signs the wrong payload — the block must be rejected immediately.
+        // 5 valid sigs from nodes 0..4, but node 5 signs the wrong payload — the block must be
+        // rejected immediately by the "any failed verify rejects" rule, regardless of how many
+        // other sigs are valid.
         final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L);
         final byte[] wrongData = "tampered-payload".getBytes();
         final Signature engine = Signature.getInstance("SHA384withRSA");
@@ -360,7 +371,7 @@ class RsaWrbVerificationTest {
         assertFalse(
                 result.success(),
                 "Block must be rejected immediately when any signature from a known node fails — "
-                        + "even if the remaining valid sigs would satisfy the majority count");
+                        + "regardless of how many other sigs are valid");
     }
 
     @Test
@@ -378,38 +389,34 @@ class RsaWrbVerificationTest {
     void malformedKeyExcludedFromMap_restStillCounted() throws Exception {
         // Build a key map where node 5 has a malformed (random) key — RsaKeyDecoder would skip it.
         // Here we simulate by simply omitting node 5 from the map (as if buildKeyMap had skipped it).
-        // 5-node roster — strict majority threshold: > 2.5, i.e. ≥ 3 valid sigs.
         final Map<Long, PublicKey> reducedMap = new HashMap<>(KEY_MAP);
-        reducedMap.remove(5L); // 5-node roster now — threshold: validCount*2 > 5 → ≥ 3
+        reducedMap.remove(5L);
 
         final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L);
         final VerificationNotification result = runVerification(reducedMap, sigs);
 
         assertNotNull(result);
-        // 5 valid sigs, 5*2=10 > 5 → accepted
-        assertTrue(result.success(), "5 valid sigs out of 5-node roster exceeds the strict majority threshold of > 2");
+        assertTrue(result.success(), "5 valid sigs against a 5-key map must be accepted");
     }
 
     @Test
-    @DisplayName("duplicate node_id in proof is counted only once toward the threshold")
-    void duplicateNodeId_countedOnlyOnce() throws Exception {
-        // 6-node roster; strict majority requires > 3 (i.e. ≥ 4 valid).
-        // Send 3 distinct valid signatures + 1 duplicate of node 0 → validCount stays at 3.
-        // 3*2=6 not > 6 → rejected.
-        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L);
-        sigs.add(new RecordFileSignature(Bytes.wrap(sign(0L)), 0L)); // duplicate node 0
+    @DisplayName("duplicate node_id in proof is handled without crash and block is accepted")
+    void duplicateNodeId_skippedNotCrashed() throws Exception {
+        // 2 distinct valid sigs + 1 duplicate of node 0. The dedup branch must skip the
+        // duplicate (defence-in-depth against an inflated validCount) without affecting the
+        // accept/reject outcome under the at-least-one-valid rule.
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L);
+        sigs.add(new RecordFileSignature(Bytes.wrap(sign(0L)), 0L)); // duplicate of node 0
         final VerificationNotification result = runVerification(KEY_MAP, sigs);
 
         assertNotNull(result);
-        assertFalse(
-                result.success(),
-                "Duplicate signature from node 0 must not count twice — validCount stays at 3, not > rosterSize/2");
+        assertTrue(result.success(), "Block must still be accepted when a duplicate signature is present");
     }
 
     @Test
     @DisplayName("multiple RSA proofs all valid are accepted")
     void multipleValidProofs_accepted() throws Exception {
-        // Two RSA proofs, both with the threshold of 4 valid signatures — both must verify.
+        // Two RSA proofs, each with all-valid signatures — both must verify for the block to accept.
         final List<List<RecordFileSignature>> proofs =
                 List.of(signaturesFor(0L, 1L, 2L, 3L), signaturesFor(0L, 1L, 2L, 3L, 4L, 5L));
         final List<BlockItemUnparsed> items = buildWrbBlockWithMultipleProofs(proofs);
@@ -425,13 +432,19 @@ class RsaWrbVerificationTest {
     }
 
     @Test
-    @DisplayName("multiple RSA proofs with one failing causes block rejection")
+    @DisplayName("multiple RSA proofs with one containing a failed signature rejects the block")
     void multipleProofs_oneFailing_rejected() throws Exception {
-        // First proof is valid at threshold; second proof has too few valid signatures.
-        // The block must be rejected because every RSA proof present must pass verification.
-        final List<List<RecordFileSignature>> proofs = List.of(
-                signaturesFor(0L, 1L, 2L, 3L, 4L, 5L),
-                signaturesFor(0L, 1L, 2L)); // 3 valid sigs — below strict majority for 6-node roster
+        // First proof is fully valid; second proof contains one signature against a wrong
+        // payload — that single failed verify must reject the whole block.
+        final List<RecordFileSignature> secondProofSigs = signaturesFor(0L, 1L);
+        final byte[] wrongData = "tampered-payload".getBytes();
+        final Signature wrongEngine = Signature.getInstance("SHA384withRSA");
+        wrongEngine.initSign(PRIVATE_KEY_MAP.get(2L));
+        wrongEngine.update(wrongData);
+        secondProofSigs.add(new RecordFileSignature(Bytes.wrap(wrongEngine.sign()), 2L));
+
+        final List<List<RecordFileSignature>> proofs =
+                List.of(signaturesFor(0L, 1L, 2L, 3L, 4L, 5L), secondProofSigs);
         final List<BlockItemUnparsed> items = buildWrbBlockWithMultipleProofs(proofs);
         final ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(
                 BLOCK_NUMBER, BlockSource.PUBLISHER, null, null, null, KEY_MAP, VerificationProofMetrics.NONE);
@@ -591,50 +604,38 @@ class RsaWrbVerificationTest {
     }
 
     /**
-     * Verifies that the strict majority threshold (`validCount * 2 > rosterSize`) is correctly
-     * enforced across a range of roster sizes. The minimum valid count is the smallest integer
-     * strictly greater than half the roster: `floor(rosterSize / 2) + 1`.
+     * Verifies the at-least-one-valid acceptance rule across a range of roster sizes:
+     * a single valid signature accepts, zero valid signatures rejects.
      */
-    @ParameterizedTest(name = "rosterSize={0} → minValidCount={1}")
-    @MethodSource("thresholdCases")
-    @DisplayName("strict majority threshold (validCount*2 > rosterSize) is correct across roster sizes")
-    void strictMajorityThreshold_exactlyMet_acceptedOneLess_rejected(final int rosterSize, final int expectedThreshold)
-            throws Exception {
+    @ParameterizedTest(name = "rosterSize={0}")
+    @MethodSource("rosterSizes")
+    @DisplayName("one valid signature accepts and zero valid signatures rejects across roster sizes")
+    void oneValidSignatureSuffices_zeroRejected(final int rosterSize) throws Exception {
         // Build a key map from the extended pool so existing 6-node KEY_MAP is unaffected.
         final Map<Long, PublicKey> keyMap = new HashMap<>();
         for (long id = 0; id < rosterSize; id++) {
             keyMap.put(id, EXTENDED_KEY_MAP.get(id));
         }
 
-        // Exactly threshold valid sigs → must be accepted
-        final List<RecordFileSignature> atThreshold = new ArrayList<>();
-        for (long id = 0; id < expectedThreshold; id++) {
-            atThreshold.add(extendedSignature(id));
-        }
+        // 1 valid sig → must be accepted
+        final List<RecordFileSignature> one = List.of(extendedSignature(0L));
         assertTrue(
-                runVerification(keyMap, atThreshold).success(),
-                "rosterSize=" + rosterSize + ": " + expectedThreshold + " sigs (= threshold) must be accepted");
+                runVerification(keyMap, one).success(), "rosterSize=" + rosterSize + ": 1 valid sig must be accepted");
 
-        // One below threshold → must be rejected
-        final List<RecordFileSignature> oneLess = new ArrayList<>();
-        for (long id = 0; id < expectedThreshold - 1; id++) {
-            oneLess.add(extendedSignature(id));
-        }
+        // 0 valid sigs (empty list) → must be rejected
         assertFalse(
-                runVerification(keyMap, oneLess).success(),
-                "rosterSize=" + rosterSize + ": " + (expectedThreshold - 1) + " sigs (threshold-1) must be rejected");
+                runVerification(keyMap, List.of()).success(),
+                "rosterSize=" + rosterSize + ": 0 valid sigs must be rejected");
     }
 
-    static Stream<Arguments> thresholdCases() {
-        // Minimum validCount such that validCount * 2 > rosterSize (i.e. floor(rosterSize/2) + 1)
+    static Stream<Arguments> rosterSizes() {
         return Stream.of(
-                Arguments.of(3, 2), // 2*2=4 > 3 ✓ ; 1*2=2 not > 3
-                Arguments.of(4, 3), // 3*2=6 > 4 ✓ ; 2*2=4 not > 4
-                Arguments.of(5, 3), // 3*2=6 > 5 ✓ ; 2*2=4 not > 5
-                Arguments.of(6, 4), // 4*2=8 > 6 ✓ ; 3*2=6 not > 6
-                Arguments.of(7, 4), // 4*2=8 > 7 ✓ ; 3*2=6 not > 7
-                Arguments.of(8, 5), // 5*2=10 > 8 ✓ ; 4*2=8 not > 8
-                Arguments.of(9, 5) // 5*2=10 > 9 ✓ ; 4*2=8 not > 9
-                );
+                Arguments.of(3),
+                Arguments.of(4),
+                Arguments.of(5),
+                Arguments.of(6),
+                Arguments.of(7),
+                Arguments.of(8),
+                Arguments.of(9));
     }
 }

--- a/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
+++ b/block-node/verification/src/test/java/org/hiero/block/node/verification/session/impl/RsaWrbVerificationTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  *
  * <p>Tests use synthetic blocks and in-process RSA key pairs — no real testnet blocks are required.
  * The acceptance rule is: at least one signature in the proof must verify, AND every signature
- * present that we are able to verify must succeed — any single failed cryptographic verification
+ * present must succeed — any single failed cryptographic verification
  * causes immediate block rejection regardless of how many other sigs are valid.
  *
  * <p>The raw `RecordFileItem` proto is assembled manually using protobuf wire format so that
@@ -276,6 +276,8 @@ class RsaWrbVerificationTest {
 
         assertNotNull(result);
         assertTrue(result.success(), "Proof signed by all nodes must be accepted");
+        assertNotNull(result.blockHash(), "Block hash must be set on success");
+        assertNotNull(result.block(), "Block must be present on success");
     }
 
     @Test
@@ -316,13 +318,18 @@ class RsaWrbVerificationTest {
         assertFalse(result.success(), "Empty signature list must be rejected");
     }
 
+    // TODO(2808): both tests below cover the current skip-on-missing-key behaviour; once issue 2808
+    //   (historical roster lookup by block number) is resolved, update them to verify against the
+    //   roster that was active when the block was produced rather than the current local roster.
+
     @Test
     @DisplayName("signature from unknown node_id is skipped; rest still counted")
     void unknownNodeId_sigSkipped_othersStillCounted() throws Exception {
         // Nodes 0..4 produce valid sigs; node 99 is not in the key map and is skipped.
         final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L);
         // Add a sig from an unknown node
-        sigs.add(new RecordFileSignature(Bytes.wrap(sign(0L) /* use node 0's key bytes */), 99L));
+        sigs.add(
+                new RecordFileSignature(Bytes.wrap(sign(0L)), 99L)); // content irrelevant — node 99 absent from key map
 
         final Map<Long, PublicKey> keyMap = new HashMap<>(KEY_MAP); // node 99 absent
         final VerificationNotification result = runVerification(keyMap, sigs);
@@ -331,6 +338,27 @@ class RsaWrbVerificationTest {
         assertTrue(
                 result.success(),
                 "Sig from unknown node is skipped (no key to verify); valid sigs from known nodes still accept");
+    }
+
+    @Test
+    @DisplayName("roster transition: sig from new node not yet in local AB is skipped; block still accepted")
+    void rosterTransition_newNodeSigSkipped_blockAccepted() throws Exception {
+        // AB1 has nodes 0..4 (5 nodes). AB2 adds node 5. Local roster is still AB1.
+        // The proof arrives with 6 signatures (all AB2 nodes). Node 5 is unknown → skipped.
+        // The 5 known-node signatures all verify → at-least-one-valid rule accepts the block.
+        final Map<Long, PublicKey> ab1KeyMap = new HashMap<>();
+        for (long id = 0; id < 5; id++) {
+            ab1KeyMap.put(id, KEY_MAP.get(id));
+        }
+        // Build proof with all 6 signatures (nodes 0..5)
+        final List<RecordFileSignature> sigs = signaturesFor(0L, 1L, 2L, 3L, 4L, 5L);
+        final VerificationNotification result = runVerification(ab1KeyMap, sigs);
+
+        assertNotNull(result);
+        assertTrue(
+                result.success(),
+                "Sig from roster-transition node (not in local AB) must be skipped, not fail; "
+                        + "5 known valid sigs still accept the block");
     }
 
     @Test
@@ -400,8 +428,8 @@ class RsaWrbVerificationTest {
     }
 
     @Test
-    @DisplayName("duplicate node_id in proof is handled without crash and block is accepted")
-    void duplicateNodeId_skippedNotCrashed() throws Exception {
+    @DisplayName("duplicate node_id in proof is skipped and block is accepted")
+    void duplicateNodeId_skippedAndBlockAccepted() throws Exception {
         // 2 distinct valid sigs + 1 duplicate of node 0. The dedup branch must skip the
         // duplicate (defence-in-depth against an inflated validCount) without affecting the
         // accept/reject outcome under the at-least-one-valid rule.
@@ -443,8 +471,7 @@ class RsaWrbVerificationTest {
         wrongEngine.update(wrongData);
         secondProofSigs.add(new RecordFileSignature(Bytes.wrap(wrongEngine.sign()), 2L));
 
-        final List<List<RecordFileSignature>> proofs =
-                List.of(signaturesFor(0L, 1L, 2L, 3L, 4L, 5L), secondProofSigs);
+        final List<List<RecordFileSignature>> proofs = List.of(signaturesFor(0L, 1L, 2L, 3L, 4L, 5L), secondProofSigs);
         final List<BlockItemUnparsed> items = buildWrbBlockWithMultipleProofs(proofs);
         final ExtendedMerkleTreeSession session = new ExtendedMerkleTreeSession(
                 BLOCK_NUMBER, BlockSource.PUBLISHER, null, null, null, KEY_MAP, VerificationProofMetrics.NONE);


### PR DESCRIPTION

Replace the strict-majority RSA WRB acceptance rule (`validCount * 2 > rosterSize`) with at-least-one-valid (`validCount >= 1`) in `ExtendedMerkleTreeSession#verifyRsaProof`. The fail-fast rule "any signature present that fails cryptographic verification rejects the block" is unchanged and still covers tampering detection.

`RsaWrbVerificationTest` updated to match the new contract: flipped assertions on the now-accepting cases (3-of-6, duplicate-nodeId), added a single-signature acceptance test, replaced the parametrised strict-majority test with a roster-size-parametrised `oneValidSignatureSuffices_zeroRejected`, and reworked `multipleProofs_oneFailing_rejected` to fail via a wrong-payload signature instead of sub-quorum.

Fixes #2801 