### PR TITLE
fix: remove blob.exists() call that triggers GCS IAM policy checks

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/utils/gcp/MainNetBucket.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/utils/gcp/MainNetBucket.java
@@ -449,7 +449,9 @@ public class MainNetBucket {
         BlobId blobId = BlobId.of(bucketName, path);
         try {
             var blob = STORAGE.get(blobId, Storage.BlobGetOption.fields(BlobField.NAME));
-            return blob != null && blob.exists();
+            // Just check if blob is non-null instead of calling exists()
+            // exists() may trigger additional IAM policy checks (storage.objects.getIamPolicy)
+            return blob != null;
         } catch (Exception e) {
             //noinspection CallToPrintStackTrace
             e.printStackTrace();


### PR DESCRIPTION
## Summary
Fixes GCS IAM policy check audit log alerts by removing unnecessary `blob.exists()` call.

## Problem
Security team reported 2.1M `storage.objects.getIamPolicy` permission denied audit log entries on May 19, 2026.

Investigation found that `MainNetBucket.signatureFileExists()` was calling `blob.exists()` which triggers additional IAM policy checks in the Google Cloud Storage SDK, even though the user account has permission to get the blob data.

Each sidecar signature file check generated an IAM policy check → 2.1M files × 1 check = 2.1M audit log entries.

## Solution
Replace `blob.exists()` with simple null check in `MainNetBucket.java:452`.

**Before:**
```java
var blob = STORAGE.get(blobId, Storage.BlobGetOption.fields(BlobField.NAME));
return blob != null && blob.exists();
```

**After:**
```java
var blob = STORAGE.get(blobId, Storage.BlobGetOption.fields(BlobField.NAME));
return blob != null;
```

## Impact
Eliminates millions of IAM policy check audit log entries  
Reduces GCS API calls  
Same functional behavior  
No security impact  

## Testing
- Existing tests pass
- Will monitor audit logs after deployment

Related to security team audit log investigation.