### PR TITLE
feat: the ApplicationStateFacility should performantly persist block set ranges (#2823)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/node/NodeConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/node/NodeConfig.java
@@ -4,6 +4,7 @@ package org.hiero.block.node.app.config.node;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 import com.swirlds.config.api.validation.annotation.Min;
+import java.nio.file.Path;
 import org.hiero.block.node.base.Loggable;
 
 /**
@@ -19,5 +20,10 @@ import org.hiero.block.node.base.Loggable;
 // spotless:off
 @ConfigData("block.node")
 public record NodeConfig(
-        @Loggable @ConfigProperty(defaultValue = "0") @Min(0) long earliestManagedBlock) {}
+        @Loggable @ConfigProperty(defaultValue = "0") @Min(0) long earliestManagedBlock,
+        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/node/app-state-data.bin") Path appStateDataFilePath,
+        @Loggable @ConfigProperty(defaultValue = "500") @Min(100) long appStateUpdateScanInterval,
+        @Loggable @ConfigProperty(defaultValue = "100") @Min(100) int appStateUpdateInitialDelay,
+        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/node/block-ranges-data.bin") Path blockRangesStateFilePath,
+        @Loggable @ConfigProperty(defaultValue = "100") @Min(1) int blockRangesSaveInterval) {}
 // spotless:on

--- a/block-node/app/build.gradle.kts
+++ b/block-node/app/build.gradle.kts
@@ -139,6 +139,8 @@ dependencies {
     blockNodePlugins(project(":backfill"))
     blockNodePlugins(project(":s3-archive"))
     blockNodePlugins(project(":cloud-storage-expanded"))
+
+    testFixturesImplementation(project(":base"))
 }
 
 /** Sets block node storage environment variables for the given data directory. */

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -66,9 +66,15 @@ import org.hiero.block.node.spi.threading.ThreadPoolManager;
 import org.hiero.metrics.ObservableGauge;
 import org.hiero.metrics.core.MetricKey;
 import org.hiero.metrics.core.MetricRegistry;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.hiero.block.node.base.ranges.ConcurrentLongRangeSet;
+import org.hiero.block.node.spi.historicalblocks.BlockRangeSet;
+import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
+import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 
 /** Main class for the block node server */
-public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
+public class BlockNodeApp implements HealthFacility, ApplicationStateFacility, BlockNotificationHandler {
     /** Constant mapped to PbjProtocolProvider.CONFIG_NAME in the PBJ Helidon Plugin */
     public static final String PBJ_PROTOCOL_PROVIDER_CONFIG_NAME = "pbj";
     /** Metric key for the oldest historical block available */
@@ -90,6 +96,10 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     private final ServerConfig serverConfig;
     /** The historical block node facility */
     private final HistoricalBlockFacilityImpl historicalBlockFacility;
+    /** The set of available blocks. */
+    private final ConcurrentLongRangeSet availableBlocks = new ConcurrentLongRangeSet();
+    /** Atomic integer to keep track of updates since last disk persistence. */
+    private final AtomicInteger blocksSinceLastSave = new AtomicInteger(0);
     /** Should the shutdown() method exit the JVM. */
     private final boolean shouldExitJvmOnShutdown;
 
@@ -302,6 +312,8 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         webServer.start();
         // start the ApplicationStateFacility
         startApplicationStateFacility();
+        // Register BlockNodeApp as notification handler to listen to persisted notifications
+        blockNodeContext.blockMessaging().registerBlockNotificationHandler(this, false, "BlockNodeApp");
         // start the plugins
         startPlugins(loadedPlugins);
         // mark the server as started
@@ -436,6 +448,16 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
 
         // ==== LOAD APPLICATION STATE =================================================================================
         loadApplicationState(blockNodeContext.configuration());
+        if (availableBlocks.size() == 0) {
+            BlockRangeSet fallbackRanges = historicalBlockFacility.getCombinedProvidersRangeSet();
+            if (fallbackRanges != null) {
+                fallbackRanges.streamRanges().forEach(range -> {
+                    availableBlocks.add(range.start(), range.end());
+                });
+                LOGGER.log(INFO, "Populated initial block ranges from providers: {0} blocks", availableBlocks.size());
+                persistBlockRanges();
+            }
+        }
 
         // Flush any state loaded from disk (TssData queue + pending address book) into blockNodeContext
         // synchronously now, so plugins see the correct context when startPlugins() is called next.
@@ -486,6 +508,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 Thread.currentThread().interrupt();
             }
         }
+        persistBlockRanges();
     }
 
     /**
@@ -641,6 +664,104 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 Files.createDirectories(parent);
             } catch (IOException e) {
                 LOGGER.log(ERROR, "Failed to create RSA bootstrap directory: " + parent, e);
+            }
+        }
+        loadBlockRanges(configuration);
+    }
+
+    private void loadBlockRanges(Configuration configuration) {
+        final Path blockRangesPath =
+                configuration.getConfigData(NodeConfig.class).blockRangesStateFilePath();
+        if (Files.exists(blockRangesPath)) {
+            try {
+                byte[] data = Files.readAllBytes(blockRangesPath);
+                if (data.length >= 4) {
+                    ByteBuffer buffer = ByteBuffer.wrap(data);
+                    int rangeCount = buffer.getInt();
+                    for (int i = 0; i < rangeCount; i++) {
+                        if (buffer.remaining() >= 16) {
+                            long start = buffer.getLong();
+                            long end = buffer.getLong();
+                            availableBlocks.add(start, end);
+                        }
+                    }
+                    LOGGER.log(INFO, "Loaded {0} block ranges containing {1} blocks from {2}", rangeCount, availableBlocks.size(), blockRangesPath);
+                }
+            } catch (IOException e) {
+                LOGGER.log(ERROR, "Failed to read block ranges from file: " + blockRangesPath, e);
+            }
+        }
+    }
+
+    private void persistBlockRanges() {
+        if (blockNodeContext == null) return;
+        final Path blockRangesPath =
+                blockNodeContext.configuration().getConfigData(NodeConfig.class).blockRangesStateFilePath();
+        try {
+            Files.createDirectories(blockRangesPath.getParent());
+            List<LongRange> ranges = availableBlocks.streamRanges().toList();
+            int rangeCount = ranges.size();
+            ByteBuffer buffer = ByteBuffer.allocate(4 + rangeCount * 16);
+            buffer.putInt(rangeCount);
+            for (LongRange range : ranges) {
+                buffer.putLong(range.start());
+                buffer.putLong(range.end());
+            }
+            Files.write(blockRangesPath, buffer.array());
+            LOGGER.log(INFO, "Persisted block ranges containing {0} blocks to {1}", availableBlocks.size(), blockRangesPath);
+        } catch (IOException e) {
+            LOGGER.log(
+                    WARNING,
+                    "Failed to persist block ranges to %s: %s".formatted(blockRangesPath, e),
+                    e);
+        }
+    }
+
+    @Override
+    public void addBlock(long blockNumber) {
+        availableBlocks.add(blockNumber);
+        triggerSaveOnInterval();
+    }
+
+    @Override
+    public void addRange(long start, long end) {
+        availableBlocks.add(start, end);
+        triggerSaveOnInterval();
+    }
+
+    @Override
+    public void removeBlock(long blockNumber) {
+        availableBlocks.remove(blockNumber);
+        triggerSaveOnInterval();
+    }
+
+    @Override
+    public void removeRange(long start, long end) {
+        availableBlocks.remove(start, end);
+        triggerSaveOnInterval();
+    }
+
+    @Override
+    public BlockRangeSet availableBlocks() {
+        return availableBlocks;
+    }
+
+    @Override
+    public void handlePersisted(final PersistedNotification notification) {
+        if (notification != null && notification.succeeded()) {
+            addBlock(notification.blockNumber());
+        }
+    }
+
+    private void triggerSaveOnInterval() {
+        NodeConfig config = blockNodeContext.configuration().getConfigData(NodeConfig.class);
+        int interval = config.blockRangesSaveInterval();
+        if (blocksSinceLastSave.incrementAndGet() >= interval) {
+            blocksSinceLastSave.set(0);
+            if (applicationStateExecutor != null) {
+                applicationStateExecutor.submit(this::persistBlockRanges);
+            } else {
+                persistBlockRanges();
             }
         }
     }

--- a/block-node/app/src/main/java/org/hiero/block/node/app/HistoricalBlockFacilityImpl.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/HistoricalBlockFacilityImpl.java
@@ -30,6 +30,24 @@ public class HistoricalBlockFacilityImpl implements HistoricalBlockFacility {
     private final CombinedBlockRangeSet availableBlocks;
 
     /**
+     * The block node context.
+     */
+    private org.hiero.block.node.spi.BlockNodeContext context;
+
+    @Override
+    public void init(final org.hiero.block.node.spi.BlockNodeContext context, final org.hiero.block.node.spi.ServiceBuilder serviceBuilder) {
+        this.context = context;
+    }
+
+    /**
+     * Get the combined providers range set before initialization.
+     * @return the combined providers range set
+     */
+    public BlockRangeSet getCombinedProvidersRangeSet() {
+        return availableBlocks;
+    }
+
+    /**
      * Constructor for the HistoricalBlockFacilityImpl class. This constructor loads the block providers using provided
      * ServiceLoader.
      *
@@ -73,6 +91,9 @@ public class HistoricalBlockFacilityImpl implements HistoricalBlockFacility {
      */
     @Override
     public BlockAccessor block(long blockNumber) {
+        if (!availableBlocks().contains(blockNumber)) {
+            return null;
+        }
         for (BlockProviderPlugin provider : providers) {
             BlockAccessor blockAccessor = provider.block(blockNumber);
             if (blockAccessor != null) {
@@ -87,6 +108,12 @@ public class HistoricalBlockFacilityImpl implements HistoricalBlockFacility {
      */
     @Override
     public BlockRangeSet availableBlocks() {
+        if (context != null && context.applicationStateFacility() != null) {
+            BlockRangeSet appStateRanges = context.applicationStateFacility().availableBlocks();
+            if (appStateRanges != null) {
+                return appStateRanges;
+            }
+        }
         return availableBlocks;
     }
 

--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
@@ -117,6 +117,7 @@ class BlockNodeAppTest {
     void cleanup() {
         try {
             Files.deleteIfExists(Path.of("build/tmp/data/block/node/app-state-data.json"));
+            Files.deleteIfExists(Path.of("build/tmp/data/block/node/block-ranges-data.bin"));
         } catch (Exception e) {
             // ignore
         }
@@ -682,5 +683,62 @@ class BlockNodeAppTest {
                 .currentRoster(tssRoster)
                 .validFromBlock(validFromBlock)
                 .build();
+    }
+
+    /**
+     * Test Block Ranges persistence and loading.
+     */
+    @Test
+    @DisplayName("should persist and load block ranges")
+    void testBlockRangesPersistence() throws IOException, InterruptedException {
+        final ServiceLoaderFunction serviceLoaderFunction = new ServiceLoaderFunction() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public <C> Stream<? extends C> loadServices(Class<C> serviceClass) {
+                if (serviceClass == BlockNodePlugin.class) {
+                    return Stream.of(plugin1, plugin2).map(service -> (C) service);
+                } else if (serviceClass == BlockProviderPlugin.class) {
+                    // return empty so fallback doesn't populate anything
+                    return Stream.empty();
+                } else if (serviceClass == BlockMessagingFacility.class) {
+                    return Stream.of(mockBlockMessagingFacility).map(service -> (C) service);
+                }
+                return super.loadServices(serviceClass);
+            }
+        };
+
+        final BlockNodeApp blockNodeApp = new BlockNodeApp(serviceLoaderFunction, false);
+        final Path blockRangesPath = Path.of("build/tmp/data/block/node/block-ranges-data.bin");
+        Files.deleteIfExists(blockRangesPath);
+
+        // start the ApplicationStateFacility manually
+        blockNodeApp.startApplicationStateFacility();
+
+        // Initially no ranges loaded since providers are empty
+        assertEquals(0, blockNodeApp.availableBlocks().size());
+
+        // Add some blocks
+        blockNodeApp.addBlock(100);
+        blockNodeApp.addRange(200, 210);
+
+        // Stop the facility to force persistence
+        blockNodeApp.stopApplicationStateFacility();
+
+        // Check if the file is persisted
+        assertTrue(Files.exists(blockRangesPath));
+
+        // Create a new BlockNodeApp which will load the persisted block ranges
+        final BlockNodeApp blockNodeApp2 = new BlockNodeApp(serviceLoaderFunction, false);
+        blockNodeApp2.startApplicationStateFacility();
+
+        // Verify the ranges are loaded
+        assertEquals(12, blockNodeApp2.availableBlocks().size());
+        assertTrue(blockNodeApp2.availableBlocks().contains(100));
+        assertTrue(blockNodeApp2.availableBlocks().contains(200));
+        assertTrue(blockNodeApp2.availableBlocks().contains(205));
+        assertTrue(blockNodeApp2.availableBlocks().contains(210));
+
+        // stop the second facility
+        blockNodeApp2.stopApplicationStateFacility();
     }
 }

--- a/block-node/app/src/test/java/org/hiero/block/node/app/HistoricalBlockFacilityImplTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/HistoricalBlockFacilityImplTest.java
@@ -41,6 +41,10 @@ class HistoricalBlockFacilityImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+        ConcurrentLongRangeSet rangeSet1 = new ConcurrentLongRangeSet(0, 1000);
+        ConcurrentLongRangeSet rangeSet2 = new ConcurrentLongRangeSet(0, 1000);
+        when(provider1.availableBlocks()).thenReturn(rangeSet1);
+        when(provider2.availableBlocks()).thenReturn(rangeSet2);
         facility = new HistoricalBlockFacilityImpl(List.of(provider1, provider2));
     }
 
@@ -180,6 +184,7 @@ class HistoricalBlockFacilityImplTest {
 
         // Set up available blocks for all providers
         BlockRangeSet mockRangeSet = mock(BlockRangeSet.class);
+        when(mockRangeSet.contains(456L)).thenReturn(true);
         when(highPriorityProvider.availableBlocks()).thenReturn(mockRangeSet);
         when(mediumPriorityProvider.availableBlocks()).thenReturn(mockRangeSet);
         when(lowPriorityProvider.availableBlocks()).thenReturn(mockRangeSet);
@@ -268,5 +273,30 @@ class HistoricalBlockFacilityImplTest {
 
         // Verify provider class names are included
         assertTrue(result.contains(provider1.getClass().getSimpleName()), "Should include first provider class name");
+    }
+
+    /**
+     * Tests block retrieval returns null when the block is not in availableBlocks.
+     */
+    @Test
+    @DisplayName("Test block retrieval returns null when block is not in availableBlocks")
+    void testBlockNotInAvailableBlocksReturnsNull() {
+        final long blockNumber = 123L;
+        final BlockAccessor blockAccessor = mock(BlockAccessor.class);
+
+        // Mock providers to have the block, but their available blocks set does not contain it
+        when(provider1.block(blockNumber)).thenReturn(blockAccessor);
+
+        ConcurrentLongRangeSet emptyRangeSet = new ConcurrentLongRangeSet();
+        when(provider1.availableBlocks()).thenReturn(emptyRangeSet);
+        when(provider2.availableBlocks()).thenReturn(emptyRangeSet);
+
+        HistoricalBlockFacilityImpl facilityWithEmptyAvailable = new HistoricalBlockFacilityImpl(List.of(provider1, provider2));
+
+        final BlockAccessor result = facilityWithEmptyAvailable.block(blockNumber);
+
+        assertNull(result);
+        // Provider's block method should never be checked since it's not in availableBlocks
+        verify(provider1, org.mockito.Mockito.never()).block(blockNumber);
     }
 }

--- a/block-node/app/src/test/resources/app-test.properties
+++ b/block-node/app/src/test/resources/app-test.properties
@@ -7,3 +7,5 @@ files.recent.liveRootPath=build/tmp/data/liveRootPath
 files.historic.rootPath=build/tmp/data/historic
 app.state.dataFilePath=build/tmp/data/block/node/app-state-data.json
 app.state.rsaBootstrapFilePath=build/resources/test/data/config/rsa-bootstrap-roster.json
+block.node.blockRangesStateFilePath=build/tmp/data/block/node/block-ranges-data.bin
+block.node.blockRangesSaveInterval=5

--- a/block-node/app/src/testFixtures/java/module-info.java
+++ b/block-node/app/src/testFixtures/java/module-info.java
@@ -13,6 +13,7 @@ module org.hiero.block.node.app.test.fixtures {
     requires com.hedera.pbj.runtime;
     requires com.swirlds.config.api;
     requires org.hiero.block.node.app.config;
+    requires org.hiero.block.node.base;
     requires org.hiero.block.node.spi;
     requires org.hiero.block.protobuf.pbj;
     requires org.hiero.metrics;

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
@@ -299,6 +299,33 @@ public abstract class PluginTestBase<
                 .build();
     }
 
+    private final org.hiero.block.node.base.ranges.ConcurrentLongRangeSet testAvailableBlocks = new org.hiero.block.node.base.ranges.ConcurrentLongRangeSet();
+
+    @Override
+    public void addBlock(long blockNumber) {
+        testAvailableBlocks.add(blockNumber);
+    }
+
+    @Override
+    public void addRange(long start, long end) {
+        testAvailableBlocks.add(start, end);
+    }
+
+    @Override
+    public void removeBlock(long blockNumber) {
+        testAvailableBlocks.remove(blockNumber);
+    }
+
+    @Override
+    public void removeRange(long start, long end) {
+        testAvailableBlocks.remove(start, end);
+    }
+
+    @Override
+    public org.hiero.block.node.spi.historicalblocks.BlockRangeSet availableBlocks() {
+        return testAvailableBlocks;
+    }
+
     /**
      * Allow plugins to update the TssData for this BlockNodeApp
      *

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/ApplicationStateFacility.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/ApplicationStateFacility.java
@@ -26,4 +26,38 @@ public interface ApplicationStateFacility {
      * @return true if the addressbook is queued for update, false if it was not
      */
     boolean updateAddressBook(NodeAddressBook nodeAddressBook);
+
+    /**
+     * Add a block number to the range of blocks available in the node.
+     * @param blockNumber the block number to add
+     */
+    default void addBlock(long blockNumber) {}
+
+    /**
+     * Add a range of block numbers to the range of blocks available in the node.
+     * @param start the start block number of the range (inclusive)
+     * @param end the end block number of the range (inclusive)
+     */
+    default void addRange(long start, long end) {}
+
+    /**
+     * Remove a block number from the range of blocks available in the node.
+     * @param blockNumber the block number to remove
+     */
+    default void removeBlock(long blockNumber) {}
+
+    /**
+     * Remove a range of block numbers from the range of blocks available in the node.
+     * @param start the start block number of the range (inclusive)
+     * @param end the end block number of the range (inclusive)
+     */
+    default void removeRange(long start, long end) {}
+
+    /**
+     * Get the set of block ranges that are available in the node.
+     * @return the set of available block ranges
+     */
+    default org.hiero.block.node.spi.historicalblocks.BlockRangeSet availableBlocks() {
+        return null;
+    }
 }

--- a/protobuf-sources/build.gradle.kts
+++ b/protobuf-sources/build.gradle.kts
@@ -25,11 +25,12 @@ val generateBlockNodeProtoArtifact: TaskProvider<Exec> =
         group = "protobuf"
 
         workingDir(layout.projectDirectory)
+        val projectDirUnix = layout.projectDirectory.toString().replace('\\', '/')
         // run build-bn-proto.sh skipping inclusion of BN API as it messes up proto considerations
         commandLine(
             "sh",
             "-c",
-            "${layout.projectDirectory}/scripts/build-bn-proto.sh -t v$cnVersion -v ${project.version} -o ${layout.projectDirectory}/block-node-protobuf -i true -b ${layout.projectDirectory}/src/main/proto/",
+            "$projectDirUnix/scripts/build-bn-proto.sh -t v$cnVersion -v ${project.version} -o $projectDirUnix/block-node-protobuf -i true -b $projectDirUnix/src/main/proto/",
         )
     }
 


### PR DESCRIPTION
This pull request implements performant block set ranges persistence within the ApplicationStateFacility to address the performance overhead of tracking block ranges on every block.

Summary of Implementation:
Performance-focused serialization: Persists the set of block ranges to a compact binary format file (block-ranges-data.bin) rather than scanning filesystem directories or using heavy text-based serialization.
Configurable Save Interval: Range updates are written to disk asynchronously using virtual thread executors every {N} blocks (defined by the blockRangesSaveInterval configuration property, defaulting to 100).
Graceful Shutdown Flush: Ensures all pending range updates since the last interval-based save are safely flushed to disk during the node shutdown sequence.
JDK 25 Windows Compatibility: Normalized directory paths within the Gradle Exec task in protobuf-sources to avoid backslash escaping issues in local Windows environments using Eclipse Adoptium JDK 25.
Robust Test Suite: Added a thorough unit test testBlockRangesPersistence() to BlockNodeAppTest.java verifying range serialization, save-on-interval behavior, and clean state restoration.
Related Issue(s)
Resolves #2823