### PR TITLE
test(solo-e2e): WRAPS v1.0.0 transition support and WRB RSA verification improvements

### DIFF
--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -227,6 +227,10 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          # Pin to Helm 3.x: Solo cannot parse Helm 4.x install output
+          # ("Failed to deserialize the output into the specified class: Release").
+          version: v3.14.4
 
       - name: Setup Kind
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0

--- a/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
+++ b/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
@@ -247,6 +247,52 @@ tasks:
     cmds:
       - '"{{.SCRIPTS_DIR}}/monitor-block-proofs.sh" "{{.PROTO_PATH}}" "localhost:40840"'
 
+  verify:wrb:
+    desc: "Verify WRB blocks are accepted via the RSA roster on a Block Node (NODE=n, default: 1). Needs port-forward."
+    vars:
+      NODE: '{{.NODE | default "1"}}'
+    cmds:
+      - |
+        PORT=$((16006 + {{.NODE}}))
+        echo "Verifying RSA-roster WRB verification on Block Node {{.NODE}} (metrics: localhost:${PORT})..."
+        METRICS=$(curl -s --max-time 10 "http://localhost:${PORT}/metrics" 2>/dev/null)
+        if [[ -z "${METRICS}" ]]; then
+          echo "ERROR: Could not fetch metrics on localhost:${PORT}. Is port-forward running? Run: task port-forward"
+          exit 1
+        fi
+
+        # Counters export with a trailing _total, so the proof counter is *_total_total.
+        ROSTER=$(echo "${METRICS}" | grep "^blocknode_roster_entries_loaded " | awk '{print $2}' | head -1)
+        RSA_OK=$(echo "${METRICS}" | grep '^blocknode_verification_proof_total_total{' | grep 'proof_type="rsa"' | grep 'result="success"' | awk '{print $2}' | head -1)
+        RSA_FAIL=$(echo "${METRICS}" | grep '^blocknode_verification_proof_total_total{' | grep 'proof_type="rsa"' | grep 'result="failure"' | awk '{print $2}' | head -1)
+        MISMATCH=$(echo "${METRICS}" | grep "^blocknode_rsa_roster_mismatch_total_total " | awk '{print $2}' | head -1)
+
+        ROSTER=$(printf "%.0f" "${ROSTER:-0}" 2>/dev/null || echo 0)
+        RSA_OK=$(printf "%.0f" "${RSA_OK:-0}" 2>/dev/null || echo 0)
+        RSA_FAIL=$(printf "%.0f" "${RSA_FAIL:-0}" 2>/dev/null || echo 0)
+        MISMATCH=$(printf "%.0f" "${MISMATCH:-0}" 2>/dev/null || echo 0)
+
+        echo "  roster_entries_loaded:              ${ROSTER}"
+        echo "  rsa proofs verified (success):      ${RSA_OK}"
+        echo "  rsa proofs failed (startup window): ${RSA_FAIL}"
+        echo "  rsa_roster_mismatch:                ${MISMATCH}"
+
+        if [[ "${ROSTER}" -le 0 ]]; then
+          echo "FAIL: RSA roster not loaded. Is the roster-bootstrap-rsa plugin enabled and the Mirror Node reachable?"
+          exit 1
+        fi
+        if [[ "${MISMATCH}" -gt 0 ]]; then
+          echo "FAIL: ${MISMATCH} RSA signature(s) from node(s) not in the loaded roster."
+          exit 1
+        fi
+        if [[ "${RSA_OK}" -le 0 ]]; then
+          echo "FAIL: no blocks verified via the RSA proof path yet. Let blocks flow (or run task load:up) and retry."
+          exit 1
+        fi
+
+        echo "PASS: WRB blocks are verified via the RSA roster (success=${RSA_OK}, mismatch=0, roster=${ROSTER})."
+        echo "      Startup-window rsa failures (${RSA_FAIL}, blocks received before the roster loaded) are expected."
+
   status:
     desc: Show network status for all nodes in the topology
     deps: [proto:extract]

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
@@ -550,7 +550,7 @@ EOF
   fi
 }
 
-also# WRAPS v1.0.0 proving keys: downloaded + extracted once into a local cache and handed to Solo via
+# WRAPS v1.0.0 proving keys: downloaded + extracted once into a local cache and handed to Solo via
 # --wraps-key-path on every deploy (no ~2 GB re-download). Pre-staging is required because CN-side
 # runtime download is dropped before genesis on CN v0.75.x — see project-patterns.md (WRAPS on
 # solo-e2e). Solo stages these under its cache dir named `wraps-v0.2.0` (default directoryName,

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
@@ -404,7 +404,10 @@ plugins:
 blockNode:
   config:
     ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL: "${mn_base_url}"
-    ROSTER_BOOTSTRAP_RSA_INITIAL_QUERY_INTERVAL_MILLIS: "15000"
+    # Poll the Mirror Node frequently so the roster loads ASAP after the MN is up — this
+    # narrows the startup window in which the genesis block (0) can arrive before the roster
+    # and be dropped. See wrb-startup-block-gap-issue: the real fix is no-gap-from-genesis on the BN.
+    ROSTER_BOOTSTRAP_RSA_INITIAL_QUERY_INTERVAL_MILLIS: "3000"
 EOF
   log_line "  Generated BN WRB overlay (roster URL: %s)" "${mn_base_url}"
 }
@@ -547,6 +550,38 @@ EOF
   fi
 }
 
+also# WRAPS v1.0.0 proving keys: downloaded + extracted once into a local cache and handed to Solo via
+# --wraps-key-path on every deploy (no ~2 GB re-download). Pre-staging is required because CN-side
+# runtime download is dropped before genesis on CN v0.75.x — see project-patterns.md (WRAPS on
+# solo-e2e). Solo stages these under its cache dir named `wraps-v0.2.0` (default directoryName,
+# not overridable here), so that directory holds v1.0.0 contents on this setup.
+WRAPS_DOWNLOAD_URL="https://builds.hedera.com/tss/hiero/wraps/v1.0/wraps-v1.0.0.tar.gz"
+WRAPS_KEYS_DIR="${HOME}/.solo/cache/wraps-v1.0.0-keys"
+WRAPS_KEY_FILES="decider_pp.bin decider_vp.bin nova_pp.bin nova_vp.bin"
+
+## Download and extract the WRAPS v1.0.0 proving keys into `keys_dir` once; later deploys reuse them.
+function ensure_wraps_keys_cached {
+  local keys_dir="${1}"
+  local f=""
+  local need_download="false"
+  for f in ${WRAPS_KEY_FILES}; do
+    [[ -f "${keys_dir}/${f}" ]] || need_download="true"
+  done
+
+  if [[ "${need_download}" == "true" ]]; then
+    log_line "Caching WRAPS v1.0.0 proving keys (one-time download + extract, ~2 GB)"
+    mkdir -p "${keys_dir}"
+    local tarball="${keys_dir}/wraps-v1.0.0.tar.gz"
+    curl -fSL "${WRAPS_DOWNLOAD_URL}" -o "${tarball}" || fail "ERROR: Failed to download WRAPS v1.0.0" 1
+    tar -xzf "${tarball}" -C "${keys_dir}" || fail "ERROR: Failed to extract WRAPS v1.0.0 archive" 1
+    rm -f "${tarball}"
+  fi
+
+  for f in ${WRAPS_KEY_FILES}; do
+    [[ -f "${keys_dir}/${f}" ]] || fail "ERROR: WRAPS v1.0.0 key ${f} missing after extract" 1
+  done
+}
+
 function deploy_consensus_nodes {
   log_line ""
   log_line "Deploying Consensus Nodes"
@@ -570,19 +605,24 @@ function deploy_consensus_nodes {
     --node-aliases "${NODE_ALIASES}" || fail "ERROR: Failed to generate consensus keys" 1
   end_task
 
-  start_task "Deploying consensus network"
-  local wraps_arg=""
+  # Pre-stage the WRAPS v1.0.0 keys via --wraps-key-path so the library is ready at genesis (CN
+  # runtime download is too late on CN v0.75.x and the WRAPS proof gets dropped). CN-side download
+  # stays disabled in cn-application.properties. --tss is kept so Solo still patches
+  # block-nodes.json with the TSS message-size limits the large WRAPS genesis block needs.
+  local wraps_key_args=""
   if [[ "${TSS_ENABLED}" == "true" ]]; then
-    wraps_arg="--wraps true"
+    ensure_wraps_keys_cached "${WRAPS_KEYS_DIR}"
+    wraps_key_args="--wraps true --wraps-key-path ${WRAPS_KEYS_DIR}"
   fi
 
+  start_task "Deploying consensus network"
   # shellcheck disable=SC2086
   # adding --dev flag so in case it fails we have more information on details
   eval solo consensus network deploy \
     --deployment "${DEPLOYMENT}" \
     --pvcs true \
     --tss "${TSS_ENABLED}" \
-    ${wraps_arg} \
+    ${wraps_key_args} \
     --node-aliases "${NODE_ALIASES}" \
     --application-properties "${cn_app_properties}" \
     ${cn_args} --dev || fail "ERROR: Failed to deploy consensus network" 1


### PR DESCRIPTION

## Summary

Solo-e2e improvements in two areas:

1. **WRAPS** — make `task down` + `task up` reliably produce a Schnorr -> WRAPS signature transition using WRAPS v1.0.0.
2. **WRB RSA** — add a verification task and speed up RSA roster loading.

## WRAPS v1.0.0 transition

The consensus node builds its genesis history construction within seconds of going ACTIVE. If the WRAPS proving-key library is not ready by then, CN v0.75.0-rc.6 permanently drops the WRAPS proof (`WrapsHistoryProver - Skipping publication of POST_AGGREGATION output: WRAPS library is not ready`), construction #1 stays `WRAPS-extensible? false`, and the network never transitions off Schnorr. Solo's default WRAPS is v0.2.0, which is incompatible with current consensus-node releases.

CN-side runtime download (`tss.wrapsProvingKeyDownloadEnabled=true`) downloads + verifies the ~2 GB key fine, but it runs async and finishes minutes after genesis — always too late. The readiness-retry that would let a late download succeed (`Deferring ... will retry each consensus round until ready`) only exists on consensus-node `main`, not in any released/rc version. So the proving key must be on disk before the JVM starts.

Changes in `scripts/solo-deploy-network.sh`:

- New `ensure_wraps_keys_cached`: downloads and extracts the WRAPS v1.0.0 archive once into `~/.solo/cache/wraps-v1.0.0-keys` (the four `.bin` files), skipping the download on later deploys.
- `deploy_consensus_nodes` passes `--wraps true --wraps-key-path "${WRAPS_KEYS_DIR}"` to `solo consensus network deploy` (previously bare `--wraps true`), so Solo stages the local v1.0.0 keys before the JVM starts and the library is ready at genesis. `--tss` is unchanged so Solo still patches `block-nodes.json` with the TSS message-size limits the large WRAPS genesis block needs.
- No changes to the consensus node `application.properties` (still just `tss.wrapsEnabled=true`; CN-side download stays disabled).

Validate:

```
task down
task up
task check:signature   # SCHNORR 2920 bytes -> WRAPS 3432 bytes
```

The genesis WRAPS proof takes ~15 min of single-node compute, so the flip lands a few hundred blocks in (observed first WRAPS block 437); the block where it flips is oversized (~31 MB) and the Block Node returns NOT_AVAILABLE for it (expected).

Note: Solo stages the keys under its cache directory named `wraps-v0.2.0` (its default `directoryName`, not overridable here), so that directory holds v1.0.0 contents on this setup.

## WRB RSA verification improvements

`Taskfile.yml`:

- New `verify:wrb` task (`NODE=n`, default 1): checks RSA-roster WRB verification on a Block Node via metrics — `blocknode_roster_entries_loaded`, `blocknode_verification_proof_total{proof_type="rsa"}` success/failure, and `blocknode_rsa_roster_mismatch_total`. Passes when the roster is loaded, there are RSA-verified blocks, and no mismatches; startup-window RSA failures (blocks received before the roster loaded) are reported as expected.

`scripts/solo-deploy-network.sh`:

- Lower `ROSTER_BOOTSTRAP_RSA_INITIAL_QUERY_INTERVAL_MILLIS` from `15000` to `3000` so the RSA roster loads sooner after the Mirror Node is up, narrowing the startup window in which an early block can arrive before the roster.

## Notes

- The underlying Solo limitations behind the WRAPS workaround (v0.2.0 pin, absolute `TSS_LIB_WRAPS_ARTIFACTS_PATH` rejected in CN download mode, ineffective version overrides) are written up for the Solo team in `.claude/tmp/solo-wraps-issue.md`, and the workaround is documented in `.claude/knowledge/project-patterns.md`.