### PR TITLE
feat: add tss-enablement.json output for Block Node consumption

### DIFF
--- a/docs/block-node/operations/wrb-cli-runbook.md
+++ b/docs/block-node/operations/wrb-cli-runbook.md
@@ -522,10 +522,10 @@ During validation, the CLI automatically detects and extracts TSS (Threshold Sig
 
 **Output Files**:
 
-| File | Format | Purpose |
-|------|--------|---------|
-| `tss-enablement.bin` | Protobuf binary | TssData in protobuf format for archival |
-| `tss-bootstrap-roster.json` | JSON | TssData in JSON format matching Block Node's ApplicationStateConfig |
+|            File             |     Format      |                               Purpose                               |
+|-----------------------------|-----------------|---------------------------------------------------------------------|
+| `tss-enablement.bin`        | Protobuf binary | TssData in protobuf format for archival                             |
+| `tss-bootstrap-roster.json` | JSON            | TssData in JSON format matching Block Node's ApplicationStateConfig |
 
 **Example JSON Output** (`tss-bootstrap-roster.json`):
 
@@ -540,8 +540,7 @@ During validation, the CLI automatically detects and extracts TSS (Threshold Sig
         "weight": 1000,
         "schnorr_public_key": "0a1b2c3d4e5f6a7b8c9d0e1f..."
       }
-    ],
-    "valid_from_block": 42
+    ]
   },
   "valid_from_block": 42
 }

--- a/docs/block-node/operations/wrb-cli-runbook.md
+++ b/docs/block-node/operations/wrb-cli-runbook.md
@@ -79,6 +79,8 @@ Recommended layout for operations:
 │   └── ...
 └── wrappedBlocks/                    # Wrapped Block Stream output
     ├── addressBookHistory.json       # Address book changes over time
+    ├── tss-enablement.bin            # TSS parameters protobuf (if TSS enabled)
+    ├── tss-bootstrap-roster.json     # TSS parameters JSON (if TSS enabled)
     ├── 0/                            # Block 0
     ├── 1/                            # Block 1
     └── ...
@@ -513,6 +515,42 @@ nohup java \
 - **Workaround**: Use `--skip-supply` for testnet validation
 - **Root cause**: Testnet Consensus Node bug from HAPI v0.52.0 (August 2024)
 - **Reference**: [Testnet Mirror API](https://testnet.mirrornode.hedera.com/api/v1/blocks/7557270)
+
+**TSS Enablement Detection**:
+
+During validation, the CLI automatically detects and extracts TSS (Threshold Signature Scheme) enablement data from `LedgerIdPublication` transactions. When detected, two files are written to the wrapped blocks directory:
+
+**Output Files**:
+
+| File | Format | Purpose |
+|------|--------|---------|
+| `tss-enablement.bin` | Protobuf binary | TssData in protobuf format for archival |
+| `tss-bootstrap-roster.json` | JSON | TssData in JSON format matching Block Node's ApplicationStateConfig |
+
+**Example JSON Output** (`tss-bootstrap-roster.json`):
+
+```json
+{
+  "ledger_id": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+  "wraps_verification_key": "a1b2c3d4e5f6a7b8c9d0...",
+  "current_roster": {
+    "roster_entries": [
+      {
+        "node_id": 0,
+        "weight": 1000,
+        "schnorr_public_key": "0a1b2c3d4e5f6a7b8c9d0e1f..."
+      }
+    ],
+    "valid_from_block": 42
+  },
+  "valid_from_block": 42
+}
+```
+
+**Usage**:
+- The JSON file can be directly consumed by the Block Node's `ApplicationStateConfig`
+- Both files are updated automatically on each TSS publication detection
+- Validation output shows: `TSS publication at block <N>: <description>`
 
 ---
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/TssEnablementValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/TssEnablementValidation.java
@@ -37,6 +37,7 @@ public final class TssEnablementValidation implements BlockValidation {
 
     private final TssEnablementRegistry tssRegistry;
     private final Path tssParametersBinPath;
+    private final Path tssParametersJsonPath;
     private boolean firstPublicationSeen = false;
 
     /**
@@ -48,6 +49,8 @@ public final class TssEnablementValidation implements BlockValidation {
     public TssEnablementValidation(final TssEnablementRegistry tssRegistry, final Path tssParametersBinPath) {
         this.tssRegistry = tssRegistry;
         this.tssParametersBinPath = tssParametersBinPath;
+        // Derive JSON path from bin path: change tss-enablement.bin to tss-bootstrap-roster.json
+        this.tssParametersJsonPath = tssParametersBinPath.getParent().resolve("tss-bootstrap-roster.json");
     }
 
     @Override
@@ -57,7 +60,7 @@ public final class TssEnablementValidation implements BlockValidation {
 
     @Override
     public String description() {
-        return "Discovers LedgerIdPublication transactions from block data and writes tss-enablement.bin";
+        return "Discovers LedgerIdPublication transactions from block data and writes tss-enablement.bin and tss-bootstrap-roster.json";
     }
 
     @Override
@@ -111,12 +114,18 @@ public final class TssEnablementValidation implements BlockValidation {
                         tssRegistry.recordPublication(blockInstant, blockNumber, body.ledgerIdPublicationOrThrow());
                 System.out.println(
                         Ansi.AUTO.string("@|yellow TSS publication at block " + blockNumber + ":|@ " + description));
-                // Write tss-enablement.bin immediately on each detection
+                // Write tss-enablement.bin and tss-bootstrap-roster.json immediately on each detection
                 try {
                     tssRegistry.writeTssParametersBin(tssParametersBinPath);
                 } catch (Exception e) {
                     System.err.println(
                             "[TssEnablement] WARNING: Failed to write " + tssParametersBinPath + ": " + e.getMessage());
+                }
+                try {
+                    tssRegistry.writeTssDataJson(tssParametersJsonPath);
+                } catch (Exception e) {
+                    System.err.println("[TssEnablement] WARNING: Failed to write " + tssParametersJsonPath + ": "
+                            + e.getMessage());
                 }
             }
         }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/TssEnablementRegistry.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/TssEnablementRegistry.java
@@ -141,6 +141,26 @@ public class TssEnablementRegistry {
     }
 
     /**
+     * Write the latest {@link TssData} as JSON for the block node to consume.
+     * This writes a single TssData snapshot (not the full history) in JSON format,
+     * suitable for use as the Block Node's tss-bootstrap-roster.json file.
+     *
+     * @param file the output file path
+     * @throws Exception if the file cannot be written
+     */
+    public void writeTssDataJson(final Path file) throws Exception {
+        final TssData tssData = getLatestTssData();
+        if (tssData == null) {
+            return;
+        }
+        HasherStateFiles.saveAtomically(file, tmpPath -> {
+            try (var out = new WritableStreamingData(Files.newOutputStream(tmpPath))) {
+                TssData.JSON.write(tssData, out);
+            }
+        });
+    }
+
+    /**
      * Returns whether any TSS publication data has been recorded.
      *
      * @return true if at least one publication exists

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/model/TssEnablementRegistryTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/model/TssEnablementRegistryTest.java
@@ -210,4 +210,36 @@ class TssEnablementRegistryTest {
             assertFalse(Files.exists(binFile));
         }
     }
+
+    @Nested
+    @DisplayName("writeTssDataJson")
+    class WriteJson {
+
+        @Test
+        @DisplayName("writes parseable TssData JSON")
+        void writesParseableJson(@TempDir Path tempDir) throws Exception {
+            TssEnablementRegistry registry = new TssEnablementRegistry();
+            LedgerIdPublicationTransactionBody original = createPublication(LEDGER_ID, WRAPS_VK, 0, 1000, 1, 2000);
+            registry.recordPublication(Instant.ofEpochSecond(100), 42, original);
+
+            Path jsonFile = tempDir.resolve("tss-bootstrap-roster.json");
+            registry.writeTssDataJson(jsonFile);
+
+            assertTrue(Files.exists(jsonFile));
+            Bytes fileBytes = Bytes.wrap(Files.readAllBytes(jsonFile));
+            TssData parsed = TssData.JSON.parse(fileBytes.toReadableSequentialData());
+            assertEquals(LEDGER_ID, parsed.ledgerId());
+            assertEquals(WRAPS_VK, parsed.wrapsVerificationKey());
+            assertEquals(2, parsed.currentRosterOrThrow().rosterEntries().size());
+        }
+
+        @Test
+        @DisplayName("does nothing when registry is empty")
+        void doesNothingWhenEmpty(@TempDir Path tempDir) throws Exception {
+            TssEnablementRegistry registry = new TssEnablementRegistry();
+            Path jsonFile = tempDir.resolve("tss-bootstrap-roster.json");
+            registry.writeTssDataJson(jsonFile);
+            assertFalse(Files.exists(jsonFile));
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add JSON output alongside existing bin file to provide 1:1 format match with Block Node's ApplicationStateConfig expectations
- CLI now writes both `tss-enablement.bin` (protobuf) and `tss-enablement.json` (JSON) with the same TssData content

## Changes
- **TssEnablementRegistry**: Add `writeTssDataJson()` method to write latest TssData snapshot as JSON
- **TssEnablementValidation**: Write both tss-enablement.bin and tss-enablement.json on each TSS publication detection

## Output Files
- `tss-enablement.bin`: TssData protobuf (existing)
- `tss-bootstrap-roster.json`: TssData JSON (new) ← matches BN's ApplicationStateConfig format
- `tssPublicationHistory.json`: Full history array (unchanged)


## Example

```

{
  "ledger_id": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
  "wraps_verification_key": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
  "current_roster": {
    "roster_entries": [
      {
        "node_id": 0,
        "weight": 1000,
        "schnorr_public_key": "0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
      },
      {
        "node_id": 1,
        "weight": 2000,
        "schnorr_public_key": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3"
      },
      {
        "node_id": 2,
        "weight": 1500,
        "schnorr_public_key": "2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4"
      }
    ],
    "valid_from_block": 42
  },
  "valid_from_block": 42
}

```
