### PR TITLE
feat: add S3/HMAC credential support for previewnet storage access

### DIFF
--- a/tools-and-tests/tools/build.gradle.kts
+++ b/tools-and-tests/tools/build.gradle.kts
@@ -24,6 +24,7 @@ mainModuleInfo {
     requires("info.picocli")
     requires("org.apache.commons.compress")
     requires("com.google.common.jimfs")
+    requires("com.hedera.bucky")
     runtimeOnly("com.swirlds.config.impl")
     runtimeOnly("io.grpc.netty")
     runtimeOnly("com.hedera.pbj.grpc.helidon.config")

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/config/NetworkConfigLoader.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/config/NetworkConfigLoader.java
@@ -38,6 +38,7 @@ public final class NetworkConfigLoader {
 
     private static final Gson GSON = new GsonBuilder()
             .registerTypeAdapter(LocalDate.class, new LocalDateDeserializer())
+            .registerTypeAdapter(NetworkConfig.class, new NetworkConfigDeserializer())
             .create();
 
     private NetworkConfigLoader() {
@@ -102,6 +103,10 @@ public final class NetworkConfigLoader {
         } catch (IOException e) {
             throw new IllegalArgumentException("Failed to read network config file: " + configPath, e);
         } catch (JsonParseException e) {
+            // Preserve validation error messages (e.g., "missing required field")
+            if (e.getMessage() != null && e.getMessage().contains("missing required field")) {
+                throw new IllegalArgumentException(e.getMessage(), e);
+            }
             throw new IllegalArgumentException("Invalid JSON in network config file: " + configPath, e);
         }
     }
@@ -149,6 +154,64 @@ public final class NetworkConfigLoader {
         public LocalDate deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
                 throws JsonParseException {
             return LocalDate.parse(json.getAsString(), DateTimeFormatter.ISO_LOCAL_DATE);
+        }
+    }
+
+    /**
+     * Custom deserializer for NetworkConfig to handle Java records properly.
+     */
+    private static class NetworkConfigDeserializer implements JsonDeserializer<NetworkConfig> {
+        @Override
+        public NetworkConfig deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
+            var obj = json.getAsJsonObject();
+
+            try {
+                return new NetworkConfig(
+                        getRequiredString(obj, "networkName"),
+                        getRequiredString(obj, "gcsBucketName"),
+                        obj.has("bucketPathPrefix")
+                                        && !obj.get("bucketPathPrefix").isJsonNull()
+                                ? obj.get("bucketPathPrefix").getAsString()
+                                : "recordstreams/", // default
+                        getRequiredString(obj, "mirrorNodeApiUrl"),
+                        context.deserialize(obj.get("genesisDate"), LocalDate.class),
+                        getRequiredString(obj, "genesisTimestamp"),
+                        getRequiredInt(obj, "minNodeAccountId"),
+                        getRequiredInt(obj, "maxNodeAccountId"),
+                        getRequiredLong(obj, "totalHbarSupplyTinybar"),
+                        obj.has("genesisAddressBookResource")
+                                        && !obj.get("genesisAddressBookResource")
+                                                .isJsonNull()
+                                ? obj.get("genesisAddressBookResource").getAsString()
+                                : null);
+            } catch (NullPointerException e) {
+                throw new JsonParseException("Network config missing required field", e);
+            }
+        }
+
+        private String getRequiredString(com.google.gson.JsonObject obj, String fieldName) {
+            JsonElement element = obj.get(fieldName);
+            if (element == null || element.isJsonNull()) {
+                throw new JsonParseException("Network config missing required field: " + fieldName);
+            }
+            return element.getAsString();
+        }
+
+        private int getRequiredInt(com.google.gson.JsonObject obj, String fieldName) {
+            JsonElement element = obj.get(fieldName);
+            if (element == null || element.isJsonNull()) {
+                throw new JsonParseException("Network config missing required field: " + fieldName);
+            }
+            return element.getAsInt();
+        }
+
+        private long getRequiredLong(com.google.gson.JsonObject obj, String fieldName) {
+            JsonElement element = obj.get(fieldName);
+            if (element == null || element.isJsonNull()) {
+                throw new JsonParseException("Network config missing required field: " + fieldName);
+            }
+            return element.getAsLong();
         }
     }
 }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/downloadlive/LiveDownloader.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/downloadlive/LiveDownloader.java
@@ -490,7 +490,7 @@ public class LiveDownloader {
         }
 
         try {
-            final BlockTimeReader blockTimeReader = new BlockTimeReader();
+            final BlockTimeReader blockTimeReader = BlockTimeReader.forCurrentNetwork();
             long highest = -1L;
             final long startTime = System.currentTimeMillis();
             final int totalBlocks = context.sortedBatch.size();
@@ -567,7 +567,7 @@ public class LiveDownloader {
      */
     private BlockTimeReader getBlockTimeReader() throws IOException {
         if (cachedBlockTimeReader == null) {
-            cachedBlockTimeReader = new BlockTimeReader();
+            cachedBlockTimeReader = BlockTimeReader.forCurrentNetwork();
         }
         return cachedBlockTimeReader;
     }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/DownloadDaysV2.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/DownloadDaysV2.java
@@ -59,7 +59,7 @@ public class DownloadDaysV2 implements Runnable {
 
     @Override
     public void run() {
-        try (BlockTimeReader blockTimeReader = new BlockTimeReader();
+        try (BlockTimeReader blockTimeReader = BlockTimeReader.forCurrentNetwork();
                 Storage storage = StorageOptions.grpc()
                         .setAttemptDirectPath(false)
                         .setProjectId(GCP_PROJECT_ID)

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/DownloadDaysV3.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/DownloadDaysV3.java
@@ -62,7 +62,7 @@ public class DownloadDaysV3 implements Runnable {
 
     @Override
     public void run() {
-        try (BlockTimeReader blockTimeReader = new BlockTimeReader();
+        try (BlockTimeReader blockTimeReader = BlockTimeReader.forCurrentNetwork();
                 // Use HTTP transport + platform threads for most stable operation
                 Storage storage = StorageOptions.http()
                         .setProjectId(GCP_PROJECT_ID)

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/DownloadLive2.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/DownloadLive2.java
@@ -371,7 +371,7 @@ public class DownloadLive2 implements Runnable {
                             .setMaxConcurrency(maxConcurrency)
                             .build();
 
-            final BlockTimeReader blockTimeReader = new BlockTimeReader();
+            final BlockTimeReader blockTimeReader = BlockTimeReader.forCurrentNetwork();
 
             // Initialize stats CSV path (same file as validate-with-stats for consistency)
             if (statsCsvPath == null) {
@@ -548,7 +548,8 @@ public class DownloadLive2 implements Runnable {
         UpdateBlockData.updateMirrorNodeData(MetadataFiles.BLOCK_TIMES_FILE, MetadataFiles.DAY_BLOCKS_FILE);
 
         // Reload BlockTimeReader after updating block data to pick up new block times
-        final BlockTimeReader updatedBlockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+        final BlockTimeReader updatedBlockTimeReader =
+                BlockTimeReader.forCurrentNetwork(MetadataFiles.BLOCK_TIMES_FILE);
 
         final Map<LocalDate, DayBlockInfo> daysInfo = loadDayBlockInfoMap();
         final List<LocalDate> daysToDownload = startDay.datesUntil(today).toList();
@@ -746,7 +747,7 @@ public class DownloadLive2 implements Runnable {
 
         try {
             FixBlockTime.fixBlockTimeRange(MetadataFiles.BLOCK_TIMES_FILE, fixStartBlock, fixEndBlock);
-            BlockTimeReader newReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+            BlockTimeReader newReader = BlockTimeReader.forCurrentNetwork(MetadataFiles.BLOCK_TIMES_FILE);
             System.out.println("[CATCH-UP] Block times fixed, retrying day " + dayDate + "...");
 
             state.previousRecordHash = downloadDayWithFullValidation(
@@ -1223,7 +1224,7 @@ public class DownloadLive2 implements Runnable {
                                 "[LIVE] Block " + nextBlockNumber + " not in BlockTimeReader, refreshing...");
                         UpdateBlockData.updateMirrorNodeData(
                                 MetadataFiles.BLOCK_TIMES_FILE, MetadataFiles.DAY_BLOCKS_FILE);
-                        blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                        blockTimeReader = BlockTimeReader.forCurrentNetwork(MetadataFiles.BLOCK_TIMES_FILE);
                         lastBlockTimeRefreshMs = now;
                     } else {
                         System.out.println(
@@ -1253,7 +1254,7 @@ public class DownloadLive2 implements Runnable {
                         System.out.println("[download-live2] Refreshing block times from mirror node...");
                         UpdateBlockData.updateMirrorNodeData(
                                 MetadataFiles.BLOCK_TIMES_FILE, MetadataFiles.DAY_BLOCKS_FILE);
-                        blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                        blockTimeReader = BlockTimeReader.forCurrentNetwork(MetadataFiles.BLOCK_TIMES_FILE);
                         continue; // Retry with fresh data
                     } else {
                         // After 3 retries, try fixBlockTime to query individual block timestamps
@@ -1261,7 +1262,7 @@ public class DownloadLive2 implements Runnable {
                                 "[download-live2] Trying fixBlockTime to correct individual block entries...");
                         FixBlockTime.fixBlockTimeRange(
                                 MetadataFiles.BLOCK_TIMES_FILE, nextBlockNumber, nextBlockNumber + 100);
-                        blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                        blockTimeReader = BlockTimeReader.forCurrentNetwork(MetadataFiles.BLOCK_TIMES_FILE);
                         staleTimestampRetries = 0; // Reset after fix attempt
                         continue;
                     }
@@ -1395,7 +1396,7 @@ public class DownloadLive2 implements Runnable {
                 // Update block times before batch mode to ensure we have current timestamps
                 System.out.println("[download-live2] Updating block times from mirror node...");
                 UpdateBlockData.updateMirrorNodeData(MetadataFiles.BLOCK_TIMES_FILE, MetadataFiles.DAY_BLOCKS_FILE);
-                blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                blockTimeReader = BlockTimeReader.forCurrentNetwork(MetadataFiles.BLOCK_TIMES_FILE);
 
                 // Sanity check: verify next block's timestamp is on expected day or later
                 // If timestamp goes backwards (e.g., 2026-01-16 when we're on 2026-02-01), data is corrupt
@@ -1408,7 +1409,7 @@ public class DownloadLive2 implements Runnable {
                                 + "), running fixBlockTime...");
                         long endBlock = currentBlockNumber + BATCH_SIZE;
                         FixBlockTime.fixBlockTimeRange(MetadataFiles.BLOCK_TIMES_FILE, nextBlock, endBlock);
-                        blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                        blockTimeReader = BlockTimeReader.forCurrentNetwork(MetadataFiles.BLOCK_TIMES_FILE);
                     }
                 } catch (Exception e) {
                     // Block time not available yet - that's fine, will be handled by download logic
@@ -1433,7 +1434,7 @@ public class DownloadLive2 implements Runnable {
                         long estimatedEndBlock = currentBlockNumber + BATCH_SIZE + 100;
                         FixBlockTime.fixBlockTimeRange(
                                 MetadataFiles.BLOCK_TIMES_FILE, currentBlockNumber + 1, estimatedEndBlock);
-                        blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                        blockTimeReader = BlockTimeReader.forCurrentNetwork(MetadataFiles.BLOCK_TIMES_FILE);
 
                         // Retry the batch
                         System.out.println("[download-live2] Retrying batch after fix...");
@@ -1554,7 +1555,7 @@ public class DownloadLive2 implements Runnable {
                     // No block times ahead - need to refresh from mirror node
                     System.out.println("[LIVE] Refreshing block times from mirror node...");
                     UpdateBlockData.updateMirrorNodeData(MetadataFiles.BLOCK_TIMES_FILE, MetadataFiles.DAY_BLOCKS_FILE);
-                    blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                    blockTimeReader = BlockTimeReader.forCurrentNetwork(MetadataFiles.BLOCK_TIMES_FILE);
                     lastBlockTimeRefreshMs = now;
 
                     // Refresh listings in case new files appeared - skip historical days at live edge

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/FixMissingSignatures.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/FixMissingSignatures.java
@@ -24,7 +24,7 @@ import org.hiero.block.tools.records.model.unparsed.InMemoryFile;
 import org.hiero.block.tools.records.model.unparsed.UnparsedRecordBlock;
 import org.hiero.block.tools.utils.ConcurrentTarZstdWriter;
 import org.hiero.block.tools.utils.PrettyPrint;
-import org.hiero.block.tools.utils.gcp.MainNetBucket;
+import org.hiero.block.tools.utils.gcp.GCPBucketLister;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Option;
@@ -169,7 +169,7 @@ public class FixMissingSignatures implements Runnable {
         System.out.println(Ansi.AUTO.string(
                 "@|green ✓ Found source date range: " + days.getFirst() + " to " + days.getLast() + "|@\n"));
         // Set up GCP bucket access
-        final MainNetBucket bucket = new MainNetBucket(
+        final GCPBucketLister bucket = new GCPBucketLister(
                 false, Path.of("metadata/gcp-cache"), minNodeAccountId, maxNodeAccountId, userProject);
 
         // Producer-consumer queue with bounded capacity for backpressure
@@ -242,7 +242,7 @@ public class FixMissingSignatures implements Runnable {
             int numOfDays,
             int dayIndex,
             LocalDate day,
-            MainNetBucket bucket,
+            GCPBucketLister bucket,
             final Map<Instant, Set<String>> bucketSignatures,
             long startNanos,
             AtomicLong totalProgress,

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -303,7 +303,7 @@ public class LiveSequential implements Runnable {
                             .setMaxConcurrency(64)
                             .build();
 
-            final BlockTimeReader blockTimeReader = new BlockTimeReader();
+            final BlockTimeReader blockTimeReader = BlockTimeReader.forCurrentNetwork();
 
             // Determine starting point
             final State initialState = determineStartingPoint(blockTimeReader);
@@ -550,7 +550,7 @@ public class LiveSequential implements Runnable {
                         System.out.println(
                                 "[LIVE] Block " + nextBlockNumber + " not in BlockTimeReader, refreshing...");
                         UpdateBlockData.updateBlockTimesOnly(MetadataFiles.BLOCK_TIMES_FILE);
-                        state.blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                        state.blockTimeReader = BlockTimeReader.forCurrentNetwork(MetadataFiles.BLOCK_TIMES_FILE);
                         lastBlockTimeRefreshMs = now;
                     }
                     state.prefetchWindow.clear();
@@ -1388,7 +1388,7 @@ public class LiveSequential implements Runnable {
                         MetadataFiles.BLOCK_TIMES_FILE, nextBlockNumber, nextBlockNumber + 100);
                 if (fixedCount > 0) {
                     // Block times were fixed, reload and retry
-                    state.blockTimeReader = new BlockTimeReader(MetadataFiles.BLOCK_TIMES_FILE);
+                    state.blockTimeReader = BlockTimeReader.forCurrentNetwork(MetadataFiles.BLOCK_TIMES_FILE);
                     return null;
                 } else {
                     // No block times were fixed, files are genuinely missing or not uploaded yet

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/UpdateDayListingsCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/UpdateDayListingsCommand.java
@@ -22,8 +22,10 @@ import org.hiero.block.tools.days.listing.ListingRecordFile;
 import org.hiero.block.tools.metadata.MetadataFiles;
 import org.hiero.block.tools.records.ChainFile;
 import org.hiero.block.tools.records.RecordFileDates;
+import org.hiero.block.tools.utils.BucketLister;
 import org.hiero.block.tools.utils.PrettyPrint;
-import org.hiero.block.tools.utils.gcp.MainNetBucket;
+import org.hiero.block.tools.utils.gcp.GCPBucketLister;
+import org.hiero.block.tools.utils.s3.BuckyBucketLister;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -142,6 +144,37 @@ public class UpdateDayListingsCommand implements Runnable {
     }
 
     /**
+     * Creates the appropriate BucketLister implementation based on available credentials.
+     *
+     * <p>If HMAC credentials are available in environment variables (GCS_HMAC_ACCESS_ID and GCS_HMAC_SECRET),
+     * creates a BuckyBucketLister for S3-compatible access. Otherwise, creates a GCPBucketLister for
+     * standard GCS access with Application Default Credentials.
+     *
+     * @param cacheEnabled whether to enable GCS caching (only applies to GCPBucketLister)
+     * @param cacheDir the directory for GCS cache (only applies to GCPBucketLister)
+     * @param minNodeAccountId minimum node account ID
+     * @param maxNodeAccountId maximum node account ID
+     * @param userProject GCP project for requester-pays billing (only applies to GCPBucketLister)
+     * @return configured BucketLister implementation
+     */
+    private static BucketLister createBucketLister(
+            boolean cacheEnabled, Path cacheDir, int minNodeAccountId, int maxNodeAccountId, String userProject) {
+
+        final String hmacAccessId = System.getenv("GCS_HMAC_ACCESS_ID");
+        final String hmacSecret = System.getenv("GCS_HMAC_SECRET");
+
+        // If HMAC credentials are present, use BuckyBucketLister for S3-compatible access
+        if (hmacAccessId != null && !hmacAccessId.isBlank() && hmacSecret != null && !hmacSecret.isBlank()) {
+            System.out.println("[UpdateDayListingsCommand] Using BuckyBucketLister with HMAC credentials");
+            return BuckyBucketLister.fromEnvironment(minNodeAccountId, maxNodeAccountId);
+        }
+
+        // Otherwise use GCPBucketLister for standard GCS access
+        System.out.println("[UpdateDayListingsCommand] Using GCPBucketLister with Application Default Credentials");
+        return new GCPBucketLister(cacheEnabled, cacheDir, minNodeAccountId, maxNodeAccountId, userProject);
+    }
+
+    /**
      * Update day listing files by fetching file metadata from Google Cloud Storage.
      *
      * <p>This method scans the local listing directory to find missing days (including gaps),
@@ -191,9 +224,9 @@ public class UpdateDayListingsCommand implements Runnable {
             System.out.println("First missing: " + missingDays.getFirst() + ", Last missing: " + missingDays.getLast());
             System.out.println("Using nodes " + minNodeAccountId + " to " + maxNodeAccountId);
 
-            // Create MainNetBucket for GCS access
-            final MainNetBucket mainNetBucket =
-                    new MainNetBucket(cacheEnabled, cacheDir, minNodeAccountId, maxNodeAccountId, userProject);
+            // Create appropriate BucketLister implementation based on available credentials
+            final BucketLister bucketLister =
+                    createBucketLister(cacheEnabled, cacheDir, minNodeAccountId, maxNodeAccountId, userProject);
 
             // Process each missing day
             final long totalDays = missingDays.size();
@@ -201,7 +234,7 @@ public class UpdateDayListingsCommand implements Runnable {
             final long startTimeNanos = System.nanoTime();
 
             for (LocalDate missingDay : missingDays) {
-                processDayStatic(listingDir, mainNetBucket, missingDay, processedDays, totalDays, startTimeNanos);
+                processDayStatic(listingDir, bucketLister, missingDay, processedDays, totalDays, startTimeNanos);
                 processedDays++;
             }
 
@@ -326,7 +359,7 @@ public class UpdateDayListingsCommand implements Runnable {
      */
     private static void processDayStatic(
             final Path listingPath,
-            final MainNetBucket mainNetBucket,
+            final BucketLister bucketLister,
             final LocalDate day,
             final long processedDays,
             final long totalDays,
@@ -344,8 +377,8 @@ public class UpdateDayListingsCommand implements Runnable {
         // Update progress before listing
         updateProgressStatic(day, processedDays, totalDays, startTimeNanos, 0, 100);
 
-        // List all files for this day using MainNetBucket
-        final List<ChainFile> chainFiles = mainNetBucket.listDay(blockTime);
+        // List all files for this day using BucketLister
+        final List<ChainFile> chainFiles = bucketLister.listDay(blockTime);
 
         // Update progress after listing
         updateProgressStatic(day, processedDays, totalDays, startTimeNanos, 50, 100);
@@ -449,13 +482,13 @@ public class UpdateDayListingsCommand implements Runnable {
                 Files.createDirectories(cacheDir);
             }
 
-            // Create MainNetBucket for GCS access
-            final MainNetBucket mainNetBucket =
-                    new MainNetBucket(cacheEnabled, cacheDir, minNodeAccountId, maxNodeAccountId, userProject);
+            // Create appropriate BucketLister implementation based on available credentials
+            final BucketLister bucketLister =
+                    createBucketLister(cacheEnabled, cacheDir, minNodeAccountId, maxNodeAccountId, userProject);
 
             // Process the single day
             final long startTimeNanos = System.nanoTime();
-            processDayStatic(listingDir, mainNetBucket, targetDay, 0, 1, startTimeNanos);
+            processDayStatic(listingDir, bucketLister, targetDay, 0, 1, startTimeNanos);
 
             PrettyPrint.clearProgress();
             System.out.println("Updated listings for " + targetDay);
@@ -582,10 +615,10 @@ public class UpdateDayListingsCommand implements Runnable {
     }
 
     /**
-     * Processes a single day by listing all files from GCS and writing to a listing file.
+     * Processes a single day by listing all files from cloud storage and writing to a listing file.
      *
      * @param listingPath the base directory for listings
-     * @param mainNetBucket the MainNetBucket for GCS access
+     * @param bucketLister the BucketLister for cloud storage access
      * @param day the day to process
      * @param processedDays number of days already processed
      * @param totalDays total number of days to process
@@ -594,7 +627,7 @@ public class UpdateDayListingsCommand implements Runnable {
      */
     private void processDay(
             final Path listingPath,
-            final MainNetBucket mainNetBucket,
+            final BucketLister bucketLister,
             final LocalDate day,
             final long processedDays,
             final long totalDays,
@@ -612,8 +645,8 @@ public class UpdateDayListingsCommand implements Runnable {
         // Update progress before listing
         updateProgress(day, processedDays, totalDays, startTimeNanos, 0, 100);
 
-        // List all files for this day using MainNetBucket
-        final List<ChainFile> chainFiles = mainNetBucket.listDay(blockTime);
+        // List all files for this day using BucketLister
+        final List<ChainFile> chainFiles = bucketLister.listDay(blockTime);
 
         // Update progress after listing
         updateProgress(day, processedDays, totalDays, startTimeNanos, 50, 100);

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/ValidateSignatureCounts.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/ValidateSignatureCounts.java
@@ -29,7 +29,7 @@ import org.hiero.block.tools.days.model.TarZstdDayUtils;
 import org.hiero.block.tools.records.model.unparsed.InMemoryFile;
 import org.hiero.block.tools.utils.TarReader;
 import org.hiero.block.tools.utils.ZstCmdInputStream;
-import org.hiero.block.tools.utils.gcp.MainNetBucket;
+import org.hiero.block.tools.utils.gcp.GCPBucketLister;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Option;
@@ -286,8 +286,8 @@ public class ValidateSignatureCounts implements Runnable {
 
         // Check blocks against the GCP bucket
         if (!blocksToCheck.isEmpty()) {
-            // Create MainNetBucket instance (no caching for this use case, with user project for requester-pays)
-            MainNetBucket bucket = new MainNetBucket(false, Path.of("data/gcp-cache"), 3, 37, userProject);
+            // Create GCPBucketLister instance (no caching for this use case, with user project for requester-pays)
+            GCPBucketLister bucket = new GCPBucketLister(false, Path.of("data/gcp-cache"), 3, 37, userProject);
 
             if (checkAllBlocks) {
                 // Comprehensive mode: fetch all signatures from bucket for this day and compare

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/AddNewerBlockTimes.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/AddNewerBlockTimes.java
@@ -15,7 +15,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.hiero.block.tools.metadata.MetadataFiles;
 import org.hiero.block.tools.records.RecordFileDates;
-import org.hiero.block.tools.utils.gcp.MainNetBucket;
+import org.hiero.block.tools.utils.gcp.GCPBucketLister;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Option;
@@ -80,7 +80,7 @@ public class AddNewerBlockTimes implements Runnable {
             System.out.println(Ansi.AUTO.string("@|yellow lastBlockTime = |@" + lastBlockTime + " nanos @|yellow =|@ "
                     + RecordFileDates.blockTimeLongToInstant(lastBlockTime)));
             // Open connection to get data from mainnet GCP bucket
-            final MainNetBucket mainNetBucket = new MainNetBucket(
+            final GCPBucketLister mainNetBucket = new GCPBucketLister(
                     cacheEnabled, dataDir.resolve("gcp-cache"), minNodeAccountId, maxNodeAccountId, userProject);
 
             // find the day containing the last block time

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/UpdateBlockData.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/UpdateBlockData.java
@@ -3,7 +3,6 @@ package org.hiero.block.tools.mirrornode;
 
 import static org.hiero.block.tools.config.NetworkConfig.current;
 import static org.hiero.block.tools.records.RecordFileDates.extractRecordFileTime;
-import static org.hiero.block.tools.records.RecordFileDates.instantToBlockTimeLong;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -57,6 +56,19 @@ public class UpdateBlockData implements Runnable {
 
     /** The batch size for fetching blocks from the mirror node. */
     private static final int BATCH_SIZE = 100;
+
+    /**
+     * Convert an instant to a block time long using the current network's genesis.
+     * This ensures block_times.bin values are relative to the correct network's genesis
+     * (mainnet: 2019-09-13, testnet: 2024-02-01, previewnet: custom, etc).
+     *
+     * @param instant the instant to convert
+     * @return nanoseconds since the current network's genesis
+     */
+    private static long instantToBlockTimeLong(Instant instant) {
+        Instant genesisInstant = Instant.parse(current().genesisTimestamp().replace('_', ':'));
+        return java.time.Duration.between(genesisInstant, instant).toNanos();
+    }
 
     /**
      * Update block data files with newer blocks from the mirror node.

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/ChainFile.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/ChainFile.java
@@ -7,7 +7,7 @@ import static org.hiero.block.tools.records.RecordFileDates.extractRecordFileTim
 import java.io.InputStream;
 import java.io.Serializable;
 import java.util.regex.Pattern;
-import org.hiero.block.tools.utils.gcp.MainNetBucket;
+import org.hiero.block.tools.utils.gcp.GCPBucketLister;
 
 /**
  * Represents a file in the record stream blockchain.
@@ -96,7 +96,7 @@ public record ChainFile(
      * @param mainNetBucket the main net bucket that contains the file
      * @return the file as a byte array
      */
-    public byte[] download(MainNetBucket mainNetBucket) {
+    public byte[] download(GCPBucketLister mainNetBucket) {
         return mainNetBucket.download(path);
     }
 
@@ -106,7 +106,7 @@ public record ChainFile(
      * @param mainNetBucket the main net bucket that contains the file
      * @return the file as a stream
      */
-    public InputStream downloadStreaming(MainNetBucket mainNetBucket) {
+    public InputStream downloadStreaming(GCPBucketLister mainNetBucket) {
         return mainNetBucket.downloadStreaming(path);
     }
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/utils/BucketLister.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/utils/BucketLister.java
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.utils;
+
+import java.util.List;
+import org.hiero.block.tools.records.ChainFile;
+
+/**
+ * Interface for listing files from cloud storage buckets.
+ *
+ * <p>Provides abstraction over different cloud storage implementations
+ * (Google Cloud Storage with service accounts, S3-compatible with HMAC, etc.)
+ */
+public interface BucketLister {
+
+    /**
+     * Lists all files for a given day.
+     *
+     * @param blockStartTime the block start time (nanoseconds since epoch) for the day
+     * @return list of chain files for the day
+     */
+    List<ChainFile> listDay(long blockStartTime);
+
+    /**
+     * Lists all file names for a given day.
+     *
+     * @param blockStartTime the block start time (nanoseconds since epoch) for the day
+     * @return list of file names for the day
+     */
+    List<String> listDayFileNames(long blockStartTime);
+}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/utils/gcp/GCPBucketLister.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/utils/gcp/GCPBucketLister.java
@@ -33,18 +33,27 @@ import java.util.zip.GZIPOutputStream;
 import org.hiero.block.tools.config.NetworkConfig;
 import org.hiero.block.tools.records.ChainFile;
 import org.hiero.block.tools.records.RecordFileDates;
+import org.hiero.block.tools.utils.BucketLister;
 
 /**
- * A class to list and download files from the mainnet bucket. This is designed to be thread safe.
- * <p>
- * <b>Example bucket paths</b>
+ * GCP bucket lister using Google Cloud Storage SDK with Application Default Credentials.
+ *
+ * <p>This implementation uses the GCS Java SDK and requires service account credentials
+ * via the GOOGLE_APPLICATION_CREDENTIALS environment variable.
+ *
+ * <p>For HMAC credentials, use {@link org.hiero.block.tools.utils.s3.BuckyBucketLister} instead,
+ * which accesses GCS via the S3-compatible API.
+ *
+ * <p>This class is thread-safe.
+ *
+ * <p><b>Example bucket paths</b>
  * <ul>
  *    <li><code>gs://hedera-mainnet-streams/recordstreams/record0.0.3/2019-09-13T21_53_51.396440Z.rcd</code></li>
  *    <li><code>gs://hedera-mainnet-streams/recordstreams/record0.0.3/sidecar/2023-04-25T17_42_16.032498578Z_01.rcd.gz</code></li>
  * </ul>
  */
 @SuppressWarnings("unused")
-public class MainNetBucket {
+public class GCPBucketLister implements BucketLister {
     /** The required fields we need from blobs */
     private static final Storage.BlobListOption REQUIRED_FIELDS =
             BlobListOption.fields(BlobField.NAME, BlobField.SIZE, BlobField.MD5HASH);
@@ -53,7 +62,22 @@ public class MainNetBucket {
     /** Glob filter to signature files only */
     private static final Storage.BlobListOption SIGNATURE_FILES_ONLY = BlobListOption.matchGlob("**.rcd_sig");
     /** The GCP Storage service instance - use Storage.list() directly to avoid needing bucket metadata access */
-    private static final Storage STORAGE = StorageOptions.getDefaultInstance().getService();
+    private static final Storage STORAGE = createStorageClient();
+
+    /**
+     * Creates a Storage client using Application Default Credentials.
+     *
+     * <p>This uses the standard GCS SDK authentication, which supports service account JSON files
+     * via the GOOGLE_APPLICATION_CREDENTIALS environment variable.
+     *
+     * <p><b>Note:</b> For HMAC credentials, use {@link org.hiero.block.tools.utils.s3.BuckyBucketLister}
+     * instead, which accesses GCS via the S3-compatible API.
+     *
+     * @return a configured Storage client
+     */
+    private static Storage createStorageClient() {
+        return StorageOptions.getDefaultInstance().getService();
+    }
 
     /**
      * The cache enabled switch. When caching is enabled all fetched data is saved on disk and reused between runs. This
@@ -78,19 +102,19 @@ public class MainNetBucket {
     private final String bucketName;
 
     /**
-     * Create a new MainNetBucket instance with the given cache enabled switch and cache directory.
+     * Create a new GCPBucketLister instance with the given cache enabled switch and cache directory.
      *
      * @param cacheEnabled the cache enabled switch
      * @param cacheDir the cache directory
      * @param minNodeAccountId the minimum node account id in the network
      * @param maxNodeAccountId the maximum node account id in the network
      */
-    public MainNetBucket(boolean cacheEnabled, Path cacheDir, int minNodeAccountId, int maxNodeAccountId) {
+    public GCPBucketLister(boolean cacheEnabled, Path cacheDir, int minNodeAccountId, int maxNodeAccountId) {
         this(cacheEnabled, cacheDir, minNodeAccountId, maxNodeAccountId, null);
     }
 
     /**
-     * Create a new MainNetBucket instance with the given cache enabled switch, cache directory, and user project.
+     * Create a new GCPBucketLister instance with the given cache enabled switch, cache directory, and user project.
      *
      * @param cacheEnabled the cache enabled switch
      * @param cacheDir the cache directory
@@ -98,7 +122,7 @@ public class MainNetBucket {
      * @param maxNodeAccountId the maximum node account id in the network
      * @param userProject the GCP project to bill for requester-pays bucket access (can be null)
      */
-    public MainNetBucket(
+    public GCPBucketLister(
             boolean cacheEnabled, Path cacheDir, int minNodeAccountId, int maxNodeAccountId, String userProject) {
         this(
                 cacheEnabled,
@@ -110,7 +134,7 @@ public class MainNetBucket {
     }
 
     /**
-     * Create a new MainNetBucket instance with all parameters including bucket name.
+     * Create a new GCPBucketLister instance with all parameters including bucket name.
      *
      * @param cacheEnabled the cache enabled switch
      * @param cacheDir the cache directory
@@ -119,7 +143,7 @@ public class MainNetBucket {
      * @param userProject the GCP project to bill for requester-pays bucket access (can be null)
      * @param bucketName the GCS bucket name to use
      */
-    public MainNetBucket(
+    public GCPBucketLister(
             boolean cacheEnabled,
             Path cacheDir,
             int minNodeAccountId,
@@ -546,7 +570,7 @@ public class MainNetBucket {
      * The main method test listing all the files in the bucket for the given day and hour.
      */
     public static void main(String[] args) {
-        MainNetBucket mainNetBucket = new MainNetBucket(true, Path.of("data/gcp-cache"), 0, 34);
+        GCPBucketLister mainNetBucket = new GCPBucketLister(true, Path.of("data/gcp-cache"), 0, 34);
         mainNetBucket.listHour(0).forEach(System.out::println);
         System.out.println("==========================================================================");
         final Instant dec1st2024 = Instant.parse("2024-12-01T00:00:00Z");

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/utils/s3/BuckyBucketLister.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/utils/s3/BuckyBucketLister.java
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.utils.s3;
+
+import static org.hiero.block.tools.config.NetworkConfig.current;
+
+import com.hedera.bucky.S3Client;
+import java.util.ArrayList;
+import java.util.List;
+import org.hiero.block.tools.records.ChainFile;
+import org.hiero.block.tools.records.RecordFileDates;
+import org.hiero.block.tools.utils.BucketLister;
+
+/**
+ * S3-compatible bucket lister using Hedera Bucky client.
+ *
+ * <p>Provides file listing capabilities for S3-compatible storage (AWS S3, GCS S3-compatible API,
+ * MinIO, etc.) using HMAC credentials.
+ *
+ * <p>This implementation uses Hedera's Bucky library which provides a lightweight S3 client
+ * that works with any S3-compatible endpoint.
+ */
+public final class BuckyBucketLister implements BucketLister {
+
+    private final S3Client s3Client;
+    private final String bucketName;
+    private final int minNodeAccountId;
+    private final int maxNodeAccountId;
+
+    /**
+     * Creates a new Bucky-based S3 bucket lister.
+     *
+     * @param endpoint S3 endpoint URL (e.g., "https://storage.googleapis.com")
+     * @param accessKey S3/HMAC access key
+     * @param secretKey S3/HMAC secret key
+     * @param bucketName S3 bucket name
+     * @param minNodeAccountId minimum node account ID
+     * @param maxNodeAccountId maximum node account ID
+     */
+    public BuckyBucketLister(
+            final String endpoint,
+            final String accessKey,
+            final String secretKey,
+            final String bucketName,
+            final int minNodeAccountId,
+            final int maxNodeAccountId) {
+        this.bucketName = bucketName;
+        this.minNodeAccountId = minNodeAccountId;
+        this.maxNodeAccountId = maxNodeAccountId;
+
+        try {
+            // Bucky S3Client constructor: S3Client(regionName, endpointUrl, bucketName, accessKey, secretKey)
+            // Region is not critical for GCS S3-compatible API
+            this.s3Client = new S3Client("us-east-1", endpoint, bucketName, accessKey, secretKey);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create Bucky S3 client", e);
+        }
+    }
+
+    /**
+     * Creates a Bucky bucket lister from environment variables.
+     *
+     * <p>Reads configuration from:
+     * <ul>
+     *   <li>GCS_ENDPOINT or defaults to "https://storage.googleapis.com"</li>
+     *   <li>GCS_HMAC_ACCESS_ID - required</li>
+     *   <li>GCS_HMAC_SECRET - required</li>
+     *   <li>GCS_BUCKET_NAME - required</li>
+     * </ul>
+     *
+     * @param minNodeAccountId minimum node account ID
+     * @param maxNodeAccountId maximum node account ID
+     * @return configured BuckyBucketLister
+     * @throws IllegalArgumentException if required environment variables are missing
+     */
+    public static BuckyBucketLister fromEnvironment(final int minNodeAccountId, final int maxNodeAccountId) {
+        final String endpoint = System.getenv().getOrDefault("GCS_ENDPOINT", "https://storage.googleapis.com");
+        final String accessKey = System.getenv("GCS_HMAC_ACCESS_ID");
+        final String secretKey = System.getenv("GCS_HMAC_SECRET");
+        final String bucketName = System.getenv("GCS_BUCKET_NAME");
+
+        if (accessKey == null || accessKey.isBlank()) {
+            throw new IllegalArgumentException("Missing required environment variable: GCS_HMAC_ACCESS_ID");
+        }
+        if (secretKey == null || secretKey.isBlank()) {
+            throw new IllegalArgumentException("Missing required environment variable: GCS_HMAC_SECRET");
+        }
+        if (bucketName == null || bucketName.isBlank()) {
+            throw new IllegalArgumentException("Missing required environment variable: GCS_BUCKET_NAME");
+        }
+
+        System.out.println("[BuckyBucketLister] Using S3-compatible access with endpoint: " + endpoint);
+        System.out.println("[BuckyBucketLister] Bucket: " + bucketName);
+
+        return new BuckyBucketLister(endpoint, accessKey, secretKey, bucketName, minNodeAccountId, maxNodeAccountId);
+    }
+
+    @Override
+    public List<ChainFile> listDay(long blockStartTime) {
+        final String datePrefix = RecordFileDates.blockTimeLongToRecordFilePrefix(blockStartTime);
+        // crop to the day (e.g., "2024-01-01")
+        final String dayPrefix = datePrefix.substring(0, datePrefix.indexOf('T'));
+        final String bucketPrefix = current().bucketPathPrefix();
+
+        System.out.println("[BuckyBucketLister] Listing files for day: " + dayPrefix);
+
+        final List<ChainFile> allFiles = new ArrayList<>();
+        int failedNodes = 0;
+
+        // List files for each node
+        for (int nodeId = minNodeAccountId; nodeId <= maxNodeAccountId; nodeId++) {
+            try {
+                // List record files
+                String recordPrefix = bucketPrefix + "record0.0." + nodeId + "/" + dayPrefix;
+                allFiles.addAll(listObjectsWithPrefix(recordPrefix, nodeId));
+
+                // List sidecar files
+                String sidecarPrefix = bucketPrefix + "record0.0." + nodeId + "/sidecar/" + dayPrefix;
+                allFiles.addAll(listObjectsWithPrefix(sidecarPrefix, nodeId));
+            } catch (Exception e) {
+                failedNodes++;
+                System.err.println(
+                        "[BuckyBucketLister] Failed to list files for node " + nodeId + ": " + e.getMessage());
+            }
+        }
+
+        // Fail if all nodes failed to list
+        int totalNodes = maxNodeAccountId - minNodeAccountId + 1;
+        if (failedNodes == totalNodes) {
+            throw new RuntimeException("Failed to list files for all nodes on day: " + dayPrefix);
+        }
+
+        System.out.println("[BuckyBucketLister] Found " + allFiles.size() + " files for " + dayPrefix);
+        return allFiles;
+    }
+
+    @Override
+    public List<String> listDayFileNames(long blockStartTime) {
+        final String datePrefix = RecordFileDates.blockTimeLongToRecordFilePrefix(blockStartTime);
+        final String dayPrefix = datePrefix.substring(0, datePrefix.indexOf('T'));
+        final String bucketPrefix = current().bucketPathPrefix();
+
+        final List<String> allNames = new ArrayList<>();
+        int failedNodes = 0;
+
+        for (int nodeId = minNodeAccountId; nodeId <= maxNodeAccountId; nodeId++) {
+            try {
+                String recordPrefix = bucketPrefix + "record0.0." + nodeId + "/" + dayPrefix;
+                allNames.addAll(listObjectNamesWithPrefix(recordPrefix));
+
+                String sidecarPrefix = bucketPrefix + "record0.0." + nodeId + "/sidecar/" + dayPrefix;
+                allNames.addAll(listObjectNamesWithPrefix(sidecarPrefix));
+            } catch (Exception e) {
+                failedNodes++;
+                System.err.println(
+                        "[BuckyBucketLister] Failed to list file names for node " + nodeId + ": " + e.getMessage());
+            }
+        }
+
+        // Fail if all nodes failed to list
+        int totalNodes = maxNodeAccountId - minNodeAccountId + 1;
+        if (failedNodes == totalNodes) {
+            throw new RuntimeException("Failed to list file names for all nodes on day: " + dayPrefix);
+        }
+
+        return allNames;
+    }
+
+    private List<ChainFile> listObjectsWithPrefix(String prefix, int nodeAccountId) {
+        final List<ChainFile> files = new ArrayList<>();
+        final List<String> keys = listObjectKeysWithPrefix(prefix);
+
+        for (String key : keys) {
+            try {
+                // NOTE: Bucky's listObjectsPage only returns keys, not metadata (size, etag)
+                // We'll create ChainFile with size=0 and etag=null as placeholders
+                // This is a limitation of the Bucky library
+                // TODO: Consider using AWS S3 SDK which returns full metadata
+                ChainFile cf = ChainFile.createOrNull(nodeAccountId, key, 0, null);
+                if (cf != null) {
+                    files.add(cf);
+                }
+            } catch (Exception e) {
+                System.err.println("[BuckyBucketLister] Failed to process object: " + e.getMessage());
+            }
+        }
+
+        return files;
+    }
+
+    private List<String> listObjectNamesWithPrefix(String prefix) {
+        return listObjectKeysWithPrefix(prefix);
+    }
+
+    /**
+     * Performs paginated S3 object listing with the given prefix.
+     *
+     * @param prefix the S3 key prefix to filter objects
+     * @return list of all object keys matching the prefix
+     * @throws RuntimeException if the S3 listing operation fails
+     */
+    private List<String> listObjectKeysWithPrefix(String prefix) {
+        final List<String> keys = new ArrayList<>();
+
+        try {
+            // Bucky's listObjectsPage: (prefix, continuationToken, delimiter, maxResults)
+            String token = null;
+            do {
+                S3Client.ListPage page = s3Client.listObjectsPage(prefix, token, null, S3Client.LIST_OBJECTS_MAX);
+                keys.addAll(page.keys());
+                token = page.continuationToken();
+            } while (token != null);
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to list objects with prefix " + prefix + ": " + e.getMessage(), e);
+        }
+
+        return keys;
+    }
+}

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/subcommands/BucketListerFactoryTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/subcommands/BucketListerFactoryTest.java
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.days.subcommands;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import org.hiero.block.tools.utils.BucketLister;
+import org.hiero.block.tools.utils.gcp.GCPBucketLister;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for BucketLister creation logic in UpdateDayListingsCommand.
+ *
+ * <p>Tests verify that the correct BucketLister implementation is selected
+ * based on environment variables for HMAC credentials.
+ *
+ * <p><b>Note on testing HMAC credential detection:</b> The credential detection
+ * logic reads from {@code System.getenv()}, which cannot be easily mocked in unit tests
+ * without complex reflection hacks that don't work reliably with the Java module system.
+ * Therefore, this test suite focuses on the default behavior (no HMAC credentials).
+ *
+ * <p><b>Manual testing for HMAC credentials:</b> To verify HMAC credential detection:
+ * <pre>
+ * export GCS_HMAC_ACCESS_ID="your-access-id"
+ * export GCS_HMAC_SECRET="your-secret"
+ * export GCS_BUCKET_NAME="your-bucket"
+ * java -jar tools.jar days updateDayListings
+ * # Should print: "[UpdateDayListingsCommand] Using BuckyBucketLister with HMAC credentials"
+ * </pre>
+ *
+ * <p>The logic being tested is:
+ * <pre>
+ * if (hmacAccessId != null && !hmacAccessId.isBlank() && hmacSecret != null && !hmacSecret.isBlank()) {
+ *     return BuckyBucketLister.fromEnvironment(...);
+ * } else {
+ *     return new GCPBucketLister(...);
+ * }
+ * </pre>
+ */
+class BucketListerFactoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    /**
+     * Test that GCPBucketLister is returned when no HMAC credentials are present.
+     *
+     * <p>This test verifies the default behavior when environment variables
+     * are not set - the system should fall back to GCS with Application Default Credentials.
+     *
+     * <p>This test assumes a clean test environment without GCS_HMAC_ACCESS_ID
+     * or GCS_HMAC_SECRET environment variables set.
+     */
+    @Test
+    void testCreateBucketLister_DefaultBehavior_ReturnsGCPBucketLister() {
+        // Use reflection to invoke the private static method
+        try {
+            java.lang.reflect.Method method = UpdateDayListingsCommand.class.getDeclaredMethod(
+                    "createBucketLister", boolean.class, Path.class, int.class, int.class, String.class);
+            method.setAccessible(true);
+
+            BucketLister result = (BucketLister) method.invoke(null, false, tempDir, 3, 9, "test-project");
+
+            assertNotNull(result, "BucketLister should not be null");
+            assertTrue(
+                    result instanceof GCPBucketLister,
+                    "Should return GCPBucketLister when HMAC credentials are not present");
+
+            System.out.println("✓ Default behavior verified: returns GCPBucketLister without HMAC credentials");
+        } catch (Exception e) {
+            fail("Failed to test createBucketLister: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Test that the method can be invoked with different node ranges.
+     *
+     * <p>Verifies that the factory method correctly passes through parameters
+     * to the GCPBucketLister constructor.
+     */
+    @Test
+    void testCreateBucketLister_DifferentNodeRanges() {
+        try {
+            java.lang.reflect.Method method = UpdateDayListingsCommand.class.getDeclaredMethod(
+                    "createBucketLister", boolean.class, Path.class, int.class, int.class, String.class);
+            method.setAccessible(true);
+
+            // Test with previewnet node range
+            BucketLister result1 = (BucketLister) method.invoke(null, false, tempDir, 3, 9, "test-project");
+            assertNotNull(result1, "BucketLister should not be null for previewnet range");
+
+            // Test with testnet/mainnet node range
+            BucketLister result2 = (BucketLister) method.invoke(null, false, tempDir, 3, 37, "test-project");
+            assertNotNull(result2, "BucketLister should not be null for mainnet range");
+
+            System.out.println("✓ Factory method works with different node ranges");
+        } catch (Exception e) {
+            fail("Failed to test with different node ranges: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Test that the method can be invoked with caching enabled.
+     *
+     * <p>Verifies that the caching parameter is correctly passed through.
+     */
+    @Test
+    void testCreateBucketLister_WithCaching() {
+        try {
+            java.lang.reflect.Method method = UpdateDayListingsCommand.class.getDeclaredMethod(
+                    "createBucketLister", boolean.class, Path.class, int.class, int.class, String.class);
+            method.setAccessible(true);
+
+            // Test with caching enabled
+            BucketLister result = (BucketLister) method.invoke(null, true, tempDir, 3, 9, "test-project");
+            assertNotNull(result, "BucketLister should not be null with caching enabled");
+            assertTrue(result instanceof GCPBucketLister, "Should still return GCPBucketLister");
+
+            System.out.println("✓ Factory method works with caching enabled");
+        } catch (Exception e) {
+            fail("Failed to test with caching: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add support for accessing GCS buckets using HMAC credentials via S3-compatible API, required for previewnet and other networks without service account credentials.

When `GCS_HMAC_ACCESS_ID` and `GCS_HMAC_SECRET` environment variables are present, the system automatically uses S3-compatible access via Hedera's Bucky library. Otherwise, it falls back to MainNetBucket with standard GCS Application Default Credentials.

## Changes

### New Files
- **BucketLister.java**: Interface for cloud storage abstraction
- **BuckyBucketLister.java**: S3-compatible implementation using Hedera Bucky library

### Modified Files
- **MainNetBucket.java**: Now implements BucketLister interface
- **UpdateDayListingsCommand.java**: Auto-detects HMAC credentials and chooses appropriate implementation
- **build.gradle.kts**: Added Bucky dependency and com.google.auth module requirement
- **gradle/modules.properties**: Added com.google.auth module mapping

## How It Works

The `UpdateDayListingsCommand.createBucketLister()` method checks for HMAC credentials in environment variables:
- If `GCS_HMAC_ACCESS_ID` and `GCS_HMAC_SECRET` are present → uses `BuckyBucketLister`
- Otherwise → uses `MainNetBucket` with Application Default Credentials

## Environment Variables

For previewnet (or any HMAC-based access):
```
export GCS_HMAC_ACCESS_ID="your-access-id"
export GCS_HMAC_SECRET="your-secret-key"
export GCS_BUCKET_NAME="hedera-preview-testnet-streams"
export GCS_ENDPOINT="https://storage.googleapis.com"  # optional, defaults to this
```

## Known Limitation

**Metadata Limitation**: Bucky's \`listObjectsPage()\` API only returns object keys, not metadata (size, etag). Current implementation creates \`ChainFile\` objects with \`size=0\` and \`etag=null\` as placeholders.

**Potential Solutions**:
1. Add AWS S3 SDK dependency (returns full metadata with S3-compatible APIs)
2. Make individual HEAD requests for each file (slow but complete)
3. Determine if size/etag are actually critical for the use case

## Testing

To test with previewnet:

```bash
export GCS_HMAC_ACCESS_ID=\$(jq -r .access_id ~/previewnet/gcp.json)
export GCS_HMAC_SECRET=\$(jq -r .secret ~/previewnet/gcp.json)
export GCS_BUCKET_NAME="hedera-preview-testnet-streams"

java -jar tools.jar days updateDayListings --network previewnet
```
