### PR TITLE
feat: add new S3 plugins for cloud storage

### DIFF
--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
     published(project(":block-access-service"))
     published(project(":blocks-file-historic"))
     published(project(":blocks-file-recent"))
+    published(project(":cloud-storage-archive"))
+    published(project(":cloud-storage-expanded"))
     published(project(":health"))
     published(project(":facility-messaging"))
     published(project(":s3-archive"))


### PR DESCRIPTION
## Reviewer Notes

Allows plugins to be published to Maven Central

Adds plugins: `cloud-storage-archive`,  `cloud-storage-expanded`

