### PR TITLE
docs: fix s3_archive_tasks metric name typo in metrics.md

### DIFF
--- a/docs/block-node/metrics.md
+++ b/docs/block-node/metrics.md
@@ -209,7 +209,7 @@ Tracks long‑term archival jobs that push blocks to S3.
 | Counter | `s3_archive_blocks_written`     | Blocks archived to S3                   |
 | Gauge   | `s3_archive_latest_block`       | Latest block number archived            |
 | Counter | `s3_archive_tasks_failed_total` | Failed archival tasks                   |
-| Counter | `s3_archive_tasks_sucess_total` | Successful archival tasks               |
+| Counter | `s3_archive_tasks_success_total` | Successful archival tasks               |
 | Gauge   | `s3_archive_total_bytes_stored` | Total bytes stored in S3 (cost metric)  |
 | Counter | `s3_archive_chunks_uploaded`    | Chunks uploaded to S3                   |
 | Gauge   | `s3_archive_chunks_opened`      | Open chucks currently                   |

--- a/docs/block-node/metrics.md
+++ b/docs/block-node/metrics.md
@@ -139,7 +139,7 @@ Observes inbound streams from publishers.
 
 ### Subscriber
 
-**Plugin:** `stream-subscriber` [block-node-stream-subscriber]`
+**Plugin:** `stream-subscriber [block-node-stream-subscriber]`
 Observes outbound streams served to subscribers.
 
 |  Type   |             Name              |              Description              |
@@ -204,16 +204,16 @@ Activity and utilization of the historic on‑disk tier.
 **Plugin:** `s3-archive [hiero-block-node.s3-archive]`
 Tracks long‑term archival jobs that push blocks to S3.
 
-|  Type   |              Name               |               Description               |
-|---------|---------------------------------|-----------------------------------------|
-| Counter | `s3_archive_blocks_written`     | Blocks archived to S3                   |
-| Gauge   | `s3_archive_latest_block`       | Latest block number archived            |
-| Counter | `s3_archive_tasks_failed_total` | Failed archival tasks                   |
+|  Type   |               Name               |               Description               |
+|---------|----------------------------------|-----------------------------------------|
+| Counter | `s3_archive_blocks_written`      | Blocks archived to S3                   |
+| Gauge   | `s3_archive_latest_block`        | Latest block number archived            |
+| Counter | `s3_archive_tasks_failed_total`  | Failed archival tasks                   |
 | Counter | `s3_archive_tasks_success_total` | Successful archival tasks               |
-| Gauge   | `s3_archive_total_bytes_stored` | Total bytes stored in S3 (cost metric)  |
-| Counter | `s3_archive_chunks_uploaded`    | Chunks uploaded to S3                   |
-| Gauge   | `s3_archive_chunks_opened`      | Open chucks currently                   |
-| Counter | `s3_archive_files_closed`       | Total number of files closed, finished. |
+| Gauge   | `s3_archive_total_bytes_stored`  | Total bytes stored in S3 (cost metric)  |
+| Counter | `s3_archive_chunks_uploaded`     | Chunks uploaded to S3                   |
+| Gauge   | `s3_archive_chunks_opened`       | Open chunks currently                   |
+| Counter | `s3_archive_files_closed`        | Total number of files closed, finished. |
 
 ---
 


### PR DESCRIPTION
Fixes a typo in `docs/metrics.md`: `s3_archive_tasks_sucess_total` → `s3_archive_tasks_success_total`. Operators wiring up Prometheus alerts against the misspelled metric name would get silent failures with no data. Closes #2729.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._