### PR TITLE
feat: Expose per-service ports for the API plugins

### DIFF
--- a/block-node/app/src/main/java/org/hiero/block/node/app/logging/ConfigLogger.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/logging/ConfigLogger.java
@@ -70,8 +70,11 @@ public final class ConfigLogger {
                         final String fieldName = component.getName();
                         final Record configRecord = configuration.getConfigData(configType);
                         try {
-                            final String value =
-                                    component.getAccessor().invoke(configRecord).toString();
+                            final Object rawValue = component.getAccessor().invoke(configRecord);
+                            // A null value means an optional property (e.g. a nullable Integer declared with
+                            // ConfigProperty.NULL_DEFAULT_VALUE, such as a per-service port) was not set. Log it
+                            // as "null" rather than throwing an NPE on toString().
+                            final String value = rawValue == null ? "null" : rawValue.toString();
                             // If the field is not annotated as '@Loggable' then it's a sensitive value and needs to
                             // be handled differently.
                             if (component.getAnnotation(Loggable.class) == null) {

--- a/block-node/block-access-service/src/main/java/module-info.java
+++ b/block-node/block-access-service/src/main/java/module-info.java
@@ -4,10 +4,18 @@ import org.hiero.block.node.access.service.BlockAccessServicePlugin;
 module org.hiero.block.node.access.service {
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    // export configuration classes to the config module and app
+    exports org.hiero.block.node.access.service to
+            com.swirlds.config.impl,
+            com.swirlds.config.extensions,
+            org.hiero.block.node.app;
+
     requires transitive com.hedera.pbj.runtime;
     requires transitive org.hiero.block.node.spi;
     requires transitive org.hiero.block.protobuf.pbj;
     requires transitive org.hiero.metrics;
+    requires com.swirlds.config.api;
+    requires org.hiero.block.node.base;
 
     provides org.hiero.block.node.spi.BlockNodePlugin with
             BlockAccessServicePlugin;

--- a/block-node/block-access-service/src/main/java/module-info.java
+++ b/block-node/block-access-service/src/main/java/module-info.java
@@ -11,10 +11,10 @@ module org.hiero.block.node.access.service {
             org.hiero.block.node.app;
 
     requires transitive com.hedera.pbj.runtime;
+    requires transitive com.swirlds.config.api;
     requires transitive org.hiero.block.node.spi;
     requires transitive org.hiero.block.protobuf.pbj;
     requires transitive org.hiero.metrics;
-    requires com.swirlds.config.api;
     requires org.hiero.block.node.base;
 
     provides org.hiero.block.node.spi.BlockNodePlugin with

--- a/block-node/block-access-service/src/main/java/org/hiero/block/node/access/service/BlockAccessConfig.java
+++ b/block-node/block-access-service/src/main/java/org/hiero/block/node/access/service/BlockAccessConfig.java
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.access.service;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import org.hiero.block.node.base.Loggable;
+
+/**
+ * Configuration for the block-access service plugin.
+ *
+ * @param port the dedicated port the block-access gRPC service binds to. When {@code null} (the
+ *     default) the plugin shares the default {@code server.port}. When set it must be a valid
+ *     port in the range {@code 1024}–{@code 65535}. No {@code @Min}/{@code @Max} is declared
+ *     because those validators reject a {@code null} value (they would fail when the property is
+ *     unset); the range is enforced by the web server when binding.
+ */
+@ConfigData("block.access")
+public record BlockAccessConfig(
+        @Loggable @ConfigProperty(defaultValue = ConfigProperty.NULL_DEFAULT_VALUE)
+        Integer port) {}

--- a/block-node/block-access-service/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
+++ b/block-node/block-access-service/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
@@ -9,6 +9,7 @@ import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.Pipelines;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
 import org.hiero.block.api.BlockAccessServiceInterface;
 import org.hiero.block.api.BlockRequest;
 import org.hiero.block.api.BlockResponse;
@@ -182,7 +183,18 @@ public class BlockAccessServicePlugin implements BlockNodePlugin, BlockAccessSer
                 .getOrCreateNotLabeled();
         // Get the block provider
         this.blockProvider = context.historicalBlockProvider();
-        // Register this service
-        serviceBuilder.registerGrpcService(this, null);
+        // Register this service; a null port (the default) shares server.port
+        final Integer port =
+                context.configuration().getConfigData(BlockAccessConfig.class).port();
+        serviceBuilder.registerGrpcService(this, port);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public List<Class<? extends Record>> configDataTypes() {
+        return List.of(BlockAccessConfig.class);
     }
 }

--- a/block-node/health/src/main/java/module-info.java
+++ b/block-node/health/src/main/java/module-info.java
@@ -11,9 +11,9 @@ module org.hiero.block.node.health {
             com.swirlds.config.extensions,
             org.hiero.block.node.app;
 
+    requires transitive com.swirlds.config.api;
     requires transitive org.hiero.block.node.spi;
     requires transitive io.helidon.webserver;
-    requires com.swirlds.config.api;
     requires org.hiero.block.node.base;
     requires com.github.spotbugs.annotations;
 

--- a/block-node/health/src/main/java/module-info.java
+++ b/block-node/health/src/main/java/module-info.java
@@ -3,8 +3,18 @@ import org.hiero.block.node.health.HealthServicePlugin;
 
 // SPDX-License-Identifier: Apache-2.0
 module org.hiero.block.node.health {
+    uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
+
+    // export configuration classes to the config module and app
+    exports org.hiero.block.node.health to
+            com.swirlds.config.impl,
+            com.swirlds.config.extensions,
+            org.hiero.block.node.app;
+
     requires transitive org.hiero.block.node.spi;
     requires transitive io.helidon.webserver;
+    requires com.swirlds.config.api;
+    requires org.hiero.block.node.base;
     requires com.github.spotbugs.annotations;
 
     provides org.hiero.block.node.spi.BlockNodePlugin with

--- a/block-node/health/src/main/java/org/hiero/block/node/health/HealthConfig.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/HealthConfig.java
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.health;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import org.hiero.block.node.base.Loggable;
+
+/**
+ * Configuration for the health service plugin.
+ *
+ * @param port the dedicated port the health HTTP endpoints bind to. When {@code null} (the
+ *     default) the plugin shares the default {@code server.port}. When set it must be a valid
+ *     port in the range {@code 1024}–{@code 65535}. No {@code @Min}/{@code @Max} is declared
+ *     because those validators reject a {@code null} value (they would fail when the property is
+ *     unset); the range is enforced by the web server when binding.
+ */
+@ConfigData("health")
+public record HealthConfig(
+        @Loggable @ConfigProperty(defaultValue = ConfigProperty.NULL_DEFAULT_VALUE)
+        Integer port) {}

--- a/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
@@ -10,6 +10,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 import java.lang.System.Logger;
+import java.util.List;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
@@ -31,10 +32,22 @@ public class HealthServicePlugin implements BlockNodePlugin {
     @Override
     public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
         healthFacility = context.serverHealth();
-        serviceBuilder.registerHttpService(HEALTHZ_PATH, null, httpRules -> httpRules
+        // A null port (the default) shares server.port
+        final Integer port =
+                context.configuration().getConfigData(HealthConfig.class).port();
+        serviceBuilder.registerHttpService(HEALTHZ_PATH, port, httpRules -> httpRules
                 .get(LIVEZ_PATH, this::handleLivez)
                 .get(READYZ_PATH, this::handleReadyz));
         LOGGER.log(DEBUG, "Completed health facility initialization");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public List<Class<? extends Record>> configDataTypes() {
+        return List.of(HealthConfig.class);
     }
 
     /**

--- a/block-node/health/src/test/java/org/hiero/block/node/health/HealthServiceTest.java
+++ b/block-node/health/src/test/java/org/hiero/block/node/health/HealthServiceTest.java
@@ -4,6 +4,7 @@ package org.hiero.block.node.health;
 import static org.hiero.block.node.health.HealthServicePlugin.*;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.swirlds.config.api.Configuration;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http.ServerRequest;
@@ -28,9 +29,12 @@ class HealthServiceTest {
     @Mock
     ServiceBuilder serviceBuilder;
 
-    /** No-op: health plugin no longer reads configuration during init. */
-    @SuppressWarnings("unused")
-    private static void setupContextConfig(BlockNodeContext context) {}
+    /** Stub the context configuration so {@code init} can read {@link HealthConfig} (port unset = null). */
+    private static void setupContextConfig(BlockNodeContext context) {
+        final Configuration configuration = Mockito.mock(Configuration.class);
+        Mockito.when(configuration.getConfigData(HealthConfig.class)).thenReturn(new HealthConfig(null));
+        Mockito.when(context.configuration()).thenReturn(configuration);
+    }
 
     @Test
     public void testHandleLivez() {

--- a/block-node/server-status/build.gradle.kts
+++ b/block-node/server-status/build.gradle.kts
@@ -14,7 +14,8 @@ mainModuleInfo {
 }
 
 testModuleInfo {
-    requires("com.swirlds.config.api")
+    // com.swirlds.config.api now comes transitively from the main module's requires-transitive
+    // directive
     requires("org.junit.jupiter.api")
     requires("org.hiero.block.node.app.test.fixtures")
 }

--- a/block-node/server-status/src/main/java/module-info.java
+++ b/block-node/server-status/src/main/java/module-info.java
@@ -4,10 +4,18 @@ import org.hiero.block.node.server.status.ServerStatusServicePlugin;
 module org.hiero.block.node.server.status {
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    // export configuration classes to the config module and app
+    exports org.hiero.block.node.server.status to
+            com.swirlds.config.impl,
+            com.swirlds.config.extensions,
+            org.hiero.block.node.app;
+
     requires transitive org.hiero.block.node.spi;
     requires transitive org.hiero.block.protobuf.pbj;
     requires transitive org.hiero.metrics;
     requires com.hedera.pbj.runtime;
+    requires com.swirlds.config.api;
+    requires org.hiero.block.node.base;
     requires com.github.spotbugs.annotations;
 
     provides org.hiero.block.node.spi.BlockNodePlugin with

--- a/block-node/server-status/src/main/java/module-info.java
+++ b/block-node/server-status/src/main/java/module-info.java
@@ -10,11 +10,11 @@ module org.hiero.block.node.server.status {
             com.swirlds.config.extensions,
             org.hiero.block.node.app;
 
+    requires transitive com.swirlds.config.api;
     requires transitive org.hiero.block.node.spi;
     requires transitive org.hiero.block.protobuf.pbj;
     requires transitive org.hiero.metrics;
     requires com.hedera.pbj.runtime;
-    requires com.swirlds.config.api;
     requires org.hiero.block.node.base;
     requires com.github.spotbugs.annotations;
 

--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusConfig.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusConfig.java
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.server.status;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import org.hiero.block.node.base.Loggable;
+
+/**
+ * Configuration for the server-status service plugin.
+ *
+ * @param port the dedicated port the server-status gRPC service binds to. When {@code null} (the
+ *     default) the plugin shares the default {@code server.port}. When set it must be a valid
+ *     port in the range {@code 1024}–{@code 65535}. No {@code @Min}/{@code @Max} is declared
+ *     because those validators reject a {@code null} value (they would fail when the property is
+ *     unset); the range is enforced by the web server when binding.
+ */
+@ConfigData("server.status")
+public record ServerStatusConfig(
+        @Loggable @ConfigProperty(defaultValue = ConfigProperty.NULL_DEFAULT_VALUE)
+        Integer port) {}

--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
@@ -146,8 +146,19 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
                         .setDescription("Number of server status details requests"))
                 .getOrCreateNotLabeled();
 
-        // Register this service
-        serviceBuilder.registerGrpcService(this, null);
+        // Register this service; a null port (the default) shares server.port
+        final Integer port =
+                context.configuration().getConfigData(ServerStatusConfig.class).port();
+        serviceBuilder.registerGrpcService(this, port);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public List<Class<? extends Record>> configDataTypes() {
+        return List.of(ServerStatusConfig.class);
     }
 
     /**

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfig.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfig.java
@@ -39,6 +39,10 @@ import org.hiero.block.node.base.Loggable;
 /// `EndOfStream(DUPLICATE_BLOCK)`. A publisher that is only slightly behind can then
 /// fast-forward without reconnecting; a publisher that is further behind than the
 /// window is still ended so it reconnects from the correct point.
+/// @param port The dedicated port this plugin's gRPC service binds to. When `null` (the default)
+/// the plugin shares the default `server.port`. When set it must be a valid port in `1024`-`65535`;
+/// no `@Min`/`@Max` is declared because those validators reject a `null` value (they would fail when
+/// the property is unset), so the range is enforced by the web server when binding.
 @ConfigData("producer")
 public record PublisherConfig(
         // spotless:off
@@ -52,6 +56,7 @@ public record PublisherConfig(
         @Loggable @ConfigProperty(defaultValue = "15") @Min(10) int consecutiveFullBudgetIntervalsForPenalty,
         @Loggable @ConfigProperty(defaultValue = "30") @Min(2) @Max(600) int penaltyDurationSeconds,
         @Loggable @ConfigProperty(defaultValue = "3600") @Min(600) @Max(86400) long penaltyResetIntervalSeconds,
-        @Loggable @ConfigProperty(defaultValue = "5") @Min(1) @Max(10) int duplicateBlockSkipWindow) {
+        @Loggable @ConfigProperty(defaultValue = "5") @Min(1) @Max(10) int duplicateBlockSkipWindow,
+        @Loggable @ConfigProperty(defaultValue = ConfigProperty.NULL_DEFAULT_VALUE) Integer port) {
         // spotless:on
 }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
@@ -164,8 +164,10 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
         this.context = Objects.requireNonNull(context);
         // register us as a service, we need to register the gRPC service in
         // the init method, otherwise the server will be started and we will not
-        // have registered at all
-        serviceBuilder.registerGrpcService(this, null);
+        // have registered at all. A null port (the default) shares server.port.
+        final Integer port =
+                context.configuration().getConfigData(PublisherConfig.class).port();
+        serviceBuilder.registerGrpcService(this, port);
     }
 
     @Override

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberConfig.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberConfig.java
@@ -29,6 +29,11 @@ import org.hiero.block.node.base.Loggable;
  *     within PBJ's buffer allocation limit (4MB). The default of 1MB provides
  *     headroom for protobuf overhead. If a single item exceeds this limit but is
  *     under 4MB, it will be sent by itself.
+ * @param port The dedicated port this plugin's gRPC service binds to. When {@code null} (the
+ *     default) the plugin shares the default {@code server.port}. When set it must be a valid port
+ *     in {@code 1024}-{@code 65535}; no {@code @Min}/{@code @Max} is declared because those
+ *     validators reject a {@code null} value (they would fail when the property is unset), so the
+ *     range is enforced by the web server when binding.
  */
 // spotless:off
 @ConfigData("subscriber")
@@ -36,5 +41,6 @@ public record SubscriberConfig(
         @Loggable @ConfigProperty(defaultValue = "4000") @Min(100) int liveQueueSize,
         @Loggable @ConfigProperty(defaultValue = "4000") @Min(10) long maximumFutureRequest,
         @Loggable @ConfigProperty(defaultValue = "400") @Min(10) int minimumLiveQueueCapacity,
-        @Loggable @ConfigProperty(defaultValue = "1_048_576") @Min(100_000) int maxChunkSizeBytes) {}
+        @Loggable @ConfigProperty(defaultValue = "1_048_576") @Min(100_000) int maxChunkSizeBytes,
+        @Loggable @ConfigProperty(defaultValue = ConfigProperty.NULL_DEFAULT_VALUE) Integer port) {}
 // spotless:on

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
@@ -68,8 +68,10 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
     @Override
     public void init(@NonNull final BlockNodeContext context, @NonNull final ServiceBuilder serviceBuilder) {
         this.context = requireNonNull(context);
-        // register us as a service
-        serviceBuilder.registerGrpcService(this, null);
+        // register us as a service; a null port (the default) shares server.port
+        final Integer port =
+                context.configuration().getConfigData(SubscriberConfig.class).port();
+        serviceBuilder.registerGrpcService(this, port);
     }
 
     @Override

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -139,7 +139,9 @@ for the JSON schema.
 
 ### Block Access Plugin Configuration
 
-Currently, no specific options.
+| ENV Variable      | Description                                                                                     | Default |
+|:------------------|:------------------------------------------------------------------------------------------------|--------:|
+| BLOCK_ACCESS_PORT | Dedicated port for the block-access gRPC service. When unset, the service shares `SERVER_PORT`. | (unset) |
 
 ### Files Historic Plugin Configuration
 
@@ -162,7 +164,9 @@ Currently, no specific options.
 
 ### Health Plugin Configuration
 
-Currently, no specific options.
+| ENV Variable | Description                                                                                 | Default |
+|:-------------|:--------------------------------------------------------------------------------------------|--------:|
+| HEALTH_PORT  | Dedicated port for the health HTTP endpoints. When unset, the service shares `SERVER_PORT`. | (unset) |
 
 ### Messaging Plugin Configuration
 
@@ -186,7 +190,9 @@ Currently, no specific options.
 
 ### Server Status Plugin Configuration
 
-Currently, no specific options.
+| ENV Variable       | Description                                                                                      | Default |
+|:-------------------|:-------------------------------------------------------------------------------------------------|--------:|
+| SERVER_STATUS_PORT | Dedicated port for the server-status gRPC service. When unset, the service shares `SERVER_PORT`. | (unset) |
 
 ### Publisher Plugin Configuration
 
@@ -197,6 +203,7 @@ Currently, no specific options.
 | PRODUCER_STALE_RESEND_PRUNE_BUFFER        | Number of blocks behind `lastPersistedBlockNumber` that a `blocksToResend` entry may sit before `handlePersisted` prunes it. Entries within the buffer are still considered fillable by a publisher; entries older than the buffer are dropped (the gap is owned by backfill at that point). Set to ~CN block-history depth. Must be 0 ≤ value ≤ 200.                                                                                                          |                       100 |
 | PRODUCER_FLOW_CONTROL_PAUSE_DELAY_NANOS   | Duration in nanoseconds that `onNext` parks the request-processing thread when a request arrives while the handler is paused. The handler is paused as part of the staged shutdown sequence, which schedules the actual shutdown to run after a fixed delay; parking the next incoming request prevents it from racing that pending shutdown and lets any final outbound messages flush before the connection closes. Must be 100,000 ≤ value ≤ 5,000,000,000. |               100,000,000 |
 | PRODUCER_DUPLICATE_BLOCK_SKIP_WINDOW      | Number of blocks behind `lastPersistedBlockNumber` for which a duplicate block header is answered with `SkipBlock` instead of `EndOfStream(DUPLICATE_BLOCK)`. A publisher only slightly behind can fast-forward without reconnecting; duplicates further behind than the window still close the stream so the publisher reconnects. Must be 1 ≤ value ≤ 10.                                                                                                    |                         5 |
+| PRODUCER_PORT                             | Dedicated port for the publisher gRPC service. When unset, the service shares `SERVER_PORT`.                                                                                                                                                                                                                                                                                                                                                                   |                   (unset) |
 
 ### RSA Bootstrap Plugin Configuration
 
@@ -216,6 +223,7 @@ Currently, no specific options.
 | SUBSCRIBER_LIVE_QUEUE_SIZE             | Queue size (in batches) for transferring live data between messaging and client threads. Must be ≥100. |    4000 |
 | SUBSCRIBER_MAXIMUM_FUTURE_REQUEST      | Max blocks ahead of latest "live" block a request can start from. Must be ≥10.                         |    4000 |
 | SUBSCRIBER_MINIMUM_LIVE_QUEUE_CAPACITY | Minimum free capacity in the live queue before dropping oldest blocks. Typically ~10% of queue size.   |     400 |
+| SUBSCRIBER_PORT                        | Dedicated port for the subscriber gRPC service. When unset, the service shares `SERVER_PORT`.          | (unset) |
 
 ### TSS Bootstrap Plugin Configuration
 

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -778,6 +778,225 @@ public class BlockNodeAPITests {
         assertThat(responseObserver.getClientEndStreamCalls().get()).isEqualTo(0);
     }
 
+    /**
+     * Verifies the per-service port wiring (PR #2880): each plugin reads a nullable {@code port} from
+     * its own config and registers its service on that dedicated port. The default-port app from
+     * {@link #beforeEach()} is shut down and a fresh app is booted with a unique port configured for
+     * each of the five API plugins. Every API must answer on its own port and must NOT answer on the
+     * default {@code server.port}, which has no API routes once all services are moved off it.
+     */
+    @Test
+    void servicesBindToConfiguredUniquePortsOnly() throws Exception {
+        // Derive the per-service ports from the suite's base port (SERVER_PORT) so they shift with it.
+        // CI runs the api suite on a non-default SERVER_PORT to avoid parallel-run port conflicts; basing
+        // these ports on it keeps that isolation rather than hardcoding a fixed range that could collide
+        // with a concurrent run on the same host.
+        final int defaultPort = Integer.parseInt(serverPort); // no API routes after the move
+        final int blockAccessPort = defaultPort + 1;
+        final int healthPort = defaultPort + 2;
+        final int serverStatusPort = defaultPort + 3;
+        final int publisherPort = defaultPort + 4;
+        final int subscriberPort = defaultPort + 5;
+
+        // The @BeforeEach app holds the default port; release it before rebinding with per-service ports.
+        app.shutdown("BlockNodeAPITests", "rebind with per-service ports");
+        awaitState(app, false);
+
+        System.setProperty("block.access.port", Integer.toString(blockAccessPort));
+        System.setProperty("health.port", Integer.toString(healthPort));
+        System.setProperty("server.status.port", Integer.toString(serverStatusPort));
+        System.setProperty("producer.port", Integer.toString(publisherPort));
+        System.setProperty("subscriber.port", Integer.toString(subscriberPort));
+        try {
+            app = new BlockNodeApp(new ServiceLoaderFunction(), false);
+            app.start();
+            awaitState(app, true);
+
+            // ==== Positive: every API routes on its own dedicated port ====
+            // Publisher: publishing genesis on its port and getting an ACK proves it routes there.
+            publishGenesisBlock(publisherPort);
+            // ServerStatus: reachable on its port and reflects the persisted block.
+            assertThat(serverStatusOn(serverStatusPort).lastAvailableBlock()).isEqualTo(0L);
+            // BlockAccess: reachable on its port and returns the persisted block.
+            assertThat(getBlockOn(blockAccessPort, 0L).status()).isEqualTo(BlockResponse.Code.SUCCESS);
+            // Subscriber: reachable on its port and streams the persisted block 0.
+            assertSubscriberReceivesBlock0(subscriberPort);
+            // Health: reachable on its port.
+            assertThat(healthLivezStatusCode(healthPort)).isEqualTo(200);
+
+            // ==== Negative: none of the services answer on the default port ====
+            assertThat(healthLivezStatusCode(defaultPort))
+                    .as("health must not be routed on the default port")
+                    .isEqualTo(404);
+            assertGrpcNotRoutedOnDefaultPort(defaultPort);
+            assertPublisherNotRoutedOnDefaultPort(defaultPort);
+            assertSubscriberNotRoutedOnDefaultPort(defaultPort);
+        } finally {
+            System.clearProperty("block.access.port");
+            System.clearProperty("health.port");
+            System.clearProperty("server.status.port");
+            System.clearProperty("producer.port");
+            System.clearProperty("subscriber.port");
+        }
+    }
+
+    /** Publishes genesis block 0 on the given port and awaits the ACK (proves the publisher routes there). */
+    private void publishGenesisBlock(final int port) throws InterruptedException {
+        final var client = new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
+                createGrpcClientForPort(Integer.toString(port)), OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> observer = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> stream = client.publishBlockStream(observer);
+        final AtomicReference<CountDownLatch> ackLatch = observer.setAndGetOnNextLatch(1);
+        stream.onNext(PublishStreamRequest.newBuilder()
+                .blockItems(BlockItemSet.newBuilder()
+                        .blockItems(BlockItemBuilderUtils.createSimpleBlockWithNumber(0L))
+                        .build())
+                .build());
+        endBlock(0L, stream);
+        awaitLatch(ackLatch, "publisher ACK on port " + port);
+        assertThat(observer.getOnNextCalls())
+                .first()
+                .returns(PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor)
+                .returns(0L, acknowledgementBlockNumberExtractor);
+        stream.closeConnection();
+        client.close();
+    }
+
+    private ServerStatusResponse serverStatusOn(final int port) {
+        final var client = new BlockNodeServiceInterface.BlockNodeServiceClient(
+                createGrpcClientForPort(Integer.toString(port)), OPTIONS);
+        try {
+            return client.serverStatus(SIMPLE_SERVER_STAUS_REQUEST);
+        } finally {
+            client.close();
+        }
+    }
+
+    private BlockResponse getBlockOn(final int port, final long blockNumber) {
+        final var client = new BlockAccessServiceInterface.BlockAccessServiceClient(
+                createGrpcClientForPort(Integer.toString(port)), OPTIONS);
+        try {
+            return client.getBlock(
+                    BlockRequest.newBuilder().blockNumber(blockNumber).build());
+        } finally {
+            client.close();
+        }
+    }
+
+    private void assertSubscriberReceivesBlock0(final int port) throws InterruptedException {
+        final var client = new BlockStreamSubscribeServiceInterface.BlockStreamSubscribeServiceClient(
+                createGrpcClientForPort(Integer.toString(port)), OPTIONS);
+        final ResponsePipelineUtils<SubscribeStreamResponse> observer = new ResponsePipelineUtils<>();
+        final AtomicReference<CountDownLatch> latch = observer.setAndGetOnNextLatch(2);
+        client.subscribeBlockStream(
+                SubscribeStreamRequest.newBuilder()
+                        .startBlockNumber(0L)
+                        .endBlockNumber(0L)
+                        .build(),
+                observer);
+        awaitLatch(latch, "subscriber stream of block 0 on port " + port);
+        assertThat(observer.getOnNextCalls().getFirst().blockItems().blockItems())
+                .as("subscriber on port %d must stream block 0", port)
+                .isNotEmpty();
+        client.close();
+    }
+
+    /** Returns the HTTP status code of GET {@code /healthz/livez} on the given port. */
+    private int healthLivezStatusCode(final int port) {
+        final Http2Client http2Client =
+                Http2Client.builder().baseUri("http://localhost:" + port).build();
+        try (var response =
+                http2Client.method(Method.create("GET")).path("/healthz/livez").request()) {
+            return response.status().code();
+        }
+    }
+
+    /**
+     * Asserts that the four gRPC API services do not route on the default port. Once each plugin binds
+     * its own port, the default port has no PBJ routes, so a unary call there fails rather than
+     * returning a valid domain response.
+     */
+    private void assertGrpcNotRoutedOnDefaultPort(final int defaultPort) {
+        assertThrows(
+                Exception.class,
+                () -> serverStatusOn(defaultPort),
+                "server-status must not be routed on the default port");
+        assertThrows(
+                Exception.class,
+                () -> getBlockOn(defaultPort, 0L),
+                "block-access must not be routed on the default port");
+    }
+
+    /** Asserts the publisher gRPC service is not routed on the default port: no ACK and the stream is rejected. */
+    private void assertPublisherNotRoutedOnDefaultPort(final int port) throws InterruptedException {
+        final var client = new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
+                createGrpcClientForPort(Integer.toString(port)), OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> observer = new ResponsePipelineUtils<>();
+        final AtomicReference<CountDownLatch> endedLatch = observer.setAndGetConnectionEndedLatch(1);
+        try {
+            final Pipeline<? super PublishStreamRequest> stream = client.publishBlockStream(observer);
+            stream.onNext(PublishStreamRequest.newBuilder()
+                    .blockItems(BlockItemSet.newBuilder()
+                            .blockItems(BlockItemBuilderUtils.createSimpleBlockWithNumber(0L))
+                            .build())
+                    .build());
+            endBlock(0L, stream);
+            endedLatch.get().await(DEFAULT_AWAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            assertEquals(
+                    0, endedLatch.get().getCount(), "publisher stream on the default port must be rejected (no route)");
+            assertThat(observer.getOnNextCalls())
+                    .as("publisher must not acknowledge on the default port")
+                    .isEmpty();
+        } catch (final RuntimeException rejectedDuringSend) {
+            // Sending on an unrouted stream may throw directly (e.g. closed socket); that also proves "not routed".
+        } finally {
+            client.close();
+        }
+    }
+
+    /** Asserts the subscriber gRPC service is not routed on the default port: the stream is rejected/closed. */
+    private void assertSubscriberNotRoutedOnDefaultPort(final int port) throws InterruptedException {
+        final var client = new BlockStreamSubscribeServiceInterface.BlockStreamSubscribeServiceClient(
+                createGrpcClientForPort(Integer.toString(port)), OPTIONS);
+        final ResponsePipelineUtils<SubscribeStreamResponse> observer = new ResponsePipelineUtils<>();
+        final AtomicReference<CountDownLatch> endedLatch = observer.setAndGetConnectionEndedLatch(1);
+        // subscribeBlockStream blocks until the server-streaming RPC ends; run it off-thread so a stuck call
+        // can't stall the test, then require the connection to have ended (been rejected) within the timeout.
+        final Thread subscribeThread = new Thread(
+                () -> {
+                    try {
+                        client.subscribeBlockStream(
+                                SubscribeStreamRequest.newBuilder()
+                                        .startBlockNumber(0L)
+                                        .endBlockNumber(0L)
+                                        .build(),
+                                observer);
+                    } catch (final RuntimeException rejected) {
+                        // expected — not routed
+                    }
+                },
+                "api-subscribe-default-port-negative");
+        subscribeThread.start();
+        endedLatch.get().await(DEFAULT_AWAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        subscribeThread.join(DEFAULT_AWAIT_TIMEOUT.toMillis());
+        assertEquals(
+                0, endedLatch.get().getCount(), "subscriber stream on the default port must be rejected (no route)");
+        client.close();
+    }
+
+    /** Waits until the app reaches (running == true) or leaves (running == false) the RUNNING state. */
+    private static void awaitState(final BlockNodeApp app, final boolean running) throws InterruptedException {
+        final long deadline = System.currentTimeMillis() + 10_000L;
+        while (System.currentTimeMillis() < deadline) {
+            final boolean isRunning = app.blockNodeState() == State.RUNNING;
+            if (isRunning == running) {
+                return;
+            }
+            Thread.sleep(20);
+        }
+        assertEquals(running, app.blockNodeState() == State.RUNNING, "app did not reach expected running=" + running);
+    }
+
     private void endBlock(final long blockNumber, final Pipeline<? super PublishStreamRequest> requestStream) {
         PublishStreamRequest request = PublishStreamRequest.newBuilder()
                 .endOfBlock(BlockEnd.newBuilder().blockNumber(blockNumber).build())


### PR DESCRIPTION
## Reviewer Notes

[PR #2880](https://github.com/hiero-ledger/hiero-block-node/pull/2880) made the API service port
server-configurable by adding a nullable per-service `port` to `ServiceBuilder` (and the multi-socket
wiring in `BlockNodeApp`), but left every plugin passing `null` — so all services still bind the single
default `server.port`. This PR finishes that work: each API plugin now reads an optional `port` from its
own config and registers its service on that dedicated port, letting node operators put individual
services on their own ports when needed.

Five plugins gain a port:

| Plugin | Config key | Service |
|--------|-----------|---------|
| Block Access | `block.access.port` | gRPC |
| Health | `health.port` | HTTP (`/healthz/*`) |
| Server Status | `server.status.port` | gRPC |
| Publisher | `producer.port` | gRPC |
| Subscriber | `subscriber.port` | gRPC |

Each port is a **nullable `Integer`**. When unset (the default) the plugin passes `null` and the service
shares `server.port` — i.e. **default behavior is unchanged**. Set a port to move just that service onto
its own listener.

## What changed

- **Configs**
  - New `HealthConfig`, `ServerStatusConfig`, `BlockAccessConfig` records (those plugins had no config
    class), each registered via the plugin's `configDataTypes()`.
  - Added a `port` field to the existing `PublisherConfig` (`producer.*`) and `SubscriberConfig`
    (`subscriber.*`).
  - The port is declared `@ConfigProperty(defaultValue = ConfigProperty.NULL_DEFAULT_VALUE) Integer port`
    so it resolves to `null` when unset.
- **Plugin wiring** — each plugin reads `context.configuration().getConfigData(<X>Config.class).port()`
  in `init()` and passes it to `registerGrpcService(...)` / `registerHttpService(...)`. A `null` port
  resolves to `server.port` in `ServiceBuilderImpl`.
- **`module-info`** — the three new-config modules export their config package to the config framework
  (`com.swirlds.config.impl`, `com.swirlds.config.extensions`) and `org.hiero.block.node.app`, and
  declare `requires transitive com.swirlds.config.api` (the config records expose the config annotations
  as API). Matches the existing `stream-publisher` module setup.
- **`ConfigLogger` null-tolerance (required)** — `ConfigLogger.collectConfig` called
  `accessor.invoke(record).toString()` unconditionally, so any config property that resolves to `null`
  threw an NPE during `BlockNodeApp` construction. These nullable ports are the first null-valued config
  in the codebase, so this would break **every** app boot. Guarded the null case (logs `"null"`).
- **Docs** — `docs/block-node/configuration.md` documents the new `*_PORT` keys.

## Design notes

- **Nullable, not a sentinel.** `null` cleanly means "share `server.port`". No magic default value.
- **No `@Min`/`@Max` on the port.** swirlds' `@Min`/`@Max` validators call `requireNonNull` on the value,
  so a nullable port with those annotations would NPE at startup when unset. The valid range
  (`1024`–`65535`) is documented in each config's Javadoc and enforced by the web server when it binds.
- **Backward compatible / non-intrusive.** With no port set, the registration path is identical to before
  (`null` → `server.port`); nothing about the default single-port deployment changes.

## Testing

- New E2E test `BlockNodeAPITests.servicesBindToConfiguredUniquePortsOnly`: boots `BlockNodeApp` with a
  unique port per plugin (`40891`–`40895`) and asserts, for **all five** services, that each is reachable
  on its own port (publish→ACK, server-status, get-block, subscribe-streams-block-0, health `200`) **and**
  is **not** reachable on the default `server.port` (gRPC unary calls throw / streams are rejected; health
  returns `404`).
- Updated `HealthServiceTest` to stub `context.configuration()` now that the plugin reads its port in
  `init()`.
- `./gradlew :suites:runAPISuites` is green (14 passing); unit tests for all changed modules pass;
  `qualityCheck` (incl. `checkModuleDirectivesScope` and spotless) passes on every changed module.

> Note: run `:suites:runAPISuites` on its own — running the real-port E2E suite in parallel with other
> port-binding module tests can cause port contention.

## Related Issue(s)
Resolves #2880 