### PR TITLE
fix: prevent infinite loop in live-sequential and listing file corruption.

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/listing/DayListingFileWriter.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/listing/DayListingFileWriter.java
@@ -25,7 +25,8 @@ public class DayListingFileWriter implements AutoCloseable {
 
     public DayListingFileWriter(Path listingDir, int year, int month, int day) throws IOException {
         this.filePath = getFileForDay(listingDir, year, month, day);
-        this.out = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(filePath, CREATE, TRUNCATE_EXISTING), 4096));
+        this.out = new DataOutputStream(
+                new BufferedOutputStream(Files.newOutputStream(filePath, CREATE, TRUNCATE_EXISTING), 4096));
         out.writeLong(0); // reserve space for number of files
     }
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/listing/DayListingFileWriter.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/listing/DayListingFileWriter.java
@@ -2,6 +2,7 @@
 package org.hiero.block.tools.days.listing;
 
 import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static org.hiero.block.tools.days.listing.ListingRecordFile.getFileForDay;
 
 import java.io.BufferedOutputStream;
@@ -24,7 +25,7 @@ public class DayListingFileWriter implements AutoCloseable {
 
     public DayListingFileWriter(Path listingDir, int year, int month, int day) throws IOException {
         this.filePath = getFileForDay(listingDir, year, month, day);
-        this.out = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(filePath, CREATE), 4096));
+        this.out = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(filePath, CREATE, TRUNCATE_EXISTING), 4096));
         out.writeLong(0); // reserve space for number of files
     }
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -1384,9 +1384,17 @@ public class LiveSequential implements Runnable {
             if (group == null || group.isEmpty()) {
                 System.out.println("[live-sequential] No files found for block " + nextBlockNumber + " at time "
                         + blockTime + ", fixing block times...");
-                FixBlockTime.fixBlockTimeRange(MetadataFiles.BLOCK_TIMES_FILE, nextBlockNumber, nextBlockNumber + 100);
-                state.blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
-                return null;
+                int fixedCount = FixBlockTime.fixBlockTimeRange(MetadataFiles.BLOCK_TIMES_FILE, nextBlockNumber, nextBlockNumber + 100);
+                if (fixedCount > 0) {
+                    // Block times were fixed, reload and retry
+                    state.blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                    return null;
+                } else {
+                    // No block times were fixed, files are genuinely missing or not uploaded yet
+                    throw new RuntimeException("No record files found for block " + nextBlockNumber
+                            + " at time " + blockTime + " and block time could not be fixed. "
+                            + "The block may not be available yet (live edge) or may be missing from the network.");
+                }
             }
         }
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -1384,7 +1384,8 @@ public class LiveSequential implements Runnable {
             if (group == null || group.isEmpty()) {
                 System.out.println("[live-sequential] No files found for block " + nextBlockNumber + " at time "
                         + blockTime + ", fixing block times...");
-                int fixedCount = FixBlockTime.fixBlockTimeRange(MetadataFiles.BLOCK_TIMES_FILE, nextBlockNumber, nextBlockNumber + 100);
+                int fixedCount = FixBlockTime.fixBlockTimeRange(
+                        MetadataFiles.BLOCK_TIMES_FILE, nextBlockNumber, nextBlockNumber + 100);
                 if (fixedCount > 0) {
                     // Block times were fixed, reload and retry
                     state.blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/listing/DayListingFileWriterTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/listing/DayListingFileWriterTest.java
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.days.listing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for {@link DayListingFileWriter}.
+ *
+ * <p>Verifies that listing files are correctly truncated when regenerated
+ * to prevent corruption from appending to existing files.
+ */
+class DayListingFileWriterTest {
+
+    @TempDir
+    Path tempDir;
+
+    /**
+     * Tests that writing to the same listing file twice truncates the file
+     * instead of appending, preventing corruption.
+     */
+    @Test
+    void testTruncateExistingPreventsCorruption() throws Exception {
+        int year = 2024;
+        int month = 1;
+        int day = 15;
+
+        // First write: Create a file with 2 entries
+        try (DayListingFileWriter writer = new DayListingFileWriter(tempDir, year, month, day)) {
+            writer.writeRecordFile(createTestRecordFile("record0.0.3/2024-01-15T10_00_00.123456789Z.rcd.gz", 2024, 1, 15, 10, 0, 0));
+            writer.writeRecordFile(createTestRecordFile("record0.0.3/2024-01-15T10_00_01.987654321Z.rcd.gz", 2024, 1, 15, 10, 0, 1));
+        }
+
+        Path listingFile = ListingRecordFile.getFileForDay(tempDir, year, month, day);
+        assertTrue(Files.exists(listingFile), "Listing file should exist");
+        long firstSize = Files.size(listingFile);
+
+        // Read first write to verify 2 entries
+        try (DataInputStream in = new DataInputStream(Files.newInputStream(listingFile))) {
+            long count = in.readLong();
+            assertEquals(2, count, "First write should have 2 entries");
+        }
+
+        // Second write: Write 1 entry to the same file
+        // Without TRUNCATE_EXISTING, this would append and corrupt the file
+        try (DayListingFileWriter writer = new DayListingFileWriter(tempDir, year, month, day)) {
+            writer.writeRecordFile(createTestRecordFile("record0.0.3/2024-01-15T10_00_02.111111111Z.rcd.gz", 2024, 1, 15, 10, 0, 2));
+        }
+
+        long secondSize = Files.size(listingFile);
+        assertTrue(secondSize < firstSize, "File should be smaller after truncation (1 entry vs 2)");
+
+        // Verify the file was truncated and only has the new entry
+        try (DataInputStream in = new DataInputStream(Files.newInputStream(listingFile))) {
+            long count = in.readLong();
+            assertEquals(1, count, "Second write should have truncated and written 1 entry, not appended");
+        }
+    }
+
+    /**
+     * Tests basic write and read functionality.
+     */
+    @Test
+    void testBasicWriteAndRead() throws Exception {
+        int year = 2024;
+        int month = 3;
+        int day = 10;
+
+        // Write 3 entries
+        try (DayListingFileWriter writer = new DayListingFileWriter(tempDir, year, month, day)) {
+            writer.writeRecordFile(createTestRecordFile("record0.0.3/2024-03-10T08_00_00.000000000Z.rcd.gz", 2024, 3, 10, 8, 0, 0));
+            writer.writeRecordFile(createTestRecordFile("record0.0.3/2024-03-10T08_00_01.000000000Z.rcd.gz", 2024, 3, 10, 8, 0, 1));
+            writer.writeRecordFile(createTestRecordFile("record0.0.3/2024-03-10T08_00_02.000000000Z.rcd.gz", 2024, 3, 10, 8, 0, 2));
+        }
+
+        Path listingFile = ListingRecordFile.getFileForDay(tempDir, year, month, day);
+        assertTrue(Files.exists(listingFile), "Listing file should exist");
+
+        // Verify content
+        try (DataInputStream in = new DataInputStream(Files.newInputStream(listingFile))) {
+            long count = in.readLong();
+            assertEquals(3, count, "Should have 3 entries");
+        }
+    }
+
+    private ListingRecordFile createTestRecordFile(String path, int year, int month, int day, int hour, int minute, int second) {
+        return new ListingRecordFile(
+                path,
+                LocalDateTime.of(year, month, day, hour, minute, second),
+                1000, // sizeBytes
+                "00112233445566778899aabbccddeeff" // md5Hex (32 chars)
+        );
+    }
+}

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/listing/DayListingFileWriterTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/listing/DayListingFileWriterTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.DataInputStream;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
@@ -35,8 +34,10 @@ class DayListingFileWriterTest {
 
         // First write: Create a file with 2 entries
         try (DayListingFileWriter writer = new DayListingFileWriter(tempDir, year, month, day)) {
-            writer.writeRecordFile(createTestRecordFile("record0.0.3/2024-01-15T10_00_00.123456789Z.rcd.gz", 2024, 1, 15, 10, 0, 0));
-            writer.writeRecordFile(createTestRecordFile("record0.0.3/2024-01-15T10_00_01.987654321Z.rcd.gz", 2024, 1, 15, 10, 0, 1));
+            writer.writeRecordFile(
+                    createTestRecordFile("record0.0.3/2024-01-15T10_00_00.123456789Z.rcd.gz", 2024, 1, 15, 10, 0, 0));
+            writer.writeRecordFile(
+                    createTestRecordFile("record0.0.3/2024-01-15T10_00_01.987654321Z.rcd.gz", 2024, 1, 15, 10, 0, 1));
         }
 
         Path listingFile = ListingRecordFile.getFileForDay(tempDir, year, month, day);
@@ -52,7 +53,8 @@ class DayListingFileWriterTest {
         // Second write: Write 1 entry to the same file
         // Without TRUNCATE_EXISTING, this would append and corrupt the file
         try (DayListingFileWriter writer = new DayListingFileWriter(tempDir, year, month, day)) {
-            writer.writeRecordFile(createTestRecordFile("record0.0.3/2024-01-15T10_00_02.111111111Z.rcd.gz", 2024, 1, 15, 10, 0, 2));
+            writer.writeRecordFile(
+                    createTestRecordFile("record0.0.3/2024-01-15T10_00_02.111111111Z.rcd.gz", 2024, 1, 15, 10, 0, 2));
         }
 
         long secondSize = Files.size(listingFile);
@@ -76,9 +78,12 @@ class DayListingFileWriterTest {
 
         // Write 3 entries
         try (DayListingFileWriter writer = new DayListingFileWriter(tempDir, year, month, day)) {
-            writer.writeRecordFile(createTestRecordFile("record0.0.3/2024-03-10T08_00_00.000000000Z.rcd.gz", 2024, 3, 10, 8, 0, 0));
-            writer.writeRecordFile(createTestRecordFile("record0.0.3/2024-03-10T08_00_01.000000000Z.rcd.gz", 2024, 3, 10, 8, 0, 1));
-            writer.writeRecordFile(createTestRecordFile("record0.0.3/2024-03-10T08_00_02.000000000Z.rcd.gz", 2024, 3, 10, 8, 0, 2));
+            writer.writeRecordFile(
+                    createTestRecordFile("record0.0.3/2024-03-10T08_00_00.000000000Z.rcd.gz", 2024, 3, 10, 8, 0, 0));
+            writer.writeRecordFile(
+                    createTestRecordFile("record0.0.3/2024-03-10T08_00_01.000000000Z.rcd.gz", 2024, 3, 10, 8, 0, 1));
+            writer.writeRecordFile(
+                    createTestRecordFile("record0.0.3/2024-03-10T08_00_02.000000000Z.rcd.gz", 2024, 3, 10, 8, 0, 2));
         }
 
         Path listingFile = ListingRecordFile.getFileForDay(tempDir, year, month, day);
@@ -91,12 +96,13 @@ class DayListingFileWriterTest {
         }
     }
 
-    private ListingRecordFile createTestRecordFile(String path, int year, int month, int day, int hour, int minute, int second) {
+    private ListingRecordFile createTestRecordFile(
+            String path, int year, int month, int day, int hour, int minute, int second) {
         return new ListingRecordFile(
                 path,
                 LocalDateTime.of(year, month, day, hour, minute, second),
                 1000, // sizeBytes
                 "00112233445566778899aabbccddeeff" // md5Hex (32 chars)
-        );
+                );
     }
 }

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/subcommands/LiveSequentialInfiniteLoopTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/subcommands/LiveSequentialInfiniteLoopTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import org.hiero.block.tools.mirrornode.FixBlockTime;
 import org.junit.jupiter.api.Test;

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/subcommands/LiveSequentialInfiniteLoopTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/subcommands/LiveSequentialInfiniteLoopTest.java
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.days.subcommands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hiero.block.tools.mirrornode.FixBlockTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for the infinite loop fix in {@link LiveSequential}.
+ *
+ * <p>Issue #2829: LiveSequential would get stuck in an infinite loop when
+ * {@code fixBlockTimeRange()} returned 0 (no blocks fixed) but the code
+ * always retried. The fix checks the return value and only retries if blocks
+ * were actually fixed.
+ *
+ * <p>This test verifies the behavior of {@link FixBlockTime#fixBlockTimeRange}
+ * which is the dependency that LiveSequential relies on. The fix ensures that
+ * when this method returns 0, LiveSequential throws an exception instead of
+ * retrying infinitely.
+ */
+class LiveSequentialInfiniteLoopTest {
+
+    @TempDir
+    Path tempDir;
+
+    /**
+     * Tests that {@code fixBlockTimeRange} returns 0 when the block_times.bin
+     * file doesn't exist, which would trigger the exception path in LiveSequential
+     * instead of infinite retry.
+     */
+    @Test
+    void testFixBlockTimeReturnsZeroWhenFileNotFound() {
+        Path nonExistentFile = tempDir.resolve("nonexistent-block_times.bin");
+
+        int fixedCount = FixBlockTime.fixBlockTimeRange(nonExistentFile, 100, 200);
+
+        assertEquals(0, fixedCount, "Should return 0 when file doesn't exist");
+        // In LiveSequential, this would trigger the exception:
+        // "No record files found for block X and block time could not be fixed"
+    }
+
+    /**
+     * Tests that {@code fixBlockTimeRange} returns 0 when the requested range
+     * is beyond the file's size, which would trigger the exception path instead
+     * of infinite retry.
+     */
+    @Test
+    void testFixBlockTimeReturnsZeroWhenRangeOutOfBounds() throws IOException {
+        Path blockTimesFile = tempDir.resolve("block_times.bin");
+
+        // Create a small file with only 10 blocks (10 * 8 bytes = 80 bytes)
+        try (RandomAccessFile raf = new RandomAccessFile(blockTimesFile.toFile(), "rw")) {
+            for (int i = 0; i < 10; i++) {
+                raf.writeLong(1000000000000L + i); // Some timestamp values
+            }
+        }
+
+        // Try to fix blocks way beyond the file size
+        int fixedCount = FixBlockTime.fixBlockTimeRange(blockTimesFile, 1000, 1100);
+
+        assertEquals(0, fixedCount, "Should return 0 when range is beyond file size");
+        // In LiveSequential, this would trigger the exception instead of retry
+    }
+
+    /**
+     * Tests that {@code fixBlockTimeRange} returns 0 when the range is invalid
+     * (fromBlock > toBlock after adjustments).
+     */
+    @Test
+    void testFixBlockTimeReturnsZeroWhenRangeInvalid() throws IOException {
+        Path blockTimesFile = tempDir.resolve("block_times.bin");
+
+        // Create a file with 5 blocks
+        try (RandomAccessFile raf = new RandomAccessFile(blockTimesFile.toFile(), "rw")) {
+            for (int i = 0; i < 5; i++) {
+                raf.writeLong(1000000000000L + i);
+            }
+        }
+
+        // Try to fix blocks starting beyond the file (fromBlock > maxBlockInFile)
+        int fixedCount = FixBlockTime.fixBlockTimeRange(blockTimesFile, 100, 200);
+
+        assertEquals(0, fixedCount, "Should return 0 when fromBlock exceeds file size");
+        // In LiveSequential, this would trigger the exception instead of retry
+    }
+
+    /**
+     * Documents the expected behavior: when fixBlockTimeRange returns 0,
+     * LiveSequential should throw a RuntimeException with a clear message
+     * instead of retrying infinitely.
+     *
+     * <p>This test documents the contract that the fix depends on. The actual
+     * LiveSequential logic (lines 1387-1398) is:
+     * <pre>
+     * int fixedCount = FixBlockTime.fixBlockTimeRange(...);
+     * if (fixedCount > 0) {
+     *     // Reload and retry
+     *     return null;
+     * } else {
+     *     // Throw exception instead of infinite retry
+     *     throw new RuntimeException("No record files found...");
+     * }
+     * </pre>
+     */
+    @Test
+    void testInfiniteLoopPreventionContract() {
+        // This test documents the contract:
+        // - If fixBlockTimeRange returns 0, don't retry
+        // - If fixBlockTimeRange returns > 0, retry is valid
+
+        // Simulating the LiveSequential decision logic
+        int fixedCount = 0; // Simulate fixBlockTimeRange returning 0
+
+        if (fixedCount > 0) {
+            // Should NOT reach here when fixedCount is 0
+            throw new AssertionError("Should not retry when fixedCount is 0");
+        } else {
+            // Should reach here and throw exception
+            RuntimeException exception = assertThrows(
+                    RuntimeException.class,
+                    () -> {
+                        throw new RuntimeException("No record files found for block X at time Y "
+                                + "and block time could not be fixed. "
+                                + "The block may not be available yet (live edge) or may be missing from the network.");
+                    },
+                    "Should throw exception when fixedCount is 0");
+
+            assertEquals(
+                    "No record files found for block X at time Y and block time could not be fixed. "
+                            + "The block may not be available yet (live edge) or may be missing from the network.",
+                    exception.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2829

This PR implements two critical fixes:

1. **DayListingFileWriter corruption** - Adds `TRUNCATE_EXISTING` to prevent corrupted listing files when regenerating
2. **LiveSequential infinite loop** - Checks `fixBlockTimeRange()` return value to prevent infinite retry loops

See issue #2829 for full details.