### PR TITLE
chore: add RSA bootstrap roster support

### DIFF
--- a/charts/block-node-server/templates/configmap.yaml
+++ b/charts/block-node-server/templates/configmap.yaml
@@ -9,6 +9,9 @@ metadata:
 data:
   VERSION: {{ include "hiero-block-node.appVersion" .  | quote }}
   JAVA_TOOL_OPTIONS: {{ printf "%s %s" (include "hiero-block-node.javaToolOptions" .) (default "" (index .Values.blockNode.config "JAVA_TOOL_OPTIONS")) | trim | quote }}
+  {{- if .Values.blockNode.rsaBootstrap.enabled }}
+  APP_STATE_RSA_BOOTSTRAP_FILE_PATH: {{ .Values.blockNode.rsaBootstrap.filePath | quote }}
+  {{- end }}
 {{- range $key, $value := .Values.blockNode.config }}
 {{- if ne $key "JAVA_TOOL_OPTIONS" }}
   {{ $key }}: {{ $value | quote }}

--- a/charts/block-node-server/templates/statefulset.yaml
+++ b/charts/block-node-server/templates/statefulset.yaml
@@ -32,6 +32,9 @@ spec:
       serviceAccountName: {{ include "hiero-block-node.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if and .Values.blockNode.rsaBootstrap.enabled (not .Values.blockNode.rsaBootstrap.rosterBase64) }}
+        {{- fail "blockNode.rsaBootstrap.enabled is true but rosterBase64 is empty" }}
+      {{- end }}
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       dnsPolicy: {{ default "ClusterFirstWithHostNet" .Values.dnsPolicy }}
@@ -77,7 +80,6 @@ spec:
         {{- with .Values.blockNode.initContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-
         {{- if .Values.blockNode.rsaBootstrap.enabled }}
         - name: write-rsa-bootstrap-roster
           image: {{ .Values.blockNode.rsaBootstrap.image | quote }}
@@ -96,7 +98,6 @@ spec:
             - name: {{ default "verification-storage" .Values.blockNode.persistence.verification.volumeName }}
               mountPath: {{ .Values.blockNode.rsaBootstrap.mountPath | quote }}
         {{- end }}
-
         {{- if .Values.plugins.names }}
         - name: copy-core-modules
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -219,80 +220,80 @@ spec:
       {{- end }}
       {{- $hostPorts := default (dict) .Values.blockNode.hostPorts }}
       containers:
-        - name: {{ .Chart.Name }}
-          securityContext:
+      - name: {{ .Chart.Name }}
+        securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: http
-              containerPort: {{ .Values.service.port }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+          - name: http
+            containerPort: {{ .Values.service.port }}
             {{- if hasKey $hostPorts "http" }}
-              hostPort: {{ index $hostPorts "http" }}
+            hostPort: {{ index $hostPorts "http" }}
             {{- end }}
-              protocol: TCP
-            - name: metrics
-              containerPort: {{ .Values.blockNode.metrics.port }}
+            protocol: TCP
+          - name: metrics
+            containerPort: {{ .Values.blockNode.metrics.port }}
             {{- if hasKey $hostPorts "metrics" }}
-              hostPort: {{ index $hostPorts "metrics" }}
+            hostPort: {{ index $hostPorts "metrics" }}
             {{- end }}
-              protocol: TCP
-          envFrom:
-            - configMapRef:
-                name: {{ include "hiero-block-node.fullname" . }}-config
+            protocol: TCP
+        envFrom:
+          - configMapRef:
+              name: {{ include "hiero-block-node.fullname" . }}-config
           {{- if .Values.blockNode.secret }}
-            - secretRef:
-                name: {{ include "hiero-block-node.fullname" . }}-secret
+          - secretRef:
+              name: {{ include "hiero-block-node.fullname" . }}-secret
           {{- else if .Values.blockNode.secretRef }}
-            - secretRef:
-                name: {{ .Values.blockNode.secretRef }}
+          - secretRef:
+              name: {{ .Values.blockNode.secretRef }}
           {{- end }}
-          volumeMounts:
-            - name: logging-config
-              mountPath: {{ .Values.blockNode.logs.configMountPath }}
-              readOnly: true
-            - name: {{ default "logging-storage" .Values.blockNode.persistence.logging.volumeName }}
-              mountPath: {{ .Values.blockNode.persistence.logging.mountPath }}
-            - name: {{ default "archive-storage" .Values.blockNode.persistence.archive.volumeName }}
-              mountPath: {{ .Values.blockNode.persistence.archive.mountPath }}
-              subPath: {{ .Values.blockNode.persistence.archive.subPath }}
-            - name: {{ default "live-storage" .Values.blockNode.persistence.live.volumeName }}
-              mountPath: {{ .Values.blockNode.persistence.live.mountPath }}
-              subPath: {{ .Values.blockNode.persistence.live.subPath }}
-            - name: {{ default "verification-storage" .Values.blockNode.persistence.verification.volumeName }}
-              mountPath: {{ .Values.blockNode.persistence.verification.mountPath }}
+        volumeMounts:
+          - name: logging-config
+            mountPath: {{ .Values.blockNode.logs.configMountPath }}
+            readOnly: true
+          - name: {{ default "logging-storage" .Values.blockNode.persistence.logging.volumeName }}
+            mountPath: {{ .Values.blockNode.persistence.logging.mountPath }}
+          - name: {{ default "archive-storage" .Values.blockNode.persistence.archive.volumeName }}
+            mountPath: {{ .Values.blockNode.persistence.archive.mountPath }}
+            subPath: {{ .Values.blockNode.persistence.archive.subPath }}
+          - name: {{ default "live-storage" .Values.blockNode.persistence.live.volumeName }}
+            mountPath: {{ .Values.blockNode.persistence.live.mountPath }}
+            subPath: {{ .Values.blockNode.persistence.live.subPath }}
+          - name: {{ default "verification-storage" .Values.blockNode.persistence.verification.volumeName }}
+            mountPath: {{ .Values.blockNode.persistence.verification.mountPath }}
           {{- if and .Values.blockNode.backfill .Values.blockNode.backfill.sources }}
-            - name: block-node-sources
-              mountPath: {{ .Values.blockNode.backfill.path }}
-              readOnly: true
+          - name: block-node-sources
+            mountPath: {{ .Values.blockNode.backfill.path }}
+            readOnly: true
           {{- end }}
           {{- if or .Values.plugins.names .Values.blockNode.persistence.plugins.existingClaim }}
-            - name: {{ default "plugins-storage" .Values.blockNode.persistence.plugins.volumeName }}
-              mountPath: /opt/hiero/block-node/app-{{ include "hiero-block-node.appVersion" . }}/plugins
-              readOnly: true
+          - name: {{ default "plugins-storage" .Values.blockNode.persistence.plugins.volumeName }}
+            mountPath: /opt/hiero/block-node/app-{{ include "hiero-block-node.appVersion" . }}/plugins
+            readOnly: true
           {{- end }}
         {{- with  .Values.resources }}
         {{- if not (and .limits .requests) }}
           {{- fail "Both resource requests and limits must be specified for containers" }}
         {{- end }}
-          resources:
+        resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-          livenessProbe:
-            httpGet:
-              path: {{ .Values.blockNode.health.liveness.endpoint }}
-              port: {{ .Values.service.port }}
-            initialDelaySeconds: {{ .Values.blockNode.health.liveness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.blockNode.health.liveness.periodSeconds }}
-            timeoutSeconds: {{ .Values.blockNode.health.liveness.timeoutSeconds }}
-            successThreshold: {{ .Values.blockNode.health.liveness.successThreshold }}
-            failureThreshold: {{ .Values.blockNode.health.liveness.failureThreshold }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.blockNode.health.readiness.endpoint }}
-              port: {{ .Values.service.port }}
-            initialDelaySeconds: {{ .Values.blockNode.health.readiness.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.blockNode.health.readiness.timeoutSeconds }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.blockNode.health.liveness.endpoint }}
+            port: {{ .Values.service.port }}
+          initialDelaySeconds: {{ .Values.blockNode.health.liveness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.blockNode.health.liveness.periodSeconds }}
+          timeoutSeconds: {{ .Values.blockNode.health.liveness.timeoutSeconds }}
+          successThreshold: {{ .Values.blockNode.health.liveness.successThreshold }}
+          failureThreshold: {{ .Values.blockNode.health.liveness.failureThreshold }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.blockNode.health.readiness.endpoint }}
+            port: {{ .Values.service.port }}
+          initialDelaySeconds: {{ .Values.blockNode.health.readiness.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.blockNode.health.readiness.timeoutSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/block-node-server/templates/statefulset.yaml
+++ b/charts/block-node-server/templates/statefulset.yaml
@@ -72,11 +72,31 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.blockNode.persistence.plugins.existingClaim }}
         {{- end }}
-      {{- if or .Values.blockNode.initContainers .Values.plugins.names .Values.blockNode.persistence.plugins.existingClaim }}
+      {{- if or .Values.blockNode.initContainers .Values.blockNode.rsaBootstrap.enabled .Values.plugins.names .Values.blockNode.persistence.plugins.existingClaim }}
       initContainers:
         {{- with .Values.blockNode.initContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+
+        {{- if .Values.blockNode.rsaBootstrap.enabled }}
+        - name: write-rsa-bootstrap-roster
+          image: {{ .Values.blockNode.rsaBootstrap.image | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p {{ .Values.blockNode.rsaBootstrap.mountPath }} && \
+              printf "%s" "$RSA_BOOTSTRAP_ROSTER_BASE64" | base64 -d > {{ .Values.blockNode.rsaBootstrap.filePath }} && \
+              chown 2000:2000 {{ .Values.blockNode.rsaBootstrap.filePath }} && \
+              chmod 0444 {{ .Values.blockNode.rsaBootstrap.filePath }}
+          env:
+            - name: RSA_BOOTSTRAP_ROSTER_BASE64
+              value: {{ .Values.blockNode.rsaBootstrap.rosterBase64 | quote }}
+          volumeMounts:
+            - name: {{ default "verification-storage" .Values.blockNode.persistence.verification.volumeName }}
+              mountPath: {{ .Values.blockNode.rsaBootstrap.mountPath | quote }}
+        {{- end }}
+
         {{- if .Values.plugins.names }}
         - name: copy-core-modules
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -199,80 +219,80 @@ spec:
       {{- end }}
       {{- $hostPorts := default (dict) .Values.blockNode.hostPorts }}
       containers:
-      - name: {{ .Chart.Name }}
-        securityContext:
+        - name: {{ .Chart.Name }}
+          securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        ports:
-          - name: http
-            containerPort: {{ .Values.service.port }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
             {{- if hasKey $hostPorts "http" }}
-            hostPort: {{ index $hostPorts "http" }}
+              hostPort: {{ index $hostPorts "http" }}
             {{- end }}
-            protocol: TCP
-          - name: metrics
-            containerPort: {{ .Values.blockNode.metrics.port }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.blockNode.metrics.port }}
             {{- if hasKey $hostPorts "metrics" }}
-            hostPort: {{ index $hostPorts "metrics" }}
+              hostPort: {{ index $hostPorts "metrics" }}
             {{- end }}
-            protocol: TCP
-        envFrom:
-          - configMapRef:
-              name: {{ include "hiero-block-node.fullname" . }}-config
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "hiero-block-node.fullname" . }}-config
           {{- if .Values.blockNode.secret }}
-          - secretRef:
-              name: {{ include "hiero-block-node.fullname" . }}-secret
+            - secretRef:
+                name: {{ include "hiero-block-node.fullname" . }}-secret
           {{- else if .Values.blockNode.secretRef }}
-          - secretRef:
-              name: {{ .Values.blockNode.secretRef }}
+            - secretRef:
+                name: {{ .Values.blockNode.secretRef }}
           {{- end }}
-        volumeMounts:
-          - name: logging-config
-            mountPath: {{ .Values.blockNode.logs.configMountPath }}
-            readOnly: true
-          - name: {{ default "logging-storage" .Values.blockNode.persistence.logging.volumeName }}
-            mountPath: {{ .Values.blockNode.persistence.logging.mountPath }}
-          - name: {{ default "archive-storage" .Values.blockNode.persistence.archive.volumeName }}
-            mountPath: {{ .Values.blockNode.persistence.archive.mountPath }}
-            subPath: {{ .Values.blockNode.persistence.archive.subPath }}
-          - name: {{ default "live-storage" .Values.blockNode.persistence.live.volumeName }}
-            mountPath: {{ .Values.blockNode.persistence.live.mountPath }}
-            subPath: {{ .Values.blockNode.persistence.live.subPath }}
-          - name: {{ default "verification-storage" .Values.blockNode.persistence.verification.volumeName }}
-            mountPath: {{ .Values.blockNode.persistence.verification.mountPath }}
+          volumeMounts:
+            - name: logging-config
+              mountPath: {{ .Values.blockNode.logs.configMountPath }}
+              readOnly: true
+            - name: {{ default "logging-storage" .Values.blockNode.persistence.logging.volumeName }}
+              mountPath: {{ .Values.blockNode.persistence.logging.mountPath }}
+            - name: {{ default "archive-storage" .Values.blockNode.persistence.archive.volumeName }}
+              mountPath: {{ .Values.blockNode.persistence.archive.mountPath }}
+              subPath: {{ .Values.blockNode.persistence.archive.subPath }}
+            - name: {{ default "live-storage" .Values.blockNode.persistence.live.volumeName }}
+              mountPath: {{ .Values.blockNode.persistence.live.mountPath }}
+              subPath: {{ .Values.blockNode.persistence.live.subPath }}
+            - name: {{ default "verification-storage" .Values.blockNode.persistence.verification.volumeName }}
+              mountPath: {{ .Values.blockNode.persistence.verification.mountPath }}
           {{- if and .Values.blockNode.backfill .Values.blockNode.backfill.sources }}
-          - name: block-node-sources
-            mountPath: {{ .Values.blockNode.backfill.path }}
-            readOnly: true
+            - name: block-node-sources
+              mountPath: {{ .Values.blockNode.backfill.path }}
+              readOnly: true
           {{- end }}
           {{- if or .Values.plugins.names .Values.blockNode.persistence.plugins.existingClaim }}
-          - name: {{ default "plugins-storage" .Values.blockNode.persistence.plugins.volumeName }}
-            mountPath: /opt/hiero/block-node/app-{{ include "hiero-block-node.appVersion" . }}/plugins
-            readOnly: true
+            - name: {{ default "plugins-storage" .Values.blockNode.persistence.plugins.volumeName }}
+              mountPath: /opt/hiero/block-node/app-{{ include "hiero-block-node.appVersion" . }}/plugins
+              readOnly: true
           {{- end }}
         {{- with  .Values.resources }}
         {{- if not (and .limits .requests) }}
           {{- fail "Both resource requests and limits must be specified for containers" }}
         {{- end }}
-        resources:
+          resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        livenessProbe:
-          httpGet:
-            path: {{ .Values.blockNode.health.liveness.endpoint }}
-            port: {{ .Values.service.port }}
-          initialDelaySeconds: {{ .Values.blockNode.health.liveness.initialDelaySeconds }}
-          periodSeconds: {{ .Values.blockNode.health.liveness.periodSeconds }}
-          timeoutSeconds: {{ .Values.blockNode.health.liveness.timeoutSeconds }}
-          successThreshold: {{ .Values.blockNode.health.liveness.successThreshold }}
-          failureThreshold: {{ .Values.blockNode.health.liveness.failureThreshold }}
-        readinessProbe:
-          httpGet:
-            path: {{ .Values.blockNode.health.readiness.endpoint }}
-            port: {{ .Values.service.port }}
-          initialDelaySeconds: {{ .Values.blockNode.health.readiness.initialDelaySeconds }}
-          timeoutSeconds: {{ .Values.blockNode.health.readiness.timeoutSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.blockNode.health.liveness.endpoint }}
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: {{ .Values.blockNode.health.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.blockNode.health.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.blockNode.health.liveness.timeoutSeconds }}
+            successThreshold: {{ .Values.blockNode.health.liveness.successThreshold }}
+            failureThreshold: {{ .Values.blockNode.health.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.blockNode.health.readiness.endpoint }}
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: {{ .Values.blockNode.health.readiness.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.blockNode.health.readiness.timeoutSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -33,7 +33,7 @@ securityContext: {}
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
-# runAsNonRoot: true
+  # runAsNonRoot: true
 # runAsUser: 1000
 
 hostNetwork: false
@@ -44,7 +44,7 @@ service:
   type: ClusterIP
   port: 40840
   annotations: {}
-  # metallb.io/address-pool: public-address-pool
+    # metallb.io/address-pool: public-address-pool
 
 loadBalancer:
   enabled: false
@@ -62,14 +62,14 @@ loadBalancer:
   loadBalancerSourceRanges: []
     # - 203.0.113.0/24  # your clients
     # - 35.191.0.0/16   # GCP health check (example)
-  # - 130.211.0.0/22  # GCP health check (example)
+    # - 130.211.0.0/22  # GCP health check (example)
 
 ingress:
   enabled: false
   className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
-  # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
@@ -158,10 +158,10 @@ blockNode:
 
     # Path where the init container writes the decoded roster file.
     # This path is also exposed to the block node through APP_STATE_RSA_BOOTSTRAP_FILE_PATH.
-    filePath: "/opt/hiero/block-node/verification/rsa-bootstrap-roster.json"
+    filePath: "/opt/hiero/block-node/node/rsa-bootstrap-roster.json"
 
     # Existing mounted verification PVC path used to persist the generated file.
-    mountPath: "/opt/hiero/block-node/verification"
+    mountPath: "/opt/hiero/block-node/node"
 
     # Image used by the init container to decode/write the roster.
     image: "busybox"

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -33,7 +33,7 @@ securityContext: {}
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
+# runAsNonRoot: true
 # runAsUser: 1000
 
 hostNetwork: false
@@ -44,7 +44,7 @@ service:
   type: ClusterIP
   port: 40840
   annotations: {}
-    # metallb.io/address-pool: public-address-pool
+  # metallb.io/address-pool: public-address-pool
 
 loadBalancer:
   enabled: false
@@ -62,14 +62,14 @@ loadBalancer:
   loadBalancerSourceRanges: []
     # - 203.0.113.0/24  # your clients
     # - 35.191.0.0/16   # GCP health check (example)
-    # - 130.211.0.0/22  # GCP health check (example)
+  # - 130.211.0.0/22  # GCP health check (example)
 
 ingress:
   enabled: false
   className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
@@ -142,6 +142,30 @@ blockNode:
           mountPath: /archive-pvc
         - name: verification-storage
           mountPath: /verification-pvc
+
+  rsaBootstrap:
+    # Enables writing an RSA bootstrap roster file before the main block-node JVM starts.
+    # The roster is expected to be a base64-encoded JSON document with shape:
+    # {
+    #   "nodeAddress": [
+    #     { "RSAPubKey": "<hex-encoded DER SPKI RSA public key>", "nodeId": 0 }
+    #   ]
+    # }
+    enabled: false
+
+    # Base64-encoded rsa-bootstrap-roster.json content.
+    rosterBase64: ""
+
+    # Path where the init container writes the decoded roster file.
+    # This path is also exposed to the block node through APP_STATE_RSA_BOOTSTRAP_FILE_PATH.
+    filePath: "/opt/hiero/block-node/verification/rsa-bootstrap-roster.json"
+
+    # Existing mounted verification PVC path used to persist the generated file.
+    mountPath: "/opt/hiero/block-node/verification"
+
+    # Image used by the init container to decode/write the roster.
+    image: "busybox"
+
   # To add plugins not available in Maven (e.g. download from a URL at pod start).
   # Note: for non-Maven plugins, dependencies are NOT auto-resolved.
   # You must include the plugin JAR and all of its transitive dependencies.


### PR DESCRIPTION
## Description

Adds RSA bootstrap roster support for block node deployments.The block-node Helm chart now supports receiving an RSA bootstrap roster through chart values, writing the roster file during pod initialization, and exposing the configured file path through `APP_STATE_RSA_BOOTSTRAP_FILE_PATH`.This enables Solo to provide RSA bootstrap data directly during deployment without relying on Mirror Node APIs.

## Changes

- Added `blockNode.rsaBootstrap` chart values.- Added init container support for writing the RSA bootstrap roster file.
- Added support for configuring `APP_STATE_RSA_BOOTSTRAP_FILE_PATH`.
- Mounted the generated roster file into the block-node container.
- Added conditional handling so deployments without RSA bootstrap configuration continue to behave as before.

## Validation

Manually verified using solo that:

- Helm receives the generated roster values.
- The block-node pod includes the RSA bootstrap init container.
- The roster file is written to the pod.
- `APP_STATE_RSA_BOOTSTRAP_FILE_PATH` points to the generated roster file.

## Related Issue(s)

- Requirement for # https://github.com/hiero-ledger/solo/issues/4426