### PR TITLE
feat: Improve and extend handling of persisted notifications

### DIFF
--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -5,6 +5,7 @@ import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
+import static java.util.concurrent.locks.LockSupport.parkNanos;
 import static org.hiero.block.api.PublishStreamResponse.EndOfStream.Code.TIMEOUT;
 import static org.hiero.block.node.spi.BlockNodePlugin.UNKNOWN_BLOCK_NUMBER;
 import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_BLOCKS_CLOSED_COMPLETE;
@@ -43,6 +44,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
@@ -78,6 +80,10 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     /// Value assigned as a Handler message budget when that handler is being paused
     /// due to overload or other ill-advised behaviors.
     private static final long MESSAGE_BUDGET_PENALTY_FLAG_VALUE = -1L;
+    /// Wait 10 microseconds per pause if a reset is in progress. A reset
+    /// should generally take less than one microsecond, but waiting
+    /// less than 10 microseconds is not completely reliable.
+    private static final long RESET_WAIT_TIME_NANOS = 10_000L;
     private final System.Logger LOGGER = System.getLogger(LiveStreamPublisherManager.class.getName());
     private final MetricsHolder metrics;
     private final BlockNodeContext serverContext;
@@ -90,6 +96,9 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     private final AtomicLong blocksClosedComplete;
     private final Condition dataReadyLatch;
     private final ReentrantLock dataReadyLock;
+    /// Flag indicating that the plugin is in the middle of a reset and must
+    /// not accept new connections, create new Handlers, or forward data.
+    private final AtomicBoolean resetIsActive;
     private final long earliestManagedBlock;
     private final int maxBlocksBeforeStalled;
     private final long staleResendPruneBuffer;
@@ -133,6 +142,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     /// todo(1420) add documentation
     public LiveStreamPublisherManager(
             @NonNull final BlockNodeContext context, @NonNull final MetricsHolder metricsHolder) {
+        resetIsActive = new AtomicBoolean(true);
         serverContext = Objects.requireNonNull(context);
         metrics = Objects.requireNonNull(metricsHolder);
         threadManager = serverContext.threadPoolManager();
@@ -161,6 +171,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         handlerFlowState = new ConcurrentSkipListMap<>();
         initializeBlockNumbers(serverContext);
         scheduleFlowControlRefresh();
+        resetIsActive.compareAndSet(true, false);
     }
 
     /// todo(1420) add documentation
@@ -180,6 +191,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             @NonNull final Pipeline<? super PublishStreamResponse> replies,
             @NonNull final PublisherHandler.MetricsHolder handlerMetrics,
             final String correlationId) {
+        awaitReset();
         final long handlerId = nextHandlerId.getAndIncrement();
         final PublisherHandler newHandler =
                 new PublisherHandler(handlerId, replies, handlerMetrics, this, correlationId);
@@ -195,6 +207,20 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         sendPublisherStatusUpdate(UpdateType.PUBLISHER_CONNECTED, handlers);
         LOGGER.log(DEBUG, "Added new handler {0}", handlerId);
         return newHandler;
+    }
+
+    /// Method to wait for a boolean value to be false.
+    /// We do _not_ want a lock here, a lock ensures a single entry
+    /// at a time, while here we just do not want to proceed when this value is
+    /// true. It's not quite a condition wait, and not quite a lock situation,
+    /// it's more like a gate condition.
+    private void awaitReset() {
+        // Busy wait loop, but will almost always return immediately
+        // when it does pause, it will almost always return after a single pause
+        // because reset takes a few hundred nanoseconds.
+        while (resetIsActive.get()) {
+            parkNanos(RESET_WAIT_TIME_NANOS);
+        }
     }
 
     @Override
@@ -215,16 +241,21 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     @Override
     public BlockAction getActionForBlock(
             final long blockNumber, final BlockAction previousAction, final long handlerId) {
-        return switch (previousAction) {
-            case null -> getActionForHeader(blockNumber);
-            case ACCEPT -> getActionForCurrentlyStreaming(blockNumber);
-            case END_ERROR, END_DUPLICATE ->
-                // This should not happen because the Handler should have shut down.
-                BlockAction.END_ERROR;
-            case SKIP, RESEND, SEND_BEHIND ->
-                // This should not happen because the Handler should have reset the previous action.
-                BlockAction.END_ERROR;
-        };
+        awaitReset();
+        if (handlers.containsKey(handlerId)) {
+            return switch (previousAction) {
+                case null -> getActionForHeader(blockNumber);
+                case ACCEPT -> getActionForCurrentlyStreaming(blockNumber);
+                case END_ERROR, END_DUPLICATE ->
+                    // This should not happen because the Handler should have shut down.
+                    BlockAction.END_ERROR;
+                case SKIP, RESEND, SEND_BEHIND ->
+                    // This should not happen because the Handler should have reset the previous action.
+                    BlockAction.END_ERROR;
+            };
+        } else {
+            return BlockAction.END_ERROR;
+        }
     }
 
     @Override
@@ -457,28 +488,46 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 }
             } else {
                 if (notification.blockSource() == BlockSource.PUBLISHER) {
-                    if (blockNumber <= lastPersistedBlockNumber.get()) {
-                        nextUnstreamedBlockNumber.set(blockNumber);
-                    }
-                    Collection<PublisherHandler> handlersToClose = handlers.values();
-                    // Notify the handlers that persistence failed.
-                    handlersToClose.parallelStream()
-                            .unordered()
-                            .forEach((handler) -> handler.endStreamWithCode(Code.PERSISTENCE_FAILED, false));
-                    queueByBlockMap.clear();
-                    // Note, nothing stops another publisher from connecting
-                    //     immediately after clearing the map, and that is
-                    //     fine. If the failure was intermittent, then we will
-                    //     succeed storing that block. If the failure is
-                    //     permanent, then we will fail again.
-                    // Make sure to schedule resend for this failed persistence
-                    // This is actually unnecessary, _for now_, add back in if
-                    // we no longer end all handlers.
-                    // blocksToResend.add(blockNumber);
+                    endAllHandlersAndClearTracking(blockNumber);
                     // @todo(2240,2236) Mark the publisher plugin _unhealthy_
                     //     when the Health Plugin supports that.
                 }
             }
+        }
+    }
+
+    /// Method to reset internal tracking and close all active connections.
+    /// This method sets a flag so that new connections are briefly paused
+    /// to let the process complete; we avoid a lock because the rare brief
+    /// delay is more efficient than frequent lock acquisition (even a Condition
+    /// or Latch would be significantly more costly).
+    /// This method does reset the flag in a finally block, however, to ensure
+    /// that if an exception is thrown the flag is still cleared.
+    private void endAllHandlersAndClearTracking(final long blockNumber) {
+        resetIsActive.compareAndSet(false, true);
+        try {
+            nextUnstreamedBlockNumber.set(blockNumber);
+            activeStreamHandlerByBlock.clear();
+            Collection<PublisherHandler> handlersToClose = handlers.values();
+            // Notify the handlers that persistence failed.
+            handlersToClose.parallelStream()
+                    .unordered()
+                    .forEach((handler) -> handler.endStreamWithCode(Code.PERSISTENCE_FAILED, true));
+            // Order matters here. Reordering these can lead to _extremely rare_
+            // cases where we get unnecessary errors or a block is scheduled to be
+            // resent that was never sent.
+            blocksToResend.clear();
+            activeResendBlocks.clear();
+            blockProofs.clear();
+            queueByBlockMap.clear();
+            endBlocksReceived.clear();
+            // Note, nothing stops another publisher from connecting immediately
+            //     after clearing the maps, or while clearing them, and that is
+            //     fine. If the failure was intermittent, then we will succeed
+            //     storing that block. If the failure is permanent, then we will
+            //     fail again.
+        } finally {
+            resetIsActive.compareAndSet(true, false);
         }
     }
 
@@ -1109,7 +1158,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
 
         /// todo(1420) add documentation
         public MessagingForwarderTask(final LiveStreamPublisherManager liveStreamPublisherManager) {
-            this.publisherManager = Objects.requireNonNull(liveStreamPublisherManager);
+            publisherManager = Objects.requireNonNull(liveStreamPublisherManager);
         }
 
         // This needs more work, particularly handling the next block if it's already
@@ -1122,11 +1171,8 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             // End this thread after some number of batches, so we don't have
             // a thread that becomes overly "old" and experiences "senescence".
             while (!forwardingLimitReached) {
-                // @todo(2347) we can improve the loop because we have new way of doing resends, we can also
-                //   improve on the way we determine the current block number below, but also the way we decide
-                //   which items and how to hold them for a bit, to await for the end of block message so we can
-                //   send them to messaging as the end of the block.
                 final long currentBlockNumber = determineCurrentBlockNumber();
+                publisherManager.awaitReset(); // Hold here if the manager is resetting
                 final Deque<BlockItemSetUnparsed> queueToForward =
                         publisherManager.queueByBlockMap.get(currentBlockNumber);
                 if (queueToForward != null && !publisherManager.blockProofs.containsKey(currentBlockNumber)) {
@@ -1138,8 +1184,6 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                         // runtime exception if the queue is empty.
                         final BlockItemSetUnparsed currentBatch = queueToForward.poll();
                         if (currentBatch != null) {
-                            // @todo(2347) as an improvement we can opt in to possibly change the
-                            //    way we send the last batch of BlockItems
                             final boolean hasBlockProof =
                                     currentBatch.blockItems().getLast().hasBlockProof();
                             final int itemsSent;

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -22,6 +22,7 @@ import com.hedera.pbj.runtime.grpc.Pipeline;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -455,19 +456,28 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                     ensureNextGreaterThanPersisted(blockNumber);
                 }
             } else {
-                if (blockNumber <= lastPersistedBlockNumber.get()) {
-                    // @todo(2198): We may have an extremely rare race condition here
-                    nextUnstreamedBlockNumber.set(blockNumber);
+                if (notification.blockSource() == BlockSource.PUBLISHER) {
+                    if (blockNumber <= lastPersistedBlockNumber.get()) {
+                        nextUnstreamedBlockNumber.set(blockNumber);
+                    }
+                    Collection<PublisherHandler> handlersToClose = handlers.values();
+                    // Notify the handlers that persistence failed.
+                    handlersToClose.parallelStream()
+                            .unordered()
+                            .forEach((handler) -> handler.endStreamWithCode(Code.PERSISTENCE_FAILED, false));
+                    queueByBlockMap.clear();
+                    // Note, nothing stops another publisher from connecting
+                    //     immediately after clearing the map, and that is
+                    //     fine. If the failure was intermittent, then we will
+                    //     succeed storing that block. If the failure is
+                    //     permanent, then we will fail again.
+                    // Make sure to schedule resend for this failed persistence
+                    // This is actually unnecessary, _for now_, add back in if
+                    // we no longer end all handlers.
+                    // blocksToResend.add(blockNumber);
+                    // @todo(2240,2236) Mark the publisher plugin _unhealthy_
+                    //     when the Health Plugin supports that.
                 }
-                // Make sure to schedule resend for this failed persistence
-                // This is actually unnecessary, _for now_, add back in when
-                // we no longer end all handlers.
-                // blocksToResend.add(blockNumber);
-                // Notify the handlers that persistence failed.
-                handlers.values().parallelStream()
-                        .unordered()
-                        .forEach((handler) -> handler.endStreamWithCode(Code.PERSISTENCE_FAILED, false));
-                queueByBlockMap.clear();
             }
         }
     }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -111,6 +111,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
     private final NavigableSet<Long> unacknowledgedStreamedBlocks;
     /// The state of the publisher, true if it is still active.
     private final AtomicBoolean isActive;
+    private final AtomicBoolean shutdownActive;
     /// Remaining message budget for the current interval. Decremented on each `onNext` call.
     /// Refreshed by the manager at the end of each interval, or set to 0 when aggregate budget
     /// is exceeded, or set to -1L when penalized. Long.MIN_VALUE signals shutdown in progress
@@ -150,6 +151,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
         blockAction = new AtomicReference<>();
         unacknowledgedStreamedBlocks = new ConcurrentSkipListSet<>();
         isActive = new AtomicBoolean(true);
+        shutdownActive = new AtomicBoolean(false);
         configuration = publisherManager.configuration();
         messageBudget = new AtomicLong(configuration.perHandlerMessageBudget());
     }
@@ -342,23 +344,27 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
 
     /// todo add documentation
     private void checkMidBlockAndShutdown(final long blockNumber, final boolean scheduleWithDelay) {
-        try {
-            if (isCurrentlyMidBlock(blockNumber)) {
-                publisherManager.blockIsEnding(currentStreamingBlockNumber.get(), handlerId);
+        if (!shutdownActive.get()) {
+            try {
+                if (isCurrentlyMidBlock(blockNumber)) {
+                    publisherManager.blockIsEnding(currentStreamingBlockNumber.get(), handlerId);
+                }
+            } finally {
+                shutdownActive.set(true);
+                if (scheduleWithDelay) {
+                    // Set budget to Long.MIN_VALUE so any subsequent onNext calls park
+                    // until shutdown completes. Long.MIN_VALUE is also a signal to the
+                    // refresh task to skip this handler.
+                    messageBudget.set(Long.MIN_VALUE);
+                    // Do not shutdown instantly, allow for final messages to send first.
+                    publisherManager.scheduleAfterDelay(this::shutdown, SHUTDOWN_DELAY_TIME);
+                } else {
+                    // shouldn't be needed, but set just in case.
+                    isActive.compareAndSet(true, false);
+                    shutdown();
+                }
+                resetState();
             }
-        } finally {
-            if (scheduleWithDelay) {
-                // Set budget to Long.MIN_VALUE so any subsequent onNext calls park
-                // until shutdown completes. Long.MIN_VALUE is also a signal to the
-                // refresh task to skip this handler.
-                messageBudget.set(Long.MIN_VALUE);
-                // Do not shutdown instantly, allow for final messages to send first.
-                publisherManager.scheduleAfterDelay(this::shutdown, SHUTDOWN_DELAY_TIME);
-            } else {
-                isActive.compareAndSet(true, false); // shouldn't be needed, but set just in case.
-                shutdown();
-            }
-            resetState();
         }
     }
 

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -1444,11 +1444,6 @@ class LiveStreamPublisherManagerTest {
                         .returns(-1L, endStreamBlockNumberExtractor);
                 // As a pre-check, we expect no onComplete calls
                 assertThat(responsePipeline.getOnCompleteCalls().get()).isZero();
-                // We expect a shutdown to be scheduled
-                // We need to send any request or trigger any pipeline method
-                // to do the actual shutdown
-                publisherHandler.onNext(
-                        TestBlockBuilder.generateBlockWithNumber(0L).asPublishStreamRequestUnparsed());
                 // Invoke the delayed shutdown so it actually runs
                 threadPoolManager.scheduledExecutor().executeSerially();
                 // Assert that the latest known block number is still -1L, it was not updated
@@ -1458,10 +1453,6 @@ class LiveStreamPublisherManagerTest {
                 assertThat(responsePipeline.getOnErrorCalls()).isEmpty();
                 assertThat(responsePipeline.getOnSubscriptionCalls()).isEmpty();
                 assertThat(responsePipeline.getClientEndStreamCalls().get()).isEqualTo(0);
-                publisherHandler2.onNext(
-                        TestBlockBuilder.generateBlockWithNumber(0L).asPublishStreamRequestUnparsed());
-                // Invoke the delayed shutdown so it actually runs
-                threadPoolManager.scheduledExecutor().executeSerially();
                 // Assert that the response pipeline has received a PERSISTENCE_FAILED
                 assertThat(responsePipeline2.getOnNextCalls())
                         .hasSize(1)

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherManagerRegressionTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherManagerRegressionTest.java
@@ -356,6 +356,9 @@ class PublisherManagerRegressionTest {
                 .build();
         publisherHandler.onNext(
                 PublishStreamRequestUnparsed.newBuilder().endStream(endStream).build());
+        // !! IMPORTANT !!
+        //    This removes `publisherHandler`, so remainder of this test _must_ use
+        //    `publisherHandler2` or the results will be wrong.
 
         // 3. Backfill persists a block far past the configured prune buffer (default 100).
         //    handlePersisted's prune step must drop blocksToResend entries <= 200 - 100 = 100,
@@ -370,7 +373,7 @@ class PublisherManagerRegressionTest {
         //    END_DUPLICATE — not ACCEPT pulled out of blocksToResend, which would prove
         //    the entry was never pruned. (END_DUPLICATE comes from blockNumber <= lastPersisted,
         //    which only happens if both prune and ack-advancement succeeded.)
-        final BlockAction action = toTest.getActionForBlock(staleResendBlock, null, publisherHandlerId);
+        final BlockAction action = toTest.getActionForBlock(staleResendBlock, null, publisherHandler2.getId());
         assertThat(action)
                 .describedAs(
                         "block %d is already persisted (lastPersisted should be %d). The handler must see "


### PR DESCRIPTION
## Reviewer Notes
* Improved handling of failed persistence notifications.
* Cleared most maps on failed verification
* Added a flag and wait method to prevent certain tasks while a reset is pending.
   * Could have used a Lock or Condition, but those are vastly more expensive
     when not resetting, which is expected to outnumber reset by a ratio
     over one million to one.
* Add flag to ensure `checkMidBlockAndShutdown` only executes `blockIsEnding`
  once, regardless of the number of calls.
* Ensured `getActionForBlock` returns error response if called by a handler
  that is no longer in the `handlers` map.
* Removed an unnecessary condition in `endAllHandlersAndClearTracking`.
* Fixed some tests that were not structured correctly
  (e.g. using a disconnected handler to send more data)

## Related Issue(s)
 Resolves #2198
