### PR TITLE
fix: Delay the actual closure of a connection after end stream

### DIFF
--- a/block-node/app/src/testFixtures/java/module-info.java
+++ b/block-node/app/src/testFixtures/java/module-info.java
@@ -12,6 +12,7 @@ module org.hiero.block.node.app.test.fixtures {
     requires com.hedera.pbj.grpc.helidon;
     requires com.hedera.pbj.runtime;
     requires com.swirlds.config.api;
+    requires com.swirlds.config.extensions;
     requires org.hiero.block.node.app.config;
     requires org.hiero.block.node.spi;
     requires org.hiero.block.protobuf.pbj;

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/TestConfigurationBuilder.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/TestConfigurationBuilder.java
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.app.fixtures;
+
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
+import com.swirlds.config.api.converter.ConfigConverter;
+import com.swirlds.config.api.source.ConfigSource;
+import com.swirlds.config.api.validation.ConfigValidator;
+import com.swirlds.config.extensions.sources.SimpleConfigSource;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
+
+/// Helper for use in tests and to change the config for specific tests.
+/// Instance can be used per class or per test.
+public class TestConfigurationBuilder {
+    private final ReentrantLock configLock = new ReentrantLock();
+    private Configuration configuration = null;
+    private final ConfigurationBuilder builder;
+
+    /// Creates a new instance and automatically registers all config data records
+    /// (see [ConfigData]) on classpath/modulepath that are part of the packages
+    /// `com.swirlds` and `com.hedera`.
+    public TestConfigurationBuilder() {
+        this(true);
+    }
+
+    /// Creates a new instance and automatically registers all given config data
+    /// records. This call will not do a class scan for config data records on
+    /// classpath/modulepath like some of the other constructors do.
+    ///
+    /// @param dataTypes
+    public TestConfigurationBuilder(@Nullable final Class<? extends Record> dataTypes) {
+        this(false);
+        if (dataTypes != null) {
+            builder.withConfigDataTypes(dataTypes);
+        }
+    }
+
+    /// Creates a new instance and automatically registers all config data records
+    /// (see [ConfigData]) on classpath/modulepath that are part of the packages
+    /// `com.swirlds` and `com.hedera` if the `registerAllTypes` param is true.
+    ///
+    /// @param registerAllTypes if true all config data records on classpath will automatically be registered
+    public TestConfigurationBuilder(final boolean registerAllTypes) {
+        if (registerAllTypes) {
+            builder = ConfigurationBuilder.create().autoDiscoverExtensions();
+        } else {
+            builder = ConfigurationBuilder.create();
+        }
+    }
+
+    /// Sets the value for the config.
+    ///
+    /// @param propertyName name of the property
+    /// @param values list of values
+    /// @return the [TestConfigurationBuilder] instance (for fluent API)
+    @NonNull
+    public TestConfigurationBuilder withValues(@NonNull final String propertyName, @Nullable final List<?> values) {
+        return withSource(new SimpleConfigSource(propertyName, values));
+    }
+
+    /// Sets the value for the config.
+    ///
+    /// @param propertyName name of the property
+    /// @param value the value
+    /// @return the [TestConfigurationBuilder] instance (for fluent API)
+    @NonNull
+    public TestConfigurationBuilder withValue(@NonNull final String propertyName, @Nullable final String value) {
+        return withSource(new SimpleConfigSource(propertyName, value));
+    }
+
+    /// Sets the value for the config.
+    ///
+    /// @param propertyName name of the property
+    /// @param value the value
+    /// @return the [TestConfigurationBuilder] instance (for fluent API)
+    @NonNull
+    public TestConfigurationBuilder withValue(@NonNull final String propertyName, final int value) {
+        return withSource(new SimpleConfigSource(propertyName, value));
+    }
+
+    /// Sets the value for the config.
+    ///
+    /// @param propertyName name of the property
+    /// @param value the value
+    /// @return the [TestConfigurationBuilder] instance (for fluent API)
+    @NonNull
+    public TestConfigurationBuilder withValue(@NonNull final String propertyName, final double value) {
+        return withSource(new SimpleConfigSource(propertyName, value));
+    }
+
+    /// Sets the value for the config.
+    ///
+    /// @param propertyName name of the property
+    /// @param value the value
+    /// @return the [TestConfigurationBuilder] instance (for fluent API)
+    @NonNull
+    public TestConfigurationBuilder withValue(@NonNull final String propertyName, final long value) {
+        return withSource(new SimpleConfigSource(propertyName, value));
+    }
+
+    /// Sets the value for the config.
+    ///
+    /// @param propertyName name of the property
+    /// @param value the value
+    /// @return the [TestConfigurationBuilder] instance (for fluent API)
+    @NonNull
+    public TestConfigurationBuilder withValue(@NonNull final String propertyName, final boolean value) {
+        return withSource(new SimpleConfigSource(propertyName, value));
+    }
+
+    /// Sets the value for the config.
+    ///
+    /// @param propertyName name of the property
+    /// @param value the value
+    /// @return the [TestConfigurationBuilder] instance (for fluent API)
+    @NonNull
+    public TestConfigurationBuilder withValue(@NonNull final String propertyName, @NonNull final Object value) {
+        Objects.requireNonNull(value, "value must not be null");
+        return withSource(new SimpleConfigSource(propertyName, value.toString()));
+    }
+
+    /// This method returns the [Configuration] instance. If the method is called
+    /// for the first time the [Configuration] instance will be created. All
+    /// values that have been set (see [#withValue(String, int)]) methods will
+    /// be part of the config. Next to this the config will support all config
+    /// data record types (see [ConfigData]) that are on the classpath.
+    ///
+    /// @return the created configuration
+    @NonNull
+    public Configuration getOrCreateConfig() {
+        configLock.lock();
+        try {
+            if (configuration == null) {
+                configuration = builder.build();
+            }
+            return configuration;
+        } finally {
+            configLock.unlock();
+        }
+    }
+
+    private void checkConfigState() {
+        configLock.lock();
+        try {
+            if (configuration != null) {
+                throw new IllegalStateException("Configuration already created!");
+            }
+        } finally {
+            configLock.unlock();
+        }
+    }
+
+    /// Adds the given config source to the builder
+    ///
+    /// @param configSource the config source that will be added
+    /// @return the [TestConfigurationBuilder] instance (for fluent API)
+    @NonNull
+    public TestConfigurationBuilder withSource(@NonNull final ConfigSource configSource) {
+        checkConfigState();
+        builder.withSource(configSource);
+        return this;
+    }
+
+    /// Adds the given config converter to the builder
+    ///
+    /// @param converterType the type of the config converter
+    /// @param converter the config converter that will be added
+    /// @return the [TestConfigurationBuilder] instance (for fluent API)
+    @NonNull
+    public <T> TestConfigurationBuilder withConverter(
+            @NonNull final Class<T> converterType, @NonNull final ConfigConverter<T> converter) {
+        checkConfigState();
+        builder.withConverter(converterType, converter);
+        return this;
+    }
+
+    /// Adds the given config validator to the builder
+    ///
+    /// @param validator the config validator that will be added
+    /// @return the [TestConfigurationBuilder] instance (for fluent API)
+    @NonNull
+    public TestConfigurationBuilder withValidator(@NonNull final ConfigValidator validator) {
+        checkConfigState();
+        builder.withValidator(validator);
+        return this;
+    }
+
+    /// Adds the given config data type to the builder
+    ///
+    /// @param type the config data type that will be added
+    /// @param <T> the type of the config data type
+    /// @return the [TestConfigurationBuilder] instance (for fluent API)
+    @NonNull
+    public <T extends Record> TestConfigurationBuilder withConfigDataType(@NonNull final Class<T> type) {
+        checkConfigState();
+        builder.withConfigDataType(type);
+        return this;
+    }
+}

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/async/BlockingExecutor.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/async/BlockingExecutor.java
@@ -22,34 +22,30 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
-/**
- * A very simple executor to be used only for testing! This executor has the
- * ability to block the caller and execute tasks until completion either
- * on the caller thread, or on a single thread per task. It will
- * collect all submitted tasks to it and will hold them in order. After that
- * when the {@link #executeSerially()} method is called, all tasks will be
- * executed in order serially on the same thread that called the method. This
- * will ensure that all tasks will complete before doing any asserts. This pool
- * can also execute tasks asynchronously using any of the
- * {@link #executeAsync()} methods. The tasks will be executed in the
- * order they were submitted to the pool, and will be executed using a
- * {@link java.util.concurrent.ThreadPerTaskExecutor} internally. There are
- * options to join the tasks, effectively blocking until all tasks are completed.
- */
+/// A very simple executor to be used only for testing! This executor has the
+/// ability to block the caller and execute tasks until completion either
+/// on the caller thread, or on a single thread per task. It will
+/// collect all submitted tasks to it and will hold them in order. After that
+/// when the [#executeSerially()] method is called, all tasks will be
+/// executed in order serially on the same thread that called the method. This
+/// will ensure that all tasks will complete before doing any asserts. This pool
+/// can also execute tasks asynchronously using any of the
+/// [#executeAsync()] methods. The tasks will be executed in the
+/// order they were submitted to the pool, and will be executed using a
+/// [java.util.concurrent.ThreadPerTaskExecutor] internally. There are
+/// options to join the tasks, effectively blocking until all tasks are completed.
 public class BlockingExecutor extends ThreadPoolExecutor {
-    private static final Logger LOGGER = System.getLogger(BlockingExecutor.class.getName());
+    private final Logger LOGGER = System.getLogger(getClass().getCanonicalName());
     private static final long TASK_TIMEOUT_MILLIS = 5_000L;
     private static final long RUNNABLE_FUTURE_MAX_TIMEOUT_SECONDS = 60L;
-    /** The work queue that will be used to hold the tasks. */
+    /// The work queue that will be used to hold the tasks.
     private final BlockingQueue<Runnable> workQueue;
-    /** Counter to indicate total submitted tasks. */
+    /// Counter to indicate total submitted tasks.
     private int tasksSubmitted;
     /// All async executors created when running tasks async
     private final Queue<ExecutorService> asyncExecutors;
 
-    /**
-     * Constructor.
-     */
+    /// Constructor.
     public BlockingExecutor(@NonNull final BlockingQueue<Runnable> workQueue) {
         // supply super with arbitrary values, they will not be used
         super(
@@ -105,16 +101,14 @@ public class BlockingExecutor extends ThreadPoolExecutor {
         tasksSubmitted++;
     }
 
-    /**
-     * Invoke this method once you have submitted all the tasks that need to be
-     * run by this executor. This method will then proceed to poll each task
-     * (in the same order that they have been submitted) and will execute the
-     * tasks serially on the same thread that called this method. Once this
-     * method returns (or throws), we are certain that all tasks have run and
-     * can safely assert based on that. This method will throw an
-     * {@link IllegalStateException} to indicate a broken state, when the queue
-     * is empty.
-     */
+    /// Invoke this method once you have submitted all the tasks that need to be
+    /// run by this executor. This method will then proceed to poll each task
+    /// (in the same order that they have been submitted) and will execute the
+    /// tasks serially on the same thread that called this method. Once this
+    /// method returns (or throws), we are certain that all tasks have run and
+    /// can safely assert based on that. This method will throw an
+    /// [IllegalStateException] to indicate a broken state, when the queue
+    /// is empty.
     public void executeSerially() {
         if (workQueue.isEmpty()) {
             throw new IllegalStateException("Queue is empty");
@@ -125,62 +119,52 @@ public class BlockingExecutor extends ThreadPoolExecutor {
         }
     }
 
-    /**
-     * This method executes all tasks that were submitted to this executor
-     * asynchronously.
-     * <p>
-     * Timeout is {@value TASK_TIMEOUT_MILLIS} milliseconds, blocking is enabled,
-     * and exceptions will be thrown on exceptional completion.
-     * Logging on exceptional completion is disabled.
-     * @see #executeAsync(boolean, long, boolean, boolean, Supplier)
-     */
+    /// This method executes all tasks that were submitted to this executor
+    /// asynchronously.
+    ///
+    /// Timeout is {@value TASK_TIMEOUT_MILLIS} milliseconds, blocking is enabled,
+    /// and exceptions will be thrown on exceptional completion.
+    /// Logging on exceptional completion is disabled.
+    /// @see #executeAsync(boolean, long, boolean, boolean, Supplier)
     public List<CompletableFuture<Void>> executeAsync() {
         return executeAsync(true);
     }
 
-    /**
-     * This method executes all tasks that were submitted to this executor
-     * asynchronously.
-     * <p>
-     * Timeout is {@value TASK_TIMEOUT_MILLIS} milliseconds and blocking is
-     * enabled. Logging on exceptional completion is disabled.
-     * @see #executeAsync(boolean, long, boolean, boolean, Supplier)
-     */
+    /// This method executes all tasks that were submitted to this executor
+    /// asynchronously.
+    ///
+    /// Timeout is {@value TASK_TIMEOUT_MILLIS} milliseconds and blocking is
+    /// enabled. Logging on exceptional completion is disabled.
+    /// @see #executeAsync(boolean, long, boolean, boolean, Supplier)
     public List<CompletableFuture<Void>> executeAsync(final boolean throwOnExceptionalCompletion) {
         return executeAsync(TASK_TIMEOUT_MILLIS, throwOnExceptionalCompletion);
     }
 
-    /**
-     * This method executes all tasks that were submitted to this executor
-     * asynchronously.
-     * <p>
-     * Blocking is enabled and exceptions will be thrown on exceptional
-     * completion. Logging on exceptional completion is disabled.
-     * @see #executeAsync(boolean, long, boolean, boolean, Supplier)
-     */
+    /// This method executes all tasks that were submitted to this executor
+    /// asynchronously.
+    ///
+    /// Blocking is enabled and exceptions will be thrown on exceptional
+    /// completion. Logging on exceptional completion is disabled.
+    /// @see #executeAsync(boolean, long, boolean, boolean, Supplier)
     public List<CompletableFuture<Void>> executeAsync(final long timeoutMillis) {
         return executeAsync(timeoutMillis, true);
     }
 
-    /**
-     * This method executes all tasks that were submitted to this executor
-     * asynchronously.
-     * <p>
-     * Blocking is enabled. Logging on exceptional completion is disabled.
-     * @see #executeAsync(boolean, long, boolean, boolean, Supplier)
-     */
+    /// This method executes all tasks that were submitted to this executor
+    /// asynchronously.
+    ///
+    /// Blocking is enabled. Logging on exceptional completion is disabled.
+    /// @see #executeAsync(boolean, long, boolean, boolean, Supplier)
     public List<CompletableFuture<Void>> executeAsync(
             final long blockTimeoutMillis, final boolean throwOnExceptionalCompletion) {
         return executeAsync(blockTimeoutMillis, throwOnExceptionalCompletion, false);
     }
 
-    /**
-     * This method executes all tasks that were submitted to this executor
-     * asynchronously.
-     * <p>
-     * Blocking is enabled.
-     * @see #executeAsync(boolean, long, boolean, boolean, Supplier)
-     */
+    /// This method executes all tasks that were submitted to this executor
+    /// asynchronously.
+    ///
+    /// Blocking is enabled.
+    /// @see #executeAsync(boolean, long, boolean, boolean, Supplier)
     public List<CompletableFuture<Void>> executeAsync(
             final long blockTimeoutMillis,
             final boolean throwOnExceptionalCompletion,
@@ -193,13 +177,11 @@ public class BlockingExecutor extends ThreadPoolExecutor {
                 () -> Executors.newThreadPerTaskExecutor(Executors.defaultThreadFactory()));
     }
 
-    /**
-     * This method executes all tasks that were submitted to this executor
-     * asynchronously.
-     * <p>
-     * Default pool implementation used.
-     * @see #executeAsync(boolean, long, boolean, boolean, Supplier)
-     */
+    /// This method executes all tasks that were submitted to this executor
+    /// asynchronously.
+    ///
+    /// Default pool implementation used.
+    /// @see #executeAsync(boolean, long, boolean, boolean, Supplier)
     public List<CompletableFuture<Void>> executeAsync(
             final long blockTimeoutMillis,
             final boolean blockUntilDone,
@@ -213,38 +195,36 @@ public class BlockingExecutor extends ThreadPoolExecutor {
                 () -> Executors.newThreadPerTaskExecutor(Executors.defaultThreadFactory()));
     }
 
-    /**
-     * This method executes all tasks that were submitted to this executor
-     * asynchronously.
-     * <p>
-     * Internally, a {@link java.util.concurrent.ThreadPerTaskExecutor} is used
-     * to submit each task. All tasks are started in the order they were
-     * submitted to the executor. The way tasks are submitted is by
-     * calling {@link CompletableFuture#runAsync(Runnable, java.util.concurrent.Executor)}
-     * on each task in the internal worker queue. Depending on the parameters
-     * described below, this method will either block or not, throw an
-     * exception or not, log an exceptional execution or not, and will use a
-     * timeout for each task or not.
-     *
-     * @param blockUntilDone boolean value indicating if the method should
-     * block until all tasks are done or not. If true, the method will
-     * call {@link CompletableFuture#join()} on each submitted task.
-     * @param blockTimeoutMillis long value indicating the timeout in
-     * milliseconds for each task to complete. Internally,
-     * {@link CompletableFuture#orTimeout(long, TimeUnit)} will be used on each
-     * task with the supplied timeout value, unit is always
-     * {@link TimeUnit#MILLISECONDS}.
-     * @param throwOnExceptionalCompletion boolean value indicating if the
-     * method should throw an exception if any of the tasks completes
-     * exceptionally. This includes timeouts as well. If true, the method
-     * will throw a {@link RuntimeException} with the cause. This will be done
-     * for the first encounter of an exceptional completion, given that tasks
-     * are started in the order they were submitted and joined in the same\
-     * order.
-     * @return List of {@link CompletableFuture} objects, each representing a
-     * submitted task. The list will contain the same number of futures as the
-     * number of tasks submitted to the executor.
-     */
+    /// This method executes all tasks that were submitted to this executor
+    /// asynchronously.
+    ///
+    /// Internally, a [java.util.concurrent.ThreadPerTaskExecutor] is used
+    /// to submit each task. All tasks are started in the order they were
+    /// submitted to the executor. The way tasks are submitted is by
+    /// calling [CompletableFuture#runAsync(Runnable, java.util.concurrent.Executor)]
+    /// on each task in the internal worker queue. Depending on the parameters
+    /// described below, this method will either block or not, throw an
+    /// exception or not, log an exceptional execution or not, and will use a
+    /// timeout for each task or not.
+    ///
+    /// @param blockUntilDone boolean value indicating if the method should
+    /// block until all tasks are done or not. If true, the method will
+    /// call [CompletableFuture#join()] on each submitted task.
+    /// @param blockTimeoutMillis long value indicating the timeout in
+    /// milliseconds for each task to complete. Internally,
+    /// [CompletableFuture#orTimeout(long, TimeUnit)] will be used on each
+    /// task with the supplied timeout value, unit is always
+    /// [TimeUnit#MILLISECONDS].
+    /// @param throwOnExceptionalCompletion boolean value indicating if the
+    /// method should throw an exception if any of the tasks completes
+    /// exceptionally. This includes timeouts as well. If true, the method
+    /// will throw a [RuntimeException] with the cause. This will be done
+    /// for the first encounter of an exceptional completion, given that tasks
+    /// are started in the order they were submitted and joined in the same\
+    /// order.
+    /// @return List of [CompletableFuture] objects, each representing a
+    /// submitted task. The list will contain the same number of futures as the
+    /// number of tasks submitted to the executor.
     public List<CompletableFuture<Void>> executeAsync(
             final boolean blockUntilDone,
             final long blockTimeoutMillis,
@@ -289,20 +269,18 @@ public class BlockingExecutor extends ThreadPoolExecutor {
         }
     }
 
-    /**
-     * This method indicates if any task was ever submitted to this executor.
-     * This is useful during tests in order to assert that the pool was
-     * essentially not interacted with. An example would be if we have a test
-     * where we want to assert that some production logic will never submit a
-     * task to the executor given some condition, then we can use this method
-     * to assert that. This method does not reflect the current state of the
-     * queue, meaning the queue might be empty due to a call to the
-     * {@link #executeSerially()} method, but this method will still return
-     * true if any task was submitted before that.
-     *
-     * @return boolean value, true if any task was ever submitted, false
-     * otherwise
-     */
+    /// This method indicates if any task was ever submitted to this executor.
+    /// This is useful during tests in order to assert that the pool was
+    /// essentially not interacted with. An example would be if we have a test
+    /// where we want to assert that some production logic will never submit a
+    /// task to the executor given some condition, then we can use this method
+    /// to assert that. This method does not reflect the current state of the
+    /// queue, meaning the queue might be empty due to a call to the
+    /// [#executeSerially()] method, but this method will still return
+    /// true if any task was submitted before that.
+    ///
+    /// @return boolean value, true if any task was ever submitted, false
+    /// otherwise
     public boolean wasAnyTaskSubmitted() {
         return tasksSubmitted > 0;
     }
@@ -330,18 +308,14 @@ public class BlockingExecutor extends ThreadPoolExecutor {
         return super.shutdownNow();
     }
 
-    /**
-     * Operation currently not supported!
-     */
+    /// Operation currently not supported!
     @Override
     @NonNull
     public <T> T invokeAny(@NonNull final Collection<? extends Callable<T>> tasks) {
         throw new UnsupportedOperationException("Operation not supported, to be extended as needed");
     }
 
-    /**
-     * Operation currently not supported!
-     */
+    /// Operation currently not supported!
     @Override
     @NonNull
     public <T> T invokeAny(
@@ -349,18 +323,14 @@ public class BlockingExecutor extends ThreadPoolExecutor {
         throw new UnsupportedOperationException("Operation not supported, to be extended as needed");
     }
 
-    /**
-     * Operation currently not supported!
-     */
+    /// Operation currently not supported!
     @Override
     @NonNull
     public <T> List<Future<T>> invokeAll(@NonNull final Collection<? extends Callable<T>> tasks) {
         throw new UnsupportedOperationException("Operation not supported, to be extended as needed");
     }
 
-    /**
-     * Operation currently not supported!
-     */
+    /// Operation currently not supported!
     @Override
     @NonNull
     public <T> List<Future<T>> invokeAll(

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/async/ScheduledBlockingExecutor.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/async/ScheduledBlockingExecutor.java
@@ -2,42 +2,359 @@
 package org.hiero.block.node.app.fixtures.async;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.lang.System.Logger;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 public class ScheduledBlockingExecutor extends ScheduledThreadPoolExecutor {
-    /** The work queue that will be used to hold the tasks. */
+    private final Logger LOGGER = System.getLogger(getClass().getCanonicalName());
+    private static final long TASK_TIMEOUT_MILLIS = 5_000L;
+    private static final long RUNNABLE_FUTURE_MAX_TIMEOUT_SECONDS = 60L;
+    /// The Map that will be used to hold the tasks.
+    private final ConcurrentLinkedQueue<Schedule> scheduleQueue;
+    /// Queue used to execute tasks
     private final BlockingQueue<Runnable> workQueue;
+    /// Counter to indicate total submitted tasks.
+    private int tasksSubmitted;
+    /// All async executors created when running tasks async
+    private final Queue<ExecutorService> asyncExecutors;
 
     public ScheduledBlockingExecutor(@NonNull final BlockingQueue<Runnable> workQueue) {
         super(1, Thread.ofVirtual().factory(), new AbortPolicy());
-
         this.workQueue = workQueue; // actual work queue
+        asyncExecutors = new ConcurrentLinkedQueue<>();
+        scheduleQueue = new ConcurrentLinkedQueue<>();
     }
 
     public ScheduledBlockingExecutor(int corePoolSize, @NonNull final BlockingQueue<Runnable> workQueue) {
         super(corePoolSize, Thread.ofVirtual().factory(), new AbortPolicy());
-
         this.workQueue = workQueue; // actual work queue
+        asyncExecutors = new ConcurrentLinkedQueue<>();
+        scheduleQueue = new ConcurrentLinkedQueue<>();
     }
 
-    /**
-     * Captures the task into the work queue without executing it.
-     * <p>
-     * We intentionally do NOT call {@code super.execute(command)} here. The
-     * purpose of this executor is to hold tasks until tests explicitly drain
-     * the queue, giving tests full control over execution ordering and timing.
-     * Calling the parent's execute would defeat that contract. Tests that need
-     * tasks to actually run should use a real {@link java.util.concurrent.ScheduledThreadPoolExecutor}.
-     */
+    @Override
+    public long getTaskCount() {
+        return workQueue.size() + scheduleQueue.size();
+    }
+
+    /// Overriding this method in order to make sure this logic will be called
+    /// every time we will submit a task to the pool.
     @Override
     @SuppressWarnings("all")
     public void execute(@NonNull final Runnable command) {
-        try {
-            workQueue.put(command);
-        } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Thread was interrupted while trying to put a task into the work queue", e);
+        if (command instanceof RunnableFuture<?> ft) {
+            // Wrap the FutureTask in a Runnable that will call get() on it
+            // otherwise when executing async below, we will not get an exception
+            // since the FutureTask will capture it. Super's submit() methods
+            // wrap the task as a FutureTask.
+            workQueue.offer(new FutureRunnable(ft));
+        } else {
+            workQueue.offer(command);
+        }
+        tasksSubmitted++;
+    }
+
+    /// Invoke this method once you have submitted all the tasks that need to be
+    /// run by this executor. This method will then proceed to poll each task
+    /// (in the same order that they have been submitted) and will execute the
+    /// tasks serially on the same thread that called this method. Once this
+    /// method returns (or throws), we are certain that all tasks have run and
+    /// can safely assert based on that. This method will throw an
+    /// [IllegalStateException] to indicate a broken state, when the queue
+    /// is empty.
+    public void executeSerially() {
+        moveScheduledToWorkQueue();
+        if (!workQueue.isEmpty()) {
+            while (!workQueue.isEmpty()) {
+                workQueue.poll().run();
+            }
+        }
+    }
+
+    /// This method executes all tasks that were submitted to this executor
+    /// asynchronously.
+    ///
+    /// Timeout is {@value TASK_TIMEOUT_MILLIS} milliseconds, blocking is enabled,
+    /// and exceptions will be thrown on exceptional completion.
+    /// Logging on exceptional completion is disabled.
+    /// @see #executeAsync(boolean, long, boolean, boolean, Supplier)
+    public List<CompletableFuture<Void>> executeAsync() {
+        return executeAsync(true);
+    }
+
+    /// This method executes all tasks that were submitted to this executor
+    /// asynchronously.
+    ///
+    /// Timeout is {@value TASK_TIMEOUT_MILLIS} milliseconds and blocking is
+    /// enabled. Logging on exceptional completion is disabled.
+    /// @see #executeAsync(boolean, long, boolean, boolean, Supplier)
+    public List<CompletableFuture<Void>> executeAsync(final boolean throwOnExceptionalCompletion) {
+        return executeAsync(TASK_TIMEOUT_MILLIS, throwOnExceptionalCompletion);
+    }
+
+    /// This method executes all tasks that were submitted to this executor
+    /// asynchronously.
+    ///
+    /// Blocking is enabled and exceptions will be thrown on exceptional
+    /// completion. Logging on exceptional completion is disabled.
+    /// @see #executeAsync(boolean, long, boolean, boolean, Supplier)
+    public List<CompletableFuture<Void>> executeAsync(final long timeoutMillis) {
+        return executeAsync(timeoutMillis, true);
+    }
+
+    /// This method executes all tasks that were submitted to this executor
+    /// asynchronously.
+    ///
+    /// Blocking is enabled. Logging on exceptional completion is disabled.
+    /// @see #executeAsync(boolean, long, boolean, boolean, Supplier)
+    public List<CompletableFuture<Void>> executeAsync(
+            final long blockTimeoutMillis, final boolean throwOnExceptionalCompletion) {
+        return executeAsync(blockTimeoutMillis, throwOnExceptionalCompletion, false);
+    }
+
+    /// This method executes all tasks that were submitted to this executor
+    /// asynchronously.
+    ///
+    /// Blocking is enabled.
+    /// @see #executeAsync(boolean, long, boolean, boolean, Supplier)
+    public List<CompletableFuture<Void>> executeAsync(
+            final long blockTimeoutMillis,
+            final boolean throwOnExceptionalCompletion,
+            final boolean logOnExceptionalCompletion) {
+        return executeAsync(
+                true,
+                blockTimeoutMillis,
+                throwOnExceptionalCompletion,
+                logOnExceptionalCompletion,
+                () -> Executors.newThreadPerTaskExecutor(Executors.defaultThreadFactory()));
+    }
+
+    /// This method executes all tasks that were submitted to this executor
+    /// asynchronously.
+    ///
+    /// Default pool implementation used.
+    /// @see #executeAsync(boolean, long, boolean, boolean, Supplier)
+    public List<CompletableFuture<Void>> executeAsync(
+            final long blockTimeoutMillis,
+            final boolean blockUntilDone,
+            final boolean throwOnExceptionalCompletion,
+            final boolean logOnExceptionalCompletion) {
+        return executeAsync(
+                blockUntilDone,
+                blockTimeoutMillis,
+                throwOnExceptionalCompletion,
+                logOnExceptionalCompletion,
+                () -> Executors.newThreadPerTaskExecutor(Executors.defaultThreadFactory()));
+    }
+
+    /// This method executes all tasks that were submitted to this executor
+    /// asynchronously.
+    ///
+    /// Internally, a [java.util.concurrent.ThreadPerTaskExecutor] is used
+    /// to submit each task. All tasks are started in the order they were
+    /// submitted to the executor. The way tasks are submitted is by
+    /// calling [CompletableFuture#runAsync(Runnable, java.util.concurrent.Executor)]
+    /// on each task in the internal worker queue. Depending on the parameters
+    /// described below, this method will either block or not, throw an
+    /// exception or not, log an exceptional execution or not, and will use a
+    /// timeout for each task or not.
+    ///
+    /// @param blockUntilDone boolean value indicating if the method should
+    /// block until all tasks are done or not. If true, the method will
+    /// call [CompletableFuture#join()] on each submitted task.
+    /// @param blockTimeoutMillis long value indicating the timeout in
+    /// milliseconds for each task to complete. Internally,
+    /// [CompletableFuture#orTimeout(long, TimeUnit)] will be used on each
+    /// task with the supplied timeout value, unit is always
+    /// [TimeUnit#MILLISECONDS].
+    /// @param throwOnExceptionalCompletion boolean value indicating if the
+    /// method should throw an exception if any of the tasks completes
+    /// exceptionally. This includes timeouts as well. If true, the method
+    /// will throw a [RuntimeException] with the cause. This will be done
+    /// for the first encounter of an exceptional completion, given that tasks
+    /// are started in the order they were submitted and joined in the same\
+    /// order.
+    /// @return List of [CompletableFuture] objects, each representing a
+    /// submitted task. The list will contain the same number of futures as the
+    /// number of tasks submitted to the executor.
+    public List<CompletableFuture<Void>> executeAsync(
+            final boolean blockUntilDone,
+            final long blockTimeoutMillis,
+            final boolean throwOnExceptionalCompletion,
+            final boolean logOnExceptionalCompletion,
+            final Supplier<ExecutorService> executorServiceSupplier) {
+        if (blockTimeoutMillis <= 0) {
+            throw new IllegalArgumentException("Timeout per task must be greater than 0");
+        } else {
+            final List<CompletableFuture<Void>> futures = new ArrayList<>();
+            final ExecutorService pool = executorServiceSupplier.get();
+            asyncExecutors.add(pool);
+            moveScheduledToWorkQueue();
+            if (!workQueue.isEmpty()) {
+                while (!workQueue.isEmpty()) {
+                    futures.add(CompletableFuture.runAsync(workQueue.poll(), pool)
+                            .orTimeout(blockTimeoutMillis, TimeUnit.MILLISECONDS));
+                }
+            }
+            if (blockUntilDone) {
+                try {
+                    // If we block until done, we will wait for all tasks to complete.
+                    // If any timeout, an exception will be thrown, which will either be propagated or logged
+                    // depending on the throwOnExceptionalCompletion parameter.
+                    final CompletableFuture<?>[] arr = futures.toArray(new CompletableFuture[0]);
+                    CompletableFuture.allOf(arr).join();
+                } catch (final Exception e) {
+                    // if any task completed exceptionally, we will either throw an exception or log it
+                    final String message = "Exception occurred while running task in [%s]: %s"
+                            .formatted(getClass().getCanonicalName(), e.getMessage());
+                    if (throwOnExceptionalCompletion) {
+                        // Throw an exception if configured to do so
+                        throw new RuntimeException(message, e);
+                    } else if (logOnExceptionalCompletion) {
+                        // Log if configured to do so
+                        LOGGER.log(Logger.Level.ERROR, message, e);
+                    }
+                }
+            }
+            return futures;
+        }
+    }
+
+    /// Move all current scheduled tasks to the work queue for execution.
+    /// Any non-recurring tasks are then removed from the work map, but
+    /// recurring tasks remain to be executed again on the next cycle
+    private void moveScheduledToWorkQueue() {
+        List<Schedule> toRemove = new LinkedList<>();
+        for (Schedule entry : scheduleQueue) {
+            workQueue.add(entry.task());
+            if (!entry.repeat()) {
+                toRemove.add(entry);
+            }
+        }
+        for (Schedule next : toRemove) {
+            scheduleQueue.remove(next);
+        }
+    }
+
+    // Override the schedule methods to ensure that we aren't waiting for schedules
+    // We will just run the scheduled tasks whenever the test is ready to do
+    // so using executeSerially or executeAsync.
+
+    @Override
+    public ScheduledFuture<?> schedule(final Runnable command, final long delay, final TimeUnit unit) {
+        ScheduledTask<Void> item = new ScheduledTask<>(command, null, delay, unit);
+        final Schedule schedule = new Schedule(item, unit, delay, 0, false);
+        scheduleQueue.add(schedule);
+        return item;
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(final Callable<V> callable, final long delay, final TimeUnit unit) {
+        ScheduledTask<V> item = new ScheduledTask<>(callable, delay, unit);
+        final Schedule schedule = new Schedule(item, unit, delay, 0, false);
+        scheduleQueue.add(schedule);
+        return item;
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(
+            final Runnable command, final long initialDelay, final long period, final TimeUnit unit) {
+        ScheduledTask<Void> item = new ScheduledTask<>(command, null, initialDelay, unit);
+        final Schedule schedule = new Schedule(item, unit, initialDelay, period, true);
+        scheduleQueue.add(schedule);
+        return item;
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(
+            final Runnable command, final long initialDelay, final long delay, final TimeUnit unit) {
+        ScheduledTask<Void> item = new ScheduledTask<>(command, null, delay, unit);
+        final Schedule schedule = new Schedule(item, unit, initialDelay, delay, true);
+        scheduleQueue.add(schedule);
+        return item;
+    }
+
+    private static record Schedule(ScheduledTask<?> task, TimeUnit unit, long delay, long period, boolean repeat) {}
+
+    private static final class FutureRunnable implements Runnable {
+        private final RunnableFuture<?> innerRunnable;
+
+        FutureRunnable(final RunnableFuture<?> futureToRun) {
+            innerRunnable = futureToRun;
+        }
+
+        public void run() {
+            try {
+                // run the task
+                innerRunnable.run();
+                // get, but with a timeout to ensure we do not block forever
+                innerRunnable.get(RUNNABLE_FUTURE_MAX_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } catch (final ExecutionException e) {
+                // this is expected to happen, if we throw here, this means
+                // that the task has thrown an exception during execution.
+                throw new RuntimeException(e);
+            } catch (final TimeoutException e) {
+                // this is not expected to happen, if we throw here, this means
+                // that either the timeout is too low, or the task is
+                // potentially blocking forever.
+                final String message =
+                        "A task that executed in the %s took more than the allowed time of %d seconds. It is possible that the task is blocking forever."
+                                .formatted(getClass().getName(), RUNNABLE_FUTURE_MAX_TIMEOUT_SECONDS);
+                throw new RuntimeException(message, e);
+            }
+        }
+    }
+
+    private static final class ScheduledTask<V> extends FutureTask<V> implements ScheduledFuture<V> {
+        private final long delay;
+        private final TimeUnit unit;
+
+        private ScheduledTask(final Callable<V> callable, long delay, TimeUnit unit) {
+            super(callable);
+            this.delay = delay;
+            this.unit = unit;
+        }
+
+        private ScheduledTask(final Runnable runnable, final V result, long delay, TimeUnit unit) {
+            super(runnable, result);
+            this.delay = delay;
+            this.unit = unit;
+        }
+
+        @Override
+        public long getDelay(final TimeUnit unit) {
+            return unit.convert(delay, this.unit);
+        }
+
+        @Override
+        public int compareTo(final Delayed o) {
+            long otherDelay = o.getDelay(this.unit);
+            if (delay != otherDelay) {
+                return delay > otherDelay ? 1 : -1;
+            } else {
+                return 0;
+            }
         }
     }
 }

--- a/block-node/roster-bootstrap-tss/src/test/java/org/hiero/block/node/roster/bootstrap/tss/RosterBootstrapTssPluginTest.java
+++ b/block-node/roster-bootstrap-tss/src/test/java/org/hiero/block/node/roster/bootstrap/tss/RosterBootstrapTssPluginTest.java
@@ -96,18 +96,10 @@ public class RosterBootstrapTssPluginTest
         final TssData[] tssData = {null};
         CountDownLatch latch = new CountDownLatch(1);
 
-        RosterBootstrapTssPlugin plugin = new RosterBootstrapTssPlugin() {
-
-            @Override
-            public void onContextUpdate(BlockNodeContext context) {
-                contextUpdated[0]++;
-                tssData[0] = context.tssData();
-                latch.countDown();
-            }
-        };
+        RosterBootstrapTssPlugin plugin = new TestBootstrapPlugin(contextUpdated, tssData, latch);
 
         start(plugin, new SimpleInMemoryHistoricalBlockFacility(), configOverride);
-
+        testThreadPoolManager.scheduledExecutor().executeSerially();
         latch.await();
 
         assertTrue(contextUpdated[0] > 0);
@@ -179,6 +171,25 @@ public class RosterBootstrapTssPluginTest
                     "roster.bootstrap.tss.queryPeerInitialDelay", String.valueOf(queryPeerInitialDelay),
                     "roster.bootstrap.tss.maxIncomingBufferSize", String.valueOf(maxIncomingBufferSize),
                     "roster.bootstrap.tss.enableTLS", String.valueOf(enableTLS)));
+        }
+    }
+
+    private class TestBootstrapPlugin extends RosterBootstrapTssPlugin {
+        private final int[] contextUpdated;
+        private final TssData[] tssData;
+        private final CountDownLatch latch;
+
+        private TestBootstrapPlugin(int[] contextUpdated, TssData[] tssData, CountDownLatch latch) {
+            this.contextUpdated = contextUpdated;
+            this.tssData = tssData;
+            this.latch = latch;
+        }
+
+        @Override
+        public void onContextUpdate(BlockNodeContext context) {
+            contextUpdated[0]++;
+            tssData[0] = context.tssData();
+            latch.countDown();
         }
     }
 }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -131,8 +131,12 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         dataReadyLatch = dataReadyLock.newCondition();
         NodeConfig nodeConfiguration = serverContext.configuration().getConfigData(NodeConfig.class);
         earliestManagedBlock = nodeConfiguration.earliestManagedBlock();
-        scheduledExecutor =
-                threadManager.createVirtualThreadScheduledExecutor(1, null, this::uncaughtScheduledExecutorException);
+        int threadCount = Runtime.getRuntime().availableProcessors();
+        // Ensure at least 2 threads for scheduled tasks so we do not have
+        // excessive contention with the idle detector task.
+        threadCount = threadCount < 2 ? 2 : threadCount;
+        scheduledExecutor = threadManager.createVirtualThreadScheduledExecutor(
+                threadCount, null, this::uncaughtScheduledExecutorException);
         publisherConfig = serverContext.configuration().getConfigData(PublisherConfig.class);
         maxBlocksBeforeStalled = publisherConfig.MaxFutureBlocksBeforeStalled();
         staleResendPruneBuffer = publisherConfig.staleResendPruneBuffer();
@@ -311,6 +315,16 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         } finally {
             dataReadyLock.unlock();
         }
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAfterDelay(final Runnable taskToSchedule, final long delayInNanoseconds) {
+        return scheduledExecutor.schedule(taskToSchedule, delayInNanoseconds, TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public PublisherConfig configuration() {
+        return publisherConfig;
     }
 
     /// {@inheritDoc}

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfig.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfig.java
@@ -25,6 +25,7 @@ public record PublisherConfig(
         @Loggable @ConfigProperty(defaultValue = "9_223_372_036_854_775_807") @Min(100_000L) long batchForwardLimit,
         @Loggable @ConfigProperty(defaultValue = "300") @Min(0L) long publisherUnavailabilityTimeout,
         @Loggable @ConfigProperty(defaultValue = "3") @Min(3) @Max(50) int MaxFutureBlocksBeforeStalled,
-        @Loggable @ConfigProperty(defaultValue = "100") @Min(0L) @Max(200L) long staleResendPruneBuffer) {
+        @Loggable @ConfigProperty(defaultValue = "100") @Min(0L) @Max(200L) long staleResendPruneBuffer,
+        @Loggable @ConfigProperty(defaultValue = "100_000_000") @Min(100_000L) @Max(5_000_000_000L) long flowControlPauseDelayNanos) {
         // spotless:on
 }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -38,6 +38,7 @@ import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
 import org.hiero.block.api.BlockEnd;
 import org.hiero.block.api.PublishStreamRequest.EndStream;
 import org.hiero.block.api.PublishStreamResponse;
@@ -80,6 +81,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
             "metric-end-to-end-latency-by-block-end block={0,number,#} nsTimestamp={1,number,#} handlerId={2} correlationId={3}";
     private static final String LATENCY_START_MESSAGE =
             "metric-end-to-end-latency-by-block-start block={0,number,#} nsTimestamp={1,number,#} handlerId={2} correlationId={3}";
+    private static final long SHUTDOWN_DELAY_TIME = 10_000_000; // 10 milliseconds
 
     private final Logger LOGGER = System.getLogger(getClass().getName());
     /// The replies pipeline, used for sending responses to the publisher.
@@ -102,6 +104,10 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
     private final NavigableSet<Long> unacknowledgedStreamedBlocks;
     /// The state of the publisher, true if it is still active.
     private final AtomicBoolean isActive;
+    /// Set true to pause the handler, and stop accepting input.
+    private final AtomicBoolean isPaused;
+    /// The current configuration for the publisher.
+    private final PublisherConfig configuration;
     // @todo() remove this (and its usage) and use telemetry or metrics queries instead
     /// The start time in nanos of block being currently streamed
     private long currentStreamingBlockHeaderReceivedTime = System.nanoTime();
@@ -134,6 +140,8 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
         blockAction = new AtomicReference<>();
         unacknowledgedStreamedBlocks = new ConcurrentSkipListSet<>();
         isActive = new AtomicBoolean(true);
+        isPaused = new AtomicBoolean(false);
+        configuration = publisherManager.configuration();
     }
 
     // A package-private method for accessing correlation ID for tracing support.
@@ -180,6 +188,10 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
 
     @Override
     public void onNext(@NonNull final PublishStreamRequestUnparsed request) {
+        if (isPaused.compareAndSet(true, false)) {
+            // If we need to pause, park for the configured delay.
+            LockSupport.parkNanos(configuration.flowControlPauseDelayNanos());
+        }
         if (!isActive.get()) {
             checkMidBlockAndShutdown(currentStreamingBlockNumber.get());
         } else {
@@ -305,7 +317,10 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
                 publisherManager.blockIsEnding(currentStreamingBlockNumber.get(), handlerId);
             }
         } finally {
-            shutdown();
+            // pause the handler while we delay shutdown
+            isPaused.set(true);
+            // Do not shutdown immediately, allow for final messages to send first.
+            publisherManager.scheduleAfterDelay(this::shutdown, SHUTDOWN_DELAY_TIME);
             resetState();
         }
     }
@@ -750,6 +765,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
         } finally {
             try {
                 replies.onComplete();
+                isPaused.set(false); // unpause to prevent deadlocks.
                 replies.closeConnection();
                 // @todo() Add labeled metric when possible.
                 //    Metric: "handler-closed" Labels: "clean" or "with-exception"

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
@@ -5,6 +5,7 @@ import com.hedera.pbj.runtime.grpc.Pipeline;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Deque;
+import java.util.concurrent.ScheduledFuture;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.internal.BlockItemSetUnparsed;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
@@ -82,6 +83,18 @@ public interface StreamPublisherManager extends BlockNotificationHandler {
     /// The messaging thread may wait on this condition to limit spin cycles
     /// and still have a low impact on latency.
     void signalDataReady();
+
+    /// Schedule a task to run with a fixed delay.
+    ///
+    /// @param taskToSchedule a runnable task to schedule to run after a short delay
+    /// @param delayInNanoseconds The length of delay, this should always be less than 1 second.
+    ///
+    /// @return a ScheduledFuture representing the scheduled task.
+    ScheduledFuture<?> scheduleAfterDelay(Runnable taskToSchedule, final long delayInNanoseconds);
+
+    /// Get the current configuration of the publisher plugin.
+    /// @return The plugin configuration data.
+    PublisherConfig configuration();
 
     /// The action to take within the PublisherHandler for a block.
     enum BlockAction {

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -901,6 +901,8 @@ class LiveStreamPublisherManagerTest {
                 // As a pre-check, we expect no onComplete calls
                 assertThat(responsePipeline.getOnCompleteCalls().get()).isZero();
                 publisherHandler.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                threadPoolManager.scheduledExecutor().executeSerially();
                 // Assert that no more responses are sent
                 assertThat(onNextCalls).isEmpty();
                 assertThat(responsePipeline.getOnCompleteCalls().get()).isEqualTo(1);
@@ -1005,6 +1007,8 @@ class LiveStreamPublisherManagerTest {
                 // We need to send any request or trigger any pipeline method
                 // to do the actual shutdown
                 publisherHandler2.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                threadPoolManager.scheduledExecutor().executeSerially();
                 // Assert that the response pipeline has received no responses and the shared metrics is not updated.
                 assertThat(responsePipeline.getOnNextCalls()).isEmpty();
                 assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCKS_RESEND_SENT))
@@ -1072,6 +1076,8 @@ class LiveStreamPublisherManagerTest {
                 // We need to send any request or trigger any pipeline method
                 // to do the actual shutdown
                 publisherHandler2.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                threadPoolManager.scheduledExecutor().executeSerially();
                 // Assert that the response pipeline of the first publisher has received no responses.
                 // Also no metrics for resends is updated
                 assertThat(responsePipeline.getOnNextCalls()).isEmpty();
@@ -1398,6 +1404,8 @@ class LiveStreamPublisherManagerTest {
                 // to do the actual shutdown
                 publisherHandler.onNext(
                         TestBlockBuilder.generateBlockWithNumber(0L).asPublishStreamRequestUnparsed());
+                // Invoke the delayed shutdown so it actually runs
+                threadPoolManager.scheduledExecutor().executeSerially();
                 // Assert that the latest known block number is still -1L, it was not updated
                 assertThat(toTest.getLatestBlockNumber()).isEqualTo(expectedLatestPersistedFromManager);
                 assertThat(responsePipeline.getOnCompleteCalls().get()).isEqualTo(1);
@@ -1407,6 +1415,8 @@ class LiveStreamPublisherManagerTest {
                 assertThat(responsePipeline.getClientEndStreamCalls().get()).isEqualTo(0);
                 publisherHandler2.onNext(
                         TestBlockBuilder.generateBlockWithNumber(0L).asPublishStreamRequestUnparsed());
+                // Invoke the delayed shutdown so it actually runs
+                threadPoolManager.scheduledExecutor().executeSerially();
                 // Assert that the response pipeline has received a PERSISTENCE_FAILED
                 assertThat(responsePipeline2.getOnNextCalls())
                         .hasSize(1)
@@ -1614,6 +1624,8 @@ class LiveStreamPublisherManagerTest {
                         .build();
                 // Now we send the end stream request to the publisher handler.
                 publisherHandler.onNext(endStreamRequest);
+                // Invoke the delayed shutdown so it actually runs
+                threadPoolManager.scheduledExecutor().executeSerially();
                 assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_ENDSTREAM_RECEIVED))
                         .isEqualTo(1);
                 // Now we must assert that the publisher has shutdown
@@ -1682,6 +1694,8 @@ class LiveStreamPublisherManagerTest {
                         .build();
                 // Now we send the end stream request to the publisher handler.
                 publisherHandler.onNext(endStreamRequest);
+                // Invoke the delayed shutdown so it actually runs
+                threadPoolManager.scheduledExecutor().executeSerially();
                 // Now we must assert that the publisher has shutdown
                 assertThat(responsePipeline.getOnCompleteCalls().get()).isEqualTo(1);
                 assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_ENDSTREAM_RECEIVED))

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -8,7 +8,6 @@ import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.e
 import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.sendHeaderOnly;
 
 import com.swirlds.config.api.Configuration;
-import com.swirlds.config.api.ConfigurationBuilder;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +56,7 @@ import org.hiero.block.node.spi.threading.ThreadPoolManager;
 import org.hiero.block.node.stream.publisher.LiveStreamPublisherManager.MetricsHolder;
 import org.hiero.block.node.stream.publisher.StreamPublisherManager.ActionForBlock;
 import org.hiero.block.node.stream.publisher.StreamPublisherManager.BlockAction;
+import org.hiero.block.node.stream.publisher.fixtures.TestStreamPublisherManager;
 import org.hiero.metrics.core.MetricRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -2080,7 +2080,8 @@ class LiveStreamPublisherManagerTest {
                 messagingFacility = new TestBlockMessagingFacility();
                 final Map<String, String> configOverrides =
                         Map.ofEntries(Map.entry("producer.publisherUnavailabilityTimeout", "2"));
-                final Configuration testConfiguration = createTestConfiguration(configOverrides);
+                final Configuration testConfiguration =
+                        TestStreamPublisherManager.createTestConfiguration(configOverrides);
                 testPublisherConfig = testConfiguration.getConfigData(PublisherConfig.class);
                 threadPoolManager = new TestThreadPoolManager<>(
                         new BlockingExecutor(new LinkedBlockingQueue<>()),
@@ -2438,6 +2439,7 @@ class LiveStreamPublisherManagerTest {
                     publisherHandler.onNext(req);
                     endThisBlock(publisherHandler, block);
                 }
+                threadPoolManager.scheduledExecutor().executeSerially();
                 // No EndStream(TIMEOUT) should have been sent.
                 assertThat(responsePipeline.getOnNextCalls())
                         .as("single handler should never receive EndStream(TIMEOUT)")
@@ -2481,6 +2483,7 @@ class LiveStreamPublisherManagerTest {
                         .build();
                 publisherHandler2.onNext(block4Req);
                 endThisBlock(publisherHandler2, 4L);
+                threadPoolManager.scheduledExecutor().executeSerially();
                 assertThat(responsePipeline.getOnNextCalls())
                         .as("completing block 4 (> 0+3) must trigger EndStream(TIMEOUT) on handler 1")
                         .anySatisfy(r -> {
@@ -2510,6 +2513,7 @@ class LiveStreamPublisherManagerTest {
                     publisherHandler2.onNext(req);
                     endThisBlock(publisherHandler2, block);
                 }
+                threadPoolManager.scheduledExecutor().executeSerially();
                 // Handler 1 must have received EndStream(TIMEOUT) and been shut down.
                 assertThat(responsePipeline.getOnNextCalls())
                         .as("stalled handler 1 must receive EndStream(TIMEOUT)")
@@ -2588,6 +2592,8 @@ class LiveStreamPublisherManagerTest {
 
             /// When two handlers are simultaneously stalled, a single completing
             /// handler that is far enough ahead must terminate both.
+            /// NOTE: This test fails because handler 1 gets end stream, but no on complete call
+            ///       handler 2 gets both, so something might be weird in the test setup.
             @Test
             @DisplayName("all stalled handlers are terminated when multiple are stalled simultaneously")
             void testMultipleStalledHandlersAllTerminated() {
@@ -2600,7 +2606,7 @@ class LiveStreamPublisherManagerTest {
                 // Handler 2 wins ACCEPT for block 1 — sends header only.
                 sendHeaderOnly(publisherHandler2, 1L);
                 // Handler 3 completes block 5: 4 > 0+3 AND 5 > 1+3 — both stalled.
-                for (long block = 2L; block <= 5L; block++) {
+                for (long block = 2L; block <= 6L; block++) {
                     final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
                             .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
                                     .asItemSetUnparsed())
@@ -2608,6 +2614,10 @@ class LiveStreamPublisherManagerTest {
                     publisherHandler3.onNext(req);
                     endThisBlock(publisherHandler3, block);
                 }
+                // expect 3 here because we have an idle detection task in addition
+                // to the 2 end stream tasks.
+                assertThat(threadPoolManager.scheduledExecutor().getTaskCount()).isEqualTo(3);
+                threadPoolManager.scheduledExecutor().executeSerially();
                 // Both handler 1 and handler 2 must have received EndStream(TIMEOUT).
                 assertThat(responsePipeline.getOnNextCalls())
                         .as("stalled handler 1 must receive EndStream(TIMEOUT)")
@@ -2650,6 +2660,7 @@ class LiveStreamPublisherManagerTest {
                     publisherHandler2.onNext(req);
                     endThisBlock(publisherHandler2, block);
                 }
+                threadPoolManager.scheduledExecutor().executeSerially();
                 // Stall must have fired — handler 1 terminated.
                 assertThat(responsePipeline.getOnCompleteCalls().get())
                         .as("handler 1 must be shut down by stall detection before checking resend")
@@ -2700,7 +2711,7 @@ class LiveStreamPublisherManagerTest {
             final HistoricalBlockFacility historicalBlockFacility,
             final ThreadPoolManager threadPoolManager,
             final BlockMessagingFacility blockMessagingFacility) {
-        final Configuration configuration = createTestConfiguration();
+        final Configuration configuration = TestStreamPublisherManager.createTestConfiguration();
         return generateContext(historicalBlockFacility, threadPoolManager, blockMessagingFacility, configuration);
     }
 
@@ -2730,17 +2741,6 @@ class LiveStreamPublisherManagerTest {
                 BlockNodeVersions.DEFAULT,
                 null,
                 null);
-    }
-
-    private static Configuration createTestConfiguration() {
-        return createTestConfiguration(Map.of());
-    }
-
-    private static Configuration createTestConfiguration(final Map<String, String> overrides) {
-        final ConfigurationBuilder builder =
-                TestUtils.createTestConfiguration().withConfigDataType(PublisherConfig.class);
-        overrides.forEach(builder::withValue);
-        return builder.build();
     }
 
     /// This method generates a [MetricsHolder] instance with default

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherHandlerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherHandlerTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.hiero.block.api.PublishStreamRequest.EndStream;
@@ -26,6 +27,7 @@ import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.internal.PublishStreamRequestUnparsed;
 import org.hiero.block.node.app.fixtures.TestMetricsExporter;
+import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
 import org.hiero.block.node.app.fixtures.blocks.TestBlock;
 import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
 import org.hiero.block.node.app.fixtures.pipeline.TestResponsePipeline;
@@ -79,7 +81,8 @@ class PublisherHandlerTest {
             validNextId = 1L;
             validReplyPipeline = new TestResponsePipeline();
             validMetricsHodler = createMetrics();
-            validPublisherManager = new TestStreamPublisherManager(new TestBlockMessagingFacility());
+            validPublisherManager = new TestStreamPublisherManager(
+                    new TestBlockMessagingFacility(), new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
         }
 
         /**
@@ -159,7 +162,8 @@ class PublisherHandlerTest {
         void setup() {
             repliesPipeline = new TestResponsePipeline<>();
             metrics = createMetrics();
-            manager = new TestStreamPublisherManager(new TestBlockMessagingFacility());
+            manager = new TestStreamPublisherManager(
+                    new TestBlockMessagingFacility(), new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
 
             julLogger = java.util.logging.Logger.getLogger(PublisherHandler.class.getName());
             logHandler = new TestLogHandler();

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherHandlerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherHandlerTest.java
@@ -282,6 +282,7 @@ class PublisherHandlerTest {
                 response -> Objects.requireNonNull(response.resendBlock()).blockNumber();
         private final Function<PublishStreamResponse, Long> acknowledgementBlockNumberExtractor =
                 response -> Objects.requireNonNull(response.acknowledgement()).blockNumber();
+        private ScheduledBlockingExecutor scheduledExecutor;
 
         /// Environment setup executed before each test in this nested class.
         @BeforeEach
@@ -289,7 +290,8 @@ class PublisherHandlerTest {
             handlerId = 1L;
             repliesPipeline = new TestResponsePipeline();
             metrics = createMetrics();
-            manager = new TestStreamPublisherManager(new TestBlockMessagingFacility());
+            scheduledExecutor = new ScheduledBlockingExecutor(new LinkedBlockingQueue<>());
+            manager = new TestStreamPublisherManager(new TestBlockMessagingFacility(), scheduledExecutor);
             toTest = new PublisherHandler(handlerId, repliesPipeline, metrics, manager, null);
             manager.addHandler(toTest);
         }
@@ -876,6 +878,8 @@ class PublisherHandlerTest {
                 manager.setLatestBlockNumber(expectedLatestBlockNumber);
                 // Call
                 toTest.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 // Assert single response is DUPLICATE_BLOCK with block number latest known and onComplete is called
                 // (shutdown)
                 assertThat(repliesPipeline.getOnNextCalls())
@@ -1106,6 +1110,8 @@ class PublisherHandlerTest {
                 manager.setLatestBlockNumber(expectedLatestBlockNumber);
                 // Call
                 toTest.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 // Assert single response is ERROR and onComplete is called (shutdown)
                 assertThat(repliesPipeline.getOnNextCalls())
                         .hasSize(1)
@@ -1698,6 +1704,8 @@ class PublisherHandlerTest {
                         .build();
                 // Call
                 toTest.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 // Assert single response is EndOfStream with Code INVALID_REQUEST and onComplete is called (shutdown)
                 assertThat(repliesPipeline.getOnNextCalls())
                         .hasSize(1)
@@ -1798,6 +1806,8 @@ class PublisherHandlerTest {
                         .build();
                 // Call
                 toTest.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 // Assert single response is EndOfStream with Code ERROR and onComplete is called (shutdown)
                 assertThat(repliesPipeline.getOnNextCalls())
                         .hasSize(1)
@@ -1867,6 +1877,8 @@ class PublisherHandlerTest {
                         .build();
                 // Send the request to the pipeline
                 toTest.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 // Assert response and onComplete is called (shutdown)
                 assertThat(repliesPipeline.getOnNextCalls())
                         .hasSize(1)
@@ -1898,6 +1910,8 @@ class PublisherHandlerTest {
                         .build();
                 // Send the request to the pipeline
                 toTest.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 // Assert response
                 assertThat(repliesPipeline.getOnNextCalls())
                         .hasSize(1)
@@ -1926,6 +1940,8 @@ class PublisherHandlerTest {
                         PublishStreamRequestUnparsed.newBuilder().build();
                 // Send the request to the pipeline
                 toTest.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 // Assert response
                 assertThat(repliesPipeline.getOnNextCalls())
                         .hasSize(1)
@@ -1961,6 +1977,8 @@ class PublisherHandlerTest {
                         .build();
                 // Send the request to the pipeline
                 toTest.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 // Assert response
                 assertThat(repliesPipeline.getOnCompleteCalls().get()).isEqualTo(1);
                 // Assert no other responses sent
@@ -1992,6 +2010,8 @@ class PublisherHandlerTest {
                         .build();
                 // Send the request to the pipeline
                 toTest.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 // Assert response
                 assertThat(repliesPipeline.getOnCompleteCalls().get()).isEqualTo(1);
                 // Assert no other responses sent
@@ -2186,6 +2206,8 @@ class PublisherHandlerTest {
                 manager.setLatestBlockNumber(expectedLatestStreamedBlockNumber);
                 // Call onError with an arbitrary Throwable
                 toTest.onError(new RuntimeException());
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 // Assert single response is EndOfStream with Code ERROR and onComplete is called (shutdown)
                 assertThat(repliesPipeline.getOnNextCalls())
                         .hasSize(1)
@@ -2246,10 +2268,10 @@ class PublisherHandlerTest {
             void testOnCompleteRemovesHandlerAndCompletesPipeline() {
                 // Call onComplete
                 toTest.onComplete();
-
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 // Assert pipeline completed exactly once
                 assertThat(repliesPipeline.getOnCompleteCalls().get()).isEqualTo(1);
-
                 // Assert no other pipeline interactions occurred
                 assertThat(repliesPipeline.getOnNextCalls()).isEmpty();
                 assertThat(repliesPipeline.getOnErrorCalls()).isEmpty();
@@ -2322,13 +2344,12 @@ class PublisherHandlerTest {
                 assertThat(repliesPipeline.getOnErrorCalls()).isEmpty();
                 assertThat(repliesPipeline.getOnSubscriptionCalls()).isEmpty();
                 assertThat(repliesPipeline.getClientEndStreamCalls().get()).isZero();
-
                 // Invoke the method under test
                 toTest.clientEndStreamReceived();
-
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 // Post-assert: pipeline completed exactly once
                 assertThat(repliesPipeline.getOnCompleteCalls().get()).isEqualTo(1);
-
                 // Still no other interactions
                 assertThat(repliesPipeline.getOnNextCalls()).isEmpty();
                 assertThat(repliesPipeline.getOnErrorCalls()).isEmpty();
@@ -2527,6 +2548,8 @@ class PublisherHandlerTest {
                 // We need to send any request or trigger any pipeline method
                 // to do the actual shutdown
                 toTest.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 // Assert onComplete is called (shutdown that was scheduled)
                 assertThat(repliesPipeline.getOnCompleteCalls().get()).isEqualTo(1);
                 // Assert no other responses sent
@@ -2632,6 +2655,8 @@ class PublisherHandlerTest {
                 // Call
                 manager.setBlockActionForEndOfBlock(action);
                 endThisBlock(toTest, block.number());
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 // Assert that the block was ended with the manager
                 assertThat(manager.getEndOfBlocksReceived()).containsExactly(block.number());
                 // Assert single response is EndOfStream with Code ERROR and onComplete is called (shutdown)
@@ -2854,6 +2879,8 @@ class PublisherHandlerTest {
                 // Return RESEND with UNKNOWN_BLOCK_NUMBER (-1) to trigger the else branch in handleResend
                 manager.setBlockActionForEndOfBlock(new ActionForBlock(BlockAction.RESEND, -1L));
                 endThisBlock(toTest, block.number());
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
                 assertThat(repliesPipeline.getOnNextCalls())
                         .anySatisfy(r -> assertThat(r.response().kind()).isEqualTo(ResponseOneOfType.END_STREAM));
                 assertThat(repliesPipeline.getOnCompleteCalls().get()).isEqualTo(1);

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestStreamPublisherManager.java
@@ -4,6 +4,8 @@ package org.hiero.block.node.stream.publisher.fixtures;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -15,12 +17,18 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.internal.BlockItemSetUnparsed;
+import org.hiero.block.node.app.fixtures.TestUtils;
+import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
 import org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.block.node.stream.publisher.PublisherConfig;
 import org.hiero.block.node.stream.publisher.PublisherHandler;
 import org.hiero.block.node.stream.publisher.PublisherHandler.MetricsHolder;
 import org.hiero.block.node.stream.publisher.StreamPublisherManager;
@@ -46,13 +54,30 @@ public class TestStreamPublisherManager implements StreamPublisherManager {
     private ActionForBlock blockActionForEndOfBlock;
     /// The latest block number to be returned.
     private long latestBlockNumber = -1L;
+    private final ScheduledExecutorService scheduledExecutor;
+    private final Configuration testConfiguration;
 
     private final NavigableSet<Long> endOfBlocksReceived = new ConcurrentSkipListSet<>();
     private final NavigableSet<Long> blocksEndedMidBlock = new ConcurrentSkipListSet<>();
     private final ConcurrentMap<Long, Deque<BlockItemSetUnparsed>> queueByBlockMap = new ConcurrentSkipListMap<>();
 
-    public TestStreamPublisherManager(final TestBlockMessagingFacility testBlockMessagingFacility) {
+    public TestStreamPublisherManager(
+            final TestBlockMessagingFacility testBlockMessagingFacility,
+            final ScheduledBlockingExecutor scheduleExecutor) {
         this.blockMessagingFacility = Objects.requireNonNull(testBlockMessagingFacility);
+        scheduledExecutor = scheduleExecutor;
+        testConfiguration = createTestConfiguration();
+    }
+
+    public static Configuration createTestConfiguration() {
+        return createTestConfiguration(Map.of());
+    }
+
+    public static Configuration createTestConfiguration(final Map<String, String> overrides) {
+        final ConfigurationBuilder builder =
+                TestUtils.createTestConfiguration().withConfigDataType(PublisherConfig.class);
+        overrides.forEach(builder::withValue);
+        return builder.build();
     }
 
     @Override
@@ -136,6 +161,16 @@ public class TestStreamPublisherManager implements StreamPublisherManager {
     @Override
     public void signalDataReady() {
         // do nothing
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAfterDelay(final Runnable taskToSchedule, final long delayInNanoseconds) {
+        return scheduledExecutor.schedule(taskToSchedule, delayInNanoseconds, TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public PublisherConfig configuration() {
+        return testConfiguration.getConfigData(PublisherConfig.class);
     }
 
     @Override


### PR DESCRIPTION
## Reviewer Notes
* Add configuration for pause delay
* Add delay before shutdown
* Add pause support and pause the handler when a shutdown is scheduled

This is a quick fix to help reduce thrashing for publishers.  Further improvement and testing is required in follow-up.

## Related Issue(s)
Resolves #2805
Resolves #2172 
