### PR TITLE
fix: Change K6 tests to use the "minimal" solo-e2e-tests topology

### DIFF
--- a/tools-and-tests/k6/run-k6-tests.sh
+++ b/tools-and-tests/k6/run-k6-tests.sh
@@ -99,6 +99,7 @@ cleanup() {
 start_solo() {
     (
     pushd "../scripts/solo-e2e-test" || return
+    echo "TOPOLOGY=minimal" > .env
     task up
     if [[ $? -ne 0 ]]; then
         echo "FAILED TO START SOLO"


### PR DESCRIPTION
## Reviewer Notes
k6 tests do not require a mirror node. Mirror nodes are failing to load in the default topology for solo-e2e-tests.
This changes the K6 Tests to use the minimal topology of 1CN 1BN.

## Related Issue(s)
Closes #2984