### PR TITLE
fix: correct extra bytes validation in listing file reader

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/listing/DayListingFileReader.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/listing/DayListingFileReader.java
@@ -47,8 +47,10 @@ public class DayListingFileReader {
                 recordFiles.add(ListingRecordFile.read(din));
             }
             // double check there are no remaining bytes
-            if (din.available() > 0 || din.readAllBytes().length > 0) {
-                throw new IOException("Unexpected extra bytes in listing file: " + listingPath);
+            byte[] remaining = din.readAllBytes();
+            if (remaining.length > 0) {
+                throw new IOException("Unexpected extra bytes in listing file: " + listingPath + " (found "
+                        + remaining.length + " extra bytes)");
             }
         }
         return recordFiles;


### PR DESCRIPTION
## Summary

Fixes a bug in `DayListingFileReader` that was causing false positive "unexpected extra bytes" errors in the live-sequential command.

Fixes #2807

## Problem

The validation logic in `DayListingFileReader.java` line 50 had a flawed implementation:

```java
if (din.available() > 0 || din.readAllBytes().length > 0) {
    throw new IOException("Unexpected extra bytes in listing file: " + listingPath);
}
```

This caused issues because:
1. `available()` on `BufferedInputStream` returns an estimate, not an accurate count of all remaining bytes
2. Short-circuit evaluation (`||`) means `readAllBytes()` behavior is inconsistent
3. Calling `readAllBytes()` inside the condition creates a side effect

## Solution

Changed to simply call `readAllBytes()` once, check the result, and include the byte count in the error message:

```java
byte[] remaining = din.readAllBytes();
if (remaining.length > 0) {
    throw new IOException("Unexpected extra bytes in listing file: " + listingPath 
        + " (found " + remaining.length + " extra bytes)");
}
```

## Impact

Fixes fatal errors in `live-sequential` command when processing listing files that are actually valid but failed the buggy validation check.

Error seen:
```
[live-sequential] Fatal error: Unexpected extra bytes in listing file: .../metadata/listingsByDay/2026/05/12.bin
```


Fix Mainnet working:

```

 tail -f live-sequential.log
nohup: ignoring input
[live-sequential] Starting sequential block download with inline wrapping + validation
Configuration:
  listingDir=/mnt/archive-storage/JASPER_DONT_DELETE_MAINNET_RECORD_FILES/ROCKY/metadata/listingsByDay
  outputDir=/mnt/archive-storage/JASPER_DONT_DELETE_MAINNET_RECORD_FILES/ROCKY/compressedDays-FIXED
  wrapOutputDir=/mnt/archive-storage/JASPER_DONT_DELETE_MAINNET_RECORD_FILES/ROCKY/wrappedBlocks
  stateJsonPath=null
  addressBookPath=/mnt/archive-storage/JASPER_DONT_DELETE_MAINNET_RECORD_FILES/ROCKY/wrappedBlocks/addressBookHistory.json
  startDate=(auto-detect)
[live-sequential] Resuming from wrap effective highest: block 94949999
[live-sequential] Starting from block 94949999 hash[null] day=null
[live-sequential] Started new day: 2026-05-12
Initialized mainnet amendment provider
[WRAP] Mid-zip resume: truncating to 94949999
[WRAP] Starting from block: 94949999
[WRAP] Replaying 94950000 block hashes into hasher
All listings are up to date (through 2026-05-13)


Updated listings for 2026-05-12
[live-sequential] Loaded 2759370 listing entries for 2026-05-12
[live-sequential] Fetching previous hash from mirror node for block 94950000
[live-sequential] Got previous hash: 3422f935bb7b8ad9...
[WRAP] Hasher replay complete. leafCount=94950000
[WRAP] Validate checkpoint (block 94950000) is ahead of wrap effective highest (94949999); skipping checkpoint load
[WRAP] Initialized chain validation from registry at block 94949999
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by com.github.luben.zstd.util.Native$1 in an unnamed module (file:/home/rocky.thind/tools/tools-0.34.0-SNAPSHOT-all.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

[live-sequential] Block 94950099 (100 today, 0.7 blocks/sec, queue=1/32)
[WRAP] Wrapped + validated block 94950099 (100 total, sigs=30)
[live-sequential] Block 94950199 (200 today, 1.3 blocks/sec, queue=0/32)
[WRAP] Wrapped + validated block 94950199 (200 total, sigs=30)

```