### PR TITLE
fix(ci): use GH_ACCESS_TOKEN for hiero-docs sync workflow

### DIFF
--- a/.github/workflows/sync-docs-to-gitbook.yaml
+++ b/.github/workflows/sync-docs-to-gitbook.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: hiero-ledger/hiero-docs
-          token: ${{ secrets.DOCS_SYNC_TOKEN }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
           path: hiero-docs
           ref: master
 


### PR DESCRIPTION
## Reviewer Notes
Switch from secrets.DOCS_SYNC_TOKEN to secrets.GH_ACCESS_TOKEN, which has write permission to hiero-ledger/hiero-docs as confirmed by the platform CI team.

## Related Issue(s)
Fixes #2941 