### PR TITLE
fix: Remove the redundant validFromBlock from TssRoster

### DIFF
--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
@@ -672,10 +672,7 @@ class BlockNodeAppTest {
                 .weight(weight)
                 .schnorrPublicKey(schnorrPublicKey)
                 .build();
-        TssRoster tssRoster = TssRoster.newBuilder()
-                .rosterEntries(rosterEntry)
-                .validFromBlock(rosterValidFromBlock)
-                .build();
+        TssRoster tssRoster = TssRoster.newBuilder().rosterEntries(rosterEntry).build();
         return TssData.newBuilder()
                 .ledgerId(ledgerId)
                 .wrapsVerificationKey(wrapsVerificationKey)

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
@@ -234,8 +234,7 @@ public class TestBlockNodeServer {
                             Bytes.fromHex("01010101"),
                             Bytes.fromHex("02020202"),
                             List.of(buildRosterEntry(11, 22, Bytes.fromHex("03030303"))),
-                            250,
-                            50))
+                            250))
                     .build();
         }
 
@@ -244,18 +243,11 @@ public class TestBlockNodeServer {
         /// @param ledgerId The ledgerId Bytes
         /// @param wrapsVerificationKey The wrapsVerificationKey Bytes
         /// @param validFromBlock The block from which this TssData is valid
-        /// @param rosterValidFromBlock The block from which this TssRoster is valid
         /// @return a `TssData` object
         private TssData buildTssData(
-                Bytes ledgerId,
-                Bytes wrapsVerificationKey,
-                List<RosterEntry> rosterEntries,
-                long validFromBlock,
-                long rosterValidFromBlock) {
-            TssRoster tssRoster = TssRoster.newBuilder()
-                    .rosterEntries(rosterEntries)
-                    .validFromBlock(rosterValidFromBlock)
-                    .build();
+                Bytes ledgerId, Bytes wrapsVerificationKey, List<RosterEntry> rosterEntries, long validFromBlock) {
+            TssRoster tssRoster =
+                    TssRoster.newBuilder().rosterEntries(rosterEntries).build();
             return TssData.newBuilder()
                     .ledgerId(ledgerId)
                     .wrapsVerificationKey(wrapsVerificationKey)

--- a/block-node/roster-bootstrap-tss/src/test/java/org/hiero/block/node/roster/bootstrap/tss/TssDataFetcherTest.java
+++ b/block-node/roster-bootstrap-tss/src/test/java/org/hiero/block/node/roster/bootstrap/tss/TssDataFetcherTest.java
@@ -161,10 +161,7 @@ class TssDataFetcherTest {
                 .weight(weight)
                 .schnorrPublicKey(schnorrPublicKey)
                 .build();
-        TssRoster tssRoster = TssRoster.newBuilder()
-                .rosterEntries(rosterEntry)
-                .validFromBlock(rosterValidFromBlock)
-                .build();
+        TssRoster tssRoster = TssRoster.newBuilder().rosterEntries(rosterEntry).build();
         return TssData.newBuilder()
                 .ledgerId(ledgerId)
                 .wrapsVerificationKey(wrapsVerificationKey)

--- a/protobuf-sources/src/main/proto/block-node/api/node_service.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/node_service.proto
@@ -220,10 +220,6 @@ message TssRoster {
      * The list of `RosterEntry`
      */
     repeated RosterEntry roster_entries = 1;
-    /**
-     * The starting block number this TssRoster is valid from
-     */
-    uint64 valid_from_block = 2;
 }
 
 /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/TssEnablementRegistry.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/TssEnablementRegistry.java
@@ -221,10 +221,8 @@ public class TssEnablementRegistry {
         return TssData.newBuilder()
                 .ledgerId(body.ledgerId())
                 .wrapsVerificationKey(body.historyProofVerificationKey())
-                .currentRoster(TssRoster.newBuilder()
-                        .rosterEntries(rosterEntries)
-                        .validFromBlock(blockNumber)
-                        .build())
+                .currentRoster(
+                        TssRoster.newBuilder().rosterEntries(rosterEntries).build())
                 .validFromBlock(blockNumber)
                 .build();
     }

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/model/TssEnablementRegistryTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/model/TssEnablementRegistryTest.java
@@ -133,7 +133,6 @@ class TssEnablementRegistryTest {
                     HISTORY_PROOF_KEY_0,
                     tssData.currentRosterOrThrow().rosterEntries().getFirst().schnorrPublicKey());
             assertEquals(42, tssData.validFromBlock());
-            assertEquals(42, tssData.currentRosterOrThrow().validFromBlock());
         }
     }
 


### PR DESCRIPTION
____________________________________________________________________

## Reviewer Notes
The TssRoster proto contains a redundant validFromBlock entry. Removed it. The entry on TssData is sufficient.

## Related Issue(s)
 Closes #2921
