### PR TITLE
feat: Helm chart per-plugin port configuration (#3001)

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -96,3 +96,148 @@ jobs:
       - name: Run chart-testing (install)
         if: steps.install-needed.outputs.needed == 'true'
         run: ${CGEXEC} ct install --config ct.yaml --all
+
+  multi-port-install-test:
+    timeout-minutes: 20
+    name: Multi-Port Plugin Install Test
+    runs-on: hl-bn-lin-md
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Check if install test is needed
+        id: install-needed
+        run: |
+          changed_files=$(git diff --name-only origin/${{ github.event.repository.default_branch }}...HEAD)
+          if echo "$changed_files" | grep -qE "^(block-node/app/(docker/|build\.gradle\.kts)|charts/|tools-and-tests/simulator/(docker/|build\.gradle\.kts))"; then
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "Image/chart/build files changed - will run multi-port test"
+          else
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "No relevant changes - skipping multi-port install test"
+          fi
+
+      - name: Set up Helm
+        if: steps.install-needed.outputs.needed == 'true'
+        uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.14.4
+
+      - name: Set up Java
+        if: steps.install-needed.outputs.needed == 'true'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Create kind cluster
+        if: steps.install-needed.outputs.needed == 'true'
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+
+      - name: Build Docker images
+        if: steps.install-needed.outputs.needed == 'true'
+        run: ${CGEXEC} ./gradlew :app:createDockerImage
+
+      - name: Load image into kind
+        if: steps.install-needed.outputs.needed == 'true'
+        run: |
+          APP_VERSION=$(cat version.txt)
+          docker tag "block-node-server:${APP_VERSION}" "ghcr.io/hiero-ledger/hiero-block-node:${APP_VERSION}"
+          kind load docker-image "ghcr.io/hiero-ledger/hiero-block-node:${APP_VERSION}" --name chart-testing
+
+      - name: Update chart dependencies
+        if: steps.install-needed.outputs.needed == 'true'
+        run: |
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add grafana https://grafana.github.io/helm-charts
+          helm dependency update charts/block-node-server
+
+      - name: Install chart with multi-port values
+        if: steps.install-needed.outputs.needed == 'true'
+        run: |
+          APP_VERSION=$(cat version.txt)
+          helm install bn-multi-port-test charts/block-node-server \
+            --namespace default \
+            --values charts/block-node-server/ci/multi-port-values.yaml \
+            --set image.tag="${APP_VERSION}" \
+            --wait \
+            --timeout 300s
+
+      - name: Verify per-plugin ports are reachable
+        if: steps.install-needed.outputs.needed == 'true'
+        run: |
+          POD=$(kubectl get pod -n default -l app.kubernetes.io/instance=bn-multi-port-test -o jsonpath='{.items[0].metadata.name}')
+          echo "Testing pod: ${POD}"
+
+          # Forward all five plugin ports AND the shared server.port to the local runner
+          kubectl port-forward -n default "pod/${POD}" 40840:40840 40940:40940 40941:40941 40942:40942 40943:40943 40944:40944 &
+          PF_PID=$!
+          # Give port-forward time to establish
+          sleep 5
+
+          failed=0
+
+          # Health port (40940): HTTP liveness endpoint
+          echo "--- port 40940 (health) ---"
+          if curl -sf --max-time 5 http://localhost:40940/healthz/livez; then
+            echo "OK"
+          else
+            echo "FAIL: health port 40940 did not respond"
+            failed=1
+          fi
+
+          # Publisher port (40941): TCP connect (gRPC)
+          echo "--- port 40941 (publisher/gRPC) ---"
+          if timeout 5 bash -c 'echo > /dev/tcp/localhost/40941' 2>/dev/null; then
+            echo "OK"
+          else
+            echo "FAIL: publisher port 40941 not reachable"
+            failed=1
+          fi
+
+          # Subscriber port (40942): TCP connect (gRPC)
+          echo "--- port 40942 (subscriber/gRPC) ---"
+          if timeout 5 bash -c 'echo > /dev/tcp/localhost/40942' 2>/dev/null; then
+            echo "OK"
+          else
+            echo "FAIL: subscriber port 40942 not reachable"
+            failed=1
+          fi
+
+          # Block-access port (40943): TCP connect (gRPC)
+          echo "--- port 40943 (block-access/gRPC) ---"
+          if timeout 5 bash -c 'echo > /dev/tcp/localhost/40943' 2>/dev/null; then
+            echo "OK"
+          else
+            echo "FAIL: block-access port 40943 not reachable"
+            failed=1
+          fi
+
+          # Server-status port (40944): TCP connect (HTTP)
+          echo "--- port 40944 (server-status) ---"
+          if timeout 5 bash -c 'echo > /dev/tcp/localhost/40944' 2>/dev/null; then
+            echo "OK"
+          else
+            echo "FAIL: server-status port 40944 not reachable"
+            failed=1
+          fi
+
+          # Confirm that the shared server.port (40840) is NOT serving health plugin traffic.
+          # The health plugin is on 40940; nothing should respond at /healthz/livez on 40840.
+          echo "--- port 40840 (server.port — health plugin must NOT be here) ---"
+          if curl -sf --max-time 5 http://localhost:40840/healthz/livez 2>/dev/null; then
+            echo "FAIL: health plugin is still on 40840 — expected it on 40940 per test config; per-plugin port assignment is not working"
+            failed=1
+          else
+            echo "OK (health plugin correctly on 40940, not on shared server.port 40840 as configured)"
+          fi
+
+          kill ${PF_PID} 2>/dev/null || true
+          exit ${failed}

--- a/charts/block-node-server/NOTES.txt
+++ b/charts/block-node-server/NOTES.txt
@@ -1,0 +1,66 @@
+{{- /*
+SPDX-License-Identifier: Apache-2.0
+*/}}
+Thank you for installing {{ .Chart.Name }} {{ .Chart.AppVersion }}.
+
+Release name: {{ .Release.Name }}
+Namespace:    {{ .Release.Namespace }}
+
+==> Access the Block Node
+
+To reach the Block Node from your local machine, run:
+
+  kubectl port-forward svc/{{ include "hiero-block-node.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+
+Then connect gRPC clients to localhost:{{ .Values.service.port }}.
+
+{{- if or .Values.blockNode.ports.publisher .Values.blockNode.ports.subscriber .Values.blockNode.ports.blockAccess .Values.blockNode.ports.health .Values.blockNode.ports.serverStatus }}
+
+==> Per-Plugin Ports Active
+
+The following plugins have been assigned dedicated ports:
+{{- with .Values.blockNode.ports }}
+{{- if .publisher }}
+  publisher    (PRODUCER_PORT)     -> {{ .publisher }}
+{{- end }}
+{{- if .subscriber }}
+  subscriber   (SUBSCRIBER_PORT)   -> {{ .subscriber }}
+{{- end }}
+{{- if .blockAccess }}
+  blockAccess  (BLOCK_ACCESS_PORT) -> {{ .blockAccess }}
+{{- end }}
+{{- if .health }}
+  health       (HEALTH_PORT)       -> {{ .health }}
+{{- end }}
+{{- if .serverStatus }}
+  serverStatus (SERVER_STATUS_PORT)-> {{ .serverStatus }}
+{{- end }}
+{{- end }}
+
+To forward all active plugin ports locally, run:
+
+  kubectl port-forward svc/{{ include "hiero-block-node.fullname" . }}{{ with .Values.blockNode.ports }}{{ if .publisher }} {{ .publisher }}:{{ .publisher }}{{ end }}{{ if .subscriber }} {{ .subscriber }}:{{ .subscriber }}{{ end }}{{ if .blockAccess }} {{ .blockAccess }}:{{ .blockAccess }}{{ end }}{{ if .health }} {{ .health }}:{{ .health }}{{ end }}{{ if .serverStatus }} {{ .serverStatus }}:{{ .serverStatus }}{{ end }}{{ end }}
+
+{{- end }}
+
+==> Health Endpoints
+
+{{- $healthPort := default .Values.service.port .Values.blockNode.ports.health }}
+  Liveness:   http://localhost:{{ $healthPort }}{{ .Values.blockNode.health.liveness.endpoint }}
+  Readiness:  http://localhost:{{ $healthPort }}{{ .Values.blockNode.health.readiness.endpoint }}
+
+{{- if and (index .Values.blockNode.config "HEALTH_PORT") (not .Values.blockNode.ports.health) }}
+
+⚠ MIGRATION WARNING ⚠
+  HEALTH_PORT is set in blockNode.config but blockNode.ports.health is not set.
+  The liveness and readiness probes still target service.port ({{ .Values.service.port }}).
+  If HEALTH_PORT differs from service.port, probes WILL FAIL and the pod will not become Ready.
+  Fix: move the value to blockNode.ports.health and remove it from blockNode.config.
+{{- end }}
+
+==> Metrics
+
+  Prometheus metrics: http://localhost:{{ .Values.blockNode.metrics.port }}{{ .Values.blockNode.metrics.path }}
+
+  Port-forward metrics:
+    kubectl port-forward svc/{{ include "hiero-block-node.fullname" . }} {{ .Values.blockNode.metrics.port }}:{{ .Values.blockNode.metrics.port }}

--- a/charts/block-node-server/README.md
+++ b/charts/block-node-server/README.md
@@ -220,6 +220,58 @@ plugins:
 
 **Note:** `facility-messaging` is required for the application to start. The `health` plugin is recommended for Kubernetes liveness/readiness probes.
 
+#### Per-Plugin Port Configuration
+
+By default all plugins share a single port (`service.port`, default `40840`). Use `blockNode.ports` to assign each plugin its own dedicated port:
+
+```yaml
+blockNode:
+  ports:
+    # gRPC port for block producers (env: PRODUCER_PORT). hostPorts key: publisher
+    publisher: 40841
+    # gRPC port for block subscribers (env: SUBSCRIBER_PORT). hostPorts key: subscriber
+    subscriber: 40842
+    # gRPC/HTTP port for block access/query API (env: BLOCK_ACCESS_PORT). hostPorts key: block-access
+    blockAccess: 40843
+    # HTTP port for /healthz endpoints (env: HEALTH_PORT). hostPorts key: health
+    # When set, liveness and readiness probes automatically redirect to this port.
+    health: 40844
+    # HTTP port for server-status endpoint (env: SERVER_STATUS_PORT). hostPorts key: server-status
+    serverStatus: 40845
+```
+
+Setting a port here automatically:
+- Declares it as a named `containerPort` in the StatefulSet
+- Adds it to the ClusterIP Service
+- Injects the corresponding environment variable into the pod
+
+> **Do not** also set `PRODUCER_PORT`, `SUBSCRIBER_PORT`, etc. in `blockNode.config` when using `blockNode.ports`. Use `blockNode.ports` as the single source of truth for per-plugin ports to avoid duplicate or conflicting env var values.
+>
+> **Health probe note:** If you set `blockNode.ports.health`, the liveness and readiness probes are automatically redirected to that port. If you set `HEALTH_PORT` in `blockNode.config` instead, the probes will still target the default `service.port` and **will fail** if the two values differ. Prefer `blockNode.ports.health`.
+
+Named ports created by `blockNode.ports` can also be bound to host ports:
+
+```yaml
+blockNode:
+  hostPorts:
+    publisher: 40841
+    subscriber: 40842
+```
+
+##### LoadBalancer and Per-Plugin Ports
+
+The current `loadBalancer` resource exposes a single port pointing to one target port. When plugins are split across ports on a single physical box with a single IP, configure the LoadBalancer to point to the specific plugin port you want to expose externally:
+
+```yaml
+loadBalancer:
+  enabled: true
+  portName: grpc
+  port: 40841        # the external port on the LoadBalancer
+  targetPort: publisher  # matches the containerPort name set by blockNode.ports.publisher
+```
+
+> **Note:** Multi-port LoadBalancer support (exposing publisher and subscriber on separate LB ports simultaneously) is planned as a follow-on. Today, configure separate `targetPort` values per release or use an Ingress/gateway layer above the Service.
+
 #### Disabling Plugins
 
 To deploy without any plugins (bare image), set `plugins.names` to an empty string:

--- a/charts/block-node-server/ci/multi-port-values.yaml
+++ b/charts/block-node-server/ci/multi-port-values.yaml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI values for multi-port install test.
+# Each plugin is assigned a distinct port; the default server.port (40840) is deliberately
+# left unused by all plugins to verify that per-plugin port routing is working end-to-end.
+#
+# Port assignments:
+#   health      → 40940   (health probes redirect here automatically)
+#   publisher   → 40941
+#   subscriber  → 40942
+#   blockAccess → 40943
+#   serverStatus→ 40944
+#   server.port → 40840   (shared fallback — no plugin should bind here in this test)
+
+blockNode:
+  ports:
+    health: 40940
+    publisher: 40941
+    subscriber: 40942
+    blockAccess: 40943
+    serverStatus: 40944
+  config:
+    SERVER_PORT: "40840"
+    JAVA_OPTS: '-Xms1G -Xmx2G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
+  persistence:
+    archive:
+      size: 1Gi
+    live:
+      size: 1Gi
+    logging:
+      size: 500Mi
+    verification:
+      size: 500Mi
+    plugins:
+      size: 500Mi
+
+resources:
+  requests:
+    cpu: "1"
+    memory: "2Gi"
+  limits:
+    cpu: "2"
+    memory: "3Gi"
+
+plugins:
+  names: "facility-messaging,health,server-status,block-access-service,stream-publisher,stream-subscriber"

--- a/charts/block-node-server/templates/_helpers.tpl
+++ b/charts/block-node-server/templates/_helpers.tpl
@@ -93,6 +93,121 @@ Build JAVA_TOOL_OPTIONS combining logging config and metrics system properties.
 {{- end }}
 
 {{/*
+Emit ConfigMap data lines (KEY: "value") for each non-null plugin port in blockNode.ports.
+These are emitted before the blockNode.config range so that explicit config values win on conflict.
+Usage: include "hiero-block-node.pluginPortEnvVars" .
+*/}}
+{{- define "hiero-block-node.pluginPortEnvVars" -}}
+{{- with .Values.blockNode.ports -}}
+{{- if .health }}
+  HEALTH_PORT: {{ .health | quote }}
+{{- end -}}
+{{- if .publisher }}
+  PRODUCER_PORT: {{ .publisher | quote }}
+{{- end -}}
+{{- if .subscriber }}
+  SUBSCRIBER_PORT: {{ .subscriber | quote }}
+{{- end -}}
+{{- if .blockAccess }}
+  BLOCK_ACCESS_PORT: {{ .blockAccess | quote }}
+{{- end -}}
+{{- if .serverStatus }}
+  SERVER_STATUS_PORT: {{ .serverStatus | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Emit Service port entries for each non-null plugin port in blockNode.ports.
+Usage: include "hiero-block-node.pluginServicePorts" . | nindent 4
+*/}}
+{{- define "hiero-block-node.pluginServicePorts" -}}
+{{- with .Values.blockNode.ports -}}
+{{- if .publisher }}
+- name: publisher
+  port: {{ .publisher }}
+  targetPort: publisher
+  protocol: TCP
+{{- end -}}
+{{- if .subscriber }}
+- name: subscriber
+  port: {{ .subscriber }}
+  targetPort: subscriber
+  protocol: TCP
+{{- end -}}
+{{- if .blockAccess }}
+- name: block-access
+  port: {{ .blockAccess }}
+  targetPort: block-access
+  protocol: TCP
+{{- end -}}
+{{- if .health }}
+- name: health
+  port: {{ .health }}
+  targetPort: health
+  protocol: TCP
+{{- end -}}
+{{- if .serverStatus }}
+- name: server-status
+  port: {{ .serverStatus }}
+  targetPort: server-status
+  protocol: TCP
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Emit container port entries for each non-null plugin port in blockNode.ports.
+Accepts a dict context: (dict "Values" .Values "hostPorts" $hostPorts)
+Usage: include "hiero-block-node.pluginContainerPorts" (dict "Values" .Values "hostPorts" $hostPorts) | nindent 10
+*/}}
+{{- define "hiero-block-node.pluginContainerPorts" -}}
+{{- $hp := .hostPorts -}}
+{{- with .Values.blockNode.ports -}}
+{{- if .publisher }}
+- name: publisher
+  containerPort: {{ .publisher }}
+  {{- if hasKey $hp "publisher" }}
+  hostPort: {{ index $hp "publisher" }}
+  {{- end }}
+  protocol: TCP
+{{- end -}}
+{{- if .subscriber }}
+- name: subscriber
+  containerPort: {{ .subscriber }}
+  {{- if hasKey $hp "subscriber" }}
+  hostPort: {{ index $hp "subscriber" }}
+  {{- end }}
+  protocol: TCP
+{{- end -}}
+{{- if .blockAccess }}
+- name: block-access
+  containerPort: {{ .blockAccess }}
+  {{- if hasKey $hp "block-access" }}
+  hostPort: {{ index $hp "block-access" }}
+  {{- end }}
+  protocol: TCP
+{{- end -}}
+{{- if .health }}
+- name: health
+  containerPort: {{ .health }}
+  {{- if hasKey $hp "health" }}
+  hostPort: {{ index $hp "health" }}
+  {{- end }}
+  protocol: TCP
+{{- end -}}
+{{- if .serverStatus }}
+- name: server-status
+  containerPort: {{ .serverStatus }}
+  {{- if hasKey $hp "server-status" }}
+  hostPort: {{ index $hp "server-status" }}
+  {{- end }}
+  protocol: TCP
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 The service name to connect to Loki. Defaults to the same logic as "loki.fullname"
 */}}
 {{- define "loki.serviceName" -}}

--- a/charts/block-node-server/templates/configmap.yaml
+++ b/charts/block-node-server/templates/configmap.yaml
@@ -9,6 +9,7 @@ metadata:
 data:
   VERSION: {{ include "hiero-block-node.appVersion" .  | quote }}
   JAVA_TOOL_OPTIONS: {{ printf "%s %s" (include "hiero-block-node.javaToolOptions" .) (default "" (index .Values.blockNode.config "JAVA_TOOL_OPTIONS")) | trim | quote }}
+{{- include "hiero-block-node.pluginPortEnvVars" . }}
 {{- range $key, $value := .Values.blockNode.config }}
 {{- if ne $key "JAVA_TOOL_OPTIONS" }}
   {{ $key }}: {{ $value | quote }}

--- a/charts/block-node-server/templates/service.yaml
+++ b/charts/block-node-server/templates/service.yaml
@@ -23,5 +23,6 @@ spec:
     - name: metrics
       port: {{ .Values.blockNode.metrics.port }}
       targetPort: metrics
+    {{- include "hiero-block-node.pluginServicePorts" . | nindent 4 }}
   selector:
     {{- include "hiero-block-node.selectorLabels" . | nindent 4 }}

--- a/charts/block-node-server/templates/statefulset.yaml
+++ b/charts/block-node-server/templates/statefulset.yaml
@@ -217,6 +217,7 @@ spec:
             hostPort: {{ index $hostPorts "metrics" }}
             {{- end }}
             protocol: TCP
+          {{- include "hiero-block-node.pluginContainerPorts" (dict "Values" .Values "hostPorts" $hostPorts) | nindent 10 }}
         envFrom:
           - configMapRef:
               name: {{ include "hiero-block-node.fullname" . }}-config
@@ -258,10 +259,11 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- $healthPort := default .Values.service.port .Values.blockNode.ports.health }}
         livenessProbe:
           httpGet:
             path: {{ .Values.blockNode.health.liveness.endpoint }}
-            port: {{ .Values.service.port }}
+            port: {{ $healthPort }}
           initialDelaySeconds: {{ .Values.blockNode.health.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.blockNode.health.liveness.periodSeconds }}
           timeoutSeconds: {{ .Values.blockNode.health.liveness.timeoutSeconds }}
@@ -270,7 +272,7 @@ spec:
         readinessProbe:
           httpGet:
             path: {{ .Values.blockNode.health.readiness.endpoint }}
-            port: {{ .Values.service.port }}
+            port: {{ $healthPort }}
           initialDelaySeconds: {{ .Values.blockNode.health.readiness.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.blockNode.health.readiness.timeoutSeconds }}
       {{- with .Values.nodeSelector }}

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -155,6 +155,26 @@ blockNode:
   # and reference it via blockNode.persistence.plugins.existingClaim with plugins.names set to "".
   # if blank will use same as AppVersion of chart.
   version: ""
+  # Per-plugin port overrides. When null/unset, the plugin shares service.port (default: 40840).
+  # Setting a port here automatically:
+  #   - declares it as a named containerPort in the StatefulSet
+  #   - adds it to the ClusterIP Service
+  #   - injects the corresponding env var (no need to set it in blockNode.config too)
+  #   - allows hostPort binding via blockNode.hostPorts.<portName>
+  # Do NOT also set PRODUCER_PORT/SUBSCRIBER_PORT/etc. in blockNode.config when using this
+  # section — blockNode.ports is the single source of truth for per-plugin ports.
+  ports:
+    # gRPC port for block producers (env: PRODUCER_PORT). hostPorts key: publisher
+    publisher: null
+    # gRPC port for block subscribers (env: SUBSCRIBER_PORT). hostPorts key: subscriber
+    subscriber: null
+    # gRPC/HTTP port for block access/query API (env: BLOCK_ACCESS_PORT). hostPorts key: block-access
+    blockAccess: null
+    # HTTP port for /healthz endpoints (env: HEALTH_PORT). hostPorts key: health
+    # IMPORTANT: when set, liveness and readiness probes are automatically redirected to this port.
+    health: null
+    # HTTP port for server-status endpoint (env: SERVER_STATUS_PORT). hostPorts key: server-status
+    serverStatus: null
   config:
     # Add any additional env configuration here
     # key: value


### PR DESCRIPTION
## Summary
Cherry-pick of #3001 (via #3002) onto `release/0.36` for v0.36.0-rc2.

- Adds per-plugin port configuration to the Helm chart — to support provisioner development and testing of the security feature set.
