### PR TITLE
chore: Replace hard coded BlockAccessor.MAX_BLOCK_SIZE_BYTES with protobuf config max message size

### DIFF
--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ProtobufConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ProtobufConfig.java
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.app.config;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import com.swirlds.config.api.validation.annotation.Max;
+import com.swirlds.config.api.validation.annotation.Min;
+import org.hiero.block.node.base.Loggable;
+
+/**
+ * Configuration for protobuf message handling.
+ *
+ * <p>This is the single, operator-settable source of truth for the maximum protobuf message size
+ * the node will parse. It is read once at start-up and pushed into
+ * {@code org.hiero.block.node.protobuf.ProtobufHandler}, which every module uses when parsing block
+ * data — so raising this value lets a node ingest or serve unusually large blocks (e.g. TSS Wraps
+ * transition blocks) without a code change.
+ *
+ * @param maxMessageSizeBytes the maximum protobuf message size, in bytes, the node will parse
+ */
+@ConfigData("protobuf")
+public record ProtobufConfig(
+        @Loggable @ConfigProperty(defaultValue = "131_072_000") @Min(1_048_576) @Max(1_610_612_736)
+        int maxMessageSizeBytes) {}

--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ServerConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ServerConfig.java
@@ -12,7 +12,9 @@ import org.hiero.block.node.base.Loggable;
  *
  * <p>ServerConfig will have settings for the server.
  *
- * @param maxMessageSizeBytes the PBJ max message size in bytes
+ * @param maxMessageSizeBytes the gRPC/HTTP-2 transport max message size in bytes. This is the
+ *     transport ceiling and is intentionally a little larger than the protobuf parse limit
+ *     ({@code protobuf.maxMessageSizeBytes}) to allow for framing/transport overhead.
  * @param socketSendBufferSizeBytes the socket send buffer size in bytes
  * @param socketReceiveBufferSizeBytes the socket receive buffer size in bytes
  * @param port the port the server will listen on
@@ -27,7 +29,7 @@ import org.hiero.block.node.base.Loggable;
 // spotless:off
 @ConfigData("server")
 public record ServerConfig(
-        @Loggable @ConfigProperty(defaultValue = "131_072_000")
+        @Loggable @ConfigProperty(defaultValue = "134_217_728")
             @Min(1_048_576) @Max(1_610_612_736) int maxMessageSizeBytes,
         @Loggable @ConfigProperty(defaultValue = "131_072")
             @Min(32768) @Max(Integer.MAX_VALUE) int socketSendBufferSizeBytes,

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -676,9 +676,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         final Path tssDataJsonPath = appStateConfig.tssBootstrapFilePath();
         if (Files.exists(tssDataJsonPath)) {
             try {
-                TssData tssData = ProtobufHandler.parse(
-                        TssData.JSON,
-                        Bytes.wrap(Files.readAllBytes(tssDataJsonPath)).toReadableSequentialData());
+                TssData tssData = ProtobufHandler.parse(TssData.JSON, Bytes.wrap(Files.readAllBytes(tssDataJsonPath)));
                 updateTssData(tssData);
                 LOGGER.log(INFO, "Loaded TssData from file: {0}", tssDataJsonPath);
             } catch (ParseException | IOException e) {
@@ -699,7 +697,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         if (Files.exists(rsaFilePath)) {
             try {
                 final byte[] raw = Files.readAllBytes(rsaFilePath);
-                final NodeAddressBook book = NodeAddressBook.JSON.parse(Bytes.wrap(raw));
+                final NodeAddressBook book = ProtobufHandler.parse(NodeAddressBook.JSON, Bytes.wrap(raw));
                 validateAddressBook(book, rsaFilePath.toString());
                 pendingAddressBook.set(book);
                 LOGGER.log(
@@ -730,7 +728,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         if (Files.exists(blockRangesPath)) {
             try {
                 final BlockRangesState rangeSet =
-                        BlockRangesState.JSON.parse(Bytes.wrap(Files.readAllBytes(blockRangesPath)));
+                    ProtobufHandler.parse(BlockRangesState.JSON, Bytes.wrap(Files.readAllBytes(blockRangesPath)));
                 rangeSet.storedBlocks().forEach(r -> storedBlocks.add(new LongRange(r.rangeStart(), r.rangeEnd())));
                 rangeSet.availableBlocks()
                         .forEach(r -> availableBlocks.add(new LongRange(r.rangeStart(), r.rangeEnd())));

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -49,6 +49,7 @@ import org.hiero.block.api.BlockRange;
 import org.hiero.block.api.TssData;
 import org.hiero.block.internal.BlockRangesState;
 import org.hiero.block.node.app.config.AutomaticEnvironmentVariableConfigSource;
+import org.hiero.block.node.app.config.ProtobufConfig;
 import org.hiero.block.node.app.config.ServerConfig;
 import org.hiero.block.node.app.config.WebServerHttp2Config;
 import org.hiero.block.node.app.config.node.NodeConfig;
@@ -56,6 +57,7 @@ import org.hiero.block.node.app.config.state.ApplicationStateConfig;
 import org.hiero.block.node.app.logging.CleanColorfulFormatter;
 import org.hiero.block.node.app.logging.ConfigLogger;
 import org.hiero.block.node.base.ranges.ConcurrentLongRangeSet;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodeContext.Builder;
@@ -186,6 +188,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         // Collect all the config data types from the plugins and global server level
         final List<Class<? extends Record>> allConfigDataTypes = new ArrayList<>();
         allConfigDataTypes.add(ServerConfig.class);
+        allConfigDataTypes.add(ProtobufConfig.class);
         allConfigDataTypes.add(WebServerHttp2Config.class);
         allConfigDataTypes.add(NodeConfig.class);
         allConfigDataTypes.add(ApplicationStateConfig.class);
@@ -207,6 +210,10 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         ConfigLogger.log(configuration);
         // now that configuration is loaded we can get config for server
         serverConfig = configuration.getConfigData(ServerConfig.class);
+        // Push the configured protobuf max message size into ProtobufHandler so every module parses
+        // block data with the same operator-configurable bound (see ProtobufConfig).
+        ProtobufHandler.setMaxMessageSizeBytes(
+                configuration.getConfigData(ProtobufConfig.class).maxMessageSizeBytes());
         WebServerHttp2Config webServerHttp2Config = configuration.getConfigData(WebServerHttp2Config.class);
         // ==== METRICS ================================================================================================
         // discover all metrics providers via SPI

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -728,7 +728,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         if (Files.exists(blockRangesPath)) {
             try {
                 final BlockRangesState rangeSet =
-                    ProtobufHandler.parse(BlockRangesState.JSON, Bytes.wrap(Files.readAllBytes(blockRangesPath)));
+                        ProtobufHandler.parse(BlockRangesState.JSON, Bytes.wrap(Files.readAllBytes(blockRangesPath)));
                 rangeSet.storedBlocks().forEach(r -> storedBlocks.add(new LongRange(r.rangeStart(), r.rangeEnd())));
                 rangeSet.availableBlocks()
                         .forEach(r -> availableBlocks.add(new LongRange(r.rangeStart(), r.rangeEnd())));

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -676,7 +676,9 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         final Path tssDataJsonPath = appStateConfig.tssBootstrapFilePath();
         if (Files.exists(tssDataJsonPath)) {
             try {
-                TssData tssData = TssData.JSON.parse(Bytes.wrap(Files.readAllBytes(tssDataJsonPath)));
+                TssData tssData = ProtobufHandler.parse(
+                        TssData.JSON,
+                        Bytes.wrap(Files.readAllBytes(tssDataJsonPath)).toReadableSequentialData());
                 updateTssData(tssData);
                 LOGGER.log(INFO, "Loaded TssData from file: {0}", tssDataJsonPath);
             } catch (ParseException | IOException e) {

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/blocks/BlockItemUtils.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/blocks/BlockItemUtils.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import org.hiero.block.internal.BlockItemUnparsed;
-import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 
 /**
  * Utility class for testing block items.
@@ -39,7 +39,7 @@ public final class BlockItemUtils {
                     false,
                     false,
                     Codec.DEFAULT_MAX_DEPTH,
-                    BlockAccessor.MAX_BLOCK_SIZE_BYTES));
+                    ProtobufHandler.maxMessageSizeBytes()));
         } catch (ParseException e) {
             throw new RuntimeException(e);
         }
@@ -59,7 +59,7 @@ public final class BlockItemUtils {
                     false,
                     false,
                     Codec.DEFAULT_MAX_DEPTH,
-                    BlockAccessor.MAX_BLOCK_SIZE_BYTES);
+                    ProtobufHandler.maxMessageSizeBytes());
         } catch (ParseException e) {
             throw new RuntimeException(e);
         }
@@ -89,7 +89,7 @@ public final class BlockItemUtils {
                     false,
                     false,
                     Codec.DEFAULT_MAX_DEPTH,
-                    BlockAccessor.MAX_BLOCK_SIZE_BYTES);
+                    ProtobufHandler.maxMessageSizeBytes());
         } catch (ParseException e) {
             throw new RuntimeException(e);
         }

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/blocks/BlockUtils.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/blocks/BlockUtils.java
@@ -18,7 +18,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.zip.GZIPInputStream;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.app.fixtures.TestUtils;
-import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 
 /*
  * Utility class for getting test blocks.
@@ -87,7 +87,7 @@ public final class BlockUtils {
                     false,
                     false,
                     Codec.DEFAULT_MAX_DEPTH,
-                    BlockAccessor.MAX_BLOCK_SIZE_BYTES);
+                    ProtobufHandler.maxMessageSizeBytes());
         }
 
         return new SampleBlockInfo(sampleBlock.getBlockHash(), sampleBlock.getBlockNumber(), blockUnparsed);

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
@@ -30,6 +30,7 @@ import org.hiero.block.api.SubscribeStreamResponse;
 import org.hiero.block.api.SubscribeStreamResponse.Code;
 import org.hiero.block.api.TssData;
 import org.hiero.block.api.TssRoster;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
 import org.hiero.block.node.spi.historicalblocks.LongRange;
@@ -41,7 +42,7 @@ public class TestBlockNodeServer {
         // Override the default message size in PBJ
         final PbjConfig pbjConfig = PbjConfig.builder()
                 .name("pbj")
-                .maxMessageSizeBytes(BlockAccessor.MAX_BLOCK_SIZE_BYTES)
+                .maxMessageSizeBytes(ProtobufHandler.maxMessageSizeBytes())
                 .build();
 
         // Create the service builder
@@ -117,7 +118,7 @@ public class TestBlockNodeServer {
                                 false,
                                 false,
                                 Codec.DEFAULT_MAX_DEPTH,
-                                BlockAccessor.MAX_BLOCK_SIZE_BYTES);
+                                ProtobufHandler.maxMessageSizeBytes());
                         sendBlockItemsInBatches(block.items(), replies);
                         replies.onNext(SubscribeStreamResponse.newBuilder()
                                 .endOfBlock(BlockEnd.newBuilder().blockNumber(i).build())

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/BlockNodeClient.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/client/BlockNodeClient.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.ToIntFunction;
 import org.hiero.block.api.BlockNodeServiceInterface;
-import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 
 public class BlockNodeClient {
     private static final Logger LOGGER = System.getLogger(BlockNodeClient.class.getName());
@@ -146,7 +146,7 @@ public class BlockNodeClient {
                 "application/grpc",
                 GrpcCompression.IDENTITY,
                 GrpcCompression.getDecompressorNames(),
-                BlockAccessor.MAX_BLOCK_SIZE_BYTES,
+                ProtobufHandler.maxMessageSizeBytes(),
                 maxIncomingBufferSize);
 
         webClient = WebClient.builder()

--- a/block-node/block-access-service/src/test/java/org/hiero/block/node/access/service/BlockAccessServicePluginTest.java
+++ b/block-node/block-access-service/src/test/java/org/hiero/block/node/access/service/BlockAccessServicePluginTest.java
@@ -22,8 +22,8 @@ import org.hiero.block.node.app.fixtures.blocks.TestBlock;
 import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
 import org.hiero.block.node.app.fixtures.plugintest.GrpcPluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
-import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -185,7 +185,7 @@ public class BlockAccessServicePluginTest
                 false,
                 false,
                 Codec.DEFAULT_MAX_DEPTH,
-                BlockAccessor.MAX_BLOCK_SIZE_BYTES);
+                ProtobufHandler.maxMessageSizeBytes());
         assertEquals(Code.SUCCESS, response.status());
         assertEquals(466, response.block().items().getFirst().blockHeader().number());
     }

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
@@ -33,11 +33,11 @@ import org.hiero.block.common.hasher.NaiveStreamingTreeHasher;
 import org.hiero.block.common.hasher.StreamingTreeHasher;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureType;
-import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 import org.hiero.block.node.verification.VerificationServicePlugin;
 import org.hiero.block.node.verification.session.VerificationSession;
 
@@ -442,13 +442,13 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
                 false,
                 false,
                 Codec.DEFAULT_MAX_DEPTH,
-                BlockAccessor.MAX_BLOCK_SIZE_BYTES);
+                ProtobufHandler.maxMessageSizeBytes());
         TransactionBody body = TransactionBody.PROTOBUF.parse(
                 signedTx.bodyBytes().toReadableSequentialData(),
                 false,
                 false,
                 Codec.DEFAULT_MAX_DEPTH,
-                BlockAccessor.MAX_BLOCK_SIZE_BYTES);
+                ProtobufHandler.maxMessageSizeBytes());
         if (!body.hasLedgerIdPublication()) {
             return null;
         }

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockStagingFileAccessor.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockStagingFileAccessor.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.util.Objects;
 import org.hiero.block.common.utils.Preconditions;
 import org.hiero.block.node.base.CompressionType;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 
 /**
@@ -140,7 +141,7 @@ final class BlockStagingFileAccessor implements BlockAccessor {
                         false,
                         false,
                         Codec.DEFAULT_MAX_DEPTH,
-                        BlockAccessor.MAX_BLOCK_SIZE_BYTES));
+                        ProtobufHandler.maxMessageSizeBytes()));
             } catch (final UncheckedIOException | ParseException e) {
                 final String message = FAILED_TO_PARSE_MESSAGE.formatted(blockFilePath);
                 LOGGER.log(WARNING, message, e);

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessor.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessor.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 import org.hiero.block.node.base.CompressionType;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 
 /**
@@ -151,7 +152,7 @@ final class ZipBlockAccessor implements BlockAccessor {
                         false,
                         false,
                         Codec.DEFAULT_MAX_DEPTH,
-                        BlockAccessor.MAX_BLOCK_SIZE_BYTES));
+                        ProtobufHandler.maxMessageSizeBytes()));
             } catch (final RuntimeException | ParseException e) {
                 String entryName = blockPathData.blockFileName();
                 final String message = FAILED_TO_PARSE_MESSAGE.formatted(blockNumber, absoluteZipFilePath, entryName);

--- a/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileBlockAccessor.java
+++ b/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileBlockAccessor.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.util.UUID;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.base.CompressionType;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 
 /**
@@ -87,7 +88,7 @@ final class BlockFileBlockAccessor implements BlockAccessor {
                             false,
                             false,
                             Codec.DEFAULT_MAX_DEPTH,
-                            BlockAccessor.MAX_BLOCK_SIZE_BYTES);
+                            ProtobufHandler.maxMessageSizeBytes());
         } catch (final RuntimeException | ParseException e) {
             LOGGER.log(WARNING, FAILED_TO_PARSE_MESSAGE.formatted(absolutePathToBlock), e);
             return null;
@@ -166,7 +167,7 @@ final class BlockFileBlockAccessor implements BlockAccessor {
                         false,
                         false,
                         Codec.DEFAULT_MAX_DEPTH,
-                        BlockAccessor.MAX_BLOCK_SIZE_BYTES));
+                        ProtobufHandler.maxMessageSizeBytes()));
             } catch (final RuntimeException | ParseException e) {
                 final String message = FAILED_TO_PARSE_MESSAGE.formatted(absolutePathToBlock);
                 LOGGER.log(WARNING, message, e);

--- a/block-node/protobuf-pbj/src/main/java/module-info.java
+++ b/block-node/protobuf-pbj/src/main/java/module-info.java
@@ -68,6 +68,7 @@ module org.hiero.block.protobuf.pbj {
     exports com.hedera.hapi.block.stream.schema;
     exports org.hiero.block.api;
     exports org.hiero.block.internal;
+    exports org.hiero.block.node.protobuf;
 
     requires transitive com.hedera.pbj.runtime;
     requires org.antlr.antlr4.runtime;

--- a/block-node/protobuf-pbj/src/main/java/org/hiero/block/node/protobuf/ProtobufHandler.java
+++ b/block-node/protobuf-pbj/src/main/java/org/hiero/block/node/protobuf/ProtobufHandler.java
@@ -4,6 +4,7 @@ package org.hiero.block.node.protobuf;
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -58,7 +59,7 @@ public final class ProtobufHandler {
      * @return the parsed message
      * @throws ParseException if parsing fails
      */
-    public static <T> T parse(@NonNull final Codec<T> codec, @NonNull final ReadableSequentialData input)
+    public static <T> T parse(@NonNull final Codec<T> codec, @NonNull final Bytes input)
             throws ParseException {
         return parse(codec, input, maxMessageSizeBytes);
     }
@@ -75,8 +76,8 @@ public final class ProtobufHandler {
      * @throws ParseException if parsing fails
      */
     public static <T> T parse(
-            @NonNull final Codec<T> codec, @NonNull final ReadableSequentialData input, final int maxMessageSizeBytes)
+            @NonNull final Codec<T> codec, @NonNull final Bytes input, final int maxMessageSizeBytes)
             throws ParseException {
-        return codec.parse(input, false, false, Codec.DEFAULT_MAX_DEPTH, maxMessageSizeBytes);
+        return codec.parse(input.toReadableSequentialData(), false, true, maxMessageSizeBytes / 8, maxMessageSizeBytes);
     }
 }

--- a/block-node/protobuf-pbj/src/main/java/org/hiero/block/node/protobuf/ProtobufHandler.java
+++ b/block-node/protobuf-pbj/src/main/java/org/hiero/block/node/protobuf/ProtobufHandler.java
@@ -4,7 +4,6 @@ package org.hiero.block.node.protobuf;
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -49,28 +48,35 @@ public final class ProtobufHandler {
     }
 
     /**
-     * Parse the given input with the supplied codec, applying the node-wide maximum message size.
+     * Parse {@code input} into a message of type {@code T} using the supplied codec and the
+     * node-wide maximum message size. Lets callers write {@code T msg = ProtobufHandler.parse(
+     * SomeType.PROTOBUF, input)} without repeating the parse flags or the size limit.
      *
-     * @param codec the PBJ codec
+     * @param codec the PBJ codec for the target message type
      * @param input the data to parse
-     * @return the parsed value as {@link Bytes}
+     * @param <T> the parsed message type
+     * @return the parsed message
      * @throws ParseException if parsing fails
      */
-    public static Bytes parse(@NonNull Codec codec, @NonNull ReadableSequentialData input) throws ParseException {
+    public static <T> T parse(@NonNull final Codec<T> codec, @NonNull final ReadableSequentialData input)
+            throws ParseException {
         return parse(codec, input, maxMessageSizeBytes);
     }
 
     /**
-     * Parse the given input with the supplied codec and an explicit maximum message size.
+     * Parse {@code input} into a message of type {@code T} using the supplied codec and an explicit
+     * maximum message size.
      *
-     * @param codec the PBJ codec
+     * @param codec the PBJ codec for the target message type
      * @param input the data to parse
      * @param maxMessageSizeBytes the maximum protobuf message size in bytes
-     * @return the parsed value as {@link Bytes}
+     * @param <T> the parsed message type
+     * @return the parsed message
      * @throws ParseException if parsing fails
      */
-    public static Bytes parse(@NonNull Codec codec, @NonNull ReadableSequentialData input, int maxMessageSizeBytes)
+    public static <T> T parse(
+            @NonNull final Codec<T> codec, @NonNull final ReadableSequentialData input, final int maxMessageSizeBytes)
             throws ParseException {
-        return (Bytes) codec.parse(input, false, true, maxMessageSizeBytes / 8, maxMessageSizeBytes);
+        return codec.parse(input, false, false, Codec.DEFAULT_MAX_DEPTH, maxMessageSizeBytes);
     }
 }

--- a/block-node/protobuf-pbj/src/main/java/org/hiero/block/node/protobuf/ProtobufHandler.java
+++ b/block-node/protobuf-pbj/src/main/java/org/hiero/block/node/protobuf/ProtobufHandler.java
@@ -3,7 +3,6 @@ package org.hiero.block.node.protobuf;
 
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -59,8 +58,7 @@ public final class ProtobufHandler {
      * @return the parsed message
      * @throws ParseException if parsing fails
      */
-    public static <T> T parse(@NonNull final Codec<T> codec, @NonNull final Bytes input)
-            throws ParseException {
+    public static <T> T parse(@NonNull final Codec<T> codec, @NonNull final Bytes input) throws ParseException {
         return parse(codec, input, maxMessageSizeBytes);
     }
 
@@ -75,8 +73,7 @@ public final class ProtobufHandler {
      * @return the parsed message
      * @throws ParseException if parsing fails
      */
-    public static <T> T parse(
-            @NonNull final Codec<T> codec, @NonNull final Bytes input, final int maxMessageSizeBytes)
+    public static <T> T parse(@NonNull final Codec<T> codec, @NonNull final Bytes input, final int maxMessageSizeBytes)
             throws ParseException {
         return codec.parse(input.toReadableSequentialData(), false, true, maxMessageSizeBytes / 8, maxMessageSizeBytes);
     }

--- a/block-node/protobuf-pbj/src/main/java/org/hiero/block/node/protobuf/ProtobufHandler.java
+++ b/block-node/protobuf-pbj/src/main/java/org/hiero/block/node/protobuf/ProtobufHandler.java
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.protobuf;
+
+import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Centralized helper for parsing protobuf messages with a single, node-wide maximum message size.
+ *
+ * <p>The limit is sourced from {@code protobuf.maxMessageSizeBytes} ({@code ProtobufConfig}) and
+ * applied here so every module — including those that cannot depend on the configuration module —
+ * parses with the same operator-configurable bound. {@code BlockNodeApp} calls
+ * {@link #setMaxMessageSizeBytes(int)} once at start-up; until then a sensible default applies so
+ * tests and tools work without wiring.
+ */
+public final class ProtobufHandler {
+
+    /**
+     * Default maximum protobuf message size in bytes, equal to the {@code protobuf.maxMessageSizeBytes}
+     * configuration default. Used until {@link #setMaxMessageSizeBytes(int)} is called at start-up.
+     */
+    public static final int DEFAULT_MAX_MESSAGE_SIZE_BYTES = 131_072_000;
+
+    /** The node-wide maximum protobuf message size in bytes, set once at start-up from configuration. */
+    private static volatile int maxMessageSizeBytes = DEFAULT_MAX_MESSAGE_SIZE_BYTES;
+
+    private ProtobufHandler() {}
+
+    /**
+     * Set the node-wide maximum protobuf message size. Called once by {@code BlockNodeApp} at start-up
+     * with the configured {@code protobuf.maxMessageSizeBytes} value.
+     *
+     * @param maxMessageSizeBytes the maximum protobuf message size in bytes
+     */
+    public static void setMaxMessageSizeBytes(final int maxMessageSizeBytes) {
+        ProtobufHandler.maxMessageSizeBytes = maxMessageSizeBytes;
+    }
+
+    /**
+     * The node-wide maximum protobuf message size in bytes used when parsing block data.
+     *
+     * @return the maximum protobuf message size in bytes
+     */
+    public static int maxMessageSizeBytes() {
+        return maxMessageSizeBytes;
+    }
+
+    /**
+     * Parse the given input with the supplied codec, applying the node-wide maximum message size.
+     *
+     * @param codec the PBJ codec
+     * @param input the data to parse
+     * @return the parsed value as {@link Bytes}
+     * @throws ParseException if parsing fails
+     */
+    public static Bytes parse(@NonNull Codec codec, @NonNull ReadableSequentialData input) throws ParseException {
+        return parse(codec, input, maxMessageSizeBytes);
+    }
+
+    /**
+     * Parse the given input with the supplied codec and an explicit maximum message size.
+     *
+     * @param codec the PBJ codec
+     * @param input the data to parse
+     * @param maxMessageSizeBytes the maximum protobuf message size in bytes
+     * @return the parsed value as {@link Bytes}
+     * @throws ParseException if parsing fails
+     */
+    public static Bytes parse(@NonNull Codec codec, @NonNull ReadableSequentialData input, int maxMessageSizeBytes)
+            throws ParseException {
+        return (Bytes) codec.parse(input, false, true, maxMessageSizeBytes / 8, maxMessageSizeBytes);
+    }
+}

--- a/block-node/roster-bootstrap-tss/src/main/java/org/hiero/block/node/roster/bootstrap/tss/client/BlockNodeClient.java
+++ b/block-node/roster-bootstrap-tss/src/main/java/org/hiero/block/node/roster/bootstrap/tss/client/BlockNodeClient.java
@@ -21,9 +21,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.ToIntFunction;
 import org.hiero.block.api.BlockNodeServiceInterface;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 import org.hiero.block.node.roster.bootstrap.tss.BlockNodeSourceConfig;
 import org.hiero.block.node.roster.bootstrap.tss.GrpcWebClientTuning;
-import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 
 public class BlockNodeClient implements Closeable {
     private static final Logger LOGGER = System.getLogger(BlockNodeClient.class.getName());
@@ -146,7 +146,7 @@ public class BlockNodeClient implements Closeable {
                 "application/grpc",
                 GrpcCompression.IDENTITY,
                 GrpcCompression.getDecompressorNames(),
-                BlockAccessor.MAX_BLOCK_SIZE_BYTES,
+                ProtobufHandler.maxMessageSizeBytes(),
                 maxIncomingBufferSize);
 
         webClient = WebClient.builder()

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/historicalblocks/BlockAccessor.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/historicalblocks/BlockAccessor.java
@@ -7,6 +7,7 @@ import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 
 /**
  * The BlockAccessor interface is used to provide access to a block.
@@ -15,13 +16,6 @@ import org.hiero.block.internal.BlockUnparsed;
  * but that attempt is unsuccessful.
  */
 public interface BlockAccessor extends AutoCloseable {
-    /**
-     * Maximum protobuf parse size in bytes (125 MB). This matches the consensus node limit
-     * and accommodates the largest known block items (TSS Wraps transition blocks) which
-     * can exceed PBJ's default 2 MB limit.
-     */
-    int MAX_BLOCK_SIZE_BYTES = 125 * 1024 * 1024;
-
     /**
      * The format of the block data. The consumer can choose the format that is most efficient for them.
      */
@@ -51,7 +45,11 @@ public interface BlockAccessor extends AutoCloseable {
                 return null;
             }
             return BlockUnparsed.PROTOBUF.parse(
-                    rawData.toReadableSequentialData(), false, false, Codec.DEFAULT_MAX_DEPTH, MAX_BLOCK_SIZE_BYTES);
+                    rawData.toReadableSequentialData(),
+                    false,
+                    false,
+                    Codec.DEFAULT_MAX_DEPTH,
+                    ProtobufHandler.maxMessageSizeBytes());
         } catch (final RuntimeException | ParseException e) {
             final System.Logger LOGGER = System.getLogger(getClass().getName());
             LOGGER.log(WARNING, "Failed to parse block", e);

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
@@ -36,6 +36,7 @@ import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.internal.SubscribeStreamResponseUnparsed;
 import org.hiero.block.internal.SubscribeStreamResponseUnparsed.Builder;
 import org.hiero.block.internal.SubscribeStreamResponseUnparsed.ResponseOneOfType;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.NoBackPressureBlockItemHandler;
@@ -459,7 +460,7 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
                             false,
                             false,
                             Codec.DEFAULT_MAX_DEPTH,
-                            BlockAccessor.MAX_BLOCK_SIZE_BYTES);
+                            ProtobufHandler.maxMessageSizeBytes());
                     // We have retrieved the block to send, so send it.
                     sendOneFullBlock(block, blockByteSize);
                     // Trim the queue if necessary, also increment the next block to send.

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberServicePluginTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberServicePluginTest.java
@@ -28,8 +28,8 @@ import org.hiero.block.node.app.fixtures.blocks.TestBlock;
 import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
 import org.hiero.block.node.app.fixtures.plugintest.GrpcPluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
-import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -58,7 +58,7 @@ class SubscriberServicePluginTest {
                     false,
                     false,
                     Codec.DEFAULT_MAX_DEPTH,
-                    BlockAccessor.MAX_BLOCK_SIZE_BYTES);
+                    ProtobufHandler.maxMessageSizeBytes());
         } catch (final ParseException e) {
             throw new RuntimeException(e);
         }

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/session/impl/ExtendedMerkleTreeSession.java
@@ -46,11 +46,11 @@ import org.hiero.block.common.hasher.NaiveStreamingTreeHasher;
 import org.hiero.block.common.hasher.StreamingTreeHasher;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.node.protobuf.ProtobufHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureType;
-import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 import org.hiero.block.node.verification.VerificationServicePlugin;
 import org.hiero.block.node.verification.session.VerificationProofMetrics;
 import org.hiero.block.node.verification.session.VerificationSession;
@@ -368,13 +368,13 @@ public class ExtendedMerkleTreeSession implements VerificationSession {
                 false,
                 false,
                 Codec.DEFAULT_MAX_DEPTH,
-                BlockAccessor.MAX_BLOCK_SIZE_BYTES);
+                ProtobufHandler.maxMessageSizeBytes());
         TransactionBody body = TransactionBody.PROTOBUF.parse(
                 signedTx.bodyBytes().toReadableSequentialData(),
                 false,
                 false,
                 Codec.DEFAULT_MAX_DEPTH,
-                BlockAccessor.MAX_BLOCK_SIZE_BYTES);
+                ProtobufHandler.maxMessageSizeBytes());
         if (!body.hasLedgerIdPublication()) {
             return null;
         }

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -40,7 +40,7 @@ Each plugin has its own properties, but this focuses on core options and core pl
 
 | ENV Variable                            | Description                                  |    Default |
 |:----------------------------------------|:---------------------------------------------|-----------:|
-| SERVER_MAX_MESSAGE_SIZE_BYTES           | Max gRPC/HTTP-2 transport message size (bytes). Block *parsing* size is governed separately by `PROTOBUF_MAX_MESSAGE_SIZE_BYTES`. | 131,072,000 |
+| SERVER_MAX_MESSAGE_SIZE_BYTES           | Max gRPC/HTTP-2 transport message size (bytes); slightly larger than the parse limit to allow framing overhead. Block *parsing* size is governed separately by `PROTOBUF_MAX_MESSAGE_SIZE_BYTES`. | 134,217,728 |
 | SERVER_SOCKET_SEND_BUFFER_SIZE_BYTES    | Send buffer size (bytes).                    |      32768 |
 | SERVER_SOCKET_RECEIVE_BUFFER_SIZE_BYTES | Receive buffer size (bytes).                 |  8,388,608 |
 | SERVER_PORT                             | Server listening port.                       |      40840 |

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -40,7 +40,7 @@ Each plugin has its own properties, but this focuses on core options and core pl
 
 | ENV Variable                            | Description                                  |    Default |
 |:----------------------------------------|:---------------------------------------------|-----------:|
-| SERVER_MAX_MESSAGE_SIZE_BYTES           | Max message size (bytes) for HTTP/2.         | 37,748,736 |
+| SERVER_MAX_MESSAGE_SIZE_BYTES           | Max gRPC/HTTP-2 transport message size (bytes). Block *parsing* size is governed separately by `PROTOBUF_MAX_MESSAGE_SIZE_BYTES`. | 131,072,000 |
 | SERVER_SOCKET_SEND_BUFFER_SIZE_BYTES    | Send buffer size (bytes).                    |      32768 |
 | SERVER_SOCKET_RECEIVE_BUFFER_SIZE_BYTES | Receive buffer size (bytes).                 |  8,388,608 |
 | SERVER_PORT                             | Server listening port.                       |      40840 |
@@ -48,6 +48,12 @@ Each plugin has its own properties, but this focuses on core options and core pl
 | SERVER_MAX_TCP_CONNECTIONS              | Max TCP connections allowed.                 |       1000 |
 | SERVER_IDLE_CONNECTION_PERIOD_MINUTES   | Period for idle connections check (minutes). |          5 |
 | SERVER_IDLE_CONNECTION_TIMEOUT_MINUTES  | Timeout for idle connections (minutes).      |         30 |
+
+### Protobuf Configuration
+
+| ENV Variable                    | Description                                                                                                                          |     Default |
+|:--------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|------------:|
+| PROTOBUF_MAX_MESSAGE_SIZE_BYTES | Maximum protobuf message size (bytes) the node will parse. Raise to ingest or serve unusually large blocks (e.g. TSS Wraps transition blocks). Applied node-wide via `ProtobufHandler`. | 131,072,000 |
 
 ### WebServerHttp2 Configuration
 

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -39,21 +39,21 @@ Each plugin has its own properties, but this focuses on core options and core pl
 
 ### Server Configuration
 
-| ENV Variable                            | Description                                  |    Default |
-|:----------------------------------------|:---------------------------------------------|-----------:|
+| ENV Variable                            | Description                                                                                                                                                                                       |     Default |
+|:----------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------:|
 | SERVER_MAX_MESSAGE_SIZE_BYTES           | Max gRPC/HTTP-2 transport message size (bytes); slightly larger than the parse limit to allow framing overhead. Block *parsing* size is governed separately by `PROTOBUF_MAX_MESSAGE_SIZE_BYTES`. | 134,217,728 |
-| SERVER_SOCKET_SEND_BUFFER_SIZE_BYTES    | Send buffer size (bytes).                    |      32768 |
-| SERVER_SOCKET_RECEIVE_BUFFER_SIZE_BYTES | Receive buffer size (bytes).                 |  8,388,608 |
-| SERVER_PORT                             | Server listening port.                       |      40840 |
-| SERVER_SHUTDOWN_DELAY_MILLIS            | Delay before shutdown (ms).                  |        500 |
-| SERVER_MAX_TCP_CONNECTIONS              | Max TCP connections allowed.                 |       1000 |
-| SERVER_IDLE_CONNECTION_PERIOD_MINUTES   | Period for idle connections check (minutes). |          5 |
-| SERVER_IDLE_CONNECTION_TIMEOUT_MINUTES  | Timeout for idle connections (minutes).      |         30 |
+| SERVER_SOCKET_SEND_BUFFER_SIZE_BYTES    | Send buffer size (bytes).                                                                                                                                                                         |       32768 |
+| SERVER_SOCKET_RECEIVE_BUFFER_SIZE_BYTES | Receive buffer size (bytes).                                                                                                                                                                      |   8,388,608 |
+| SERVER_PORT                             | Server listening port.                                                                                                                                                                            |       40840 |
+| SERVER_SHUTDOWN_DELAY_MILLIS            | Delay before shutdown (ms).                                                                                                                                                                       |         500 |
+| SERVER_MAX_TCP_CONNECTIONS              | Max TCP connections allowed.                                                                                                                                                                      |        1000 |
+| SERVER_IDLE_CONNECTION_PERIOD_MINUTES   | Period for idle connections check (minutes).                                                                                                                                                      |           5 |
+| SERVER_IDLE_CONNECTION_TIMEOUT_MINUTES  | Timeout for idle connections (minutes).                                                                                                                                                           |          30 |
 
 ### Protobuf Configuration
 
-| ENV Variable                    | Description                                                                                                                          |     Default |
-|:--------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|------------:|
+| ENV Variable                    | Description                                                                                                                                                                             |     Default |
+|:--------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------:|
 | PROTOBUF_MAX_MESSAGE_SIZE_BYTES | Maximum protobuf message size (bytes) the node will parse. Raise to ingest or serve unusually large blocks (e.g. TSS Wraps transition blocks). Applied node-wide via `ProtobufHandler`. | 131,072,000 |
 
 ### WebServerHttp2 Configuration

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -5,6 +5,7 @@
 - [Overview](#overview)
 - [Core Configuration Options](#core-configuration-options)
 - [Server Configuration](#server-configuration)
+- [Protobuf Configuration](#protobuf-configuration)
 - [Application State Configuration](#application-state-configuration)
 - [Metrics Endpoint Configuration](#metrics-endpoint-configuration)
 - [Configurations By Plugin](#configurations-by-plugin)


### PR DESCRIPTION
## Reviewer Notes
Removes the hard-coded `BlockAccessor.MAX_BLOCK_SIZE_BYTES` constant (125 MiB, used across nearly
every plugin) and replaces it with an operator-configurable, node-wide protobuf parse limit sourced
from a new `ProtobufConfig` and applied through the centralized `ProtobufHandler`. Previously the
parse limit was a fixed constant, so raising the message-size config had no effect on block
parsing — operators could not ingest or serve blocks larger than 125 MiB. They can now.

This PR also separates the two concerns that were previously conflated under one value:

- **Parsing** limit → `protobuf.maxMessageSizeBytes` (`ProtobufConfig`), default `131,072,000` (125 MiB).
- **gRPC/HTTP-2 transport** ceiling → `server.maxMessageSizeBytes` (`ServerConfig`), default raised to
  `134,217,728` (128 MiB) so it sits just above the parse limit and absorbs framing/transport overhead.

### Approach

`protobuf-pbj` is depended on by every block-node module (including `spi-plugins`), so the parse limit
lives where everyone can reach it — no constructor/field threading required:

- New **`ProtobufConfig`** (`@ConfigData("protobuf")`) in `app-config` — the single, operator-settable
  source of truth for the parse limit.
- **`ProtobufHandler`** (`protobuf-pbj`, now exported) holds a node-wide `maxMessageSizeBytes()` value,
  defaulted to the canonical value and set once at start-up by `BlockNodeApp` from `ProtobufConfig`.
  It also gains a generic parse helper: `T msg = ProtobufHandler.parse(SomeType.PROTOBUF, bytes)`
  (plus an explicit-size overload), parsing directly into the target type with the node-wide limit.
- **`BlockAccessor`** drops the constant; its default `blockUnparsed()` uses
  `ProtobufHandler.maxMessageSizeBytes()`.
- Every former `MAX_BLOCK_SIZE_BYTES` parse site now calls `ProtobufHandler.maxMessageSizeBytes()`.
- `BlockNodeApp` registers `ProtobufConfig` and pushes its value into `ProtobufHandler` at boot, and
  loads start-up `TssData` via the new generic `ProtobufHandler.parse`.

> Design note: the boot-set static in `ProtobufHandler` is a deliberate trade-off — it removes all
> constructor threading at the cost of a single global value set once at start-up. An alternative
> pure dependency-injection implementation exists on
> `chore/2707-replace-block-size-constant-with-config` for comparison.

### Changes

- `app-config`: **new** `ProtobufConfig`; `ServerConfig.maxMessageSizeBytes` default → `134_217_728`
  (transport ceiling, documented as distinct from the parse limit).
- `protobuf-pbj`: `ProtobufHandler` gains the node-wide size holder + generic `parse(...)`; package exported.
- `app`: `BlockNodeApp` registers `ProtobufConfig`, sets `ProtobufHandler` at boot, loads `TssData`
  via `ProtobufHandler.parse`.
- `spi-plugins`: `BlockAccessor` constant removed; `blockUnparsed()` uses `ProtobufHandler`.
- Parse-site swaps in: `blocks-file-recent`, `blocks-file-historic`, `verification`,
  `block-verification`, `stream-subscriber`, `backfill`, `roster-bootstrap-tss`, and test fixtures.
- `docs/block-node/configuration.md`: documents `PROTOBUF_MAX_MESSAGE_SIZE_BYTES` (parse) and the
  updated `SERVER_MAX_MESSAGE_SIZE_BYTES` (transport), with a TOC entry.
- `tools` `ConvertToJson` (its own unrelated CLI constant) intentionally left untouched.

20 files changed.

### Operator-facing config

| Env var | Concern | Default |
|---|---|---|
| `PROTOBUF_MAX_MESSAGE_SIZE_BYTES` | maximum block/protobuf size the node will **parse** | `131,072,000` |
| `SERVER_MAX_MESSAGE_SIZE_BYTES` | gRPC/HTTP-2 **transport** ceiling (a little larger for framing) | `134,217,728` |

To handle unusually large blocks, raise both (keep transport ≥ parse).

### Testing

- Repo-wide `compileJava` + `compileTestJava` + `spotlessCheck` — green.
- `:app:test` (boots `BlockNodeApp`, exercising `ProtobufConfig` registration + `ProtobufHandler` wiring) — passing.
- Module test suites for all affected modules — passing.
- Confirmed no `MAX_BLOCK_SIZE_BYTES` references remain (outside the unrelated `ConvertToJson` tool).

## Related Issue(s)
Resolves #2707 