### PR TITLE
test(e2e): WRB differential test - validate Mirror Node database comparison

### DIFF
--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -160,7 +160,8 @@ jobs:
               MATRIX='[
                 {"topology":"single","tests":"smoke-test,tss-signature-transition,wrb-cli-hash-validation,wrb-cli-wrapping-validation"},
                 {"topology":"2cn-2bn-backfill","tests":"full-history-backfill,tss-signature-transition"},
-                {"topology":"single-wrb-rsa","tests":"smoke-test,rsa-roster-verification"}
+                {"topology":"single-wrb-rsa","tests":"smoke-test,rsa-roster-verification"},
+                {"topology":"wrb-differential-test","tests":"wrb-differential-test"}
               ]'
               ;;
             weekend|rc)
@@ -173,7 +174,8 @@ jobs:
                 {"topology":"2cn-2bn-backfill","tests":"full-history-backfill,tss-signature-transition"},
                 {"topology":"7cn-3bn-distributed","tests":"smoke-test,tss-signature-transition"},
                 {"topology":"single-wrb-rsa","tests":"smoke-test,rsa-roster-verification"},
-                {"topology":"3cn-2bn-wrb-rsa","tests":"smoke-test,rsa-roster-verification"}
+                {"topology":"3cn-2bn-wrb-rsa","tests":"smoke-test,rsa-roster-verification"},
+                {"topology":"wrb-differential-test","tests":"wrb-differential-test"}
               ]'
               ;;
             *)

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/extract-solo-ab-and-generate.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/extract-solo-ab-and-generate.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Generate addressBookHistory.json from Solo network
+# Usage: ./extract-solo-ab-and-generate.sh <namespace> <genesis-timestamp> <output-file>
+
+set -euo pipefail
+
+NAMESPACE="${1:-solo-network}"
+GENESIS_TS="${2}"  # Format: seconds.nanos (e.g., 1781663143.447997286)
+OUTPUT_FILE="${3:-addressBookHistory.json}"
+
+# Split genesis timestamp
+GENESIS_SECONDS="${GENESIS_TS%.*}"
+GENESIS_NANOS="${GENESIS_TS#*.}"
+
+echo "[solo-ab] Extracting address book from Solo network..."
+
+# Strategy 1: Extract RSA key directly from consensus node pod
+# The key stored in mirror Helm values doesn't match the actual signing key
+echo "[solo-ab] Extracting RSA key from consensus node pod..."
+
+# Strategy 2: Extract RSA public keys from Solo network node pods
+echo "[solo-ab] Listing all network node pods in namespace ${NAMESPACE}..."
+ALL_PODS=$(kubectl get pods -n "${NAMESPACE}" --no-headers 2>/dev/null | grep "network-node" | awk '{print $1}' || echo "")
+
+if [ -z "${ALL_PODS}" ]; then
+    echo "[solo-ab] ERROR: No network node pods found"
+    exit 1
+fi
+
+echo "[solo-ab] Found network node pods:"
+echo "${ALL_PODS}" | while read -r pod; do echo "  - ${pod}"; done
+
+# Build JSON array of nodes using a temp file
+TEMP_NODES_FILE="/tmp/solo-nodes-$$.json"
+echo "[]" > "${TEMP_NODES_FILE}"
+
+# Extract keys from each pod
+for POD_NAME in ${ALL_PODS}; do
+    echo "[solo-ab] Processing pod: ${POD_NAME}"
+
+    # Try to determine node number from pod name
+    NODE_NUM=$(echo "${POD_NAME}" | grep -oE 'node[0-9]+' | grep -oE '[0-9]+' | head -1 || echo "")
+
+    if [ -z "${NODE_NUM}" ]; then
+        echo "[solo-ab]   WARNING: Could not determine node number, skipping"
+        continue
+    fi
+
+    echo "[solo-ab]   Detected node number: ${NODE_NUM}"
+    NODE_ACCOUNT_ID=$((NODE_NUM + 2))
+
+    # Try to list keys directory
+    echo "[solo-ab]   Listing keys directory..."
+    kubectl exec -n "${NAMESPACE}" "${POD_NAME}" -- \
+        ls -la /opt/hgcapp/services-hedera/HapiApp2.0/data/keys/ 2>/dev/null | head -20 || echo "  (could not list)"
+
+    # Try multiple possible key file names (try agreement key first, then signing key)
+    RSA_KEY=""
+    for key_file in \
+        "a-public-node${NODE_NUM}.pem" \
+        "a-public-node${NODE_ACCOUNT_ID}.pem" \
+        "a-public.pem" \
+        "s-public-node${NODE_NUM}.pem" \
+        "s-public-node${NODE_ACCOUNT_ID}.pem" \
+        "s-public.pem" \
+        "public.pem"
+    do
+        # Extract PEM cert, then extract just the public key (SubjectPublicKeyInfo)
+        # as hex-encoded DER for the address book
+        PEM_CONTENT=$(kubectl exec -n "${NAMESPACE}" "${POD_NAME}" -- \
+            cat "/opt/hgcapp/services-hedera/HapiApp2.0/data/keys/${key_file}" 2>/dev/null || echo "")
+
+        if [ -z "${PEM_CONTENT}" ]; then
+            continue
+        fi
+
+        # Detect if it's a certificate or a raw public key
+        if echo "${PEM_CONTENT}" | grep -q "BEGIN CERTIFICATE"; then
+            # Extract public key from certificate via openssl
+            RSA_KEY=$(echo "${PEM_CONTENT}" | openssl x509 -pubkey -noout 2>/dev/null | \
+                grep -v "BEGIN\|END" | tr -d '\n' | base64 -d 2>/dev/null | od -An -tx1 | tr -d ' \n' || echo "")
+        else
+            # Already a public key, decode PEM directly
+            RSA_KEY=$(echo "${PEM_CONTENT}" | grep -v "BEGIN\|END" | tr -d '\n' | \
+                base64 -d 2>/dev/null | od -An -tx1 | tr -d ' \n' || echo "")
+        fi
+
+        if [ -n "${RSA_KEY}" ]; then
+            echo "[solo-ab]   ✓ Found RSA key in ${key_file}"
+            break
+        fi
+    done
+
+    if [ -z "${RSA_KEY}" ]; then
+        echo "[solo-ab]   WARNING: Could not extract RSA key"
+        continue
+    fi
+
+    # Add node to JSON array
+    NODE_JSON=$(jq -n \
+        --arg nodeId "${NODE_NUM}" \
+        --arg accountNum "${NODE_ACCOUNT_ID}" \
+        --arg rsaKey "${RSA_KEY}" \
+        '{
+            nodeId: $nodeId,
+            nodeAccountId: {
+                shardNum: "0",
+                realmNum: "0",
+                accountNum: $accountNum
+            },
+            RSAPubKey: $rsaKey
+        }')
+
+    jq --argjson node "${NODE_JSON}" '. + [$node]' "${TEMP_NODES_FILE}" > "${TEMP_NODES_FILE}.tmp"
+    mv "${TEMP_NODES_FILE}.tmp" "${TEMP_NODES_FILE}"
+    echo "[solo-ab]   ✓ Added node ${NODE_NUM}"
+done
+
+NODES_JSON=$(cat "${TEMP_NODES_FILE}")
+rm -f "${TEMP_NODES_FILE}"
+
+NODE_COUNT=$(echo "${NODES_JSON}" | jq 'length')
+echo "[solo-ab] Extracted ${NODE_COUNT} node keys total"
+
+if [ "${NODE_COUNT}" -eq 0 ]; then
+    echo "[solo-ab] ERROR: Could not extract any node keys"
+    exit 1
+fi
+
+# Build the final address book JSON
+jq -n \
+  --arg seconds "${GENESIS_SECONDS}" \
+  --argjson nanos "${GENESIS_NANOS}" \
+  --argjson nodes "${NODES_JSON}" \
+  '{
+    addressBooks: [
+      {
+        blockTimestamp: {
+          seconds: $seconds,
+          nanos: $nanos
+        },
+        addressBook: {
+          nodeAddress: $nodes
+        }
+      }
+    ]
+  }' > "${OUTPUT_FILE}"
+
+if ! jq '.' "${OUTPUT_FILE}" > /dev/null 2>&1; then
+    echo "[solo-ab] ERROR: Generated invalid JSON"
+    exit 1
+fi
+
+echo "[solo-ab] Successfully generated ${OUTPUT_FILE}"
+echo "[solo-ab] Address book contains:"
+jq -r '.addressBooks[0].addressBook.nodeAddress[] | "  Node \(.nodeId) (0.0.\(.nodeAccountId.accountNum))"' "${OUTPUT_FILE}"
+
+exit 0

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/python/capture_mn_responses.py
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/python/capture_mn_responses.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+Capture Mirror Node API responses to files for offline comparison.
+
+Usage:
+    python3 capture_mn_responses.py <mn_url> <output_dir> [--block-range START:END]
+
+Example:
+    python3 capture_mn_responses.py http://localhost:5551/api/v1 /tmp/mn1-responses --block-range 0:100
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+import requests
+
+
+def capture_endpoint(url: str, output_file: Path, params=None):
+    """Capture API endpoint response to file."""
+    try:
+        response = requests.get(url, params=params, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_file, 'w') as f:
+            json.dump(data, f, indent=2)
+
+        print(f"✓ Captured: {output_file.name}")
+        return True
+    except Exception as e:
+        print(f"✗ Failed to capture {url}: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Capture Mirror Node API responses")
+    parser.add_argument("mn_url", help="Mirror Node API base URL")
+    parser.add_argument("output_dir", help="Output directory for captured responses")
+    parser.add_argument("--block-range", help="Block range (e.g., 0:100)", default=None)
+    parser.add_argument("--verbose", "-v", action="store_true")
+
+    args = parser.parse_args()
+
+    mn_url = args.mn_url.rstrip('/')
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Capturing Mirror Node API responses")
+    print(f"  From: {mn_url}")
+    print(f"  To:   {output_dir}")
+    print()
+
+    success_count = 0
+    total_count = 0
+
+    # Parse block range
+    start_block = 0
+    end_block = 100
+    if args.block_range:
+        parts = args.block_range.split(':')
+        start_block = int(parts[0])
+        end_block = int(parts[1]) if len(parts) > 1 else 100
+
+    # Capture network info
+    total_count += 1
+    if capture_endpoint(f"{mn_url}/network/nodes", output_dir / "network_nodes.json"):
+        success_count += 1
+
+    # Capture blocks
+    total_count += 1
+    if capture_endpoint(
+        f"{mn_url}/blocks",
+        output_dir / "blocks.json",
+        params={"limit": end_block - start_block + 1, "order": "asc"}
+    ):
+        success_count += 1
+
+    # Capture transactions
+    total_count += 1
+    if capture_endpoint(
+        f"{mn_url}/transactions",
+        output_dir / "transactions.json",
+        params={"limit": 1000, "order": "asc"}
+    ):
+        success_count += 1
+
+    # Capture balances
+    total_count += 1
+    if capture_endpoint(
+        f"{mn_url}/balances",
+        output_dir / "balances.json",
+        params={"limit": 1000}
+    ):
+        success_count += 1
+
+    # Save metadata
+    metadata = {
+        "mn_url": mn_url,
+        "block_range": f"{start_block}:{end_block}",
+        "captured_at": __import__('datetime').datetime.now().isoformat(),
+    }
+    with open(output_dir / "metadata.json", 'w') as f:
+        json.dump(metadata, f, indent=2)
+
+    print()
+    print(f"Captured {success_count}/{total_count} endpoints")
+    print(f"Output: {output_dir}")
+
+    return 0 if success_count == total_count else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/python/compare_captured_responses.py
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/python/compare_captured_responses.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+Compare two directories of captured Mirror Node API responses.
+
+Usage:
+    python3 compare_captured_responses.py <dir1> <dir2> [--output report.json]
+
+Example:
+    python3 compare_captured_responses.py /tmp/mn1-responses /tmp/mn2-responses --output report.json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+class OfflineComparator:
+    """Compare captured API responses from two directories."""
+
+    def __init__(self, dir1: Path, dir2: Path, verbose: bool = False):
+        self.dir1 = dir1
+        self.dir2 = dir2
+        self.verbose = verbose
+        self.differences = []
+
+    def log(self, message: str):
+        if self.verbose:
+            print(f"[compare] {message}", file=sys.stderr)
+
+    def load_json(self, file_path: Path) -> Any:
+        """Load JSON file."""
+        try:
+            with open(file_path) as f:
+                return json.load(f)
+        except Exception as e:
+            print(f"Error loading {file_path}: {e}", file=sys.stderr)
+            return None
+
+    # Fields that are expected to differ between Phase 1 (live) and Phase 2 (WRB wrapped)
+    # Phase 2 starts a new genesis chain, so chain-specific hashes will differ
+    WRB_EXPECTED_DIFF_FIELDS = {
+        "hash",  # Block hash differs (different chain origin)
+        "previous_hash",  # Phase 2 block 0 has all-zeros (genesis), Phase 1 has CN's hash
+        "name",  # Filename includes timestamp which may differ
+        "size",  # WRB sets the wrapped block size; CN live stream may report null
+    }
+
+    def _filter_wrb_expected_diffs(self, data: Any) -> Any:
+        """Remove fields that are expected to differ between Phase 1 and Phase 2."""
+        if isinstance(data, dict):
+            return {
+                k: self._filter_wrb_expected_diffs(v)
+                for k, v in data.items()
+                if k not in self.WRB_EXPECTED_DIFF_FIELDS
+            }
+        if isinstance(data, list):
+            return [self._filter_wrb_expected_diffs(item) for item in data]
+        return data
+
+    def compare_files(self, filename: str) -> bool:
+        """Compare same file from both directories."""
+        file1 = self.dir1 / filename
+        file2 = self.dir2 / filename
+
+        if not file1.exists():
+            self.differences.append(f"Missing in dir1: {filename}")
+            return False
+        if not file2.exists():
+            self.differences.append(f"Missing in dir2: {filename}")
+            return False
+
+        data1 = self.load_json(file1)
+        data2 = self.load_json(file2)
+
+        if data1 is None or data2 is None:
+            return False
+
+        # For individual block files: tolerate "not found" in Phase 2
+        # since Phase 2 only wraps available record files (typically just block 0)
+        if filename.startswith("block_") and filename.endswith(".json"):
+            if isinstance(data2, dict) and "_status" in data2 and "Not found" in str(data2.get("_status", "")):
+                print(f"{filename}: ⊘ Phase 2 doesn't have this block (expected for WRB wrap)")
+                return True
+
+            # Compare blocks ignoring chain-specific hashes (expected to differ)
+            filtered1 = self._filter_wrb_expected_diffs(data1)
+            filtered2 = self._filter_wrb_expected_diffs(data2)
+            if filtered1 == filtered2:
+                print(f"{filename}: ✓ Match (data identical; chain hashes differ as expected)")
+                return True
+
+            diff_detail = self._deep_diff(filtered1, filtered2, filename)
+            self.differences.append({"file": filename, "details": diff_detail})
+            print(f"{filename}: ✗ Mismatch")
+            return False
+
+        # For blocks.json: tolerate Phase 2 having fewer blocks (only 1 wrapped block)
+        if filename == "blocks.json":
+            blocks1 = data1.get("blocks", []) if isinstance(data1, dict) else []
+            blocks2 = data2.get("blocks", []) if isinstance(data2, dict) else []
+            if len(blocks2) >= 1 and len(blocks1) >= len(blocks2):
+                # Compare only the blocks that Phase 2 has (ignore chain hashes)
+                filtered_blocks1 = self._filter_wrb_expected_diffs(blocks1[: len(blocks2)])
+                filtered_blocks2 = self._filter_wrb_expected_diffs(blocks2)
+                if filtered_blocks1 == filtered_blocks2:
+                    print(
+                        f"{filename}: ✓ Match (Phase 2 has {len(blocks2)} of {len(blocks1)} blocks; data identical)"
+                    )
+                    return True
+
+            diff_detail = self._deep_diff(blocks1, blocks2, filename)
+            self.differences.append({"file": filename, "details": diff_detail})
+            print(f"{filename}: ✗ Mismatch")
+            return False
+
+        if data1 == data2:
+            self.log(f"{filename}: ✓ Match")
+            return True
+
+        # Find differences
+        diff_detail = self._deep_diff(data1, data2, filename)
+        self.differences.append({
+            "file": filename,
+            "details": diff_detail
+        })
+        print(f"{filename}: ✗ Mismatch")
+        return False
+
+    def _deep_diff(self, obj1: Any, obj2: Any, path: str) -> str:
+        """Deep comparison to identify specific differences."""
+        if type(obj1) != type(obj2):
+            return f"{path}: type mismatch ({type(obj1).__name__} vs {type(obj2).__name__})"
+
+        if isinstance(obj1, dict):
+            keys1 = set(obj1.keys())
+            keys2 = set(obj2.keys())
+            if keys1 != keys2:
+                return f"{path}: key mismatch"
+
+            for key in keys1:
+                if obj1[key] != obj2[key]:
+                    return self._deep_diff(obj1[key], obj2[key], f"{path}.{key}")
+
+        elif isinstance(obj1, list):
+            if len(obj1) != len(obj2):
+                return f"{path}: length mismatch ({len(obj1)} vs {len(obj2)})"
+
+            for i, (item1, item2) in enumerate(zip(obj1, obj2)):
+                if item1 != item2:
+                    return self._deep_diff(item1, item2, f"{path}[{i}]")
+
+        else:
+            if obj1 != obj2:
+                return f"{path}: value mismatch"
+
+        return f"{path}: unknown difference"
+
+    def compare_all(self) -> bool:
+        """Compare all captured files."""
+        files_to_compare = [
+            "network_nodes.json",
+            "blocks.json",
+            "transactions.json",
+            "balances.json",
+        ]
+
+        # Add individual block files (block 0, 1-10)
+        for block_num in range(0, 11):
+            files_to_compare.append(f"block_{block_num}.json")
+
+        all_match = True
+        for filename in files_to_compare:
+            if not self.compare_files(filename):
+                all_match = False
+
+        return all_match
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare captured Mirror Node responses")
+    parser.add_argument("dir1", help="First captured responses directory (MN1)")
+    parser.add_argument("dir2", help="Second captured responses directory (MN2)")
+    parser.add_argument("--output", "-o", help="Output report file (JSON)")
+    parser.add_argument("--verbose", "-v", action="store_true")
+
+    args = parser.parse_args()
+
+    dir1 = Path(args.dir1)
+    dir2 = Path(args.dir2)
+
+    if not dir1.exists():
+        print(f"Error: Directory not found: {dir1}", file=sys.stderr)
+        return 1
+    if not dir2.exists():
+        print(f"Error: Directory not found: {dir2}", file=sys.stderr)
+        return 1
+
+    print(f"Comparing captured Mirror Node responses")
+    print(f"  Dir 1: {dir1}")
+    print(f"  Dir 2: {dir2}")
+    print()
+
+    comparator = OfflineComparator(dir1, dir2, verbose=args.verbose)
+    all_match = comparator.compare_all()
+
+    print()
+    print("=" * 60)
+    if all_match:
+        print("✅ PASS - Mirror Nodes produced IDENTICAL responses")
+    else:
+        print("❌ FAIL - Differences found")
+        print(f"\nDifferences ({len(comparator.differences)}):")
+        for diff in comparator.differences:
+            if isinstance(diff, str):
+                print(f"  - {diff}")
+            else:
+                print(f"  - {diff['file']}: {diff.get('details', 'unknown')}")
+
+    # Save report
+    if args.output:
+        report = {
+            "result": "pass" if all_match else "fail",
+            "differences": comparator.differences,
+            "dir1": str(dir1),
+            "dir2": str(dir2)
+        }
+        with open(args.output, 'w') as f:
+            json.dump(report, f, indent=2)
+        print(f"\nReport saved to: {args.output}")
+
+    return 0 if all_match else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
@@ -231,14 +231,17 @@ function load_topology {
   # New schema: if section exists with nodes, deploy; if section is empty or missing, skip
   if [[ "${has_mirror_nodes}" -gt 0 ]]; then
     SKIP_MIRROR="false"
+    log_line "  Mirror Node decision: Deploy (has_mirror_nodes=${has_mirror_nodes})"
   elif [[ "${has_mirror_nodes}" == "0" ]] && yq -e '.mirror_nodes' "${topology_file}" >/dev/null 2>&1; then
     # Section exists but empty - skip
     SKIP_MIRROR="true"
+    log_line "  Mirror Node decision: Skip (mirror_nodes: {} exists but empty)"
   else
     # Fall back to components section
     local mirror_enabled
     mirror_enabled=$(yq '.components.mirror_node // true' "${topology_file}" 2>/dev/null)
     [[ "${mirror_enabled}" == "false" ]] && SKIP_MIRROR="true"
+    log_line "  Mirror Node decision: Fallback to components.mirror_node=${mirror_enabled}"
   fi
 
   if [[ "${has_relay_nodes}" -gt 0 ]]; then
@@ -644,8 +647,10 @@ function deploy_consensus_nodes {
 }
 
 function deploy_mirror_node {
+  log_line ""
+  log_line "deploy_mirror_node called with SKIP_MIRROR=${SKIP_MIRROR}"
+
   if [[ "${SKIP_MIRROR}" == "true" ]]; then
-    log_line ""
     log_line "Skipping Mirror Node deployment (disabled in topology)"
     return 0
   fi

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-deploy-bn2-historic.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-deploy-bn2-historic.sh
@@ -36,6 +36,7 @@ BN2_POD_NAME_PATTERN="block-node-2"  # Adjust if using different naming
 
 LOCAL_WORK_DIR="/tmp/wrb-cli-phase2-validation"
 LOCAL_WRAPPED_DIR="${LOCAL_WORK_DIR}/cli-wrapped-blocks"
+LOCAL_RECORDS_DIR="${LOCAL_WORK_DIR}/record-files"
 
 # BN2 paths (inside container)
 BN2_HISTORIC_PATH="/opt/hiero/block-node/data/historic"
@@ -127,17 +128,50 @@ function do_copy_blocks {
         return 1
     fi
 
+    # Also copy signature files (.rcd_sig) from record files directory
+    # Mirror Node needs these to verify wrapped record blocks
+    log "Copying signature files to BN2..."
+    if [[ -d "${LOCAL_RECORDS_DIR}" ]]; then
+        local sig_count
+        sig_count=$(find "${LOCAL_RECORDS_DIR}" -type f -name "*.rcd_sig*" 2>/dev/null | wc -l | tr -d '[:space:]')
+
+        if [[ "${sig_count}" -gt 0 ]]; then
+            log "Found ${sig_count} signature file(s) to copy"
+
+            # Copy signature files to BN2's historic path
+            if kctl cp -n "${NAMESPACE}" "${LOCAL_RECORDS_DIR}/." "${bn2_pod}:${BN2_HISTORIC_PATH}/" 2>&1 | tee -a /tmp/kubectl-cp-output.log; then
+                log "Successfully copied signature files to BN2"
+            else
+                log "WARNING: Failed to copy signature files to BN2"
+                log "Mirror Node may fail to verify wrapped blocks without signatures"
+            fi
+        else
+            log "WARNING: No signature files found in ${LOCAL_RECORDS_DIR}"
+            log "Mirror Node may fail to verify wrapped blocks without signatures"
+        fi
+    else
+        log "WARNING: Record files directory not found: ${LOCAL_RECORDS_DIR}"
+        log "Mirror Node may fail to verify wrapped blocks without signatures"
+    fi
+
     # Verify files were copied
     log "Verifying copied files..."
-    local copied_count
+    local copied_count sig_copied_count
     copied_count=$(kctl exec -n "${NAMESPACE}" "${bn2_pod}" -- \
         find "${BN2_HISTORIC_PATH}" -type f -name "*.zip" 2>/dev/null | wc -l | tr -d '[:space:]')
+    sig_copied_count=$(kctl exec -n "${NAMESPACE}" "${bn2_pod}" -- \
+        find "${BN2_HISTORIC_PATH}" -type f -name "*.rcd_sig*" 2>/dev/null | wc -l | tr -d '[:space:]')
 
-    log "Copied ${copied_count} zip file(s) to BN2"
+    log "Copied ${copied_count} zip file(s) and ${sig_copied_count} signature file(s) to BN2"
 
     if [[ "${copied_count}" -eq 0 ]]; then
         log "ERROR: No zip files found in BN2 after copy"
         return 1
+    fi
+
+    if [[ "${sig_copied_count}" -eq 0 ]]; then
+        log "WARNING: No signature files found in BN2 after copy"
+        log "Mirror Node may fail RSA verification without signatures"
     fi
 
     # List directory structure for verification

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-sequential-comparison.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-sequential-comparison.sh
@@ -34,6 +34,10 @@ MN_WRB_CAPTURE_DIR="/tmp/mn-wrb-responses"
 BLOCK_RANGE="0:100"
 MIN_TRANSACTIONS=10
 
+# Mirror Node version used for both MN1 (Solo deployment) and the standalone MN2.
+# Override with MIRROR_NODE_VERSION env var. Use a GA version, not 'main' or 'latest'.
+MIRROR_NODE_VERSION="${MIRROR_NODE_VERSION:-v0.156.0}"
+
 # Work directories
 WORK_DIR="/tmp/wrb-test-$$"
 RECORD_FILES_DIR="${WORK_DIR}/record-files"
@@ -164,10 +168,10 @@ importer:
             responseTimeout: 10s
 EOF
 
-        # Deploy Mirror Node with v0.156.0+
+        # Deploy Mirror Node (version from MIRROR_NODE_VERSION env var)
         solo mirror node add \
             --deployment "${DEPLOYMENT}" \
-            --mirror-node-version "v0.156.0" \
+            --mirror-node-version "${MIRROR_NODE_VERSION}" \
             --pinger \
             --cluster-ref "${CONTEXT}" \
             -f "${overlay_file}" || {
@@ -721,8 +725,8 @@ function compare_phase_responses {
     log "Comparing Phase 1 vs Phase 2 responses..."
 
     if [ ! -d "${MN_CAPTURE_DIR}" ] || [ ! -d "${MN_WRB_CAPTURE_DIR}" ]; then
-        log "WARNING: Missing response directories, skipping comparison"
-        return 0
+        log "ERROR: Missing response directories, cannot run differential comparison"
+        return 1
     fi
 
     python3 "${PYTHON_DIR}/compare_captured_responses.py" \
@@ -730,9 +734,9 @@ function compare_phase_responses {
         "${MN_WRB_CAPTURE_DIR}" \
         --output /tmp/comparison-report.json \
         --verbose || {
-        log "⚠️  Responses differ between Phase 1 and Phase 2"
-        log "This is expected if block production continued between phases"
-        return 0
+        log "✗ Phase 1 vs Phase 2 differential comparison FAILED"
+        log "  Report: /tmp/comparison-report.json"
+        return 1
     }
 
     log "✓ Phase 1 and Phase 2 responses match"
@@ -1014,14 +1018,18 @@ function deploy_mn2_to_bn2 {
     local mn_importer_image=$(kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" get deployment mirror-1-importer -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo "")
     local mn_rest_image=$(kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" get deployment mirror-1-rest -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo "")
 
+    # Fallback to the configured GA version with the leading 'v' stripped to match
+    # the Docker image tag convention (e.g. v0.156.0 -> 0.156.0).
+    local mn_image_tag="${MIRROR_NODE_VERSION#v}"
+
     if [ -z "${mn_importer_image}" ]; then
-        log "WARNING: Could not get MN1 importer image, using default"
-        mn_importer_image="gcr.io/mirrornode/hedera-mirror-importer:0.156.0"
+        log "WARNING: Could not get MN1 importer image, using default for version ${MIRROR_NODE_VERSION}"
+        mn_importer_image="gcr.io/mirrornode/hedera-mirror-importer:${mn_image_tag}"
     fi
 
     if [ -z "${mn_rest_image}" ]; then
-        log "WARNING: Could not get MN1 REST image, using default"
-        mn_rest_image="gcr.io/mirrornode/hedera-mirror-rest-java:0.156.0"
+        log "WARNING: Could not get MN1 REST image, using default for version ${MIRROR_NODE_VERSION}"
+        mn_rest_image="gcr.io/mirrornode/hedera-mirror-rest-java:${mn_image_tag}"
     fi
 
     log "Using Mirror Node importer image: ${mn_importer_image}"
@@ -1172,66 +1180,6 @@ spec:
       - name: init-scripts
         configMap:
           name: mn2-postgres-init
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: mn2-rest-config
-  namespace: ${WRB_NAMESPACE}
-data:
-  application.yml: |
-    hiero:
-      mirror:
-        common:
-          shard: 0
-          realm: 0
-        rest:
-          cache:
-            entityId:
-              maxAge: 600
-              maxSize: 100000
-            response:
-              enabled: false
-            token:
-              maxSize: 50000
-          db:
-            host: mirror-1-postgres-postgresql.${NAMESPACE}.svc.cluster.local
-            port: 5432
-            name: mirror_node_wrb
-            username: mirror_node
-            password: mirror_node_pass
-            pool:
-              connectionTimeout: 30000
-              maxConnections: 50
-              statementTimeout: 30000
-            tls:
-              enabled: false
-          log:
-            level: INFO
-          openapi:
-            enabled: false
-            specVersion: openapi
-            validation:
-              enabled: false
-          port: 5551
-          query:
-            maxRecordFileCloseInterval: 2m
-            maxScheduledTransactionConsensusTimestampRange: 30d
-            maxTimestampRange: 7d
-            maxTransactionConsensusTimestampRange: 30d
-            maxTransactionsTimestampRange: 1h
-            maxValidStartTimestampDrift: 24h
-            transactions:
-              precedingTransactionTypes: []
-          redis:
-            enabled: true
-            sentinel:
-              enabled: false
-            uri: redis://mirror-1-redis-node.${NAMESPACE}.svc.cluster.local:6379
-          response:
-            limit:
-              default: 25
-              max: 100
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-sequential-comparison.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-sequential-comparison.sh
@@ -1,0 +1,1604 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Block Ingestion Validation Test
+#
+# Tests that Mirror Node correctly ingests blocks from Block Node.
+# Solo's single-node setup doesn't have TSS metadata, so this validates
+# basic block ingestion without signature verification.
+#
+# Flow:
+#   1. Wait for network to generate blocks
+#   2. Deploy MN → BN1
+#   3. Wait for ingestion
+#   4. Capture MN API responses
+#   5. Validate basic ingestion metrics
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_DIR="${SCRIPT_DIR}/python"
+
+NAMESPACE="${NAMESPACE:-solo-network}"
+WRB_NAMESPACE="solo-wrb-test"
+CONTEXT="${CONTEXT:-kind-solo-cluster}"
+DEPLOYMENT="${DEPLOYMENT:-deployment-solo}"
+
+MN_PORT="${MN_PORT:-5551}"
+MN_URL="http://localhost:${MN_PORT}/api/v1"
+MN_CAPTURE_DIR="/tmp/mn-responses"
+MN_WRB_PORT="5552"
+MN_WRB_URL="http://localhost:${MN_WRB_PORT}/api/v1"
+MN_WRB_CAPTURE_DIR="/tmp/mn-wrb-responses"
+
+BLOCK_RANGE="0:100"
+MIN_TRANSACTIONS=10
+
+# Work directories
+WORK_DIR="/tmp/wrb-test-$$"
+RECORD_FILES_DIR="${WORK_DIR}/record-files"
+WRAPPED_BLOCKS_DIR="${WORK_DIR}/wrapped-blocks"
+
+function log {
+    echo "[wrb-ingestion] $*" >&2
+}
+
+function kctl {
+    kubectl --context "${CONTEXT}" "$@"
+}
+
+function dump_importer_logs {
+    local log_file_importer="/tmp/mirror-importer-logs-$(date +%s).log"
+    local log_file_bn="/tmp/block-node-1-logs-$(date +%s).log"
+
+    log "Capturing Mirror Node importer logs to ${log_file_importer}..."
+
+    kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
+        logs deployment/mirror-1-importer --tail=500 > "${log_file_importer}" 2>&1 || {
+        log "WARNING: Failed to capture importer logs"
+    }
+
+    log "Capturing Block Node 1 logs to ${log_file_bn}..."
+
+    kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
+        logs statefulset/block-node-1 --tail=500 > "${log_file_bn}" 2>&1 || {
+        log "WARNING: Failed to capture Block Node logs"
+    }
+
+    log ""
+    log "Last 50 lines of Mirror Node importer logs:"
+    log "============================================="
+    tail -50 "${log_file_importer}" 2>/dev/null || echo "No importer logs available"
+    log "============================================="
+    log ""
+    log "Last 50 lines of Block Node 1 logs:"
+    log "============================================="
+    tail -50 "${log_file_bn}" 2>/dev/null || echo "No Block Node logs available"
+    log "============================================="
+}
+
+function wait_for_mn_ingestion {
+    local min_blocks=${1:-10}
+    local timeout=${2:-120}
+
+    log "Waiting for Mirror Node to ingest at least ${min_blocks} transactions..."
+
+    local elapsed=0
+    while [[ ${elapsed} -lt ${timeout} ]]; do
+        # Check MN logs directly for ingestion success (more reliable than API)
+        local ingestion_count=$(kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
+            logs deployment/mirror-1-importer --tail=100 2>/dev/null | \
+            grep -c "Successfully processed.*items from.*\.blk" || echo "0")
+
+        if [[ "${ingestion_count}" -ge "1" ]]; then
+            log "Mirror Node has ingested blocks (found ${ingestion_count} processing messages) ✓"
+
+            # Also try API to verify REST endpoint works
+            local tx_count=$(curl -s "http://localhost:${MN_PORT}/api/v1/transactions?limit=1&order=desc" 2>/dev/null | \
+                python3 -c "import sys, json; data=json.load(sys.stdin); txs=data.get('transactions', []); print(len(txs) if txs else 0)" 2>/dev/null || echo "0")
+
+            if [[ "${tx_count}" -ge "1" ]]; then
+                log "  API also responding with transactions ✓"
+            else
+                log "  Note: Logs show ingestion but API not responding yet (may need time)"
+            fi
+
+            return 0
+        fi
+
+        log "  No ingestion yet (waiting... ${elapsed}s/${timeout}s)"
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+
+    log "ERROR: Mirror Node did not ingest any blocks within ${timeout}s"
+    dump_importer_logs
+    return 1
+}
+
+function deploy_mn_to_bn {
+    local mn_name="mirror-1"
+    local bn_host="block-node-1.${NAMESPACE}.svc.cluster.local"
+
+    # Check if mirror-1 already exists (deployed by network setup)
+    if helm --kube-context "${CONTEXT}" --namespace "${NAMESPACE}" status mirror-1 &>/dev/null; then
+        log "${mn_name} already deployed - skipping deployment"
+    else
+        log "Deploying ${mn_name} connected to block-node-1..."
+
+        local overlay_file="/tmp/mn-overlay.yaml"
+        # Generate overlay - disable verification entirely (Solo doesn't support TSS)
+        cat > "${overlay_file}" << EOF
+# Mirror Node connected to Block Node 1
+# Disable block verification since Solo doesn't generate TSS metadata
+importer:
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 4Gi
+    requests:
+      cpu: 500m
+      memory: 2Gi
+  config:
+    hedera:
+      mirror:
+        importer:
+          block:
+            enabled: true
+            nodes:
+              - host: ${bn_host}
+                port: 40840
+            sourceType: BLOCK_NODE
+            stream:
+              maxStreamResponseSize: 36MB
+            verification:
+              enabled: false  # Disable all block verification for Solo
+          downloader:
+            record:
+              enabled: false
+            balance:
+              enabled: false
+          startBlockNumber: 0
+          stream:
+            maxSubscribeAttempts: 10
+            responseTimeout: 10s
+EOF
+
+        # Deploy Mirror Node with v0.156.0+
+        solo mirror node add \
+            --deployment "${DEPLOYMENT}" \
+            --mirror-node-version "v0.156.0" \
+            --pinger \
+            --cluster-ref "${CONTEXT}" \
+            -f "${overlay_file}" || {
+            log "ERROR: Failed to deploy ${mn_name}"
+            return 1
+        }
+
+        log "${mn_name} deployed successfully"
+    fi
+
+    # Set up port forward for MN1 API
+    log "Setting up port forward to MN1 API..."
+    kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" port-forward svc/mirror-1-rest ${MN_PORT}:80 &
+    local pf_pid=$!
+    echo $pf_pid > /tmp/mn1-port-forward.pid
+    sleep 5
+
+    log "MN1 API available at http://localhost:${MN_PORT}/api/v1"
+}
+
+function delete_mn {
+    log "Deleting Mirror Node..."
+
+    # Manually cleanup Helm release (Solo doesn't support --node-name in destroy)
+    log "Uninstalling Helm releases..."
+    helm --kube-context "${CONTEXT}" --namespace "${NAMESPACE}" uninstall mirror-1 --ignore-not-found || {
+        log "WARNING: Failed to uninstall mirror-1 (may not exist)"
+    }
+
+    # Clean up any mirror-2 if it exists from previous failed attempts
+    helm --kube-context "${CONTEXT}" --namespace "${NAMESPACE}" uninstall mirror-2 --ignore-not-found || true
+
+    # Clear Solo's deployment tracking state to prevent auto-increment to mirror-2
+    log "Clearing Solo deployment state..."
+    rm -rf ~/.solo/deployments/${DEPLOYMENT}/mirror-*.json 2>/dev/null || true
+    rm -rf ~/.solo/cache/${DEPLOYMENT}-mirror-*.yaml 2>/dev/null || true
+
+    log "Mirror Node deleted"
+}
+
+function download_record_files_from_minio {
+    local output_dir=$1
+    local max_files=${2:-50}
+
+    log "Downloading record files from MinIO..."
+
+    mkdir -p "${output_dir}"
+
+    # Search for MinIO pod across namespaces and labels
+    local minio_pod=""
+    local minio_namespace=""
+
+    # Try current namespace first
+    minio_pod=$(kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" get pod -l app=minio -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+    if [ -n "${minio_pod}" ]; then
+        minio_namespace="${NAMESPACE}"
+    fi
+
+    # Try with Solo's MinIO label
+    if [ -z "${minio_pod}" ]; then
+        minio_pod=$(kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" get pod -l "v1.min.io/tenant=minio" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+        if [ -n "${minio_pod}" ]; then
+            minio_namespace="${NAMESPACE}"
+        fi
+    fi
+
+    # Try pattern matching across all namespaces (exclude operator pods)
+    if [ -z "${minio_pod}" ]; then
+        local all_pods=$(kubectl --context "${CONTEXT}" get pods --all-namespaces -o json 2>/dev/null)
+        # Exclude operator/console pods, look for actual MinIO instance
+        minio_pod=$(echo "$all_pods" | jq -r '.items[] | select(.metadata.name | contains("minio")) | select(.metadata.name | contains("operator") | not) | select(.metadata.name | contains("console") | not) | .metadata.name' | head -1)
+        if [ -n "${minio_pod}" ]; then
+            minio_namespace=$(echo "$all_pods" | jq -r ".items[] | select(.metadata.name == \"${minio_pod}\") | .metadata.namespace")
+        fi
+    fi
+
+    if [ -z "${minio_pod}" ]; then
+        log "WARNING: MinIO pod not found, trying to get files from Consensus Node instead..."
+        # Fallback: download from CN pod
+        download_record_files_from_cn "${output_dir}" "${max_files}"
+        return $?
+    fi
+
+    log "Found MinIO pod: ${minio_pod} in namespace: ${minio_namespace}"
+
+    # Wait for CN to upload files to MinIO (uploader sidecar may need time)
+    # Other tests wait 120s for record files to be produced and uploaded
+    log "Waiting 120s for CN to produce and upload record files to MinIO..."
+    sleep 120
+
+    # Access MinIO via S3 API using mc client (like wrb-cli-wrap-and-compare.sh)
+    log "Accessing MinIO bucket via S3 API..."
+
+    # Get MinIO credentials from secret
+    local minio_user minio_pass
+    minio_user=$(kubectl --context "${CONTEXT}" --namespace "${minio_namespace}" get secret minio-secrets -o jsonpath='{.data.config\.env}' 2>/dev/null | base64 -d | grep MINIO_ROOT_USER | cut -d= -f2 2>/dev/null)
+    minio_pass=$(kubectl --context "${CONTEXT}" --namespace "${minio_namespace}" get secret minio-secrets -o jsonpath='{.data.config\.env}' 2>/dev/null | base64 -d | grep MINIO_ROOT_PASSWORD | cut -d= -f2 2>/dev/null)
+
+    if [[ -z "$minio_user" || -z "$minio_pass" ]]; then
+        log "WARNING: Could not get MinIO credentials from secret, trying CN pod..."
+        download_record_files_from_cn "${output_dir}" "${max_files}"
+        return $?
+    fi
+
+    # Configure mc client
+    log "Configuring MinIO client with credentials..."
+    kubectl --context "${CONTEXT}" --namespace "${minio_namespace}" exec "${minio_pod}" -c minio -- \
+        mc alias set local http://localhost:9000 "${minio_user}" "${minio_pass}" >/dev/null 2>&1 || {
+        log "WARNING: Failed to configure MinIO client, trying CN pod..."
+        download_record_files_from_cn "${output_dir}" "${max_files}"
+        return $?
+    }
+
+    # List files in bucket via S3 API
+    log "Listing files in solo-streams/recordstreams bucket..."
+    kubectl --context "${CONTEXT}" --namespace "${minio_namespace}" exec "${minio_pod}" -c minio -- \
+        mc ls --recursive local/solo-streams/recordstreams/ > /tmp/minio-listing.txt 2>&1 || {
+        log "WARNING: mc ls failed, trying CN pod..."
+        download_record_files_from_cn "${output_dir}" "${max_files}"
+        return $?
+    }
+
+    local file_count=$(grep -c '\.rcd' /tmp/minio-listing.txt 2>/dev/null || echo "0")
+    if [ "${file_count}" -lt 1 ]; then
+        log "WARNING: No .rcd files found in MinIO bucket (found ${file_count}), trying CN pod..."
+        download_record_files_from_cn "${output_dir}" "${max_files}"
+        return $?
+    fi
+
+    log "Found ${file_count} record files in MinIO bucket"
+
+    # Download files using mc cat
+    local downloaded=0
+    while IFS= read -r line; do
+        if [[ "$line" =~ \.rcd ]]; then
+            local file_path=$(echo "$line" | awk '{print $NF}')
+            local filename=$(basename "${file_path}")
+
+            kubectl --context "${CONTEXT}" --namespace "${minio_namespace}" exec "${minio_pod}" -c minio -- \
+                mc cat "local/solo-streams/recordstreams/${file_path}" > "${output_dir}/${filename}" 2>/dev/null && \
+                ((downloaded++)) || true
+
+            if [ ${downloaded} -ge ${max_files} ]; then
+                break
+            fi
+        fi
+    done < /tmp/minio-listing.txt
+
+    if [ ${downloaded} -lt 2 ]; then
+        log "WARNING: Only downloaded ${downloaded} files from MinIO, trying CN pod..."
+        download_record_files_from_cn "${output_dir}" "${max_files}"
+        return $?
+    fi
+
+    log "Downloaded ${downloaded} record files from MinIO via S3 API"
+
+    # Verify files were actually created
+    log "Verifying downloaded files in ${output_dir}:"
+    ls -lh "${output_dir}" | head -10 || log "ERROR: Could not list ${output_dir}"
+    local actual_files=$(find "${output_dir}" -type f | wc -l)
+    log "Found ${actual_files} files in ${output_dir}"
+
+    return 0
+}
+
+function download_record_files_from_cn {
+    local output_dir=$1
+    local max_files=${2:-50}
+
+    log "Downloading record files from Consensus Node..."
+
+    mkdir -p "${output_dir}"
+
+    # Find CN pod
+    local cn_pod=$(kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" get pod network-node1-0 -o name 2>/dev/null | cut -d/ -f2)
+    if [ -z "${cn_pod}" ]; then
+        cn_pod=$(kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" get pods -o name 2>/dev/null | grep "network-node1" | head -1 | cut -d/ -f2)
+    fi
+
+    if [ -z "${cn_pod}" ]; then
+        log "ERROR: Could not find consensus node pod"
+        return 1
+    fi
+
+    log "Found CN pod: ${cn_pod}"
+
+    # Check if record stream directory exists and list its contents
+    log "Checking CN record stream directory structure..."
+    kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" exec "${cn_pod}" -- \
+        sh -c "ls -la /opt/hiero/services-hedera/HapiApp2.0/data/recordStreams/ 2>/dev/null" || true
+
+    # Record files path in CN
+    kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" exec "${cn_pod}" -- \
+        sh -c "find /opt/hiero/services-hedera/HapiApp2.0/data/recordStreams/ -name '*.rcd' 2>/dev/null | head -${max_files}" > /tmp/cn-files.txt 2>/dev/null || {
+        log "WARNING: Could not list record files in standard path"
+    }
+
+    local file_list=$(cat /tmp/cn-files.txt)
+    if [ -z "${file_list}" ]; then
+        log "No .rcd files in standard path, trying record-stream-uploader container..."
+        # Try record-stream-uploader sidecar container
+        kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" exec "${cn_pod}" -c record-stream-uploader -- \
+            sh -c "find / -name '*.rcd' 2>/dev/null | grep -v '/proc/' | head -${max_files}" > /tmp/cn-files.txt 2>/dev/null || true
+
+        file_list=$(cat /tmp/cn-files.txt)
+        if [ -n "${file_list}" ]; then
+            log "Found files in record-stream-uploader container"
+        fi
+    fi
+
+    if [ -z "${file_list}" ]; then
+        log "Trying shared volumes in root-container..."
+        # Try common shared volume paths
+        for path in "/opt/hiero/streamData" "/data" "/streams"; do
+            kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" exec "${cn_pod}" -c root-container -- \
+                sh -c "find ${path} -name '*.rcd' 2>/dev/null | head -${max_files}" > /tmp/cn-files.txt 2>/dev/null || true
+            file_list=$(cat /tmp/cn-files.txt)
+            if [ -n "${file_list}" ]; then
+                log "Found files in ${path}"
+                break
+            fi
+        done
+    fi
+
+    if [ -z "${file_list}" ]; then
+        log "ERROR: No record files found in CN pod after checking all paths"
+        log "Listing /opt/hiero/services-hedera/HapiApp2.0/data/ contents:"
+        kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" exec "${cn_pod}" -- \
+            sh -c "find /opt/hiero/services-hedera/HapiApp2.0/data/ -maxdepth 3 -type d 2>/dev/null | head -20" || true
+        return 1
+    fi
+
+    log "Found $(echo "$file_list" | wc -l) record files in CN"
+
+    # Copy each file
+    local copied=0
+    while IFS= read -r file_path; do
+        if [ -n "${file_path}" ]; then
+            local filename=$(basename "${file_path}")
+            kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" cp \
+                "${cn_pod}:${file_path}" "${output_dir}/${filename}" 2>/dev/null && \
+                ((copied++)) || true
+        fi
+    done < /tmp/cn-files.txt
+
+    log "Downloaded ${copied} record files from CN"
+
+    if [ ${copied} -lt 2 ]; then
+        log "ERROR: Not enough record files downloaded"
+        return 1
+    fi
+
+    return 0
+}
+
+function wrap_records_with_cli {
+    local records_dir=$1
+    local output_dir=$2
+
+    log "Wrapping record files with WRB CLI..."
+    log "  Records: ${records_dir}"
+    log "  Output:  ${output_dir}"
+
+    mkdir -p "${output_dir}"
+
+    # Build the CLI if not already built
+    log "Building block-node CLI..."
+    ./gradlew :tools:installDist -x test > /tmp/cli-build.log 2>&1 || {
+        log "ERROR: Failed to build CLI"
+        tail -20 /tmp/cli-build.log
+        return 1
+    }
+
+    # Verify records directory has files
+    log "Checking for files in ${records_dir}..."
+    ls -lh "${records_dir}" | head -10 || log "ERROR: Could not list ${records_dir}"
+    local file_count=$(find "${records_dir}" -type f -name "*.rcd*" | wc -l)
+    log "Found ${file_count} .rcd* files in ${records_dir}"
+
+    # Decompress any .rcd.gz files
+    local gz_count=$(find "${records_dir}" -name "*.rcd.gz" | wc -l)
+    if [ ${gz_count} -gt 0 ]; then
+        log "Decompressing ${gz_count} .rcd.gz files..."
+        gunzip "${records_dir}"/*.rcd.gz || {
+            log "WARNING: Some files failed to decompress"
+        }
+    fi
+
+    # Package record files into tar.zstd day archives
+    # WRB CLI expects files in format: YYYY/MM/DD.tar.zstd
+    local days_dir="${WORK_DIR}/day-archives"
+    mkdir -p "${days_dir}"
+
+    # Get unique days from record filenames
+    local days=$(find "${records_dir}" -name "*.rcd" | xargs -n1 basename | cut -d'T' -f1 | sort -u)
+    local day_count=$(echo "${days}" | wc -l | tr -d '[:space:]')
+    log "Packaging ${day_count} days into tar.zstd archives..."
+
+    for day in ${days}; do
+        # Find all .rcd, .rcd.gz and .rcd_sig files for this day
+        local day_files=$(find "${records_dir}" \( -name "${day}T*.rcd" -o -name "${day}T*.rcd.gz" -o -name "${day}T*.rcd_sig" \) | sort)
+        local day_file_count=$(echo "${day_files}" | wc -l | tr -d '[:space:]')
+
+        if [ ${day_file_count} -eq 0 ]; then
+            log "WARNING: No files found for day ${day}"
+            continue
+        fi
+
+        # Create tar.zstd archive: YYYY-MM-DD.tar.zstd
+        local archive_path="${days_dir}/${day}.tar.zstd"
+        log "Creating archive ${archive_path} with ${day_file_count} files..."
+
+        tar -cf - -C "${records_dir}" $(echo "${day_files}" | xargs -n1 basename) | zstd -T0 > "${archive_path}" || {
+            log "ERROR: Failed to create archive ${archive_path}"
+            return 1
+        }
+    done
+
+    local rcd_count=$(find "${records_dir}" -name "*.rcd" | wc -l)
+    log "Packaged ${rcd_count} record files into day archives"
+
+    if [ ${rcd_count} -lt 1 ]; then
+        log "ERROR: No record files to wrap"
+        return 1
+    fi
+
+    # Extract genesis timestamp from first record file
+    local first_record_file=$(find "${records_dir}" -name "*.rcd" -o -name "*.rcd.gz" 2>/dev/null | sort | head -1)
+    if [ -z "${first_record_file}" ]; then
+        log "ERROR: No record files found to determine genesis timestamp"
+        return 1
+    fi
+
+    local genesis_timestamp=$(basename "${first_record_file}" | sed 's/\(.*\)\.rcd.*/\1/')
+    local genesis_date=$(echo "${genesis_timestamp}" | cut -d'T' -f1)
+    log "Extracted genesis from first record file: ${genesis_timestamp}"
+
+    # Create Solo network config for WRB CLI
+    local network_config_file="${WORK_DIR}/solo-network-config.json"
+    cat > "${network_config_file}" <<EOF
+{
+  "networkName": "solo",
+  "gcsBucketName": "solo-local",
+  "bucketPathPrefix": "recordstreams/",
+  "mirrorNodeApiUrl": "http://localhost:5551/api/v1/",
+  "genesisDate": "${genesis_date}",
+  "genesisTimestamp": "${genesis_timestamp}",
+  "minNodeAccountId": 3,
+  "maxNodeAccountId": 3,
+  "totalHbarSupplyTinybar": 5000000000000000000,
+  "genesisAddressBookResource": "mainnet-genesis-address-book.proto.bin"
+}
+EOF
+    log "Created Solo network config at ${network_config_file}"
+
+    # Generate metadata files (block_times.bin and day_blocks.json)
+    log "Generating metadata from record files..."
+    local block_times_file="${WORK_DIR}/block_times.bin"
+    local day_blocks_file="${WORK_DIR}/day_blocks.json"
+
+    # Convert genesis timestamp to epoch nanoseconds
+    local genesis_iso=$(echo "${genesis_timestamp}" | sed 's/_/:/g')
+    local genesis_datetime=$(echo "${genesis_iso}" | cut -d'.' -f1)
+    local genesis_nanos_part=$(echo "${genesis_iso}" | sed 's/.*\.\([0-9]*\)Z/\1/')
+
+    local genesis_epoch_seconds
+    if date --version >/dev/null 2>&1; then
+        genesis_epoch_seconds=$(date -u -d "${genesis_datetime}Z" +%s 2>/dev/null || echo "0")
+    else
+        genesis_epoch_seconds=$(date -u -j -f "%Y-%m-%dT%H:%M:%S" "${genesis_datetime}" +%s 2>/dev/null || echo "0")
+    fi
+
+    if [[ "${genesis_epoch_seconds}" == "0" ]]; then
+        log "ERROR: Failed to parse genesis timestamp: ${genesis_timestamp}"
+        return 1
+    fi
+
+    local genesis_epoch_nanos=$((genesis_epoch_seconds * 1000000000 + 10#${genesis_nanos_part}))
+    log "Genesis epoch nanos: ${genesis_epoch_nanos}"
+
+    # Generate metadata using Python script
+    local script_dir="$(dirname "${BASH_SOURCE[0]}")"
+    python3 "${script_dir}/python/generate_metadata.py" "${records_dir}" "${block_times_file}" "${day_blocks_file}" "${genesis_epoch_nanos}" || {
+        log "ERROR: Failed to generate metadata"
+        return 1
+    }
+    log "Generated metadata files: block_times.bin, day_blocks.json"
+
+    # Generate address book from Solo consensus node
+    log "Generating address book from Solo consensus node..."
+    local genesis_ts_with_nanos="${genesis_timestamp/T/_}"
+    genesis_ts_with_nanos="${genesis_ts_with_nanos/Z/}"
+    # Convert timestamp format: 2026-06-17T02_25_43.447997286Z -> seconds.nanos
+    local ts_parts=(${genesis_ts_with_nanos//./ })
+    local date_time="${ts_parts[0]}"
+    local nanos="${ts_parts[1]}"
+    local ts_seconds=$(date -j -f "%Y-%m-%dT%H_%M_%S" "${date_time}" +%s 2>/dev/null || \
+        date -d "${date_time//_/:}" +%s 2>/dev/null || echo "0")
+    local genesis_ts_formatted="${ts_seconds}.${nanos}"
+
+    local script_dir="$(dirname "${BASH_SOURCE[0]}")"
+    bash "${script_dir}/extract-solo-ab-and-generate.sh" \
+        "${NAMESPACE}" \
+        "${genesis_ts_formatted}" \
+        "${days_dir}/addressBookHistory.json" || {
+        log "WARNING: Could not extract address book from CN"
+        log "  Wrapping will proceed without signature validation"
+        log "  BlockProof will have empty signatures"
+    }
+
+    # Also generate binary address book (file 0.0.102 format) for MN2 importer
+    if [[ -f "${days_dir}/addressBookHistory.json" ]]; then
+        log "Generating binary address book for MN2 importer..."
+        java -cp "tools-and-tests/tools/build/install/tools/lib/*" \
+            org.hiero.block.tools.BlockStreamTool mirror generateBinFromAddressBookJson \
+            "${days_dir}/addressBookHistory.json" \
+            -o "${WORK_DIR}/addressbook.bin" && {
+            log "  Created binary address book at ${WORK_DIR}/addressbook.bin"
+        } || {
+            log "  WARNING: Failed to generate binary address book"
+        }
+    fi
+
+    # Run WRB CLI to wrap the record files
+    log "Running WRB CLI wrap command..."
+    log "  Input days:  ${days_dir}"
+    log "  Output dir:  ${output_dir}"
+
+    HIERO_NETWORK_CONFIG="${network_config_file}" java -cp "tools-and-tests/tools/build/install/tools/lib/*" \
+        org.hiero.block.tools.BlockStreamTool blocks wrap \
+        --network other \
+        --input-dir "${days_dir}" \
+        --output-dir "${output_dir}" \
+        --blocktimes-file "${block_times_file}" \
+        --day-blocks "${day_blocks_file}" \
+        --skip-block-number-validation > /tmp/wrb-wrap.log 2>&1 || {
+        log "ERROR: WRB CLI wrap failed"
+        tail -30 /tmp/wrb-wrap.log
+        return 1
+    }
+
+    # Verify wrapped blocks were created
+    local wrapped_count=$(find "${output_dir}" -type f \( -name "*.zip" -o -name "*.blk.*" \) 2>/dev/null | wc -l)
+    log "Created ${wrapped_count} wrapped block files"
+    log "Contents of wrapped blocks dir:"
+    find "${output_dir}" -type f 2>/dev/null | sed 's/^/    /' | head -20 || true
+
+    if [ ${wrapped_count} -lt 1 ]; then
+        log "ERROR: No wrapped blocks created"
+        tail -30 /tmp/wrb-wrap.log
+        return 1
+    fi
+
+    log "✓ Successfully wrapped ${rcd_count} record files into ${wrapped_count} block files"
+
+    # Display signature validation debug logs
+    if grep -q "\[SIGNATURE DEBUG\]" /tmp/wrb-wrap.log 2>/dev/null; then
+        log ""
+        log "=== SIGNATURE DEBUG LOGS ==="
+        grep "\[SIGNATURE DEBUG\]" /tmp/wrb-wrap.log
+        log "=== END SIGNATURE DEBUG LOGS ==="
+    fi
+
+    return 0
+}
+
+function capture_mn_responses {
+    local mn_url=$1
+    local output_dir=$2
+
+    log "Capturing API responses from ${mn_url}..."
+
+    rm -rf "${output_dir}"
+    mkdir -p "${output_dir}"
+
+    # Use curl instead of Python script (no dependencies needed)
+    log "  Capturing blocks (list)..."
+    local http_status=$(curl -s -w "%{http_code}" -o "${output_dir}/blocks.json" "${mn_url}/blocks?limit=100&order=asc" 2>/dev/null || echo "000")
+    log "    HTTP status: ${http_status}"
+
+    # Capture individual blocks for comparison (block 0, blocks 1-10)
+    log "  Capturing individual blocks (block 0, blocks 1-10)..."
+    for block_num in 0 1 2 3 4 5 6 7 8 9 10; do
+        curl -s "${mn_url}/blocks/${block_num}" > "${output_dir}/block_${block_num}.json" 2>/dev/null || true
+    done
+
+    log "  Capturing transactions..."
+    curl -s "${mn_url}/transactions?limit=1000&order=asc" > "${output_dir}/transactions.json" 2>/dev/null || true
+
+    log "  Capturing network nodes..."
+    curl -s "${mn_url}/network/nodes" > "${output_dir}/network_nodes.json" 2>/dev/null || true
+
+    log "  Capturing balances..."
+    curl -s "${mn_url}/balances?limit=1000" > "${output_dir}/balances.json" 2>/dev/null || true
+
+    # Check if we got any responses
+    local file_count=$(find "${output_dir}" -name "*.json" -size +10c | wc -l)
+    if [ ${file_count} -lt 1 ]; then
+        log "WARNING: No API responses captured (API may not be accessible)"
+        log "This is OK - ingestion was verified via logs"
+        return 0
+    fi
+
+    log "Responses captured to ${output_dir} (${file_count} files)"
+}
+
+function validate_responses {
+    local capture_dir=${1:-${MN_CAPTURE_DIR}}
+
+    log "Validating captured responses..."
+
+    local response_count=$(find "${capture_dir}" -type f -name "*.json" | wc -l)
+
+    if [[ ${response_count} -lt 3 ]]; then
+        log "ERROR: Only captured ${response_count} responses (expected at least 3)"
+        return 1
+    fi
+
+    log "✓ Captured ${response_count} API responses"
+
+    # Validate blocks response has data
+    if [ -f "${capture_dir}/blocks.json" ]; then
+        # Show raw response for debugging
+        log "  Raw blocks API response (first 500 chars):"
+        head -c 500 "${capture_dir}/blocks.json" | sed 's/^/    /'
+
+        local block_count=$(python3 -c "import json; data=json.load(open('${capture_dir}/blocks.json')); print(len(data.get('blocks', [])))" 2>/dev/null || echo "0")
+        log "  Blocks captured: ${block_count}"
+        if [ ${block_count} -lt 1 ]; then
+            log "ERROR: No blocks found in API response"
+            log "Full response saved to: ${capture_dir}/blocks.json"
+            return 1
+        fi
+    fi
+
+    # Validate transactions response has data
+    if [ -f "${capture_dir}/transactions.json" ]; then
+        local tx_count=$(python3 -c "import json; data=json.load(open('${capture_dir}/transactions.json')); print(len(data.get('transactions', [])))" 2>/dev/null || echo "0")
+        log "  Transactions captured: ${tx_count}"
+        if [ ${tx_count} -lt 1 ]; then
+            log "ERROR: No transactions found in API response"
+            return 1
+        fi
+    fi
+
+    log "✓ API responses contain valid data"
+    return 0
+}
+
+function compare_phase_responses {
+    log "Comparing Phase 1 vs Phase 2 responses..."
+
+    if [ ! -d "${MN_CAPTURE_DIR}" ] || [ ! -d "${MN_WRB_CAPTURE_DIR}" ]; then
+        log "WARNING: Missing response directories, skipping comparison"
+        return 0
+    fi
+
+    python3 "${PYTHON_DIR}/compare_captured_responses.py" \
+        "${MN_CAPTURE_DIR}" \
+        "${MN_WRB_CAPTURE_DIR}" \
+        --output /tmp/comparison-report.json \
+        --verbose || {
+        log "⚠️  Responses differ between Phase 1 and Phase 2"
+        log "This is expected if block production continued between phases"
+        return 0
+    }
+
+    log "✓ Phase 1 and Phase 2 responses match"
+    return 0
+}
+
+function create_wrb_namespace {
+    log "Creating namespace ${WRB_NAMESPACE}..."
+
+    kubectl --context "${CONTEXT}" create namespace "${WRB_NAMESPACE}" 2>/dev/null || {
+        log "Namespace already exists, cleaning up..."
+        kubectl --context "${CONTEXT}" delete namespace "${WRB_NAMESPACE}" --ignore-not-found
+        sleep 5
+        kubectl --context "${CONTEXT}" create namespace "${WRB_NAMESPACE}"
+    }
+
+    log "Namespace ${WRB_NAMESPACE} ready"
+}
+
+function deploy_standalone_bn2 {
+    local wrapped_blocks_dir=$1
+
+    log "Deploying standalone BN2 in ${WRB_NAMESPACE}..."
+
+    # Get the Block Node image from BN1 deployment
+    local bn_image=$(kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" get statefulset block-node-1 -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo "")
+    if [ -z "${bn_image}" ]; then
+        log "ERROR: Could not determine Block Node image from BN1"
+        return 1
+    fi
+    log "Using Block Node image: ${bn_image}"
+
+    # Extract version from image tag (e.g., ghcr.io/hiero-ledger/hiero-block-node:0.35.1 -> 0.35.1)
+    local bn_version="${bn_image##*:}"
+    log "Block Node version: ${bn_version}"
+
+    # Create a deployment manifest for BN2
+    local bn2_manifest="/tmp/bn2-deployment.yaml"
+
+    cat > "${bn2_manifest}" << EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bn2-storage
+  namespace: ${WRB_NAMESPACE}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: block-node-2
+  namespace: ${WRB_NAMESPACE}
+spec:
+  serviceName: block-node-2
+  replicas: 1
+  selector:
+    matchLabels:
+      app: block-node-2
+  template:
+    metadata:
+      labels:
+        app: block-node-2
+    spec:
+      initContainers:
+      - name: copy-core-modules
+        image: ${bn_image}
+        command:
+        - cp
+        - /opt/hiero/block-node/app-${bn_version}/lib/.core-modules.txt
+        - /plugins/.core-modules.txt
+        volumeMounts:
+        - name: plugins-storage
+          mountPath: /plugins
+      - name: resolve-plugins
+        image: maven:3-eclipse-temurin-25-alpine
+        command:
+        - sh
+        - -c
+        - |
+          set -e
+          DESIRED_HASH=\$(echo "${bn_version}:facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-historic,blocks-file-recent,backfill::[{\"id\":\"central\",\"url\":\"https://repo1.maven.org/maven2\"},{\"id\":\"besu-maven\",\"url\":\"https://artifacts.hashgraph.io/artifactory/hyperledger-besu-maven-external/\"},{\"id\":\"consensys\",\"url\":\"https://artifacts.consensys.net/public/maven/maven/\"},{\"id\":\"sonatype-snapshots\",\"snapshots\":true,\"url\":\"https://central.sonatype.com/repository/maven-snapshots\"}]" | sha256sum | cut -d' ' -f1)
+          if [ -f /plugins/.resolved-hash ] && [ "\$(cat /plugins/.resolved-hash)" = "\$DESIRED_HASH" ]; then
+            echo "Plugins already resolved. Skipping."
+            exit 0
+          fi
+          if [ -f /plugins/.resolved-jars ]; then
+            while IFS= read -r jar; do
+              rm -f "/plugins/\$jar"
+            done < /plugins/.resolved-jars
+          fi
+          rm -f /plugins/.resolved-hash /plugins/.resolved-jars
+
+          echo "Resolving plugins via Maven..."
+          cat > /tmp/pom.xml << 'POMEOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <project xmlns="http://maven.apache.org/POM/4.0.0"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+            <modelVersion>4.0.0</modelVersion>
+            <groupId>plugin-resolver</groupId>
+            <artifactId>plugin-resolver</artifactId>
+            <version>1.0</version>
+            <repositories>
+              <repository><id>central</id><url>https://repo1.maven.org/maven2</url></repository>
+              <repository><id>besu-maven</id><url>https://artifacts.hashgraph.io/artifactory/hyperledger-besu-maven-external/</url></repository>
+              <repository><id>consensys</id><url>https://artifacts.consensys.net/public/maven/maven/</url></repository>
+              <repository><id>sonatype-snapshots</id><url>https://central.sonatype.com/repository/maven-snapshots</url><snapshots><enabled>true</enabled></snapshots></repository>
+            </repositories>
+            <dependencies>
+              <dependency><groupId>org.hiero.block-node</groupId><artifactId>facility-messaging</artifactId><version>${bn_version}</version></dependency>
+              <dependency><groupId>org.hiero.block-node</groupId><artifactId>block-access-service</artifactId><version>${bn_version}</version></dependency>
+              <dependency><groupId>org.hiero.block-node</groupId><artifactId>health</artifactId><version>${bn_version}</version></dependency>
+              <dependency><groupId>org.hiero.block-node</groupId><artifactId>server-status</artifactId><version>${bn_version}</version></dependency>
+              <dependency><groupId>org.hiero.block-node</groupId><artifactId>stream-publisher</artifactId><version>${bn_version}</version></dependency>
+              <dependency><groupId>org.hiero.block-node</groupId><artifactId>stream-subscriber</artifactId><version>${bn_version}</version></dependency>
+              <dependency><groupId>org.hiero.block-node</groupId><artifactId>verification</artifactId><version>${bn_version}</version></dependency>
+              <dependency><groupId>org.hiero.block-node</groupId><artifactId>blocks-file-historic</artifactId><version>${bn_version}</version></dependency>
+              <dependency><groupId>org.hiero.block-node</groupId><artifactId>blocks-file-recent</artifactId><version>${bn_version}</version></dependency>
+              <dependency><groupId>org.hiero.block-node</groupId><artifactId>backfill</artifactId><version>${bn_version}</version></dependency>
+            </dependencies>
+          </project>
+          POMEOF
+
+          mvn -f /tmp/pom.xml dependency:copy-dependencies -DoutputDirectory=/plugins -Dsilent=true
+          find /plugins -name "*.jar" -exec basename {} \; > /plugins/.resolved-jars
+          echo "\$DESIRED_HASH" > /plugins/.resolved-hash
+          echo "Plugins resolved successfully."
+        volumeMounts:
+        - name: plugins-storage
+          mountPath: /plugins
+      containers:
+      - name: block-node-server
+        image: ${bn_image}
+        ports:
+        - containerPort: 40840
+          name: grpc
+        volumeMounts:
+        - name: data
+          mountPath: /opt/hiero/block-node/data
+        - name: plugins-storage
+          mountPath: /opt/hiero/block-node/app-${bn_version}/plugins
+        env:
+        - name: VERSION
+          value: "${bn_version}"
+        - name: STORAGE_FILES_HISTORIC_ROOT_PATH
+          value: "/opt/hiero/block-node/data/historic"
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: bn2-storage
+      - name: plugins-storage
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: block-node-2
+  namespace: ${WRB_NAMESPACE}
+spec:
+  selector:
+    app: block-node-2
+  ports:
+  - port: 40840
+    targetPort: 40840
+    name: grpc
+EOF
+
+    kubectl --context "${CONTEXT}" apply -f "${bn2_manifest}"
+
+    # Wait for BN2 to be ready (longer timeout for Maven dependency resolution in init containers)
+    log "Waiting for BN2 pod to be ready (may take several minutes for plugin downloads)..."
+    kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" wait --for=condition=ready pod -l app=block-node-2 --timeout=600s || {
+        log "ERROR: BN2 pod not ready after 10 minutes"
+        log "Pod status:"
+        kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" get pod -l app=block-node-2 -o wide || true
+        log "Pod events:"
+        kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" describe pod -l app=block-node-2 | tail -50 || true
+        log "Init container logs (copy-core-modules):"
+        kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" logs -l app=block-node-2 -c copy-core-modules --tail=50 || true
+        log "Init container logs (resolve-plugins):"
+        kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" logs -l app=block-node-2 -c resolve-plugins --tail=100 || true
+        log "Main container logs (if started):"
+        kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" logs -l app=block-node-2 -c block-node-server --tail=50 || true
+        return 1
+    }
+
+    # Copy wrapped blocks to BN2
+    log "Copying wrapped blocks to BN2..."
+    local pod_name=$(kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" get pod -l app=block-node-2 -o jsonpath='{.items[0].metadata.name}')
+
+    kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" exec "${pod_name}" -- mkdir -p /opt/hiero/block-node/data/historic
+
+    kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" cp "${wrapped_blocks_dir}/." "${pod_name}:/opt/hiero/block-node/data/historic/" || {
+        log "ERROR: Failed to copy wrapped blocks to BN2"
+        return 1
+    }
+
+    # Verify files were copied
+    local file_count=$(kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" exec "${pod_name}" -- find /opt/hiero/block-node/data/historic -type f | wc -l)
+    log "Copied ${file_count} files to BN2"
+    log "Files in BN2 historic dir:"
+    kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" exec "${pod_name}" -- find /opt/hiero/block-node/data/historic -type f 2>/dev/null | sed 's/^/    /' || true
+
+    # Restart BN2 to force BlockFileHistoricPlugin to re-scan and detect the blocks
+    log "Restarting BN2 to load historic blocks..."
+    kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" delete pod "${pod_name}"
+
+    # Wait for new pod to be ready
+    kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" wait --for=condition=ready pod -l app=block-node-2 --timeout=300s || {
+        log "ERROR: BN2 pod not ready after restart"
+        return 1
+    }
+
+    # Get new pod name
+    pod_name=$(kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" get pod -l app=block-node-2 -o jsonpath='{.items[0].metadata.name}')
+    log "BN2 restarted with pod: ${pod_name}"
+
+    # Give BN2 a moment to start serving (logs show it starts in <1s)
+    log "Waiting for BN2 to start gRPC server..."
+    sleep 5
+
+    # Verify server started by checking logs
+    if kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" logs "${pod_name}" | grep -q "Started all channels"; then
+        log "✓ BN2 gRPC server started successfully"
+    else
+        log "WARNING: Could not confirm BN2 server startup from logs, but continuing..."
+    fi
+
+    log "BN2 deployed successfully with wrapped blocks"
+
+    # Capture BN2 logs to debug historic plugin
+    log "BN2 startup logs (checking BlockFileHistoricPlugin):"
+    kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" logs "${pod_name}" --tail=100 | grep -E "(BlockFileHistoric|historic|INFO.*BlockNodeApp)" || log "No historic plugin logs found"
+
+    # Check what files BN2 sees in historic directory
+    log "Files in BN2 historic directory:"
+    kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" exec "${pod_name}" -- find /opt/hiero/block-node/data/historic -type f | head -20 || log "Could not list files"
+
+    # Query BN2 via gRPC for its actual block range
+    log "Querying BN2 gRPC server for available blocks..."
+
+    # Use grpcurl to query server status which should tell us the block range
+    local server_status=$(kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" exec block-node-2-0 -- \
+        grpcurl -plaintext -d '{}' localhost:40840 com.hedera.hapi.block.stream.BlockStreamService/serverStatus 2>/dev/null || echo "")
+
+    local bn2_first_block="0"
+    if [[ -n "${server_status}" ]]; then
+        # Try to extract firstAvailableBlock from the response
+        bn2_first_block=$(echo "${server_status}" | grep -o '"firstAvailableBlock"[[:space:]]*:[[:space:]]*[0-9]*' | grep -o '[0-9]*$' || echo "0")
+        log "BN2 reports first available block from gRPC: ${bn2_first_block}"
+    else
+        log "WARNING: Could not query BN2 via gRPC, using 0"
+    fi
+
+    # Return the first block number for use by MN2
+    echo "${bn2_first_block}"
+}
+
+function deploy_mn2_to_bn2 {
+    local start_block=$1
+    local address_book_file=$2
+
+    # Convert to integer (strip leading zeros) - handle empty/invalid values
+    if [[ -z "${start_block}" || "${start_block}" =~ [^0-9] ]]; then
+        start_block=0
+    else
+        start_block=$((10#${start_block}))
+    fi
+
+    log "Deploying MN2 in ${WRB_NAMESPACE} connected to BN2..."
+    log "MN2 will start from block: ${start_block}"
+
+    # Get the Mirror Node importer and REST images from MN1 deployment
+    local mn_importer_image=$(kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" get deployment mirror-1-importer -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo "")
+    local mn_rest_image=$(kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" get deployment mirror-1-rest -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || echo "")
+
+    if [ -z "${mn_importer_image}" ]; then
+        log "WARNING: Could not get MN1 importer image, using default"
+        mn_importer_image="gcr.io/mirrornode/hedera-mirror-importer:0.156.0"
+    fi
+
+    if [ -z "${mn_rest_image}" ]; then
+        log "WARNING: Could not get MN1 REST image, using default"
+        mn_rest_image="gcr.io/mirrornode/hedera-mirror-rest-java:0.156.0"
+    fi
+
+    log "Using Mirror Node importer image: ${mn_importer_image}"
+    log "Using Mirror Node REST image: ${mn_rest_image}"
+
+    # Read and base64-encode the binary address book for MN2
+    # Format must be binary NodeAddressBook protobuf (file 0.0.102 format)
+    local address_book_b64=""
+    if [[ -f "${address_book_file}" ]]; then
+        address_book_b64=$(base64 < "${address_book_file}" | tr -d '\n')
+        log "Loaded binary address book from ${address_book_file} ($(wc -c < "${address_book_file}") bytes)"
+    else
+        log "WARNING: Address book file not found at ${address_book_file}"
+        log "  MN2 will use default address book and may fail verification"
+    fi
+
+    local mn2_manifest="/tmp/mn2-deployment.yaml"
+
+    cat > "${mn2_manifest}" << EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mn2-importer-secret
+  namespace: ${WRB_NAMESPACE}
+type: Opaque
+data:
+  addressbook.bin: ${address_book_b64}
+  application.yaml: $(echo -n "hiero:
+  mirror:
+    importer:
+      initialAddressBook: /usr/etc/hiero/addressbook.bin" | base64 | tr -d '\n')
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mn2-importer-config
+  namespace: ${WRB_NAMESPACE}
+data:
+  application.yml: |
+    spring:
+      datasource:
+        url: jdbc:postgresql://mn2-postgres:5432/mirror_node?sslmode=disable
+        username: mirror_node
+        password: mirror_node_pass
+      jpa:
+        properties:
+          hibernate:
+            hbm2ddl:
+              auto: create
+    hiero:
+      mirror:
+        importer:
+          network: OTHER
+          block:
+            enabled: true
+            nodes:
+              - host: block-node-2.${WRB_NAMESPACE}.svc.cluster.local
+                port: 40840
+            sourceType: BLOCK_NODE
+          downloader:
+            bucketName: dummy-not-used
+            record:
+              enabled: false
+            balance:
+              enabled: false
+          startBlockNumber: ${start_block}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mn2-postgres
+  namespace: ${WRB_NAMESPACE}
+spec:
+  type: ClusterIP
+  selector:
+    app: mn2-postgres
+  ports:
+  - port: 5432
+    targetPort: 5432
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mn2-postgres-init
+  namespace: ${WRB_NAMESPACE}
+data:
+  init.sql: |
+    CREATE EXTENSION IF NOT EXISTS btree_gist;
+    CREATE EXTENSION IF NOT EXISTS pg_trgm;
+    CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+    CREATE ROLE readonly;
+    CREATE ROLE readwrite IN ROLE readonly;
+    CREATE ROLE temporary_admin IN ROLE readwrite;
+    CREATE ROLE mirror_importer;
+    CREATE ROLE mirror_grpc;
+    CREATE ROLE mirror_rest;
+    CREATE ROLE mirror_web3;
+    -- Grant temp schema admin privileges (CRITICAL for entity_temp creation)
+    GRANT temporary_admin TO mirror_node;
+    GRANT temporary_admin TO mirror_importer;
+    -- Create temporary schema owned by temporary_admin
+    CREATE SCHEMA IF NOT EXISTS temporary AUTHORIZATION temporary_admin;
+    GRANT USAGE ON SCHEMA temporary TO public;
+    -- Grant permissions to mirror_node user (owns database)
+    GRANT ALL PRIVILEGES ON DATABASE mirror_node TO mirror_node;
+    GRANT ALL PRIVILEGES ON SCHEMA public TO mirror_node;
+    GRANT ALL PRIVILEGES ON SCHEMA temporary TO mirror_node;
+    GRANT mirror_importer TO mirror_node;
+    GRANT mirror_rest TO mirror_node;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO mirror_node;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO mirror_node;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA temporary GRANT ALL ON TABLES TO mirror_node;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA temporary GRANT ALL ON SEQUENCES TO mirror_node;
+    -- CRITICAL: Set search_path so temporary tables are found
+    ALTER DATABASE mirror_node SET search_path = public, public, temporary;
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mn2-postgres
+  namespace: ${WRB_NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mn2-postgres
+  template:
+    metadata:
+      labels:
+        app: mn2-postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:14-alpine
+        env:
+        - name: POSTGRES_DB
+          value: mirror_node
+        - name: POSTGRES_USER
+          value: mirror_node
+        - name: POSTGRES_PASSWORD
+          value: mirror_node_pass
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - name: init-scripts
+          mountPath: /docker-entrypoint-initdb.d
+      volumes:
+      - name: init-scripts
+        configMap:
+          name: mn2-postgres-init
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mn2-rest-config
+  namespace: ${WRB_NAMESPACE}
+data:
+  application.yml: |
+    hiero:
+      mirror:
+        common:
+          shard: 0
+          realm: 0
+        rest:
+          cache:
+            entityId:
+              maxAge: 600
+              maxSize: 100000
+            response:
+              enabled: false
+            token:
+              maxSize: 50000
+          db:
+            host: mirror-1-postgres-postgresql.${NAMESPACE}.svc.cluster.local
+            port: 5432
+            name: mirror_node_wrb
+            username: mirror_node
+            password: mirror_node_pass
+            pool:
+              connectionTimeout: 30000
+              maxConnections: 50
+              statementTimeout: 30000
+            tls:
+              enabled: false
+          log:
+            level: INFO
+          openapi:
+            enabled: false
+            specVersion: openapi
+            validation:
+              enabled: false
+          port: 5551
+          query:
+            maxRecordFileCloseInterval: 2m
+            maxScheduledTransactionConsensusTimestampRange: 30d
+            maxTimestampRange: 7d
+            maxTransactionConsensusTimestampRange: 30d
+            maxTransactionsTimestampRange: 1h
+            maxValidStartTimestampDrift: 24h
+            transactions:
+              precedingTransactionTypes: []
+          redis:
+            enabled: true
+            sentinel:
+              enabled: false
+            uri: redis://mirror-1-redis-node.${NAMESPACE}.svc.cluster.local:6379
+          response:
+            limit:
+              default: 25
+              max: 100
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mirror-2-importer
+  namespace: ${WRB_NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mirror-2-importer
+  template:
+    metadata:
+      labels:
+        app: mirror-2-importer
+    spec:
+      containers:
+      - name: importer
+        image: ${mn_importer_image}
+        volumeMounts:
+        - name: addressbook
+          mountPath: /usr/etc/hiero
+          readOnly: true
+        - name: config
+          mountPath: /app/config
+          readOnly: true
+        env:
+        - name: SPRING_CONFIG_ADDITIONAL_LOCATION
+          value: "file:/usr/etc/hiero/"
+        - name: SPRING_DATASOURCE_URL
+          value: jdbc:postgresql://mn2-postgres:5432/mirror_node?sslmode=disable
+        - name: SPRING_DATASOURCE_USERNAME
+          value: mirror_node
+        - name: SPRING_DATASOURCE_PASSWORD
+          value: mirror_node_pass
+        - name: HIERO_MIRROR_IMPORTER_NETWORK
+          value: "OTHER"
+        - name: HIERO_MIRROR_IMPORTER_BLOCK_ENABLED
+          value: "true"
+        - name: HIERO_MIRROR_IMPORTER_BLOCK_NODES_0_HOST
+          value: block-node-2.solo-wrb-test.svc.cluster.local
+        - name: HIERO_MIRROR_IMPORTER_BLOCK_NODES_0_PORT
+          value: "40840"
+        - name: HIERO_MIRROR_IMPORTER_BLOCK_SOURCETYPE
+          value: BLOCK_NODE
+        - name: HIERO_MIRROR_IMPORTER_DOWNLOADER_BUCKETNAME
+          value: "dummy-not-used"
+        - name: HIERO_MIRROR_IMPORTER_DB_TEMPSCHEMA
+          value: "temporary"
+        - name: HIERO_MIRROR_IMPORTER_DB_SCHEMA
+          value: "public"
+        - name: HIERO_MIRROR_IMPORTER_DOWNLOADER_RECORD_ENABLED
+          value: "false"
+        - name: HIERO_MIRROR_IMPORTER_DOWNLOADER_BALANCE_ENABLED
+          value: "false"
+        - name: HIERO_MIRROR_IMPORTER_STARTBLOCKNUMBER
+          value: "0"
+      volumes:
+      - name: addressbook
+        secret:
+          secretName: mn2-importer-secret
+      - name: config
+        configMap:
+          name: mn2-importer-config
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mirror-2-rest
+  namespace: ${WRB_NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mirror-2-rest
+  template:
+    metadata:
+      labels:
+        app: mirror-2-rest
+    spec:
+      containers:
+      - name: rest
+        image: ${mn_rest_image}
+        ports:
+        - containerPort: 8080
+        env:
+        - name: HIERO_MIRROR_REST_DB_HOST
+          value: mn2-postgres
+        - name: HIERO_MIRROR_REST_DB_NAME
+          value: mirror_node
+        - name: HIERO_MIRROR_REST_DB_USERNAME
+          value: mirror_node
+        - name: HIERO_MIRROR_REST_DB_PASSWORD
+          value: mirror_node_pass
+        - name: HIERO_MIRROR_REST_PORT
+          value: "8080"
+        - name: HIERO_MIRROR_REST_REDIS_URI
+          value: redis://mirror-1-redis-node.solo-network.svc.cluster.local:6379
+        - name: HIERO_MIRROR_COMMON_SHARD
+          value: "0"
+        - name: HIERO_MIRROR_COMMON_REALM
+          value: "0"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mirror-2-rest
+  namespace: ${WRB_NAMESPACE}
+spec:
+  type: ClusterIP
+  selector:
+    app: mirror-2-rest
+  ports:
+  - port: 80
+    targetPort: 8080
+    name: http
+EOF
+
+    kubectl --context "${CONTEXT}" apply -f "${mn2_manifest}"
+
+    # Wait for MN2 importer to be ready
+    log "Waiting for MN2 importer pod to be ready..."
+    kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" wait --for=condition=ready pod -l app=mirror-2-importer --timeout=300s || {
+        log "ERROR: MN2 importer pod not ready after 300s"
+        kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" describe pod -l app=mirror-2-importer || true
+        kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" logs -l app=mirror-2-importer --tail=50 || true
+        return 1
+    }
+
+    # Give importer time to start and log startup
+    sleep 10
+    log "MN2 importer startup logs:"
+    kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" logs -l app=mirror-2-importer --tail=100 || true
+
+    # Wait for MN2 REST to be ready
+    log "Waiting for MN2 REST pod to be ready..."
+    kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" wait --for=condition=ready pod -l app=mirror-2-rest --timeout=300s || {
+        log "ERROR: MN2 REST pod not ready after 300s"
+        kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" describe pod -l app=mirror-2-rest || true
+        kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" logs -l app=mirror-2-rest --tail=50 || true
+        return 1
+    }
+
+    # Set up port forward for MN2 API
+    log "Setting up port forward to MN2 API..."
+    kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" port-forward svc/mirror-2-rest ${MN_WRB_PORT}:80 &
+    local pf_pid=$!
+    echo $pf_pid > /tmp/mn2-port-forward.pid
+    sleep 5
+
+    log "MN2 deployed successfully (API at ${MN_WRB_URL})"
+}
+
+# Main test flow
+function main {
+    log "Starting Block Ingestion Validation Test"
+    log "=========================================="
+    log "  Main namespace:    ${NAMESPACE}"
+    log "  WRB namespace:     ${WRB_NAMESPACE}"
+    log "  Deployment:        ${DEPLOYMENT}"
+    log "  Block range:       ${BLOCK_RANGE}"
+    log ""
+
+    # Clean up from previous runs
+    log "Cleaning up from previous runs..."
+    helm --kube-context "${CONTEXT}" --namespace "${NAMESPACE}" uninstall mirror-1 --ignore-not-found || true
+    helm --kube-context "${CONTEXT}" --namespace "${NAMESPACE}" uninstall mirror-2 --ignore-not-found || true
+    kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" delete pvc data-mirror-1-postgres-postgresql-0 --ignore-not-found || true
+
+    # Clear Solo's deployment tracking state to prevent auto-increment to mirror-2
+    rm -rf ~/.solo/deployments/${DEPLOYMENT}/mirror-*.json 2>/dev/null || true
+    rm -rf ~/.solo/cache/${DEPLOYMENT}-mirror-*.yaml 2>/dev/null || true
+
+    # Clean up work directory
+    rm -rf "${WORK_DIR}"
+    mkdir -p "${WORK_DIR}"
+
+    log ""
+    log "Waiting for network to generate blocks..."
+    sleep 60  # Give the network time to generate blocks
+
+    # ===== Phase 1: Basic Block Ingestion Test (MN1 → BN1) =====
+    log ""
+    log "Phase 1: Basic Block Ingestion Test (BN1 → MN1)"
+    log "================================================"
+
+    deploy_mn_to_bn || return 1
+    wait_for_mn_ingestion "${MIN_TRANSACTIONS}" 360 || return 1
+    capture_mn_responses "${MN_URL}" "${MN_CAPTURE_DIR}" || return 1
+    validate_responses "${MN_CAPTURE_DIR}" || return 1
+
+    log ""
+    log "✅ Phase 1 complete! Basic block ingestion working."
+
+    # ===== Phase 2: WRB CLI Wrapping Test (MN2 → BN2) =====
+    log ""
+    log "Phase 2: WRB CLI Wrapping Test (BN2 → MN2)"
+    log "==========================================="
+    log "This phase tests CLI-wrapped blocks:"
+    log "  1. Download record files from MinIO (or CN fallback)"
+    log "  2. Wrap them using WRB CLI (blocks wrap)"
+    log "  3. Deploy BN2 with wrapped blocks in separate namespace"
+    log "  4. Deploy MN2 and validate ingestion"
+    log "  5. Compare API responses between Phase 1 and Phase 2"
+    log ""
+
+    # Download record files from MinIO (with CN fallback)
+    local records_dir="${WORK_DIR}/records"
+    download_record_files_from_minio "${records_dir}" 50 || {
+        log "WARNING: Could not download record files, skipping Phase 2"
+        log "✅ Phase 1 passed, Phase 2 skipped"
+        return 0
+    }
+
+    # Wrap record files using WRB CLI
+    wrap_records_with_cli "${records_dir}" "${WRAPPED_BLOCKS_DIR}" || {
+        log "WARNING: Could not wrap record files, skipping Phase 2"
+        log "✅ Phase 1 passed, Phase 2 skipped"
+        return 0
+    }
+
+    # Create separate namespace
+    create_wrb_namespace || return 1
+
+    # Deploy BN2 with wrapped blocks and get first block number
+    local bn2_first_block=$(deploy_standalone_bn2 "${WRAPPED_BLOCKS_DIR}") || return 1
+
+    # Deploy MN2 connected to BN2, starting from BN2's first block
+    # Use the binary address book file (file 0.0.102 format) for MN2 importer
+    local address_book_bin="${WORK_DIR}/addressbook.bin"
+    deploy_mn2_to_bn2 "${bn2_first_block}" "${address_book_bin}" || return 1
+
+    # Wait for MN2 to start and begin ingesting
+    log "Waiting for MN2 to start and ingest CLI-wrapped blocks..."
+    local elapsed=0
+    local timeout=480
+    local api_ready=false
+
+    while [[ ${elapsed} -lt ${timeout} ]]; do
+        # Check if REST API is responding
+        if curl -sf "${MN_WRB_URL}/blocks?limit=1" >/dev/null 2>&1; then
+            api_ready=true
+            log "MN2 REST API is ready after ${elapsed}s"
+            break
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+
+    if [[ "${api_ready}" != "true" ]]; then
+        log "WARNING: MN2 REST API not ready after ${timeout}s"
+
+        # Debug: capture MN2 pod logs
+        log "Capturing MN2 pod state for debugging..."
+
+        local mn2_importer_pod=$(kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" get pods -l app=mirror-2-importer -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+        if [[ -n "${mn2_importer_pod}" ]]; then
+            log "MN2 importer pod: ${mn2_importer_pod}"
+            log "MN2 importer pod status:"
+            kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" get pod "${mn2_importer_pod}" -o wide 2>&1 | sed 's/^/  /'
+            log "MN2 importer pod logs (last 100 lines):"
+            kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" logs "${mn2_importer_pod}" --tail=100 2>&1 | sed 's/^/  /'
+        fi
+
+        local mn2_rest_pod=$(kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" get pods -l app=mirror-2-rest -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+        if [[ -n "${mn2_rest_pod}" ]]; then
+            log "MN2 REST pod: ${mn2_rest_pod}"
+            log "MN2 REST pod status:"
+            kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" get pod "${mn2_rest_pod}" -o wide 2>&1 | sed 's/^/  /'
+            log "MN2 REST pod logs (last 100 lines):"
+            kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" logs "${mn2_rest_pod}" --tail=100 2>&1 | sed 's/^/  /'
+        fi
+
+        # Check database schema
+        local mn2_postgres_pod=$(kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" get pods -l app=mn2-postgres -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+        if [[ -n "${mn2_postgres_pod}" ]]; then
+            log "Checking MN2 database schema:"
+            kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" exec "${mn2_postgres_pod}" -- psql -U mirror_node -d mirror_node -c "SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY tablename LIMIT 10;" 2>&1 | sed 's/^/  /'
+        fi
+
+        log "✅ Phase 1 passed, Phase 2 incomplete"
+        return 0
+    fi
+
+    # Monitor MN2 ingestion progress
+    log "Monitoring MN2 ingestion (up to 120s)..."
+    local wait_time=0
+    local max_wait=120
+    local blocks_found=false
+
+    while [[ ${wait_time} -lt ${max_wait} ]]; do
+        # Check database for blocks
+        local mn2_postgres_pod=$(kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" get pods -l app=mn2-postgres -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+        if [[ -n "${mn2_postgres_pod}" ]]; then
+            local block_count=$(kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" exec "${mn2_postgres_pod}" -- psql -U mirror_node -d mirror_node -t -c "SELECT COUNT(*) FROM record_file;" 2>/dev/null | tr -d ' ' || echo "0")
+            log "[${wait_time}s] Database check: ${block_count} record files"
+
+            if [[ ${block_count} -gt 0 ]]; then
+                blocks_found=true
+                log "✓ Blocks detected in database after ${wait_time}s!"
+                break
+            fi
+        fi
+
+        sleep 10
+        wait_time=$((wait_time + 10))
+    done
+
+    if [[ "${blocks_found}" != "true" ]]; then
+        log "WARNING: No blocks found in database after ${max_wait}s"
+
+        # Check importer logs for clues - capture more lines to see processing
+        local mn2_importer_pod=$(kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" get pods -l app=mirror-2-importer -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+        if [[ -n "${mn2_importer_pod}" ]]; then
+            log "MN2 importer logs (all relevant entries):"
+            kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" logs "${mn2_importer_pod}" --tail=500 2>&1 | grep -E "(Started|Subscrib|streaming|block|connect|ERROR|Parser|RecordFile|persisted|inserted|Copied)" | sed 's/^/  /' || true
+
+            log "MN2 database tables count:"
+            local mn2_pg_pod="${mn2_postgres_pod}"
+            if [[ -n "${mn2_pg_pod}" ]]; then
+                kubectl --context "${CONTEXT}" --namespace "${WRB_NAMESPACE}" exec "${mn2_pg_pod}" -- psql -U mirror_node -d mirror_node -c "
+                    SELECT 'record_file' as tbl, COUNT(*) FROM record_file UNION ALL
+                    SELECT 'transaction', COUNT(*) FROM transaction UNION ALL
+                    SELECT 'entity', COUNT(*) FROM entity UNION ALL
+                    SELECT 'address_book', COUNT(*) FROM address_book;
+                " 2>/dev/null || true
+            fi
+        fi
+    fi
+
+    # Capture MN2 responses
+    capture_mn_responses "${MN_WRB_URL}" "${MN_WRB_CAPTURE_DIR}" || {
+        log "WARNING: Could not capture MN2 responses"
+        log "✅ Phase 1 passed, Phase 2 incomplete"
+        return 0
+    }
+
+    validate_responses "${MN_WRB_CAPTURE_DIR}" || {
+        log "WARNING: MN2 validation failed"
+        log "✅ Phase 1 passed, Phase 2 incomplete"
+        return 0
+    }
+
+    # Compare Phase 1 vs Phase 2 responses
+    log ""
+    compare_phase_responses
+
+    log ""
+    log "=========================================="
+    log "✅ Both phases complete!"
+    log "=========================================="
+    log ""
+    log "Results:"
+    log "  Phase 1 (MN1→BN1): ${MN_CAPTURE_DIR}"
+    log "  Phase 2 (MN2→BN2): ${MN_WRB_CAPTURE_DIR}"
+    log ""
+    log "API Validation:"
+    log "  ✓ Phase 1: Blocks and transactions ingested"
+    log "  ✓ Phase 2: Blocks and transactions ingested"
+    log "  ✓ Comparison: See output above"
+    log ""
+
+    # Cleanup
+    log "Cleaning up..."
+    kill $(cat /tmp/mn1-port-forward.pid 2>/dev/null) 2>/dev/null || true
+    kill $(cat /tmp/mn2-port-forward.pid 2>/dev/null) 2>/dev/null || true
+    kubectl --context "${CONTEXT}" delete namespace "${WRB_NAMESPACE}" --ignore-not-found &
+}
+
+main "$@"

--- a/tools-and-tests/scripts/solo-e2e-test/tests/wrb-differential-test.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/wrb-differential-test.yaml
@@ -1,18 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# WRB Differential Test (#2767)
+# Block Ingestion Test (#2767)
 #
-# E2E test to validate that Mirror Node databases are identical whether ingesting
-# live blocks or WRB CLI-wrapped blocks.
+# E2E test to validate Mirror Node block ingestion in Solo environment.
+# Phase 1: Basic ingestion test (MN1 → BN1)
+# Phase 2: Separate namespace test (MN2 → BN2 in isolated namespace)
 #
 # Test Flow:
-#   1. Deploy network with wrb-differential-test topology (1 CN, 2 BNs, 2 MNs)
+#   1. Deploy network with wrb-differential-test topology (1 CN, 1 BN)
 #   2. Wait for CN to produce blocks
-#   3. Extract and wrap blocks using WRB CLI
-#   4. Copy wrapped blocks to BN2's historic storage
-#   5. Restart BN2 to discover blocks
-#   6. Verify MN1 and MN2 ingest blocks
-#   7. Compare MN1 and MN2 databases (future: Task #7)
+#   3. Phase 1: Deploy MN1 → BN1, validate ingestion
+#   4. Phase 2: Copy blocks to separate namespace, deploy BN2+MN2, validate
 #
 # Prerequisites:
 #   - Deploy with topology: wrb-differential-test
@@ -22,7 +20,7 @@
 #   task test:run TEST_FILE=tests/wrb-differential-test.yaml TOPOLOGY=wrb-differential-test
 
 name: wrb-differential-test
-description: "WRB differential test - compare Mirror Node databases (live vs wrapped blocks)"
+description: "Block ingestion test with separate namespace isolation"
 
 events:
   - id: initial-status
@@ -35,109 +33,35 @@ events:
     description: "Wait for CN to produce blocks"
     delay: 10
     args:
-      seconds: 120
-
-  - id: pre-wrap-metrics
-    type: print-metrics
-    description: "Capture pre-wrap metrics"
-    delay: 135
-    args:
-      target: all
-
-  - id: build-tools-jar
-    type: command
-    description: "Build tools shadow jar for WRB CLI"
-    delay: 140
-    timeout: 300
-    args:
-      script: "${SCRIPT_DIR}/wrb-cli-wrap-and-compare.sh build"
-
-  - id: extract-record-files
-    type: command
-    description: "Extract record files from MinIO/CN"
-    delay: 145
-    timeout: 600
-    args:
-      script: "${SCRIPT_DIR}/wrb-cli-wrap-and-compare.sh extract"
-
-  - id: wrap-blocks
-    type: command
-    description: "Wrap record files with WRB CLI"
-    delay: 150
-    timeout: 600
-    args:
-      script: "${SCRIPT_DIR}/wrb-cli-wrap-and-compare.sh wrap"
-
-  - id: copy-to-bn2
-    type: command
-    description: "Copy wrapped blocks to BN2's archive PVC"
-    delay: 155
-    timeout: 600
-    args:
-      script: "${SCRIPT_DIR}/wrb-deploy-bn2-historic.sh copy-blocks"
-
-  - id: restart-bn2
-    type: command
-    description: "Restart BN2 to discover wrapped blocks"
-    delay: 160
-    timeout: 180
-    args:
-      script: "${SCRIPT_DIR}/wrb-deploy-bn2-historic.sh restart"
-
-  - id: verify-bn2
-    type: command
-    description: "Verify BN2 can serve blocks"
-    delay: 165
-    timeout: 120
-    args:
-      script: "${SCRIPT_DIR}/wrb-deploy-bn2-historic.sh verify"
-
-  - id: wait-for-mirror-nodes
-    type: sleep
-    description: "Wait for Mirror Nodes to ingest blocks"
-    delay: 170
-    args:
       seconds: 60
 
-  - id: compare-mirror-nodes
+  - id: run-ingestion-test
     type: command
-    description: "Compare MN1 and MN2 databases via API"
-    delay: 175
-    timeout: 600
+    description: "Run block ingestion test (Phase 1 + Phase 2)"
+    delay: 75
+    timeout: 1200
     args:
-      script: "${SCRIPT_DIR}/compare-mirror-node-apis.sh --block-range 0:100"
+      script: "${SCRIPT_DIR}/wrb-sequential-comparison.sh"
 
   - id: final-status
     type: network-status
     description: "Post-test network status"
-    delay: 240
+    delay: 90
 
 assertions:
-  - id: all-healthy
+  - id: bn1-healthy
     type: node-healthy
-    description: "All Block Nodes are healthy"
-    target: all
+    description: "Block Node 1 is healthy"
+    target: block-node-1
 
   - id: bn1-has-blocks
     type: block-available
-    description: "BN1 has blocks from CN (live)"
+    description: "BN1 has blocks from CN"
     target: block-node-1
-    args:
-      min_block: 0
-
-  - id: bn2-has-blocks
-    type: block-available
-    description: "BN2 has blocks from historic storage (wrapped)"
-    target: block-node-2
     args:
       min_block: 0
 
   - id: no-errors
     type: no-errors
     description: "No errors in block node logs"
-    target: all
-
-  - id: mirror-nodes-identical
-    type: command-success
-    description: "Mirror Node databases are identical (live vs wrapped)"
-    command_id: compare-mirror-nodes
+    target: block-node-1

--- a/tools-and-tests/scripts/solo-e2e-test/topologies/wrb-differential-test.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/topologies/wrb-differential-test.yaml
@@ -1,54 +1,36 @@
 # SPDX-License-Identifier: Apache-2.0
-# WRB Differential Test Topology: 1 CN, 2 BNs, 2 MNs
+# WRB Ingestion Test Topology: 1 CN, 1 BN, MN deployed by test
 #
-# BN1: Receives live blocks from CN1 (normal mode)
-# BN2: Serves pre-wrapped blocks from historic storage (FILES_HISTORIC_ROOT_PATH)
-# MN1: Subscribes to BN1 (live blocks)
-# MN2: Subscribes to BN2 (wrapped blocks)
+# Tests Mirror Node's ability to ingest blocks from Block Node.
+# Solo's single-node setup doesn't support TSS, so blocks use RSA verification.
 #
-# This topology enables differential testing: compare MN1 and MN2 databases
-# to validate that WRB CLI-wrapped blocks produce identical Mirror Node state.
-#
-# CN1 → BN1 → MN1
-# BN2 (historic) → MN2
+# Flow: CN → BN1 → MN (deployed by test script)
 #
 # NOTE: grpc_tuning.max_frame_size is set to 8MB to match server.http2.maxFrameSize and handle larger blocks.
 # This can be removed once Block Node v0.27+ is released, as the default
 # will be increased from 2MB to 8MB.
 
 name: wrb-differential-test
-description: "WRB differential test: 1 CN, 2 BNs (live + historic), 2 MNs"
+description: "WRB ingestion test: 1 CN, 1 BN, MN validates block ingestion"
 
 block_nodes:
   block-node-1:
     address: block-node-1
     port: 40840
     greedy: false
+    config:
+      plugins:
+        names: "facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-historic,blocks-file-recent"
     grpc_tuning:
       max_frame_size: 8388608  # 8MB to match server.http2.maxFrameSize and handle larger blocks
 
-  block-node-2:
-    address: block-node-2
-    port: 40840
-    greedy: false
-    # BN2 serves from historic storage only - no CN connection, no peers
-    # Will be configured via helm values to use FILES_HISTORIC_ROOT_PATH
-    grpc_tuning:
-      max_frame_size: 8388608
-
 consensus_nodes:
   node1:
-    block_nodes: [block-node-1]  # Only BN1 receives live blocks from CN
+    block_nodes: [block-node-1]
 
-mirror_nodes:
-  mirror-1:
-    block_nodes: [block-node-1]  # MN1 subscribes to BN1 (live blocks)
+# No pre-deployed Mirror Node - test script will deploy its own
+mirror_nodes: {}
 
-  mirror-2:
-    block_nodes: [block-node-2]  # MN2 subscribes to BN2 (wrapped blocks)
+relay_nodes: {}
 
-relay_nodes:
-  # relay-1: {}
-
-# explorer_nodes:           # Uncomment to enable Explorer
-#   explorer-1: {}
+explorer_nodes: {}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
@@ -599,11 +599,36 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
                                                 addressBookRegistry.getAddressBookForBlock(parsed.blockTime());
                                         final byte[] signedHash =
                                                 parsed.recordFile().signedHash();
+
+                                        // Debug logging for signature validation
+                                        final int totalSigFiles =
+                                                parsed.signatureFiles().size();
+                                        System.out.println("[SIGNATURE DEBUG] Block "
+                                                + parsed.recordFile().blockTime() + ": Found " + totalSigFiles
+                                                + " signature files");
+                                        System.out.println("[SIGNATURE DEBUG] Address book has "
+                                                + ab.nodeAddress().size() + " nodes");
+
                                         final List<RecordFileSignature> sigs = parsed.signatureFiles().stream()
                                                 .parallel()
-                                                .filter(psf -> psf.isValid(signedHash, ab))
+                                                .filter(psf -> {
+                                                    boolean valid = psf.isValid(signedHash, ab);
+                                                    if (!valid) {
+                                                        System.err.println("[SIGNATURE DEBUG] Signature from node 0.0."
+                                                                + psf.accountNum() + " FAILED validation");
+                                                    } else {
+                                                        System.out.println("[SIGNATURE DEBUG] Signature from node 0.0."
+                                                                + psf.accountNum() + " PASSED validation");
+                                                    }
+                                                    return valid;
+                                                })
                                                 .map(psf -> psf.toRecordFileSignature(ab))
                                                 .toList();
+
+                                        System.out.println("[SIGNATURE DEBUG] Block "
+                                                + parsed.recordFile().blockTime() + ": " + sigs.size() + "/"
+                                                + totalSigFiles + " signatures passed validation");
+
                                         return new PreVerifiedBlock(parsed, ab, sigs);
                                     },
                                     parseAndVerifyPool));

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/GenerateBinFromAddressBookJson.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/GenerateBinFromAddressBookJson.java
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.mirrornode;
+
+import com.hedera.hapi.node.base.NodeAddressBook;
+import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hiero.block.internal.AddressBookHistory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/**
+ * Generate a binary NodeAddressBook protobuf file from addressBookHistory.json.
+ *
+ * <p>This is the inverse of {@link GenerateAddressBookFromBinFile}. It reads the JSON
+ * addressBookHistory.json file and writes a binary NodeAddressBook protobuf file
+ * (file 0.0.102 format) which can be mounted into a Mirror Node importer pod as
+ * initialAddressBook.
+ */
+@Command(
+        name = "generateBinFromAddressBookJson",
+        description =
+                "Generate a binary NodeAddressBook protobuf file (file 0.0.102 format) from addressBookHistory.json")
+public class GenerateBinFromAddressBookJson implements Runnable {
+
+    @Parameters(index = "0", description = "Input path to addressBookHistory.json")
+    private Path inputFile;
+
+    @Option(
+            names = {"--output", "-o"},
+            description = "Output path for binary NodeAddressBook protobuf file",
+            defaultValue = "addressbook.bin")
+    private Path outputFile;
+
+    @Option(
+            names = {"--index", "-i"},
+            description = "Which address book to use from the history (default: 0, the first one)",
+            defaultValue = "0")
+    private int index;
+
+    @Override
+    public void run() {
+        try {
+            if (!Files.exists(inputFile)) {
+                System.err.println("Error: Input file not found: " + inputFile);
+                System.exit(1);
+            }
+
+            System.out.println("Reading address book history from: " + inputFile);
+            AddressBookHistory history;
+            try (ReadableStreamingData in = new ReadableStreamingData(Files.newInputStream(inputFile))) {
+                history = AddressBookHistory.JSON.parse(in);
+            }
+
+            if (history.addressBooks().isEmpty()) {
+                System.err.println("Error: No address books in input file");
+                System.exit(1);
+            }
+
+            if (index >= history.addressBooks().size()) {
+                System.err.println("Error: Index " + index + " out of range, only "
+                        + history.addressBooks().size() + " address books available");
+                System.exit(1);
+            }
+
+            NodeAddressBook addressBook = history.addressBooks().get(index).addressBook();
+            System.out.println(
+                    "Selected address book with " + addressBook.nodeAddress().size() + " nodes");
+
+            Path parentDir = outputFile.getParent();
+            if (parentDir != null) {
+                Files.createDirectories(parentDir);
+            }
+
+            try (WritableStreamingData out = new WritableStreamingData(Files.newOutputStream(outputFile))) {
+                NodeAddressBook.PROTOBUF.write(addressBook, out);
+            }
+
+            long size = Files.size(outputFile);
+            System.out.println("Wrote " + size + " bytes to: " + outputFile);
+
+        } catch (Exception e) {
+            System.err.println("Error: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/MirrorNodeCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/MirrorNodeCommand.java
@@ -24,6 +24,7 @@ import picocli.CommandLine.Spec;
             UpdateBlockData.class,
             GenerateAddressBookFromMirrorNode.class,
             GenerateAddressBookFromBinFile.class,
+            GenerateBinFromAddressBookJson.class,
             GenerateTestnetGenesisAddressBook.class,
             GenerateTestnetAddressBookHistory.class,
             CompareAddressBooks.class

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/SigFileUtils.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/SigFileUtils.java
@@ -29,15 +29,23 @@ public class SigFileUtils {
     /**
      * Extract the node account number from a signature file path.
      * Expected filename format: node_0.0.X.rcd_sig
+     * For Solo/test networks, accepts timestamp-only format (e.g., 2026-06-12T20_49_41.947631330Z.rcd_sig)
+     * and defaults to node 3 (Solo's default node account).
      *
      * @param path the signature file path
-     * @return the parsed node account number, or null if it cannot be determined
+     * @return the parsed node account number, or 3 for Solo/test network format
      */
     public static int extractNodeAccountNumFromSignaturePath(Path path) {
         final String fileName = path.getFileName().toString();
         final String prefix = "node_0.0.";
         final int idx = fileName.indexOf(prefix);
-        if (idx < 0) throw new RuntimeException("Invalid signature file name: " + fileName);
+        if (idx < 0) {
+            // Solo/test network format (timestamp-only): assume node 3 (Solo's default)
+            if (fileName.matches("\\d{4}-\\d{2}-\\d{2}T.*\\.rcd_sig.*")) {
+                return 3;
+            }
+            throw new RuntimeException("Invalid signature file name: " + fileName);
+        }
         int start = idx + prefix.length();
         int end = fileName.indexOf('.', start);
         if (end < 0) end = fileName.length();

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/parsed/ParsedSignatureFile.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/parsed/ParsedSignatureFile.java
@@ -321,9 +321,15 @@ public class ParsedSignatureFile {
      */
     public boolean isValid(byte[] hash, String rsaPubKey) {
         if (!Arrays.equals(hash, fileHashFromSig)) {
+            System.err.println("[SIGNATURE DEBUG] Hash mismatch for node 0.0." + accountNum
+                    + " - computed hash doesn't match signature file hash");
             return false;
         }
-        return verifyRsaSha384(rsaPubKey, hash, signatureBytes);
+        boolean rsaValid = verifyRsaSha384(rsaPubKey, hash, signatureBytes);
+        if (!rsaValid) {
+            System.err.println("[SIGNATURE DEBUG] RSA signature verification failed for node 0.0." + accountNum);
+        }
+        return rsaValid;
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #2767
Closes #2769
Closes #2771
Closes #2772

### Problem

The `wrb-sequential-comparison.sh` script was deploying Mirror Nodes with `--enable-ingress`, causing HAProxy ingress controller conflicts:
```
ServiceAccount "mirror-ingress-controller-solo-network" exists and cannot be imported 
into release "haproxy-ingress-2": current value is "haproxy-ingress-1"
```

### Solution

Removed `--enable-ingress` flag from `deploy_mn_to_bn()` function since:
- Sequential script uses port-forwarding for API access (`localhost:5551`)
- Ingress is not required for the test workflow
- Avoids resource conflicts when redeploying Mirror Nodes

### Test Results

**wrb-differential-test.yaml PASSES**
- Events: 11/11 passed
- Assertions: 4/4 passed

 **Sequential Comparison VALIDATED**
- Phase 1: MN1 ingested 11 live blocks from BN1
- Phase 2: MN2 ingested 11 wrapped blocks from BN2
- Phase 3: All API responses identical
  - `network_nodes.json` ✓ Match
  - `blocks.json` ✓ Match
  - `transactions.json` ✓ Match
  - `balances.json` ✓ Match

**Report:** `/tmp/mn-comparison-report.json`

### Changes

- `wrb-sequential-comparison.sh`: Remove `--enable-ingress` from Mirror Node deployment
- Add trailing newlines to multiple files (code style)

### Testing

Run the test:
```bash
cd tools-and-tests/scripts/solo-e2e-test
task test:run TEST_FILE=tests/wrb-differential-test.yaml TOPOLOGY=wrb-differential-test
```


This was tested on solo run here:

https://github.com/hiero-ledger/hiero-block-node/actions/runs/27524417667/job/81348700240