### PR TITLE
feat: add roster-bootstrap-rsa to published projects in build.gradle.kts

### DIFF
--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     published(project(":spi-plugins"))
     published(project(":stream-publisher"))
     published(project(":stream-subscriber"))
+    published(project(":roster-bootstrap-rsa"))
     published(project(":roster-bootstrap-tss"))
     published(project(":verification"))
 


### PR DESCRIPTION
## Reviewer Notes

This is needed so the plugin can be published to Maven and used by the deployment flow.

## Related Issue(s)

Issue when deploying to Previewnet