### PR TITLE
fix(Messaging Facility): non-backpressure item handler blocks disruptor Block Node

### DIFF
--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
@@ -28,6 +29,7 @@ import org.hiero.block.node.spi.blockmessaging.BlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
+import org.hiero.block.node.spi.blockmessaging.GatingHandler;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.NoBackPressureBlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
@@ -387,18 +389,23 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
     @Override
     public synchronized void registerNoBackpressureBlockItemHandler(
             final NoBackPressureBlockItemHandler handler, final boolean cpuIntensiveHandler, final String handlerName) {
+        // One-shot eviction guard: the event processor may deliver a few more buffered events after halt()
+        // is called, so we use an AtomicBoolean to ensure unregister and onTooFarBehindError fire exactly once.
+        final AtomicBoolean evicted = new AtomicBoolean(false);
         final InformedEventHandler<BlockItemBatchRingEvent> informedEventHandler =
                 (event, sequence, endOfBatch, percentageBehindRingHead) -> {
-                    // send on the event block items
-                    handler.handleBlockItemsReceived(event.get());
-                    if (percentageBehindRingHead > 80) {
-                        // If the event processor is more than 80% behind, we need to stop it.
-                        // This is a sign that the event processor is not able to keep up with the
-                        // rate of events being published.
-                        unregisterBlockItemHandler(handler);
-                        // the handler it got too far behind
-                        handler.onTooFarBehindError();
+                    if (evicted.get()) {
+                        // Already evicted; skip remaining buffered events.
+                        return;
                     }
+                    if (percentageBehindRingHead > 80 && evicted.compareAndSet(false, true)) {
+                        // Check lag BEFORE dispatching: if already too far behind, evict now rather
+                        // than calling handleBlockItemsReceived (which might block indefinitely).
+                        unregisterBlockItemHandler(handler);
+                        handler.onTooFarBehindError();
+                        return;
+                    }
+                    handler.handleBlockItemsReceived(event.get());
                 };
         if (blockItemDisruptor.hasStarted()) {
             registerHandler(
@@ -640,7 +647,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
      * Registers a handler with the ring buffer. This generic method allows all the logic to be common and hence any bug
      * hopefully only need fixing once. Any improvements can be made in one place.
      *
-     * @param <H> the type of the handler
+     * @param <H> the type of the GatingHandler
      * @param <E> the type of the event
      * @param handler the handler to register
      * @param cpuIntensiveHandler hint to the service that this handler is CPU intensive vs IO intensive
@@ -650,7 +657,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
      * @param handlerToEventProcessor the map of handlers to event processors
      * @param handlerToThread the map of handlers to threads
      */
-    private static <H, E> void registerHandler(
+    private static <H extends GatingHandler, E> void registerHandler(
             final H handler,
             final boolean cpuIntensiveHandler,
             final String handlerName,
@@ -669,7 +676,9 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                     informedEventHandler.onEvent(event, sequence, endOfBatch, percentageBehindHead);
                 });
         // Dynamically add sequences to the ring buffer
-        ringBuffer.addGatingSequences(batchEventProcessor.getSequence());
+        if (handler.isGating()) {
+            ringBuffer.addGatingSequences(batchEventProcessor.getSequence());
+        }
         // Create the new virtual thread to power the batch processor
         final Thread handlerThread = cpuIntensiveHandler
                 ? PLATFORM_THREAD_FACTORY.newThread(batchEventProcessor)
@@ -686,14 +695,14 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
      * Unregisters the handler from the ring buffer and stops the event processor. This generic method allows all the
      * logic to be common and hence any bug hopefully only need fixing once. Any improvements can be made in one place.
      *
-     * @param <H> the type of the handler
+     * @param <H> the type of the GatingHandler
      * @param <E> the type of the event
      * @param handler the handler to unregister
      * @param ringBuffer the ring buffer to unregister from
      * @param handlerToEventProcessor the map of handlers to event processors
      * @param handlerToThread the map of handlers to threads
      */
-    private static <H, E> void unregisterHandler(
+    private static <H extends GatingHandler, E> void unregisterHandler(
             final H handler,
             final RingBuffer<E> ringBuffer,
             final Map<H, BatchEventProcessor<E>> handlerToEventProcessor,
@@ -701,7 +710,9 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
         final Thread handlerThread = handlerToThread.remove(handler);
         final BatchEventProcessor<E> eventProcessor = handlerToEventProcessor.remove(handler);
         if (eventProcessor != null) {
-            ringBuffer.removeGatingSequence(eventProcessor.getSequence());
+            if (handler.isGating()) {
+                ringBuffer.removeGatingSequence(eventProcessor.getSequence());
+            }
             // stop the event processor
             eventProcessor.halt();
         }

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -404,8 +404,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                         handler.onTooFarBehindError();
                         return;
                     }
-                    final BlockItems blockItems = event.get();
-                    handler.handleBlockItemsReceived(blockItems);
+                    handler.handleBlockItemsReceived(event.get());
                 };
         if (blockItemDisruptor.hasStarted()) {
             registerHandler(

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -408,6 +408,11 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                         return;
                     }
                     final BlockItems blockItems = event.get();
+                    LOGGER.log(
+                            DEBUG,
+                            "Received event {0}",
+                            blockItems);
+
                     long totalBlockItems =
                             blockItemsReceived.addAndGet(blockItems.blockItems().size());
                     LOGGER.log(

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -671,7 +671,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                 .build(ringBuffer, barrier, (event, sequence, endOfBatch) -> {
                     // calculate position in the ring buffer
                     final double percentageBehindHead =
-                            (100d * ((double) (barrier.getCursor() - sequence) / (double) ringBuffer.getBufferSize()));
+                            (100d * ((double) (ringBuffer.getCursor() - sequence) / (double) ringBuffer.getBufferSize()));
                     // send on the event
                     informedEventHandler.onEvent(event, sequence, endOfBatch, percentageBehindHead);
                 });

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -3,7 +3,6 @@ package org.hiero.block.node.messaging;
 
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.TRACE;
-import static org.hiero.block.node.spi.BlockNodePlugin.METRICS_CATEGORY;
 
 import com.lmax.disruptor.BatchEventProcessor;
 import com.lmax.disruptor.BatchEventProcessorBuilder;
@@ -22,7 +21,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
@@ -216,7 +214,6 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
             new ArrayList<>();
 
     private ExecutorService messageForwarder;
-    AtomicLong blockItemsReceived = new AtomicLong(0);
 
     /**
      * {@inheritDoc}
@@ -408,16 +405,6 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                         return;
                     }
                     final BlockItems blockItems = event.get();
-                    LOGGER.log(DEBUG, "Received event {0}", blockItems);
-
-                    long totalBlockItems =
-                            blockItemsReceived.addAndGet(blockItems.blockItems().size());
-                    LOGGER.log(
-                            DEBUG,
-                            "Total Block {0}, block items = {1} for handler {2}:",
-                            blockItems.blockNumber(),
-                            totalBlockItems,
-                            handlerName);
                     handler.handleBlockItemsReceived(blockItems);
                 };
         if (blockItemDisruptor.hasStarted()) {

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -677,6 +677,12 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
         // Dynamically add sequences to the ring buffer
         if (handler.isGating()) {
             ringBuffer.addGatingSequences(batchEventProcessor.getSequence());
+        } else {
+            // Non-gating (no-backpressure) handlers must start from the current cursor so they
+            // only receive future events. The default starting sequence is -1, which causes the
+            // processor to replay every past event still in the ring buffer — for a backfill
+            // subscriber this fills liveBlockQueue and bypasses the historical read path.
+            batchEventProcessor.getSequence().set(ringBuffer.getCursor());
         }
         // Create the new virtual thread to power the batch processor
         final Thread handlerThread = cpuIntensiveHandler

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
@@ -215,6 +216,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
             new ArrayList<>();
 
     private ExecutorService messageForwarder;
+    AtomicLong blockItemsReceived = new AtomicLong(0);
 
     /**
      * {@inheritDoc}
@@ -401,10 +403,14 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                     if (percentageBehindRingHead > 80 && evicted.compareAndSet(false, true)) {
                         // Check lag BEFORE dispatching: if already too far behind, evict now rather
                         // than calling handleBlockItemsReceived (which might block indefinitely).
-                        handler.onTooFarBehindError();
                         unregisterBlockItemHandler(handler);
+                        handler.onTooFarBehindError();
                         return;
                     }
+                    BlockItems blockItems = event.get();
+                    long totalBlockItems =
+                            blockItemsReceived.addAndGet(blockItems.blockItems().size());
+                    LOGGER.log(DEBUG, "Total block items = {0} for handler {1}:", totalBlockItems, handlerName);
                     handler.handleBlockItemsReceived(event.get());
                 };
         if (blockItemDisruptor.hasStarted()) {

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -407,7 +407,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                         handler.onTooFarBehindError();
                         return;
                     }
-                    BlockItems blockItems = event.get();
+                    final BlockItems blockItems = event.get();
                     long totalBlockItems =
                             blockItemsReceived.addAndGet(blockItems.blockItems().size());
                     LOGGER.log(
@@ -416,7 +416,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                             blockItems.blockNumber(),
                             totalBlockItems,
                             handlerName);
-                    handler.handleBlockItemsReceived(event.get());
+                    handler.handleBlockItemsReceived(blockItems);
                 };
         if (blockItemDisruptor.hasStarted()) {
             registerHandler(

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -408,10 +408,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                         return;
                     }
                     final BlockItems blockItems = event.get();
-                    LOGGER.log(
-                            DEBUG,
-                            "Received event {0}",
-                            blockItems);
+                    LOGGER.log(DEBUG, "Received event {0}", blockItems);
 
                     long totalBlockItems =
                             blockItemsReceived.addAndGet(blockItems.blockItems().size());

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -401,8 +401,8 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                     if (percentageBehindRingHead > 80 && evicted.compareAndSet(false, true)) {
                         // Check lag BEFORE dispatching: if already too far behind, evict now rather
                         // than calling handleBlockItemsReceived (which might block indefinitely).
-                        unregisterBlockItemHandler(handler);
                         handler.onTooFarBehindError();
+                        unregisterBlockItemHandler(handler);
                         return;
                     }
                     handler.handleBlockItemsReceived(event.get());
@@ -670,8 +670,8 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
         final BatchEventProcessor<E> batchEventProcessor = new BatchEventProcessorBuilder()
                 .build(ringBuffer, barrier, (event, sequence, endOfBatch) -> {
                     // calculate position in the ring buffer
-                    final double percentageBehindHead = (100d
-                            * ((double) (ringBuffer.getCursor() - sequence) / (double) ringBuffer.getBufferSize()));
+                    final double percentageBehindHead =
+                            (100d * ((double) (barrier.getCursor() - sequence) / (double) ringBuffer.getBufferSize()));
                     // send on the event
                     informedEventHandler.onEvent(event, sequence, endOfBatch, percentageBehindHead);
                 });

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -670,8 +670,8 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
         final BatchEventProcessor<E> batchEventProcessor = new BatchEventProcessorBuilder()
                 .build(ringBuffer, barrier, (event, sequence, endOfBatch) -> {
                     // calculate position in the ring buffer
-                    final double percentageBehindHead =
-                            (100d * ((double) (ringBuffer.getCursor() - sequence) / (double) ringBuffer.getBufferSize()));
+                    final double percentageBehindHead = (100d
+                            * ((double) (ringBuffer.getCursor() - sequence) / (double) ringBuffer.getBufferSize()));
                     // send on the event
                     informedEventHandler.onEvent(event, sequence, endOfBatch, percentageBehindHead);
                 });

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -410,7 +410,12 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                     BlockItems blockItems = event.get();
                     long totalBlockItems =
                             blockItemsReceived.addAndGet(blockItems.blockItems().size());
-                    LOGGER.log(DEBUG, "Total block items = {0} for handler {1}:", totalBlockItems, handlerName);
+                    LOGGER.log(
+                            DEBUG,
+                            "Total Block {0}, block items = {1} for handler {2}:",
+                            blockItems.blockNumber(),
+                            totalBlockItems,
+                            handlerName);
                     handler.handleBlockItemsReceived(event.get());
                 };
         if (blockItemDisruptor.hasStarted()) {

--- a/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/DynamicBlockItemTest.java
+++ b/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/DynamicBlockItemTest.java
@@ -2,6 +2,7 @@
 package org.hiero.block.server.messaging;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -12,14 +13,19 @@ import java.util.List;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockItemUnparsed.ItemOneOfType;
 import org.hiero.block.node.messaging.BlockMessagingFacilityImpl;
 import org.hiero.block.node.messaging.MessagingConfig;
+import org.hiero.block.node.spi.blockmessaging.BlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
 import org.hiero.block.node.spi.blockmessaging.NoBackPressureBlockItemHandler;
@@ -239,6 +245,171 @@ public class DynamicBlockItemTest {
         // check that the second handler processed all items
         assertEquals(TEST_DATA_COUNT, handler2Counter.get());
         assertEquals(expectedTotal, handler2Sum.get());
+    }
+
+    /**
+     * Verify that a no-backpressure handler that blocks indefinitely does NOT gate the ring buffer.
+     * The publisher must be able to fill and wrap the ring buffer without deadlocking, even while the
+     * handler is stuck. This is the core invariant of the no-backpressure contract.
+     */
+    @Test
+    void testNoBackpressureHandlerDoesNotGateRingBuffer() throws Exception {
+        final int ringSize =
+                TestConfig.getConfig().getConfigData(MessagingConfig.class).blockItemQueueSize();
+        // This latch is never released — the handler blocks forever.
+        final CountDownLatch blockForever = new CountDownLatch(1);
+        final AtomicBoolean tooFarBehindCalled = new AtomicBoolean(false);
+
+        final NoBackPressureBlockItemHandler blockingHandler = new NoBackPressureBlockItemHandler() {
+            @Override
+            public void handleBlockItemsReceived(BlockItems items) {
+                try {
+                    blockForever.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            @Override
+            public void onTooFarBehindError() {
+                tooFarBehindCalled.set(true);
+                blockForever.countDown(); // release so stop() can clean up
+            }
+        };
+
+        final BlockMessagingFacility messagingService = new BlockMessagingFacilityImpl();
+        messagingService.init(TestConfig.getBlockNodeContext(), null);
+        messagingService.registerNoBackpressureBlockItemHandler(blockingHandler, false, "blocking");
+        messagingService.start();
+
+        // Publish more events than the ring buffer size; if the handler is a gating sequence this deadlocks.
+        final ExecutorService publisher = Executors.newSingleThreadExecutor();
+        final Future<?> publishFuture = publisher.submit(() -> {
+            for (int i = 0; i < ringSize * 2; i++) {
+                messagingService.sendBlockItems(new BlockItems(
+                        List.of(new BlockItemUnparsed(new OneOf<>(ItemOneOfType.BLOCK_HEADER, intToBytes(i)))),
+                        i,
+                        true,
+                        false));
+            }
+        });
+
+        // If the handler were a gating sequence this would time out.
+        publishFuture.get(10, TimeUnit.SECONDS);
+
+        blockForever.countDown(); // ensure handler thread can exit
+        messagingService.stop();
+        publisher.shutdown();
+    }
+
+    /**
+     * Verify that the lag eviction check fires BEFORE dispatching to the handler, not after.
+     * When a no-backpressure handler falls more than 80% behind the ring head, it must be evicted
+     * and onTooFarBehindError() called even if the handler would otherwise block indefinitely.
+     * No further events should be dispatched to the handler after eviction.
+     */
+    @Test
+    void testNoBackpressureEvictionCheckedBeforeDispatch() throws Exception {
+        final int ringSize =
+                TestConfig.getConfig().getConfigData(MessagingConfig.class).blockItemQueueSize();
+        final CountDownLatch evicted = new CountDownLatch(1);
+        final AtomicInteger dispatchCount = new AtomicInteger(0);
+        // Once evicted is set, any further dispatch is a bug.
+        final AtomicBoolean dispatchAfterEviction = new AtomicBoolean(false);
+
+        final NoBackPressureBlockItemHandler slowHandler = new NoBackPressureBlockItemHandler() {
+            @Override
+            public void handleBlockItemsReceived(BlockItems items) {
+                if (evicted.getCount() == 0) {
+                    dispatchAfterEviction.set(true);
+                }
+                dispatchCount.incrementAndGet();
+                // Block long enough to fall far behind, but not forever.
+                try {
+                    Thread.sleep(5);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            @Override
+            public void onTooFarBehindError() {
+                evicted.countDown();
+            }
+        };
+
+        // Fast handler to keep the ring head advancing.
+        final CountDownLatch fastDone = new CountDownLatch(1);
+        final int totalItems = ringSize * 2;
+        final AtomicInteger fastCount = new AtomicInteger(0);
+        final NoBackPressureBlockItemHandler fastHandler = new NoBackPressureBlockItemHandler() {
+            @Override
+            public void handleBlockItemsReceived(BlockItems items) {
+                if (fastCount.incrementAndGet() >= totalItems) {
+                    fastDone.countDown();
+                }
+            }
+
+            @Override
+            public void onTooFarBehindError() {
+                fail("Fast handler should never be evicted");
+            }
+        };
+
+        final BlockMessagingFacility messagingService = new BlockMessagingFacilityImpl();
+        messagingService.init(TestConfig.getBlockNodeContext(), null);
+        messagingService.registerNoBackpressureBlockItemHandler(slowHandler, false, "slow");
+        messagingService.registerNoBackpressureBlockItemHandler(fastHandler, false, "fast");
+        messagingService.start();
+
+        for (int i = 0; i < totalItems; i++) {
+            messagingService.sendBlockItems(new BlockItems(
+                    List.of(new BlockItemUnparsed(new OneOf<>(ItemOneOfType.BLOCK_HEADER, intToBytes(i)))),
+                    i,
+                    true,
+                    false));
+        }
+
+        assertTrue(evicted.await(15, TimeUnit.SECONDS), "Slow handler was never evicted");
+        assertTrue(fastDone.await(15, TimeUnit.SECONDS), "Fast handler did not finish");
+        assertFalse(dispatchAfterEviction.get(), "Events were dispatched to handler after eviction");
+
+        messagingService.stop();
+    }
+
+    /**
+     * Regression test: a regular BlockItemHandler must still receive all published events after the
+     * no-backpressure fix. Verifies that the gating sequence plumbing for regular handlers is not
+     * accidentally broken by the fix (e.g. sequences not added, removed too early, or stop() skipping cleanup).
+     */
+    @Test
+    void testRegularHandlerReceivesAllEvents() throws Exception {
+        final int totalItems = TEST_DATA_COUNT;
+        final CountDownLatch allReceived = new CountDownLatch(1);
+        final AtomicInteger receiveCount = new AtomicInteger(0);
+
+        final BlockItemHandler gatingHandler = items -> {
+            if (receiveCount.incrementAndGet() >= totalItems) {
+                allReceived.countDown();
+            }
+        };
+
+        final BlockMessagingFacility messagingService = new BlockMessagingFacilityImpl();
+        messagingService.init(TestConfig.getBlockNodeContext(), null);
+        messagingService.registerBlockItemHandler(gatingHandler, false, "regular");
+        messagingService.start();
+
+        for (int i = 0; i < totalItems; i++) {
+            messagingService.sendBlockItems(new BlockItems(
+                    List.of(new BlockItemUnparsed(new OneOf<>(ItemOneOfType.BLOCK_HEADER, intToBytes(i)))),
+                    i,
+                    true,
+                    false));
+        }
+
+        assertTrue(allReceived.await(20, TimeUnit.SECONDS), "Regular handler did not receive all events");
+        assertEquals(totalItems, receiveCount.get());
+        messagingService.stop();
     }
 
     /**

--- a/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/DynamicBlockItemTest.java
+++ b/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/DynamicBlockItemTest.java
@@ -307,13 +307,16 @@ public class DynamicBlockItemTest {
      * When a no-backpressure handler falls more than 80% behind the ring head, it must be evicted
      * and onTooFarBehindError() called even if the handler would otherwise block indefinitely.
      * No further events should be dispatched to the handler after eviction.
+     *
+     * <p>Design note: the ring head advances purely from publishing — no second "fast" handler is
+     * needed. A second handler would be unreliable on a loaded CI runner where the publisher can
+     * outpace both virtual threads, inadvertently evicting the "fast" handler too.
      */
     @Test
     void testNoBackpressureEvictionCheckedBeforeDispatch() throws Exception {
         final int ringSize =
                 TestConfig.getConfig().getConfigData(MessagingConfig.class).blockItemQueueSize();
         final CountDownLatch evicted = new CountDownLatch(1);
-        final AtomicInteger dispatchCount = new AtomicInteger(0);
         // Once evicted is set, any further dispatch is a bug.
         final AtomicBoolean dispatchAfterEviction = new AtomicBoolean(false);
 
@@ -323,7 +326,6 @@ public class DynamicBlockItemTest {
                 if (evicted.getCount() == 0) {
                     dispatchAfterEviction.set(true);
                 }
-                dispatchCount.incrementAndGet();
                 // Block long enough to fall far behind, but not forever.
                 try {
                     Thread.sleep(5);
@@ -338,30 +340,14 @@ public class DynamicBlockItemTest {
             }
         };
 
-        // Fast handler to keep the ring head advancing.
-        final CountDownLatch fastDone = new CountDownLatch(1);
-        final int totalItems = ringSize * 2;
-        final AtomicInteger fastCount = new AtomicInteger(0);
-        final NoBackPressureBlockItemHandler fastHandler = new NoBackPressureBlockItemHandler() {
-            @Override
-            public void handleBlockItemsReceived(BlockItems items) {
-                if (fastCount.incrementAndGet() >= totalItems) {
-                    fastDone.countDown();
-                }
-            }
-
-            @Override
-            public void onTooFarBehindError() {
-                fail("Fast handler should never be evicted");
-            }
-        };
-
         final BlockMessagingFacility messagingService = new BlockMessagingFacilityImpl();
         messagingService.init(TestConfig.getBlockNodeContext(), null);
         messagingService.registerNoBackpressureBlockItemHandler(slowHandler, false, "slow");
-        messagingService.registerNoBackpressureBlockItemHandler(fastHandler, false, "fast");
         messagingService.start();
 
+        // Publishing twice the ring size with no delay: the publisher fills and wraps the ring
+        // far faster than the 5ms/event slow handler can drain it, guaranteeing >80% lag.
+        final int totalItems = ringSize * 2;
         for (int i = 0; i < totalItems; i++) {
             messagingService.sendBlockItems(new BlockItems(
                     List.of(new BlockItemUnparsed(new OneOf<>(ItemOneOfType.BLOCK_HEADER, intToBytes(i)))),
@@ -371,7 +357,6 @@ public class DynamicBlockItemTest {
         }
 
         assertTrue(evicted.await(15, TimeUnit.SECONDS), "Slow handler was never evicted");
-        assertTrue(fastDone.await(15, TimeUnit.SECONDS), "Fast handler did not finish");
         assertFalse(dispatchAfterEviction.get(), "Events were dispatched to handler after eviction");
 
         messagingService.stop();

--- a/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/DynamicBlockItemTest.java
+++ b/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/DynamicBlockItemTest.java
@@ -413,6 +413,164 @@ public class DynamicBlockItemTest {
     }
 
     /**
+     * Regression test: a no-backpressure handler that uses an internal blocking queue (mimicking
+     * {@code LiveBlockHandler}) must never receive the same {@link BlockItems} more than once.
+     *
+     * <p>Root cause: {@code handleBlockItemsReceived} may call a blocking {@code put()} on an internal
+     * bounded queue. While the messaging thread is blocked inside {@code put()}, the ring buffer head
+     * keeps advancing (non-gating — the producer never stalls). If the head advances more than one full
+     * ring revolution before {@code put()} returns, the ring wraps and <em>overwrites</em> slots the
+     * handler has not yet read. When {@code put()} finally unblocks the handler reads those overwritten
+     * slots — which now hold <em>newer</em> events — and enqueues them. Later the handler's sequence
+     * cursor naturally reaches those same newer events and dispatches them a <em>second time</em>,
+     * causing the consumer to see duplicate {@link BlockItems}.
+     *
+     * <p>The eviction threshold (80 %) is meant to prevent wrap-around, but the check only runs between
+     * {@code put()} calls, not during one. This test verifies that each published value is received
+     * <em>at most once</em>.
+     */
+    @Test
+    void testNoBackpressureHandlerWithBlockingInternalQueueDoesNotDeliverDuplicates() throws Exception {
+        final int ringSize =
+                TestConfig.getConfig().getConfigData(MessagingConfig.class).blockItemQueueSize();
+        // Internal transfer queue with a small capacity to force the handler to block in put() quickly.
+        // The eviction fires at > 80 % lag (> 0.8 * ringSize events behind). We size the internal
+        // queue smaller than ringSize * 0.2 so that a fast producer can fill it before 80 % lag is
+        // reached, thereby causing the handler to block during put() while the ring keeps advancing.
+        final int internalQueueCapacity = Math.max(2, ringSize / 10);
+        final java.util.concurrent.BlockingQueue<BlockItems> internalQueue =
+                new java.util.concurrent.ArrayBlockingQueue<>(internalQueueCapacity);
+
+        final AtomicBoolean evicted = new AtomicBoolean(false);
+        // Track every sequence value dispatched; a duplicate means the same event payload was delivered twice.
+        final java.util.concurrent.ConcurrentHashMap<Integer, Integer> seenValues =
+                new java.util.concurrent.ConcurrentHashMap<>();
+        final AtomicInteger duplicateCount = new AtomicInteger(0);
+        final CountDownLatch evictedLatch = new CountDownLatch(1);
+
+        final NoBackPressureBlockItemHandler blockingHandler = new NoBackPressureBlockItemHandler() {
+            @Override
+            public void handleBlockItemsReceived(BlockItems items) {
+                int value = bytesToInt(items.blockItems().getFirst().blockHeader());
+                // Record any duplicate deliveries before blocking in put().
+                if (seenValues.put(value, value) != null) {
+                    duplicateCount.incrementAndGet();
+                }
+                try {
+                    // Blocking put — this is the pattern used by LiveBlockHandler.
+                    internalQueue.put(items);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            @Override
+            public void onTooFarBehindError() {
+                evicted.set(true);
+                evictedLatch.countDown();
+            }
+        };
+
+        // A fast consumer drains the internal queue slowly enough to let it fill but not so slow
+        // that the test takes forever. The goal is to keep the queue nearly full so the handler
+        // blocks on put() while the ring advances.
+        final AtomicBoolean consumerRunning = new AtomicBoolean(true);
+        final Thread consumerThread = Thread.ofVirtual().start(() -> {
+            while (consumerRunning.get() || !internalQueue.isEmpty()) {
+                try {
+                    internalQueue.poll(1, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        });
+
+        final BlockMessagingFacility messagingService = new BlockMessagingFacilityImpl();
+        messagingService.init(TestConfig.getBlockNodeContext(), null);
+        messagingService.registerNoBackpressureBlockItemHandler(blockingHandler, false, "blocking-internal-queue");
+        messagingService.start();
+
+        // Publish ringSize * 2 events as fast as possible; this should outpace the handler and
+        // trigger the eviction (or expose duplicate delivery if eviction misfires).
+        final int totalItems = ringSize * 2;
+        for (int i = 0; i < totalItems; i++) {
+            messagingService.sendBlockItems(new BlockItems(
+                    List.of(new BlockItemUnparsed(new OneOf<>(ItemOneOfType.BLOCK_HEADER, intToBytes(i)))),
+                    i,
+                    true,
+                    false));
+        }
+
+        // Either eviction fires (expected happy path) or the test continues to completion.
+        // Either way, no value should have been delivered twice.
+        evictedLatch.await(15, TimeUnit.SECONDS);
+
+        consumerRunning.set(false);
+        consumerThread.interrupt();
+        consumerThread.join(2000);
+        messagingService.stop();
+
+        assertEquals(
+                0,
+                duplicateCount.get(),
+                "Handler received " + duplicateCount.get() + " duplicate BlockItems deliveries. "
+                        + "A blocking put() inside handleBlockItemsReceived allows the ring buffer to "
+                        + "wrap and overwrite unread slots, causing the same event to be dispatched twice.");
+    }
+
+    /**
+     * Verify that a fast no-backpressure handler receives every item that is sent. Removing the gating
+     * sequence means the ring buffer can wrap and overwrite unread slots, so a handler that keeps up must
+     * still see all events without any being silently dropped.
+     */
+    @Test
+    void testNoBackpressureHandlerReceivesAllItemsWhenFastEnough() throws Exception {
+        final int totalItems = TEST_DATA_COUNT;
+        final CountDownLatch allReceived = new CountDownLatch(1);
+        final AtomicInteger receiveCount = new AtomicInteger(0);
+        final AtomicInteger receiveSum = new AtomicInteger(0);
+
+        final NoBackPressureBlockItemHandler fastHandler = new NoBackPressureBlockItemHandler() {
+            @Override
+            public void handleBlockItemsReceived(BlockItems items) {
+                int value = bytesToInt(items.blockItems().getFirst().blockHeader());
+                receiveSum.addAndGet(value);
+                if (receiveCount.incrementAndGet() >= totalItems) {
+                    allReceived.countDown();
+                }
+            }
+
+            @Override
+            public void onTooFarBehindError() {
+                fail("Fast handler should never be evicted");
+            }
+        };
+
+        final BlockMessagingFacility messagingService = new BlockMessagingFacilityImpl();
+        messagingService.init(TestConfig.getBlockNodeContext(), null);
+        messagingService.registerNoBackpressureBlockItemHandler(fastHandler, false, "fast-all-items");
+        messagingService.start();
+
+        for (int i = 0; i < totalItems; i++) {
+            messagingService.sendBlockItems(new BlockItems(
+                    List.of(new BlockItemUnparsed(new OneOf<>(ItemOneOfType.BLOCK_HEADER, intToBytes(i)))),
+                    i,
+                    true,
+                    false));
+        }
+
+        assertTrue(
+                allReceived.await(20, TimeUnit.SECONDS),
+                "No-backpressure handler did not receive all " + totalItems + " items");
+        assertEquals(totalItems, receiveCount.get(), "Item count mismatch");
+        assertEquals(
+                IntStream.range(0, totalItems).sum(), receiveSum.get(), "Item sum mismatch — some items were lost");
+
+        messagingService.stop();
+    }
+
+    /**
      * Utility method to convert an int to a Bytes object. So that we can send a simple int inside a BlockItem.
      *
      * @param value the int to convert

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockItemHandler.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockItemHandler.java
@@ -19,8 +19,4 @@ public interface BlockItemHandler extends GatingHandler {
      * @param blockItems the immutable list of block items to handle
      */
     void handleBlockItemsReceived(BlockItems blockItems);
-
-    default boolean isGating() {
-        return true;
-    }
 }

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockItemHandler.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockItemHandler.java
@@ -4,7 +4,7 @@ package org.hiero.block.node.spi.blockmessaging;
 /**
  * Interface for handling block items.
  */
-public interface BlockItemHandler {
+public interface BlockItemHandler extends GatingHandler {
     /**
      * Handle a list of block items. Always called on handler thread. Each registered handler will have its own virtual
      * thread.
@@ -19,4 +19,8 @@ public interface BlockItemHandler {
      * @param blockItems the immutable list of block items to handle
      */
     void handleBlockItemsReceived(BlockItems blockItems);
+
+    default boolean isGating() {
+        return true;
+    }
 }

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockNotificationHandler.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockNotificationHandler.java
@@ -4,7 +4,7 @@ package org.hiero.block.node.spi.blockmessaging;
 /**
  * Interface for handling block notifications.
  */
-public interface BlockNotificationHandler {
+public interface BlockNotificationHandler extends GatingHandler {
     /**
      * Handle a block verification notification.
      * <p>

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/GatingHandler.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/GatingHandler.java
@@ -1,7 +1,35 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.spi.blockmessaging;
-
+/**
+ * Marker interface that controls whether a handler participates as a gating sequence on the
+ * underlying LMAX Disruptor ring buffer.
+ *
+ * <p>When a handler is <em>gating</em> ({@link #isGating()} returns {@code true}), the ring
+ * buffer will not overwrite any slot until the handler has consumed it.  This provides
+ * backpressure: a slow handler stalls the publisher once the buffer is full.  Use this for
+ * handlers that <em>must</em> process every event (e.g. block persistence, verification).
+ *
+ * <p>When a handler is <em>non-gating</em> ({@link #isGating()} returns {@code false}), the
+ * handler's sequence is <strong>not</strong> added to the ring buffer's gating sequences.  The
+ * publisher is never stalled by a slow or absent handler.  Additionally, the processor is
+ * initialized at the ring buffer's current cursor so it only receives <em>future</em> events;
+ * past events already in the buffer are not replayed.  Use this for best-effort consumers such
+ * as live-streaming subscribers that must not impede block ingestion.
+ *
+ * <p>Both {@link BlockItemHandler} and {@link NoBackPressureBlockItemHandler} extend this
+ * interface; the default implementation here returns {@code true} (gating), and
+ * {@link NoBackPressureBlockItemHandler} overrides it to return {@code false}.
+ */
 public interface GatingHandler {
+
+    /**
+     * Returns {@code true} if this handler should act as a gating sequence on the ring buffer,
+     * applying backpressure to publishers when the handler falls behind; {@code false} if the
+     * handler should receive only future events without ever stalling the publisher.
+     *
+     * @return {@code true} for gating (backpressure) semantics; {@code false} for no-backpressure
+     *         (best-effort, future-only) semantics
+     */
     default boolean isGating() {
         return true;
     }

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/GatingHandler.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/GatingHandler.java
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.blockmessaging;
+
+public interface GatingHandler {
+    default boolean isGating() {
+        return true;
+    }
+}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/NoBackPressureBlockItemHandler.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/NoBackPressureBlockItemHandler.java
@@ -13,4 +13,9 @@ public interface NoBackPressureBlockItemHandler extends BlockItemHandler {
      * items.
      */
     void onTooFarBehindError();
+
+    @Override
+    default boolean isGating() {
+        return false;
+    }
 }

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
@@ -202,7 +202,7 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
                 // register us to listen to block items from the block messaging system
                 blockNodeContext
                         .blockMessaging()
-                        .registerNoBackpressureBlockItemHandler(liveBlockHandler, false, sessionContext.handlerName);
+                        .registerBlockItemHandler(liveBlockHandler, false, sessionContext.handlerName);
                 if (canFulfillRequest()) {
                     // the request can be fulfilled, so we can start sending blocks
                     sessionReadyLatch.countDown();

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
@@ -202,7 +202,7 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
                 // register us to listen to block items from the block messaging system
                 blockNodeContext
                         .blockMessaging()
-                        .registerBlockItemHandler(liveBlockHandler, false, sessionContext.handlerName);
+                        .registerNoBackpressureBlockItemHandler(liveBlockHandler, false, sessionContext.handlerName);
                 if (canFulfillRequest()) {
                     // the request can be fulfilled, so we can start sending blocks
                     sessionReadyLatch.countDown();

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
@@ -174,6 +174,10 @@ public abstract class BaseSuite {
                 .getDockerClient()
                 .restartContainerCmd(genericContainer.getContainerId())
                 .exec();
+        // Wait for the container to accept connections before returning so that callers'
+        // subsequent sleep timers start from a known-ready baseline, not from the moment
+        // the Docker restart command fires (which precedes JVM start by several seconds).
+        Wait.forListeningPort().waitUntilReady(genericContainer);
     }
 
     /**

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -305,14 +305,12 @@ public class BlockNodeAPITests {
                 .startBlockNumber(blockNumber)
                 .build();
 
-        // Wait for all 3 expected responses (block items, end-of-block, success status) before
-        // asserting, so there is no race between the latch release and the size check.
         final AtomicReference<CountDownLatch> blockItemsSubscribe1Latch =
-                subscribeResponseObserver.setAndGetOnNextLatch(3);
+                subscribeResponseObserver.setAndGetOnNextLatch(2);
         blockStreamSubscribeServiceClient.subscribeBlockStream(subscribeRequest1, subscribeResponseObserver);
 
         awaitLatch(blockItemsSubscribe1Latch, "historical subscription");
-        // block items (all 4 items in one batch), end-of-block, and success status
+        // block items, end block, and success status
         assertThat(subscribeResponseObserver.getOnNextCalls()).hasSize(3);
         assertThat(subscribeResponseObserver.getOnCompleteCalls().get()).isEqualTo(1);
 

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -311,7 +311,12 @@ public class BlockNodeAPITests {
 
         awaitLatch(blockItemsSubscribe1Latch, "historical subscription");
         // block items, end block, and success status
-        assertThat(subscribeResponseObserver.getOnNextCalls()).hasSize(3);
+        assertThat(subscribeResponseObserver
+                        .getOnNextCalls()
+                        .getFirst()
+                        .blockItems()
+                        .blockItems())
+                .hasSize(3);
         assertThat(subscribeResponseObserver.getOnCompleteCalls().get()).isEqualTo(1);
 
         final SubscribeStreamResponse subscribeResponse0 =

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -311,8 +311,8 @@ public class BlockNodeAPITests {
 
         awaitLatch(blockItemsSubscribe1Latch, "historical subscription");
         // block items, end block, and success status
+        assertThat(subscribeResponseObserver.getOnNextCalls()).hasSize(4);
         assertThat(subscribeResponseObserver.getOnCompleteCalls().get()).isEqualTo(1);
-        assertThat(subscribeResponseObserver.getOnNextCalls()).hasSize(3);
 
         final SubscribeStreamResponse subscribeResponse0 =
                 subscribeResponseObserver.getOnNextCalls().get(0);

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -311,8 +311,8 @@ public class BlockNodeAPITests {
 
         awaitLatch(blockItemsSubscribe1Latch, "historical subscription");
         // block items, end block, and success status
-        assertThat(subscribeResponseObserver.getOnNextCalls()).hasSize(3);
         assertThat(subscribeResponseObserver.getOnCompleteCalls().get()).isEqualTo(1);
+        assertThat(subscribeResponseObserver.getOnNextCalls()).hasSize(3);
 
         final SubscribeStreamResponse subscribeResponse0 =
                 subscribeResponseObserver.getOnNextCalls().get(0);

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -305,8 +305,10 @@ public class BlockNodeAPITests {
                 .startBlockNumber(blockNumber)
                 .build();
 
+        // Wait for all 3 expected responses (block items, end-of-block, success status) before
+        // asserting, so there is no race between the latch release and the size check.
         final AtomicReference<CountDownLatch> blockItemsSubscribe1Latch =
-                subscribeResponseObserver.setAndGetOnNextLatch(2);
+                subscribeResponseObserver.setAndGetOnNextLatch(3);
         blockStreamSubscribeServiceClient.subscribeBlockStream(subscribeRequest1, subscribeResponseObserver);
 
         awaitLatch(blockItemsSubscribe1Latch, "historical subscription");

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -317,7 +317,7 @@ public class BlockNodeAPITests {
 
         int responseBlockItemCount = 0;
         for (SubscribeStreamResponse response : subscribeResponseObserver.getOnNextCalls()) {
-            if (response.hasBlockItems())
+            if (response.blockItems() != null)
                 responseBlockItemCount += response.blockItems().blockItems().size();
         }
         assertThat(responseBlockItemCount).isEqualTo(blockItems.length);
@@ -428,6 +428,26 @@ public class BlockNodeAPITests {
             });
             // success status should be the last response
             assertThat(subscribeResponseObserver.getOnNextCalls()).element(6).satisfies(response -> {
+                assertThat(response.status()).isEqualTo(SubscribeStreamResponse.Code.SUCCESS);
+            });
+        } else if (subscribeResponseObserver.getOnNextCalls().size() == 8) {
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(4).satisfies(response -> {
+                assertThat(response.blockItems().blockItems())
+                        .hasSize(blockItems1.length - 1)
+                        .first()
+                        .returns(blockNumber1, i -> i.blockHeader().number());
+            });
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(5).satisfies(response -> {
+                assertThat(response.blockItems().blockItems())
+                        .hasSize(1)
+                        .first()
+                        .returns(blockNumber1, i -> i.blockProof().block());
+            });
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(6).satisfies(response -> {
+                assertThat(response.endOfBlock().blockNumber()).isEqualTo(blockNumber1);
+            });
+            // success status should be the last response
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(7).satisfies(response -> {
                 assertThat(response.status()).isEqualTo(SubscribeStreamResponse.Code.SUCCESS);
             });
         } else {

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -412,12 +412,13 @@ public class BlockNodeAPITests {
             // block 0 items, end block 0, success status, block 1 items w/o proof, block 1 proof, end block 1,
             // success status
             assertThat(subscribeResponseObserver.getOnNextCalls()).element(3).satisfies(response -> {
-                if (response.blockItems() != null){
+                if (response.blockItems() != null) {
                     assertThat(response.blockItems().blockItems())
                             .hasSize(blockItems1.length - 1)
                             .first()
                             .returns(blockNumber1, i -> i.blockHeader().number());
-            }});
+                }
+            });
             assertThat(subscribeResponseObserver.getOnNextCalls()).element(4).satisfies(response -> {
                 assertThat(response.blockItems().blockItems())
                         .hasSize(1)

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -311,7 +311,7 @@ public class BlockNodeAPITests {
 
         awaitLatch(blockItemsSubscribe1Latch, "historical subscription");
         // block items, end block, and success status
-        assertThat(subscribeResponseObserver.getOnNextCalls()).hasSize(4);
+        assertThat(subscribeResponseObserver.getOnNextCalls()).hasSize(3);
         assertThat(subscribeResponseObserver.getOnCompleteCalls().get()).isEqualTo(1);
 
         final SubscribeStreamResponse subscribeResponse0 =

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -311,17 +311,18 @@ public class BlockNodeAPITests {
 
         awaitLatch(blockItemsSubscribe1Latch, "historical subscription");
         // block items, end block, and success status
+        // sometimes we get the block proof as well
+        assertThat(subscribeResponseObserver.getOnNextCalls()).isIn(3, 4);
+        assertThat(subscribeResponseObserver.getOnCompleteCalls().get()).isEqualTo(1);
+
+        //        final SubscribeStreamResponse subscribeResponse0 =
+        //                subscribeResponseObserver.getOnNextCalls().get(0);
         assertThat(subscribeResponseObserver
                         .getOnNextCalls()
                         .getFirst()
                         .blockItems()
                         .blockItems())
-                .hasSize(3);
-        assertThat(subscribeResponseObserver.getOnCompleteCalls().get()).isEqualTo(1);
-
-        final SubscribeStreamResponse subscribeResponse0 =
-                subscribeResponseObserver.getOnNextCalls().get(0);
-        assertThat(subscribeResponse0.blockItems().blockItems()).hasSize(blockItems.length);
+                .hasSize(blockItems.length);
 
         // ==== Scenario 6: Subscribe to live block stream and confirm receipt of newly published block ===
         final long blockNumber1 = 1;

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -305,16 +305,15 @@ public class BlockNodeAPITests {
                 .startBlockNumber(blockNumber)
                 .build();
 
-        // Wait for all 4 expected responses (two block-item batches, end-of-block, success status)
-        // before asserting, so there is no race between the latch release and the size check.
-        // The block is published in two sends: header+round+footer first, then proof via endBlock().
+        // Wait for all 3 expected responses (block items, end-of-block, success status) before
+        // asserting, so there is no race between the latch release and the size check.
         final AtomicReference<CountDownLatch> blockItemsSubscribe1Latch =
-                subscribeResponseObserver.setAndGetOnNextLatch(4);
+                subscribeResponseObserver.setAndGetOnNextLatch(3);
         blockStreamSubscribeServiceClient.subscribeBlockStream(subscribeRequest1, subscribeResponseObserver);
 
         awaitLatch(blockItemsSubscribe1Latch, "historical subscription");
-        // header+round+footer batch, proof batch, end-of-block, and success status
-        assertThat(subscribeResponseObserver.getOnNextCalls()).hasSize(4);
+        // block items (all 4 items in one batch), end-of-block, and success status
+        assertThat(subscribeResponseObserver.getOnNextCalls()).hasSize(3);
         assertThat(subscribeResponseObserver.getOnCompleteCalls().get()).isEqualTo(1);
 
         final SubscribeStreamResponse subscribeResponse0 =
@@ -382,50 +381,51 @@ public class BlockNodeAPITests {
 
         // Close publisher connections and wait for the subscribe thread to finish receiving all responses
         // before asserting on subscribe content. The subscribe thread's subscribeBlockStream call only returns
-        // once the subscription ends, guaranteeing all 7 or 8 responses have been delivered.
+        // once the subscription ends, guaranteeing all 6 or 7 responses have been delivered.
         requestStream.closeConnection();
         requestStream2.closeConnection();
         awaitThread(subscribeThread, "live subscribe thread");
 
-        // Block 0 contributes 4 responses: header+round+footer batch, proof batch, end-of-block, success status.
-        // Block 1 contributes 3 or 4: if served from history all items arrive in one batch (3 total);
-        // if served from the live stream the proof arrives separately (4 total).
-        if (subscribeResponseObserver.getOnNextCalls().size() == 7) {
-            // 7 items: block 0 header+round+footer, block 0 proof, end block 0, success,
-            //          block 1 items, end block 1, success
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(4).satisfies(response -> {
+        // When subscribed initially, block 1 was already persisted, so it will be streamed from history.
+        // Then, the session will either supply the block from history, if it is persisted, or from the live stream
+        // if not persisted yet. If it comes from the live stream, we expect one more onNext call, because the
+        // proof will be sent separately to the live queue from the rest of the block.
+        if (subscribeResponseObserver.getOnNextCalls().size() == 6) {
+            // 6 items expected: block 0 items, end block 0, success status, block 1 items, end block 1, success status
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(3).satisfies(response -> {
                 assertThat(response.blockItems().blockItems())
                         .hasSize(blockItems1.length)
                         .first()
                         .returns(blockNumber1, i -> i.blockHeader().number());
             });
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(5).satisfies(response -> {
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(4).satisfies(response -> {
                 assertThat(response.endOfBlock().blockNumber()).isEqualTo(blockNumber1);
             });
             // success status should be the last response
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(6).satisfies(response -> {
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(5).satisfies(response -> {
                 assertThat(response.status()).isEqualTo(SubscribeStreamResponse.Code.SUCCESS);
             });
-        } else if (subscribeResponseObserver.getOnNextCalls().size() == 8) {
-            // 8 items: block 0 header+round+footer, block 0 proof, end block 0, success,
-            //          block 1 items w/o proof, block 1 proof, end block 1, success
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(4).satisfies(response -> {
+        } else if (subscribeResponseObserver.getOnNextCalls().size() == 7) {
+            // 7 items expected:
+            // block 0 items, end block 0, success status, block 1 items w/o proof, block 1 proof, end block 1,
+            // success status
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(3).satisfies(response -> {
                 assertThat(response.blockItems().blockItems())
                         .hasSize(blockItems1.length - 1)
                         .first()
                         .returns(blockNumber1, i -> i.blockHeader().number());
             });
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(5).satisfies(response -> {
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(4).satisfies(response -> {
                 assertThat(response.blockItems().blockItems())
                         .hasSize(1)
                         .first()
                         .returns(blockNumber1, i -> i.blockProof().block());
             });
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(6).satisfies(response -> {
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(5).satisfies(response -> {
                 assertThat(response.endOfBlock().blockNumber()).isEqualTo(blockNumber1);
             });
             // success status should be the last response
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(7).satisfies(response -> {
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(6).satisfies(response -> {
                 assertThat(response.status()).isEqualTo(SubscribeStreamResponse.Code.SUCCESS);
             });
         } else {

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -412,11 +412,12 @@ public class BlockNodeAPITests {
             // block 0 items, end block 0, success status, block 1 items w/o proof, block 1 proof, end block 1,
             // success status
             assertThat(subscribeResponseObserver.getOnNextCalls()).element(3).satisfies(response -> {
-                assertThat(response.blockItems().blockItems())
-                        .hasSize(blockItems1.length - 1)
-                        .first()
-                        .returns(blockNumber1, i -> i.blockHeader().number());
-            });
+                if (response.blockItems() != null){
+                    assertThat(response.blockItems().blockItems())
+                            .hasSize(blockItems1.length - 1)
+                            .first()
+                            .returns(blockNumber1, i -> i.blockHeader().number());
+            }});
             assertThat(subscribeResponseObserver.getOnNextCalls()).element(4).satisfies(response -> {
                 assertThat(response.blockItems().blockItems())
                         .hasSize(1)

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -311,16 +311,16 @@ public class BlockNodeAPITests {
 
         awaitLatch(blockItemsSubscribe1Latch, "historical subscription");
         // block items, end block, and success status
-        // sometimes we get the block proof as well
+        // sometimes we get 3 calls, sometimes 4
         assertThat(subscribeResponseObserver.getOnNextCalls().size()).isIn(3, 4);
         assertThat(subscribeResponseObserver.getOnCompleteCalls().get()).isEqualTo(1);
 
-        assertThat(subscribeResponseObserver
-                        .getOnNextCalls()
-                        .getFirst()
-                        .blockItems()
-                        .blockItems())
-                .hasSize(blockItems.length);
+        int responseBlockItemCount = 0;
+        for (SubscribeStreamResponse response : subscribeResponseObserver.getOnNextCalls()) {
+            if (response.hasBlockItems())
+                responseBlockItemCount += response.blockItems().blockItems().size();
+        }
+        assertThat(responseBlockItemCount).isEqualTo(blockItems.length);
 
         // ==== Scenario 6: Subscribe to live block stream and confirm receipt of newly published block ===
         final long blockNumber1 = 1;

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -33,7 +34,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.hiero.block.api.BlockAccessServiceInterface;
 import org.hiero.block.api.BlockEnd;
 import org.hiero.block.api.BlockItemSet;
@@ -388,77 +388,63 @@ public class BlockNodeAPITests {
         requestStream2.closeConnection();
         awaitThread(subscribeThread, "live subscribe thread");
 
-        // When subscribed initially, block 1 was already persisted, so it will be streamed from history.
-        // Then, the session will either supply the block from history, if it is persisted, or from the live stream
-        // if not persisted yet. If it comes from the live stream, we expect one more onNext call, because the
-        // proof will be sent separately to the live queue from the rest of the block.
-        if (subscribeResponseObserver.getOnNextCalls().size() == 6) {
-            // 6 items expected: block 0 items, end block 0, success status, block 1 items, end block 1, success status
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(3).satisfies(response -> {
-                assertThat(response.blockItems().blockItems())
-                        .hasSize(blockItems1.length)
-                        .first()
-                        .returns(blockNumber1, i -> i.blockHeader().number());
-            });
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(4).satisfies(response -> {
-                assertThat(response.endOfBlock().blockNumber()).isEqualTo(blockNumber1);
-            });
-            // success status should be the last response
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(5).satisfies(response -> {
-                assertThat(response.status()).isEqualTo(SubscribeStreamResponse.Code.SUCCESS);
-            });
-        } else if (subscribeResponseObserver.getOnNextCalls().size() == 7) {
-            // 7 items expected:
-            // block 0 items, end block 0, success status, block 1 items w/o proof, block 1 proof, end block 1,
-            // success status
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(3).satisfies(response -> {
-                if (response.blockItems() != null) {
-                    assertThat(response.blockItems().blockItems())
-                            .hasSize(blockItems1.length - 1)
-                            .first()
-                            .returns(blockNumber1, i -> i.blockHeader().number());
-                }
-            });
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(4).satisfies(response -> {
-                assertThat(response.blockItems().blockItems())
-                        .hasSize(1)
-                        .first()
-                        .returns(blockNumber1, i -> i.blockProof().block());
-            });
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(5).satisfies(response -> {
-                assertThat(response.endOfBlock().blockNumber()).isEqualTo(blockNumber1);
-            });
-            // success status should be the last response
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(6).satisfies(response -> {
-                assertThat(response.status()).isEqualTo(SubscribeStreamResponse.Code.SUCCESS);
-            });
-        } else if (subscribeResponseObserver.getOnNextCalls().size() == 8) {
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(4).satisfies(response -> {
-                assertThat(response.blockItems().blockItems())
-                        .hasSize(blockItems1.length - 1)
-                        .first()
-                        .returns(blockNumber1, i -> i.blockHeader().number());
-            });
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(5).satisfies(response -> {
-                assertThat(response.blockItems().blockItems())
-                        .hasSize(1)
-                        .first()
-                        .returns(blockNumber1, i -> i.blockProof().block());
-            });
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(6).satisfies(response -> {
-                assertThat(response.endOfBlock().blockNumber()).isEqualTo(blockNumber1);
-            });
-            // success status should be the last response
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(7).satisfies(response -> {
-                assertThat(response.status()).isEqualTo(SubscribeStreamResponse.Code.SUCCESS);
-            });
-        } else {
-            final String responses = subscribeResponseObserver.getOnNextCalls().stream()
-                    .map(SubscribeStreamResponse::toString)
-                    .collect(Collectors.joining(", "));
-            final int size = subscribeResponseObserver.getOnNextCalls().size();
-            fail("Unexpected number of subscribe responses: %d, Responses: %s".formatted(size, responses));
+        // The `subscribeResponseObserver.getOnNextCalls()` is not deterministic now that live streams are non-gating
+        // The best way to test the responses and block items is by creating lists and checking the non-blockitems and
+        // blockitems separately
+        List<BlockItem> responseBlockItems = new ArrayList<>();
+        List<SubscribeStreamResponse> responses = new ArrayList<>();
+        for (SubscribeStreamResponse response : subscribeResponseObserver.getOnNextCalls()) {
+            if (response.blockItems() != null)
+                responseBlockItems.addAll(response.blockItems().blockItems());
+            else responses.add(response);
         }
+
+        assertThat(responses).hasSize(4);
+        assertThat(responses).element(0).satisfies(response -> {
+            assertThat(response.endOfBlock().blockNumber()).isEqualTo(0);
+        });
+        assertThat(responses).element(1).satisfies(response -> {
+            assertThat(response.status()).isEqualTo(SubscribeStreamResponse.Code.SUCCESS);
+        });
+        assertThat(responses).element(2).satisfies(response -> {
+            assertThat(response.endOfBlock().blockNumber()).isEqualTo(1);
+        });
+        assertThat(responses).element(3).satisfies(response -> {
+            assertThat(response.status()).isEqualTo(SubscribeStreamResponse.Code.SUCCESS);
+        });
+
+        assertThat(responseBlockItems).hasSize(8);
+        assertThat(responseBlockItems).element(0).satisfies(blockItem -> {
+            assertThat(blockItem.blockHeader()).isNotNull();
+            assertThat(blockItem.blockHeader().number()).isEqualTo(0);
+        });
+        assertThat(responseBlockItems).element(1).satisfies(blockItem -> {
+            assertThat(blockItem.roundHeader()).isNotNull();
+            assertThat(blockItem.roundHeader().roundNumber()).isEqualTo(0);
+        });
+        assertThat(responseBlockItems).element(2).satisfies(blockItem -> {
+            assertThat(blockItem.blockFooter()).isNotNull();
+        });
+        assertThat(responseBlockItems).element(3).satisfies(blockItem -> {
+            assertThat(blockItem.blockProof()).isNotNull();
+            assertThat(blockItem.blockProof().block()).isEqualTo(0);
+        });
+        assertThat(responseBlockItems).element(4).satisfies(blockItem -> {
+            assertThat(blockItem.blockHeader()).isNotNull();
+            assertThat(blockItem.blockHeader().number()).isEqualTo(1);
+        });
+        assertThat(responseBlockItems).element(5).satisfies(blockItem -> {
+            assertThat(blockItem.roundHeader()).isNotNull();
+            assertThat(blockItem.roundHeader().roundNumber()).isEqualTo(10);
+        });
+        assertThat(responseBlockItems).element(6).satisfies(blockItem -> {
+            assertThat(blockItem.blockFooter()).isNotNull();
+        });
+        assertThat(responseBlockItems).element(7).satisfies(blockItem -> {
+            assertThat(blockItem.blockProof()).isNotNull();
+            assertThat(blockItem.blockProof().block()).isEqualTo(1);
+        });
+
         blockStreamPublishServiceClient.close();
         blockStreamPublishServiceClient2.close();
         blockStreamSubscribeServiceClient.close();

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -312,7 +312,7 @@ public class BlockNodeAPITests {
         awaitLatch(blockItemsSubscribe1Latch, "historical subscription");
         // block items, end block, and success status
         // sometimes we get the block proof as well
-        assertThat(subscribeResponseObserver.getOnNextCalls()).isIn(3, 4);
+        assertThat(subscribeResponseObserver.getOnNextCalls().size()).isIn(3, 4);
         assertThat(subscribeResponseObserver.getOnCompleteCalls().get()).isEqualTo(1);
 
         assertThat(subscribeResponseObserver

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -315,8 +315,6 @@ public class BlockNodeAPITests {
         assertThat(subscribeResponseObserver.getOnNextCalls()).isIn(3, 4);
         assertThat(subscribeResponseObserver.getOnCompleteCalls().get()).isEqualTo(1);
 
-        //        final SubscribeStreamResponse subscribeResponse0 =
-        //                subscribeResponseObserver.getOnNextCalls().get(0);
         assertThat(subscribeResponseObserver
                         .getOnNextCalls()
                         .getFirst()

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -305,15 +305,16 @@ public class BlockNodeAPITests {
                 .startBlockNumber(blockNumber)
                 .build();
 
-        // Wait for all 3 expected responses (block items, end-of-block, success status) before
-        // asserting, so there is no race between the latch release and the size check.
+        // Wait for all 4 expected responses (two block-item batches, end-of-block, success status)
+        // before asserting, so there is no race between the latch release and the size check.
+        // The block is published in two sends: header+round+footer first, then proof via endBlock().
         final AtomicReference<CountDownLatch> blockItemsSubscribe1Latch =
-                subscribeResponseObserver.setAndGetOnNextLatch(3);
+                subscribeResponseObserver.setAndGetOnNextLatch(4);
         blockStreamSubscribeServiceClient.subscribeBlockStream(subscribeRequest1, subscribeResponseObserver);
 
         awaitLatch(blockItemsSubscribe1Latch, "historical subscription");
-        // block items, end block, and success status
-        assertThat(subscribeResponseObserver.getOnNextCalls()).hasSize(3);
+        // header+round+footer batch, proof batch, end-of-block, and success status
+        assertThat(subscribeResponseObserver.getOnNextCalls()).hasSize(4);
         assertThat(subscribeResponseObserver.getOnCompleteCalls().get()).isEqualTo(1);
 
         final SubscribeStreamResponse subscribeResponse0 =
@@ -381,51 +382,50 @@ public class BlockNodeAPITests {
 
         // Close publisher connections and wait for the subscribe thread to finish receiving all responses
         // before asserting on subscribe content. The subscribe thread's subscribeBlockStream call only returns
-        // once the subscription ends, guaranteeing all 6 or 7 responses have been delivered.
+        // once the subscription ends, guaranteeing all 7 or 8 responses have been delivered.
         requestStream.closeConnection();
         requestStream2.closeConnection();
         awaitThread(subscribeThread, "live subscribe thread");
 
-        // When subscribed initially, block 1 was already persisted, so it will be streamed from history.
-        // Then, the session will either supply the block from history, if it is persisted, or from the live stream
-        // if not persisted yet. If it comes from the live stream, we expect one more onNext call, because the
-        // proof will be sent separately to the live queue from the rest of the block.
-        if (subscribeResponseObserver.getOnNextCalls().size() == 6) {
-            // 6 items expected: block 0 items, end block 0, success status, block 1 items, end block 1, success status
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(3).satisfies(response -> {
+        // Block 0 contributes 4 responses: header+round+footer batch, proof batch, end-of-block, success status.
+        // Block 1 contributes 3 or 4: if served from history all items arrive in one batch (3 total);
+        // if served from the live stream the proof arrives separately (4 total).
+        if (subscribeResponseObserver.getOnNextCalls().size() == 7) {
+            // 7 items: block 0 header+round+footer, block 0 proof, end block 0, success,
+            //          block 1 items, end block 1, success
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(4).satisfies(response -> {
                 assertThat(response.blockItems().blockItems())
                         .hasSize(blockItems1.length)
                         .first()
                         .returns(blockNumber1, i -> i.blockHeader().number());
-            });
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(4).satisfies(response -> {
-                assertThat(response.endOfBlock().blockNumber()).isEqualTo(blockNumber1);
-            });
-            // success status should be the last response
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(5).satisfies(response -> {
-                assertThat(response.status()).isEqualTo(SubscribeStreamResponse.Code.SUCCESS);
-            });
-        } else if (subscribeResponseObserver.getOnNextCalls().size() == 7) {
-            // 7 items expected:
-            // block 0 items, end block 0, success status, block 1 items w/o proof, block 1 proof, end block 1,
-            // success status
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(3).satisfies(response -> {
-                assertThat(response.blockItems().blockItems())
-                        .hasSize(blockItems1.length - 1)
-                        .first()
-                        .returns(blockNumber1, i -> i.blockHeader().number());
-            });
-            assertThat(subscribeResponseObserver.getOnNextCalls()).element(4).satisfies(response -> {
-                assertThat(response.blockItems().blockItems())
-                        .hasSize(1)
-                        .first()
-                        .returns(blockNumber1, i -> i.blockProof().block());
             });
             assertThat(subscribeResponseObserver.getOnNextCalls()).element(5).satisfies(response -> {
                 assertThat(response.endOfBlock().blockNumber()).isEqualTo(blockNumber1);
             });
             // success status should be the last response
             assertThat(subscribeResponseObserver.getOnNextCalls()).element(6).satisfies(response -> {
+                assertThat(response.status()).isEqualTo(SubscribeStreamResponse.Code.SUCCESS);
+            });
+        } else if (subscribeResponseObserver.getOnNextCalls().size() == 8) {
+            // 8 items: block 0 header+round+footer, block 0 proof, end block 0, success,
+            //          block 1 items w/o proof, block 1 proof, end block 1, success
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(4).satisfies(response -> {
+                assertThat(response.blockItems().blockItems())
+                        .hasSize(blockItems1.length - 1)
+                        .first()
+                        .returns(blockNumber1, i -> i.blockHeader().number());
+            });
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(5).satisfies(response -> {
+                assertThat(response.blockItems().blockItems())
+                        .hasSize(1)
+                        .first()
+                        .returns(blockNumber1, i -> i.blockProof().block());
+            });
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(6).satisfies(response -> {
+                assertThat(response.endOfBlock().blockNumber()).isEqualTo(blockNumber1);
+            });
+            // success status should be the last response
+            assertThat(subscribeResponseObserver.getOnNextCalls()).element(7).satisfies(response -> {
                 assertThat(response.status()).isEqualTo(SubscribeStreamResponse.Code.SUCCESS);
             });
         } else {


### PR DESCRIPTION
## Reviewer Notes

###What was done

- Added a GatingHandler interface that all Handlers extend. The isGating() method returns true by default. NoBackPressureBlockItemHandler overrides isGating() to return false.

- Added import java.util.concurrent.atomic.AtomicBoolean — needed for the one-shot guard.

- Fixed the registerNoBackpressureBlockItemHandler lambda — two problems corrected:

1. Lag check moved before dispatch. The original code called handleBlockItemsReceived first, then checked lag — dead code when the handler blocks. The check now runs first: if the handler is already >80% behind, it's evicted immediately without ever calling handleBlockItemsReceived.
2. One-shot eviction guard (AtomicBoolean evicted). After halt() is called, the BatchEventProcessor may deliver a few more buffered events from its current batch before stopping. Without the guard, onTooFarBehindError() and unregisterBlockItemHandler() would be called repeatedly. compareAndSet(false, true) ensures exactly one eviction fires.

## Related Issue(s)
Closes: #2932
