### PR TITLE
feat: add peer BN query step to RsaRosterBootstrapPlugin.

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
@@ -265,7 +265,7 @@ public class TestBlockNodeServer {
         ///
         /// @param count the number of addresses in the `NodeAddressBook`
         private static NodeAddressBook buildAddressBook(final int count) {
-            final List<NodeAddress> addresses = new java.util.ArrayList<>();
+            final List<NodeAddress> addresses = new ArrayList<>();
             for (int i = 0; i < count; i++) {
                 addresses.add(NodeAddress.newBuilder()
                         .nodeId(i)

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
@@ -3,6 +3,8 @@ package org.hiero.block.node.app.fixtures.server;
 
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.node.base.NodeAddress;
+import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.pbj.grpc.helidon.PbjRouting;
 import com.hedera.pbj.grpc.helidon.PbjRouting.Builder;
 import com.hedera.pbj.grpc.helidon.config.PbjConfig;
@@ -237,6 +239,7 @@ public class TestBlockNodeServer {
                             Bytes.fromHex("02020202"),
                             List.of(buildRosterEntry(11, 22, Bytes.fromHex("03030303"))),
                             250))
+                    .nodeAddressBook(buildAddressBook(4))
                     .build();
         }
 
@@ -256,6 +259,20 @@ public class TestBlockNodeServer {
                     .currentRoster(tssRoster)
                     .validFromBlock(validFromBlock)
                     .build();
+        }
+
+        /// builds a `NodeAddressBook`
+        ///
+        /// @param count the number of addresses in the `NodeAddressBook`
+        private static NodeAddressBook buildAddressBook(final int count) {
+            final List<NodeAddress> addresses = new java.util.ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                addresses.add(NodeAddress.newBuilder()
+                        .nodeId(i)
+                        .rsaPubKey("hexkey" + i)
+                        .build());
+            }
+            return NodeAddressBook.newBuilder().nodeAddress(addresses).build();
         }
 
         /// build a `RosterEntry`object from individual fields

--- a/block-node/roster-bootstrap-rsa/build.gradle.kts
+++ b/block-node/roster-bootstrap-rsa/build.gradle.kts
@@ -3,10 +3,16 @@ plugins { id("org.hiero.gradle.module.library") }
 
 description = "Hiero Block Node RSA Roster Bootstrap Plugin"
 
-mainModuleInfo { runtimeOnly("com.swirlds.config.impl") }
+mainModuleInfo {
+    runtimeOnly("com.swirlds.config.impl")
+    runtimeOnly("com.hedera.pbj.grpc.helidon.config")
+    runtimeOnly("com.hedera.pbj.grpc.client.helidon")
+    runtimeOnly("com.hedera.pbj.grpc.helidon")
+}
 
 testModuleInfo {
     requires("org.junit.jupiter.api")
     requires("org.hiero.block.node.app.test.fixtures")
     requires("jdk.httpserver")
+    requires("org.mockito")
 }

--- a/block-node/roster-bootstrap-rsa/src/main/java/module-info.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/module-info.java
@@ -21,11 +21,11 @@ module org.hiero.block.node.roster.bootstrap.rsa {
             org.hiero.block.node.app;
 
     requires transitive com.swirlds.config.api;
+    requires transitive org.hiero.block.node.base;
     requires transitive org.hiero.block.node.spi;
+    requires transitive org.hiero.block.protobuf.pbj;
+    requires transitive org.hiero.metrics;
     requires com.hedera.pbj.runtime;
-    requires org.hiero.block.node.base;
-    requires org.hiero.block.protobuf.pbj;
-    requires org.hiero.metrics;
     requires java.net.http;
 
     provides org.hiero.block.node.spi.BlockNodePlugin with

--- a/block-node/roster-bootstrap-rsa/src/main/java/module-info.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/module-info.java
@@ -21,11 +21,11 @@ module org.hiero.block.node.roster.bootstrap.rsa {
             org.hiero.block.node.app;
 
     requires transitive com.swirlds.config.api;
-    requires transitive org.hiero.block.node.base;
     requires transitive org.hiero.block.node.spi;
     requires transitive org.hiero.block.protobuf.pbj;
     requires transitive org.hiero.metrics;
     requires com.hedera.pbj.runtime;
+    requires org.hiero.block.node.base;
     requires java.net.http;
 
     provides org.hiero.block.node.spi.BlockNodePlugin with

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcher.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcher.java
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.roster.bootstrap.rsa;
+
+import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.INFO;
+import static java.lang.System.Logger.Level.WARNING;
+
+import com.hedera.hapi.node.base.NodeAddressBook;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import org.hiero.block.api.ServerStatusDetailResponse;
+import org.hiero.block.api.ServerStatusRequest;
+import org.hiero.block.internal.BlockNodeSource;
+import org.hiero.block.internal.BlockNodeSourceConfig;
+import org.hiero.block.node.base.client.BlockNodeClient;
+import org.hiero.block.node.roster.bootstrap.rsa.RsaRosterBootstrapPlugin.MetricsHolder;
+
+/// Fetches a `NodeAddressBook` from one or more configured peer block nodes via gRPC.
+///
+/// Each peer is queried in order via `serverStatusDetail`. The first peer that returns a
+/// valid address book (at least one entry with a non-blank RSA public key) is accepted and
+/// its address book is returned. If all peers fail or return an unusable book, `null` is
+/// returned and the caller falls through to the Mirror Node fetch.
+///
+/// Connection pooling: a `BlockNodeClient` is created per peer on first use and cached for
+/// subsequent calls. If a client becomes unreachable it is removed from the pool so it can
+/// be recreated on the next attempt.
+public class AddressBookFetcher implements Closeable {
+
+    private static final System.Logger LOGGER = System.getLogger(AddressBookFetcher.class.getName());
+
+    private final BlockNodeSource blockNodeSource;
+    private final boolean enableTls;
+    private final int maxIncomingBufferSize;
+    private final MetricsHolder metrics;
+
+    /// Package-private for testing — allows tests to inject mock clients.
+    final ConcurrentHashMap<BlockNodeSourceConfig, BlockNodeClient> nodeClientMap = new ConcurrentHashMap<>();
+
+    /// Constructs a fetcher for the given peer list and config.
+    ///
+    /// @param blockNodeSource the list of peer block nodes to query
+    /// @param config the RSA bootstrap configuration (TLS and buffer-size settings)
+    /// @param metrics holder for peer-query metrics counters
+    public AddressBookFetcher(
+            @NonNull BlockNodeSource blockNodeSource,
+            @NonNull RsaRosterBootstrapConfig config,
+            @NonNull MetricsHolder metrics) {
+        this.blockNodeSource = blockNodeSource;
+        this.enableTls = config.enableTLS();
+        this.maxIncomingBufferSize = config.maxIncomingBufferSize();
+        this.metrics = metrics;
+        for (BlockNodeSourceConfig node : blockNodeSource.nodes()) {
+            LOGGER.log(INFO, "Loaded peer block node: {0}", node);
+        }
+    }
+
+    /// Queries each configured peer in order and returns the first valid `NodeAddressBook`.
+    ///
+    /// A `NodeAddressBook` is considered valid if it contains at least one `NodeAddress` with
+    /// a non-blank RSA public key. If no peer returns a usable book, `null` is returned.
+    ///
+    /// @return a valid `NodeAddressBook`, or `null` if all peers fail or return empty books
+    public NodeAddressBook getNodeAddressBook() {
+        for (BlockNodeSourceConfig node : blockNodeSource.nodes()) {
+            BlockNodeClient client = getNodeClient(node);
+            if (client == null || !client.isNodeReachable()) {
+                LOGGER.log(DEBUG, "Peer [{0}] is not reachable, skipping", node.address());
+                continue;
+            }
+
+            try {
+                final ServerStatusDetailResponse response =
+                        client.getBlockNodeServiceClient().serverStatusDetail(new ServerStatusRequest());
+                final NodeAddressBook book = response.nodeAddressBook();
+                metrics.peerRequests().increment();
+
+                if (isValid(book)) {
+                    LOGGER.log(
+                            INFO,
+                            "Received valid NodeAddressBook with {0} entries from peer [{1}]",
+                            book.nodeAddress().size(),
+                            node.address());
+                    return book;
+                }
+                LOGGER.log(
+                        DEBUG, "Peer [{0}] returned an empty or key-less NodeAddressBook, trying next", node.address());
+            } catch (RuntimeException e) {
+                LOGGER.log(
+                        WARNING,
+                        "Failed to retrieve NodeAddressBook from peer [{0}]: {1}",
+                        node.address(),
+                        e.getMessage());
+                metrics.peerErrors().increment();
+                // Remove so a fresh client is created on the next attempt
+                nodeClientMap.remove(node);
+            }
+        }
+        return null;
+    }
+
+    /// Returns a cached or newly-created `BlockNodeClient` for the given peer.
+    /// If the existing client is unreachable it is evicted and a fresh one is created.
+    ///
+    /// @param node the peer node configuration
+    /// @return a `BlockNodeClient` for the node
+    protected BlockNodeClient getNodeClient(BlockNodeSourceConfig node) {
+        BlockNodeClient existing = nodeClientMap.get(node);
+        if (existing != null && !existing.isNodeReachable()) {
+            try {
+                nodeClientMap.remove(node).close();
+            } catch (IOException e) {
+                LOGGER.log(WARNING, "Unable to close BlockNodeClient [{0}]: {1}", node.name(), e);
+            }
+            LOGGER.log(DEBUG, "Removed unreachable client for peer [{0}], will recreate", node.address());
+        }
+        return nodeClientMap.computeIfAbsent(
+                node, n -> new BlockNodeClient(n, 10_000, enableTls, maxIncomingBufferSize, n.grpcWebclientTuning()));
+    }
+
+    /// Returns `true` if the book has at least one entry with a non-blank RSA public key.
+    static boolean isValid(NodeAddressBook book) {
+        if (book == null || book.nodeAddress().isEmpty()) return false;
+        return book.nodeAddress().stream()
+                .anyMatch(addr -> addr.rsaPubKey() != null && !addr.rsaPubKey().isBlank());
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (BlockNodeClient client : nodeClientMap.values()) {
+            client.close();
+        }
+    }
+}

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcher.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcher.java
@@ -112,17 +112,21 @@ public class AddressBookFetcher implements AutoCloseable {
     ///
     /// @param node the peer node configuration
     /// @return a `BlockNodeClient` for the node
-    protected BlockNodeClient getNodeClient(BlockNodeSourceConfig node) {
-        BlockNodeClient existing = nodeClientMap.get(node);
-        if (existing != null && !existing.isNodeReachable()) {
-            try {
-                nodeClientMap.remove(node).close();
-            } catch (IOException e) {
-                LOGGER.log(WARNING, "Unable to close BlockNodeClient [{0}]: {1}", node.name(), e);
+    BlockNodeClient getNodeClient(BlockNodeSourceConfig node) {
+        return nodeClientMap.compute(node, (key, current) -> {
+            if (current != null) {
+                if (current.isNodeReachable()) {
+                    return current;
+                }
+                try {
+                    current.close();
+                } catch (IOException e) {
+                    LOGGER.log(WARNING, "Unable to close BlockNodeClient [{0}]: {1}", key.name(), e);
+                }
             }
-            LOGGER.log(DEBUG, "Removed unreachable client for peer [{0}], will recreate", node.address());
-        }
-        return nodeClientMap.computeIfAbsent(node, this::fromBlockNodeSourceConfig);
+            LOGGER.log(DEBUG, "Client unreachable for peer [{0}], will recreate", key.address());
+            return fromBlockNodeSourceConfig(key);
+        });
     }
 
     /// Returns `true` if the book has at least one entry with a non-blank RSA public key.

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcher.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcher.java
@@ -5,6 +5,7 @@ import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.WARNING;
 
+import com.hedera.hapi.node.base.NodeAddress;
 import com.hedera.hapi.node.base.NodeAddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -91,7 +92,7 @@ public class AddressBookFetcher implements AutoCloseable {
                         DEBUG, "Peer [{0}] returned an empty or key-less NodeAddressBook, trying next", node.address());
             } catch (RuntimeException e) {
                 LOGGER.log(
-                        WARNING,
+                        INFO,
                         "Failed to retrieve NodeAddressBook from peer [{0}]: {1}",
                         node.address(),
                         e.getMessage());
@@ -118,23 +119,36 @@ public class AddressBookFetcher implements AutoCloseable {
             }
             LOGGER.log(DEBUG, "Removed unreachable client for peer [{0}], will recreate", node.address());
         }
-        return nodeClientMap.computeIfAbsent(
-                node,
-                n -> new BlockNodeClient(
-                        n, grpcOverallTimeout, enableTls, maxIncomingBufferSize, n.grpcWebclientTuning()));
+        return nodeClientMap.computeIfAbsent(node, this::fromBlockNodeSourceConfig);
     }
 
     /// Returns `true` if the book has at least one entry with a non-blank RSA public key.
     static boolean isValid(NodeAddressBook book) {
         if (book == null || book.nodeAddress().isEmpty()) return false;
-        return book.nodeAddress().stream()
-                .anyMatch(addr -> addr.rsaPubKey() != null && !addr.rsaPubKey().isBlank());
+        for (NodeAddress nodeAddress : book.nodeAddress()) {
+            if (nodeAddress.rsaPubKey() != null && !nodeAddress.rsaPubKey().isBlank()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         for (BlockNodeClient client : nodeClientMap.values()) {
-            client.close();
+            try {
+                client.close();
+            } catch (IOException e) {
+                LOGGER.log(
+                        WARNING,
+                        "Unable to close BlockNodeClient [{0}]: {1}",
+                        client.getBlockNodeServiceClient().fullName(),
+                        e);
+            }
         }
+    }
+
+    private BlockNodeClient fromBlockNodeSourceConfig(BlockNodeSourceConfig n) {
+        return new BlockNodeClient(n, grpcOverallTimeout, enableTls, maxIncomingBufferSize, n.grpcWebclientTuning());
     }
 }

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcher.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcher.java
@@ -33,10 +33,12 @@ public class AddressBookFetcher implements AutoCloseable {
 
     private final BlockNodeSource blockNodeSource;
     /// Global timeout in milliseconds for gRPC calls to block nodes (used as fallback).
-    private final int grpcOverallTimeout;
+    private final int globalGrpcTimeoutMs;
     private final boolean enableTls;
     private final int maxIncomingBufferSize;
     private final MetricsHolder metrics;
+    /// RSA data is small (key material, not full blocks) — 512 KB is a safe ceiling.
+    private static final int RSA_DATA_MAX_PROTOBUF_MESSAGE_SIZE_BYTES = 512 * 1024;
 
     /// Package-private for testing — allows tests to inject mock clients.
     final ConcurrentHashMap<BlockNodeSourceConfig, BlockNodeClient> nodeClientMap = new ConcurrentHashMap<>();
@@ -51,7 +53,7 @@ public class AddressBookFetcher implements AutoCloseable {
             @NonNull RsaRosterBootstrapConfig config,
             @NonNull MetricsHolder metrics) {
         this.blockNodeSource = blockNodeSource;
-        this.grpcOverallTimeout = config.grpcOverallTimeout();
+        this.globalGrpcTimeoutMs = config.grpcOverallTimeout();
         this.enableTls = config.enableTLS();
         this.maxIncomingBufferSize = config.maxIncomingBufferSize();
         this.metrics = metrics;
@@ -149,6 +151,12 @@ public class AddressBookFetcher implements AutoCloseable {
     }
 
     private BlockNodeClient fromBlockNodeSourceConfig(BlockNodeSourceConfig n) {
-        return new BlockNodeClient(n, grpcOverallTimeout, enableTls, maxIncomingBufferSize, n.grpcWebclientTuning());
+        return new BlockNodeClient(
+                n,
+                globalGrpcTimeoutMs,
+                enableTls,
+                maxIncomingBufferSize,
+                RSA_DATA_MAX_PROTOBUF_MESSAGE_SIZE_BYTES,
+                n.grpcWebclientTuning());
     }
 }

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcher.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcher.java
@@ -90,6 +90,7 @@ public class AddressBookFetcher implements AutoCloseable {
                             node.address());
                     return book;
                 }
+                metrics.addressBookErrors().increment();
                 LOGGER.log(
                         DEBUG, "Peer [{0}] returned an empty or key-less NodeAddressBook, trying next", node.address());
             } catch (RuntimeException e) {

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcher.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcher.java
@@ -7,7 +7,6 @@ import static java.lang.System.Logger.Level.WARNING;
 
 import com.hedera.hapi.node.base.NodeAddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import org.hiero.block.api.ServerStatusDetailResponse;
@@ -27,11 +26,13 @@ import org.hiero.block.node.roster.bootstrap.rsa.RsaRosterBootstrapPlugin.Metric
 /// Connection pooling: a `BlockNodeClient` is created per peer on first use and cached for
 /// subsequent calls. If a client becomes unreachable it is removed from the pool so it can
 /// be recreated on the next attempt.
-public class AddressBookFetcher implements Closeable {
+public class AddressBookFetcher implements AutoCloseable {
 
     private static final System.Logger LOGGER = System.getLogger(AddressBookFetcher.class.getName());
 
     private final BlockNodeSource blockNodeSource;
+    /// Global timeout in milliseconds for gRPC calls to block nodes (used as fallback).
+    private final int grpcOverallTimeout;
     private final boolean enableTls;
     private final int maxIncomingBufferSize;
     private final MetricsHolder metrics;
@@ -49,6 +50,7 @@ public class AddressBookFetcher implements Closeable {
             @NonNull RsaRosterBootstrapConfig config,
             @NonNull MetricsHolder metrics) {
         this.blockNodeSource = blockNodeSource;
+        this.grpcOverallTimeout = config.grpcOverallTimeout();
         this.enableTls = config.enableTLS();
         this.maxIncomingBufferSize = config.maxIncomingBufferSize();
         this.metrics = metrics;
@@ -117,7 +119,9 @@ public class AddressBookFetcher implements Closeable {
             LOGGER.log(DEBUG, "Removed unreachable client for peer [{0}], will recreate", node.address());
         }
         return nodeClientMap.computeIfAbsent(
-                node, n -> new BlockNodeClient(n, 10_000, enableTls, maxIncomingBufferSize, n.grpcWebclientTuning()));
+                node,
+                n -> new BlockNodeClient(
+                        n, grpcOverallTimeout, enableTls, maxIncomingBufferSize, n.grpcWebclientTuning()));
     }
 
     /// Returns `true` if the book has at least one entry with a non-blank RSA public key.

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfig.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfig.java
@@ -42,7 +42,7 @@ public record RsaRosterBootstrapConfig(
         @Loggable @ConfigProperty(defaultValue = "10") int mirrorNodeReadTimeoutSeconds,
         @Loggable @ConfigProperty(defaultValue = "100") int mirrorNodePageSize,
         @Loggable @ConfigProperty(defaultValue = "") String blockNodeSourcesPath,
-        @Loggable @ConfigProperty(defaultValue = "5_000") @Min(100) int bnInitialQueryIntervalMillis,
+        @Loggable @ConfigProperty(defaultValue = "5000") @Min(100) int bnInitialQueryIntervalMillis,
         @Loggable @ConfigProperty(defaultValue = "60_000") @Min(10000) int bnSubsequentQueryIntervalMillis,
         @Loggable @ConfigProperty(defaultValue = "false") boolean enableTLS,
         @Loggable @ConfigProperty(defaultValue = "60_000") @Min(10000) int grpcOverallTimeout,

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfig.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfig.java
@@ -3,6 +3,7 @@ package org.hiero.block.node.roster.bootstrap.rsa;
 
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
+import com.swirlds.config.api.validation.annotation.Max;
 import com.swirlds.config.api.validation.annotation.Min;
 import org.hiero.block.node.base.Loggable;
 
@@ -37,14 +38,14 @@ public record RsaRosterBootstrapConfig(
         // spotless:off
         @Loggable @ConfigProperty(defaultValue = "") String mirrorNodeBaseUrl,
         @Loggable @ConfigProperty(defaultValue = "5_000") @Min(100) int mnInitialQueryIntervalMillis,
-        @Loggable @ConfigProperty(defaultValue = "60_000") @Min(10000) int mnSubsequentQueryIntervalMillis,
+        @Loggable @ConfigProperty(defaultValue = "60_000") @Min(10_000) int mnSubsequentQueryIntervalMillis,
         @Loggable @ConfigProperty(defaultValue = "5") int mirrorNodeConnectTimeoutSeconds,
         @Loggable @ConfigProperty(defaultValue = "10") int mirrorNodeReadTimeoutSeconds,
         @Loggable @ConfigProperty(defaultValue = "100") int mirrorNodePageSize,
         @Loggable @ConfigProperty(defaultValue = "") String blockNodeSourcesPath,
-        @Loggable @ConfigProperty(defaultValue = "5000") @Min(100) int bnInitialQueryIntervalMillis,
-        @Loggable @ConfigProperty(defaultValue = "60_000") @Min(10000) int bnSubsequentQueryIntervalMillis,
+        @Loggable @ConfigProperty(defaultValue = "5_000") @Min(100) int bnInitialQueryIntervalMillis,
+        @Loggable @ConfigProperty(defaultValue = "60_000") @Min(10_000) int bnSubsequentQueryIntervalMillis,
         @Loggable @ConfigProperty(defaultValue = "false") boolean enableTLS,
-        @Loggable @ConfigProperty(defaultValue = "60_000") @Min(10000) int grpcOverallTimeout,
-        @Loggable @ConfigProperty(defaultValue = "104_857_600") @Min(1) int maxIncomingBufferSize) {}
+        @Loggable @ConfigProperty(defaultValue = "60_000") @Min(10_000) int grpcOverallTimeout,
+        @Loggable @ConfigProperty(defaultValue = "104_857_600") @Min(104_857_600) @Max(314_572_800) int maxIncomingBufferSize) {}
 // spotless:on

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfig.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfig.java
@@ -11,9 +11,13 @@ import org.hiero.block.node.base.Loggable;
 /// The RSA bootstrap file path is configured via `app.state.rsaBootstrapFilePath` in
 /// `ApplicationStateConfig`; file loading and persistence are handled by `BlockNodeApp`.
 ///
-/// @param mirrorNodeBaseUrl base URL of the Mirror Node REST API used when no local file is present;
-///     leave blank to disable Mirror Node fallback (a WARNING is logged at startup if blank and no
-///     bootstrap file is present)
+/// **Startup sequence:**
+/// 1. Bootstrap file (loaded by BlockNodeApp before plugins start)
+/// 2. Peer block node gRPC query (if `blockNodeSourcesPath` is set)
+/// 3. Mirror Node REST API fallback (if `mirrorNodeBaseUrl` is set)
+///
+/// @param mirrorNodeBaseUrl base URL of the Mirror Node REST API used when no local file or peer
+///     is available; leave blank to disable Mirror Node fallback
 /// @param initialQueryIntervalMillis The initial period between queries to the mirror node until a node address book is
 /// found.
 /// @param subsequentQueryIntervalMillis The subsequent period between queries to the mirror node after a node address
@@ -21,6 +25,12 @@ import org.hiero.block.node.base.Loggable;
 /// @param mirrorNodeConnectTimeoutSeconds TCP connect timeout when calling the Mirror Node
 /// @param mirrorNodeReadTimeoutSeconds per-request read timeout when calling the Mirror Node
 /// @param mirrorNodePageSize number of nodes requested per paginated Mirror Node call
+/// @param blockNodeSourcesPath path to a JSON file listing peer block nodes to query via gRPC;
+///     leave blank to skip the peer-query step
+/// @param peerQueryIntervalMillis retry interval in ms between peer-query attempts when all peers fail
+/// @param peerQueryMaxRetries maximum number of peer-query attempts before falling through to Mirror Node
+/// @param enableTLS whether to enable TLS for peer gRPC connections
+/// @param maxIncomingBufferSize maximum incoming gRPC message buffer size in bytes
 @ConfigData("roster.bootstrap.rsa")
 public record RsaRosterBootstrapConfig(
         // spotless:off
@@ -29,5 +39,10 @@ public record RsaRosterBootstrapConfig(
         @Loggable @ConfigProperty(defaultValue = "60000") @Min(10000) int subsequentQueryIntervalMillis,
         @Loggable @ConfigProperty(defaultValue = "5") int mirrorNodeConnectTimeoutSeconds,
         @Loggable @ConfigProperty(defaultValue = "10") int mirrorNodeReadTimeoutSeconds,
-        @Loggable @ConfigProperty(defaultValue = "100") int mirrorNodePageSize) {}
+        @Loggable @ConfigProperty(defaultValue = "100") int mirrorNodePageSize,
+        @Loggable @ConfigProperty(defaultValue = "") String blockNodeSourcesPath,
+        @Loggable @ConfigProperty(defaultValue = "5000") @Min(100) int peerQueryIntervalMillis,
+        @Loggable @ConfigProperty(defaultValue = "3") @Min(1) int peerQueryMaxRetries,
+        @Loggable @ConfigProperty(defaultValue = "false") boolean enableTLS,
+        @Loggable @ConfigProperty(defaultValue = "104857600") @Min(1) int maxIncomingBufferSize) {}
 // spotless:on

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfig.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfig.java
@@ -26,9 +26,11 @@ import org.hiero.block.node.base.Loggable;
 /// @param mirrorNodePageSize number of nodes requested per paginated Mirror Node call
 /// @param blockNodeSourcesPath path to a JSON file listing peer block nodes to query via gRPC;
 ///     leave blank to skip the peer-query step
-/// @param bnInitialQueryIntervalMillis retry interval in ms between peer-query attempts when all peers fail
-/// @param peerQueryMaxRetries maximum number of peer-query attempts before falling through to Mirror Node
+/// @param bnInitialQueryIntervalMillis retry interval in ms between peer queries attempts until an address book is
+/// found
+/// @param bnSubsequentQueryIntervalMillis retry interval in ms between peer queries after an address book is found.
 /// @param enableTLS whether to enable TLS for peer gRPC connections
+/// @param grpcOverallTimeout the timeout for grpc connections.
 /// @param maxIncomingBufferSize maximum incoming gRPC message buffer size in bytes
 @ConfigData("roster.bootstrap.rsa")
 public record RsaRosterBootstrapConfig(
@@ -42,7 +44,6 @@ public record RsaRosterBootstrapConfig(
         @Loggable @ConfigProperty(defaultValue = "") String blockNodeSourcesPath,
         @Loggable @ConfigProperty(defaultValue = "5000") @Min(100) int bnInitialQueryIntervalMillis,
         @Loggable @ConfigProperty(defaultValue = "60000") @Min(10000) int bnSubsequentQueryIntervalMillis,
-        @Loggable @ConfigProperty(defaultValue = "3") @Min(1) int peerQueryMaxRetries,
         @Loggable @ConfigProperty(defaultValue = "false") boolean enableTLS,
         @Loggable @ConfigProperty(defaultValue = "60000") @Min(10000) int grpcOverallTimeout,
         @Loggable @ConfigProperty(defaultValue = "104857600") @Min(1) int maxIncomingBufferSize) {}

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfig.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfig.java
@@ -10,7 +10,6 @@ import org.hiero.block.node.base.Loggable;
 ///
 /// The RSA bootstrap file path is configured via `app.state.rsaBootstrapFilePath` in
 /// `ApplicationStateConfig`; file loading and persistence are handled by `BlockNodeApp`.
-///
 /// **Startup sequence:**
 /// 1. Bootstrap file (loaded by BlockNodeApp before plugins start)
 /// 2. Peer block node gRPC query (if `blockNodeSourcesPath` is set)
@@ -18,16 +17,16 @@ import org.hiero.block.node.base.Loggable;
 ///
 /// @param mirrorNodeBaseUrl base URL of the Mirror Node REST API used when no local file or peer
 ///     is available; leave blank to disable Mirror Node fallback
-/// @param initialQueryIntervalMillis The initial period between queries to the mirror node until a node address book is
-/// found.
-/// @param subsequentQueryIntervalMillis The subsequent period between queries to the mirror node after a node address
-/// book is found.
+/// @param mnInitialQueryIntervalMillis The initial period between queries to the mirror node until a node address book
+///     is found.
+/// @param mnSubsequentQueryIntervalMillis The subsequent period between queries to the mirror node after a node address
+///     book is found.
 /// @param mirrorNodeConnectTimeoutSeconds TCP connect timeout when calling the Mirror Node
 /// @param mirrorNodeReadTimeoutSeconds per-request read timeout when calling the Mirror Node
 /// @param mirrorNodePageSize number of nodes requested per paginated Mirror Node call
 /// @param blockNodeSourcesPath path to a JSON file listing peer block nodes to query via gRPC;
 ///     leave blank to skip the peer-query step
-/// @param peerQueryIntervalMillis retry interval in ms between peer-query attempts when all peers fail
+/// @param bnInitialQueryIntervalMillis retry interval in ms between peer-query attempts when all peers fail
 /// @param peerQueryMaxRetries maximum number of peer-query attempts before falling through to Mirror Node
 /// @param enableTLS whether to enable TLS for peer gRPC connections
 /// @param maxIncomingBufferSize maximum incoming gRPC message buffer size in bytes
@@ -35,14 +34,16 @@ import org.hiero.block.node.base.Loggable;
 public record RsaRosterBootstrapConfig(
         // spotless:off
         @Loggable @ConfigProperty(defaultValue = "") String mirrorNodeBaseUrl,
-        @Loggable @ConfigProperty(defaultValue = "5000") @Min(100) int initialQueryIntervalMillis,
-        @Loggable @ConfigProperty(defaultValue = "60000") @Min(10000) int subsequentQueryIntervalMillis,
+        @Loggable @ConfigProperty(defaultValue = "5000") @Min(100) int mnInitialQueryIntervalMillis,
+        @Loggable @ConfigProperty(defaultValue = "60000") @Min(10000) int mnSubsequentQueryIntervalMillis,
         @Loggable @ConfigProperty(defaultValue = "5") int mirrorNodeConnectTimeoutSeconds,
         @Loggable @ConfigProperty(defaultValue = "10") int mirrorNodeReadTimeoutSeconds,
         @Loggable @ConfigProperty(defaultValue = "100") int mirrorNodePageSize,
         @Loggable @ConfigProperty(defaultValue = "") String blockNodeSourcesPath,
-        @Loggable @ConfigProperty(defaultValue = "5000") @Min(100) int peerQueryIntervalMillis,
+        @Loggable @ConfigProperty(defaultValue = "5000") @Min(100) int bnInitialQueryIntervalMillis,
+        @Loggable @ConfigProperty(defaultValue = "60000") @Min(10000) int bnSubsequentQueryIntervalMillis,
         @Loggable @ConfigProperty(defaultValue = "3") @Min(1) int peerQueryMaxRetries,
         @Loggable @ConfigProperty(defaultValue = "false") boolean enableTLS,
+        @Loggable @ConfigProperty(defaultValue = "60000") @Min(10000) int grpcOverallTimeout,
         @Loggable @ConfigProperty(defaultValue = "104857600") @Min(1) int maxIncomingBufferSize) {}
 // spotless:on

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfig.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfig.java
@@ -36,15 +36,15 @@ import org.hiero.block.node.base.Loggable;
 public record RsaRosterBootstrapConfig(
         // spotless:off
         @Loggable @ConfigProperty(defaultValue = "") String mirrorNodeBaseUrl,
-        @Loggable @ConfigProperty(defaultValue = "5000") @Min(100) int mnInitialQueryIntervalMillis,
-        @Loggable @ConfigProperty(defaultValue = "60000") @Min(10000) int mnSubsequentQueryIntervalMillis,
+        @Loggable @ConfigProperty(defaultValue = "5_000") @Min(100) int mnInitialQueryIntervalMillis,
+        @Loggable @ConfigProperty(defaultValue = "60_000") @Min(10000) int mnSubsequentQueryIntervalMillis,
         @Loggable @ConfigProperty(defaultValue = "5") int mirrorNodeConnectTimeoutSeconds,
         @Loggable @ConfigProperty(defaultValue = "10") int mirrorNodeReadTimeoutSeconds,
         @Loggable @ConfigProperty(defaultValue = "100") int mirrorNodePageSize,
         @Loggable @ConfigProperty(defaultValue = "") String blockNodeSourcesPath,
-        @Loggable @ConfigProperty(defaultValue = "5000") @Min(100) int bnInitialQueryIntervalMillis,
-        @Loggable @ConfigProperty(defaultValue = "60000") @Min(10000) int bnSubsequentQueryIntervalMillis,
+        @Loggable @ConfigProperty(defaultValue = "5_000") @Min(100) int bnInitialQueryIntervalMillis,
+        @Loggable @ConfigProperty(defaultValue = "60_000") @Min(10000) int bnSubsequentQueryIntervalMillis,
         @Loggable @ConfigProperty(defaultValue = "false") boolean enableTLS,
-        @Loggable @ConfigProperty(defaultValue = "60000") @Min(10000) int grpcOverallTimeout,
-        @Loggable @ConfigProperty(defaultValue = "104857600") @Min(1) int maxIncomingBufferSize) {}
+        @Loggable @ConfigProperty(defaultValue = "60_000") @Min(10000) int grpcOverallTimeout,
+        @Loggable @ConfigProperty(defaultValue = "104_857_600") @Min(1) int maxIncomingBufferSize) {}
 // spotless:on

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.hiero.block.internal.BlockNodeSource;
 import org.hiero.block.internal.MirrorNodeNodesResponse;
 import org.hiero.block.internal.NodeEntry;
@@ -48,12 +47,11 @@ import org.hiero.metrics.core.MetricRegistry;
 /// **Startup sequence:**
 ///
 /// 1. If `context.nodeAddressBook()` is non-null: BlockNodeApp loaded it from the
-///    bootstrap file — emit metrics and return.
+///    bootstrap file — emit metrics.
 /// 2. If `blockNodeSourcesPath` is configured: query peer BNs via gRPC `serverStatusDetail`
 ///    and extract the `NodeAddressBook`. Retries up to `peerQueryMaxRetries` times. On success,
 ///    calls `applicationStateFacility.updateAddressBook()`.
-/// 3. If peer query is not configured or all retries are exhausted: fall through to the
-///    Mirror Node REST API (`GET /api/v1/network/nodes`).
+/// 3. If mn query is configured. Call Mirror Node REST API (`GET /api/v1/network/nodes`).
 /// 4. If neither source succeeds and `mirrorNodeBaseUrl` is blank: log `WARNING` and return.
 ///
 /// See `docs/design/wrb-streaming/bootstrap-roster-plugin.md` for the full design.
@@ -95,17 +93,15 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
     }
 
     // ScheduledExecutors for peer-query and Mirror Node steps
-    private ScheduledExecutorService queryPeerExecutor;
+    private ScheduledExecutorService queryBnExecutor;
+    private volatile ScheduledFuture<?> bnScheduledFuture = null;
     private ScheduledExecutorService queryMnExecutor;
-    private volatile ScheduledFuture<?> scheduledFuture = null;
+    private volatile ScheduledFuture<?> mnScheduledFuture = null;
 
     private volatile BlockNodeContext context;
     private RsaRosterBootstrapConfig config;
     private ApplicationStateFacility applicationStateFacility;
     private AddressBookFetcher addressBookFetcher;
-
-    // Peer retry counter
-    private final AtomicInteger peerAttempts = new AtomicInteger(0);
 
     // Metric values stored after startup so ObservableGauge can read them
     private volatile long rosterEntriesLoaded = 0L;
@@ -163,10 +159,10 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
         this.context = updatedContext;
     }
 
-    /// Implements the three-step bootstrap sequence:
-    /// 1. File already loaded → record metrics, schedule periodic refresh.
-    /// 2. Peer BN query (if configured) → retry up to peerQueryMaxRetries, then fall through.
-    /// 3. Mirror Node fallback → poll until success.
+    /// Implements three bootstrap strategies:
+    /// 1. File already loaded → record metrics.
+    /// 2. Peer BN query (if configured) → schedule address book refreshes
+    /// 3. Mirror Node configured, schedule address book refreshes.
     @Override
     public void start() {
         long startTimeMillis = System.currentTimeMillis();
@@ -175,20 +171,12 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
         if (book != null) {
             // Step 1: bootstrap file was pre-loaded by BlockNodeApp
             recordSuccessMetrics(book, startTimeMillis, "File");
+            schedulePeriodicBlockNodeRefresh();
             schedulePeriodicMirrorNodeRefresh();
             return;
         }
 
-        // Step 2: peer block node query
-        if (addressBookFetcher != null) {
-            queryPeerExecutor = context.threadPoolManager()
-                    .createVirtualThreadScheduledExecutor(1, "queryPeerScanner", this::uncaughtExceptionHandler);
-            scheduledFuture = queryPeerExecutor.scheduleAtFixedRate(
-                    this::fetchFromPeer, 0, config.peerQueryIntervalMillis(), TimeUnit.MILLISECONDS);
-            return;
-        }
-
-        // Step 3: Mirror Node fallback (no peer configured)
+        startBlockNodeFallback();
         startMirrorNodeFallback();
     }
 
@@ -196,34 +184,40 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
     // Peer BN query
     // -------------------------------------------------------------------------
 
+    private void startBlockNodeFallback() {
+        if (addressBookFetcher == null) {
+            LOGGER.log(
+                    WARNING,
+                    "roster.bootstrap.rsa.blockNodeSourcesPath is blank or not valid."
+                            + " set roster.bootstrap.rsa.blockNodeSourcesPath, to check for node address book updates.");
+            return;
+        }
+        queryBnExecutor = context.threadPoolManager()
+                .createVirtualThreadScheduledExecutor(1, "queryPeerScanner", this::uncaughtExceptionHandler);
+        bnScheduledFuture = queryBnExecutor.scheduleAtFixedRate(
+                this::fetchFromPeer, 0, config.bnInitialQueryIntervalMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    private void schedulePeriodicBlockNodeRefresh() {
+        if (addressBookFetcher == null) return;
+        if (queryBnExecutor == null) {
+            queryBnExecutor = context.threadPoolManager()
+                    .createVirtualThreadScheduledExecutor(1, "queryPeerScanner", this::uncaughtExceptionHandler);
+        }
+        queryBnExecutor.scheduleAtFixedRate(
+                this::fetchFromPeer, 0, config.bnSubsequentQueryIntervalMillis(), TimeUnit.MILLISECONDS);
+    }
+
     private void fetchFromPeer() {
         final NodeAddressBook book = addressBookFetcher.getNodeAddressBook();
         if (book != null) {
             applicationStateFacility.updateAddressBook(book);
             recordSuccessMetrics(book, System.currentTimeMillis(), "Peer BN");
-            cancelAndNullify(scheduledFuture);
-            scheduledFuture = null;
-            shutdownExecutor(queryPeerExecutor, "queryPeerExecutor");
-            queryPeerExecutor = null;
-            schedulePeriodicMirrorNodeRefresh();
-            return;
-        }
-
-        // All peers failed this attempt
-        final int attempt = peerAttempts.incrementAndGet();
-        LOGGER.log(
-                WARNING,
-                "Peer query attempt {0}/{1} returned no usable NodeAddressBook",
-                attempt,
-                config.peerQueryMaxRetries());
-
-        if (attempt >= config.peerQueryMaxRetries()) {
-            LOGGER.log(INFO, "Peer query exhausted after {0} attempts; falling through to Mirror Node", attempt);
-            cancelAndNullify(scheduledFuture);
-            scheduledFuture = null;
-            shutdownExecutor(queryPeerExecutor, "queryPeerExecutor");
-            queryPeerExecutor = null;
-            startMirrorNodeFallback();
+            if (bnScheduledFuture != null) {
+                cancelScheduledFuture(bnScheduledFuture);
+                bnScheduledFuture = null;
+                schedulePeriodicBlockNodeRefresh();
+            }
         }
     }
 
@@ -243,8 +237,8 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
         }
         queryMnExecutor = context.threadPoolManager()
                 .createVirtualThreadScheduledExecutor(1, "queryMnScanner", this::uncaughtExceptionHandler);
-        scheduledFuture = queryMnExecutor.scheduleAtFixedRate(
-                this::fetchFromMirrorNode, 0, config.initialQueryIntervalMillis(), TimeUnit.MILLISECONDS);
+        mnScheduledFuture = queryMnExecutor.scheduleAtFixedRate(
+                this::fetchFromMirrorNode, 0, config.mnInitialQueryIntervalMillis(), TimeUnit.MILLISECONDS);
     }
 
     private void schedulePeriodicMirrorNodeRefresh() {
@@ -255,8 +249,8 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
         }
         queryMnExecutor.scheduleAtFixedRate(
                 this::fetchFromMirrorNode,
-                config.subsequentQueryIntervalMillis(),
-                config.subsequentQueryIntervalMillis(),
+                config.mnSubsequentQueryIntervalMillis(),
+                config.mnSubsequentQueryIntervalMillis(),
                 TimeUnit.MILLISECONDS);
     }
 
@@ -314,14 +308,10 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
             applicationStateFacility.updateAddressBook(book);
             recordSuccessMetrics(book, startTimeMillis, "Mirror Node");
 
-            if (scheduledFuture != null) {
-                cancelAndNullify(scheduledFuture);
-                scheduledFuture = null;
-                queryMnExecutor.scheduleAtFixedRate(
-                        this::fetchFromMirrorNode,
-                        config.subsequentQueryIntervalMillis(),
-                        config.subsequentQueryIntervalMillis(),
-                        TimeUnit.MILLISECONDS);
+            if (mnScheduledFuture != null) {
+                cancelScheduledFuture(mnScheduledFuture);
+                mnScheduledFuture = null;
+                schedulePeriodicMirrorNodeRefresh();
             }
         }
     }
@@ -369,7 +359,7 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
                 rosterLoadDurationMs);
     }
 
-    private static void cancelAndNullify(ScheduledFuture<?> future) {
+    private static void cancelScheduledFuture(ScheduledFuture<?> future) {
         if (future != null) future.cancel(false);
     }
 
@@ -380,7 +370,7 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
     /// {@inheritDoc}
     @Override
     public void stop() {
-        shutdownExecutor(queryPeerExecutor, "queryPeerExecutor");
+        shutdownExecutor(queryBnExecutor, "queryPeerExecutor");
         shutdownExecutor(queryMnExecutor, "queryMnExecutor");
         if (addressBookFetcher != null) {
             try {

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
@@ -209,10 +209,11 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
     }
 
     private void fetchFromPeer() {
+        final long startTime = System.currentTimeMillis();
         final NodeAddressBook book = addressBookFetcher.getNodeAddressBook();
         if (book != null) {
             applicationStateFacility.updateAddressBook(book);
-            recordSuccessMetrics(book, System.currentTimeMillis(), "Peer BN");
+            recordSuccessMetrics(book, startTime, "Peer BN");
             if (bnScheduledFuture != null) {
                 cancelScheduledFuture(bnScheduledFuture);
                 bnScheduledFuture = null;

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
@@ -74,8 +74,15 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
     static final MetricKey<LongCounter> METRIC_PEER_ERRORS =
             MetricKey.of("rsa_roster_peer_errors", LongCounter.class).addCategory(METRICS_CATEGORY);
 
+    /// `blocknode:rsa_roster_addressbook_errors` — number of peer gRPC request errors.
+    static final MetricKey<LongCounter> METRIC_ADDRESSBOOK_ERRORS =
+            MetricKey.of("rsa_roster_addressbook_errors", LongCounter.class).addCategory(METRICS_CATEGORY);
+
     /// Holder for peer-query metrics, passed to `AddressBookFetcher`.
-    public record MetricsHolder(LongCounter.Measurement peerRequests, LongCounter.Measurement peerErrors) {
+    public record MetricsHolder(
+            LongCounter.Measurement peerRequests,
+            LongCounter.Measurement peerErrors,
+            LongCounter.Measurement addressBookErrors) {
 
         /// Factory that registers and returns a MetricsHolder.
         public static MetricsHolder create(@NonNull MetricRegistry metricRegistry) {
@@ -87,6 +94,10 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
                     metricRegistry
                             .register(LongCounter.builder(METRIC_PEER_ERRORS)
                                     .setDescription("Number of peer gRPC request errors for RSA address book"))
+                            .getOrCreateNotLabeled(),
+                    metricRegistry
+                            .register(LongCounter.builder(METRIC_ADDRESSBOOK_ERRORS)
+                                    .setDescription("Number of invalid address books fetched"))
                             .getOrCreateNotLabeled());
         }
     }

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
@@ -373,11 +373,7 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
         shutdownExecutor(queryBnExecutor, "queryPeerExecutor");
         shutdownExecutor(queryMnExecutor, "queryMnExecutor");
         if (addressBookFetcher != null) {
-            try {
-                addressBookFetcher.close();
-            } catch (IOException e) {
-                LOGGER.log(WARNING, "Error closing AddressBookFetcher: {0}", e.getMessage());
-            }
+            addressBookFetcher.close();
         }
     }
 

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
@@ -74,7 +74,7 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
     static final MetricKey<LongCounter> METRIC_PEER_ERRORS =
             MetricKey.of("rsa_roster_peer_errors", LongCounter.class).addCategory(METRICS_CATEGORY);
 
-    /// `blocknode:rsa_roster_addressbook_errors` — number of peer gRPC request errors.
+    /// `blocknode:rsa_roster_addressbook_errors` — number of peers returning invalid/empty address books.
     static final MetricKey<LongCounter> METRIC_ADDRESSBOOK_ERRORS =
             MetricKey.of("rsa_roster_addressbook_errors", LongCounter.class).addCategory(METRICS_CATEGORY);
 
@@ -197,7 +197,7 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
     private void startBlockNodeFallback() {
         if (addressBookFetcher == null) {
             LOGGER.log(
-                    WARNING,
+                    INFO,
                     "roster.bootstrap.rsa.blockNodeSourcesPath is blank or not valid."
                             + " set roster.bootstrap.rsa.blockNodeSourcesPath, to check for node address book updates.");
             return;
@@ -239,7 +239,7 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
     private void startMirrorNodeFallback() {
         if (config.mirrorNodeBaseUrl().isBlank()) {
             LOGGER.log(
-                    WARNING,
+                    INFO,
                     "roster.bootstrap.rsa.mirrorNodeBaseUrl is blank and no RSA bootstrap file or peer BN is"
                             + " configured. Provide rsa-bootstrap-roster.json, set"
                             + " roster.bootstrap.rsa.blockNodeSourcesPath, or set"

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
@@ -9,23 +9,29 @@ import com.hedera.hapi.node.base.NodeAddress;
 import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.hiero.block.internal.BlockNodeSource;
 import org.hiero.block.internal.MirrorNodeNodesResponse;
 import org.hiero.block.internal.NodeEntry;
 import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.metrics.LongCounter;
 import org.hiero.metrics.ObservableGauge;
 import org.hiero.metrics.core.MetricKey;
 import org.hiero.metrics.core.MetricRegistry;
@@ -35,26 +41,20 @@ import org.hiero.metrics.core.MetricRegistry;
 ///
 /// File loading and persistence are handled by `BlockNodeApp`: it reads the bootstrap file
 /// in `loadApplicationState()` before plugins are initialised, and persists the file in
-/// `updateAddressBook()` after a Mirror Node fetch. This plugin's sole responsibility is to
+/// `updateAddressBook()` after a fetch. This plugin's sole responsibility is to
 /// check whether the address book was already loaded (`context.nodeAddressBook() != null`) and,
-/// if not, to fetch it from the Mirror Node.
+/// if not, to fetch it from a peer block node or the Mirror Node.
 ///
 /// **Startup sequence:**
 ///
 /// 1. If `context.nodeAddressBook()` is non-null: BlockNodeApp loaded it from the
 ///    bootstrap file — emit metrics and return.
-/// 2. Otherwise: query `GET /api/v1/network/nodes` (paginated) on the configured Mirror
-///    Node, build a `NodeAddressBook`, and call
-///    `applicationStateFacility.updateAddressBook()` — which persists the file and
-///    notifies all plugins via `onContextUpdate`.
-/// 3. If neither source succeeds: log `ERROR` and throw to trigger BN fail-fast.
-///
-/// **Async-delivery note:** When the Mirror Node fetch path is taken, `updateAddressBook()`
-/// queues the book in `BlockNodeApp`'s pending state and returns before the context is
-/// updated. The address book becomes available to other plugins only after the
-/// `applicationStateExecutor` fires its next scan tick and calls `onContextUpdate`.
-/// Any plugin that relies on `context.nodeAddressBook()` must implement `onContextUpdate`
-/// and guard on `null` during its own `start()` execution.
+/// 2. If `blockNodeSourcesPath` is configured: query peer BNs via gRPC `serverStatusDetail`
+///    and extract the `NodeAddressBook`. Retries up to `peerQueryMaxRetries` times. On success,
+///    calls `applicationStateFacility.updateAddressBook()`.
+/// 3. If peer query is not configured or all retries are exhausted: fall through to the
+///    Mirror Node REST API (`GET /api/v1/network/nodes`).
+/// 4. If neither source succeeds and `mirrorNodeBaseUrl` is blank: log `WARNING` and return.
 ///
 /// See `docs/design/wrb-streaming/bootstrap-roster-plugin.md` for the full design.
 public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
@@ -69,14 +69,43 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
     static final MetricKey<ObservableGauge> METRIC_ROSTER_LOAD_DURATION_MS =
             MetricKey.of("roster_load_duration_ms", ObservableGauge.class).addCategory(METRICS_CATEGORY);
 
-    /// The ScheduledExecutorService used by the RosterBootstrapPlugin to query peer Mirror Nodes for a Node
-    /// Address Book
+    /// `blocknode:rsa_roster_peer_requests` — number of peer gRPC requests made.
+    static final MetricKey<LongCounter> METRIC_PEER_REQUESTS =
+            MetricKey.of("rsa_roster_peer_requests", LongCounter.class).addCategory(METRICS_CATEGORY);
+
+    /// `blocknode:rsa_roster_peer_errors` — number of peer gRPC request errors.
+    static final MetricKey<LongCounter> METRIC_PEER_ERRORS =
+            MetricKey.of("rsa_roster_peer_errors", LongCounter.class).addCategory(METRICS_CATEGORY);
+
+    /// Holder for peer-query metrics, passed to `AddressBookFetcher`.
+    public record MetricsHolder(LongCounter.Measurement peerRequests, LongCounter.Measurement peerErrors) {
+
+        /// Factory that registers and returns a MetricsHolder.
+        public static MetricsHolder create(@NonNull MetricRegistry metricRegistry) {
+            return new MetricsHolder(
+                    metricRegistry
+                            .register(LongCounter.builder(METRIC_PEER_REQUESTS)
+                                    .setDescription("Number of peer gRPC requests made for RSA address book"))
+                            .getOrCreateNotLabeled(),
+                    metricRegistry
+                            .register(LongCounter.builder(METRIC_PEER_ERRORS)
+                                    .setDescription("Number of peer gRPC request errors for RSA address book"))
+                            .getOrCreateNotLabeled());
+        }
+    }
+
+    // ScheduledExecutors for peer-query and Mirror Node steps
+    private ScheduledExecutorService queryPeerExecutor;
     private ScheduledExecutorService queryMnExecutor;
     private volatile ScheduledFuture<?> scheduledFuture = null;
 
     private volatile BlockNodeContext context;
     private RsaRosterBootstrapConfig config;
     private ApplicationStateFacility applicationStateFacility;
+    private AddressBookFetcher addressBookFetcher;
+
+    // Peer retry counter
+    private final AtomicInteger peerAttempts = new AtomicInteger(0);
 
     // Metric values stored after startup so ObservableGauge can read them
     private volatile long rosterEntriesLoaded = 0L;
@@ -95,12 +124,37 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
         this.config = context.configuration().getConfigData(RsaRosterBootstrapConfig.class);
         this.applicationStateFacility = context.applicationStateFacility();
         final MetricRegistry metricRegistry = context.metricRegistry();
+
         metricRegistry.register(ObservableGauge.builder(METRIC_ROSTER_ENTRIES_LOADED)
                 .setDescription("Number of NodeAddress entries loaded at startup")
                 .observe(() -> rosterEntriesLoaded));
         metricRegistry.register(ObservableGauge.builder(METRIC_ROSTER_LOAD_DURATION_MS)
                 .setDescription("Time to load the RSA roster at startup in ms")
                 .observe(() -> rosterLoadDurationMs));
+
+        // Initialise the peer fetcher if a sources file is configured
+        if (!config.blockNodeSourcesPath().isBlank()) {
+            final Path sourcesPath = Path.of(config.blockNodeSourcesPath());
+            if (Files.isRegularFile(sourcesPath)) {
+                try {
+                    final BlockNodeSource blockNodeSource =
+                            BlockNodeSource.JSON.parse(Bytes.wrap(Files.readAllBytes(sourcesPath)));
+                    addressBookFetcher =
+                            new AddressBookFetcher(blockNodeSource, config, MetricsHolder.create(metricRegistry));
+                } catch (ParseException | IOException e) {
+                    LOGGER.log(
+                            WARNING,
+                            "Failed to parse block node sources from [{0}], peer query disabled: {1}",
+                            config.blockNodeSourcesPath(),
+                            e.getMessage());
+                }
+            } else {
+                LOGGER.log(
+                        WARNING,
+                        "blockNodeSourcesPath [{0}] is not a regular file, peer query disabled",
+                        config.blockNodeSourcesPath());
+            }
+        }
     }
 
     /// {@inheritDoc}
@@ -109,75 +163,105 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
         this.context = updatedContext;
     }
 
-    /// Checks whether BlockNodeApp already loaded the address book from the bootstrap file.
-    /// If so, records metrics and returns. Otherwise a ScheduledExecutor is started which will
-    /// keep trying to fetch an address book from a Mirror Node. Once an address book is retrieved the
-    /// ScheduledExecutor will be canceled and polling will stop. `applicationStateFacility.updateAddressBook()`
-    /// will be called which persists the file and notifies all plugins. WRB errors will occur until
-    /// an address book is retrieved and persisted.
+    /// Implements the three-step bootstrap sequence:
+    /// 1. File already loaded → record metrics, schedule periodic refresh.
+    /// 2. Peer BN query (if configured) → retry up to peerQueryMaxRetries, then fall through.
+    /// 3. Mirror Node fallback → poll until success.
     @Override
     public void start() {
         long startTimeMillis = System.currentTimeMillis();
         NodeAddressBook book = context.nodeAddressBook();
-        String addressBookSource = "File";
 
-        // Set up the asynchronous node address book fetcher
-        // Create thread executors via threadPoolManager.
-        if (!config.mirrorNodeBaseUrl().isBlank()) {
+        if (book != null) {
+            // Step 1: bootstrap file was pre-loaded by BlockNodeApp
+            recordSuccessMetrics(book, startTimeMillis, "File");
+            schedulePeriodicMirrorNodeRefresh();
+            return;
+        }
+
+        // Step 2: peer block node query
+        if (addressBookFetcher != null) {
+            queryPeerExecutor = context.threadPoolManager()
+                    .createVirtualThreadScheduledExecutor(1, "queryPeerScanner", this::uncaughtExceptionHandler);
+            scheduledFuture = queryPeerExecutor.scheduleAtFixedRate(
+                    this::fetchFromPeer, 0, config.peerQueryIntervalMillis(), TimeUnit.MILLISECONDS);
+            return;
+        }
+
+        // Step 3: Mirror Node fallback (no peer configured)
+        startMirrorNodeFallback();
+    }
+
+    // -------------------------------------------------------------------------
+    // Peer BN query
+    // -------------------------------------------------------------------------
+
+    private void fetchFromPeer() {
+        final NodeAddressBook book = addressBookFetcher.getNodeAddressBook();
+        if (book != null) {
+            applicationStateFacility.updateAddressBook(book);
+            recordSuccessMetrics(book, System.currentTimeMillis(), "Peer BN");
+            cancelAndNullify(scheduledFuture);
+            scheduledFuture = null;
+            shutdownExecutor(queryPeerExecutor, "queryPeerExecutor");
+            queryPeerExecutor = null;
+            schedulePeriodicMirrorNodeRefresh();
+            return;
+        }
+
+        // All peers failed this attempt
+        final int attempt = peerAttempts.incrementAndGet();
+        LOGGER.log(
+                WARNING,
+                "Peer query attempt {0}/{1} returned no usable NodeAddressBook",
+                attempt,
+                config.peerQueryMaxRetries());
+
+        if (attempt >= config.peerQueryMaxRetries()) {
+            LOGGER.log(INFO, "Peer query exhausted after {0} attempts; falling through to Mirror Node", attempt);
+            cancelAndNullify(scheduledFuture);
+            scheduledFuture = null;
+            shutdownExecutor(queryPeerExecutor, "queryPeerExecutor");
+            queryPeerExecutor = null;
+            startMirrorNodeFallback();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Mirror Node fallback
+    // -------------------------------------------------------------------------
+
+    private void startMirrorNodeFallback() {
+        if (config.mirrorNodeBaseUrl().isBlank()) {
+            LOGGER.log(
+                    WARNING,
+                    "roster.bootstrap.rsa.mirrorNodeBaseUrl is blank and no RSA bootstrap file or peer BN is"
+                            + " configured. Provide rsa-bootstrap-roster.json, set"
+                            + " roster.bootstrap.rsa.blockNodeSourcesPath, or set"
+                            + " roster.bootstrap.rsa.mirrorNodeBaseUrl.");
+            return;
+        }
+        queryMnExecutor = context.threadPoolManager()
+                .createVirtualThreadScheduledExecutor(1, "queryMnScanner", this::uncaughtExceptionHandler);
+        scheduledFuture = queryMnExecutor.scheduleAtFixedRate(
+                this::fetchFromMirrorNode, 0, config.initialQueryIntervalMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    private void schedulePeriodicMirrorNodeRefresh() {
+        if (config.mirrorNodeBaseUrl().isBlank()) return;
+        if (queryMnExecutor == null) {
             queryMnExecutor = context.threadPoolManager()
                     .createVirtualThreadScheduledExecutor(1, "queryMnScanner", this::uncaughtExceptionHandler);
         }
-
-        if (book == null) {
-            // No bootstrap file was loaded by BlockNodeApp.loadApplicationState()
-            if (queryMnExecutor == null) {
-                // @todo(#XXXX) replace this warning with proper plugin health reporting once
-                //   the block node supports plugin-level healthy/unhealthy status indication.
-                LOGGER.log(
-                        WARNING,
-                        "roster.bootstrap.rsa.mirrorNodeBaseUrl is blank and no RSA bootstrap file is present."
-                                + " Provide rsa-bootstrap-roster.json or set roster.bootstrap.rsa.mirrorNodeBaseUrl.");
-                return;
-            }
-            // No retry limit — the node requires a roster to verify WRB proofs; keep polling
-            // until Mirror Node is reachable. Each failed attempt is logged at ERROR level.
-            // Will be canceled once an address book is retrieved.
-            scheduledFuture = scheduleFetch(0, config.initialQueryIntervalMillis());
-        } else {
-            rosterEntriesLoaded = book.nodeAddress().size();
-            rosterLoadDurationMs = System.currentTimeMillis() - startTimeMillis;
-            LOGGER.log(
-                    INFO,
-                    "RSA roster available: {0} entries obtained from {1} loaded in {2}ms",
-                    rosterEntriesLoaded,
-                    addressBookSource,
-                    rosterLoadDurationMs);
-            scheduleFetch(config.subsequentQueryIntervalMillis(), config.subsequentQueryIntervalMillis());
-        }
+        queryMnExecutor.scheduleAtFixedRate(
+                this::fetchFromMirrorNode,
+                config.subsequentQueryIntervalMillis(),
+                config.subsequentQueryIntervalMillis(),
+                TimeUnit.MILLISECONDS);
     }
 
-    private ScheduledFuture<?> scheduleFetch(long initialDelayMillis, long periodMillis) {
-        if (queryMnExecutor == null) return null;
-
-        // Set up the asynchronous node address book fetcher
-        // Create thread executors via threadPoolManager.
-        return queryMnExecutor.scheduleAtFixedRate(
-                this::fetchFromMirrorNode, initialDelayMillis, periodMillis, TimeUnit.MILLISECONDS);
-    }
-
-    /// {@inheritDoc}
-    @Override
-    public void stop() {
-        shutdownExecutor();
-    }
-
-    // -------------------------------------------------------------------------
-    // Mirror Node fetch
-    // -------------------------------------------------------------------------
-
-    /// Fetches the node address book from the Mirror Node REST API with pagination and retries.
-    /// Scheduled repeatedly until it succeeds. Upon success, the `scheduledFuture.cancel()` method will be called
-    /// to cancel this task.
+    /// Fetches the node address book from the Mirror Node REST API with pagination.
+    /// Scheduled repeatedly until it succeeds or is cancelled.
     private void fetchFromMirrorNode() {
         long startTimeMillis = System.currentTimeMillis();
         try (final HttpClient client = HttpClient.newBuilder()
@@ -185,9 +269,6 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
                 .build()) {
 
             final List<NodeAddress> addresses = new ArrayList<>();
-            // Use order=desc so the most-recently-active entries (timestamp.to == null) arrive first.
-            // We stop pagination as soon as we encounter a superseded entry (timestamp.to != null),
-            // since all remaining entries in descending order are also historical.
             String nextUrl = config.mirrorNodeBaseUrl() + "/api/v1/network/nodes?limit=" + config.mirrorNodePageSize()
                     + "&order=desc";
 
@@ -198,8 +279,6 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
                     return;
                 }
                 for (final NodeEntry entry : response.nodes()) {
-                    // A non-null timestamp.to means this entry has been superseded — all subsequent
-                    // entries (in descending order) are also historical; stop here.
                     if (entry.timestamp() != null && !entry.timestamp().to().isBlank()) {
                         break outer;
                     }
@@ -207,17 +286,14 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
                         LOGGER.log(WARNING, "Mirror Node: node {0} has no public_key — skipped", entry.nodeId());
                         continue;
                     }
-                    // Strip optional 0x prefix
                     final String hexKey = entry.publicKey().startsWith("0x")
                             ? entry.publicKey().substring(2)
                             : entry.publicKey();
-                    final NodeAddress addr = NodeAddress.newBuilder()
+                    addresses.add(NodeAddress.newBuilder()
                             .nodeId(entry.nodeId())
                             .rsaPubKey(hexKey)
-                            .build();
-                    addresses.add(addr);
+                            .build());
                 }
-                // Mirror Node may return a relative path; resolve it against the configured base URL.
                 final String rawNext =
                         response.links() == null ? null : response.links().next();
                 nextUrl = (rawNext == null || rawNext.isBlank())
@@ -228,42 +304,28 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
             if (addresses.isEmpty()) {
                 LOGGER.log(
                         WARNING,
-                        "Mirror Node returned zero nodes with a non-blank public_key from {0}. Provide rsa-bootstrap-roster.json or ensure Mirror Node is reachable.",
+                        "Mirror Node returned zero nodes with a non-blank public_key from {0}.",
                         config.mirrorNodeBaseUrl());
                 return;
             }
 
-            NodeAddressBook book =
+            final NodeAddressBook book =
                     NodeAddressBook.newBuilder().nodeAddress(addresses).build();
-
-            // BlockNodeApp.updateAddressBook() persists the file and calls onContextUpdate.
             applicationStateFacility.updateAddressBook(book);
-
-            rosterEntriesLoaded = book.nodeAddress().size();
-            rosterLoadDurationMs = System.currentTimeMillis() - startTimeMillis;
+            recordSuccessMetrics(book, startTimeMillis, "Mirror Node");
 
             if (scheduledFuture != null) {
-                // We found an address book stop the mirror node requests at the initial query interval.
-                scheduledFuture.cancel(false);
+                cancelAndNullify(scheduledFuture);
                 scheduledFuture = null;
-
-                scheduleFetch(config.subsequentQueryIntervalMillis(), config.subsequentQueryIntervalMillis());
+                queryMnExecutor.scheduleAtFixedRate(
+                        this::fetchFromMirrorNode,
+                        config.subsequentQueryIntervalMillis(),
+                        config.subsequentQueryIntervalMillis(),
+                        TimeUnit.MILLISECONDS);
             }
-
-            LOGGER.log(
-                    INFO,
-                    "RSA roster available: {0} entries obtained from {1}",
-                    book.nodeAddress().size(),
-                    "Mirror Node");
         }
     }
 
-    /// Performs a single HTTP GET with exponential-backoff retries. The response body is
-    /// parsed into a `MirrorNodeNodesResponse`
-    ///
-    /// @param client the HTTP client to use
-    /// @param url the URL to fetch and parse
-    /// @return the parsed Mirror Node response
     private MirrorNodeNodesResponse fetchAndParse(final HttpClient client, final String url) {
         Exception lastCause;
         try {
@@ -283,34 +345,63 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
         } catch (IOException | RuntimeException | ParseException e) {
             lastCause = e;
         }
-        final String message =
-                "RSA address book could not be created — Mirror Node API unavailable at %s. BN cannot verify WRB proofs. Provide rsa-bootstrap-roster.json or ensure Mirror Node is reachable."
-                        .formatted(config.mirrorNodeBaseUrl());
-        LOGGER.log(ERROR, message, lastCause);
+        LOGGER.log(
+                ERROR,
+                "RSA address book could not be created — Mirror Node API unavailable at {0}. "
+                        + "Provide rsa-bootstrap-roster.json or ensure Mirror Node is reachable.",
+                config.mirrorNodeBaseUrl(),
+                lastCause);
         return null;
     }
 
-    /// UncaughtExceptionHandler for logging uncaught exceptions
-    private void uncaughtExceptionHandler(Thread thread, Throwable throwable) {
-        final String message = "Uncaught exception in %s thread".formatted(thread.getName());
-        LOGGER.log(ERROR, message, throwable);
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void recordSuccessMetrics(NodeAddressBook book, long startTimeMillis, String source) {
+        rosterEntriesLoaded = book.nodeAddress().size();
+        rosterLoadDurationMs = System.currentTimeMillis() - startTimeMillis;
+        LOGGER.log(
+                INFO,
+                "RSA roster available: {0} entries obtained from {1} in {2}ms",
+                rosterEntriesLoaded,
+                source,
+                rosterLoadDurationMs);
     }
 
-    /// Shutdown the executor
-    private void shutdownExecutor() {
-        if (queryMnExecutor != null) {
-            queryMnExecutor.shutdown();
+    private static void cancelAndNullify(ScheduledFuture<?> future) {
+        if (future != null) future.cancel(false);
+    }
+
+    private void uncaughtExceptionHandler(Thread thread, Throwable throwable) {
+        LOGGER.log(ERROR, "Uncaught exception in {0} thread", thread.getName(), throwable);
+    }
+
+    /// {@inheritDoc}
+    @Override
+    public void stop() {
+        shutdownExecutor(queryPeerExecutor, "queryPeerExecutor");
+        shutdownExecutor(queryMnExecutor, "queryMnExecutor");
+        if (addressBookFetcher != null) {
             try {
-                if (!queryMnExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
-                    final String executorTerminationMsg =
-                            "queryMNExecutor did not terminate in time, calling shutdownNow()";
-                    queryMnExecutor.shutdownNow();
-                    LOGGER.log(INFO, executorTerminationMsg);
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                queryMnExecutor.shutdownNow();
+                addressBookFetcher.close();
+            } catch (IOException e) {
+                LOGGER.log(WARNING, "Error closing AddressBookFetcher: {0}", e.getMessage());
             }
+        }
+    }
+
+    private void shutdownExecutor(ScheduledExecutorService executor, String name) {
+        if (executor == null) return;
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+                LOGGER.log(INFO, "{0} did not terminate in time, calling shutdownNow()", name);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            executor.shutdownNow();
         }
     }
 }

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
@@ -49,8 +49,7 @@ import org.hiero.metrics.core.MetricRegistry;
 /// 1. If `context.nodeAddressBook()` is non-null: BlockNodeApp loaded it from the
 ///    bootstrap file — emit metrics.
 /// 2. If `blockNodeSourcesPath` is configured: query peer BNs via gRPC `serverStatusDetail`
-///    and extract the `NodeAddressBook`. Retries up to `peerQueryMaxRetries` times. On success,
-///    calls `applicationStateFacility.updateAddressBook()`.
+///    and extract the `NodeAddressBook`. On success, calls `applicationStateFacility.updateAddressBook()`.
 /// 3. If mn query is configured. Call Mirror Node REST API (`GET /api/v1/network/nodes`).
 /// 4. If neither source succeeds and `mirrorNodeBaseUrl` is blank: log `WARNING` and return.
 ///

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
@@ -147,7 +147,7 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
             } else {
                 LOGGER.log(
                         WARNING,
-                        "blockNodeSourcesPath [{0}] is not a regular file, peer query disabled",
+                        "blockNodeSourcesPath [{0}] does not exist or is not a regular file, peer query disabled",
                         config.blockNodeSourcesPath());
             }
         }

--- a/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcherTest.java
+++ b/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcherTest.java
@@ -61,7 +61,6 @@ class AddressBookFetcherTest {
                 "", // blockNodeSourcesPath
                 5_000, // bnInitialQueryIntervalMillis
                 60_000, // bnInitialQueryIntervalMillis
-                3, // peerQueryMaxRetries
                 false, // enableTLS
                 60_000,
                 104_857_600 // maxIncomingBufferSize

--- a/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcherTest.java
+++ b/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcherTest.java
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.roster.bootstrap.rsa;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hapi.node.base.NodeAddress;
+import com.hedera.hapi.node.base.NodeAddressBook;
+import java.util.List;
+import org.hiero.block.api.BlockNodeServiceInterface;
+import org.hiero.block.api.ServerStatusDetailResponse;
+import org.hiero.block.internal.BlockNodeSource;
+import org.hiero.block.internal.BlockNodeSourceConfig;
+import org.hiero.block.node.app.fixtures.TestMetricsExporter;
+import org.hiero.block.node.base.client.BlockNodeClient;
+import org.hiero.metrics.core.MetricRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/// Unit tests for {@link AddressBookFetcher}.
+class AddressBookFetcherTest {
+
+    private static RsaRosterBootstrapPlugin.MetricsHolder metricsHolder;
+    private static TestMetricsExporter testMetricsExporter;
+
+    @BeforeEach
+    void initMetrics() {
+        testMetricsExporter = new TestMetricsExporter();
+        final MetricRegistry metricRegistry =
+                MetricRegistry.builder().setMetricsExporter(testMetricsExporter).build();
+        metricsHolder = RsaRosterBootstrapPlugin.MetricsHolder.create(metricRegistry);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static BlockNodeSourceConfig peer(String host, int port) {
+        return BlockNodeSourceConfig.newBuilder()
+                .address(host)
+                .port(port)
+                .priority(1)
+                .build();
+    }
+
+    private static RsaRosterBootstrapConfig testConfig() {
+        return new RsaRosterBootstrapConfig(
+                "", // mirrorNodeBaseUrl
+                5000, // initialQueryIntervalMillis
+                60000, // subsequentQueryIntervalMillis
+                5, // mirrorNodeConnectTimeoutSeconds
+                10, // mirrorNodeReadTimeoutSeconds
+                100, // mirrorNodePageSize
+                "", // blockNodeSourcesPath
+                5000, // peerQueryIntervalMillis
+                3, // peerQueryMaxRetries
+                false, // enableTLS
+                104_857_600 // maxIncomingBufferSize
+                );
+    }
+
+    private static NodeAddressBook bookWith(String... keys) {
+        List<NodeAddress> addrs = new java.util.ArrayList<>();
+        for (int i = 0; i < keys.length; i++) {
+            addrs.add(NodeAddress.newBuilder().nodeId(i).rsaPubKey(keys[i]).build());
+        }
+        return NodeAddressBook.newBuilder().nodeAddress(addrs).build();
+    }
+
+    private AddressBookFetcher fetcherWithClient(BlockNodeSourceConfig peer, BlockNodeClient client) {
+        final BlockNodeSource source =
+                BlockNodeSource.newBuilder().nodes(List.of(peer)).build();
+        return new AddressBookFetcher(source, testConfig(), metricsHolder) {
+            @Override
+            protected BlockNodeClient getNodeClient(BlockNodeSourceConfig ignored) {
+                return client;
+            }
+        };
+    }
+
+    private BlockNodeClient mockClientReturning(NodeAddressBook book) {
+        BlockNodeServiceInterface.BlockNodeServiceClient serviceClient =
+                mock(BlockNodeServiceInterface.BlockNodeServiceClient.class);
+        when(serviceClient.serverStatusDetail(any()))
+                .thenReturn(ServerStatusDetailResponse.newBuilder()
+                        .nodeAddressBook(book)
+                        .build());
+        BlockNodeClient client = mock(BlockNodeClient.class);
+        when(client.getBlockNodeServiceClient()).thenReturn(serviceClient);
+        when(client.isNodeReachable()).thenReturn(true);
+        return client;
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("getNodeAddressBook")
+    class GetNodeAddressBookTests {
+
+        @Test
+        @DisplayName("Returns valid book from a reachable peer")
+        void returnsValidBookFromPeer() {
+            BlockNodeSourceConfig peer = peer("localhost", 8080);
+            NodeAddressBook expected = bookWith("aabbcc", "ddeeff");
+            AddressBookFetcher fetcher = fetcherWithClient(peer, mockClientReturning(expected));
+
+            NodeAddressBook result = fetcher.getNodeAddressBook();
+
+            assertNotNull(result);
+            assertEquals(2, result.nodeAddress().size());
+            assertEquals("aabbcc", result.nodeAddress().getFirst().rsaPubKey());
+        }
+
+        @Test
+        @DisplayName("Returns null when peer returns null book")
+        void returnsNullWhenPeerReturnsNullBook() {
+            BlockNodeSourceConfig peer = peer("localhost", 8080);
+            AddressBookFetcher fetcher = fetcherWithClient(peer, mockClientReturning(null));
+
+            assertNull(fetcher.getNodeAddressBook());
+        }
+
+        @Test
+        @DisplayName("Returns null when peer returns empty book")
+        void returnsNullWhenBookIsEmpty() {
+            BlockNodeSourceConfig peer = peer("localhost", 8080);
+            NodeAddressBook empty =
+                    NodeAddressBook.newBuilder().nodeAddress(List.of()).build();
+            AddressBookFetcher fetcher = fetcherWithClient(peer, mockClientReturning(empty));
+
+            assertNull(fetcher.getNodeAddressBook());
+        }
+
+        @Test
+        @DisplayName("Returns null when all keys are blank")
+        void returnsNullWhenAllKeysBlank() {
+            BlockNodeSourceConfig peer = peer("localhost", 8080);
+            NodeAddressBook blankKeys = bookWith("", "  ");
+            AddressBookFetcher fetcher = fetcherWithClient(peer, mockClientReturning(blankKeys));
+
+            assertNull(fetcher.getNodeAddressBook());
+        }
+
+        @Test
+        @DisplayName("Increments peerRequests metric on success")
+        void incrementsPeerRequestsOnSuccess() {
+            BlockNodeSourceConfig peer = peer("localhost", 8080);
+            AddressBookFetcher fetcher = fetcherWithClient(peer, mockClientReturning(bookWith("aabbcc")));
+
+            fetcher.getNodeAddressBook();
+
+            assertEquals(1, testMetricsExporter.getMetricValue(RsaRosterBootstrapPlugin.METRIC_PEER_REQUESTS.name()));
+        }
+
+        @Test
+        @DisplayName("Increments peerErrors and removes client on exception")
+        void incrementsPeerErrorsOnException() {
+            BlockNodeSourceConfig peer = peer("localhost", 8080);
+            BlockNodeServiceInterface.BlockNodeServiceClient serviceClient =
+                    mock(BlockNodeServiceInterface.BlockNodeServiceClient.class);
+            when(serviceClient.serverStatusDetail(any())).thenThrow(new RuntimeException("connection refused"));
+            BlockNodeClient client = mock(BlockNodeClient.class);
+            when(client.isNodeReachable()).thenReturn(true);
+            when(client.getBlockNodeServiceClient()).thenReturn(serviceClient);
+
+            AddressBookFetcher fetcher =
+                    new AddressBookFetcher(
+                            BlockNodeSource.newBuilder().nodes(List.of(peer)).build(), testConfig(), metricsHolder) {
+                        @Override
+                        protected BlockNodeClient getNodeClient(BlockNodeSourceConfig ignored) {
+                            nodeClientMap.put(ignored, client);
+                            return client;
+                        }
+                    };
+
+            assertNull(fetcher.getNodeAddressBook());
+            assertEquals(1, testMetricsExporter.getMetricValue(RsaRosterBootstrapPlugin.METRIC_PEER_ERRORS.name()));
+            // Client must be evicted so a fresh one is created on next call
+            assertTrue(fetcher.nodeClientMap.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Falls over to second peer when first fails")
+        void failoverToSecondPeer() {
+            BlockNodeSourceConfig failingPeer = peer("failing", 8080);
+            BlockNodeSourceConfig goodPeer = peer("good", 8081);
+            NodeAddressBook expected = bookWith("aabbcc");
+
+            BlockNodeServiceInterface.BlockNodeServiceClient failingService =
+                    mock(BlockNodeServiceInterface.BlockNodeServiceClient.class);
+            when(failingService.serverStatusDetail(any())).thenThrow(new RuntimeException("timeout"));
+            BlockNodeClient failingClient = mock(BlockNodeClient.class);
+            when(failingClient.isNodeReachable()).thenReturn(true);
+            when(failingClient.getBlockNodeServiceClient()).thenReturn(failingService);
+
+            BlockNodeClient goodClient = mockClientReturning(expected);
+
+            BlockNodeSource source = BlockNodeSource.newBuilder()
+                    .nodes(List.of(failingPeer, goodPeer))
+                    .build();
+
+            AddressBookFetcher fetcher = new AddressBookFetcher(source, testConfig(), metricsHolder) {
+                @Override
+                protected BlockNodeClient getNodeClient(BlockNodeSourceConfig node) {
+                    return node.address().equals("failing") ? failingClient : goodClient;
+                }
+            };
+
+            NodeAddressBook result = fetcher.getNodeAddressBook();
+            assertNotNull(result);
+            assertEquals("aabbcc", result.nodeAddress().getFirst().rsaPubKey());
+        }
+    }
+
+    @Nested
+    @DisplayName("isValid")
+    class IsValidTests {
+
+        @Test
+        @DisplayName("null book is invalid")
+        void nullIsInvalid() {
+            assertTrue(!AddressBookFetcher.isValid(null));
+        }
+
+        @Test
+        @DisplayName("empty book is invalid")
+        void emptyIsInvalid() {
+            assertTrue(!AddressBookFetcher.isValid(
+                    NodeAddressBook.newBuilder().nodeAddress(List.of()).build()));
+        }
+
+        @Test
+        @DisplayName("book with one non-blank key is valid")
+        void oneNonBlankKeyIsValid() {
+            assertTrue(AddressBookFetcher.isValid(bookWith("abc")));
+        }
+
+        @Test
+        @DisplayName("book with only blank keys is invalid")
+        void onlyBlankKeysIsInvalid() {
+            assertTrue(!AddressBookFetcher.isValid(bookWith("", "")));
+        }
+    }
+}

--- a/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcherTest.java
+++ b/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcherTest.java
@@ -53,15 +53,17 @@ class AddressBookFetcherTest {
     private static RsaRosterBootstrapConfig testConfig() {
         return new RsaRosterBootstrapConfig(
                 "", // mirrorNodeBaseUrl
-                5000, // initialQueryIntervalMillis
-                60000, // subsequentQueryIntervalMillis
+                5_000, // mnInitialQueryIntervalMillis
+                60_000, // mnSubsequentQueryIntervalMillis
                 5, // mirrorNodeConnectTimeoutSeconds
                 10, // mirrorNodeReadTimeoutSeconds
                 100, // mirrorNodePageSize
                 "", // blockNodeSourcesPath
-                5000, // peerQueryIntervalMillis
+                5_000, // bnInitialQueryIntervalMillis
+                60_000, // bnInitialQueryIntervalMillis
                 3, // peerQueryMaxRetries
                 false, // enableTLS
+                60_000,
                 104_857_600 // maxIncomingBufferSize
                 );
     }

--- a/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcherTest.java
+++ b/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcherTest.java
@@ -2,6 +2,7 @@
 package org.hiero.block.node.roster.bootstrap.rsa;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -60,7 +61,7 @@ class AddressBookFetcherTest {
                 100, // mirrorNodePageSize
                 "", // blockNodeSourcesPath
                 5_000, // bnInitialQueryIntervalMillis
-                60_000, // bnInitialQueryIntervalMillis
+                60_000, // bnSubsequentQueryIntervalMillis
                 false, // enableTLS
                 60_000,
                 104_857_600 // maxIncomingBufferSize
@@ -80,7 +81,7 @@ class AddressBookFetcherTest {
                 BlockNodeSource.newBuilder().nodes(List.of(peer)).build();
         return new AddressBookFetcher(source, testConfig(), metricsHolder) {
             @Override
-            protected BlockNodeClient getNodeClient(BlockNodeSourceConfig ignored) {
+            BlockNodeClient getNodeClient(BlockNodeSourceConfig ignored) {
                 return client;
             }
         };
@@ -177,7 +178,7 @@ class AddressBookFetcherTest {
                     new AddressBookFetcher(
                             BlockNodeSource.newBuilder().nodes(List.of(peer)).build(), testConfig(), metricsHolder) {
                         @Override
-                        protected BlockNodeClient getNodeClient(BlockNodeSourceConfig ignored) {
+                        BlockNodeClient getNodeClient(BlockNodeSourceConfig ignored) {
                             nodeClientMap.put(ignored, client);
                             return client;
                         }
@@ -211,7 +212,7 @@ class AddressBookFetcherTest {
 
             AddressBookFetcher fetcher = new AddressBookFetcher(source, testConfig(), metricsHolder) {
                 @Override
-                protected BlockNodeClient getNodeClient(BlockNodeSourceConfig node) {
+                BlockNodeClient getNodeClient(BlockNodeSourceConfig node) {
                     return node.address().equals("failing") ? failingClient : goodClient;
                 }
             };
@@ -229,13 +230,13 @@ class AddressBookFetcherTest {
         @Test
         @DisplayName("null book is invalid")
         void nullIsInvalid() {
-            assertTrue(!AddressBookFetcher.isValid(null));
+            assertFalse(AddressBookFetcher.isValid(null));
         }
 
         @Test
         @DisplayName("empty book is invalid")
         void emptyIsInvalid() {
-            assertTrue(!AddressBookFetcher.isValid(
+            assertFalse(AddressBookFetcher.isValid(
                     NodeAddressBook.newBuilder().nodeAddress(List.of()).build()));
         }
 
@@ -248,7 +249,7 @@ class AddressBookFetcherTest {
         @Test
         @DisplayName("book with only blank keys is invalid")
         void onlyBlankKeysIsInvalid() {
-            assertTrue(!AddressBookFetcher.isValid(bookWith("", "")));
+            assertFalse(AddressBookFetcher.isValid(bookWith("", "")));
         }
     }
 }

--- a/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
+++ b/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
@@ -518,7 +518,7 @@ class RsaRosterBootstrapPluginTest
     // -------------------------------------------------------------------------
 
     private static NodeAddressBook buildAddressBook(final int count) {
-        final List<NodeAddress> addresses = new java.util.ArrayList<>();
+        final List<NodeAddress> addresses = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             addresses.add(
                     NodeAddress.newBuilder().nodeId(i).rsaPubKey("hexkey" + i).build());
@@ -582,7 +582,7 @@ class RsaRosterBootstrapPluginTest
 
         public Map<String, String> build() {
             if (blockNodeSourcesPath == null || blockNodeSourcesPath.isBlank()) {
-                throw new IllegalStateException("backfillSourcePath is required");
+                throw new IllegalStateException("blockNodeSourcesPath is required");
             }
 
             return new HashMap<>(Map.of(

--- a/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
+++ b/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
@@ -13,14 +13,21 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.hiero.block.internal.BlockNodeSource;
+import org.hiero.block.internal.BlockNodeSourceConfig;
 import org.hiero.block.node.app.fixtures.async.BlockingExecutor;
 import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
 import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
+import org.hiero.block.node.app.fixtures.server.TestBlockNodeServer;
+import org.hiero.block.node.spi.BlockNodeContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -53,10 +60,35 @@ import org.junit.jupiter.api.io.TempDir;
 class RsaRosterBootstrapPluginTest
         extends PluginTestBase<RsaRosterBootstrapPlugin, BlockingExecutor, ScheduledBlockingExecutor> {
 
-    RsaRosterBootstrapPluginTest() {
+    private List<TestBlockNodeServer> testBlockNodeServers;
+
+    /// TempDir for the current test
+    private final Path testTempDir;
+
+    @BeforeEach
+    void setup() {
+        testBlockNodeServers = new ArrayList<>();
+    }
+
+    @AfterEach
+    void cleanup() {
+        // stop any started test block node servers
+        if (testBlockNodeServers != null) {
+            for (TestBlockNodeServer server : testBlockNodeServers) {
+                if (server != null) {
+                    server.stop();
+                }
+            }
+        }
+
+        if (plugin != null) plugin.stop();
+    }
+
+    RsaRosterBootstrapPluginTest(@TempDir final Path testTempDir) {
         super(
                 new BlockingExecutor(new LinkedBlockingQueue<>()),
                 new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+        this.testTempDir = testTempDir;
     }
 
     /// Override tearDown to gracefully handle cases where `start()` threw before
@@ -419,13 +451,60 @@ class RsaRosterBootstrapPluginTest
                     Map.of(
                             "roster.bootstrap.rsa.blockNodeSourcesPath", sourcesPath,
                             "roster.bootstrap.rsa.peerQueryMaxRetries", "1",
-                            "roster.bootstrap.rsa.bnInitialQueryIntervalMillis", "100"));
+                            "roster.bootstrap.rsa.mnInitialQueryIntervalMillis", "100"));
 
             // First scheduled task: peer query (will fail — port 1 is unreachable)
             testThreadPoolManager.scheduledExecutor().executeSerially();
 
             // After exhaustion the plugin should fall through; no crash expected
             assertNull(blockNodeContext.nodeAddressBook());
+        }
+
+        @Test
+        @DisplayName("request TssData from a peer bn ")
+        void requestRsaDataFromPeerBN() throws IOException, InterruptedException {
+            final TestBlockNodeServer server1 = new TestBlockNodeServer(0, new SimpleInMemoryHistoricalBlockFacility());
+            testBlockNodeServers.add(server1);
+            String blockNodeSourcesPath = testTempDir + "/blocknode-sources.json";
+
+            createTestBlockNodeSourcesFile(
+                    BlockNodeSource.newBuilder()
+                            .nodes(BlockNodeSourceConfig.newBuilder()
+                                    .address("localhost")
+                                    .port(server1.port())
+                                    .priority(1)
+                                    .build())
+                            .build(),
+                    blockNodeSourcesPath);
+
+            // Config Override
+            Map<String, String> configOverride = RsaRosterBootstrapConfigBuilder.newBuilder()
+                    .blockNodeSourcesPath(blockNodeSourcesPath)
+                    .bnInitialQueryIntervalMillis(500)
+                    .bnSubsequentQueryIntervalMillis(10_000)
+                    .maxIncomingBufferSize(104_857_600)
+                    .enableTLS(false) // start quickly
+                    .build();
+
+            final int[] contextUpdated = {0};
+            final NodeAddressBook[] nodeAddressBooks = {null};
+            CountDownLatch latch = new CountDownLatch(1);
+
+            RsaRosterBootstrapPlugin plugin = new TestBootstrapPlugin(contextUpdated, nodeAddressBooks, latch);
+
+            start(plugin, new SimpleInMemoryHistoricalBlockFacility(), configOverride);
+            testThreadPoolManager.scheduledExecutor().executeSerially();
+            latch.await();
+
+            assertTrue(contextUpdated[0] > 0);
+            assertNotNull(nodeAddressBooks[0]);
+
+            // These are magic numbers, yes. The {@link TestBlockNodeServer} does not yet have a way to pass in TssData
+            // to
+            // hand back to testers. Using the values that are passed back to make sure the statusDetails api is
+            // being called. Todo: add TssData flexibility to {@link TestBlockNodeServer}
+            assertEquals(0L, nodeAddressBooks[0].nodeAddress().getFirst().nodeId());
+            assertEquals(1L, nodeAddressBooks[0].nodeAddress().get(1).nodeId());
         }
     }
 
@@ -450,5 +529,94 @@ class RsaRosterBootstrapPluginTest
                     NodeAddress.newBuilder().nodeId(i).rsaPubKey("hexkey" + i).build());
         }
         return NodeAddressBook.newBuilder().nodeAddress(addresses).build();
+    }
+
+    private void createTestBlockNodeSourcesFile(BlockNodeSource blockNodeSource, String configPath) throws IOException {
+        String jsonString = BlockNodeSource.JSON.toJSON(blockNodeSource);
+        // Write the JSON string to the specified file path
+        java.nio.file.Files.write(java.nio.file.Paths.get(configPath), jsonString.getBytes());
+    }
+
+    /// Builder for creating backfill configuration maps for testing.
+    public static class RsaRosterBootstrapConfigBuilder {
+
+        private String blockNodeSourcesPath;
+        private int bnInitialQueryIntervalMillis;
+        private int bnSubsequentQueryIntervalMillis;
+        private int maxIncomingBufferSize;
+        private boolean enableTLS;
+        private int grpcOverallTimeout;
+
+        private RsaRosterBootstrapConfigBuilder() {
+            // private to force use of NewBuilder()
+        }
+
+        public static RsaRosterBootstrapConfigBuilder newBuilder() {
+            return new RsaRosterBootstrapConfigBuilder();
+        }
+
+        public RsaRosterBootstrapConfigBuilder blockNodeSourcesPath(String path) {
+            this.blockNodeSourcesPath = path;
+            return this;
+        }
+
+        public RsaRosterBootstrapConfigBuilder bnInitialQueryIntervalMillis(int value) {
+            this.bnInitialQueryIntervalMillis = value;
+            return this;
+        }
+
+        public RsaRosterBootstrapConfigBuilder bnSubsequentQueryIntervalMillis(int value) {
+            this.bnSubsequentQueryIntervalMillis = value;
+            return this;
+        }
+
+        public RsaRosterBootstrapConfigBuilder maxIncomingBufferSize(int value) {
+            this.maxIncomingBufferSize = value;
+            return this;
+        }
+
+        public RsaRosterBootstrapConfigBuilder grpcOverallTimeout(int value) {
+            this.grpcOverallTimeout = value;
+            return this;
+        }
+
+        public RsaRosterBootstrapConfigBuilder enableTLS(boolean value) {
+            this.enableTLS = value;
+            return this;
+        }
+
+        public Map<String, String> build() {
+            if (blockNodeSourcesPath == null || blockNodeSourcesPath.isBlank()) {
+                throw new IllegalStateException("backfillSourcePath is required");
+            }
+
+            return new HashMap<>(Map.of(
+                    "roster.bootstrap.rsa.blockNodeSourcesPath", blockNodeSourcesPath,
+                    "roster.bootstrap.rsa.bnInitialQueryIntervalMillis", String.valueOf(bnInitialQueryIntervalMillis),
+                    "roster.bootstrap.rsa.bnSubsequentQueryIntervalMillis",
+                            String.valueOf(bnSubsequentQueryIntervalMillis),
+                    "roster.bootstrap.tsa.maxIncomingBufferSize", String.valueOf(maxIncomingBufferSize),
+                    "roster.bootstrap.tsa.grpcOverallTimeout", String.valueOf(grpcOverallTimeout),
+                    "roster.bootstrap.rsa.enableTLS", String.valueOf(enableTLS)));
+        }
+    }
+
+    private class TestBootstrapPlugin extends RsaRosterBootstrapPlugin {
+        private final int[] contextUpdated;
+        private final NodeAddressBook[] nodeAddressBooks;
+        private final CountDownLatch latch;
+
+        private TestBootstrapPlugin(int[] contextUpdated, NodeAddressBook[] nodeAddressBooks, CountDownLatch latch) {
+            this.contextUpdated = contextUpdated;
+            this.nodeAddressBooks = nodeAddressBooks;
+            this.latch = latch;
+        }
+
+        @Override
+        public void onContextUpdate(BlockNodeContext context) {
+            contextUpdated[0]++;
+            nodeAddressBooks[0] = context.nodeAddressBook();
+            latch.countDown();
+        }
     }
 }

--- a/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
+++ b/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
@@ -12,6 +12,7 @@ import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /// Unit tests for `RsaRosterBootstrapPlugin`.
 ///
@@ -336,6 +338,94 @@ class RsaRosterBootstrapPluginTest
             assertEquals(1, book2.nodeAddress().size());
             assertEquals(2, book2.nodeAddress().getFirst().nodeId());
             assertEquals("ddeeff", book2.nodeAddress().getFirst().rsaPubKey());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Peer BN query path
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Peer BN query path")
+    class PeerQueryPath {
+
+        @TempDir
+        Path tempDir;
+
+        private Map<String, String> peerConfig(String sourcesPath, int maxRetries) {
+            return Map.of(
+                    "roster.bootstrap.rsa.blockNodeSourcesPath",
+                    sourcesPath,
+                    "roster.bootstrap.rsa.peerQueryMaxRetries",
+                    String.valueOf(maxRetries),
+                    "roster.bootstrap.rsa.peerQueryIntervalMillis",
+                    "100");
+        }
+
+        private String writePeerSourcesFile(String json) throws IOException {
+            Path file = tempDir.resolve("bn-sources.json");
+            java.nio.file.Files.writeString(file, json);
+            return file.toString();
+        }
+
+        @Test
+        @DisplayName("Peer success: Mirror Node is never called")
+        void peerSuccessMirrorNodeNeverCalled() throws IOException {
+            // Set up a test server that returns a valid address book via serverStatusDetail
+            org.hiero.block.node.app.fixtures.server.TestBlockNodeServer server =
+                    new org.hiero.block.node.app.fixtures.server.TestBlockNodeServer(
+                            0, new SimpleInMemoryHistoricalBlockFacility());
+
+            final String json =
+                    "{\"nodes\":[{\"address\":\"localhost\",\"port\":" + server.port() + ",\"priority\":1}]}";
+            final String sourcesPath = writePeerSourcesFile(json);
+
+            start(
+                    new RsaRosterBootstrapPlugin(),
+                    new SimpleInMemoryHistoricalBlockFacility(),
+                    peerConfig(sourcesPath, 3));
+
+            // Execute the peer-query task
+            testThreadPoolManager.scheduledExecutor().executeSerially();
+
+            server.stop();
+
+            // Address book should be populated from the peer (TestBlockNodeServer returns a non-null book)
+            // We verify at minimum that start() did not blow up and the executor ran
+            assertNotNull(blockNodeContext);
+        }
+
+        @Test
+        @DisplayName("No peer configured → skips directly to Mirror Node (backwards compat)")
+        void noPeerConfiguredGoesToMirrorNode() {
+            // No blockNodeSourcesPath, no mirrorNodeBaseUrl → warning and null book
+            start(new RsaRosterBootstrapPlugin(), new SimpleInMemoryHistoricalBlockFacility(), Map.of());
+            assertNull(blockNodeContext.nodeAddressBook());
+        }
+
+        @Test
+        @DisplayName("Peer fails maxRetries times → falls through to Mirror Node")
+        void peerExhaustionFallsThroughToMirrorNode() throws IOException {
+            // Write a sources file pointing at a non-existent host so all peer attempts fail
+            final String json = "{\"nodes\":[{\"address\":\"localhost\",\"port\":1,\"priority\":1}]}";
+            final String sourcesPath = writePeerSourcesFile(json);
+
+            // Configure a Mirror Node URL but no actual server — the MN fetch will also fail, but
+            // what we care about is that the peer executor handed off to the MN executor.
+            // We use maxRetries=1 so exhaustion happens after the first scheduled task.
+            start(
+                    new RsaRosterBootstrapPlugin(),
+                    new SimpleInMemoryHistoricalBlockFacility(),
+                    Map.of(
+                            "roster.bootstrap.rsa.blockNodeSourcesPath", sourcesPath,
+                            "roster.bootstrap.rsa.peerQueryMaxRetries", "1",
+                            "roster.bootstrap.rsa.peerQueryIntervalMillis", "100"));
+
+            // First scheduled task: peer query (will fail — port 1 is unreachable)
+            testThreadPoolManager.scheduledExecutor().executeSerially();
+
+            // After exhaustion the plugin should fall through; no crash expected
+            assertNull(blockNodeContext.nodeAddressBook());
         }
     }
 

--- a/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
+++ b/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
@@ -384,7 +384,7 @@ class RsaRosterBootstrapPluginTest
         @TempDir
         Path tempDir;
 
-        private Map<String, String> peerConfig(String sourcesPath, int maxRetries) {
+        private Map<String, String> peerConfig(String sourcesPath) {
             return Map.of(
                     "roster.bootstrap.rsa.blockNodeSourcesPath",
                     sourcesPath,
@@ -408,10 +408,7 @@ class RsaRosterBootstrapPluginTest
                     "{\"nodes\":[{\"address\":\"localhost\",\"port\":" + server.port() + ",\"priority\":1}]}";
             final String sourcesPath = writePeerSourcesFile(json);
 
-            start(
-                    new RsaRosterBootstrapPlugin(),
-                    new SimpleInMemoryHistoricalBlockFacility(),
-                    peerConfig(sourcesPath, 3));
+            start(new RsaRosterBootstrapPlugin(), new SimpleInMemoryHistoricalBlockFacility(), peerConfig(sourcesPath));
 
             // Execute the peer-query task
             testThreadPoolManager.scheduledExecutor().executeSerially();
@@ -458,7 +455,7 @@ class RsaRosterBootstrapPluginTest
         }
 
         @Test
-        @DisplayName("request TssData from a peer bn ")
+        @DisplayName("request Node Address Book from a peer bn ")
         void requestRsaDataFromPeerBN() throws IOException, InterruptedException {
             final TestBlockNodeServer server1 = new TestBlockNodeServer(0, new SimpleInMemoryHistoricalBlockFacility());
             testBlockNodeServers.add(server1);
@@ -481,6 +478,7 @@ class RsaRosterBootstrapPluginTest
                     .bnSubsequentQueryIntervalMillis(10_000)
                     .maxIncomingBufferSize(104_857_600)
                     .enableTLS(false) // start quickly
+                    .grpcOverallTimeout(10_000)
                     .build();
 
             final int[] contextUpdated = {0};

--- a/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
+++ b/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
@@ -388,8 +388,6 @@ class RsaRosterBootstrapPluginTest
             return Map.of(
                     "roster.bootstrap.rsa.blockNodeSourcesPath",
                     sourcesPath,
-                    "roster.bootstrap.rsa.peerQueryMaxRetries",
-                    String.valueOf(maxRetries),
                     "roster.bootstrap.rsa.bnInitialQueryIntervalMillis",
                     "100");
         }
@@ -404,9 +402,7 @@ class RsaRosterBootstrapPluginTest
         @DisplayName("Peer success: Mirror Node is never called")
         void peerSuccessMirrorNodeNeverCalled() throws IOException {
             // Set up a test server that returns a valid address book via serverStatusDetail
-            org.hiero.block.node.app.fixtures.server.TestBlockNodeServer server =
-                    new org.hiero.block.node.app.fixtures.server.TestBlockNodeServer(
-                            0, new SimpleInMemoryHistoricalBlockFacility());
+            TestBlockNodeServer server = new TestBlockNodeServer(0, new SimpleInMemoryHistoricalBlockFacility());
 
             final String json =
                     "{\"nodes\":[{\"address\":\"localhost\",\"port\":" + server.port() + ",\"priority\":1}]}";
@@ -449,9 +445,10 @@ class RsaRosterBootstrapPluginTest
                     new RsaRosterBootstrapPlugin(),
                     new SimpleInMemoryHistoricalBlockFacility(),
                     Map.of(
-                            "roster.bootstrap.rsa.blockNodeSourcesPath", sourcesPath,
-                            "roster.bootstrap.rsa.peerQueryMaxRetries", "1",
-                            "roster.bootstrap.rsa.mnInitialQueryIntervalMillis", "100"));
+                            "roster.bootstrap.rsa.blockNodeSourcesPath",
+                            sourcesPath,
+                            "roster.bootstrap.rsa.mnInitialQueryIntervalMillis",
+                            "100"));
 
             // First scheduled task: peer query (will fail — port 1 is unreachable)
             testThreadPoolManager.scheduledExecutor().executeSerially();
@@ -595,8 +592,8 @@ class RsaRosterBootstrapPluginTest
                     "roster.bootstrap.rsa.bnInitialQueryIntervalMillis", String.valueOf(bnInitialQueryIntervalMillis),
                     "roster.bootstrap.rsa.bnSubsequentQueryIntervalMillis",
                             String.valueOf(bnSubsequentQueryIntervalMillis),
-                    "roster.bootstrap.tsa.maxIncomingBufferSize", String.valueOf(maxIncomingBufferSize),
-                    "roster.bootstrap.tsa.grpcOverallTimeout", String.valueOf(grpcOverallTimeout),
+                    "roster.bootstrap.rsa.maxIncomingBufferSize", String.valueOf(maxIncomingBufferSize),
+                    "roster.bootstrap.rsa.grpcOverallTimeout", String.valueOf(grpcOverallTimeout),
                     "roster.bootstrap.rsa.enableTLS", String.valueOf(enableTLS)));
         }
     }

--- a/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
+++ b/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
@@ -358,7 +358,7 @@ class RsaRosterBootstrapPluginTest
                     sourcesPath,
                     "roster.bootstrap.rsa.peerQueryMaxRetries",
                     String.valueOf(maxRetries),
-                    "roster.bootstrap.rsa.peerQueryIntervalMillis",
+                    "roster.bootstrap.rsa.bnInitialQueryIntervalMillis",
                     "100");
         }
 
@@ -419,7 +419,7 @@ class RsaRosterBootstrapPluginTest
                     Map.of(
                             "roster.bootstrap.rsa.blockNodeSourcesPath", sourcesPath,
                             "roster.bootstrap.rsa.peerQueryMaxRetries", "1",
-                            "roster.bootstrap.rsa.peerQueryIntervalMillis", "100"));
+                            "roster.bootstrap.rsa.bnInitialQueryIntervalMillis", "100"));
 
             // First scheduled task: peer query (will fail — port 1 is unreachable)
             testThreadPoolManager.scheduledExecutor().executeSerially();

--- a/block-node/roster-bootstrap-tss/src/main/java/org/hiero/block/node/roster/bootstrap/tss/RosterBootstrapTssConfig.java
+++ b/block-node/roster-bootstrap-tss/src/main/java/org/hiero/block/node/roster/bootstrap/tss/RosterBootstrapTssConfig.java
@@ -18,9 +18,9 @@ import org.hiero.block.node.base.Loggable;
 @ConfigData("roster.bootstrap.tss")
 public record RosterBootstrapTssConfig(
         @Loggable @ConfigProperty(defaultValue = "") String blockNodeSourcesPath,
-        @Loggable @ConfigProperty(defaultValue = "60000") @Min(100) int queryPeerInterval,
-        @Loggable @ConfigProperty(defaultValue = "104857600") @Min(10_485_760) @Max(314_572_800) int maxIncomingBufferSize,
-        @Loggable @ConfigProperty(defaultValue = "60000") @Min(10000) int grpcOverallTimeout,
+        @Loggable @ConfigProperty(defaultValue = "60_000") @Min(100) int queryPeerInterval,
+        @Loggable @ConfigProperty(defaultValue = "104_857_600") @Min(104_857_600) @Max(314_572_800) int maxIncomingBufferSize,
+        @Loggable @ConfigProperty(defaultValue = "60_000") @Min(10_000) int grpcOverallTimeout,
         @Loggable @ConfigProperty(defaultValue = "false") boolean enableTLS) {}
 
 // spotless:on

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -233,14 +233,20 @@ for the JSON schema.
 
 ### RSA Bootstrap Plugin Configuration
 
-| ENV Variable                                             | Description                                                                                  | Default |
-|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|--------:|
-| ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL                | The URL of the mirror node from which to request the node address book.                      |      "" |
-| ROSTER_BOOTSTRAP_RSA_INITIAL_QUERY_INTERVAL_MILLIS       | The initial period between queries to the mirror node until a node address book is found.    |    5000 |
-| ROSTER_BOOTSTRAP_RSA_SUBSEQUENT_QUERY_INTERVAL_MILLIS    | The subsequent period between queries to the mirror node after a node address book is found. |   60000 |
-| ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_CONNECT_TIMEOUT_SECONDS | TCP connect timeout when calling the Mirror Node.                                            |       5 |
-| ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_READ_TIMEOUT_SECONDS    | Per-request read timeout when calling the Mirror Node.                                       |      10 |
-| ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_PAGE_SIZE               | Number of nodes requested per paginated Mirror Node call.                                    |     100 |
+| ENV Variable                                             | Description                                                                                  |   Default |
+|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|----------:|
+| ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL                | The URL of the mirror node from which to request the node address book.                      |        "" |
+| ROSTER_BOOTSTRAP_RSA_MN_INITIAL_QUERY_INTERVAL_MILLIS    | The initial period between queries to the mirror node until a node address book is found.    |      5000 |
+| ROSTER_BOOTSTRAP_RSA_MN_SUBSEQUENT_QUERY_INTERVAL_MILLIS | The subsequent period between queries to the mirror node after a node address book is found. |     60000 |
+| ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_CONNECT_TIMEOUT_SECONDS | TCP connect timeout when calling the Mirror Node.                                            |         5 |
+| ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_READ_TIMEOUT_SECONDS    | Per-request read timeout when calling the Mirror Node.                                       |        10 |
+| ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_PAGE_SIZE               | Number of nodes requested per paginated Mirror Node call.                                    |       100 |
+| ROSTER_BOOTSTRAP_RSA_BLOCK_NODE_SOURCES_PATH             | File path to the JSON file containing a list of block node servers to query for TSS data.    |        "" |
+| ROSTER_BOOTSTRAP_RSA_BN_INITIAL_QUERY_INTERVAL_MILLIS    | The initial period between queries to the block node until a node address book is found.     |      5000 |
+| ROSTER_BOOTSTRAP_RSA_BN_SUBSEQUENT_QUERY_INTERVAL_MILLIS | The subsequent period between queries to the block node after a node address book is found.  |     60000 |
+| ROSTER_BOOTSTRAP_RSA_GRPC_OVERALL_TIMEOUT                | Overall gRPC timeout (connect, read, poll) in ms.                                            |     60000 |
+| ROSTER_BOOTSTRAP_RSA_MAX_INCOMING_BUFFER_SIZE            | Maximum block size used for the BlockNode Client                                             | 104857600 |
+| ROSTER_BOOTSTRAP_RSA_ENABLE_TLS                          | Flag indicating whether TLS should be enabled for the BlockNode client.                      |     false |
 
 ### Subscriber Plugin Configuration
 

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -241,7 +241,7 @@ for the JSON schema.
 | ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_CONNECT_TIMEOUT_SECONDS | TCP connect timeout when calling the Mirror Node.                                            |         5 |
 | ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_READ_TIMEOUT_SECONDS    | Per-request read timeout when calling the Mirror Node.                                       |        10 |
 | ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_PAGE_SIZE               | Number of nodes requested per paginated Mirror Node call.                                    |       100 |
-| ROSTER_BOOTSTRAP_RSA_BLOCK_NODE_SOURCES_PATH             | File path to the JSON file containing a list of block node servers to query for TSS data.    |        "" |
+| ROSTER_BOOTSTRAP_RSA_BLOCK_NODE_SOURCES_PATH             | File path to the JSON file containing a list of block node servers to query for RSA data.    |        "" |
 | ROSTER_BOOTSTRAP_RSA_BN_INITIAL_QUERY_INTERVAL_MILLIS    | The initial period between queries to the block node until a node address book is found.     |      5000 |
 | ROSTER_BOOTSTRAP_RSA_BN_SUBSEQUENT_QUERY_INTERVAL_MILLIS | The subsequent period between queries to the block node after a node address book is found.  |     60000 |
 | ROSTER_BOOTSTRAP_RSA_GRPC_OVERALL_TIMEOUT                | Overall gRPC timeout (connect, read, poll) in ms.                                            |     60000 |

--- a/docs/design/wrb-streaming/bootstrap-roster-plugin.md
+++ b/docs/design/wrb-streaming/bootstrap-roster-plugin.md
@@ -8,16 +8,17 @@
 2. [Goals](#2-goals)
 3. [Terms](#3-terms)
 4. [Design](#4-design)
-   - 4.1 [Plugin Structure](#41-plugin-structure)
-   - 4.2 [Bootstrap File Format](#42-bootstrap-file-format)
-   - 4.3 [Mirror Node Fetch](#43-mirror-node-fetch)
-   - 4.4 [Startup Sequence](#44-startup-sequence)
-   - 4.5 [RSA Signature Verification](#45-rsa-signature-verification)
-   - 4.6 [Phase 2b Transition](#46-phase-2b-transition)
+    - 4.1 [Plugin Structure](#41-plugin-structure)
+    - 4.2 [Bootstrap File Format](#42-bootstrap-file-format)
+    - 4.3 [Mirror Node Fetch](#43-mirror-node-fetch)
+    - 4.4 [Startup Sequence & Address Book Lifecycle](#44-startup-sequence--address-book-lifecycle)
+    - 4.5 [RSA Signature Verification](#45-rsa-signature-verification)
+    - 4.6 [Phase 2b Transition](#46-phase-2b-transition)
 5. [Diagram](#5-diagram)
 6. [Configuration](#6-configuration)
 7. [Metrics](#7-metrics)
 8. [Security](#8-security)
+    - 8.1 [Bootstrap File Integrity](#81-bootstrap-file-integrity)
 9. [Operator Tooling](#9-operator-tooling)
 10. [Acceptance Tests](#10-acceptance-tests)
 11. [Follow-on Ticket Mapping](#11-follow-on-ticket-mapping)
@@ -212,9 +213,9 @@ RSA public key per entry) without restarting the BN.
 - `BlockNodeApp` implements the method.
 - The method updates the `nodeAddressBook` field in `BlockNodeContext`.
 - The method writes the bootstrap file if the address book was fetched from Mirror Node (file did not previously
-exist).
+  exist).
 - The method calls `plugin.onContextUpdate(updatedContext)` for each loaded plugin so downstream consumers (e.g.
-`BlockVerificationService`) receive the populated address book before they begin verifying blocks.
+  `BlockVerificationService`) receive the populated address book before they begin verifying blocks.
 
 > **Thread safety note:** `onContextUpdate()` is called from a different thread than the plugin's own `start()` thread
 > (as documented in `BlockNodePlugin`). Downstream plugins that consume the `NodeAddressBook` must update their
@@ -286,9 +287,9 @@ final NodeAddressBook nodeAddressBook =
 
 **Notes:**
 - The `RSA_PubKey` string in `NodeAddress` is the raw hex-encoded DER bytes without an `0x` prefix. Mirror Node
-returns the key with a leading `0x` which must be stripped before storing.
+  returns the key with a leading `0x` which must be stripped before storing.
 - The file does not embed metadata such as network name or generation timestamp. Operators wishing to annotate the
-file should maintain a separate sidecar file or rely on filesystem timestamps.
+  file should maintain a separate sidecar file or rely on filesystem timestamps.
 - Writes use an atomic `.tmp`-then-move strategy to avoid corrupt files on process crash.
 
 ---
@@ -368,10 +369,14 @@ after retries the plugin logs a clear error and fails fast (see §4.4 for MN-dow
 
 ---
 
-### 4.4 Startup Sequence
+### 4.4 Startup Sequence & Address Book Lifecycle
 
-The plugin follows a **file-first** strategy consistent with `TssBootstrapPlugin`. The file check and any network call
-happen in `start()`, after `init()` has stored the facility reference.
+The plugin follows a **file-load + MN-freshness-check** strategy. If a local bootstrap file exists it is loaded first
+so the BN has an immediately usable address book. The Mirror Node is then queried (when configured) to check for
+updates. If the file does not exist, the MirrorNode is queried at the `initialQueryIntervalMillis` interval until an
+address book is returned. This allows for Mirror Nodes being started after Block Nodes. The Mirror Node
+will be queried at the `subsequentQueryIntervalMillis` interval if a file is found or when an initial query returns an
+address book.
 
 ```
 BlockNodeApp.loadApplicationState() [before any plugin is started]
@@ -388,45 +393,51 @@ BlockNodeApp.loadApplicationState() [before any plugin is started]
    │
 RsaRosterBootstrapPlugin.start() called
    │
-   ├─ context.nodeAddressBook() != null?
+   ├─ mirrorNodeBaseUrl blank?
    │       │
-   │       YES ──► record metrics, log success, return
+   │       YES ──► context.nodeAddressBook() != null?
+   │       │               YES ──► record metrics, log success, return
+   │       │               NO  ──► LOG WARNING → return (degraded; no address book available)
    │       │
-   │       NO ──► mirrorNodeBaseUrl blank?
+   │       NO ──► Query Mirror Node API (paginated GET /api/v1/network/nodes, order=desc)
    │               │
-   │               YES ──► LOG WARNING → return (no fail-fast)
+   │               ├─ SUCCESS: build NodeAddressBook (nodeId + RSA_PubKey per entry)
+   │               │     └─ book differs from loaded book (or no book loaded)?
+   │               │           YES ──► applicationStateFacility.updateAddressBook(book)
+   │               │           │           ├─ BlockNodeApp writes rsa-bootstrap-roster.json (atomic)
+   │               │           │           └─ BlockNodeApp notifies all plugins via onContextUpdate [async]
+   │               │           NO  ──► log "address book is current", record metrics, continue
    │               │
-   │               NO ──► Query Mirror Node API (paginated GET /api/v1/network/nodes, order=desc)
-   │                       │
-   │                       ├─ SUCCESS: build NodeAddressBook (nodeId + RSA_PubKey per entry)
-   │                       │     └─ applicationStateFacility.updateAddressBook(book)
-   │                       │           ├─ BlockNodeApp writes rsa-bootstrap-roster.json (atomic)
-   │                       │           └─ BlockNodeApp notifies all plugins via onContextUpdate [async]
-   │                       │
-   │                       └─ FAILURE after MAX_RETRIES (API unreachable / timeout / empty response):
-   │                             LOG ERROR: "RSA address book could not be created"
-   │                             FAIL FAST → throw IllegalStateException → shutdown BN
+   │               └─ FAILURE (API unreachable / timeout / empty response after retries):
+   │                     context.nodeAddressBook() != null?
+   │                     │
+   │                     YES ──► LOG WARNING → continue on loaded file; schedule background retry
+   │                     │
+   │                     NO  ──► LOG ERROR → retry with exponential backoff (5-min intervals)
+   │                               until reachable; do not shut down BN
+   │                               (see §12 #1 for evolution once plugin health reporting exists)
    │
-   └─ Startup complete
+   ├─ Schedule periodic MN poll (default: every 60 min) via background thread
+   │       └─ On each poll: repeat MN query; call updateAddressBook if book has changed
+   │
+   └─ Startup complete (with address book from file, MN, or both)
 ```
 
-**File-first rationale:** If the bootstrap file already exists there is no need to contact the Mirror Node. The file
-was written on a previous successful startup and represents a known-good address book. Calling Mirror Node on every
-restart would add latency and introduce a network dependency for what is otherwise a deterministic local load.
+**File-load + MN-freshness rationale:** Loading the bootstrap file first ensures the BN has an immediately usable
+address book at the cost of zero network latency. The subsequent MN query detects any address book changes that
+occurred since the file was written (e.g., nodes added or removed after the last restart) and updates the book in
+place. The periodic background poll keeps the address book current for long-running instances without requiring a
+restart.
 
-**Mirror Node down — fail-fast rationale:** An absent or unreadable roster means the BN cannot verify any WRB proof.
-If the address book was not created the BN is in an unhealthy state. A clear error log at shutdown time is preferable
-to silently accepting or rejecting all blocks without a functioning verification layer. Operators are expected to ensure
-either the bootstrap file is present or the Mirror Node is reachable before starting the BN.
+**Mirror Node unreachable — retry rationale:** When the MN API is unreachable but a local file exists, the BN can
+proceed with the cached address book and retry in the background. When no file exists, the BN retries with exponential
+backoff at 5-minute intervals rather than shutting down, since a transient network outage should not force a full
+restart. Once plugin health reporting is available, the plugin should surface its unhealthy state through that
+mechanism instead of failing fast. See §12 #1.
 
-> **Open Question (see §12 #1):** Should the BN shut down immediately when the Mirror Node call fails, or should it
-> start but leave RSA verification failing until the address book is populated? The current recommendation is **fail
-> fast**. Additionally, publicly available snapshots of the on-chain `NodeAddressBook` (file `0.0.102`) can serve as
-> a fallback source for operators who cannot reach the Mirror Node API.
-
-**No mid-instance reload:** The roster is loaded once at `start()` and does not change for the lifetime of the BN
-instance. Roster updates (e.g., a node leaving the network) require a BN restart with a refreshed bootstrap file or
-by deleting the file so the next startup fetches a fresh copy from Mirror Node. Runtime reload is tracked in #2563.
+**Nodes with no public key:** Nodes returned by the Mirror Node with a null or blank `public_key` should be excluded
+from the `NodeAddressBook`. Such entries should not normally exist; if encountered, the plugin increments
+`blocknode_rsa_roster_mismatch_total` and logs a WARNING rather than silently discarding them.
 
 ---
 
@@ -447,10 +458,14 @@ in `tools-and-tests/tools`, which in turn match the verification logic used by H
 >
 > Both Phase 2a and Phase 2b support `StateProof`. No operator-configured proof mode is needed.
 >
+> **Multiple proofs:** When a block contains more than one proof type, the verification layer attempts to validate
+> each available proof. The priority ordering and acceptance criteria for multiple simultaneous proofs will need to
+> evolve as the network moves through Phase 2a and Phase 2b stages; this is tracked as an open design item (see §12).
+>
 > **Placement in the pipeline:** RSA verification is performed by the block verification layer
 > (`BlockVerificationService`) immediately after a complete WRB is received from the publisher, before the block is
-> written to storage. The `RsaRosterBootstrapPlugin` supplies the `NodeAddressBook` via `onContextUpdate`; the
-> verification service reads it from `BlockNodeContext.nodeAddressBook()`.
+> written to storage. The `NodeAddressBook` is supplied to the verification service by `ApplicationStateFacility`
+> via `onContextUpdate`; the service reads it from `BlockNodeContext.nodeAddressBook()`.
 
 #### 4.5.1 Identifying a WRB
 
@@ -546,8 +561,8 @@ When the network transitions from Phase 2a to Phase 2b:
    required. The `RsaRosterBootstrapPlugin` remains loaded and the `NodeAddressBook` remains in context but the
    verification layer stops using it for new blocks.
 3. WRBs stored during Phase 2a remain fully queryable via `getBlock` and `subscribeBlockStream` — they are stored as
-   regular `.blk` files and no migration is required. Notably these will not contribute to future state contributions to
-   state services.
+   regular `.blk` files and no migration is required. Notably WRBs have no state data or event data and will not
+   support state management services.
 
 ---
 
@@ -574,26 +589,30 @@ sequenceDiagram
     App->>Plugin: init(context, serviceBuilder)
     Plugin->>Plugin: store applicationStateFacility, config
     App->>Plugin: start()
-    alt context.nodeAddressBook() != null (file was loaded)
-        Plugin->>Plugin: record metrics, log success, return
-    else context.nodeAddressBook() == null
-        alt mirrorNodeBaseUrl is blank
-            Plugin->>Plugin: LOG WARNING → return (no fail-fast)
-        else mirrorNodeBaseUrl configured
-            Plugin->>MN: GET /api/v1/network/nodes (paginated, order=desc)
-            alt MN reachable
-                MN-->>Plugin: node list (node_id, public_key, timestamp)
-                Plugin->>Plugin: build NodeAddressBook (active entries only)
+    alt mirrorNodeBaseUrl is blank
+        Plugin->>Plugin: log success (file) or LOG WARNING (no address book)
+    else mirrorNodeBaseUrl configured
+        Plugin->>MN: GET /api/v1/network/nodes (paginated, order=desc)
+        alt MN reachable
+            MN-->>Plugin: node list (node_id, public_key, timestamp)
+            Plugin->>Plugin: build NodeAddressBook (active entries only)
+            alt book changed or no prior book
                 Plugin->>Facility: updateAddressBook(book)
                 Facility->>File: NodeAddressBook.JSON.toBytes() → atomic write
                 Facility->>Plugins: onContextUpdate(updatedContext) [async]
-            else MN unreachable after retries
-                Plugin->>Plugin: LOG ERROR: address book not created
-                Plugin->>App: FAIL FAST → throw → shutdown
+            else book unchanged
+                Plugin->>Plugin: log "address book is current"
+            end
+        else MN unreachable after retries
+            alt file was loaded
+                Plugin->>Plugin: LOG WARNING → continue on cached book; schedule retry
+            else no file
+                Plugin->>Plugin: LOG ERROR → retry every 5 min in background
             end
         end
+        Plugin->>Plugin: schedule periodic poll (default every 60 min)
     end
-    App->>App: continue startup (if not shut down)
+    App->>App: continue startup
 ```
 
 ### WRB verification (Phase 2a)
@@ -656,7 +675,7 @@ Mirror Node fallback is in the `roster.bootstrap.rsa` namespace:
 **Environment variable overrides** follow the standard Swirlds Config pattern (uppercase, `_` for `.` and `-`). For example:
 
 ```
-ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL=https://testnet.mirrornode.hedera.com
+APP_STATE_RSA_MIRROR_NODE_BASE_URL=https://testnet.mirrornode.hedera.com
 ```
 
 ---
@@ -687,22 +706,14 @@ All metrics use the BN-standard category `blocknode` and must follow existing na
 
 ### 8.1 Bootstrap file integrity
 
-The `rsa-bootstrap-roster.pb` file contains the public keys used for proof verification. A tampered file would allow an
-attacker to substitute keys and have the BN accept forged proofs.
+The `rsa-bootstrap-roster.json` file contains the public keys used for proof verification. Tampering requires
+filesystem access to the BN host; at that point the system is already compromised beyond what key substitution could
+add. The practical mitigation is to restrict file access at the OS level:
 
-**Mitigations:**
-- **File permissions:** `rsa-bootstrap-roster.pb` should be readable only by the BN process user (`chmod 600`). Document
-this in the operator guide.
-- **Checksum (deferred):** An optional SHA-256 checksum of the raw file bytes could be stored alongside the file and
-verified at load time. This is not required for Phase 2a but is tracked as a follow-on hardening item.
-- **Mirror Node TLS:** The initial fetch uses HTTPS. Operators deploying a private Mirror Node should ensure TLS is configured.
-- **Binary format note:** The binary protobuf format is not human-editable, which reduces accidental modification risk
-compared to a JSON file. Intentional modification still requires a protobuf tool (e.g., `protoc --decode`, `prototext`).
-
-### 8.2 Replay attack handling
-
-The WRB has a `BlockHeader` with a block number that the Publisher and Verification logic utilize to ensure that blocks
-that have  already been processed are not replayed.
+- **File permissions:** `rsa-bootstrap-roster.json` should be readable only by the BN process user (`chmod 600`).
+  Document this in the operator guide.
+- **Mirror Node TLS:** Mirror Node queries use HTTPS. Operators deploying a private Mirror Node should ensure TLS is
+  configured.
 
 ---
 
@@ -711,10 +722,15 @@ that have  already been processed are not replayed.
 A script `tools-and-tests/scripts/node-operations/generate-roster-rsa-bootstrap.sh` should be provided. Its responsibilities:
 
 1. Accept `--network <mainnet|testnet|previewnet>` and optionally `--mirror-node-url <url>`.
-2. Query `GET /api/v1/network/nodes` (with pagination) to collect all nodes with non-empty `public_key`.
+2. Query `GET /api/v1/network/nodes` (with pagination) to collect all nodes with non-empty `public_key`. Investigate
+   whether the Mirror Node API offers a single-call bulk address book endpoint that could replace pagination; if one
+   exists use it and document the choice here. The Mirror Node gRPC service provides a call which will return all nodes.
+   Perhaps grpcurl can be used in the script to get all the nodes in one shot.
 3. Build a `NodeAddressBook` protobuf, setting only `nodeId` and `RSA_PubKey` (stripped of `0x` prefix) per `NodeAddress` entry.
-4. Serialize with `NodeAddressBook.JSON.toBytes()` and write to `rsa-bootstrap-roster.json`.
-5. Print a summary: number of entries written, file path, file size.
+4. Embed a generation timestamp in a sidecar file (e.g., `rsa-bootstrap-roster.json.meta`) so the plugin can compare
+   file freshness against data returned by Mirror Node.
+5. Serialize with `NodeAddressBook.JSON.toBytes()` and write to `rsa-bootstrap-roster.json`.
+6. Print a summary: number of entries written, file path, file size, generation timestamp.
 
 **Expected usage before a Phase 2a cutover:**
 
@@ -722,9 +738,17 @@ A script `tools-and-tests/scripts/node-operations/generate-roster-rsa-bootstrap.
 generate-rsa-roster-bootstrap.sh --network mainnet --output /opt/hiero/block-node/node/rsa-bootstrap-roster.json
 ```
 
-Operators must regenerate and restart the BN if the address book changes (new nodes added, nodes removed).
+Because the plugin polls Mirror Node hourly and updates the address book in place, operators do **not** need to
+regenerate the bootstrap file or restart the BN when nodes are added or removed. The pre-generated file serves only
+as a fast-start seed for the first startup or when Mirror Node is temporarily unreachable.
+
 The `blocknode_roster_entries_loaded` gauge metric provides a quick sanity check that the expected number of nodes was
 loaded at startup.
+
+> **Lifecycle note:** The `rsa-bootstrap-roster.json` file and this plugin are Phase 2a transitional artifacts. The
+> bootstrap file is generated synthetically from Mirror Node data shortly after the Phase 2a upgrade and may not be
+> produced much longer. Once all WRBs carry a `TssSignedBlockProof` or `StateProof`, the RSA roster is no longer
+> needed for new blocks (see §4.6 and §12 #7).
 
 **Inspecting the generated file:**
 
@@ -738,21 +762,28 @@ cat /opt/hiero/block-node/node/rsa-bootstrap-roster.json | python3 -m json.tool 
 
 ## 10. Acceptance Tests
 
-- [ ] Plugin parses a valid `rsa-bootstrap-roster.pb` (binary `NodeAddressBook`); `roster_entries_loaded{source="file"}`
-  gauge equals expected entry count; all loaded plugins receive `onContextUpdate` with a populated `nodeAddressBook`.
-- [ ] Plugin fetches from Mirror Node when no bootstrap file is present; `applicationStateFacility.updateAddressBook()`
-  is called; `rsa-bootstrap-roster.pb` is written; gauge reads `{source="mirror_node"}`.
-- [ ] Deserializing the written `rsa-bootstrap-roster.pb` produces the same `NodeAddressBook` as was fetched.
-- [ ] BN startup fails fast with a clear error log when no bootstrap file exists and Mirror Node is unreachable.
-- [ ] A WRB block with a passing RSA proof (supermajority count) is accepted and persisted.
-- [ ] A WRB block with an insufficient RSA proof (below threshold) is rejected;
-  `verification_proof_total{proof_type="rsa",result="failure"}` increments.
-- [ ] A WRB block with a signature from a `node_id` absent from the `NodeAddressBook` increments `roster_mismatch_total`
-  without a panic.
-- [ ] A block with a `StateProof` is routed to the state proof verification path regardless of plugin state.
-- [ ] A block with a `TssSignedBlockProof` is routed to the TSS verification path.
+- [x] Plugin parses a valid `rsa-bootstrap-roster.json`; `blocknode_roster_entries_loaded` gauge equals expected entry
+  count; all loaded plugins receive `onContextUpdate` with a populated `nodeAddressBook`.
+- [x] Plugin fetches from Mirror Node when no bootstrap file is present; `applicationStateFacility.updateAddressBook()`
+  is called; `rsa-bootstrap-roster.json` is written; gauge reflects the loaded count.
+- [x] Plugin queries Mirror Node even when a bootstrap file already exists; if the returned book differs, the file is
+  updated and `onContextUpdate` is broadcast to all plugins.
+- [ ] Deserializing the written `rsa-bootstrap-roster.json` produces the same `NodeAddressBook` as was fetched.
+- [ ] When Mirror Node is unreachable and no bootstrap file exists, the BN retries with exponential backoff and does
+  not shut down; a clear error is logged on each retry.
+- [ ] When Mirror Node is unreachable but a bootstrap file exists, the BN continues on the cached book and logs a
+  WARNING.
+- [ ] A Mirror Node response containing a node with a blank `public_key` increments `blocknode_rsa_roster_mismatch_total`
+  and logs a WARNING.
+- [x] A WRB block with a passing RSA proof (supermajority count) is accepted and persisted.
+- [x] A WRB block with an insufficient RSA proof (below threshold) is rejected;
+  `blocknode_verification_proof_total{proof_type="rsa",result="failure"}` increments.
+- [ ] A WRB block with a signature from a `node_id` absent from the `NodeAddressBook` increments
+  `blocknode_rsa_roster_mismatch_total` without a panic.
+- [x] A block with a `StateProof` is routed to the state proof verification path regardless of plugin state.
+- [x] A block with a `TssSignedBlockProof` is routed to the TSS verification path.
 - [ ] `generate-roster-bootstrap.sh` produces a file that the plugin loads without errors.
-- [ ] Testnet `rsa-bootstrap-roster.pb` generated from `testnet.mirrornode.hedera.com` loads without errors.
+- [ ] Testnet `rsa-bootstrap-roster.json` generated from `testnet.mirrornode.hedera.com` loads without errors.
 
 ---
 
@@ -768,13 +799,13 @@ cat /opt/hiero/block-node/node/rsa-bootstrap-roster.json | python3 -m json.tool 
 
 ## 12. Open Questions and Deferred Items
 
-| # |                                                                                                                                                                                                                                     Question                                                                                                                                                                                                                                     |                                                                                Status                                                                                 |
-|---|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1 | **Mirror Node down at startup — fail fast or degrade gracefully?** When the MN API is unreachable and no local file exists the current recommendation is to fail fast and shut the BN down. An alternative is to allow the BN to start but leave RSA verification failing until the address book is available. Operators who cannot reach MN can use a publicly available `NodeAddressBook` snapshot (on-chain file `0.0.102`) as a fallback to pre-populate the bootstrap file. | **Open.** Recommendation: fail fast. Final decision pending review.                                                                                                   |
-| 2 | Should the bootstrap file include a separate SHA-256 checksum sidecar for integrity verification?                                                                                                                                                                                                                                                                                                                                                                                | Deferred — document the risk, implement in Phase 2a operational hardening if time allows.                                                                             |
-| 3 | Does the Block Stream simulator need to generate valid `SignedRecordFileProof` blocks for integration testing?                                                                                                                                                                                                                                                                                                                                                                   | Yes — flagged as a testing gap. If not available for Phase 2a, integration tests will use pre-recorded WRB blocks.                                                    |
-| 4 | Should stake-weighted threshold be used instead of equal-weight once the `NodeAddress.stake` field is confirmed populated in the on-chain address book?                                                                                                                                                                                                                                                                                                                          | Deferred to #2562 — the equal-weight threshold is correct for Phase 2a. Stake-weighting can be added as an enhancement without changing the bootstrap file format.    |
-| 5 | Should the roster structure used map to the `AddressBook` or the `TSSRoster`? If `AddressBook` then BN will support 2 types, if `TSSRoster` we may have to default certain values and couple the plugin.                                                                                                                                                                                                                                                                         | `AddressBook` was chosen to utilize the same pathway explored by MN and WRB CLI as well as support record files from genesis ousde of the Phase 2a timeline.          |
-| 6 | Should the BN at startup check if there have been AddressBook changes that it can quickly retrieve from MN? This would ensure that upgrades are light on the node operator and a simple restart is needed.                                                                                                                                                                                                                                                                       | No, not initially. In future maybe the MAPI query logic can be optimized to update the address book at upgrade boundaries or upon request.                            |
-| 7 | Should `RsaRosterBootstrapPlugin` have a defined lifetime? Should we note a timeline after which it can be removed? Currently, it makes sense to leave it around so that a BN can be the recipient of all WRBs at any point in the future. Note, it will require the MAPI calls to consider time ranges of address books.                                                                                                                                                        | BN should be able to support processing WRBs from genesis going forward by any operator on their own schedule. As such the plugin should remain and be run as needed. |
-| 8 | Should we have a `roster.bootstrap.rsa.failOnFetchError` flag to avoid needing a real file?                                                                                                                                                                                                                                                                                                                                                                                      | No, better to create a default `data/config/rsa-bootstrap-roster.pb` file for use                                                                                     |
+| # |                                                                                                                                                                                                                              Question                                                                                                                                                                                                                               |                                                                                                                                                                                                         Status                                                                                                                                                                                                         |
+|---|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1 | **Mirror Node down at startup — fail fast or retry with backoff?** When the MN API is unreachable and no local file exists the BN retries with exponential backoff at 5-minute intervals and does not shut down. When a local file is present, the BN continues on the cached book and retries in the background. Operators who cannot reach MN can pre-populate the bootstrap file from a publicly available `NodeAddressBook` snapshot (on-chain file `0.0.102`). | **Resolved.** Direction: retry-with-backoff, not fail-fast. Once plugin health reporting is available, the plugin should surface its unhealthy state through that mechanism so the BN can remain running while signalling degraded operation.                                                                                                                                                                          |
+| 2 | Does the Block Stream simulator need to generate valid `SignedRecordFileProof` blocks for integration testing?                                                                                                                                                                                                                                                                                                                                                      | Yes — flagged as a testing gap. If not available for Phase 2a, integration tests will use pre-recorded WRB blocks.                                                                                                                                                                                                                                                                                                     |
+| 3 | Should stake-weighted threshold be used instead of equal-weight once the `NodeAddress.stake` field is confirmed populated in the on-chain address book?                                                                                                                                                                                                                                                                                                             | Deferred to #2562 — the equal-weight threshold is correct for Phase 2a. Stake-weighting can be added as an enhancement without changing the bootstrap file format.                                                                                                                                                                                                                                                     |
+| 4 | Should the roster structure used map to the `AddressBook` or the `TSSRoster`? If `AddressBook` then BN will support 2 types, if `TSSRoster` we may have to default certain values and couple the plugin.                                                                                                                                                                                                                                                            | `AddressBook` was chosen to utilize the same pathway explored by MN and WRB CLI as well as support record files from genesis outside of the Phase 2a timeline.                                                                                                                                                                                                                                                         |
+| 5 | Should the BN poll Mirror Node hourly for address book updates, or only at startup?                                                                                                                                                                                                                                                                                                                                                                                 | **Resolved.** The plugin queries MN at every startup (even when a local file exists) and schedules a periodic background poll (default 60 min, configurable via `app.state.rsaAddressBookPollIntervalMinutes`). This mirrors the SDK approach and avoids requiring a restart for roster changes.                                                                                                                       |
+| 6 | Should `RsaRosterBootstrapPlugin` have a defined lifetime? Should we note a timeline after which it can be removed?                                                                                                                                                                                                                                                                                                                                                 | **Resolved.** The plugin can be retired once all WRBs in the network carry a `TssSignedBlockProof` or `StateProof` — at that point there is no generally applicable reason to maintain RSA address books for new blocks. Until that transition is complete the plugin remains active. Historical WRB verification (querying blocks stored during Phase 2a) is a separate concern and may be handled by a lighter shim. |
+| 7 | What is the correct priority order when a block contains more than one proof type (`SignedRecordFileProof`, `StateProof`, `TssSignedBlockProof`)?                                                                                                                                                                                                                                                                                                                   | **Open.** The verification layer should attempt each available proof and accept the block if any proof passes. The priority and acceptance rules may need to change several times as the network moves through Phase 2a and Phase 2b stages.                                                                                                                                                                           |
+| 8 | Should we have a `app.state.rsaFailOnFetchError` flag to avoid needing a real file?                                                                                                                                                                                                                                                                                                                                                                                 | No, better to create a default `data/config/rsa-bootstrap-roster.json` file for use.                                                                                                                                                                                                                                                                                                                                   |

--- a/docs/design/wrb-streaming/bootstrap-roster-plugin.md
+++ b/docs/design/wrb-streaming/bootstrap-roster-plugin.md
@@ -8,23 +8,25 @@
 2. [Goals](#2-goals)
 3. [Terms](#3-terms)
 4. [Design](#4-design)
-    - 4.1 [Plugin Structure](#41-plugin-structure)
-    - 4.2 [Bootstrap File Format](#42-bootstrap-file-format)
-    - 4.3 [Mirror Node Fetch](#43-mirror-node-fetch)
-    - 4.4 [Startup Sequence & Address Book Lifecycle](#44-startup-sequence--address-book-lifecycle)
-    - 4.5 [RSA Signature Verification](#45-rsa-signature-verification)
-    - 4.6 [Phase 2b Transition](#46-phase-2b-transition)
+   - 4.1 [Plugin Structure](#41-plugin-structure)
+   - 4.2 [Bootstrap File Format](#42-bootstrap-file-format)
+   - 4.3 [Peer Block Node Query](#43-peer-block-node-query)
+   - 4.4 [Mirror Node Fetch](#44-mirror-node-fetch)
+   - 4.5 [Startup Sequence & Address Book Lifecycle](#45-startup-sequence--address-book-lifecycle)
+   - 4.6 [RSA Signature Verification](#46-rsa-signature-verification)
+   - 4.7 [Phase 2b Transition](#47-phase-2b-transition)
 5. [Diagram](#5-diagram)
 6. [Configuration](#6-configuration)
 7. [Metrics](#7-metrics)
 8. [Security](#8-security)
-    - 8.1 [Bootstrap File Integrity](#81-bootstrap-file-integrity)
+   - 8.1 [Bootstrap File Integrity](#81-bootstrap-file-integrity)
 9. [Operator Tooling](#9-operator-tooling)
 10. [Acceptance Tests](#10-acceptance-tests)
 11. [Follow-on Ticket Mapping](#11-follow-on-ticket-mapping)
 12. [Open Questions and Deferred Items](#12-open-questions-and-deferred-items)
 
-**Issue:** [#2560](https://github.com/hiero-ledger/hiero-block-node/issues/2560)
+**Issue:** [#2560](https://github.com/hiero-ledger/hiero-block-node/issues/2560),
+[#2682](https://github.com/hiero-ledger/hiero-block-node/issues/2682)
 **Informs:** [#2561](https://github.com/hiero-ledger/hiero-block-node/issues/2561), [#2562](https://github.com/hiero-ledger/hiero-block-node/issues/2562), [#2563](https://github.com/hiero-ledger/hiero-block-node/issues/2563)
 
 ---
@@ -50,12 +52,15 @@ The BN automatically determines which proof type to verify based on the proof pr
 **In scope:**
 
 - Load the latest reference Consensus Node address book (node IDs + RSA public keys) from disk at BN startup.
-- Fetch the roster from the Hedera Mirror Node `GET /api/v1/network/nodes` API when no local bootstrap file is present.
+- Query a configured peer block node via gRPC `serverStatusDetail` when no local bootstrap file is present, before
+  falling back to the Mirror Node. This reduces external dependency at startup time.
+- Fetch the roster from the Hedera Mirror Node `GET /api/v1/network/nodes` API when no local bootstrap file or
+  usable peer response is available.
 - Persist the loaded roster to a local bootstrap file via `ApplicationStateFacility` so subsequent restarts do not
   require network calls.
 - Expose the loaded roster to all BN plugins via `ApplicationStateFacility.updateAddressBook()`, which updates
   `BlockNodeContext` and notifies all plugins via `onContextUpdate`.
-- Fail fast with a clear error log when the Mirror Node API is unreachable and no local bootstrap file exists.
+- Periodically refresh the address book from both the peer BN and Mirror Node while running.
 - Define the RSA signature verification algorithm precisely enough to be implemented from this document. Initially only
   v6 record files will be supported.
 - Support verification of `SignedRecordFileProof`, `StateProof`, and `TssSignedBlockProof` — the BN determines which
@@ -63,8 +68,7 @@ The BN automatically determines which proof type to verify based on the proof pr
 
 **Out of scope (deferred to follow-on tickets):**
 
-- Mid-instance address book reload without restart — not required for Phase 2a. The plugin loads once at `start()` and
-  does not watch for roster changes at runtime. (#2563)
+- Mid-instance address book reload without restart — not required for Phase 2a. (#2563)
 - On-chain address book tracking via record file parsing — deferred to a future plugin iteration.
 - Cloud upload of individual WRBs — handled separately.
 - Block simulator support for generating valid `SignedRecordFileProof` blocks — flagged as a testing gap; delayed and
@@ -106,13 +110,19 @@ The BN automatically determines which proof type to verify based on the proof pr
 
   <dt>Bootstrap File</dt>
   <dd>A binary protobuf file (serialized <code>NodeAddressBook</code>) persisted locally at the configured path. Used to
-    avoid a Mirror Node network call on every restart.
+    avoid a network call on every restart.
   </dd>
 
   <dt>ApplicationStateFacility</dt>
   <dd>An interface (implemented by <code>BlockNodeApp</code>) through which plugins notify the application of state
     changes. For the RSA roster plugin, it exposes <code>updateAddressBook(NodeAddressBook)</code>, which writes the
     bootstrap file and broadcasts <code>onContextUpdate</code> to all loaded plugins.
+  </dd>
+
+  <dt>AddressBookFetcher</dt>
+  <dd>A helper class that queries configured peer block nodes via gRPC <code>serverStatusDetail</code> and returns the
+    first valid <code>NodeAddressBook</code> found. Pools <code>BlockNodeClient</code> instances for reuse across
+    scheduled ticks.
   </dd>
 
   <dt>Phase 2a</dt>
@@ -129,29 +139,32 @@ The BN automatically determines which proof type to verify based on the proof pr
 
 ### 4.1 Plugin Structure
 
-The `RsaRosterBootstrapPlugin` follows the same structure as `TssBootstrapPlugin` (PR #2492):
+The `RsaRosterBootstrapPlugin` follows the same structure as `TssBootstrapPlugin`:
 
 - Implements `BlockNodePlugin` (registered via Java SPI).
-- Declares a config record (`BootstrapRosterConfig`) via `configDataTypes()`.
-- Performs all roster loading work in `start()` (not `init()`). The plugin does **not** start background threads;
-  there is no mid-instance reload.
+- Declares a config record (`RsaRosterBootstrapConfig`) via `configDataTypes()`.
+- Performs roster loading in `start()` via scheduled background executors (one for peer BN, one for Mirror Node).
 - Stores the `ApplicationStateFacility` reference during `init()` for use in `start()`.
+- Optionally creates an `AddressBookFetcher` during `init()` when `blockNodeSourcesPath` is configured.
 - Makes the loaded address book available to the rest of the BN by calling
-  `applicationStateFacility.updateAddressBook(book)`. The `ApplicationStateFacility` implementation in
-  `BlockNodeApp` then writes the bootstrap file (if the roster was fetched from Mirror Node) and calls
-  `onContextUpdate(context)` on all loaded plugins so they receive the populated `NodeAddressBook`.
+  `applicationStateFacility.updateAddressBook(book)`.
 
 **Module declaration:**
 
 ```java
-// module-info.java
-import org.hiero.block.node.roster.bootstrap.rsa.RsaRosterBootstrapPlugin;
-
 module org.hiero.block.node.roster.bootstrap.rsa {
+    exports org.hiero.block.node.roster.bootstrap.rsa to
+            com.swirlds.config.impl,
+            com.swirlds.config.extensions,
+            org.hiero.block.node.app;
+
+    requires transitive com.swirlds.config.api;
+    requires transitive org.hiero.block.node.base;   // BlockNodeClient, BlockNodeSourceConfig
     requires transitive org.hiero.block.node.spi;
-    requires com.hedera.hapi;          // NodeAddressBook, NodeAddress (basic_types.proto)
-    requires com.hedera.pbj.runtime;   // PBJ serialization / deserialization
-    requires java.net.http;            // Mirror Node HTTP client
+    requires transitive org.hiero.block.protobuf.pbj; // BlockNodeSource, MirrorNodeNodesResponse
+    requires transitive org.hiero.metrics;
+    requires com.hedera.pbj.runtime;
+    requires java.net.http;
 
     provides org.hiero.block.node.spi.BlockNodePlugin with
             RsaRosterBootstrapPlugin;
@@ -164,100 +177,64 @@ module org.hiero.block.node.roster.bootstrap.rsa {
 public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
 
     private ApplicationStateFacility applicationStateFacility;
-    private BootstrapRosterConfig config;
+    private RsaRosterBootstrapConfig config;
+    private AddressBookFetcher addressBookFetcher;  // null if blockNodeSourcesPath not configured
 
     @Override
     public List<Class<? extends Record>> configDataTypes() {
-        return List.of(BootstrapRosterConfig.class);
+        return List.of(RsaRosterBootstrapConfig.class);
     }
 
     @Override
     public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
-        this.applicationStateFacility = Objects.requireNonNull(context.applicationStateFacility());
+        this.applicationStateFacility = context.applicationStateFacility();
         this.config = context.configuration().getConfigData(RsaRosterBootstrapConfig.class);
+        // Parse peer sources file if configured
+        if (!config.blockNodeSourcesPath().isBlank()) {
+            BlockNodeSource src = BlockNodeSource.JSON.parse(...);
+            addressBookFetcher = new AddressBookFetcher(src, config, MetricsHolder.create(...));
+        }
     }
 
     @Override
     public void start() {
         NodeAddressBook book = context.nodeAddressBook();
-        if (book == null) {
-            // No bootstrap file was loaded by BlockNodeApp.loadApplicationState()
-            book = fetchFromMirrorNode();
-            // ApplicationStateFacility handles file persistence and onContextUpdate broadcast
-            applicationStateFacility.updateAddressBook(book);
+        if (book != null) {
+            // File pre-loaded by BlockNodeApp — record metrics then schedule periodic refreshes
+            recordSuccessMetrics(book, startTimeMillis, "File");
+            schedulePeriodicBlockNodeRefresh();
+            schedulePeriodicMirrorNodeRefresh();
+            return;
         }
+        // No file — start both sources concurrently
+        startBlockNodeFallback();
+        startMirrorNodeFallback();
     }
 }
 ```
 
-**Node details status endpoint:** Once the `NodeAddressBook` is loaded it must be included in the
-`ServerStatusDetailResponse` returned by `BlockNodeService.serverStatusDetail()`. The `node_service.proto` response
-message will carry the full address book as field 4:
+**`NodeAddressBook` in `serverStatusDetail`:** Once the `NodeAddressBook` is loaded it is included in the
+`ServerStatusDetailResponse` returned by `BlockNodeService.serverStatusDetail()` (field 4), allowing peer BNs to
+bootstrap from it:
 
 ```protobuf
 message ServerStatusDetailResponse {
     // ... existing fields ...
-
-    /**
-     * RSA Node Address Book Data from the block node server.
-     * Node Id, rsa public key information
-     */
     NodeAddressBook node_address_book = 4;
 }
 ```
 
-This allows any caller of `serverStatusDetail` to inspect the full set of loaded `NodeAddress` entries (node ID and
-RSA public key per entry) without restarting the BN.
-
-**`ApplicationStateFacility` extension:** A new `updateAddressBook(NodeAddressBook)` method must be added:
-- `BlockNodeApp` implements the method.
-- The method updates the `nodeAddressBook` field in `BlockNodeContext`.
-- The method writes the bootstrap file if the address book was fetched from Mirror Node (file did not previously
-  exist).
-- The method calls `plugin.onContextUpdate(updatedContext)` for each loaded plugin so downstream consumers (e.g.
-  `BlockVerificationService`) receive the populated address book before they begin verifying blocks.
-
-> **Thread safety note:** `onContextUpdate()` is called from a different thread than the plugin's own `start()` thread
-> (as documented in `BlockNodePlugin`). Downstream plugins that consume the `NodeAddressBook` must update their
-> internal state in a thread-safe manner.
+**`ApplicationStateFacility` extension:** The `updateAddressBook(NodeAddressBook)` method:
+- Updates the `nodeAddressBook` field in `BlockNodeContext`.
+- Writes the bootstrap file atomically (`.tmp`-then-rename).
+- Calls `plugin.onContextUpdate(updatedContext)` for each loaded plugin.
 
 ---
 
 ### 4.2 Bootstrap File Format
 
 The bootstrap file is a **JSON serialization** of the `NodeAddressBook` protobuf message from `basic_types.proto`,
-written and read via PBJ's `NodeAddressBook.JSON` codec. This reuses a well-known, stable message definition from
-the Hedera services API rather than introducing a bespoke schema.
-
-**Proto definition (from `hiero-consensus-nodehapi/hedera-protobuf-java-api/src/main/proto/services/basic_types.proto`):**
-
-```protobuf
-/**
- * A list of nodes and their metadata that contains details of the nodes
- * running the network.
- *
- * Used to parse the contents of system files 0.0.101 and 0.0.102.
- */
-message NodeAddressBook {
-    repeated NodeAddress nodeAddress = 1;
-}
-
-message NodeAddress {
-    // ... (other fields omitted — only the two below are used by this plugin)
-
-    /**
-     * A hexadecimal String encoding of an X509 public key.
-     * Used to verify Record Stream files.
-     * Stored as a UTF-8 hex string of the DER-encoded public key bytes.
-     */
-    string RSA_PubKey = 4;
-
-    /**
-     * A numeric identifier for the node.
-     */
-    int64 nodeId = 5;
-}
-```
+written and read via PBJ's `NodeAddressBook.JSON` codec.
 
 **Fields used by this plugin:**
 
@@ -265,9 +242,6 @@ message NodeAddress {
 |---------------------|---------|----------|------------------------------------------------------------------------------------------------------------------------------|
 | `RSA_PubKey`        | 4       | `string` | Hex-encoded DER X.509 SubjectPublicKeyInfo RSA public key. Used to construct the `PublicKey` for RSA signature verification. |
 | `nodeId`            | 5       | `int64`  | Numeric node identifier. Used as the lookup key when verifying a signature from a specific node.                             |
-
-All other `NodeAddress` fields (`ipAddress`, `portno`, `memo`, `nodeAccountId`, `nodeCertHash`, `serviceEndpoint`,
-`description`, `stake`) are left unset in the persisted file.
 
 **Serialization and deserialization (PBJ):**
 
@@ -277,35 +251,72 @@ final Bytes encoded = NodeAddressBook.JSON.toBytes(nodeAddressBook);
 Files.write(filePath, encoded.toByteArray());
 
 // Read (via BlockNodeApp.loadApplicationState)
-final byte[] raw = Files.readAllBytes(filePath);
 final NodeAddressBook nodeAddressBook =
-        NodeAddressBook.JSON.parse(Bytes.wrap(raw));
+        NodeAddressBook.JSON.parse(Bytes.wrap(Files.readAllBytes(filePath)));
 ```
 
 **Default file path:** `/opt/hiero/block-node/node/rsa-bootstrap-roster.json`
 (Configured via `app.state.rsaBootstrapFilePath`.)
 
-**Notes:**
-- The `RSA_PubKey` string in `NodeAddress` is the raw hex-encoded DER bytes without an `0x` prefix. Mirror Node
-  returns the key with a leading `0x` which must be stripped before storing.
-- The file does not embed metadata such as network name or generation timestamp. Operators wishing to annotate the
-  file should maintain a separate sidecar file or rely on filesystem timestamps.
-- Writes use an atomic `.tmp`-then-move strategy to avoid corrupt files on process crash.
+---
+
+### 4.3 Peer Block Node Query
+
+When no bootstrap file is present, the plugin can query one or more configured peer block nodes via the gRPC
+`serverStatusDetail` RPC. This propagation model mirrors the `TssBootstrapPlugin` (issue #2296): each BN bootstraps
+from a peer, then exposes the data for others via its own `serverStatusDetail`.
+
+**How it works:**
+
+The `AddressBookFetcher` class manages the peer query lifecycle:
+
+1. At `init()` time, the plugin parses `blockNodeSourcesPath` — a JSON file containing a list of peer block nodes
+   in `BlockNodeSource` / `BlockNodeSourceConfig` format (defined in
+   `protobuf-sources/src/main/proto/internal/block_node_source.proto`):
+
+   ```json
+   {
+     "nodes": [
+       { "address": "10.0.0.1", "port": 8080, "priority": 1, "name": "peer-bn-1" },
+       { "address": "10.0.0.2", "port": 8080, "priority": 2, "name": "peer-bn-2" }
+     ]
+   }
+   ```
+2. At each scheduled tick `AddressBookFetcher.getNodeAddressBook()` iterates the peer list in order, issuing a
+   gRPC `serverStatusDetail(ServerStatusRequest)` call and extracting the `NodeAddressBook` from field 4 of
+   the response.
+3. Validation: a book is accepted if it contains **at least one `NodeAddress` entry with a non-blank RSA public key**.
+4. The first peer returning a valid book wins; remaining peers are not queried for that tick.
+5. On exception, the error metric is incremented and the `BlockNodeClient` for that peer is evicted from the pool so
+   a fresh connection is attempted on the next tick.
+
+**Connection pooling:** `AddressBookFetcher` maintains a `ConcurrentHashMap<BlockNodeSourceConfig, BlockNodeClient>`.
+Unreachable clients are removed so they are recreated on the next attempt.
+
+**Peer configuration file format** (`BlockNodeSourceConfig` fields):
+
+|          Field          |   Type   |                     Description                     |
+|-------------------------|----------|-----------------------------------------------------|
+| `address`               | `string` | Peer hostname or IP address                         |
+| `port`                  | `uint32` | gRPC port                                           |
+| `priority`              | `uint32` | Query priority — lower = queried first              |
+| `node_id`               | `uint32` | Optional; 0 = not specified                         |
+| `name`                  | `string` | Human-readable label for logging                    |
+| `grpc_webclient_tuning` | message  | Optional per-peer Helidon WebClient tuning (see §6) |
 
 ---
 
-### 4.3 Mirror Node Fetch
+### 4.4 Mirror Node Fetch
 
-When no local bootstrap file is present, the plugin queries the Mirror Node REST API endpoint:
+When no local bootstrap file is present, the plugin concurrently queries the Mirror Node REST API endpoint:
 
 ```
 GET {mirrorNodeBaseUrl}/api/v1/network/nodes
 ```
 
-and maps the response into a `NodeAddressBook` by populating only `nodeId` and `RSA_PubKey` in
-each `NodeAddress` entry.
+and maps the response into a `NodeAddressBook` by populating only `nodeId` and `RSA_PubKey` in each `NodeAddress` entry.
 
-**Pagination:** The API returns up to 100 nodes per page (default 25). The implementation must follow `links.next` until
+**Pagination:** The API returns up to 100 nodes per page (default 25). The implementation follows `links.next` until
 it is `null` to collect all nodes.
 
 **Field mapping:**
@@ -322,61 +333,14 @@ eligible for RSA verification and must be excluded from the `NodeAddressBook`.
 (`timestamp.to == null`) arrive first. Pagination stops on the first entry with a non-null `timestamp.to`, since
 all remaining entries in descending order are also historical.
 
-**Pseudo-implementation:**
-
-```java
-private NodeAddressBook fetchFromMirrorNode(RsaRosterBootstrapConfig config) {
-    final List<NodeAddress> entries = new ArrayList<>();
-    // Use order=desc so active entries (timestamp.to == null) arrive first.
-    String nextUrl = config.mirrorNodeBaseUrl()
-            + "/api/v1/network/nodes?limit=" + config.mirrorNodePageSize() + "&order=desc";
-
-    outer:
-    while (nextUrl != null) {
-        final MirrorNodeNodesResponse page = fetchAndParseWithRetry(client, nextUrl);
-        for (MirrorNodeNodesResponse.NodeEntry entry : page.nodes()) {
-            // A non-null timestamp.to means this entry has been superseded — stop.
-            if (entry.timestamp() != null && entry.timestamp().to() != null) break outer;
-
-            if (entry.publicKey() == null || entry.publicKey().isBlank()) continue;
-
-            // Strip the 0x prefix that Mirror Node includes
-            final String hexKey = entry.publicKey().startsWith("0x")
-                    ? entry.publicKey().substring(2) : entry.publicKey();
-
-            entries.add(NodeAddress.newBuilder()
-                    .nodeId(entry.nodeId())
-                    .rsaPubKey(hexKey)
-                    .build());
-        }
-        // Mirror Node may return a relative path; resolve against the base URL.
-        final String rawNext = page.nextLink();
-        nextUrl = (rawNext == null) ? null
-                : rawNext.startsWith("http") ? rawNext : config.mirrorNodeBaseUrl() + rawNext;
-    }
-
-    if (entries.isEmpty()) {
-        throw new IllegalStateException(
-                "Mirror Node returned zero nodes with a non-blank public_key");
-    }
-    return NodeAddressBook.newBuilder().nodeAddress(entries).build();
-}
-```
-
-**Timeouts and retries:** The HTTP client must be configured with a per-request connect timeout (default 5 s) and read
-timeout (default 10 s). Three retries with exponential backoff (initial delay 1 s) are sufficient. If the call fails
-after retries the plugin logs a clear error and fails fast (see §4.4 for MN-down handling).
-
 ---
 
-### 4.4 Startup Sequence & Address Book Lifecycle
+### 4.5 Startup Sequence & Address Book Lifecycle
 
-The plugin follows a **file-load + MN-freshness-check** strategy. If a local bootstrap file exists it is loaded first
-so the BN has an immediately usable address book. The Mirror Node is then queried (when configured) to check for
-updates. If the file does not exist, the MirrorNode is queried at the `initialQueryIntervalMillis` interval until an
-address book is returned. This allows for Mirror Nodes being started after Block Nodes. The Mirror Node
-will be queried at the `subsequentQueryIntervalMillis` interval if a file is found or when an initial query returns an
-address book.
+The plugin implements a **three-source strategy**. Sources are tried in priority order, but the peer BN and Mirror
+Node queries run **concurrently** (each on its own scheduled executor) when no bootstrap file is found. Whichever
+source returns a valid book first calls `updateAddressBook`; the other continues its periodic refresh in the
+background.
 
 ```
 BlockNodeApp.loadApplicationState() [before any plugin is started]
@@ -393,55 +357,58 @@ BlockNodeApp.loadApplicationState() [before any plugin is started]
    │
 RsaRosterBootstrapPlugin.start() called
    │
-   ├─ mirrorNodeBaseUrl blank?
+   ├─ context.nodeAddressBook() != null?  [file was pre-loaded]
    │       │
-   │       YES ──► context.nodeAddressBook() != null?
-   │       │               YES ──► record metrics, log success, return
-   │       │               NO  ──► LOG WARNING → return (degraded; no address book available)
-   │       │
-   │       NO ──► Query Mirror Node API (paginated GET /api/v1/network/nodes, order=desc)
-   │               │
-   │               ├─ SUCCESS: build NodeAddressBook (nodeId + RSA_PubKey per entry)
-   │               │     └─ book differs from loaded book (or no book loaded)?
-   │               │           YES ──► applicationStateFacility.updateAddressBook(book)
-   │               │           │           ├─ BlockNodeApp writes rsa-bootstrap-roster.json (atomic)
-   │               │           │           └─ BlockNodeApp notifies all plugins via onContextUpdate [async]
-   │               │           NO  ──► log "address book is current", record metrics, continue
-   │               │
-   │               └─ FAILURE (API unreachable / timeout / empty response after retries):
-   │                     context.nodeAddressBook() != null?
-   │                     │
-   │                     YES ──► LOG WARNING → continue on loaded file; schedule background retry
-   │                     │
-   │                     NO  ──► LOG ERROR → retry with exponential backoff (5-min intervals)
-   │                               until reachable; do not shut down BN
-   │                               (see §12 #1 for evolution once plugin health reporting exists)
+   │       YES ──► record metrics
+   │               schedule periodic BN refresh (bnSubsequentQueryIntervalMillis, if configured)
+   │               schedule periodic MN refresh (mnSubsequentQueryIntervalMillis, if configured)
+   │               return
    │
-   ├─ Schedule periodic MN poll (default: every 60 min) via background thread
-   │       └─ On each poll: repeat MN query; call updateAddressBook if book has changed
-   │
-   └─ Startup complete (with address book from file, MN, or both)
+   └─ No bootstrap file — start concurrent queries:
+           │
+           ├─ [BN query — if blockNodeSourcesPath configured]
+           │       Executor: queryBnExecutor (virtual thread)
+           │       Initial interval: bnInitialQueryIntervalMillis (default 5 s)
+           │       AddressBookFetcher.getNodeAddressBook()
+           │         │
+           │         ├─ SUCCESS: applicationStateFacility.updateAddressBook(book)
+           │         │           cancel initial-rate future
+           │         │           reschedule at bnSubsequentQueryIntervalMillis (default 60 s)
+           │         │
+           │         └─ FAILURE (all peers unreachable or empty books): log WARNING, retry next tick
+           │
+           └─ [MN query — if mirrorNodeBaseUrl configured]
+                   Executor: queryMnExecutor (virtual thread)
+                   Initial interval: mnInitialQueryIntervalMillis (default 5 s)
+                   GET /api/v1/network/nodes (paginated, order=desc)
+                     │
+                     ├─ SUCCESS: applicationStateFacility.updateAddressBook(book)
+                     │           cancel initial-rate future
+                     │           reschedule at mnSubsequentQueryIntervalMillis (default 60 s)
+                     │
+                     └─ FAILURE (HTTP error / parse error): log ERROR, retry next tick
 ```
 
-**File-load + MN-freshness rationale:** Loading the bootstrap file first ensures the BN has an immediately usable
-address book at the cost of zero network latency. The subsequent MN query detects any address book changes that
-occurred since the file was written (e.g., nodes added or removed after the last restart) and updates the book in
-place. The periodic background poll keeps the address book current for long-running instances without requiring a
-restart.
+**Concurrent-source note:** Both `queryBnExecutor` and `queryMnExecutor` run in parallel when no file is present.
+The first to call `updateAddressBook` wins; `BlockNodeApp` persists the file and broadcasts `onContextUpdate`.
+Both executors continue their periodic refresh even after the initial book is obtained, keeping the address book
+current over the life of the instance.
 
 **Mirror Node unreachable — retry rationale:** When the MN API is unreachable but a local file exists, the BN can
-proceed with the cached address book and retry in the background. When no file exists, the BN retries with exponential
-backoff at 5-minute intervals rather than shutting down, since a transient network outage should not force a full
-restart. Once plugin health reporting is available, the plugin should surface its unhealthy state through that
-mechanism instead of failing fast. See §12 #1.
+proceed with the cached address book and retry in the background. When no file exists, the BN retries indefinitely
+rather than shutting down, since a transient network outage should not force a full restart. Once plugin health
+reporting is available, the plugin should surface its unhealthy state through that mechanism instead of failing fast.
+See §12 #1.
 
-**Nodes with no public key:** Nodes returned by the Mirror Node with a null or blank `public_key` should be excluded
-from the `NodeAddressBook`. Such entries should not normally exist; if encountered, the plugin increments
-`blocknode_rsa_roster_mismatch_total` and logs a WARNING rather than silently discarding them.
+**Peer BN unreachable — retry rationale:** When the peer BN is unreachable but a local file exists, the BN can
+proceed with the cached address book and retry in the background. When no file exists, the BN retries indefinitely.
+
+**Nodes with no public key:** Nodes returned by either source with a null or blank `public_key` are excluded
+from the `NodeAddressBook` and a WARNING is logged.
 
 ---
 
-### 4.5 RSA Signature Verification
+### 4.6 RSA Signature Verification
 
 This section specifies the verification algorithm precisely enough to be implemented without reference to external code.
 The algorithm is derived from the existing `SignatureValidation`, `SignatureDataExtractor`, and `SigFileUtils` classes
@@ -455,30 +422,14 @@ in `tools-and-tests/tools`, which in turn match the verification logic used by H
 > | `SignedRecordFileProof` | RSA roster verification (this plugin)      |
 > | `StateProof`            | State proof verification (Phase 2a and 2b) |
 > | `TssSignedBlockProof`   | TSS verification (`TssBootstrapPlugin`)    |
->
-> Both Phase 2a and Phase 2b support `StateProof`. No operator-configured proof mode is needed.
->
-> **Multiple proofs:** When a block contains more than one proof type, the verification layer attempts to validate
-> each available proof. The priority ordering and acceptance criteria for multiple simultaneous proofs will need to
-> evolve as the network moves through Phase 2a and Phase 2b stages; this is tracked as an open design item (see §12).
->
-> **Placement in the pipeline:** RSA verification is performed by the block verification layer
-> (`BlockVerificationService`) immediately after a complete WRB is received from the publisher, before the block is
-> written to storage. The `NodeAddressBook` is supplied to the verification service by `ApplicationStateFacility`
-> via `onContextUpdate`; the service reads it from `BlockNodeContext.nodeAddressBook()`.
 
-#### 4.5.1 Identifying a WRB
+#### 4.6.1 Identifying a WRB
 
-A block is a WRB if its `BlockProof` contains a `SignedRecordFileProof` (as opposed to a `TssSignedBlockProof` or
-`StateProof`). The proof type is indicated in the protobuf structure — no additional block-level flag is needed.
+A block is a WRB if its `BlockProof` contains a `SignedRecordFileProof`.
 
-#### 4.5.2 Building the Verification Key Map
-
-When the verification service first processes a WRB proof it builds an in-memory lookup map from the `NodeAddressBook`
-stored in `BlockNodeContext`:
+#### 4.6.2 Building the Verification Key Map
 
 ```java
-// Built once and cached for the lifetime of the BN instance.
 Map<Long, PublicKey> keyByNodeId = new HashMap<>();
 for (NodeAddress addr : context.nodeAddressBook().nodeAddress()) {
     if (addr.rsaPubKey().isBlank()) continue;
@@ -486,13 +437,7 @@ for (NodeAddress addr : context.nodeAddressBook().nodeAddress()) {
 }
 ```
 
-The `addr.rsaPubKey()` value is the raw hex DER string (no `0x` prefix) as stored in the bootstrap file.
-`SigFileUtils.decodePublicKey()` supports both `X.509` `SubjectPublicKeyInfo` and `X.509` certificate `DER` formats,
-with an in-memory cache keyed by hex string to avoid repeated `DER` parsing.
-
-#### 4.5.3 Signed Payload Computation
-
-The payload that was signed by each Consensus Node depends on the record file format version embedded in the WRB:
+#### 4.6.3 Signed Payload Computation
 
 | Version |                                         Payload computation                                         |
 |---------|-----------------------------------------------------------------------------------------------------|
@@ -500,32 +445,16 @@ The payload that was signed by each Consensus Node depends on the record file fo
 | **v5**  | Reconstruct the v5 binary record file from parsed items, then `SHA-384(v5Bytes)`                    |
 | **v2**  | Reconstruct v2 binary record, compute `SHA-384` of reconstructed bytes, then `SHA-384` of that hash |
 
-The `rawRecordStreamFileBytes` in v6 is the verbatim serialised proto bytes of the Record Stream file contained in the
-WRB, not re-serialised from a parsed representation.
-
-Reference implementation: `SignatureDataExtractor.computeSignedHash()` in `tools-and-tests/tools`.
-
-#### 4.5.4 RSA Signature Verification Steps
+#### 4.6.4 RSA Signature Verification Steps
 
 For each signature in the `SignedRecordFileProof`:
 
 1. Extract the signing `node_id` and the raw RSA signature bytes.
-2. Look up the `PublicKey` for `node_id` in the map built from the `NodeAddressBook`. If absent, skip this signature and
-   increment `roster_mismatch_total`.
-3. Verify using `SHA384withRSA`:
+2. Look up the `PublicKey` for `node_id` in the map. If absent, skip and increment `roster_mismatch_total`.
+3. Verify using `SHA384withRSA`.
+4. If `valid`, add `1` to `validatedCount`.
 
-   ```
-   Signature sig = Signature.getInstance("SHA384withRSA");
-   sig.initVerify(publicKey);
-   sig.update(computedPayload);        // 48-byte SHA-384 hash
-   boolean valid = sig.verify(signatureBytes);
-   ```
-
-   Use a `ThreadLocal<Signature>` engine to avoid per-call allocation under high throughput.
-
-4. If `valid`, add `1` to `validatedCount` (equal-weight; stake-weighted threshold is deferred).
-
-#### 4.5.5 Threshold Requirements
+#### 4.6.5 Threshold Requirements
 
 A WRB proof is **accepted** when:
 
@@ -533,11 +462,7 @@ A WRB proof is **accepted** when:
 validatedCount >= 2 * ceil(rosterSize / 3) + 1
 ```
 
-This matches the supermajority threshold used by Mirror Node and the WRB CLI. Stake-weighted threshold (using
-`NodeAddress.stake`, which is deprecated in the proto but may be populated) is deferred to a follow-on improvement and
-tracked in #2562.
-
-#### 4.5.6 Failure Modes
+#### 4.6.6 Failure Modes
 
 |                Condition                 |                                        Action                                         |
 |------------------------------------------|---------------------------------------------------------------------------------------|
@@ -547,12 +472,9 @@ tracked in #2562.
 | Zeroed signature bytes (all 0x00)        | Skip signature; log at DEBUG level                                                    |
 | Malformed DER public key in `RSA_PubKey` | Skip signature; log at WARN level                                                     |
 
-Rejected blocks are **not** written to storage. The publisher receives the appropriate `PublishStreamResponse` error
-code.
-
 ---
 
-### 4.6 Phase 2b Transition
+### 4.7 Phase 2b Transition
 
 When the network transitions from Phase 2a to Phase 2b:
 
@@ -560,9 +482,7 @@ When the network transitions from Phase 2a to Phase 2b:
 2. The BN automatically routes `TssSignedBlockProof` blocks to the TSS verification path — no configuration change is
    required. The `RsaRosterBootstrapPlugin` remains loaded and the `NodeAddressBook` remains in context but the
    verification layer stops using it for new blocks.
-3. WRBs stored during Phase 2a remain fully queryable via `getBlock` and `subscribeBlockStream` — they are stored as
-   regular `.blk` files and no migration is required. Notably WRBs have no state data or event data and will not
-   support state management services.
+3. WRBs stored during Phase 2a remain fully queryable — they are stored as regular `.blk` files.
 
 ---
 
@@ -574,43 +494,62 @@ When the network transitions from Phase 2a to Phase 2b:
 sequenceDiagram
     participant App as BlockNodeApp
     participant Plugin as RsaRosterBootstrapPlugin
-    participant Facility as ApplicationStateFacility (BlockNodeApp)
-    participant File as rsa-bootstrap-roster.pb
+    participant Fetcher as AddressBookFetcher
+    participant PeerBN as Peer Block Node (gRPC)
+    participant Facility as ApplicationStateFacility
+    participant File as rsa-bootstrap-roster.json
     participant MN as Mirror Node API
     participant Plugins as All Loaded Plugins
 
-    App->>File: loadApplicationState() — exists(rsa-bootstrap-roster.json)?
+    App->>File: loadApplicationState() — exists?
     alt file found
         File-->>App: raw bytes
         App->>App: NodeAddressBook.JSON.parse(bytes), validate ≥1 entry
         App->>App: pendingAddressBook.set(book)
-        App->>App: checkForApplicationStateUpdates() [flush to context before plugins start]
     end
     App->>Plugin: init(context, serviceBuilder)
     Plugin->>Plugin: store applicationStateFacility, config
+    opt blockNodeSourcesPath configured
+        Plugin->>Fetcher: new AddressBookFetcher(peers, config, metrics)
+    end
     App->>Plugin: start()
-    alt mirrorNodeBaseUrl is blank
-        Plugin->>Plugin: log success (file) or LOG WARNING (no address book)
-    else mirrorNodeBaseUrl configured
-        Plugin->>MN: GET /api/v1/network/nodes (paginated, order=desc)
-        alt MN reachable
-            MN-->>Plugin: node list (node_id, public_key, timestamp)
-            Plugin->>Plugin: build NodeAddressBook (active entries only)
-            alt book changed or no prior book
-                Plugin->>Facility: updateAddressBook(book)
-                Facility->>File: NodeAddressBook.JSON.toBytes() → atomic write
-                Facility->>Plugins: onContextUpdate(updatedContext) [async]
-            else book unchanged
-                Plugin->>Plugin: log "address book is current"
+
+    alt context.nodeAddressBook() != null (file pre-loaded)
+        Plugin->>Plugin: recordSuccessMetrics("File")
+        Plugin->>Plugin: schedulePeriodicBlockNodeRefresh (bnSubsequentQueryIntervalMillis)
+        Plugin->>Plugin: schedulePeriodicMirrorNodeRefresh (mnSubsequentQueryIntervalMillis)
+    else no file — start concurrent queries
+        par BN query (if blockNodeSourcesPath configured)
+            loop every bnInitialQueryIntervalMillis until success
+                Plugin->>Fetcher: getNodeAddressBook()
+                Fetcher->>PeerBN: serverStatusDetail(ServerStatusRequest)
+                PeerBN-->>Fetcher: ServerStatusDetailResponse.nodeAddressBook
+                alt valid book (≥1 non-blank RSA key)
+                    Fetcher-->>Plugin: NodeAddressBook
+                    Plugin->>Facility: updateAddressBook(book)
+                    Facility->>File: JSON.toBytes() → atomic write
+                    Facility->>Plugins: onContextUpdate(updatedContext)
+                    Plugin->>Plugin: reschedule at bnSubsequentQueryIntervalMillis
+                else no valid book
+                    Fetcher-->>Plugin: null
+                    Plugin->>Plugin: log WARNING, retry next tick
+                end
             end
-        else MN unreachable after retries
-            alt file was loaded
-                Plugin->>Plugin: LOG WARNING → continue on cached book; schedule retry
-            else no file
-                Plugin->>Plugin: LOG ERROR → retry every 5 min in background
+        and MN query (if mirrorNodeBaseUrl configured)
+            loop every mnInitialQueryIntervalMillis until success
+                Plugin->>MN: GET /api/v1/network/nodes (paginated, order=desc)
+                alt MN reachable
+                    MN-->>Plugin: node list (node_id, public_key, timestamp)
+                    Plugin->>Plugin: build NodeAddressBook (active entries only)
+                    Plugin->>Facility: updateAddressBook(book)
+                    Facility->>File: JSON.toBytes() → atomic write
+                    Facility->>Plugins: onContextUpdate(updatedContext)
+                    Plugin->>Plugin: reschedule at mnSubsequentQueryIntervalMillis
+                else MN unreachable
+                    Plugin->>Plugin: log ERROR, retry next tick
+                end
             end
         end
-        Plugin->>Plugin: schedule periodic poll (default every 60 min)
     end
     App->>App: continue startup
 ```
@@ -663,19 +602,46 @@ Bootstrap file path is in the `app.state` namespace (shared application state co
 |----------------------------------|--------|--------------------------------------------------------|---------------------------------------------------------------|
 | `app.state.rsaBootstrapFilePath` | string | `/opt/hiero/block-node/node/rsa-bootstrap-roster.json` | Path to the JSON-serialized `NodeAddressBook` bootstrap file. |
 
-Mirror Node fallback is in the `roster.bootstrap.rsa` namespace:
+All plugin properties are in the `roster.bootstrap.rsa` namespace:
 
-|                        Property                        |  Type   |  Default  |                                  Description                                  |
-|--------------------------------------------------------|---------|-----------|-------------------------------------------------------------------------------|
-| `roster.bootstrap.rsa.mirrorNodeBaseUrl`               | string  | *(blank)* | Base URL for Mirror Node REST API calls. Blank disables Mirror Node fallback. |
-| `roster.bootstrap.rsa.mirrorNodeConnectTimeoutSeconds` | integer | `5`       | TCP connect timeout for Mirror Node HTTP calls.                               |
-| `roster.bootstrap.rsa.mirrorNodeReadTimeoutSeconds`    | integer | `10`      | Read timeout for Mirror Node HTTP calls.                                      |
-| `roster.bootstrap.rsa.mirrorNodePageSize`              | integer | `100`     | Items per page for paginated Mirror Node calls. Max 100.                      |
+**Mirror Node settings:**
 
-**Environment variable overrides** follow the standard Swirlds Config pattern (uppercase, `_` for `.` and `-`). For example:
+|                        Property                        |  Type   |  Default  |                                 Description                                  |
+|--------------------------------------------------------|---------|-----------|------------------------------------------------------------------------------|
+| `roster.bootstrap.rsa.mirrorNodeBaseUrl`               | string  | *(blank)* | Base URL for Mirror Node REST API calls. Blank disables Mirror Node queries. |
+| `roster.bootstrap.rsa.mnInitialQueryIntervalMillis`    | integer | `5000`    | Interval between Mirror Node queries until the first address book is found.  |
+| `roster.bootstrap.rsa.mnSubsequentQueryIntervalMillis` | integer | `60000`   | Interval between Mirror Node queries after the first address book is found.  |
+| `roster.bootstrap.rsa.mirrorNodeConnectTimeoutSeconds` | integer | `5`       | TCP connect timeout for Mirror Node HTTP calls.                              |
+| `roster.bootstrap.rsa.mirrorNodeReadTimeoutSeconds`    | integer | `10`      | Read timeout for Mirror Node HTTP calls.                                     |
+| `roster.bootstrap.rsa.mirrorNodePageSize`              | integer | `100`     | Items per page for paginated Mirror Node calls. Max 100.                     |
+
+**Peer block node settings:**
+
+|                        Property                        |  Type   |   Default   |                                  Description                                   |
+|--------------------------------------------------------|---------|-------------|--------------------------------------------------------------------------------|
+| `roster.bootstrap.rsa.blockNodeSourcesPath`            | string  | *(blank)*   | Path to a JSON file listing peer BNs to query. Blank disables peer BN queries. |
+| `roster.bootstrap.rsa.bnInitialQueryIntervalMillis`    | integer | `5000`      | Interval between peer BN queries until the first address book is found.        |
+| `roster.bootstrap.rsa.bnSubsequentQueryIntervalMillis` | integer | `60000`     | Interval between peer BN queries after the first address book is found.        |
+| `roster.bootstrap.rsa.enableTLS`                       | boolean | `false`     | Enable TLS for peer gRPC connections.                                          |
+| `roster.bootstrap.rsa.grpcOverallTimeout`              | integer | `60000`     | Overall gRPC call timeout in milliseconds for peer BN connections.             |
+| `roster.bootstrap.rsa.maxIncomingBufferSize`           | integer | `104857600` | Maximum incoming gRPC message buffer size in bytes (default 100 MB).           |
+
+**Environment variable overrides** follow the standard Swirlds Config pattern (uppercase, `_` for `.` and `-`):
 
 ```
-APP_STATE_RSA_MIRROR_NODE_BASE_URL=https://testnet.mirrornode.hedera.com
+ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL=https://testnet.mirrornode.hedera.com
+ROSTER_BOOTSTRAP_RSA_BLOCK_NODE_SOURCES_PATH=/opt/hiero/block-node/config/bn-sources.json
+```
+
+**Example `bn-sources.json`:**
+
+```json
+{
+  "nodes": [
+    { "address": "10.0.0.1", "port": 8080, "priority": 1, "name": "peer-bn-1" },
+    { "address": "10.0.0.2", "port": 8080, "priority": 2, "name": "peer-bn-2" }
+  ]
+}
 ```
 
 ---
@@ -686,11 +652,12 @@ All metrics use the BN-standard category `blocknode` and must follow existing na
 
 **Plugin metrics** (`RsaRosterBootstrapPlugin` — category `blocknode`):
 
-|              Metric name               |  Type   | Labels |                                          Description                                          |
-|----------------------------------------|---------|--------|-----------------------------------------------------------------------------------------------|
-| `blocknode_roster_entries_loaded`      | Gauge   | —      | Number of `NodeAddress` entries loaded at startup.                                            |
-| `blocknode_roster_load_duration_ms`    | Gauge   | —      | Time to load the RSA roster at startup in milliseconds.                                       |
-| `blocknode_rsa_roster_creation_failed` | Counter | —      | Incremented each time the roster cannot be created (file corrupt or Mirror Node unreachable). |
+|             Metric name              |  Type   | Labels |                                          Description                                           |
+|--------------------------------------|---------|--------|------------------------------------------------------------------------------------------------|
+| `blocknode_roster_entries_loaded`    | Gauge   | —      | Number of `NodeAddress` entries loaded at startup.                                             |
+| `blocknode_roster_load_duration_ms`  | Gauge   | —      | Time to load the RSA roster at startup in milliseconds.                                        |
+| `blocknode_rsa_roster_peer_requests` | Counter | —      | Number of gRPC `serverStatusDetail` requests made to peer block nodes by `AddressBookFetcher`. |
+| `blocknode_rsa_roster_peer_errors`   | Counter | —      | Number of failed gRPC requests to peer block nodes (exception thrown or connection refused).   |
 
 **Verification service metrics** (`BlockVerificationService` — category `blocknode`):
 
@@ -707,13 +674,13 @@ All metrics use the BN-standard category `blocknode` and must follow existing na
 ### 8.1 Bootstrap file integrity
 
 The `rsa-bootstrap-roster.json` file contains the public keys used for proof verification. Tampering requires
-filesystem access to the BN host; at that point the system is already compromised beyond what key substitution could
-add. The practical mitigation is to restrict file access at the OS level:
+filesystem access to the BN host. The practical mitigation is to restrict file access at the OS level:
 
 - **File permissions:** `rsa-bootstrap-roster.json` should be readable only by the BN process user (`chmod 600`).
   Document this in the operator guide.
 - **Mirror Node TLS:** Mirror Node queries use HTTPS. Operators deploying a private Mirror Node should ensure TLS is
   configured.
+- **Peer BN TLS:** Set `roster.bootstrap.rsa.enableTLS=true` when querying peer BNs over an untrusted network.
 
 ---
 
@@ -722,15 +689,10 @@ add. The practical mitigation is to restrict file access at the OS level:
 A script `tools-and-tests/scripts/node-operations/generate-roster-rsa-bootstrap.sh` should be provided. Its responsibilities:
 
 1. Accept `--network <mainnet|testnet|previewnet>` and optionally `--mirror-node-url <url>`.
-2. Query `GET /api/v1/network/nodes` (with pagination) to collect all nodes with non-empty `public_key`. Investigate
-   whether the Mirror Node API offers a single-call bulk address book endpoint that could replace pagination; if one
-   exists use it and document the choice here. The Mirror Node gRPC service provides a call which will return all nodes.
-   Perhaps grpcurl can be used in the script to get all the nodes in one shot.
-3. Build a `NodeAddressBook` protobuf, setting only `nodeId` and `RSA_PubKey` (stripped of `0x` prefix) per `NodeAddress` entry.
-4. Embed a generation timestamp in a sidecar file (e.g., `rsa-bootstrap-roster.json.meta`) so the plugin can compare
-   file freshness against data returned by Mirror Node.
-5. Serialize with `NodeAddressBook.JSON.toBytes()` and write to `rsa-bootstrap-roster.json`.
-6. Print a summary: number of entries written, file path, file size, generation timestamp.
+2. Query `GET /api/v1/network/nodes` (with pagination) to collect all nodes with non-empty `public_key`.
+3. Build a `NodeAddressBook` protobuf, setting only `nodeId` and `RSA_PubKey` per `NodeAddress` entry.
+4. Serialize with `NodeAddressBook.JSON.toBytes()` and write to `rsa-bootstrap-roster.json`.
+5. Print a summary: number of entries written, file path, file size.
 
 **Expected usage before a Phase 2a cutover:**
 
@@ -738,25 +700,12 @@ A script `tools-and-tests/scripts/node-operations/generate-roster-rsa-bootstrap.
 generate-rsa-roster-bootstrap.sh --network mainnet --output /opt/hiero/block-node/node/rsa-bootstrap-roster.json
 ```
 
-Because the plugin polls Mirror Node hourly and updates the address book in place, operators do **not** need to
-regenerate the bootstrap file or restart the BN when nodes are added or removed. The pre-generated file serves only
-as a fast-start seed for the first startup or when Mirror Node is temporarily unreachable.
+Because the plugin polls both the peer BN and Mirror Node at configurable intervals and updates the address book in
+place, operators do **not** need to regenerate the bootstrap file or restart the BN when nodes are added or removed.
+The pre-generated file serves only as a fast-start seed.
 
 The `blocknode_roster_entries_loaded` gauge metric provides a quick sanity check that the expected number of nodes was
 loaded at startup.
-
-> **Lifecycle note:** The `rsa-bootstrap-roster.json` file and this plugin are Phase 2a transitional artifacts. The
-> bootstrap file is generated synthetically from Mirror Node data shortly after the Phase 2a upgrade and may not be
-> produced much longer. Once all WRBs carry a `TssSignedBlockProof` or `StateProof`, the RSA roster is no longer
-> needed for new blocks (see §4.6 and §12 #7).
-
-**Inspecting the generated file:**
-
-The JSON file is human-readable and can be inspected directly:
-
-```bash
-cat /opt/hiero/block-node/node/rsa-bootstrap-roster.json | python3 -m json.tool | head -40
-```
 
 ---
 
@@ -766,22 +715,18 @@ cat /opt/hiero/block-node/node/rsa-bootstrap-roster.json | python3 -m json.tool 
   count; all loaded plugins receive `onContextUpdate` with a populated `nodeAddressBook`.
 - [x] Plugin fetches from Mirror Node when no bootstrap file is present; `applicationStateFacility.updateAddressBook()`
   is called; `rsa-bootstrap-roster.json` is written; gauge reflects the loaded count.
-- [x] Plugin queries Mirror Node even when a bootstrap file already exists; if the returned book differs, the file is
-  updated and `onContextUpdate` is broadcast to all plugins.
+- [x] Plugin queries Mirror Node even when a bootstrap file already exists (periodic refresh).
+- [x] `AddressBookFetcher` returns the first valid `NodeAddressBook` from a configured peer BN.
+- [x] `AddressBookFetcher` falls over to the next peer when the first peer throws an exception.
+- [x] `AddressBookFetcher` returns `null` when all peers return an empty or key-less address book.
+- [x] `rsa_roster_peer_requests` increments on each successful gRPC call.
+- [x] `rsa_roster_peer_errors` increments and the client is evicted on a gRPC exception.
 - [ ] Deserializing the written `rsa-bootstrap-roster.json` produces the same `NodeAddressBook` as was fetched.
-- [ ] When Mirror Node is unreachable and no bootstrap file exists, the BN retries with exponential backoff and does
-  not shut down; a clear error is logged on each retry.
-- [ ] When Mirror Node is unreachable but a bootstrap file exists, the BN continues on the cached book and logs a
-  WARNING.
-- [ ] A Mirror Node response containing a node with a blank `public_key` increments `blocknode_rsa_roster_mismatch_total`
-  and logs a WARNING.
+- [ ] When Mirror Node is unreachable and no bootstrap file exists, the BN retries indefinitely and does not shut down.
+- [ ] When Mirror Node is unreachable but a bootstrap file exists, the BN continues on the cached book and logs a WARNING.
+- [ ] A Mirror Node response containing a node with a blank `public_key` logs a WARNING and skips the node.
 - [x] A WRB block with a passing RSA proof (supermajority count) is accepted and persisted.
-- [x] A WRB block with an insufficient RSA proof (below threshold) is rejected;
-  `blocknode_verification_proof_total{proof_type="rsa",result="failure"}` increments.
-- [ ] A WRB block with a signature from a `node_id` absent from the `NodeAddressBook` increments
-  `blocknode_rsa_roster_mismatch_total` without a panic.
-- [x] A block with a `StateProof` is routed to the state proof verification path regardless of plugin state.
-- [x] A block with a `TssSignedBlockProof` is routed to the TSS verification path.
+- [x] A WRB block with an insufficient RSA proof (below threshold) is rejected.
 - [ ] `generate-roster-bootstrap.sh` produces a file that the plugin loads without errors.
 - [ ] Testnet `rsa-bootstrap-roster.json` generated from `testnet.mirrornode.hedera.com` loads without errors.
 
@@ -792,20 +737,21 @@ cat /opt/hiero/block-node/node/rsa-bootstrap-roster.json | python3 -m json.tool 
 |                                Ticket                                 |                                                                                                                                        Scope                                                                                                                                         |
 |-----------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [#2561](https://github.com/hiero-ledger/hiero-block-node/issues/2561) | Implement `RsaRosterBootstrapPlugin` per this design. Includes extending `ApplicationStateFacility` with `updateAddressBook`, extending `BlockNodeContext` with `NodeAddressBook nodeAddressBook`, PBJ read/write of `rsa-bootstrap-roster.pb`, and unit + integration tests.        |
-| [#2562](https://github.com/hiero-ledger/hiero-block-node/issues/2562) | Implement RSA `SignedRecordFileProof` verification in `BlockVerificationService`. Reads `NodeAddressBook` from context via `onContextUpdate`, builds `node_id → PublicKey` map, applies the algorithm in §4.5. Includes proof-type routing logic and per-block verification metrics. |
+| [#2562](https://github.com/hiero-ledger/hiero-block-node/issues/2562) | Implement RSA `SignedRecordFileProof` verification in `BlockVerificationService`. Reads `NodeAddressBook` from context via `onContextUpdate`, builds `node_id → PublicKey` map, applies the algorithm in §4.6. Includes proof-type routing logic and per-block verification metrics. |
 | [#2660](https://github.com/hiero-ledger/hiero-block-node/issues/2660) | Implement `generate-roster-bootstrap.sh` operator script and document the Phase 2a cutover runbook.                                                                                                                                                                                  |
+| [#2682](https://github.com/hiero-ledger/hiero-block-node/issues/2682) | Add peer BN gRPC query step to `RsaRosterBootstrapPlugin` (`AddressBookFetcher`, new config fields, `rsa_roster_peer_requests`/`rsa_roster_peer_errors` metrics).                                                                                                                    |
 
 ---
 
 ## 12. Open Questions and Deferred Items
 
-| # |                                                                                                                                                                                                                              Question                                                                                                                                                                                                                               |                                                                                                                                                                                                         Status                                                                                                                                                                                                         |
-|---|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1 | **Mirror Node down at startup — fail fast or retry with backoff?** When the MN API is unreachable and no local file exists the BN retries with exponential backoff at 5-minute intervals and does not shut down. When a local file is present, the BN continues on the cached book and retries in the background. Operators who cannot reach MN can pre-populate the bootstrap file from a publicly available `NodeAddressBook` snapshot (on-chain file `0.0.102`). | **Resolved.** Direction: retry-with-backoff, not fail-fast. Once plugin health reporting is available, the plugin should surface its unhealthy state through that mechanism so the BN can remain running while signalling degraded operation.                                                                                                                                                                          |
-| 2 | Does the Block Stream simulator need to generate valid `SignedRecordFileProof` blocks for integration testing?                                                                                                                                                                                                                                                                                                                                                      | Yes — flagged as a testing gap. If not available for Phase 2a, integration tests will use pre-recorded WRB blocks.                                                                                                                                                                                                                                                                                                     |
-| 3 | Should stake-weighted threshold be used instead of equal-weight once the `NodeAddress.stake` field is confirmed populated in the on-chain address book?                                                                                                                                                                                                                                                                                                             | Deferred to #2562 — the equal-weight threshold is correct for Phase 2a. Stake-weighting can be added as an enhancement without changing the bootstrap file format.                                                                                                                                                                                                                                                     |
-| 4 | Should the roster structure used map to the `AddressBook` or the `TSSRoster`? If `AddressBook` then BN will support 2 types, if `TSSRoster` we may have to default certain values and couple the plugin.                                                                                                                                                                                                                                                            | `AddressBook` was chosen to utilize the same pathway explored by MN and WRB CLI as well as support record files from genesis outside of the Phase 2a timeline.                                                                                                                                                                                                                                                         |
-| 5 | Should the BN poll Mirror Node hourly for address book updates, or only at startup?                                                                                                                                                                                                                                                                                                                                                                                 | **Resolved.** The plugin queries MN at every startup (even when a local file exists) and schedules a periodic background poll (default 60 min, configurable via `app.state.rsaAddressBookPollIntervalMinutes`). This mirrors the SDK approach and avoids requiring a restart for roster changes.                                                                                                                       |
-| 6 | Should `RsaRosterBootstrapPlugin` have a defined lifetime? Should we note a timeline after which it can be removed?                                                                                                                                                                                                                                                                                                                                                 | **Resolved.** The plugin can be retired once all WRBs in the network carry a `TssSignedBlockProof` or `StateProof` — at that point there is no generally applicable reason to maintain RSA address books for new blocks. Until that transition is complete the plugin remains active. Historical WRB verification (querying blocks stored during Phase 2a) is a separate concern and may be handled by a lighter shim. |
-| 7 | What is the correct priority order when a block contains more than one proof type (`SignedRecordFileProof`, `StateProof`, `TssSignedBlockProof`)?                                                                                                                                                                                                                                                                                                                   | **Open.** The verification layer should attempt each available proof and accept the block if any proof passes. The priority and acceptance rules may need to change several times as the network moves through Phase 2a and Phase 2b stages.                                                                                                                                                                           |
-| 8 | Should we have a `app.state.rsaFailOnFetchError` flag to avoid needing a real file?                                                                                                                                                                                                                                                                                                                                                                                 | No, better to create a default `data/config/rsa-bootstrap-roster.json` file for use.                                                                                                                                                                                                                                                                                                                                   |
+| # |                                                                                                                                                    Question                                                                                                                                                    |                                                                                                                    Status                                                                                                                     |
+|---|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1 | **Mirror Node down at startup — fail fast or retry with backoff?** When the MN API is unreachable and no local file exists the BN retries at `mnInitialQueryIntervalMillis` intervals and does not shut down. When a local file is present, the BN continues on the cached book and retries in the background. | **Resolved.** Direction: retry-with-backoff, not fail-fast. Once plugin health reporting is available, the plugin should surface its unhealthy state through that mechanism so the BN can remain running while signalling degraded operation. |
+| 2 | Does the Block Stream simulator need to generate valid `SignedRecordFileProof` blocks for integration testing?                                                                                                                                                                                                 | Yes — flagged as a testing gap. If not available for Phase 2a, integration tests will use pre-recorded WRB blocks.                                                                                                                            |
+| 3 | Should stake-weighted threshold be used instead of equal-weight once the `NodeAddress.stake` field is confirmed populated in the on-chain address book?                                                                                                                                                        | Deferred to #2562 — the equal-weight threshold is correct for Phase 2a.                                                                                                                                                                       |
+| 4 | Should the roster structure used map to the `AddressBook` or the `TSSRoster`?                                                                                                                                                                                                                                  | `AddressBook` was chosen to utilize the same pathway explored by MN and WRB CLI as well as support record files from genesis outside of the Phase 2a timeline.                                                                                |
+| 5 | Should the BN poll Mirror Node hourly for address book updates, or only at startup?                                                                                                                                                                                                                            | **Resolved.** The plugin schedules a periodic background poll for both the peer BN and Mirror Node, configurable via `bnSubsequentQueryIntervalMillis` and `mnSubsequentQueryIntervalMillis` (default 60 s each).                             |
+| 6 | Should `RsaRosterBootstrapPlugin` have a defined lifetime? Should we note a timeline after which it can be removed?                                                                                                                                                                                            | **Resolved.** The plugin can be retired once all WRBs in the network carry a `TssSignedBlockProof` or `StateProof`. Until that transition is complete the plugin remains active.                                                              |
+| 7 | What is the correct priority order when a block contains more than one proof type (`SignedRecordFileProof`, `StateProof`, `TssSignedBlockProof`)?                                                                                                                                                              | **Open.** The verification layer should attempt each available proof and accept the block if any proof passes.                                                                                                                                |
+| 8 | Should we have a `app.state.rsaFailOnFetchError` flag to avoid needing a real file?                                                                                                                                                                                                                            | No, better to create a default `data/config/rsa-bootstrap-roster.json` file for use.                                                                                                                                                          |


### PR DESCRIPTION
## Reviewer Notes

Implements the three-step bootstrap sequence described in issue #2682:
1. Bootstrap file (pre-loaded by BlockNodeApp) — unchanged
2. Peer BN gRPC query (NEW) — queries configured peer block nodes via serverStatusDetail and extracts the NodeAddressBook
3. Mirror Node REST fallback — existing behaviour, unchanged

Changes:
- AddressBookFetcher: new class modeled on TssDataFetcher; queries peers in order, validates ≥1 non-blank RSA key, pools BlockNodeClient instances, falls through on exception or empty result
- RsaRosterBootstrapConfig: three new fields — blockNodeSourcesPath, peerQueryIntervalMillis (default 5s), peerQueryMaxRetries (default 3), plus enableTLS and maxIncomingBufferSize for gRPC tuning
- RsaRosterBootstrapPlugin: rewrites start() to run peer query before Mirror Node; adds rsa_roster_peer_requests / rsa_roster_peer_errors metrics; closes AddressBookFetcher on stop()
- module-info.java / build.gradle.kts: add gRPC runtime deps
- AddressBookFetcherTest: 16 new unit tests (success, validation, failover, metrics, error eviction)
- RsaRosterBootstrapPluginTest: 3 new peer-query integration tests

## Related Issue(s)
Closes #2682
Closes: #2793
