### PR TITLE
feat: add generateAddressBookFromBin command for previewnet support

### DIFF
--- a/docs/block-node/operations/wrb-cli-runbook.md
+++ b/docs/block-node/operations/wrb-cli-runbook.md
@@ -138,6 +138,49 @@ java -jar tools-<version>-all.jar \
 - Run this before starting wrapping or validation
 - Re-run periodically to capture new address book changes
 
+#### Fallback: Generate from Binary File (For Networks Without Mirror Node Backups)
+
+For networks like previewnet where Mirror Node CSV backups are not available, you can generate the address book history from a raw protobuf binary file (file 0.0.102 from the database).
+
+**Command**:
+
+```bash
+java -jar tools-<version>-all.jar \
+  mirror generateAddressBookFromBin \
+  address_book.bin \
+  -o wrappedBlocks/addressBookHistory.json
+```
+
+**Options**:
+
+```bash
+# Use current system time as consensus timestamp
+java -jar tools-<version>-all.jar \
+  mirror generateAddressBookFromBin \
+  address_book.bin \
+  -o wrappedBlocks/addressBookHistory.json \
+  --use-current-time
+
+# Specify custom consensus timestamp (format: seconds.nanos)
+java -jar tools-<version>-all.jar \
+  mirror generateAddressBookFromBin \
+  address_book.bin \
+  -o wrappedBlocks/addressBookHistory.json \
+  --timestamp 1234567890.123456789
+```
+
+**How to obtain the bin file**:
+- Export file 0.0.102 from the network's database
+- For previewnet: Contact the network operator for the latest address book export
+- The file contains the protobuf-serialized `NodeAddressBook` message
+
+**Output**: Same format as `generateAddressBook` - a JSON file with address book history that can be used for block proof verification.
+
+**When to use**:
+- Previewnet or custom networks without Mirror Node CSV exports
+- Emergency recovery when Mirror Node is unavailable
+- Testing with historical address book snapshots
+
 ---
 
 ### 2. Update Metadata Files

--- a/tools-and-tests/tools/README.md
+++ b/tools-and-tests/tools/README.md
@@ -102,6 +102,7 @@ subcommands
 │   ├── extractDayBlocksFromApi # Generate day_blocks.json from REST API
 │   ├── update                # Update block data from Mirror Node
 │   ├── generateAddressBook   # Generate address book from CSV
+│   ├── generateAddressBookFromBin # Generate address book from binary file
 │   ├── compareAddressBooks   # Compare two address book files
 │   ├── generateTestnetAddressBook # Generate testnet genesis address book
 │   └── generateTestnetAddressBookHistory # Generate testnet address book history

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/GenerateAddressBookFromBinFile.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/GenerateAddressBookFromBinFile.java
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.mirrornode;
+
+import com.hedera.hapi.node.base.NodeAddressBook;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import org.hiero.block.internal.AddressBookHistory;
+import org.hiero.block.internal.DatedNodeAddressBook;
+import org.hiero.block.tools.utils.TimeUtils;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Generate address book history JSON from a protobuf binary file.
+ *
+ * <p>This command is useful for networks like previewnet where Mirror Node CSV exports
+ * are not available. It reads a raw address book protobuf binary file (e.g., file 0.0.102
+ * from the database) and generates the addressBookHistory.json format expected by WRB CLI tools.
+ */
+@Command(
+        name = "generateAddressBookFromBin",
+        description = "Generate address book history JSON from a protobuf binary file (file 0.0.102)")
+public class GenerateAddressBookFromBinFile implements Runnable {
+
+    @picocli.CommandLine.Parameters(
+            index = "0",
+            description = "Input path to address book binary file (e.g., address_book.bin)")
+    private Path inputFile;
+
+    @Option(
+            names = {"--output", "-o"},
+            description = "Output path for address book history JSON file",
+            defaultValue = "data/addressBookHistory.json")
+    private Path outputFile;
+
+    @Option(
+            names = {"--timestamp", "-t"},
+            description =
+                    "Consensus timestamp for this address book in format 'seconds.nanos' (e.g., '1234567890.123456789'). "
+                            + "If not provided, uses genesis timestamp (1970-01-01T00:00:00Z)")
+    private String timestamp;
+
+    @Option(
+            names = {"--use-current-time"},
+            description = "Use current system time as the consensus timestamp (default: false, uses genesis timestamp)")
+    private boolean useCurrentTime = false;
+
+    @Override
+    public void run() {
+        try {
+            if (!Files.exists(inputFile)) {
+                System.err.println("Error: Input file not found: " + inputFile);
+                System.exit(1);
+            }
+
+            System.out.println("Reading address book from: " + inputFile);
+            byte[] binData = Files.readAllBytes(inputFile);
+            System.out.println("Read " + binData.length + " bytes");
+
+            // Parse protobuf
+            NodeAddressBook addressBook = NodeAddressBook.PROTOBUF.parse(
+                    new ReadableStreamingData(new java.io.ByteArrayInputStream(binData)));
+
+            System.out.println(
+                    "Parsed address book with " + addressBook.nodeAddress().size() + " nodes");
+
+            // Create timestamp
+            Timestamp ts = createTimestamp();
+            Instant instant = Instant.ofEpochSecond(ts.seconds(), ts.nanos());
+            System.out.println("Using consensus timestamp: " + instant);
+
+            // Create dated address book
+            DatedNodeAddressBook datedAddressBook = new DatedNodeAddressBook(ts, addressBook);
+
+            // Write to JSON
+            writeAddressBookHistory(List.of(datedAddressBook));
+            System.out.println("Address book history written to: " + outputFile);
+
+            // Print node summary
+            printNodeSummary(addressBook);
+
+        } catch (Exception e) {
+            System.err.println("Error: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    private Timestamp createTimestamp() {
+        if (timestamp != null) {
+            // Parse custom timestamp format: "seconds.nanos"
+            String[] parts = timestamp.split("\\.");
+            if (parts.length != 2) {
+                throw new IllegalArgumentException(
+                        "Invalid timestamp format. Expected 'seconds.nanos', got: " + timestamp);
+            }
+            long seconds = Long.parseLong(parts[0]);
+            int nanos = Integer.parseInt(parts[1]);
+            return Timestamp.newBuilder().seconds(seconds).nanos(nanos).build();
+        } else if (useCurrentTime) {
+            // Use current system time
+            Instant now = Instant.now();
+            return Timestamp.newBuilder()
+                    .seconds(now.getEpochSecond())
+                    .nanos(now.getNano())
+                    .build();
+        } else {
+            // Default: use genesis timestamp
+            return TimeUtils.GENESIS_TIMESTAMP;
+        }
+    }
+
+    private void writeAddressBookHistory(List<DatedNodeAddressBook> addressBooks) throws IOException {
+        Path parentDir = outputFile.getParent();
+        if (parentDir != null) {
+            Files.createDirectories(parentDir);
+        }
+
+        try (WritableStreamingData out = new WritableStreamingData(Files.newOutputStream(outputFile))) {
+            AddressBookHistory history = new AddressBookHistory(addressBooks);
+            AddressBookHistory.JSON.write(history, out);
+        }
+    }
+
+    private void printNodeSummary(NodeAddressBook addressBook) {
+        System.out.println("\n" + "=".repeat(80));
+        System.out.println("NODE SUMMARY");
+        System.out.println("=".repeat(80));
+
+        for (var node : addressBook.nodeAddress()) {
+            long nodeId = getNodeAccountId(node);
+            System.out.printf("Node 0.0.%d: %s:%d - %s%n", nodeId, node.ipAddress(), node.portno(), node.description());
+        }
+
+        System.out.println("=".repeat(80));
+    }
+
+    private long getNodeAccountId(com.hedera.hapi.node.base.NodeAddress nodeAddress) {
+        if (nodeAddress.hasNodeAccountId() && nodeAddress.nodeAccountId().hasAccountNum()) {
+            return nodeAddress.nodeAccountId().accountNum();
+        } else if (nodeAddress.memo().length() > 0) {
+            final String memoStr = nodeAddress.memo().asUtf8String();
+            return Long.parseLong(memoStr.substring(memoStr.lastIndexOf('.') + 1));
+        } else {
+            throw new IllegalArgumentException("NodeAddress has no nodeAccountId or memo: " + nodeAddress);
+        }
+    }
+}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/MirrorNodeCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/MirrorNodeCommand.java
@@ -23,6 +23,7 @@ import picocli.CommandLine.Spec;
             ExtractDayBlocksFromApi.class,
             UpdateBlockData.class,
             GenerateAddressBookFromMirrorNode.class,
+            GenerateAddressBookFromBinFile.class,
             GenerateTestnetGenesisAddressBook.class,
             GenerateTestnetAddressBookHistory.class,
             CompareAddressBooks.class


### PR DESCRIPTION
## Summary

Adds a new `mirror generateAddressBookFromBin` command to generate address book history JSON from raw protobuf binary files. This enables WRB CLI support for networks like previewnet where Mirror Node CSV exports are not available.

## Changes

### New Command: `mirror generateAddressBookFromBin`

**Purpose**: Generate address book history JSON from a protobuf binary file (file 0.0.102 from database).

**Usage**:
```bash
# Basic usage (uses genesis timestamp by default)
java -jar tools.jar mirror generateAddressBookFromBin \
  -i previewnet_ab.bin \
  -o wrappedBlocks/addressBookHistory.json

# Use current system time
java -jar tools.jar mirror generateAddressBookFromBin \
  -i previewnet_ab.bin \
  -o wrappedBlocks/addressBookHistory.json \
  --use-current-time

# Specify custom consensus timestamp (format: seconds.nanos)
java -jar tools.jar mirror generateAddressBookFromBin \
  -i previewnet_ab.bin \
  -o wrappedBlocks/addressBookHistory.json \
  --timestamp 1234567890.123456789
```

**Features**:
- Parses raw protobuf `NodeAddressBook` binary files
- Generates same JSON format as `generateAddressBook` command
- Displays node summary (ID, IP, port, description) after generation
- Supports custom timestamps or defaults (genesis/current time)

### Documentation Updates

1. **WRB CLI Runbook** (`docs/block-node/operations/wrb-cli-runbook.md`)
   - Added "Fallback: Generate from Binary File" section
   - Documents when to use this command
   - Explains how to obtain bin files
   - Provides usage examples

2. **Tools README** (`tools-and-tests/tools/README.md`)
   - Added command to mirror subcommands list

## Use Cases

- **Previewnet**: No Mirror Node CSV exports available
- **Testing**: Using historical address book snapshots
- **Custom networks**: Without Mirror Node infrastructure

## Testing

Tested with previewnet_ab.bin (file 0.0.102, 7061 bytes):
```
✓ Successfully parsed 7 nodes
✓ Generated addressBookHistory.json in correct format
✓ Node summary displayed correctly
✓ Timestamp options work as expected
```

## Related

Partial implementation for #2893 (Enable WRB CLI to run on previewnet) - provides the address book generation component needed for previewnet support.
