### PR TITLE
fix(publisher): remove closeConnection() from shutdown() to preserve shared TCP connections

### DIFF
--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -766,7 +766,6 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
             try {
                 replies.onComplete();
                 isPaused.set(false); // unpause to prevent deadlocks.
-                replies.closeConnection();
                 // @todo() Add labeled metric when possible.
                 //    Metric: "handler-closed" Labels: "clean" or "with-exception"
                 //    with-exception should be set in all exception cases, even if not logged.
@@ -782,7 +781,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
                         .formatted(handlerId, correlationIdPrefix);
                 LOGGER.log(DEBUG, message, e);
             }
-            LOGGER.log(DEBUG, "[{0}] Handler {1} issued onComplete/closeConnection", correlationIdPrefix, handlerId);
+            LOGGER.log(DEBUG, "[{0}] Handler {1} issued onComplete", correlationIdPrefix, handlerId);
         }
     }
 

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -19,8 +19,6 @@ import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.grpc.GrpcClientProtocolConfig;
 import io.helidon.webclient.http2.Http2Client;
 import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.net.SocketException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -615,14 +613,14 @@ public class BlockNodeAPITests {
     }
 
     /**
-     * End-to-end socket test for block stream publishing.
+     * End-to-end duplicate-block detection test for block stream publishing.
      * <p>
      * This test covers the following scenarios:
      * <ol>
      *   <li>Publishing a chain of blocks (0..7) so the duplicate in scenario 2 falls outside the
      *       default producer.duplicateBlockSkipWindow and triggers EndOfStream(DUPLICATE_BLOCK).</li>
-     *   <li>Publishing a far-behind duplicate (block 0, distance 7) and confirming stream closure.</li>
-     *   <li>Attempting to publish a new block after the stream is closed, expecting an UncheckedIOException caused by a closed socket.</li>
+     *   <li>Publishing a far-behind duplicate (block 0, distance 7): confirms the server sends
+     *       EndOfStream(DUPLICATE_BLOCK) and closes the HTTP/2 stream (onComplete).</li>
      * </ol>
      */
     @Test
@@ -679,7 +677,15 @@ public class BlockNodeAPITests {
 
         awaitLatch(socketDuplicateConnectionEndedLatch, "socket test duplicate block connection closed");
 
-        // query status to confirm the persisted block range covers 0..7
+        // Confirm the server sent EndOfStream(DUPLICATE_BLOCK) before closing the HTTP/2 stream.
+        assertThat(responseObserver.getOnNextCalls())
+                .as("server must send EndOfStream(DUPLICATE_BLOCK) before closing the stream")
+                .hasSize(totalBlocks + 1)
+                .last()
+                .returns(PublishStreamResponse.ResponseOneOfType.END_STREAM, responseKindExtractor)
+                .returns(PublishStreamResponse.EndOfStream.Code.DUPLICATE_BLOCK, endStreamResponseCodeExtractor);
+
+        // Query status to confirm the persisted block range covers 0..7.
         BlockNodeServiceInterface.BlockNodeServiceClient blockNodeServiceClient =
                 new BlockNodeServiceInterface.BlockNodeServiceClient(serverStatusPbjGrpcClient, OPTIONS);
         final ServerStatusResponse nodeStatusPostDuplicateBlock =
@@ -688,35 +694,13 @@ public class BlockNodeAPITests {
         assertThat(nodeStatusPostDuplicateBlock.firstAvailableBlock()).isEqualTo(0);
         assertThat(nodeStatusPostDuplicateBlock.lastAvailableBlock()).isEqualTo(headBlock);
 
-        // ==== Scenario 3: Attempt to publish a new block after stream closure and expect UncheckedIOException ====
-        final long nextBlockNumber = totalBlocks;
-        BlockItem[] nextBlockItems =
-                BlockItemBuilderUtils.createSimpleBlockWithNumber(nextBlockNumber, previousBlockHash);
-        PublishStreamRequest nextBlockRequest = PublishStreamRequest.newBuilder()
-                .blockItems(BlockItemSet.newBuilder().blockItems(nextBlockItems).build())
-                .build();
-
-        // This asserts that UncheckedIOException is thrown and its cause is a SocketException with "socket closed"
-        UncheckedIOException ex = assertThrows(UncheckedIOException.class, () -> {
-            // Expected exception to be thrown on the onNext() due to closed socket
-            // from previous duplicate block publish
-            requestStream.onNext(nextBlockRequest);
-        });
-        assertEquals(
-                SocketException.class.getSimpleName(), ex.getCause().getClass().getSimpleName());
-        boolean causeMatches = ex.getCause().getMessage().toLowerCase().contains("socket closed")
-                || ex.getCause().getMessage().toLowerCase().contains("broken pipe");
-        assertTrue(
-                causeMatches,
-                "Unexpected socket exception: " + ex.getCause().getMessage().toLowerCase());
-
-        // close the client connections
-        requestStream.closeConnection();
         blockStreamPublishServiceClient.close();
     }
 
-    // to-do: re-enable once the server-side early-close race is fixed in PublisherHandler.shutdown().
-    // The server RSTs the connection before END_STREAM is flushed, so onNext(END_STREAM) is never received.
+    // Disabled: the test setup (single block 0 resent as duplicate) triggers SKIP_BLOCK (within the
+    // default skip window of 5) instead of EndOfStream(DUPLICATE_BLOCK). To trigger END_DUPLICATE,
+    // 6+ blocks must be sent first so block 0 falls outside the window. The END_DUPLICATE +
+    // EndOfStream(DUPLICATE_BLOCK) + onComplete() behaviour is now fully covered by e2eSocketClosureTest.
     @Disabled
     @Test
     void e2eDuplicateBlockPublisherObserversOnComplete() throws InterruptedException {
@@ -753,16 +737,12 @@ public class BlockNodeAPITests {
         assertThat(responseObserver.getClientEndStreamCalls().get()).isEqualTo(0);
 
         // ==== Scenario 2: Publish duplicate genesis block and confirm duplicate block response and stream closure ===
-        // Gate on connection end (onComplete or onError) rather than onNext(END_STREAM), because the server may
-        // RST the connection before the END_STREAM frame is flushed to the client.
         final AtomicReference<CountDownLatch> duplicateConnectionEndedLatch =
                 responseObserver.setAndGetConnectionEndedLatch(1);
         requestStream.onNext(request);
 
         awaitLatch(duplicateConnectionEndedLatch, "duplicate block connection closed");
 
-        // Assert that the END_STREAM response was received with DUPLICATE_BLOCK code.
-        // If the server fixes the early-close race, this will be reliably present.
         assertThat(responseObserver.getOnNextCalls())
                 .hasSize(2)
                 .element(1)

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeApiRegressionTest.java
@@ -357,6 +357,96 @@ public class BlockNodeApiRegressionTest {
         blockAccessClient.close();
     }
 
+    /// Proves that `replies.closeConnection()` in `shutdown()` destroys stream B mid-block when
+    /// stream B has already sent its block header but has not yet sent the footer or proof.
+    ///
+    /// ## Scenario
+    ///
+    /// Stream A ACKs blocks 0–1 completely — it is **not** mid-block when `EndStream(RESET)` fires,
+    /// so `blockIsEnding()` is never called and no `RESEND` will be triggered.  Stream B (same TCP
+    /// connection) sends the block-2 header and round header **before** `EndStream`.  The test then
+    /// waits for stream A to end (`onComplete` without bug, `onError` with bug), then stream B
+    /// sends the footer and proof.
+    ///
+    /// **Without bug:** `shutdown()` calls only `replies.onComplete()`, closing only stream A's
+    /// HTTP/2 stream.  The shared TCP socket stays alive; stream B delivers the block body,
+    /// receives ACK(2), and no error is reported.
+    ///
+    /// **With bug (`closeConnection()` present):** `shutdown()` additionally calls
+    /// `replies.closeConnection()`, closing the shared TCP socket.  Stream A's observer fires
+    /// `onError`, the latch unblocks, and stream B's subsequent sends fail because the TCP socket
+    /// is already gone.
+    @Test
+    @DisplayName("stream B delivers block body after stream A EndStream(RESET) shutdown completes")
+    void streamBDeliversBlockBodyAfterStreamAShutdownDelay() throws InterruptedException {
+        final Bytes hash0 = BlockItemBuilderUtils.computeBlockHash(0L, null);
+        final Bytes hash1 = BlockItemBuilderUtils.computeBlockHash(1L, hash0);
+
+        // Stream A: ACK blocks 0–1 completely so nextUnstreamedBlockNumber = 2.
+        // Stream A is NOT mid-block when EndStream fires — no blockIsEnding(), no RESEND.
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherAClient =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
+                        publishBlockStreamPbjGrpcClient, OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> observerA = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> streamA = publisherAClient.publishBlockStream(observerA);
+
+        final Bytes[] prevHashes = {null, hash0};
+        for (long blockNum = 0L; blockNum <= 1L; blockNum++) {
+            final AtomicReference<CountDownLatch> ackLatch = observerA.setAndGetOnNextLatch(1);
+            streamA.onNext(buildPublishRequest(
+                    BlockItemBuilderUtils.createSimpleBlockWithNumber(blockNum, prevHashes[(int) blockNum])));
+            endBlock(blockNum, streamA);
+            awaitLatch(ackLatch, "ACK for block " + blockNum + " on stream A");
+        }
+
+        // Open stream B on the SAME PbjGrpcClient — same TCP connection.
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publisherBClient =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
+                        publishBlockStreamPbjGrpcClient, OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> observerB = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> streamB = publisherBClient.publishBlockStream(observerB);
+
+        // Block 2 items split: header part (sent while both streams are live) and body part
+        // (sent after the 20 ms shutdown window, when the TCP socket should still be open).
+        final BlockItem[] block2Items = BlockItemBuilderUtils.createSimpleBlockWithNumber(2L, hash1);
+        final BlockItem[] block2Header = {block2Items[0], block2Items[1]};
+        final BlockItem[] block2Body = {block2Items[2], block2Items[3]};
+
+        // Stream B sends the block-2 header and round header — in-flight while stream A is still live.
+        streamB.onNext(buildPublishRequest(block2Header));
+
+        // Stream A sends EndStream(RESET) — schedules shutdown() after SHUTDOWN_DELAY_TIME (10 ms).
+        // Arm the latch before sending so it captures whichever callback fires first.
+        final AtomicReference<CountDownLatch> streamAEndedLatch = observerA.setAndGetConnectionEndedLatch(1);
+        streamA.onNext(PublishStreamRequest.newBuilder()
+                .endStream(PublishStreamRequest.EndStream.newBuilder()
+                        .endCode(PublishStreamRequest.EndStream.Code.RESET)
+                        .build())
+                .build());
+
+        // Wait for stream A to end — fires onComplete (fix) or onError (bug).
+        // With fix: replies.onComplete() closes only stream A's HTTP/2 stream; TCP stays alive.
+        // With bug: replies.closeConnection() closes the shared TCP socket before this returns.
+        awaitLatch(streamAEndedLatch, "stream A closed after EndStream(RESET)");
+
+        // Stream B sends the footer and proof, then signals end-of-block.
+        // With the bug: TCP is closed — sends fail or ACK(2) never arrives.
+        // Without the bug: TCP is alive — ACK(2) is delivered.
+        final AtomicReference<CountDownLatch> ack2Latch = observerB.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
+                        && Objects.requireNonNull(response.acknowledgement()).blockNumber() == 2L);
+        streamB.onNext(buildPublishRequest(block2Body));
+        endBlock(2L, streamB);
+
+        awaitLatch(ack2Latch, "ACK(2) on stream B — TCP connection must survive stream A shutdown", observerB);
+        assertThat(observerB.getOnErrorCalls())
+                .as("stream B must receive no connection error — closeConnection() must not be called")
+                .isEmpty();
+
+        publisherAClient.close();
+        publisherBClient.close();
+    }
+
     private PbjGrpcClient createGrpcClient() {
         final Duration timeoutDuration = Duration.ofSeconds(30);
         final Tls tls = Tls.builder().enabled(false).build();


### PR DESCRIPTION
fix(publisher): remove closeConnection() from shutdown() to preserve shared TCP connections (#2899)

## Summary

Fixes a latent bug in `PublisherHandler.shutdown()` exposed by the receive-buffer increase in #2835. One production bug is fixed, the test suite is updated to match the corrected behaviour, and one regression test is added.

### Root cause

During the Schnorr→WRAPS signature transition the CN sends `EndStream(RESET)` on stream A then immediately opens stream B on the **same TCP connection** to deliver the first WRAPS-signed block.

`PublisherHandler.shutdown()` (introduced in #1859) calls both `replies.onComplete()` and `replies.closeConnection()`. In Helidon, `onComplete()` closes only the HTTP/2 stream (stream A). `closeConnection()` closes the underlying TCP socket — shared by all HTTP/2 streams, including stream B. Stream B never delivers its block; the BN gets stuck and loops.

The bug was masked until #2835 increased `socketReceiveBufferSizeBytes` from 128 KB to 8 MB. The larger buffer lets the CN push the full 90 MB WRAPS block into the kernel without TCP back-pressure, then immediately send EndStream(RESET) and open stream B — all before the BN application has processed the block. The tighter timing window made the race reliably observable.

## Changes

- **`PublisherHandler.java`** — remove `replies.closeConnection()` from `shutdown()`; `replies.onComplete()` is sufficient.
- **`BlockNodeAPITests.java`** — `e2eSocketClosureTest`: assert `EndOfStream(DUPLICATE_BLOCK)` instead of socket-closed exception (no longer thrown). Update `@Disabled` reason on `e2eDuplicateBlockPublisherObserversOnComplete` to reflect `SKIP_BLOCK` window from #2877.
- **`BlockNodeApiRegressionTest.java`** — add `streamBDeliversBlockBodyAfterStreamAShutdownDelay`: stream B sends a block header before EndStream on stream A, waits for stream A `onComplete`, then sends the block body; asserts ACK and no errors on stream B.

## Test plan

- [x] `./gradlew :suites:runAPISuites` — 14 tests pass, 1 skipped
- [x] `tss-signature-transition` solo-e2e passes on CI see [here](https://github.com/hiero-ledger/hiero-block-node/actions/runs/26551647484/job/78214819257)

