### PR TITLE
fix(ci): upgrade Node.js to 22.x for k6 tests to satisfy Solo 0.72.0

### DIFF
--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20.19.4"
+          node-version: "22.x"
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0


### PR DESCRIPTION
## Summary

Solo 0.72.0 declares engines.node >= 22.0.0 but BN k6 logic is using version 20x
Running it under Node 20 emits `EBADENGINE` warnings and can produce silent runtime failures, which may have been contributing to mirror-node pods not becoming ready in the k6 CI job.

Updating setup-node to "22.x" resolves the engine mismatch.


