### PR TITLE
docs: fix metrics typos

### DIFF
--- a/docs/block-node/metrics.md
+++ b/docs/block-node/metrics.md
@@ -139,7 +139,7 @@ Observes inbound streams from publishers.
 
 ### Subscriber
 
-**Plugin:** `stream-subscriber` [block-node-stream-subscriber]`
+**Plugin:** `stream-subscriber` [block-node-stream-subscriber]
 Observes outbound streams served to subscribers.
 
 |  Type   |             Name              |              Description              |
@@ -204,16 +204,16 @@ Activity and utilization of the historic on‑disk tier.
 **Plugin:** `s3-archive [hiero-block-node.s3-archive]`
 Tracks long‑term archival jobs that push blocks to S3.
 
-|  Type   |              Name               |               Description               |
-|---------|---------------------------------|-----------------------------------------|
-| Counter | `s3_archive_blocks_written`     | Blocks archived to S3                   |
-| Gauge   | `s3_archive_latest_block`       | Latest block number archived            |
-| Counter | `s3_archive_tasks_failed_total` | Failed archival tasks                   |
-| Counter | `s3_archive_tasks_sucess_total` | Successful archival tasks               |
-| Gauge   | `s3_archive_total_bytes_stored` | Total bytes stored in S3 (cost metric)  |
-| Counter | `s3_archive_chunks_uploaded`    | Chunks uploaded to S3                   |
-| Gauge   | `s3_archive_chunks_opened`      | Open chucks currently                   |
-| Counter | `s3_archive_files_closed`       | Total number of files closed, finished. |
+|    Type   |                Name                |                Description                |
+| --------- | ---------------------------------- | ----------------------------------------- |
+| Counter   | `s3_archive_blocks_written`        | Blocks archived to S3                     |
+| Gauge     | `s3_archive_latest_block`          | Latest block number archived              |
+| Counter   | `s3_archive_tasks_failed_total`    | Failed archival tasks                     |
+| Counter   | `s3_archive_tasks_success_total`   | Successful archival tasks                 |
+| Gauge     | `s3_archive_total_bytes_stored`    | Total bytes stored in S3 (cost metric)    |
+| Counter   | `s3_archive_chunks_uploaded`       | Chunks uploaded to S3                     |
+| Gauge     | `s3_archive_chunks_opened`         | Open chucks currently                     |
+| Counter   | `s3_archive_files_closed`          | Total number of files closed, finished.   |
 
 ---
 


### PR DESCRIPTION
Fixes #2729

Updates `docs/block-node/metrics.md` to:
- correct `s3_archive_tasks_sucess_total` to `s3_archive_tasks_success_total`
- remove the extra trailing backtick from the `stream-subscriber` plugin line

Verification:
- `git diff --check`
- confirmed the misspelled metric and extra backtick no longer remain in the file
- ran `npx --yes markdownlint-cli2 docs/block-node/metrics.md`; remaining 3 lint errors match the upstream baseline for this file