### PR TITLE
fix: perform all the junit version updates in one PR.

### DIFF
--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -97,9 +97,9 @@ dependencies.constraints {
     // Testing only versions
     api("com.github.docker-java:docker-java-api:3.7.1") { because("com.github.dockerjava.api") }
     api("org.assertj:assertj-core:3.27.7") { because("org.assertj.core") }
-    api("org.junit.jupiter:junit-jupiter-api:6.0.3") { because("org.junit.jupiter.api") }
-    api("org.junit.jupiter:junit-jupiter-engine:6.0.3") { because("org.junit.jupiter.engine") }
-    api("org.junit.platform:junit-platform-launcher:6.0.3") {
+    api("org.junit.jupiter:junit-jupiter-api:6.1.0") { because("org.junit.jupiter.api") }
+    api("org.junit.jupiter:junit-jupiter-engine:6.1.0") { because("org.junit.jupiter.engine") }
+    api("org.junit.platform:junit-platform-launcher:6.1.0") {
         because("org.junit.platform.launcher")
     }
     api("org.mockito:mockito-core:${mockitoVersion}") { because("org.mockito") }


### PR DESCRIPTION
These versions must be updated all at once.
The dependabot PRs split them up and are failing.

Closes #2910 and #2912 
