### PR TITLE
fix: remove blob.exists() call that triggers GCS IAM policy checks

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/utils/gcp/MainNetBucket.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/utils/gcp/MainNetBucket.java
@@ -449,7 +449,9 @@ public class MainNetBucket {
         BlobId blobId = BlobId.of(bucketName, path);
         try {
             var blob = STORAGE.get(blobId, Storage.BlobGetOption.fields(BlobField.NAME));
-            return blob != null && blob.exists();
+            // Just check if blob is non-null instead of calling exists()
+            // exists() may trigger additional IAM policy checks (storage.objects.getIamPolicy)
+            return blob != null;
         } catch (Exception e) {
             //noinspection CallToPrintStackTrace
             e.printStackTrace();


### PR DESCRIPTION
Fixes #2866

## Summary
Removes unnecessary `blob.exists()` call that triggers 2.1M GCS IAM policy check denials.

## Problem
Security team reported 2.1M `storage.objects.getIamPolicy` permission denied audit log entries on May 19, 2026 from `harpender.t@swirldslabs.com` accessing sidecar files in `hedera-mainnet-streams`.

Investigation found `MainNetBucket.signatureFileExists()` was calling `blob.exists()` which triggers additional IAM policy checks in the GCS SDK.
