### PR TITLE
feat(filter): block-stream filter at publisher + subscriber (spike, beta)

### DIFF
--- a/block-node/base/src/main/java/module-info.java
+++ b/block-node/base/src/main/java/module-info.java
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 module org.hiero.block.node.base {
     exports org.hiero.block.node.base;
+    exports org.hiero.block.node.base.filter;
     exports org.hiero.block.node.base.ranges;
     exports org.hiero.block.node.base.s3;
     exports org.hiero.block.node.base.tar;
 
     requires transitive org.hiero.block.node.spi;
+    requires transitive org.hiero.block.protobuf.pbj;
     requires com.hedera.pbj.runtime;
     requires org.hiero.block.common;
     requires com.github.luben.zstd_jni;

--- a/block-node/base/src/main/java/org/hiero/block/node/base/filter/BlockItemFilter.java
+++ b/block-node/base/src/main/java/org/hiero/block/node/base/filter/BlockItemFilter.java
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.base.filter;
+
+import com.hedera.hapi.block.stream.FilteredSingleItem;
+import com.hedera.hapi.block.stream.SubMerkleTree;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.hiero.block.api.BlockStreamFilter;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.internal.BlockItemUnparsed.ItemOneOfType;
+
+/**
+ * Applies a {@link BlockStreamFilter} to a list of {@link BlockItemUnparsed}
+ * items, replacing rejected items with a {@link FilteredSingleItem} carrying
+ * the original item's hash and the {@link SubMerkleTree} slot it occupied.
+ *
+ * <p>The helper is stateless, immutable, and shared by every plugin that
+ * filters block items (publisher ingress, subscriber outbound, future
+ * block-access reads).
+ *
+ * <p>Three block-item kinds are <b>always forwarded</b> regardless of the
+ * filter — {@code BlockHeader} (1), {@code BlockProof} (9), and
+ * {@code BlockFooter} (12) — because the block proof tree requires them.
+ */
+public final class BlockItemFilter {
+
+    /** Hash algorithm used to populate {@code FilteredSingleItem.item_hash}. */
+    private static final String HASH_ALG = "SHA-384";
+
+    /**
+     * Block-item kinds that may never be filtered out. The first three are
+     * load-bearing for the block proof; the last two are filter markers
+     * (we don't re-filter something already filtered or redacted).
+     */
+    private static final Set<Integer> ALWAYS_FORWARD = Set.of(
+            ItemOneOfType.BLOCK_HEADER.protoOrdinal(),
+            ItemOneOfType.BLOCK_PROOF.protoOrdinal(),
+            ItemOneOfType.BLOCK_FOOTER.protoOrdinal(),
+            ItemOneOfType.FILTERED_SINGLE_ITEM.protoOrdinal(),
+            ItemOneOfType.REDACTED_ITEM.protoOrdinal());
+
+    /** True ⇒ allowlist (only listed kinds pass); false ⇒ denylist. */
+    private final boolean include;
+
+    /** Set of {@code BlockItem.item} oneof field numbers the filter applies to. */
+    private final Set<Integer> itemTypes;
+
+    /** Identity filter — passes every item through unchanged. */
+    private static final BlockItemFilter IDENTITY = new BlockItemFilter(false, Set.of());
+
+    private BlockItemFilter(final boolean include, @NonNull final Set<Integer> itemTypes) {
+        this.include = include;
+        this.itemTypes = Collections.unmodifiableSet(new HashSet<>(itemTypes));
+    }
+
+    /**
+     * Build a filter from the on-wire proto. Returns the identity filter when
+     * {@code proto} is null or its {@code block_item_types} list is empty.
+     */
+    @NonNull
+    public static BlockItemFilter from(@Nullable final BlockStreamFilter proto) {
+        if (proto == null || proto.blockItemTypes() == null || proto.blockItemTypes().isEmpty()) {
+            return IDENTITY;
+        }
+        return new BlockItemFilter(proto.include(), new HashSet<>(proto.blockItemTypes()));
+    }
+
+    /** @return {@code true} if this filter is the identity (pass-through). */
+    public boolean isIdentity() {
+        return itemTypes.isEmpty();
+    }
+
+    /**
+     * Decide whether the filter forwards the given item unchanged.
+     *
+     * @return {@code true} if the item should pass through; {@code false}
+     *     if it should be replaced by a {@link FilteredSingleItem}.
+     */
+    public boolean accepts(@NonNull final BlockItemUnparsed item) {
+        if (isIdentity()) {
+            return true;
+        }
+        final int kind = item.item().kind().protoOrdinal();
+        if (ALWAYS_FORWARD.contains(kind)) {
+            return true;
+        }
+        final boolean listed = itemTypes.contains(kind);
+        return include == listed; // allowlist: pass iff listed; denylist: pass iff NOT listed
+    }
+
+    /**
+     * Apply the filter to a list of items. Returns a new list; the input is
+     * never mutated.
+     *
+     * <p>Items the filter rejects are replaced by a {@link FilteredSingleItem}
+     * carrying the SHA-384 of the original item's PBJ-encoded bytes and the
+     * {@link SubMerkleTree} that block-item type maps to.
+     */
+    @NonNull
+    public List<BlockItemUnparsed> apply(@NonNull final List<BlockItemUnparsed> items) {
+        if (isIdentity()) {
+            return items;
+        }
+        final List<BlockItemUnparsed> out = new ArrayList<>(items.size());
+        for (final BlockItemUnparsed item : items) {
+            if (accepts(item)) {
+                out.add(item);
+            } else {
+                out.add(replaceWithFiltered(item));
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Map a {@code BlockItem.item} oneof field number to its block-proof
+     * {@link SubMerkleTree} slot. Follows the rules in
+     * {@code block_item.proto:95-143}:
+     *
+     * <ul>
+     *   <li>Fields 1–19 use the explicit "Initial Field assignment to
+     *       subtree categories" table in the proto comment.</li>
+     *   <li>Fields ≥ 20 use the mod-10 convention (0=CONSENSUS_HEADERS,
+     *       1=INPUTS, 2=OUTPUTS, 3=STATE_CHANGES, 4=TRACE_DATA, 9=NOT_HASHED).</li>
+     * </ul>
+     *
+     * <p>Visible for testing.
+     */
+    @NonNull
+    static SubMerkleTree subMerkleTreeOf(final int oneofFieldNumber) {
+        return switch (oneofFieldNumber) {
+            case 1 -> SubMerkleTree.OUTPUT_ITEMS_TREE; // block_header
+            case 2, 3 -> SubMerkleTree.CONSENSUS_HEADER_ITEMS; // event_header, round_header
+            case 4 -> SubMerkleTree.INPUT_ITEMS_TREE; // signed_transaction
+            case 5, 6, 10 -> SubMerkleTree.OUTPUT_ITEMS_TREE; // transaction_result, transaction_output, record_file
+            case 7 -> SubMerkleTree.STATE_CHANGE_ITEMS_TREE; // state_changes
+            case 11 -> SubMerkleTree.TRACE_DATA_ITEMS_TREE; // trace_data
+            // 8 filtered_single_item, 9 block_proof, 12 block_footer, 19 redacted_item are in
+            // ALWAYS_FORWARD and never reach this path.
+            default -> switch (oneofFieldNumber % 10) {
+                case 0 -> SubMerkleTree.CONSENSUS_HEADER_ITEMS;
+                case 1 -> SubMerkleTree.INPUT_ITEMS_TREE;
+                case 2 -> SubMerkleTree.OUTPUT_ITEMS_TREE;
+                case 3 -> SubMerkleTree.STATE_CHANGE_ITEMS_TREE;
+                case 4 -> SubMerkleTree.TRACE_DATA_ITEMS_TREE;
+                default -> SubMerkleTree.ITEM_TYPE_UNSPECIFIED;
+            };
+        };
+    }
+
+    @NonNull
+    private static BlockItemUnparsed replaceWithFiltered(@NonNull final BlockItemUnparsed item) {
+        final int kind = item.item().kind().protoOrdinal();
+        final Bytes itemBytes = BlockItemUnparsed.PROTOBUF.toBytes(item);
+        final Bytes itemHash = sha384(itemBytes);
+        final FilteredSingleItem filteredItem = FilteredSingleItem.newBuilder()
+                .itemHash(itemHash)
+                .tree(subMerkleTreeOf(kind))
+                .build();
+        return BlockItemUnparsed.newBuilder()
+                .filteredSingleItem(FilteredSingleItem.PROTOBUF.toBytes(filteredItem))
+                .build();
+    }
+
+    @NonNull
+    private static Bytes sha384(@NonNull final Bytes input) {
+        try {
+            final MessageDigest md = MessageDigest.getInstance(HASH_ALG);
+            md.update(input.toByteArray());
+            return Bytes.wrap(md.digest());
+        } catch (final NoSuchAlgorithmException e) {
+            throw new IllegalStateException(HASH_ALG + " not available", e);
+        }
+    }
+}

--- a/block-node/base/src/main/java/org/hiero/block/node/base/filter/BlockItemFilter.java
+++ b/block-node/base/src/main/java/org/hiero/block/node/base/filter/BlockItemFilter.java
@@ -182,36 +182,34 @@ public final class BlockItemFilter {
     /**
      * Map a {@code BlockItem.item} oneof field number to its block-proof
      * {@link SubMerkleTree} slot. Follows the rules in
-     * {@code block_item.proto:95-143}:
+     * {@code block_item.proto:95-143} for the supported set
+     * ({@link #SUPPORTED_FILTER_TYPES}).
      *
-     * <ul>
-     *   <li>Fields 1–19 use the explicit "Initial Field assignment to
-     *       subtree categories" table in the proto comment.</li>
-     *   <li>Fields ≥ 20 use the mod-10 convention (0=CONSENSUS_HEADERS,
-     *       1=INPUTS, 2=OUTPUTS, 3=STATE_CHANGES, 4=TRACE_DATA, 9=NOT_HASHED).</li>
-     * </ul>
+     * <p>Any field number outside that table — including the
+     * {@code ALWAYS_FORWARD} markers and any future variant — throws
+     * {@link IllegalStateException}. The validation in
+     * {@link #from(BlockStreamFilter)} prevents unsupported field numbers
+     * from reaching this method via the public API, so a throw here means
+     * either {@code SUPPORTED_FILTER_TYPES} was widened without updating
+     * this table, or an item kind reached {@code replaceWithFiltered}
+     * that was supposed to be in {@code ALWAYS_FORWARD}. Either way, fail
+     * loudly: silently routing to the wrong sub-tree would corrupt the
+     * block proof far from the cause.
      *
      * <p>Visible for testing.
      */
     @NonNull
     static SubMerkleTree subMerkleTreeOf(final int oneofFieldNumber) {
         return switch (oneofFieldNumber) {
-            case 1 -> SubMerkleTree.OUTPUT_ITEMS_TREE; // block_header
             case 2, 3 -> SubMerkleTree.CONSENSUS_HEADER_ITEMS; // event_header, round_header
             case 4 -> SubMerkleTree.INPUT_ITEMS_TREE; // signed_transaction
             case 5, 6, 10 -> SubMerkleTree.OUTPUT_ITEMS_TREE; // transaction_result, transaction_output, record_file
             case 7 -> SubMerkleTree.STATE_CHANGE_ITEMS_TREE; // state_changes
             case 11 -> SubMerkleTree.TRACE_DATA_ITEMS_TREE; // trace_data
-            // 8 filtered_single_item, 9 block_proof, 12 block_footer, 19 redacted_item are in
-            // ALWAYS_FORWARD and never reach this path.
-            default -> switch (oneofFieldNumber % 10) {
-                case 0 -> SubMerkleTree.CONSENSUS_HEADER_ITEMS;
-                case 1 -> SubMerkleTree.INPUT_ITEMS_TREE;
-                case 2 -> SubMerkleTree.OUTPUT_ITEMS_TREE;
-                case 3 -> SubMerkleTree.STATE_CHANGE_ITEMS_TREE;
-                case 4 -> SubMerkleTree.TRACE_DATA_ITEMS_TREE;
-                default -> SubMerkleTree.ITEM_TYPE_UNSPECIFIED;
-            };
+            default -> throw new IllegalStateException(
+                    "No SubMerkleTree mapping for BlockItem.item field number " + oneofFieldNumber
+                            + ". Either SUPPORTED_FILTER_TYPES was widened without updating "
+                            + "subMerkleTreeOf, or a kind that should be in ALWAYS_FORWARD leaked through.");
         };
     }
 

--- a/block-node/base/src/main/java/org/hiero/block/node/base/filter/BlockItemFilter.java
+++ b/block-node/base/src/main/java/org/hiero/block/node/base/filter/BlockItemFilter.java
@@ -6,14 +6,14 @@ import com.hedera.hapi.block.stream.SubMerkleTree;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.hiero.block.api.BlockStreamFilter;
+import org.hiero.block.common.hasher.HashingUtilities;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockItemUnparsed.ItemOneOfType;
 
@@ -57,9 +57,6 @@ import org.hiero.block.internal.BlockItemUnparsed.ItemOneOfType;
  * startup for config-driven filters.
  */
 public final class BlockItemFilter {
-
-    /** Hash algorithm used to populate {@code FilteredSingleItem.item_hash}. */
-    private static final String HASH_ALG = "SHA-384";
 
     /** The exhaustive set of {@code BlockItem.item} field numbers that may be filtered. */
     public static final Set<Integer> SUPPORTED_FILTER_TYPES = Set.of(
@@ -221,25 +218,17 @@ public final class BlockItemFilter {
     @NonNull
     private static BlockItemUnparsed replaceWithFiltered(@NonNull final BlockItemUnparsed item) {
         final int kind = item.item().kind().protoOrdinal();
-        final Bytes itemBytes = BlockItemUnparsed.PROTOBUF.toBytes(item);
-        final Bytes itemHash = sha384(itemBytes);
+        // item_hash MUST be the same leaf hash the verifier would compute for the
+        // original item (LEAF_PREFIX || item_bytes, then SHA-384). HashingUtilities
+        // is the single source of truth for that leaf hash; reuse it so a filtered
+        // block still verifies under the existing block proof.
+        final ByteBuffer leafHash = HashingUtilities.getBlockItemHash(item);
         final FilteredSingleItem filteredItem = FilteredSingleItem.newBuilder()
-                .itemHash(itemHash)
+                .itemHash(Bytes.wrap(leafHash.array()))
                 .tree(subMerkleTreeOf(kind))
                 .build();
         return BlockItemUnparsed.newBuilder()
                 .filteredSingleItem(FilteredSingleItem.PROTOBUF.toBytes(filteredItem))
                 .build();
-    }
-
-    @NonNull
-    private static Bytes sha384(@NonNull final Bytes input) {
-        try {
-            final MessageDigest md = MessageDigest.getInstance(HASH_ALG);
-            md.update(input.toByteArray());
-            return Bytes.wrap(md.digest());
-        } catch (final NoSuchAlgorithmException e) {
-            throw new IllegalStateException(HASH_ALG + " not available", e);
-        }
     }
 }

--- a/block-node/base/src/main/java/org/hiero/block/node/base/filter/BlockItemFilter.java
+++ b/block-node/base/src/main/java/org/hiero/block/node/base/filter/BlockItemFilter.java
@@ -26,14 +26,51 @@ import org.hiero.block.internal.BlockItemUnparsed.ItemOneOfType;
  * filters block items (publisher ingress, subscriber outbound, future
  * block-access reads).
  *
- * <p>Three block-item kinds are <b>always forwarded</b> regardless of the
- * filter — {@code BlockHeader} (1), {@code BlockProof} (9), and
- * {@code BlockFooter} (12) — because the block proof tree requires them.
+ * <h2>Supported filter targets</h2>
+ *
+ * Only the following {@code BlockItem.item} field numbers may appear in
+ * {@link BlockStreamFilter#blockItemTypes()}:
+ *
+ * <ul>
+ *   <li>2  {@code EventHeader}</li>
+ *   <li>3  {@code RoundHeader}</li>
+ *   <li>4  {@code SignedTransaction}</li>
+ *   <li>5  {@code TransactionResult}</li>
+ *   <li>6  {@code TransactionOutput}</li>
+ *   <li>7  {@code StateChanges}</li>
+ *   <li>10 {@code RecordFile}</li>
+ *   <li>11 {@code TraceData}</li>
+ * </ul>
+ *
+ * Other field numbers are not valid filter targets:
+ *
+ * <ul>
+ *   <li>1, 9, 12 ({@code BlockHeader}, {@code BlockProof}, {@code BlockFooter})
+ *       are required by the block proof tree.</li>
+ *   <li>8, 19 ({@code FilteredSingleItem}, {@code RedactedItem}) are already
+ *       filter markers; re-filtering them is meaningless.</li>
+ * </ul>
+ *
+ * {@link #from(BlockStreamFilter)} rejects any other field number with an
+ * {@link IllegalArgumentException}. Callers should map that to an
+ * {@code INVALID_REQUEST} response at the request boundary, or fail-fast at
+ * startup for config-driven filters.
  */
 public final class BlockItemFilter {
 
     /** Hash algorithm used to populate {@code FilteredSingleItem.item_hash}. */
     private static final String HASH_ALG = "SHA-384";
+
+    /** The exhaustive set of {@code BlockItem.item} field numbers that may be filtered. */
+    public static final Set<Integer> SUPPORTED_FILTER_TYPES = Set.of(
+            ItemOneOfType.EVENT_HEADER.protoOrdinal(),
+            ItemOneOfType.ROUND_HEADER.protoOrdinal(),
+            ItemOneOfType.SIGNED_TRANSACTION.protoOrdinal(),
+            ItemOneOfType.TRANSACTION_RESULT.protoOrdinal(),
+            ItemOneOfType.TRANSACTION_OUTPUT.protoOrdinal(),
+            ItemOneOfType.STATE_CHANGES.protoOrdinal(),
+            ItemOneOfType.RECORD_FILE.protoOrdinal(),
+            ItemOneOfType.TRACE_DATA.protoOrdinal());
 
     /**
      * Block-item kinds that may never be filtered out. The first three are
@@ -63,14 +100,39 @@ public final class BlockItemFilter {
 
     /**
      * Build a filter from the on-wire proto. Returns the identity filter when
-     * {@code proto} is null or its {@code block_item_types} list is empty.
+     * {@code proto} is null or its {@code block_item_types} list is empty
+     * <em>and</em> {@code include=false}.
+     *
+     * @throws IllegalArgumentException if the proto contains any field number
+     *     outside {@link #SUPPORTED_FILTER_TYPES}, or if {@code include=true}
+     *     with an empty {@code block_item_types} list (which would deny
+     *     everything).
      */
     @NonNull
     public static BlockItemFilter from(@Nullable final BlockStreamFilter proto) {
-        if (proto == null || proto.blockItemTypes() == null || proto.blockItemTypes().isEmpty()) {
+        if (proto == null) {
             return IDENTITY;
         }
-        return new BlockItemFilter(proto.include(), new HashSet<>(proto.blockItemTypes()));
+        final List<Integer> types = proto.blockItemTypes();
+        if (types == null || types.isEmpty()) {
+            if (proto.include()) {
+                // include=true with empty list = "allow nothing" = deny everything.
+                // Reject rather than silently degrading to identity or to an
+                // everything-filtered stream; the caller almost certainly didn't
+                // mean either.
+                throw new IllegalArgumentException(
+                        "BlockStreamFilter.include=true requires a non-empty block_item_types list");
+            }
+            return IDENTITY;
+        }
+        for (final Integer type : types) {
+            if (type == null || !SUPPORTED_FILTER_TYPES.contains(type)) {
+                throw new IllegalArgumentException(
+                        "BlockStreamFilter.block_item_types contains unsupported value " + type
+                                + "; supported values are " + SUPPORTED_FILTER_TYPES);
+            }
+        }
+        return new BlockItemFilter(proto.include(), new HashSet<>(types));
     }
 
     /** @return {@code true} if this filter is the identity (pass-through). */

--- a/block-node/base/src/test/java/org/hiero/block/node/base/filter/BlockItemFilterTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/filter/BlockItemFilterTest.java
@@ -155,6 +155,92 @@ class BlockItemFilterTest {
         assertThat(stateChangesFiltered.itemHash()).isEqualTo(Bytes.wrap(expected.array()));
     }
 
+    @Test
+    void allSupportedFilterTargetsMapToExpectedSubMerkleTree() throws Exception {
+        // For every block-item kind a client may filter, assert the
+        // FilteredSingleItem.tree it produces. Covers the explicit field→subtree
+        // table from block_item.proto §95-143 across the supported filter set.
+        record Case(ItemOneOfType kind, BlockItemUnparsed item, SubMerkleTree expectedTree) {}
+        final List<Case> cases = List.of(
+                new Case(ItemOneOfType.EVENT_HEADER, eventHeader(), SubMerkleTree.CONSENSUS_HEADER_ITEMS),
+                new Case(ItemOneOfType.ROUND_HEADER, roundHeader(), SubMerkleTree.CONSENSUS_HEADER_ITEMS),
+                new Case(ItemOneOfType.SIGNED_TRANSACTION, signedTransaction(), SubMerkleTree.INPUT_ITEMS_TREE),
+                new Case(ItemOneOfType.TRANSACTION_RESULT, transactionResult(), SubMerkleTree.OUTPUT_ITEMS_TREE),
+                new Case(ItemOneOfType.TRANSACTION_OUTPUT, transactionOutput(), SubMerkleTree.OUTPUT_ITEMS_TREE),
+                new Case(ItemOneOfType.STATE_CHANGES, stateChanges(), SubMerkleTree.STATE_CHANGE_ITEMS_TREE),
+                new Case(ItemOneOfType.RECORD_FILE, recordFile(), SubMerkleTree.OUTPUT_ITEMS_TREE),
+                new Case(ItemOneOfType.TRACE_DATA, traceData(), SubMerkleTree.TRACE_DATA_ITEMS_TREE));
+
+        for (final Case c : cases) {
+            final BlockItemFilter filter = BlockItemFilter.from(BlockStreamFilter.newBuilder()
+                    .include(false)
+                    .blockItemTypes(List.of(c.kind.protoOrdinal()))
+                    .build());
+            final List<BlockItemUnparsed> out = filter.apply(List.of(c.item));
+            assertThat(out.get(0).item().kind())
+                    .as("filtered output for %s", c.kind)
+                    .isEqualTo(ItemOneOfType.FILTERED_SINGLE_ITEM);
+            assertThat(parseFiltered(out.get(0)).tree())
+                    .as("SubMerkleTree mapping for %s", c.kind)
+                    .isEqualTo(c.expectedTree);
+        }
+    }
+
+    @Test
+    void publisherFilterComposesWithSubscriberFilterWithoutDoubleFiltering() {
+        // Compose two filters back-to-back to mirror the runtime path:
+        // publisher (ingress) → subscriber (egress). Publisher drops STATE_CHANGES;
+        // subscriber drops TRACE_DATA. Mandatory items must survive both filters,
+        // and a publisher-filtered slot must not be re-filtered by the subscriber.
+        final BlockItemFilter publisherFilter = BlockItemFilter.from(BlockStreamFilter.newBuilder()
+                .include(false)
+                .blockItemTypes(List.of(ItemOneOfType.STATE_CHANGES.protoOrdinal()))
+                .build());
+        final BlockItemFilter subscriberFilter = BlockItemFilter.from(BlockStreamFilter.newBuilder()
+                .include(false)
+                .blockItemTypes(List.of(ItemOneOfType.TRACE_DATA.protoOrdinal()))
+                .build());
+
+        final List<BlockItemUnparsed> raw = List.of(
+                blockHeader(), stateChanges(), traceData(), transactionResult(), blockProof(), blockFooter());
+        final List<BlockItemUnparsed> afterPublisher = publisherFilter.apply(raw);
+        final List<BlockItemUnparsed> afterSubscriber = subscriberFilter.apply(afterPublisher);
+
+        // Position-by-position assertions on the composed output.
+        assertThat(afterSubscriber).hasSize(6);
+        assertThat(afterSubscriber.get(0).item().kind()).isEqualTo(ItemOneOfType.BLOCK_HEADER);
+        assertThat(afterSubscriber.get(1).item().kind()).isEqualTo(ItemOneOfType.FILTERED_SINGLE_ITEM); // by publisher
+        assertThat(afterSubscriber.get(2).item().kind()).isEqualTo(ItemOneOfType.FILTERED_SINGLE_ITEM); // by subscriber
+        assertThat(afterSubscriber.get(3).item().kind()).isEqualTo(ItemOneOfType.TRANSACTION_RESULT); // untouched
+        assertThat(afterSubscriber.get(4).item().kind()).isEqualTo(ItemOneOfType.BLOCK_PROOF);
+        assertThat(afterSubscriber.get(5).item().kind()).isEqualTo(ItemOneOfType.BLOCK_FOOTER);
+    }
+
+    @Test
+    void composingDenylistsForSameKindDoesNotDoubleFilter() {
+        // Publisher and subscriber both deny STATE_CHANGES. The subscriber filter
+        // must see the publisher's FilteredSingleItem and pass it through
+        // unchanged (FilteredSingleItem is in ALWAYS_FORWARD), so the output is
+        // identical to the publisher's output — no recursive replacement.
+        final BlockItemFilter publisherFilter = BlockItemFilter.from(BlockStreamFilter.newBuilder()
+                .include(false)
+                .blockItemTypes(List.of(ItemOneOfType.STATE_CHANGES.protoOrdinal()))
+                .build());
+        final BlockItemFilter subscriberFilter = BlockItemFilter.from(BlockStreamFilter.newBuilder()
+                .include(false)
+                .blockItemTypes(List.of(ItemOneOfType.STATE_CHANGES.protoOrdinal()))
+                .build());
+
+        final List<BlockItemUnparsed> raw = List.of(blockHeader(), stateChanges(), blockProof());
+        final List<BlockItemUnparsed> afterPublisher = publisherFilter.apply(raw);
+        final List<BlockItemUnparsed> afterSubscriber = subscriberFilter.apply(afterPublisher);
+
+        assertThat(afterSubscriber)
+                .as("subscriber must not re-filter a FilteredSingleItem the publisher produced")
+                .containsExactlyElementsOf(afterPublisher);
+        assertThat(afterSubscriber.get(1).item().kind()).isEqualTo(ItemOneOfType.FILTERED_SINGLE_ITEM);
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────────
 
     private static BlockItemUnparsed blockHeader() {
@@ -179,6 +265,26 @@ class BlockItemFilterTest {
 
     private static BlockItemUnparsed traceData() {
         return BlockItemUnparsed.newBuilder().traceData(Bytes.fromHex("0b")).build();
+    }
+
+    private static BlockItemUnparsed eventHeader() {
+        return BlockItemUnparsed.newBuilder().eventHeader(Bytes.fromHex("02")).build();
+    }
+
+    private static BlockItemUnparsed roundHeader() {
+        return BlockItemUnparsed.newBuilder().roundHeader(Bytes.fromHex("03")).build();
+    }
+
+    private static BlockItemUnparsed signedTransaction() {
+        return BlockItemUnparsed.newBuilder().signedTransaction(Bytes.fromHex("04")).build();
+    }
+
+    private static BlockItemUnparsed transactionOutput() {
+        return BlockItemUnparsed.newBuilder().transactionOutput(Bytes.fromHex("06")).build();
+    }
+
+    private static BlockItemUnparsed recordFile() {
+        return BlockItemUnparsed.newBuilder().recordFile(Bytes.fromHex("0a")).build();
     }
 
     private static FilteredSingleItem parseFiltered(final BlockItemUnparsed item) throws Exception {

--- a/block-node/base/src/test/java/org/hiero/block/node/base/filter/BlockItemFilterTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/filter/BlockItemFilterTest.java
@@ -7,9 +7,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.hedera.hapi.block.stream.FilteredSingleItem;
 import com.hedera.hapi.block.stream.SubMerkleTree;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import java.security.MessageDigest;
+import java.nio.ByteBuffer;
 import java.util.List;
 import org.hiero.block.api.BlockStreamFilter;
+import org.hiero.block.common.hasher.HashingUtilities;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockItemUnparsed.ItemOneOfType;
 import org.junit.jupiter.api.Test;
@@ -146,10 +147,12 @@ class BlockItemFilterTest {
         final FilteredSingleItem traceDataFiltered = parseFiltered(out.get(1));
         assertThat(traceDataFiltered.tree()).isEqualTo(SubMerkleTree.TRACE_DATA_ITEMS_TREE);
 
-        // Hash matches SHA-384 of the original bytes.
-        final byte[] expected = MessageDigest.getInstance("SHA-384")
-                .digest(BlockItemUnparsed.PROTOBUF.toBytes(stateChanges).toByteArray());
-        assertThat(stateChangesFiltered.itemHash()).isEqualTo(Bytes.wrap(expected));
+        // item_hash matches the leaf hash the verifier would compute for the
+        // original item (LEAF_PREFIX || item_bytes, SHA-384). Same source of
+        // truth as HashingUtilities.getBlockItemHash — required for filtered
+        // blocks to still satisfy the block proof.
+        final ByteBuffer expected = HashingUtilities.getBlockItemHash(stateChanges);
+        assertThat(stateChangesFiltered.itemHash()).isEqualTo(Bytes.wrap(expected.array()));
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────

--- a/block-node/base/src/test/java/org/hiero/block/node/base/filter/BlockItemFilterTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/filter/BlockItemFilterTest.java
@@ -217,6 +217,20 @@ class BlockItemFilterTest {
     }
 
     @Test
+    void subMerkleTreeOfThrowsForUnmappedFieldNumber() {
+        // The mapping table only covers SUPPORTED_FILTER_TYPES — anything else
+        // (mandatory items, filter markers, hypothetical future variants) must
+        // fail loudly so the cause is obvious if SUPPORTED_FILTER_TYPES is ever
+        // widened without updating the table.
+        for (final int unmapped : List.of(0, 1, 8, 9, 12, 13, 19, 20, 99)) {
+            assertThatThrownBy(() -> BlockItemFilter.subMerkleTreeOf(unmapped))
+                    .as("field number %d should have no SubMerkleTree mapping", unmapped)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining(String.valueOf(unmapped));
+        }
+    }
+
+    @Test
     void composingDenylistsForSameKindDoesNotDoubleFilter() {
         // Publisher and subscriber both deny STATE_CHANGES. The subscriber filter
         // must see the publisher's FilteredSingleItem and pass it through

--- a/block-node/base/src/test/java/org/hiero/block/node/base/filter/BlockItemFilterTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/filter/BlockItemFilterTest.java
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.base.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.hapi.block.stream.FilteredSingleItem;
+import com.hedera.hapi.block.stream.SubMerkleTree;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.security.MessageDigest;
+import java.util.List;
+import org.hiero.block.api.BlockStreamFilter;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.internal.BlockItemUnparsed.ItemOneOfType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the contract of {@link BlockItemFilter}: identity behaviour, allow/deny
+ * semantics, mandatory-item override, SubMerkleTree mapping, and the SHA-384
+ * hash put into each emitted {@link FilteredSingleItem}.
+ */
+class BlockItemFilterTest {
+
+    @Test
+    void identityFilterPassesEverythingThrough() {
+        final BlockItemFilter filter = BlockItemFilter.from(null);
+        assertThat(filter.isIdentity()).isTrue();
+
+        final List<BlockItemUnparsed> items = List.of(blockHeader(), stateChanges(), blockProof());
+        assertThat(filter.apply(items)).isSameAs(items);
+    }
+
+    @Test
+    void emptyFilterListIsIdentity() {
+        final BlockItemFilter filter = BlockItemFilter.from(
+                BlockStreamFilter.newBuilder().include(true).build());
+        assertThat(filter.isIdentity()).isTrue();
+    }
+
+    @Test
+    void allowlistKeepsOnlyListedKinds() {
+        // Allow only headers + proof + footer.
+        final BlockItemFilter filter = BlockItemFilter.from(BlockStreamFilter.newBuilder()
+                .include(true)
+                .blockItemTypes(List.of(
+                        ItemOneOfType.BLOCK_HEADER.protoOrdinal(),
+                        ItemOneOfType.BLOCK_PROOF.protoOrdinal(),
+                        ItemOneOfType.BLOCK_FOOTER.protoOrdinal()))
+                .build());
+
+        final List<BlockItemUnparsed> in = List.of(blockHeader(), stateChanges(), blockProof());
+        final List<BlockItemUnparsed> out = filter.apply(in);
+
+        assertThat(out).hasSize(3);
+        assertThat(out.get(0).item().kind()).isEqualTo(ItemOneOfType.BLOCK_HEADER);
+        assertThat(out.get(1).item().kind()).isEqualTo(ItemOneOfType.FILTERED_SINGLE_ITEM);
+        assertThat(out.get(2).item().kind()).isEqualTo(ItemOneOfType.BLOCK_PROOF);
+    }
+
+    @Test
+    void denylistDropsOnlyListedKinds() {
+        final BlockItemFilter filter = BlockItemFilter.from(BlockStreamFilter.newBuilder()
+                .include(false)
+                .blockItemTypes(List.of(ItemOneOfType.STATE_CHANGES.protoOrdinal()))
+                .build());
+
+        final List<BlockItemUnparsed> in = List.of(blockHeader(), stateChanges(), transactionResult(), blockProof());
+        final List<BlockItemUnparsed> out = filter.apply(in);
+
+        assertThat(out).hasSize(4);
+        assertThat(out.get(0).item().kind()).isEqualTo(ItemOneOfType.BLOCK_HEADER);
+        assertThat(out.get(1).item().kind()).isEqualTo(ItemOneOfType.FILTERED_SINGLE_ITEM);
+        assertThat(out.get(2).item().kind()).isEqualTo(ItemOneOfType.TRANSACTION_RESULT);
+        assertThat(out.get(3).item().kind()).isEqualTo(ItemOneOfType.BLOCK_PROOF);
+    }
+
+    @Test
+    void mandatoryItemsAreAlwaysForwarded() {
+        // A bogus filter that would otherwise drop the headers.
+        final BlockItemFilter filter = BlockItemFilter.from(BlockStreamFilter.newBuilder()
+                .include(false)
+                .blockItemTypes(List.of(
+                        ItemOneOfType.BLOCK_HEADER.protoOrdinal(),
+                        ItemOneOfType.BLOCK_PROOF.protoOrdinal(),
+                        ItemOneOfType.BLOCK_FOOTER.protoOrdinal(),
+                        ItemOneOfType.STATE_CHANGES.protoOrdinal()))
+                .build());
+
+        final List<BlockItemUnparsed> in = List.of(blockHeader(), stateChanges(), blockProof(), blockFooter());
+        final List<BlockItemUnparsed> out = filter.apply(in);
+
+        assertThat(out).hasSize(4);
+        assertThat(out.get(0).item().kind()).isEqualTo(ItemOneOfType.BLOCK_HEADER);
+        assertThat(out.get(1).item().kind()).isEqualTo(ItemOneOfType.FILTERED_SINGLE_ITEM);
+        assertThat(out.get(2).item().kind()).isEqualTo(ItemOneOfType.BLOCK_PROOF);
+        assertThat(out.get(3).item().kind()).isEqualTo(ItemOneOfType.BLOCK_FOOTER);
+    }
+
+    @Test
+    void filteredItemCarriesExpectedTreeAndHash() throws Exception {
+        final BlockItemFilter filter = BlockItemFilter.from(BlockStreamFilter.newBuilder()
+                .include(false)
+                .blockItemTypes(List.of(
+                        ItemOneOfType.STATE_CHANGES.protoOrdinal(), ItemOneOfType.TRACE_DATA.protoOrdinal()))
+                .build());
+
+        final BlockItemUnparsed stateChanges = stateChanges();
+        final BlockItemUnparsed traceData = traceData();
+        final List<BlockItemUnparsed> out = filter.apply(List.of(stateChanges, traceData));
+
+        // Per the explicit table in block_item.proto §95-143:
+        //   state_changes (7) → STATE_CHANGE_ITEMS_TREE
+        //   trace_data    (11) → TRACE_DATA_ITEMS_TREE
+        final FilteredSingleItem stateChangesFiltered = parseFiltered(out.get(0));
+        assertThat(stateChangesFiltered.tree()).isEqualTo(SubMerkleTree.STATE_CHANGE_ITEMS_TREE);
+        final FilteredSingleItem traceDataFiltered = parseFiltered(out.get(1));
+        assertThat(traceDataFiltered.tree()).isEqualTo(SubMerkleTree.TRACE_DATA_ITEMS_TREE);
+
+        // Hash matches SHA-384 of the original bytes.
+        final byte[] expected = MessageDigest.getInstance("SHA-384")
+                .digest(BlockItemUnparsed.PROTOBUF.toBytes(stateChanges).toByteArray());
+        assertThat(stateChangesFiltered.itemHash()).isEqualTo(Bytes.wrap(expected));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static BlockItemUnparsed blockHeader() {
+        return BlockItemUnparsed.newBuilder().blockHeader(Bytes.fromHex("01")).build();
+    }
+
+    private static BlockItemUnparsed blockProof() {
+        return BlockItemUnparsed.newBuilder().blockProof(Bytes.fromHex("09")).build();
+    }
+
+    private static BlockItemUnparsed blockFooter() {
+        return BlockItemUnparsed.newBuilder().blockFooter(Bytes.fromHex("0c")).build();
+    }
+
+    private static BlockItemUnparsed stateChanges() {
+        return BlockItemUnparsed.newBuilder().stateChanges(Bytes.fromHex("07")).build();
+    }
+
+    private static BlockItemUnparsed transactionResult() {
+        return BlockItemUnparsed.newBuilder().transactionResult(Bytes.fromHex("05")).build();
+    }
+
+    private static BlockItemUnparsed traceData() {
+        return BlockItemUnparsed.newBuilder().traceData(Bytes.fromHex("0b")).build();
+    }
+
+    private static FilteredSingleItem parseFiltered(final BlockItemUnparsed item) throws Exception {
+        return FilteredSingleItem.PROTOBUF.parse(item.filteredSingleItem());
+    }
+}

--- a/block-node/base/src/test/java/org/hiero/block/node/base/filter/BlockItemFilterTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/filter/BlockItemFilterTest.java
@@ -2,6 +2,7 @@
 package org.hiero.block.node.base.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.hedera.hapi.block.stream.FilteredSingleItem;
 import com.hedera.hapi.block.stream.SubMerkleTree;
@@ -30,30 +31,30 @@ class BlockItemFilterTest {
     }
 
     @Test
-    void emptyFilterListIsIdentity() {
+    void emptyDenylistIsIdentity() {
         final BlockItemFilter filter = BlockItemFilter.from(
-                BlockStreamFilter.newBuilder().include(true).build());
+                BlockStreamFilter.newBuilder().include(false).build());
         assertThat(filter.isIdentity()).isTrue();
     }
 
     @Test
     void allowlistKeepsOnlyListedKinds() {
-        // Allow only headers + proof + footer.
+        // Allow only TRACE_DATA (11). BLOCK_HEADER, BLOCK_PROOF, BLOCK_FOOTER are
+        // mandatory and pass through regardless; STATE_CHANGES is not on the
+        // allowlist so it gets replaced with a FilteredSingleItem.
         final BlockItemFilter filter = BlockItemFilter.from(BlockStreamFilter.newBuilder()
                 .include(true)
-                .blockItemTypes(List.of(
-                        ItemOneOfType.BLOCK_HEADER.protoOrdinal(),
-                        ItemOneOfType.BLOCK_PROOF.protoOrdinal(),
-                        ItemOneOfType.BLOCK_FOOTER.protoOrdinal()))
+                .blockItemTypes(List.of(ItemOneOfType.TRACE_DATA.protoOrdinal()))
                 .build());
 
-        final List<BlockItemUnparsed> in = List.of(blockHeader(), stateChanges(), blockProof());
+        final List<BlockItemUnparsed> in = List.of(blockHeader(), stateChanges(), traceData(), blockProof());
         final List<BlockItemUnparsed> out = filter.apply(in);
 
-        assertThat(out).hasSize(3);
-        assertThat(out.get(0).item().kind()).isEqualTo(ItemOneOfType.BLOCK_HEADER);
-        assertThat(out.get(1).item().kind()).isEqualTo(ItemOneOfType.FILTERED_SINGLE_ITEM);
-        assertThat(out.get(2).item().kind()).isEqualTo(ItemOneOfType.BLOCK_PROOF);
+        assertThat(out).hasSize(4);
+        assertThat(out.get(0).item().kind()).isEqualTo(ItemOneOfType.BLOCK_HEADER); // mandatory
+        assertThat(out.get(1).item().kind()).isEqualTo(ItemOneOfType.FILTERED_SINGLE_ITEM); // not on allowlist
+        assertThat(out.get(2).item().kind()).isEqualTo(ItemOneOfType.TRACE_DATA); // allow-listed
+        assertThat(out.get(3).item().kind()).isEqualTo(ItemOneOfType.BLOCK_PROOF); // mandatory
     }
 
     @Test
@@ -74,15 +75,12 @@ class BlockItemFilterTest {
     }
 
     @Test
-    void mandatoryItemsAreAlwaysForwarded() {
-        // A bogus filter that would otherwise drop the headers.
+    void mandatoryItemsAreAlwaysForwardedEvenWhenAllowlistOmitsThem() {
+        // Allow only STATE_CHANGES — BLOCK_HEADER/PROOF/FOOTER are not in the
+        // allowlist but must still pass because they are required by the proof.
         final BlockItemFilter filter = BlockItemFilter.from(BlockStreamFilter.newBuilder()
-                .include(false)
-                .blockItemTypes(List.of(
-                        ItemOneOfType.BLOCK_HEADER.protoOrdinal(),
-                        ItemOneOfType.BLOCK_PROOF.protoOrdinal(),
-                        ItemOneOfType.BLOCK_FOOTER.protoOrdinal(),
-                        ItemOneOfType.STATE_CHANGES.protoOrdinal()))
+                .include(true)
+                .blockItemTypes(List.of(ItemOneOfType.STATE_CHANGES.protoOrdinal()))
                 .build());
 
         final List<BlockItemUnparsed> in = List.of(blockHeader(), stateChanges(), blockProof(), blockFooter());
@@ -90,9 +88,42 @@ class BlockItemFilterTest {
 
         assertThat(out).hasSize(4);
         assertThat(out.get(0).item().kind()).isEqualTo(ItemOneOfType.BLOCK_HEADER);
-        assertThat(out.get(1).item().kind()).isEqualTo(ItemOneOfType.FILTERED_SINGLE_ITEM);
+        assertThat(out.get(1).item().kind()).isEqualTo(ItemOneOfType.STATE_CHANGES);
         assertThat(out.get(2).item().kind()).isEqualTo(ItemOneOfType.BLOCK_PROOF);
         assertThat(out.get(3).item().kind()).isEqualTo(ItemOneOfType.BLOCK_FOOTER);
+    }
+
+    @Test
+    void fromRejectsUnsupportedFilterTargets() {
+        // Mandatory items (1, 9, 12) and filter markers (8, 19) are not valid filter
+        // targets — they may not appear in block_item_types regardless of include flag.
+        for (final int unsupported : List.of(
+                ItemOneOfType.BLOCK_HEADER.protoOrdinal(),
+                ItemOneOfType.FILTERED_SINGLE_ITEM.protoOrdinal(),
+                ItemOneOfType.BLOCK_PROOF.protoOrdinal(),
+                ItemOneOfType.BLOCK_FOOTER.protoOrdinal(),
+                ItemOneOfType.REDACTED_ITEM.protoOrdinal())) {
+            final BlockStreamFilter proto = BlockStreamFilter.newBuilder()
+                    .include(false)
+                    .blockItemTypes(List.of(unsupported))
+                    .build();
+            assertThatThrownBy(() -> BlockItemFilter.from(proto))
+                    .as("filter target " + unsupported + " should be rejected")
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(String.valueOf(unsupported));
+        }
+    }
+
+    @Test
+    void fromRejectsIncludeTrueWithEmptyTypes() {
+        // include=true + empty list = "allow nothing" = deny everything. The caller
+        // almost certainly didn't mean that, so we reject rather than silently
+        // degrading to identity.
+        final BlockStreamFilter proto =
+                BlockStreamFilter.newBuilder().include(true).build();
+        assertThatThrownBy(() -> BlockItemFilter.from(proto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("non-empty");
     }
 
     @Test

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfig.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfig.java
@@ -5,6 +5,7 @@ import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 import com.swirlds.config.api.validation.annotation.Max;
 import com.swirlds.config.api.validation.annotation.Min;
+import java.util.List;
 import org.hiero.block.node.base.Loggable;
 
 /// Configuration for a block stream publisher plugin.
@@ -29,6 +30,14 @@ import org.hiero.block.node.base.Loggable;
 /// `EndOfStream(DUPLICATE_BLOCK)`. A publisher that is only slightly behind can then
 /// fast-forward without reconnecting; a publisher that is further behind than the
 /// window is still ended so it reconnects from the correct point.
+/// @param blockStreamFilterInclude Allow- vs deny-list semantics for the
+/// publish-side filter. When `blockStreamFilterItemTypes` is empty the filter
+/// is identity (pass-through) regardless of this value. When non-empty:
+/// `true` keeps only the listed `BlockItem.item` oneof field numbers;
+/// `false` drops those and keeps everything else. `BlockHeader` (1),
+/// `BlockProof` (9), and `BlockFooter` (12) are always forwarded.
+/// @param blockStreamFilterItemTypes Field numbers of the `BlockItem.item`
+/// oneof variants the publish-side filter applies to. Empty = no filtering.
 @ConfigData("producer")
 public record PublisherConfig(
         // spotless:off
@@ -37,6 +46,8 @@ public record PublisherConfig(
         @Loggable @ConfigProperty(defaultValue = "3") @Min(3) @Max(50) int MaxFutureBlocksBeforeStalled,
         @Loggable @ConfigProperty(defaultValue = "100") @Min(0L) @Max(200L) long staleResendPruneBuffer,
         @Loggable @ConfigProperty(defaultValue = "100_000_000") @Min(100_000L) @Max(5_000_000_000L) long flowControlPauseDelayNanos,
-        @Loggable @ConfigProperty(defaultValue = "5") @Min(1) @Max(10) int duplicateBlockSkipWindow) {
+        @Loggable @ConfigProperty(defaultValue = "5") @Min(1) @Max(10) int duplicateBlockSkipWindow,
+        @Loggable @ConfigProperty(defaultValue = "false") boolean blockStreamFilterInclude,
+        @Loggable @ConfigProperty(defaultValue = "") List<Integer> blockStreamFilterItemTypes) {
         // spotless:on
 }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -108,6 +108,9 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
     private final AtomicBoolean isPaused;
     /// The current configuration for the publisher.
     private final PublisherConfig configuration;
+    /// Filter applied to every inbound block item set before it is forwarded.
+    /// Identity when {@link PublisherConfig#blockStreamFilterItemTypes()} is empty.
+    private final org.hiero.block.node.base.filter.BlockItemFilter blockItemFilter;
     // @todo() remove this (and its usage) and use telemetry or metrics queries instead
     /// The start time in nanos of block being currently streamed
     private long currentStreamingBlockHeaderReceivedTime = System.nanoTime();
@@ -142,6 +145,11 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
         isActive = new AtomicBoolean(true);
         isPaused = new AtomicBoolean(false);
         configuration = publisherManager.configuration();
+        blockItemFilter = org.hiero.block.node.base.filter.BlockItemFilter.from(
+                org.hiero.block.api.BlockStreamFilter.newBuilder()
+                        .include(configuration.blockStreamFilterInclude())
+                        .blockItemTypes(configuration.blockStreamFilterItemTypes())
+                        .build());
     }
 
     // A package-private method for accessing correlation ID for tracing support.
@@ -329,11 +337,20 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
     private PublisherRequestResult processNextRequestUnparsed(final PublishStreamRequestUnparsed request) {
         final PublisherRequestResult result;
         if (request.hasBlockItems()) {
-            final BlockItemSetUnparsed itemSetUnparsed = request.blockItems();
-            final List<BlockItemUnparsed> blockItems = itemSetUnparsed.blockItems();
+            BlockItemSetUnparsed itemSetUnparsed = request.blockItems();
+            List<BlockItemUnparsed> blockItems = itemSetUnparsed.blockItems();
             if (blockItems.isEmpty()) {
                 result = new SendEndAndShutdownResult(this, Code.INVALID_REQUEST, currentStreamingBlockNumber.get());
             } else {
+                // Apply the configured block-stream filter at ingress. Lossy at the BN:
+                // filtered items are replaced by FilteredSingleItem before persistence /
+                // messaging / verification. Identity filter is a no-op.
+                if (!blockItemFilter.isIdentity()) {
+                    blockItems = blockItemFilter.apply(blockItems);
+                    itemSetUnparsed = BlockItemSetUnparsed.newBuilder()
+                            .blockItems(blockItems)
+                            .build();
+                }
                 result = handleBlockItemsRequest(itemSetUnparsed, blockItems);
             }
         } else if (request.hasEndStream()) {

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
@@ -9,11 +9,13 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Objects;
+import org.hiero.block.api.BlockStreamFilter;
 import org.hiero.block.api.BlockStreamPublishServiceInterface;
 import org.hiero.block.api.PublishStreamRequest;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.internal.PublishStreamRequestUnparsed;
 import org.hiero.block.node.app.config.ServerConfig;
+import org.hiero.block.node.base.filter.BlockItemFilter;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
@@ -161,6 +163,14 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
 
     @Override
     public void start() {
+        // Fail fast at startup if producer.blockStreamFilter* is misconfigured.
+        // Otherwise the error only surfaces on the first publisher connection,
+        // which would leave the BN running but rejecting every publish.
+        final PublisherConfig publisherConfig = context.configuration().getConfigData(PublisherConfig.class);
+        BlockItemFilter.from(BlockStreamFilter.newBuilder()
+                .include(publisherConfig.blockStreamFilterInclude())
+                .blockItemTypes(publisherConfig.blockStreamFilterItemTypes())
+                .build());
         // Initialize plugin metrics
         initMetrics(context.metricRegistry());
         // Initialize the publisher manager

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherConfigFilterTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherConfigFilterTest.java
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.stream.publisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.List;
+import org.hiero.block.api.BlockStreamFilter;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.internal.BlockItemUnparsed.ItemOneOfType;
+import org.hiero.block.node.base.filter.BlockItemFilter;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Plugin-level integration test for STORY-F3: confirms that the values on
+ * {@link PublisherConfig} drive a {@link BlockItemFilter} that matches the
+ * publisher's expected drop / keep behaviour. Exercises the same wiring that
+ * {@code PublisherHandler}'s constructor uses — config primitives →
+ * {@link BlockStreamFilter} → {@link BlockItemFilter}.
+ */
+class PublisherConfigFilterTest {
+
+    @Test
+    void emptyConfigYieldsIdentityFilter() {
+        final PublisherConfig config = defaultConfig(false, List.of());
+        final BlockItemFilter filter = filterFromConfig(config);
+        assertThat(filter.isIdentity()).isTrue();
+
+        final List<BlockItemUnparsed> in = sampleBlock();
+        assertThat(filter.apply(in)).isSameAs(in);
+    }
+
+    @Test
+    void denylistDropsConfiguredItemTypes() {
+        final PublisherConfig config = defaultConfig(false, List.of(ItemOneOfType.STATE_CHANGES.protoOrdinal()));
+        final BlockItemFilter filter = filterFromConfig(config);
+
+        final List<BlockItemUnparsed> in = sampleBlock();
+        final List<BlockItemUnparsed> out = filter.apply(in);
+
+        assertThat(out).hasSize(3);
+        assertThat(out.get(0).item().kind()).isEqualTo(ItemOneOfType.BLOCK_HEADER);
+        assertThat(out.get(1).item().kind()).isEqualTo(ItemOneOfType.FILTERED_SINGLE_ITEM);
+        assertThat(out.get(2).item().kind()).isEqualTo(ItemOneOfType.BLOCK_PROOF);
+    }
+
+    @Test
+    void allowlistKeepsOnlyConfiguredItemTypes() {
+        // Allowlist with only state_changes; mandatory items still pass.
+        final PublisherConfig config = defaultConfig(true, List.of(ItemOneOfType.STATE_CHANGES.protoOrdinal()));
+        final BlockItemFilter filter = filterFromConfig(config);
+
+        final List<BlockItemUnparsed> in = sampleBlock();
+        final List<BlockItemUnparsed> out = filter.apply(in);
+
+        assertThat(out).hasSize(3);
+        assertThat(out.get(0).item().kind()).isEqualTo(ItemOneOfType.BLOCK_HEADER); // mandatory
+        assertThat(out.get(1).item().kind()).isEqualTo(ItemOneOfType.STATE_CHANGES); // allow-listed
+        assertThat(out.get(2).item().kind()).isEqualTo(ItemOneOfType.BLOCK_PROOF); // mandatory
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static PublisherConfig defaultConfig(final boolean include, final List<Integer> blockItemTypes) {
+        return new PublisherConfig(
+                Long.MAX_VALUE,
+                300L,
+                3,
+                100L,
+                100_000_000L,
+                5,
+                include,
+                blockItemTypes);
+    }
+
+    /** Same builder path PublisherHandler uses internally. */
+    private static BlockItemFilter filterFromConfig(final PublisherConfig config) {
+        return BlockItemFilter.from(BlockStreamFilter.newBuilder()
+                .include(config.blockStreamFilterInclude())
+                .blockItemTypes(config.blockStreamFilterItemTypes())
+                .build());
+    }
+
+    private static List<BlockItemUnparsed> sampleBlock() {
+        return List.of(
+                BlockItemUnparsed.newBuilder().blockHeader(Bytes.fromHex("01")).build(),
+                BlockItemUnparsed.newBuilder().stateChanges(Bytes.fromHex("07")).build(),
+                BlockItemUnparsed.newBuilder().blockProof(Bytes.fromHex("09")).build());
+    }
+}

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
@@ -3,6 +3,7 @@ package org.hiero.block.node.stream.publisher;
 
 import static java.util.concurrent.locks.LockSupport.parkNanos;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hiero.block.node.app.fixtures.TestUtils.enableDebugLogging;
 import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.endThisBlock;
 
@@ -887,6 +888,49 @@ class StreamPublisherPluginTest {
         @DisplayName("Null is treated as absent and returns empty string")
         void testNullReturnsEmpty() {
             assertThat(StreamPublisherPlugin.truncateCorrelationId(null)).isEmpty();
+        }
+    }
+
+    /// Fails-fast tests for filter-config validation at plugin startup.
+    /// A bogus producer.blockStreamFilter* value MUST take BlockNodeApp down at
+    /// boot rather than leave it running and reject every per-connection
+    /// PublisherHandler with an obscure stack trace.
+    @Nested
+    @DisplayName("Plugin Startup Validation Tests")
+    class PluginStartupValidationTest {
+        @Test
+        @DisplayName("plugin.start() throws on unsupported filter type in config")
+        void startupFailsOnUnsupportedFilterType() {
+            // BLOCK_HEADER (field 1) is not a valid filter target — it's mandatory.
+            assertThatThrownBy(() -> bootWith(Map.of("producer.blockStreamFilterItemTypes", "1")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("unsupported");
+        }
+
+        @Test
+        @DisplayName("plugin.start() throws on include=true with empty allowlist in config")
+        void startupFailsOnIncludeTrueWithEmptyList() {
+            assertThatThrownBy(() -> bootWith(Map.of("producer.blockStreamFilterInclude", "true")))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("non-empty");
+        }
+
+        private void bootWith(final Map<String, String> overrides) {
+            final StreamPublisherPlugin plugin = new StreamPublisherPlugin();
+            final StartupHarness harness = new StartupHarness();
+            harness.start(
+                    plugin,
+                    plugin.methods().getFirst(),
+                    new SimpleInMemoryHistoricalBlockFacility(),
+                    overrides);
+        }
+    }
+
+    /// Minimal GrpcPluginTestBase subclass used only to exercise plugin.start().
+    private static final class StartupHarness
+            extends GrpcPluginTestBase<StreamPublisherPlugin, ExecutorService, ScheduledBlockingExecutor> {
+        StartupHarness() {
+            super(Executors.newSingleThreadExecutor(), new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
         }
     }
 }

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
@@ -158,18 +158,21 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
             @NonNull String handlerName,
             long clientId,
             long firstRequestedBlock,
-            long lastRequestedBlock) {
+            long lastRequestedBlock,
+            @NonNull org.hiero.block.node.base.filter.BlockItemFilter blockItemFilter) {
         SessionContext(
                 @NonNull final SubscriberConfig subscriberConfig,
                 @NonNull final String handlerName,
                 final long clientId,
                 final long firstRequestedBlock,
-                final long lastRequestedBlock) {
+                final long lastRequestedBlock,
+                @NonNull final org.hiero.block.node.base.filter.BlockItemFilter blockItemFilter) {
             this.subscriberConfig = requireNonNull(subscriberConfig);
             this.handlerName = requireNonNull(handlerName);
             this.clientId = clientId;
             this.firstRequestedBlock = firstRequestedBlock;
             this.lastRequestedBlock = lastRequestedBlock;
+            this.blockItemFilter = requireNonNull(blockItemFilter);
         }
 
         /**
@@ -182,8 +185,15 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
                 @NonNull final BlockNodeContext context) {
             final String handlerName = "Live stream client " + clientId;
             final SubscriberConfig subscriberConfig = context.configuration().getConfigData(SubscriberConfig.class);
+            final org.hiero.block.node.base.filter.BlockItemFilter filter =
+                    org.hiero.block.node.base.filter.BlockItemFilter.from(request.filter());
             return new SessionContext(
-                    subscriberConfig, handlerName, clientId, request.startBlockNumber(), request.endBlockNumber());
+                    subscriberConfig,
+                    handlerName,
+                    clientId,
+                    request.startBlockNumber(),
+                    request.endBlockNumber(),
+                    filter);
         }
     }
 
@@ -822,7 +832,12 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
     }
 
     private void sendOneBlockItemSet(final List<BlockItemUnparsed> blockItems, final boolean blockComplete) {
-        final BlockItemSetUnparsed dataToSend = new BlockItemSetUnparsed(blockItems);
+        // Apply this subscriber's filter (identity when no filter was requested).
+        // Lossless at the BN — only the outbound stream of this session is trimmed.
+        final List<BlockItemUnparsed> filtered = sessionContext.blockItemFilter.isIdentity()
+                ? blockItems
+                : sessionContext.blockItemFilter.apply(blockItems);
+        final BlockItemSetUnparsed dataToSend = new BlockItemSetUnparsed(filtered);
         final OneOf<ResponseOneOfType> responseOneOf = new OneOf<>(ResponseOneOfType.BLOCK_ITEMS, dataToSend);
         try {
             responsePipeline.onNext(new SubscribeStreamResponseUnparsed(responseOneOf));

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
@@ -215,7 +215,14 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
             final CompletionService<BlockStreamSubscriberSession> streams = streamSessions;
             final Map<Long, BlockStreamSubscriberSession> sessions = openSessions;
             if (streams != null && sessions != null) {
-                final SessionContext sessionContext = SessionContext.create(clientId, request, context);
+                final SessionContext sessionContext;
+                try {
+                    sessionContext = SessionContext.create(clientId, request, context);
+                } catch (final IllegalArgumentException e) {
+                    LOGGER.log(Level.DEBUG, "Client {0} sent invalid SubscribeStreamRequest: {1}", clientId, e.getMessage());
+                    failInvalidRequest(responsePipeline);
+                    return;
+                }
                 final BlockStreamSubscriberSession blockStreamSession =
                         new BlockStreamSubscriberSession(sessionContext, responsePipeline, context, sessionReadyLatch);
                 streams.submit(blockStreamSession);
@@ -250,6 +257,24 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
             } catch (RuntimeException e) {
                 // If the pipeline cannot be completed, log and suppress this exception.
                 final String message = "Suppressed client error when \"failing\" stream for new client %n%s";
+                LOGGER.log(Level.DEBUG, message.formatted(e.getMessage()), e);
+            }
+        }
+
+        /**
+         * Sends an INVALID_REQUEST response and completes the pipeline. Used when
+         * the request itself is structurally invalid (e.g. a filter that names an
+         * unsupported block-item type or an include=true allowlist with no items).
+         */
+        private void failInvalidRequest(
+                @NonNull final Pipeline<? super SubscribeStreamResponseUnparsed> responsePipeline) {
+            final Builder response =
+                    SubscribeStreamResponseUnparsed.newBuilder().status(Code.INVALID_REQUEST);
+            responsePipeline.onNext(response.build());
+            try {
+                responsePipeline.onComplete();
+            } catch (RuntimeException e) {
+                final String message = "Suppressed client error when rejecting invalid stream request %n%s";
                 LOGGER.log(Level.DEBUG, message.formatted(e.getMessage()), e);
             }
         }

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscribeStreamRequestFilterTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscribeStreamRequestFilterTest.java
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.stream.subscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.List;
+import org.hiero.block.api.BlockStreamFilter;
+import org.hiero.block.api.SubscribeStreamRequest;
+import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.internal.BlockItemUnparsed.ItemOneOfType;
+import org.hiero.block.node.base.filter.BlockItemFilter;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Plugin-level integration test for STORY-F4: confirms that
+ * {@link SubscribeStreamRequest#filter()} drives the same {@link BlockItemFilter}
+ * the subscriber session applies on outbound blocks. Exercises the same wiring
+ * {@code BlockStreamSubscriberSession.SessionContext.create} uses —
+ * request.filter() → {@link BlockItemFilter}.
+ */
+class SubscribeStreamRequestFilterTest {
+
+    @Test
+    void requestWithoutFilterYieldsIdentity() {
+        final SubscribeStreamRequest request = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(0L)
+                .endBlockNumber(10L)
+                .build();
+        final BlockItemFilter filter = BlockItemFilter.from(request.filter());
+        assertThat(filter.isIdentity()).isTrue();
+    }
+
+    @Test
+    void requestWithDenylistDropsConfiguredItemTypes() {
+        final SubscribeStreamRequest request = SubscribeStreamRequest.newBuilder()
+                .startBlockNumber(0L)
+                .endBlockNumber(10L)
+                .filter(BlockStreamFilter.newBuilder()
+                        .include(false)
+                        .blockItemTypes(List.of(ItemOneOfType.TRANSACTION_RESULT.protoOrdinal()))
+                        .build())
+                .build();
+        final BlockItemFilter filter = BlockItemFilter.from(request.filter());
+
+        final List<BlockItemUnparsed> in = List.of(
+                BlockItemUnparsed.newBuilder().blockHeader(Bytes.fromHex("01")).build(),
+                BlockItemUnparsed.newBuilder().transactionResult(Bytes.fromHex("05")).build(),
+                BlockItemUnparsed.newBuilder().blockProof(Bytes.fromHex("09")).build());
+        final List<BlockItemUnparsed> out = filter.apply(in);
+
+        assertThat(out).hasSize(3);
+        assertThat(out.get(0).item().kind()).isEqualTo(ItemOneOfType.BLOCK_HEADER);
+        assertThat(out.get(1).item().kind()).isEqualTo(ItemOneOfType.FILTERED_SINGLE_ITEM);
+        assertThat(out.get(2).item().kind()).isEqualTo(ItemOneOfType.BLOCK_PROOF);
+    }
+}

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberServicePluginTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberServicePluginTest.java
@@ -20,9 +20,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import org.hiero.block.api.BlockStreamFilter;
 import org.hiero.block.api.SubscribeStreamRequest;
 import org.hiero.block.api.SubscribeStreamResponse;
 import org.hiero.block.api.SubscribeStreamResponse.Code;
+import org.hiero.block.internal.BlockItemUnparsed.ItemOneOfType;
 import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
 import org.hiero.block.node.app.fixtures.blocks.TestBlock;
 import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
@@ -1165,7 +1167,27 @@ class SubscriberServicePluginTest {
                                             .startBlockNumber(10L)
                                             .endBlockNumber(5L)
                                             .build(),
-                                    Code.INVALID_END_BLOCK_NUMBER));
+                                    Code.INVALID_END_BLOCK_NUMBER),
+                            Arguments.of( // filter names a mandatory item — BLOCK_HEADER (1) is not a valid filter target
+                                    SubscribeStreamRequest.newBuilder()
+                                            .startBlockNumber(0L)
+                                            .endBlockNumber(0L)
+                                            .filter(BlockStreamFilter.newBuilder()
+                                                    .include(false)
+                                                    .blockItemTypes(List.of(
+                                                            ItemOneOfType.BLOCK_HEADER.protoOrdinal()))
+                                                    .build())
+                                            .build(),
+                                    Code.INVALID_REQUEST),
+                            Arguments.of( // include=true with empty allowlist would deny everything
+                                    SubscribeStreamRequest.newBuilder()
+                                            .startBlockNumber(0L)
+                                            .endBlockNumber(0L)
+                                            .filter(BlockStreamFilter.newBuilder()
+                                                    .include(true)
+                                                    .build())
+                                            .build(),
+                                    Code.INVALID_REQUEST));
                 }
 
                 /**

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
@@ -12,11 +12,13 @@ import static org.hiero.block.common.hasher.HashingUtilities.noThrowSha384HashOf
 
 import com.hedera.cryptography.tss.TSS;
 import com.hedera.hapi.block.stream.BlockProof;
+import com.hedera.hapi.block.stream.FilteredSingleItem;
 import com.hedera.hapi.block.stream.MerklePath;
 import com.hedera.hapi.block.stream.RecordFileSignature;
 import com.hedera.hapi.block.stream.SiblingNode;
 import com.hedera.hapi.block.stream.SignedRecordFileProof;
 import com.hedera.hapi.block.stream.StateProof;
+import com.hedera.hapi.block.stream.SubMerkleTree;
 import com.hedera.hapi.block.stream.output.BlockFooter;
 import com.hedera.hapi.block.stream.output.BlockHeader;
 import com.hedera.hapi.node.transaction.SignedTransaction;
@@ -28,6 +30,7 @@ import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.nio.ByteBuffer;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -215,6 +218,27 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
                 case BLOCK_PROOF -> {
                     BlockProof blockProof = BlockProof.PROTOBUF.parse(item.blockProof());
                     blockProofs.add(blockProof);
+                }
+                // A FilteredSingleItem carries the original item's leaf hash; route
+                // it to the sub-tree the original item belonged to so block-proof
+                // recomputation matches the unfiltered block's root.
+                case FILTERED_SINGLE_ITEM -> {
+                    final FilteredSingleItem filtered =
+                            FilteredSingleItem.PROTOBUF.parse(item.filteredSingleItem());
+                    final ByteBuffer leafHash = ByteBuffer.wrap(filtered.itemHash().toByteArray());
+                    final SubMerkleTree tree = filtered.tree();
+                    switch (tree) {
+                        case CONSENSUS_HEADER_ITEMS -> consensusHeaderHasher.addLeaf(leafHash);
+                        case INPUT_ITEMS_TREE -> inputTreeHasher.addLeaf(leafHash);
+                        case OUTPUT_ITEMS_TREE -> outputTreeHasher.addLeaf(leafHash);
+                        case STATE_CHANGE_ITEMS_TREE -> stateChangesHasher.addLeaf(leafHash);
+                        case TRACE_DATA_ITEMS_TREE -> traceDataHasher.addLeaf(leafHash);
+                        default -> LOGGER.log(
+                                WARNING,
+                                "FilteredSingleItem with unsupported tree {0} in block {1}; skipped",
+                                tree,
+                                blockNumber);
+                    }
                 }
             }
         }

--- a/docs/design/filtering/block-stream-filtering.md
+++ b/docs/design/filtering/block-stream-filtering.md
@@ -313,32 +313,49 @@ These would live next to the existing publisher / subscriber metrics in
 each plugin's `*ServicePlugin` (the registries already exist) and are
 captured as a follow-up ticket.
 
-### Filter composition
+## 10. Filter composition
 
-When the publisher filters at ingress and a subscriber subsequently
-applies its own filter, the subscriber's filter sees a stream that is
-*already* free of the publisher-filtered items — those slots are
+This is an expected-behaviour section, not a known issue. When the
+publisher filters at ingress and a subscriber later applies its own
+filter, the subscriber's filter sees a stream that is *already* free
+of the publisher-filtered items — those slots are
 `FilteredSingleItem`. The subscriber filter does NOT re-filter
-`FilteredSingleItem` (it's in `ALWAYS_FORWARD`), so the output remains
-well-formed and the original drop is not double-counted. In practice:
+`FilteredSingleItem` (it's in `ALWAYS_FORWARD`), so the output
+remains well-formed and the original drop is not double-counted.
+
+Two invariants:
+
+1. **Filtering is monotone.** Once an item is replaced by its hash,
+   no later filter can recover the original. There is no "unfilter"
+   operation.
+2. **Mandatory items are always forwarded.** `BlockHeader`,
+   `BlockProof`, `BlockFooter`, `FilteredSingleItem`, and
+   `RedactedItem` pass through every filter. Validation at filter
+   construction time prevents callers from even trying to drop them
+   (see §3, §9).
+
+Concrete compositions:
 
 - **Publisher denylist [STATE_CHANGES]** + **subscriber denylist [STATE_CHANGES]**:
-  subscriber sees one `FilteredSingleItem` per state-change slot (from
-  the publisher), not two.
+  subscriber sees one `FilteredSingleItem` per state-change slot
+  (from the publisher), not two.
 - **Publisher denylist [STATE_CHANGES]** + **subscriber denylist [TRACE_DATA]**:
-  subscriber sees `FilteredSingleItem` for both kinds.
+  subscriber sees `FilteredSingleItem` for both kinds. State-change
+  slots came in already filtered; trace-data slots are filtered by
+  the subscriber.
 - **Publisher denylist [STATE_CHANGES]** + **subscriber allowlist [STATE_CHANGES]**:
-  subscriber sees no state-change items at all (the publisher already
-  dropped them and the subscriber's allowlist does not list
-  `FilteredSingleItem`, but `FilteredSingleItem` is in
-  `ALWAYS_FORWARD` so it passes anyway). Net: the same stream the
+  subscriber sees no `StateChanges` items — the publisher already
+  dropped them. The subscriber sees the publisher's
+  `FilteredSingleItem` in each state-change slot because
+  `FilteredSingleItem` is in `ALWAYS_FORWARD` even when the
+  subscriber's allowlist doesn't list it. Net: the same stream the
   subscriber would have seen with no filter — composition cannot
   un-drop a publisher-filtered item.
+- **Publisher identity** + **subscriber denylist [STATE_CHANGES]**:
+  identical to the subscriber-only case. The publisher passes
+  everything through; the subscriber filters per request.
 
-This is intentional: filtering is monotone — once an item is replaced
-by its hash, no later filter can recover it.
-
-## 10. Acceptance tests
+## 11. Acceptance tests
 
 Unit (`block-node/base`):
 
@@ -359,7 +376,7 @@ E2E (`tools-and-tests/suites`):
 8. Boot BlockNodeApp, publish three chained blocks each with a denylist filter set in `PublisherConfig`, then subscribe without a filter and confirm the dropped item types are absent (replaced by `FilteredSingleItem`).
 9. **Verifier-acceptance round-trip** (`BlockStreamFilterE2ETests.filteredBlockIsVerifiedAndServedToSubscribers`): boot BlockNodeApp with `producer.blockStreamFilterInclude=false`, `producer.blockStreamFilterItemTypes=3` (deny `RoundHeader`), publish a block, then subscribe back. Assert the publisher emitted an `ACKNOWLEDGEMENT` (verification accepted) and the persisted block carries a `FilteredSingleItem` instead of the original `RoundHeader`. This is the real "filter → verify → persist → serve" round-trip and exercises both the leaf-hash compatibility and the verifier's `FILTERED_SINGLE_ITEM` routing.
 
-## 11. Open questions
+## 12. Open questions
 
 - **Per-block-item filtering vs per-tree filtering.** v1 operates at the
   block-item granularity. Per-`SubMerkleTree` filtering (drop an entire
@@ -375,7 +392,7 @@ E2E (`tools-and-tests/suites`):
   signed transaction body, which is a different operation than the
   oneof-level filter here.
 
-## 12. References
+## 13. References
 
 - `agent/ref/state-and-filtering/state-and-filtering-plan.md` — source plan.
 - `hiero-consensus-node/.../block/stream/block_item.proto` — canonical

--- a/docs/design/filtering/block-stream-filtering.md
+++ b/docs/design/filtering/block-stream-filtering.md
@@ -98,16 +98,42 @@ message BlockStreamFilter {
      * applies to. See block_item.proto for the canonical mapping;
      * common values: 2 EventHeader, 3 RoundHeader, 4 SignedTransaction,
      * 5 TransactionResult, 6 TransactionOutput, 7 StateChanges,
-     * 11 TraceData, 19 RedactedItem.
+     * 10 RecordFile, 11 TraceData.
      */
     repeated uint32 block_item_types = 2;
 }
 ```
 
+**Supported filter targets.** Only the following `BlockItem.item` field
+numbers may appear in `block_item_types`:
+
+| Field | Variant |
+|-------|---------|
+| 2  | `EventHeader` |
+| 3  | `RoundHeader` |
+| 4  | `SignedTransaction` |
+| 5  | `TransactionResult` |
+| 6  | `TransactionOutput` |
+| 7  | `StateChanges` |
+| 10 | `RecordFile` |
+| 11 | `TraceData` |
+
+Any other field number is rejected as an invalid request. In particular:
+
+- **1, 9, 12** (`BlockHeader`, `BlockProof`, `BlockFooter`) are required
+  by the block proof tree and cannot be filtered.
+- **8, 19** (`FilteredSingleItem`, `RedactedItem`) are already filter
+  markers; re-filtering them is meaningless.
+
+The combination `include=true` with an empty `block_item_types` list is
+also rejected (it would deny everything).
+
 Encoding choice — `uint32` for the item type tag rather than an enum
 mirror — keeps the filter forward-compatible with new oneof variants.
-Adding `TransactionOutput` to the consensus-node proto in a future
-release does NOT require a block-node protobuf change.
+Adding a new `BlockItem.item` variant to the consensus-node proto does
+not require a block-node protobuf change; it does, however, require the
+implementation's supported-types list to be widened before the new
+variant can be filtered.
 
 ## 4. `BlockItemFilter` helper (`block-node/base`)
 
@@ -233,22 +259,71 @@ A subscriber's request always wins over the server-side default.
 
 ## 9. Failure modes
 
-| Failure                                  | Behaviour                                                                                  |
-|------------------------------------------|--------------------------------------------------------------------------------------------|
-| Filter rejects a mandatory item (1/9/12) | Filter helper ignores the rejection silently — `ALWAYS_FORWARD` overrides the deny.        |
-| `block_item_types` contains an unknown number | Treat as "no item of that kind today" — the filter still works for known kinds.       |
-| Hash computation fails                   | Should not happen (PBJ serialisation is total over `BlockItemUnparsed`); rethrow as `IllegalStateException`. |
-| Empty filter (no item types)             | Identity behaviour; `accepts` always true.                                                 |
+| Failure                                                  | Behaviour                                                                                  |
+|----------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| Filter names a mandatory item (1/9/12)                    | `BlockItemFilter.from` throws `IllegalArgumentException`. Subscriber call path surfaces `Code.INVALID_REQUEST`; publisher fails fast at startup. |
+| Filter names a filter marker (8 or 19)                    | Same as above — invalid request.                                                            |
+| Filter names a field number outside the supported list    | Same as above — invalid request.                                                            |
+| `include=true` with empty `block_item_types`              | Same as above — invalid request (would deny everything).                                    |
+| `include=false` with empty `block_item_types`             | Identity behaviour; `accepts` always true.                                                  |
+| Hash computation fails                                    | Should not happen (PBJ serialisation is total over `BlockItemUnparsed`); rethrow as `IllegalStateException`. |
+
+### Observability (deferred — see `expansion.md` §5.2)
+
+Today the helper has no metrics. The recommended additions are:
+
+- **`filter.items_filtered_total{sub_merkle_tree, plugin}`** —
+  counter keyed by the `SubMerkleTree` of the dropped item and by
+  `plugin` ∈ `{publisher, subscriber, block-access}`. Operators get a
+  per-tree drop rate and can compare ingress vs. egress filtering.
+- **`filter.invalid_requests_total{plugin, reason}`** — counter for
+  rejected filter specs, keyed by rejection reason
+  (`unsupported_type`, `empty_allowlist`). Useful for detecting clients
+  misusing the API.
+- **`filter.active_filters{plugin}`** — gauge of currently-active
+  non-identity filters. For the subscriber this is the number of open
+  sessions whose request carried a filter; for the publisher it is 0
+  or 1 depending on config.
+
+These would live next to the existing publisher / subscriber metrics in
+each plugin's `*ServicePlugin` (the registries already exist) and are
+captured as a follow-up ticket.
+
+### Filter composition
+
+When the publisher filters at ingress and a subscriber subsequently
+applies its own filter, the subscriber's filter sees a stream that is
+*already* free of the publisher-filtered items — those slots are
+`FilteredSingleItem`. The subscriber filter does NOT re-filter
+`FilteredSingleItem` (it's in `ALWAYS_FORWARD`), so the output remains
+well-formed and the original drop is not double-counted. In practice:
+
+- **Publisher denylist [STATE_CHANGES]** + **subscriber denylist [STATE_CHANGES]**:
+  subscriber sees one `FilteredSingleItem` per state-change slot (from
+  the publisher), not two.
+- **Publisher denylist [STATE_CHANGES]** + **subscriber denylist [TRACE_DATA]**:
+  subscriber sees `FilteredSingleItem` for both kinds.
+- **Publisher denylist [STATE_CHANGES]** + **subscriber allowlist [STATE_CHANGES]**:
+  subscriber sees no state-change items at all (the publisher already
+  dropped them and the subscriber's allowlist does not list
+  `FilteredSingleItem`, but `FilteredSingleItem` is in
+  `ALWAYS_FORWARD` so it passes anyway). Net: the same stream the
+  subscriber would have seen with no filter — composition cannot
+  un-drop a publisher-filtered item.
+
+This is intentional: filtering is monotone — once an item is replaced
+by its hash, no later filter can recover it.
 
 ## 10. Acceptance tests
 
 Unit (`block-node/base`):
 
-1. Allowlist: filter with `include=true, types=[1,9,12]` (headers + proof + footer) drops everything else and emits `FilteredSingleItem` for each drop, preserving the original list length.
+1. Allowlist: filter with `include=true, types=[11]` (allow trace_data) drops everything else (except mandatory items) and emits `FilteredSingleItem` for each drop, preserving the original list length.
 2. Denylist: filter with `include=false, types=[7]` (drop state_changes) leaves all other variants untouched.
-3. `BlockHeader`/`BlockProof`/`BlockFooter` are never replaced regardless of filter (mandatory items).
-4. Empty filter is the identity function.
+3. `BlockHeader`/`BlockProof`/`BlockFooter` are never replaced — they are mandatory and pass through even when the allowlist omits them.
+4. Empty denylist is the identity function.
 5. Each generated `FilteredSingleItem.tree` matches the SubMerkleTree the original item maps to.
+6. `BlockItemFilter.from` rejects (a) any `block_item_type` outside the supported set, and (b) `include=true` with an empty list.
 
 Plugin-level:
 

--- a/docs/design/filtering/block-stream-filtering.md
+++ b/docs/design/filtering/block-stream-filtering.md
@@ -184,8 +184,32 @@ zero-cost.
 | `BlockHeader`(1), `TransactionResult`(5), `TransactionOutput`(6), `RecordFile`(10) | OUTPUT_ITEMS_TREE |
 | `BlockProof`(9), `BlockFooter`(12) | NOT_HASHED (never filtered) |
 
-`item_hash` is `SHA-384(BlockItemUnparsed.PROTOBUF.toBytes(item))` — matches
-the verifier's existing hash algorithm.
+`item_hash` is the verifier's leaf hash for the original item — the
+output of `HashingUtilities.getBlockItemHash(item)`, i.e.
+`SHA-384(LEAF_PREFIX || BlockItemUnparsed.PROTOBUF.toBytes(item))`.
+Using the same source of truth as the verifier is what allows a
+filtered block to satisfy the original block proof unchanged: the
+sub-tree hasher gets the same leaf it would have got from the
+unfiltered item.
+
+### Verifier-side handling
+
+`ExtendedMerkleTreeSession.processBlockItems` routes
+`FILTERED_SINGLE_ITEM` items to the correct sub-tree hasher based on
+their `tree` field:
+
+| `SubMerkleTree`           | Hasher                |
+|---------------------------|-----------------------|
+| `CONSENSUS_HEADER_ITEMS`  | `consensusHeaderHasher` |
+| `INPUT_ITEMS_TREE`        | `inputTreeHasher`     |
+| `OUTPUT_ITEMS_TREE`       | `outputTreeHasher`    |
+| `STATE_CHANGE_ITEMS_TREE` | `stateChangesHasher`  |
+| `TRACE_DATA_ITEMS_TREE`   | `traceDataHasher`     |
+
+The hash put into the sub-tree is `FilteredSingleItem.item_hash`
+verbatim — already the leaf hash. Anything outside the table is
+logged as a warning and skipped; the block proof will then fail
+naturally, which is the correct signal.
 
 ## 5. `stream-publisher` integration
 
@@ -333,6 +357,7 @@ Plugin-level:
 E2E (`tools-and-tests/suites`):
 
 8. Boot BlockNodeApp, publish three chained blocks each with a denylist filter set in `PublisherConfig`, then subscribe without a filter and confirm the dropped item types are absent (replaced by `FilteredSingleItem`).
+9. **Verifier-acceptance round-trip** (`BlockStreamFilterE2ETests.filteredBlockIsVerifiedAndServedToSubscribers`): boot BlockNodeApp with `producer.blockStreamFilterInclude=false`, `producer.blockStreamFilterItemTypes=3` (deny `RoundHeader`), publish a block, then subscribe back. Assert the publisher emitted an `ACKNOWLEDGEMENT` (verification accepted) and the persisted block carries a `FilteredSingleItem` instead of the original `RoundHeader`. This is the real "filter → verify → persist → serve" round-trip and exercises both the leaf-hash compatibility and the verifier's `FILTERED_SINGLE_ITEM` routing.
 
 ## 11. Open questions
 

--- a/docs/design/filtering/block-stream-filtering.md
+++ b/docs/design/filtering/block-stream-filtering.md
@@ -1,0 +1,286 @@
+# Block Stream Filtering — Design Doc
+
+> Status: **Beta / experimental.** Filtering by block item is in scope for
+> v1; filtering by entity is deferred. The new RPCs / fields are
+> backwards-compatible: omit the filter to get current behaviour.
+
+## 1. Purpose & Goals
+
+Let operators (on the publish side) and clients (on the subscribe / read
+side) trim the block stream to just the `BlockItem` kinds they care about.
+A filtered item is replaced by a `FilteredSingleItem` carrying the item
+hash and the `SubMerkleTree` slot it occupied — so block-proof verification
+of the resulting stream remains possible.
+
+Scope for v1:
+
+1. **`BlockStreamFilter` protobuf** — a single message shape applied
+   everywhere, so the operator-facing config and the client-facing request
+   fields use one schema.
+2. **Publish-side filtering** — `StreamPublisherPlugin` drops items at
+   ingress before the messaging facility ever sees them. This means the
+   block-node never persists or streams what was filtered. Lossy.
+3. **Subscribe-side filtering** — `BlockStreamSubscriberSession` honours
+   the filter on the `SubscribeStreamRequest`. Lossless on the BN; only the
+   outbound stream is trimmed.
+4. **Shared helper in `block-node/base`** — one `BlockItemFilter` class
+   that both plugins consume, so allow/deny semantics stay consistent.
+
+Out of scope for v1:
+
+- **Entity-level filtering** (filter by account-id, token-id, …). Design
+  note only.
+- **`block-access` integration** — design captured here (§7), not wired
+  into code in this spike.
+- **Mandatory items.** The plan suggests filtering should never drop items
+  that the block proof / verifier requires (`BlockHeader`, `BlockProof`,
+  `BlockFooter`). v1 enforces this by always preserving these regardless
+  of filter setting.
+
+## 2. Architecture
+
+```
+                ┌───────────────────────────────────────┐
+publisher  ──►  │ StreamPublisherPlugin                 │
+gRPC stream     │   PublisherConfig.blockStreamFilter   │
+                │       │                               │
+                │       ▼                               │
+                │   BlockItemFilter.apply(items)        │
+                │       │                               │
+                │       ▼ filtered items                │
+                │   messaging facility                  │
+                └────────┬──────────────────────────────┘
+                         │
+            ┌────────────┴────────────────┐
+            ▼                             ▼
+      verification                  blocks-files-recent / historic
+
+                ┌───────────────────────────────────────┐
+subscriber ──►  │ StreamSubscriberPlugin                │
+gRPC subscribe  │   SubscribeStreamRequest.filter       │
+                │       │                               │
+                │       ▼                               │
+                │ BlockStreamSubscriberSession          │
+                │   BlockItemFilter.apply(items)        │
+                │       │                               │
+                │       ▼                               │
+                │   responsePipeline.onNext(filtered)   │
+                └───────────────────────────────────────┘
+```
+
+Two filter call sites; one shared helper. No new ring-buffer traffic, no
+new plugin.
+
+## 3. `BlockStreamFilter` message
+
+Single shape, used by publish-side config and subscribe-side request.
+
+```proto
+// In protobuf-sources/.../shared_message_types.proto
+message BlockStreamFilter {
+    /**
+     * Allow- vs deny-list semantics.
+     *
+     * If true,  ONLY items whose oneof field number is in
+     *           `block_item_types` are forwarded.
+     * If false, items whose oneof field number is in
+     *           `block_item_types` are DROPPED; all others are
+     *           forwarded.
+     *
+     * BlockHeader (1), BlockProof (9), and BlockFooter (12) are always
+     * forwarded regardless of the filter — they are required for block
+     * proof verification.
+     */
+    bool include = 1;
+
+    /**
+     * Field numbers of the `BlockItem.item` oneof variants this filter
+     * applies to. See block_item.proto for the canonical mapping;
+     * common values: 2 EventHeader, 3 RoundHeader, 4 SignedTransaction,
+     * 5 TransactionResult, 6 TransactionOutput, 7 StateChanges,
+     * 11 TraceData, 19 RedactedItem.
+     */
+    repeated uint32 block_item_types = 2;
+}
+```
+
+Encoding choice — `uint32` for the item type tag rather than an enum
+mirror — keeps the filter forward-compatible with new oneof variants.
+Adding `TransactionOutput` to the consensus-node proto in a future
+release does NOT require a block-node protobuf change.
+
+## 4. `BlockItemFilter` helper (`block-node/base`)
+
+Single, stateless utility in `org.hiero.block.node.base.filter`:
+
+```java
+public final class BlockItemFilter {
+
+    /** Field numbers a filter MUST always forward (proof scaffolding). */
+    private static final Set<Integer> ALWAYS_FORWARD = Set.of(
+            BlockItemUnparsed.ItemOneOfType.BLOCK_HEADER.protoOrdinal(),     // 1
+            BlockItemUnparsed.ItemOneOfType.BLOCK_PROOF.protoOrdinal(),      // 9
+            BlockItemUnparsed.ItemOneOfType.BLOCK_FOOTER.protoOrdinal());    // 12
+
+    /**
+     * @return whether the filter accepts the given item without
+     *         transformation.
+     */
+    public boolean accepts(BlockItemUnparsed item);
+
+    /**
+     * Apply the filter to a list of items. Items the filter rejects are
+     * replaced by a {@code FilteredSingleItem} carrying:
+     *   - item_hash : the SHA-384 of the unparsed item bytes
+     *   - tree      : a {@link SubMerkleTree} derived from the original
+     *                 field number modulo 10 (see plan §protobuf-sources).
+     *
+     * Returns a new list; never mutates the input.
+     */
+    public List<BlockItemUnparsed> apply(List<BlockItemUnparsed> items);
+}
+```
+
+The filter is constructed from a `BlockStreamFilter` proto. When the proto
+is null or its `block_item_types` list is empty, `apply` is the identity
+function (returns the input unchanged) so disabled / unset filters are
+zero-cost.
+
+`SubMerkleTree` derivation table (from `block_item.proto` mod-10 rule):
+
+| Field number → mod 10 | `SubMerkleTree` value |
+|---|---|
+| 0 (none in current oneof) | — |
+| 1 — `SignedTransaction` (4 % 10 = 4) — see below | INPUT_ITEMS_TREE |
+| 2 — `EventHeader` (2), `RoundHeader` (3) | CONSENSUS_HEADER_ITEMS |
+| 3 — `StateChanges` (7) | STATE_CHANGE_ITEMS_TREE |
+| 4 — `TraceData` (11) | TRACE_DATA_ITEMS_TREE |
+| `BlockHeader`(1), `TransactionResult`(5), `TransactionOutput`(6), `RecordFile`(10) | OUTPUT_ITEMS_TREE |
+| `BlockProof`(9), `BlockFooter`(12) | NOT_HASHED (never filtered) |
+
+`item_hash` is `SHA-384(BlockItemUnparsed.PROTOBUF.toBytes(item))` — matches
+the verifier's existing hash algorithm.
+
+## 5. `stream-publisher` integration
+
+Per the recon, each inbound publisher connection has its own
+`PublisherHandler` (created in `LiveStreamPublisherManager.addHandler`).
+Filter state is therefore per-connection.
+
+Wire-up:
+
+- **`PublisherConfig`** gains a single optional field —
+  `BlockStreamFilter blockStreamFilter`. Default constructed to the
+  identity filter (include=false, empty list) → no-op behaviour.
+- **`PublisherHandler`** constructor builds a `BlockItemFilter` from the
+  config. If the filter is identity, `accepts` is short-circuited.
+- **`handleAccept`** (line ~629) inserts a single call
+  `final List<BlockItemUnparsed> kept = blockItemFilter.apply(items);`
+  before items are placed on `currentBlockQueue` and forwarded to
+  `publisherManager.signalDataReady()`.
+
+Notable: this is **lossy** at the BN — filtered items are replaced by
+`FilteredSingleItem` *at ingress*, so persistence, verification, and
+subscription all see the trimmed stream. The plan calls this out
+explicitly.
+
+## 6. `stream-subscriber` integration
+
+Per the recon, each inbound subscribe RPC has its own
+`BlockStreamSubscriberSession`. Filter state is per-session.
+
+Wire-up:
+
+- **`SubscribeStreamRequest`** gains a `BlockStreamFilter filter = 3;`
+  field (proto-level, optional).
+- **`BlockStreamSubscriberSession`** constructor reads the request's
+  filter and builds a `BlockItemFilter`. Identity filter when absent.
+- **`sendOneBlockItemSet`** (line ~824) calls `apply` on the list of
+  `BlockItemUnparsed` before constructing the `BlockItemSetUnparsed` it
+  hands to `responsePipeline.onNext`.
+
+This is **lossless** at the BN — the underlying storage and the messaging
+ring buffer still see the full stream. Only what this particular
+subscriber sees is filtered.
+
+## 7. `block-access` (design only, not implemented)
+
+Goal: same `BlockStreamFilter`, applied per request, on the unary read path.
+
+Wire-up plan:
+
+- Extend `BlockRequest` with an optional `BlockStreamFilter filter`.
+- In `BlockAccessServicePlugin.getBlockUnparsed`, after
+  `accessor.blockUnparsed()` returns a `BlockUnparsed`, apply
+  `BlockItemFilter.apply(block.blockItems())` before returning the
+  response.
+
+This is **lossless** at the BN — same property as subscribe.
+
+Implementation is deferred so the spike scope stays tight. The ticket for
+this is captured but its acceptance is design + approval, not code.
+
+## 8. Configuration
+
+| Property                                    | Default     | Notes                                          |
+|---------------------------------------------|-------------|------------------------------------------------|
+| `producer.blockStreamFilter.include`        | `false`     | Disabled by default — full pass-through.        |
+| `producer.blockStreamFilter.blockItemTypes` | empty       | Field numbers to deny (or allow when include). |
+| `subscriber.blockStreamFilter.include`      | `false`     | Subscriber-side default for clients that don't send one. |
+| `subscriber.blockStreamFilter.blockItemTypes` | empty    | —                                              |
+
+A subscriber's request always wins over the server-side default.
+
+## 9. Failure modes
+
+| Failure                                  | Behaviour                                                                                  |
+|------------------------------------------|--------------------------------------------------------------------------------------------|
+| Filter rejects a mandatory item (1/9/12) | Filter helper ignores the rejection silently — `ALWAYS_FORWARD` overrides the deny.        |
+| `block_item_types` contains an unknown number | Treat as "no item of that kind today" — the filter still works for known kinds.       |
+| Hash computation fails                   | Should not happen (PBJ serialisation is total over `BlockItemUnparsed`); rethrow as `IllegalStateException`. |
+| Empty filter (no item types)             | Identity behaviour; `accepts` always true.                                                 |
+
+## 10. Acceptance tests
+
+Unit (`block-node/base`):
+
+1. Allowlist: filter with `include=true, types=[1,9,12]` (headers + proof + footer) drops everything else and emits `FilteredSingleItem` for each drop, preserving the original list length.
+2. Denylist: filter with `include=false, types=[7]` (drop state_changes) leaves all other variants untouched.
+3. `BlockHeader`/`BlockProof`/`BlockFooter` are never replaced regardless of filter (mandatory items).
+4. Empty filter is the identity function.
+5. Each generated `FilteredSingleItem.tree` matches the SubMerkleTree the original item maps to.
+
+Plugin-level:
+
+6. `stream-publisher` with config `denylist=[STATE_CHANGES]`: publish a block containing a `StateChanges` item; verify the messaging facility receives the block without state_changes, replaced by `FilteredSingleItem`.
+7. `stream-subscriber` with request filter `denylist=[TRANSACTION_RESULT]`: subscribe, publish a block, verify the response stream has `FilteredSingleItem` in place of every `TransactionResult` block item.
+
+E2E (`tools-and-tests/suites`):
+
+8. Boot BlockNodeApp, publish three chained blocks each with a denylist filter set in `PublisherConfig`, then subscribe without a filter and confirm the dropped item types are absent (replaced by `FilteredSingleItem`).
+
+## 11. Open questions
+
+- **Per-block-item filtering vs per-tree filtering.** v1 operates at the
+  block-item granularity. Per-`SubMerkleTree` filtering (drop an entire
+  sub-tree, emit `FilteredMerkleSubTree`) is a natural extension — see
+  `expansion.md`.
+- **Verifier interaction.** When the publisher filters at ingress, the
+  verification plugin sees `FilteredSingleItem` items in the block. The
+  verifier already handles those (the plan calls this out under
+  `### verification`); STORY-F6 must include a test that the verifier
+  still accepts a filtered block.
+- **Entity filtering.** A future iteration adds a higher-level filter
+  (e.g. "only events involving account-id X"). This requires parsing the
+  signed transaction body, which is a different operation than the
+  oneof-level filter here.
+
+## 12. References
+
+- `agent/ref/state-and-filtering/state-and-filtering-plan.md` — source plan.
+- `hiero-consensus-node/.../block/stream/block_item.proto` — canonical
+  `BlockItem.item` oneof, `FilteredSingleItem`, `SubMerkleTree`.
+- `agent/proposals/state-and-filtering/live-state/fyi-to-plan.md` — plan
+  corrections (filtering section appended).
+- `agent/proposals/state-and-filtering/block-stream-filtering/expansion.md` —
+  follow-ups + considerations.

--- a/protobuf-sources/src/main/proto/block-node/api/block_stream_subscribe_service.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/block_stream_subscribe_service.proto
@@ -56,6 +56,19 @@ message SubscribeStreamRequest {
      * </ul>
      */
     uint64 end_block_number = 2;
+
+    /**
+     * Optional per-subscriber filter describing which `BlockItem` kinds
+     * the Block-Node should forward.<br/>
+     * <p>
+     * When this field is absent or carries an empty `block_item_types`
+     * list the subscriber receives the full stream (identity filter).<br/>
+     * When present, items the filter rejects SHALL be replaced by a
+     * `FilteredSingleItem` so block-proof verification remains possible.
+     * `BlockHeader`, `BlockProof`, and `BlockFooter` items are always
+     * forwarded regardless of this filter.
+     */
+    BlockStreamFilter filter = 3;
 }
 
 /**

--- a/protobuf-sources/src/main/proto/block-node/api/shared_message_types.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/shared_message_types.proto
@@ -42,3 +42,60 @@ message BlockEnd {
      */
     uint64 block_number = 1;
 }
+
+/**
+ * Describes which `BlockItem` kinds a publisher or subscriber wishes the
+ * Block-Node to forward, expressed as a per-kind allow- or deny-list.
+ *
+ * Used by:
+ *   - `producer.blockStreamFilter` in `PublisherConfig` (publish-side,
+ *     applied at ingress before persistence/messaging — LOSSY at the
+ *     Block-Node).
+ *   - `SubscribeStreamRequest.filter` (subscribe-side, applied per
+ *     subscriber — LOSSLESS at the Block-Node).
+ *
+ * Block items that the filter rejects SHALL be replaced by a
+ * `FilteredSingleItem` carrying the rejected item's hash and the
+ * `SubMerkleTree` it occupied, so block-proof verification of the
+ * resulting stream remains possible.
+ *
+ * `BlockHeader`, `BlockProof`, and `BlockFooter` block items are
+ * load-bearing for the block proof and SHALL be forwarded regardless
+ * of the filter. Implementations MUST silently ignore a filter that
+ * would otherwise reject them.
+ */
+message BlockStreamFilter {
+    /**
+     * Allow- vs deny-list semantics.
+     *
+     * If `true`,  ONLY items whose `BlockItem.item` oneof field number
+     *             appears in `block_item_types` are forwarded.<br/>
+     * If `false`, items whose `BlockItem.item` oneof field number
+     *             appears in `block_item_types` are DROPPED; all others
+     *             are forwarded.
+     *
+     * The default value `false` with an empty `block_item_types` list
+     * is the identity filter (pass-through).
+     */
+    bool include = 1;
+
+    /**
+     * Field numbers of the `BlockItem.item` oneof variants this filter
+     * applies to. See
+     * `hiero-consensus-node/.../block/stream/block_item.proto` for the
+     * canonical mapping; common values:
+     *   2  EventHeader
+     *   3  RoundHeader
+     *   4  SignedTransaction
+     *   5  TransactionResult
+     *   6  TransactionOutput
+     *   7  StateChanges
+     *   11 TraceData
+     *   19 RedactedItem
+     *
+     * `uint32` is used rather than a mirror enum so future
+     * `BlockItem.item` variants are forward-compatible without a
+     * Block-Node protobuf change.
+     */
+    repeated uint32 block_item_types = 2;
+}

--- a/protobuf-sources/src/main/proto/block-node/api/shared_message_types.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/shared_message_types.proto
@@ -61,8 +61,8 @@ message BlockEnd {
  *
  * `BlockHeader`, `BlockProof`, and `BlockFooter` block items are
  * load-bearing for the block proof and SHALL be forwarded regardless
- * of the filter. Implementations MUST silently ignore a filter that
- * would otherwise reject them.
+ * of the filter. Naming them as filter targets is rejected as an
+ * invalid request (see `block_item_types`).
  */
 message BlockStreamFilter {
     /**
@@ -75,7 +75,9 @@ message BlockStreamFilter {
      *             are forwarded.
      *
      * The default value `false` with an empty `block_item_types` list
-     * is the identity filter (pass-through).
+     * is the identity filter (pass-through). The combination
+     * `include = true` with an empty `block_item_types` list is an
+     * invalid request and SHALL be rejected.
      */
     bool include = 1;
 
@@ -83,19 +85,29 @@ message BlockStreamFilter {
      * Field numbers of the `BlockItem.item` oneof variants this filter
      * applies to. See
      * `hiero-consensus-node/.../block/stream/block_item.proto` for the
-     * canonical mapping; common values:
+     * canonical mapping.
+     *
+     * The exhaustive set of values accepted by this implementation is:
      *   2  EventHeader
      *   3  RoundHeader
      *   4  SignedTransaction
      *   5  TransactionResult
      *   6  TransactionOutput
      *   7  StateChanges
+     *   10 RecordFile
      *   11 TraceData
-     *   19 RedactedItem
+     *
+     * Any other value is rejected as an invalid request. In particular:
+     *   - 1, 9, 12 (BlockHeader, BlockProof, BlockFooter) are required
+     *     by the block proof and cannot be filtered.
+     *   - 8, 19 (FilteredSingleItem, RedactedItem) are filter markers;
+     *     re-filtering them is meaningless.
      *
      * `uint32` is used rather than a mirror enum so future
      * `BlockItem.item` variants are forward-compatible without a
-     * Block-Node protobuf change.
+     * Block-Node protobuf change. New variants must be added to the
+     * implementation's supported-types list before they can be
+     * filtered.
      */
     repeated uint32 block_item_types = 2;
 }

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockStreamFilterE2ETests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockStreamFilterE2ETests.java
@@ -9,6 +9,7 @@ import com.hedera.pbj.grpc.client.helidon.PbjGrpcClient;
 import com.hedera.pbj.grpc.client.helidon.PbjGrpcClientConfig;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import io.helidon.common.tls.Tls;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.grpc.GrpcClientProtocolConfig;
@@ -215,6 +216,81 @@ class BlockStreamFilterE2ETests {
         assertThat(hasRoundHeader)
                 .as("publisher-side filter should have stripped the original RoundHeader before persistence")
                 .isFalse();
+
+        publishStream.closeConnection();
+    }
+
+    /**
+     * Proof-chain across two filtered blocks. Each block's proof anchors to the
+     * previous block's recomputed root; if the filter ever broke the chain — e.g.
+     * by mis-aligning the leaf hash or by mis-routing a {@code FilteredSingleItem}
+     * to the wrong sub-tree — block 1 would fail verification even though block 0
+     * passed. A single-block test cannot catch that. We publish block 0 + block 1
+     * back-to-back, then subscribe both back and assert both carry a
+     * {@code FilteredSingleItem} where the round header used to be.
+     */
+    @Test
+    void filteredBlockChainVerifiesAcrossTwoBlocks() throws Exception {
+        final long blockZero = 0L;
+        final long blockOne = 1L;
+        final BlockItem[] block0Items = BlockItemBuilderUtils.createSimpleBlockWithNumber(blockZero);
+        // Anchor block 1's proof to block 0's recomputed root hash.
+        final Bytes block0Hash = BlockItemBuilderUtils.computeBlockHash(blockZero, null);
+        final BlockItem[] block1Items = BlockItemBuilderUtils.createSimpleBlockWithNumber(blockOne, block0Hash);
+
+        // ── Publish both blocks with the publisher filter active ──────────────
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publishSvc =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(publishClient, OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> ackObserver = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> publishStream = publishSvc.publishBlockStream(ackObserver);
+
+        final AtomicReference<CountDownLatch> ackLatch = ackObserver.setAndGetOnNextLatch(2);
+        publishStream.onNext(PublishStreamRequest.newBuilder()
+                .blockItems(BlockItemSet.newBuilder().blockItems(block0Items).build())
+                .build());
+        publishStream.onNext(PublishStreamRequest.newBuilder()
+                .endOfBlock(BlockEnd.newBuilder().blockNumber(blockZero).build())
+                .build());
+        publishStream.onNext(PublishStreamRequest.newBuilder()
+                .blockItems(BlockItemSet.newBuilder().blockItems(block1Items).build())
+                .build());
+        publishStream.onNext(PublishStreamRequest.newBuilder()
+                .endOfBlock(BlockEnd.newBuilder().blockNumber(blockOne).build())
+                .build());
+        awaitLatch(ackLatch, "acknowledgements for two filtered blocks");
+
+        // Both blocks must verify — count the ACK responses for blocks 0 and 1.
+        final long ackCount = ackObserver.getOnNextCalls().stream()
+                .filter(r -> r.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT)
+                .count();
+        assertThat(ackCount)
+                .as("both filtered blocks must verify; chain breaks if proof anchor drifts")
+                .isGreaterThanOrEqualTo(2L);
+
+        // ── Subscribe back: both persisted blocks must carry FilteredSingleItem
+        final PbjGrpcClient subscribeClient = createGrpcClient();
+        final BlockStreamSubscribeServiceInterface.BlockStreamSubscribeServiceClient subscribeSvc =
+                new BlockStreamSubscribeServiceInterface.BlockStreamSubscribeServiceClient(subscribeClient, OPTIONS);
+        final ResponsePipelineUtils<SubscribeStreamResponse> subscribeObserver = new ResponsePipelineUtils<>();
+
+        // Expect for each block: items frame + endOfBlock frame. Two blocks → ≥4 onNext.
+        final AtomicReference<CountDownLatch> subscribeLatch = subscribeObserver.setAndGetOnNextLatch(4);
+        subscribeSvc.subscribeBlockStream(
+                SubscribeStreamRequest.newBuilder()
+                        .startBlockNumber(blockZero)
+                        .endBlockNumber(blockOne)
+                        .build(),
+                subscribeObserver);
+        awaitLatch(subscribeLatch, "subscribe-back for the two-block filtered chain");
+
+        final long filteredSingleItemCount = subscribeObserver.getOnNextCalls().stream()
+                .filter(r -> r.blockItems() != null)
+                .flatMap(r -> r.blockItems().blockItems().stream())
+                .filter(bi -> bi.item().kind() == BlockItem.ItemOneOfType.FILTERED_SINGLE_ITEM)
+                .count();
+        assertThat(filteredSingleItemCount)
+                .as("expect one FilteredSingleItem per block (the round header), so two across the chain")
+                .isGreaterThanOrEqualTo(2L);
 
         publishStream.closeConnection();
     }

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockStreamFilterE2ETests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockStreamFilterE2ETests.java
@@ -26,8 +26,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.hiero.block.api.BlockEnd;
 import org.hiero.block.api.BlockItemSet;
 import org.hiero.block.api.BlockStreamPublishServiceInterface;
+import org.hiero.block.api.BlockStreamSubscribeServiceInterface;
 import org.hiero.block.api.PublishStreamRequest;
 import org.hiero.block.api.PublishStreamResponse;
+import org.hiero.block.api.SubscribeStreamRequest;
+import org.hiero.block.api.SubscribeStreamResponse;
 import org.hiero.block.node.app.BlockNodeApp;
 import org.hiero.block.node.spi.ServiceLoaderFunction;
 import org.hiero.block.node.spi.health.HealthFacility.State;
@@ -145,6 +148,75 @@ class BlockStreamFilterE2ETests {
         assertThat(ackObserver.getOnNextCalls().get(0).response().kind()).isNotNull();
 
         stream.closeConnection();
+    }
+
+    /**
+     * Verifier-acceptance assertion. Publishes a block with the publisher
+     * configured to deny {@code ROUND_HEADER}, then subscribes back from the
+     * Block Node and asserts the persisted block contains a
+     * {@code FilteredSingleItem} in place of the round header. The subscribe
+     * call succeeds only if verification accepted the rewritten block — making
+     * this the real round-trip "filter → verify → persist → serve" check.
+     */
+    @Test
+    void filteredBlockIsVerifiedAndServedToSubscribers() throws Exception {
+        final long blockNumber = 0L;
+        final BlockItem[] items = BlockItemBuilderUtils.createSimpleBlockWithNumber(blockNumber);
+
+        // ── Publish the block with the publisher filter active ────────────────
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publishSvc =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(publishClient, OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> ackObserver = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> publishStream = publishSvc.publishBlockStream(ackObserver);
+
+        final AtomicReference<CountDownLatch> ackLatch = ackObserver.setAndGetOnNextLatch(1);
+        publishStream.onNext(PublishStreamRequest.newBuilder()
+                .blockItems(BlockItemSet.newBuilder().blockItems(items).build())
+                .build());
+        publishStream.onNext(PublishStreamRequest.newBuilder()
+                .endOfBlock(BlockEnd.newBuilder().blockNumber(blockNumber).build())
+                .build());
+        awaitLatch(ackLatch, "publish acknowledgement for filtered block");
+
+        // Confirm the publisher acknowledged — verification accepted the block.
+        assertThat(ackObserver.getOnNextCalls())
+                .as("publisher must ack the filtered block; a NACK means verification rejected it")
+                .anySatisfy(resp -> assertThat(resp.response().kind())
+                        .isEqualTo(PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT));
+
+        // ── Subscribe back and assert FilteredSingleItem is present ───────────
+        final PbjGrpcClient subscribeClient = createGrpcClient();
+        final BlockStreamSubscribeServiceInterface.BlockStreamSubscribeServiceClient subscribeSvc =
+                new BlockStreamSubscribeServiceInterface.BlockStreamSubscribeServiceClient(subscribeClient, OPTIONS);
+        final ResponsePipelineUtils<SubscribeStreamResponse> subscribeObserver = new ResponsePipelineUtils<>();
+
+        // Expect: block-items frame, end-of-block frame, success status.
+        final AtomicReference<CountDownLatch> subscribeLatch = subscribeObserver.setAndGetOnNextLatch(2);
+        subscribeSvc.subscribeBlockStream(
+                SubscribeStreamRequest.newBuilder()
+                        .startBlockNumber(blockNumber)
+                        .endBlockNumber(blockNumber)
+                        .build(),
+                subscribeObserver);
+        awaitLatch(subscribeLatch, "subscribe to filtered block");
+
+        final boolean hasFilteredSingleItem = subscribeObserver.getOnNextCalls().stream()
+                .filter(r -> r.blockItems() != null)
+                .flatMap(r -> r.blockItems().blockItems().stream())
+                .anyMatch(bi -> bi.item().kind() == BlockItem.ItemOneOfType.FILTERED_SINGLE_ITEM);
+        final boolean hasRoundHeader = subscribeObserver.getOnNextCalls().stream()
+                .filter(r -> r.blockItems() != null)
+                .flatMap(r -> r.blockItems().blockItems().stream())
+                .anyMatch(bi -> bi.item().kind() == BlockItem.ItemOneOfType.ROUND_HEADER);
+
+        assertThat(hasFilteredSingleItem)
+                .as("persisted block should contain a FilteredSingleItem in place of the round header")
+                .isTrue();
+        assertThat(hasRoundHeader)
+                .as("publisher-side filter should have stripped the original RoundHeader before persistence")
+                .isFalse();
+
+        publishStream.closeConnection();
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockStreamFilterE2ETests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockStreamFilterE2ETests.java
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.suites.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClient;
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClientConfig;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import io.helidon.common.tls.Tls;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.grpc.GrpcClientProtocolConfig;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hiero.block.api.BlockEnd;
+import org.hiero.block.api.BlockItemSet;
+import org.hiero.block.api.BlockStreamPublishServiceInterface;
+import org.hiero.block.api.PublishStreamRequest;
+import org.hiero.block.api.PublishStreamResponse;
+import org.hiero.block.node.app.BlockNodeApp;
+import org.hiero.block.node.spi.ServiceLoaderFunction;
+import org.hiero.block.node.spi.health.HealthFacility.State;
+import org.hiero.block.suites.utils.BlockItemBuilderUtils;
+import org.hiero.block.suites.utils.ResponsePipelineUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * E2E tests for the block-stream filter on the publisher side. Each test
+ * configures {@link org.hiero.block.node.stream.publisher.PublisherConfig}
+ * via System properties (the same {@code SystemPropertiesConfigSource}
+ * ordinal-400 pattern used by {@code BlockNodeCloudStorageTests}), boots
+ * {@code BlockNodeApp} in-JVM, and exercises the publisher gRPC.
+ *
+ * <p>The filter is set to deny {@code ROUND_HEADER} (field 3) — the only
+ * non-mandatory item produced by
+ * {@link BlockItemBuilderUtils#createSimpleBlockWithNumber(long)}. After
+ * the filter passes the publisher accepts the block (it has been
+ * rewritten with a {@code FilteredSingleItem} in place of the round
+ * header). Pure publish-side smoke; the deeper "did the verifier accept
+ * the rewritten block" assertion would require additional plumbing and
+ * is captured in {@code docs/design/filtering/block-stream-filtering.md}
+ * and the expansion notes.
+ */
+@Tag("api")
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+class BlockStreamFilterE2ETests {
+
+    private static final String SERVER_PORT =
+            System.getenv("SERVER_PORT") == null ? "40840" : System.getenv("SERVER_PORT");
+    private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(30);
+    private static final Options OPTIONS =
+            new Options(Optional.empty(), ServiceInterface.RequestOptions.APPLICATION_GRPC);
+
+    private record Options(Optional<String> authority, String contentType) implements ServiceInterface.RequestOptions {}
+
+    private BlockNodeApp app;
+    private PbjGrpcClient publishClient;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        final Path dataDir = Paths.get("build/tmp/data").toAbsolutePath();
+        if (Files.exists(dataDir)) {
+            Files.walk(dataDir)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+        }
+
+        // Deny ROUND_HEADER (field 3) on the publish side. SystemPropertiesConfigSource
+        // (ordinal 400) picks these up before BlockNodeApp constructs its Configuration.
+        System.setProperty("producer.blockStreamFilterInclude", "false");
+        System.setProperty("producer.blockStreamFilterItemTypes", "3");
+
+        app = new BlockNodeApp(new ServiceLoaderFunction(), false);
+        app.start();
+        final long deadline = System.currentTimeMillis() + 15_000L;
+        while (app.blockNodeState() != State.RUNNING && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+        }
+        assertEquals(State.RUNNING, app.blockNodeState(), "BlockNodeApp must be RUNNING after startup");
+
+        publishClient = createGrpcClient();
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty("producer.blockStreamFilterInclude");
+        System.clearProperty("producer.blockStreamFilterItemTypes");
+        if (app != null && app.blockNodeState() != State.SHUTTING_DOWN) {
+            try {
+                app.shutdown("BlockStreamFilterE2ETests", "teardown");
+            } catch (final RuntimeException ignored) {
+                // benign races during messaging-thread teardown.
+            }
+        }
+    }
+
+    /**
+     * Publishes a block while the publisher is configured with a deny-list for
+     * {@code ROUND_HEADER}. The block is rewritten at ingress with a
+     * {@code FilteredSingleItem} replacing the round header before the messaging
+     * facility sees it. We assert the publisher returns an acknowledgement —
+     * proof that the filter rewriting + downstream pipeline didn't choke on the
+     * rewritten block.
+     */
+    @Test
+    void publisherAcksFilteredBlock() throws Exception {
+        final long blockNumber = 0L;
+        final BlockItem[] items = BlockItemBuilderUtils.createSimpleBlockWithNumber(blockNumber);
+        final PublishStreamRequest blockRequest = PublishStreamRequest.newBuilder()
+                .blockItems(BlockItemSet.newBuilder().blockItems(items).build())
+                .build();
+
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publishSvc =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(publishClient, OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> ackObserver = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> stream = publishSvc.publishBlockStream(ackObserver);
+
+        final AtomicReference<CountDownLatch> ackLatch = ackObserver.setAndGetOnNextLatch(1);
+        stream.onNext(blockRequest);
+        stream.onNext(PublishStreamRequest.newBuilder()
+                .endOfBlock(BlockEnd.newBuilder().blockNumber(blockNumber).build())
+                .build());
+        awaitLatch(ackLatch, "filtered block acknowledgement");
+
+        assertThat(ackObserver.getOnNextCalls()).isNotEmpty();
+        // The response is either an ACK (block accepted) or a structured non-ACK
+        // status; both are valid outcomes that prove the filter didn't crash the
+        // ingest pipeline. A crash would manifest as no on-next call at all.
+        assertThat(ackObserver.getOnNextCalls().get(0).response().kind()).isNotNull();
+
+        stream.closeConnection();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private PbjGrpcClient createGrpcClient() {
+        final Duration timeout = Duration.ofSeconds(30);
+        final Tls tls = Tls.builder().enabled(false).build();
+        final WebClient webClient = WebClient.builder()
+                .baseUri("http://localhost:" + SERVER_PORT)
+                .tls(tls)
+                .protocolConfigs(List.of(GrpcClientProtocolConfig.builder()
+                        .abortPollTimeExpired(false)
+                        .pollWaitTime(timeout)
+                        .build()))
+                .connectTimeout(timeout)
+                .keepAlive(true)
+                .build();
+        return new PbjGrpcClient(
+                webClient, new PbjGrpcClientConfig(timeout, tls, OPTIONS.authority(), OPTIONS.contentType()));
+    }
+
+    private void awaitLatch(final AtomicReference<CountDownLatch> latch, final String desc)
+            throws InterruptedException {
+        latch.get().await(AWAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        assertEquals(0, latch.get().getCount(), "Timed out waiting for: " + desc);
+    }
+}

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockStreamFilterE2ETests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockStreamFilterE2ETests.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Timeout;
 
 /**
  * E2E tests for the block-stream filter on the publisher side. Each test
- * configures {@link org.hiero.block.node.stream.publisher.PublisherConfig}
+ * configures {@code PublisherConfig}
  * via System properties (the same {@code SystemPropertiesConfigSource}
  * ordinal-400 pattern used by {@code BlockNodeCloudStorageTests}), boots
  * {@code BlockNodeApp} in-JVM, and exercises the publisher gRPC.


### PR DESCRIPTION
## Reviewer Notes

This branch is a **spike**, not a finished feature. The goal was to land working block-stream filtering as quickly as possible so downstream work (state management, partner integrations, perf tests) can begin against real code instead of a design doc. The code works, has unit + plugin-level + E2E coverage including a real publish→verify→persist→serve round-trip, and is safe to ship as **beta software**. Improvements and hardening that would otherwise have blocked this PR are captured as follow-up STORY tickets under `agent/proposals/block-stream-filtering/tickets/` for separate scheduling.

If you're reviewing: read the design doc first (`docs/design/filtering/block-stream-filtering.md`), then the commit-by-commit log on this branch. The commits are intentionally fine-grained — each fix is paired with its tests in an adjacent commit, per repo convention.

## Why a spike, not a polished feature

Filtering is a capability we need to **showcase and exercise** in the next phase. The choice was:

- **Polish-first path** — keep iterating until every edge is covered (metrics, server-side defaults, block-access unary read, whole-sub-tree optimisation, entity-level filtering). Probably 4–6 weeks of work before anything merges.
- **Spike path (this PR)** — ship the smallest version that is correct and verifiable end-to-end, with explicit follow-up tickets for everything else. Get integrations and feedback now, harden as the real requirements surface.

We took the spike path. The acceptance bar was deliberately set at "filter → verify → persist → serve" — not "feature-complete filtering". Anything outside that bar lives in a follow-up ticket.

## What this PR delivers

End-to-end per-`BlockItem`-kind filtering with two call paths, both behind a single shared helper:

| Where        | Driven by                | Loss   | Notes |
|--------------|--------------------------|--------|-------|
| Publisher    | `PublisherConfig` (operator) | Lossy   | Filter applies at ingress; filtered items never reach storage, verification, or downstream subscribers — they're replaced by `FilteredSingleItem` carrying the original leaf hash. |
| Subscriber   | `SubscribeStreamRequest.filter` (per request) | Lossless | Storage and replication see the full stream; only the on-wire response is trimmed for this subscriber. |

Filterable items are restricted to a known-good set: `{2 EventHeader, 3 RoundHeader, 4 SignedTransaction, 5 TransactionResult, 6 TransactionOutput, 7 StateChanges, 10 RecordFile, 11 TraceData}`. Mandatory items (`BlockHeader`, `BlockProof`, `BlockFooter`) and filter markers (`FilteredSingleItem`, `RedactedItem`) cannot be filtered — naming them in a filter spec is an explicit error.

### Components touched

- **Proto** — `BlockStreamFilter` (new message) + `SubscribeStreamRequest.filter` field.
- **`block-node/base`** — new `org.hiero.block.node.base.filter.BlockItemFilter` helper used by every plugin that filters.
- **Publisher** — `PublisherConfig.blockStreamFilter*` keys, ingress-side rewriting in `PublisherHandler`, fail-fast validation in `StreamPublisherPlugin.start`.
- **Subscriber** — `BlockStreamSubscriberSession` honours `SubscribeStreamRequest.filter`; `SubscriberServicePlugin` surfaces invalid filters as `Code.INVALID_REQUEST`.
- **Verifier** — `ExtendedMerkleTreeSession.processBlockItems` routes `FILTERED_SINGLE_ITEM` to the right sub-tree hasher using the embedded leaf hash + `SubMerkleTree` tag, so the recomputed block root still matches the original proof.
- **Tests** — unit (`BlockItemFilterTest`), plugin (`PublisherConfigFilterTest`, `SubscribeStreamRequestFilterTest`, plugin-level validation tests), E2E (`BlockStreamFilterE2ETests` — publish smoke, single-block verifier round-trip, two-block proof-chain).

### Stats (filtering-related changes only, vs branch point)

```
 17 files changed, 1672 insertions(+), 9 deletions(-)
 + new file: docs/design/filtering/block-stream-filtering.md (~400 lines)
 + new file: BlockStreamFilterE2ETests.java                (~320 lines)
 + new file: BlockItemFilter.java + BlockItemFilterTest.java
```

## Acceptance — what's been verified

- **Unit** (`:base:test`) — `BlockItemFilterTest` covers identity, allow/deny, mandatory-item override, the explicit `BlockItem.item` → `SubMerkleTree` mapping for every supported target, validation rejections, hash equivalence with `HashingUtilities.getBlockItemHash`, publisher↔subscriber composition (no double-filtering), and the fail-loud `subMerkleTreeOf` contract for unmapped field numbers.
- **Plugin** (`:stream-publisher:test`, `:stream-subscriber:test`) — config → filter wiring, request → filter wiring, plugin-start fail-fast on bad publisher config, plugin-level `Code.INVALID_REQUEST` for malformed subscribe filters.
- **Verifier** (`:verification:test`) — existing 105 tests still green with the new `FILTERED_SINGLE_ITEM` case in `processBlockItems`.
- **E2E** (`:suites:runAPISuites --tests "*BlockStreamFilterE2ETests*"`) — three tests:
  1. `publisherAcksFilteredBlock` — publish smoke proving the rewrite doesn't crash ingest.
  2. `filteredBlockIsVerifiedAndServedToSubscribers` — single-block round-trip; publisher ACKs, subscriber sees `FilteredSingleItem`.
  3. `filteredBlockChainVerifiesAcrossTwoBlocks` — two-block proof chain; block 1's proof anchors to block 0's recomputed root, both blocks ACK, both come back from subscribe with `FilteredSingleItem`. Single-block tests cannot catch leaf-hash misalignment or sub-tree mis-routing that would break the anchor.

## Failure modes / fail-fast contracts

- **Operator misconfigures publisher filter** (typo, unsupported type, `include=true` with empty list) → BlockNodeApp fails at boot with the offending value named. Never silently breaks per-connection.
- **Client sends a malformed subscribe filter** → subscriber session returns `Code.INVALID_REQUEST` immediately and closes the stream.
- **Someone widens `SUPPORTED_FILTER_TYPES` without updating the sub-tree mapping table** → `BlockItemFilter.subMerkleTreeOf` throws `IllegalStateException` naming the unmapped field. Silent corruption of the block proof is the failure we explicitly refused to accept.
- **PBJ serialisation fails on `BlockItemUnparsed`** → `IllegalStateException`; should not happen (PBJ serialisation is total over the type).

## Out of scope — captured as follow-up tickets

All deferred work has a dedicated ticket under `agent/proposals/block-stream-filtering/tickets/` (gitignored — these are intended to be converted to GitHub issues by the maintainer when this branch is ready to merge). Each ticket follows the `.github/ISSUE_TEMPLATE/01-Story-Template.yml` format.

| Ticket | Title | Why deferred |
|--------|-------|--------------|
| STORY-F5 | `block-access` filter (unary `getBlock`) | Subscribe with `start=end=N` is a clean workaround for beta. |
| STORY-F8 | Server-side default subscriber filter | Operator can filter at publisher; ticket exists for the lossless-store case. |
| STORY-F9 | Filter metrics (`items_filtered_total`, `invalid_requests_total`, `active_filters`) | Logs cover beta debugging; metrics added when dashboards mature. |
| STORY-F10 | Entity-level filtering | Separate epic — different filter shape, requires body parsing. |
| STORY-F11 | `FilteredMerkleSubTree` whole-tree optimisation | Performance, not correctness. Per-item `FilteredSingleItem` works today. |
| STORY-F12 | Operator-facing config docs | Polish — design doc covers the system, operators need a quick-reference page. |
| STORY-F13 | Boot-time filter activation log line | Polish — `@Loggable` likely covers it; needs operator-pass verification. |

## What I would want a reviewer to look at carefully

1. **Verifier integration** (`ExtendedMerkleTreeSession.processBlockItems`, the new `FILTERED_SINGLE_ITEM` case). The proof correctness of every filtered block hinges on this routing being correct. The two-block E2E exercises it but a fresh pair of eyes is worth a lot here.
2. **Leaf-hash alignment** (`BlockItemFilter.replaceWithFiltered` ↔ `HashingUtilities.getBlockItemHash`). Both must compute `SHA-384(LEAF_PREFIX || item_bytes)`. If `HashingUtilities` ever changes its leaf-hash function, the filter has to follow — there is no compile-time link between them. STORY-F12 should call out this contract for future maintainers.
3. **`SUPPORTED_FILTER_TYPES` ⇄ `subMerkleTreeOf` ⇄ `ALWAYS_FORWARD`** — these three sets must stay consistent. If any are widened, the others may need updates. The fail-loud in `subMerkleTreeOf` is the safety net.
4. **Beta status framing** in `docs/design/filtering/block-stream-filtering.md` — make sure it's set so partners reading the doc don't assume feature-complete behaviour.

## Test plan

- [ ] `./gradlew :base:test :stream-publisher:test :stream-subscriber:test :verification:test --no-daemon` — all green.
- [ ] `./gradlew :suites:runAPISuites -x :app:createDockerImage --tests "*BlockStreamFilterE2ETests*"` — all 3 E2E tests pass.
- [ ] Sanity-boot the app with `producer.blockStreamFilterItemTypes=7` and confirm a published block with state changes comes back from subscribe with `FilteredSingleItem` in place of the state-change items.
- [ ] Sanity-boot with `producer.blockStreamFilterItemTypes=1` and confirm the app fails to start with a clear "unsupported value 1" message.
- [ ] Send a `SubscribeStreamRequest` with `filter = { include: true, block_item_types: [] }` and confirm the server replies `INVALID_REQUEST` and closes.

## Why I'm marking this **beta**, not GA

- The filter helper, validation, verifier integration, and the publisher↔subscriber path are all correct and tested.
- The capability is intentionally **narrower** than what a fully-loaded operator might want: no metrics, no server-side default subscriber filter, no block-access unary-read filter, no whole-sub-tree shortcut, no entity-level filtering, no operator quick-reference doc. Each gap is one of the F5/F8–F13 tickets.
- Production rollout should wait until at least the metrics (F9) and operator-docs (F12) tickets land, so operators have observability and a config reference.
