### PR TITLE
ci(gitbook-sync): pin actions to SHA and add harden-runner (#2939)

### DIFF
--- a/.github/workflows/sync-docs-to-gitbook.yaml
+++ b/.github/workflows/sync-docs-to-gitbook.yaml
@@ -19,13 +19,18 @@ jobs:
   sync:
     runs-on: hl-bn-lin-md
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout hiero-block-node
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: block-node
 
       - name: Checkout hiero-docs
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: hiero-ledger/hiero-docs
           token: ${{ secrets.DOCS_SYNC_TOKEN }}


### PR DESCRIPTION
## Reviewer Notes

The org requires actions to be pinned to full commit SHAs (not version tags) and to be preceded by `step-security/harden-runner`.

## Changes

- `actions/checkout@v4` (×2 occurrences) → `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
- Added `step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4` step with `egress-policy: audit` as the first step in the `sync` job

## Related Issue(s)
 Fixes #2939 