### PR TITLE
fix(solo-e2e-test): CN properties override and improved log collection

### DIFF
--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -972,24 +972,26 @@ jobs:
             echo "Failed to collect CN diagnostics (deployment may be unavailable)"
           LOG_FOLDER="${HOME}/.solo/logs"
 
-          # Create filtered CN logs directory - extract only BN-relevant files
-          # This reduces artifact size from GB to MB by excluding:
-          # - solo.log/solo.ndjson (1.5+ TB of Solo CLI operations)
-          # - Most CN zip contents (consensus internals, state logs)
+          # Create filtered CN logs directory.
+          # Size driver was solo.log/solo.ndjson (GB-scale) — we truncate solo.log and skip ndjson.
+          # Per-node diagnostic zips are MB-scale, so extract them in full but exclude the
+          # size-blowing state/binary entries (hashstream, vmap, saved state, key binaries).
           mkdir -p cn-logs-filtered
 
-          # Extract only BN-relevant files from each CN diagnostic zip
           for zip in "${LOG_FOLDER}/${NAMESPACE}"/*.zip; do
             [[ -f "$zip" ]] || continue
             node_name=$(basename "$zip" .zip)
             mkdir -p "cn-logs-filtered/${node_name}"
 
-            # blocknode-comms.log - Block stream communication to BNs
-            unzip -j -o "$zip" "*/blocknode-comms.log" -d "cn-logs-filtered/${node_name}/" 2>/dev/null || true
-            # settingsUsed.txt - CN config including BN routing
-            unzip -j -o "$zip" "*/settingsUsed.txt" -d "cn-logs-filtered/${node_name}/" 2>/dev/null || true
-            # grpc-access.log - gRPC access logs (may include BN connections)
-            unzip -j -o "$zip" "*/grpc-access.log" -d "cn-logs-filtered/${node_name}/" 2>/dev/null || true
+            # Extract everything except large state/binary entries.
+            # Keeps: block-node-comms.log (and legacy blocknode-comms.log), hgcaa.log,
+            #        swirlds.log, queries.log, grpc-access.log, journalctl.log,
+            #        settingsUsed.txt, data/config/* (block-nodes.json, application.properties).
+            unzip -o "$zip" -d "cn-logs-filtered/${node_name}/" \
+              -x "*/swirlds-hashstream/*" "*/swirlds-vmap.log" \
+                 "*/state/*" "data/saved/*" "data/keys/*" "*.bin" \
+                 "data/stats/*" "hedera.key" "hedera.crt" \
+              >/dev/null 2>&1 || true
           done
 
           # Capture last 1000 lines of solo.log (recent activity only, not full history)
@@ -997,8 +999,8 @@ jobs:
 
           echo "CN_LOG_FOLDER=cn-logs-filtered" >> $GITHUB_ENV
 
-          # Show what was collected
-          echo "=== Collected CN logs (BN-relevant only) ===" && ls -laR cn-logs-filtered/
+          # Show what was collected (sizes included to spot regressions)
+          echo "=== Collected CN logs ===" && du -sh cn-logs-filtered/* 2>/dev/null && ls -laR cn-logs-filtered/
 
       - name: Upload CN Logs
         if: always()

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
@@ -413,6 +413,37 @@ function deploy_block_nodes {
   OVERLAY_DIR="${overlay_dir}"
 }
 
+function generate_cn_application_properties {
+  local output_file="${1}"
+  cat > "${output_file}" << 'EOF'
+hedera.config.version=0
+ledger.id=0x01
+netty.mode=TEST
+contracts.chainId=298
+hedera.recordStream.logPeriod=1
+balances.exportPeriodSecs=400
+files.maxSizeKb=2048
+hedera.recordStream.compressFilesOnCreation=true
+balances.compressOnCreation=true
+contracts.maxNumWithHapiSigsAccess=0
+autoRenew.targetTypes=
+nodes.gossipFqdnRestricted=false
+hedera.profiles.active=TEST
+nodes.updateAccountIdAllowed=true
+blockStream.streamMode=RECORDS
+# TODO: we can remove this after we no longer need less than v0.59.x
+networkAdmin.exportCandidateRoster=true
+# for v0.59+, write the network.json file when you freeze the network
+networkAdmin.diskNetworkExport=ONLY_FREEZE_BLOCK
+hedera.realm=0
+hedera.shard=0
+nodes.webProxyEndpointsEnabled=true
+nodes.nodeRewardsEnabled=false
+blockNode.connectionStallThresholdMillis=5000
+blockStream.streamWrappedRecordBlocks=false
+EOF
+}
+
 function deploy_consensus_nodes {
   log_line ""
   log_line "Deploying Consensus Nodes"
@@ -422,6 +453,11 @@ function deploy_consensus_nodes {
   if [[ -n "${CN_VERSION}" ]]; then
     cn_args="--release-tag ${CN_VERSION}"
   fi
+
+  local overlay_dir="${SCRIPT_DIR}/../out"
+  mkdir -p "${overlay_dir}"
+  local cn_app_properties="${overlay_dir}/cn-application.properties"
+  generate_cn_application_properties "${cn_app_properties}"
 
   start_task "Generating consensus keys for ${NODE_ALIASES}"
   solo keys consensus generate \
@@ -445,6 +481,7 @@ function deploy_consensus_nodes {
     --tss "${TSS_ENABLED}" \
     ${wraps_arg} \
     --node-aliases "${NODE_ALIASES}" \
+    --application-properties "${cn_app_properties}" \
     ${cn_args} --dev || fail "ERROR: Failed to deploy consensus network" 1
   end_task
 

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
@@ -430,7 +430,7 @@ autoRenew.targetTypes=
 nodes.gossipFqdnRestricted=false
 hedera.profiles.active=TEST
 nodes.updateAccountIdAllowed=true
-blockStream.streamMode=RECORDS
+blockStream.streamMode=BOTH
 # TODO: we can remove this after we no longer need less than v0.59.x
 networkAdmin.exportCandidateRoster=true
 # for v0.59+, write the network.json file when you freeze the network
@@ -439,6 +439,14 @@ hedera.realm=0
 hedera.shard=0
 nodes.webProxyEndpointsEnabled=true
 nodes.nodeRewardsEnabled=false
+
+tss.hintsEnabled=true
+tss.historyEnabled=true
+tss.forceMockSignatures=false
+tss.wrapsEnabled=true
+
+blockStream.writerMode=FILE_AND_GRPC
+
 blockNode.connectionStallThresholdMillis=5000
 blockStream.streamWrappedRecordBlocks=false
 EOF


### PR DESCRIPTION
Fixes #2899

## Summary

- Add `generate_cn_application_properties` function to `solo-deploy-network.sh` that writes a complete `application.properties` file for Consensus Nodes and passes it to `solo consensus network deploy` via `--application-properties`. The generated file includes all standard CN properties, TSS settings, block stream configuration (`streamMode=BOTH`, `writerMode=FILE_AND_GRPC`), and two new properties: `blockNode.connectionStallThresholdMillis=5000` and `blockStream.streamWrappedRecordBlocks=false`.

- Improve CN log collection in the CI workflow: extract all files from per-node diagnostic zips (not just a handful of BN-relevant ones) while excluding only large state/binary entries (`swirlds-hashstream/`, `saved/*`, `keys/*`, `*.bin`, etc.). Add `du -sh` output alongside `ls -laR` so artifact size regressions are immediately visible. Solo.log continues to be truncated to the last 1000 lines.

## Changes

### `solo-deploy-network.sh`
- New `generate_cn_application_properties` function generates `out/cn-application.properties` with the full CN property set on each deploy
- `deploy_consensus_nodes` calls the generator and passes `--application-properties` to `solo consensus network deploy`

### `.github/workflows/solo-e2e-test.yml`
- Replace narrow per-file `unzip` extractions with a single broad `unzip -x` that excludes known large/binary entries, retaining all diagnostic logs and config files (block-node-comms, hgcaa, swirlds, grpc-access, journalctl, settingsUsed, data/config)
- Add `du -sh` size summary to the collected logs output step


## **Successful runs:**

**With CN 0.74.0 and BN 0.35.0-SNAPSHOT**
https://github.com/hiero-ledger/hiero-block-node/actions/runs/26611479480

**With CN 0.75.0-rc.3 and BN 0.35.0-SNAPSHOT**
https://github.com/hiero-ledger/hiero-block-node/actions/runs/26613267191/job/78423572967