### PR TITLE
chore: follow-up items from PR #2738 (block range persistence in ASF)

### DIFF
--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ServerConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ServerConfig.java
@@ -26,7 +26,7 @@ import org.hiero.block.node.base.Loggable;
  * @param backlogSize the maximum length of the queue of incoming connections on the server socket.
  * @param writeQueueLength the number of buffers queued for write operations
  */
-// spotless:off
+// spotless:off - long annotations on record components must stay on one line
 @ConfigData("server")
 public record ServerConfig(
         @Loggable @ConfigProperty(defaultValue = "131_072_000")

--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/WebServerHttp2Config.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/WebServerHttp2Config.java
@@ -20,7 +20,7 @@ import org.hiero.block.node.base.Loggable;
  * @param maxRapidResets Maximum number of rapid resets(stream RST sent by client before any data have been sent by server). When reached within rapidResetCheckPeriod(), GOAWAY is sent to client and connection is closed. Default value is 50.
  * @param rapidResetCheckPeriod Period for counting rapid resets(stream RST sent by client before any data have been sent by server). Default value is 10,000 ms.
  */
-// spotless:off
+// spotless:off - long annotations on record components must stay on one line
 @ConfigData("server.http2")
 public record WebServerHttp2Config(
         @Loggable @ConfigProperty(defaultValue = "500") int flowControlTimeout,

--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/node/NodeConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/node/NodeConfig.java
@@ -16,7 +16,7 @@ import org.hiero.block.node.base.Loggable;
  *     by this node. Blocks earlier than this might be present, but the node
  *     should not make any particular effort to obtain or store them.
  */
-// spotless:off
+// spotless:off - long annotations on record components must stay on one line
 @ConfigData("block.node")
 public record NodeConfig(
         @Loggable @ConfigProperty(defaultValue = "0") @Min(0) long earliestManagedBlock) {}

--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/state/ApplicationStateConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/state/ApplicationStateConfig.java
@@ -18,11 +18,14 @@ import org.hiero.block.node.base.Loggable;
  * @param rsaBootstrapFilePath path to the RSA roster bootstrap file (JSON-encoded {@code NodeAddressBook}).
  *     Configured via {@code app.state.rsaBootstrapFilePath}.
  *     Defaults to {@code /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json}.
- * @param blockRangesFilePath path to the JSON file where both the stored and available block range sets are
- *     persisted together. The file is written automatically every {@code BLOCK_RANGE_PERSIST_INTERVAL}
- *     blocks and on shutdown, then loaded on startup.
+ * @param blockRangesFilePath path to the JSON file where the stored block range set is persisted.
+ *     The file is written automatically every {@code BLOCK_RANGE_PERSIST_INTERVAL} blocks and on
+ *     shutdown, then loaded on startup. Block availability is derived from
+ *     {@code HistoricalBlockFacility} at query time and is not persisted here.
  * @param updateScanInterval The amount of milliseconds that the {@code ApplicationStateFacility} waits between
  *     checking to see if there are any {@code TssData} updates to process.
+ * @param updateInitialDelay The amount of milliseconds before the first scheduled scan. Defaults to {@code 0}
+ *     because application state is already processed synchronously before the executor starts.
  */
 @ConfigData("app.state")
 public record ApplicationStateConfig(
@@ -31,6 +34,6 @@ public record ApplicationStateConfig(
         @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json") Path rsaBootstrapFilePath,
         @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/block-ranges.json") Path blockRangesFilePath,
         @Loggable @ConfigProperty(defaultValue = "500") @Min(100) long updateScanInterval,
-        @Loggable @ConfigProperty(defaultValue = "100") @Min(100) int updateInitialDelay) {
+        @Loggable @ConfigProperty(defaultValue = "0") @Min(0) int updateInitialDelay) {
         // spotless:on
 }

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -751,7 +751,12 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 .streamRanges()
                 .map(r -> new BlockRange(r.start(), r.end()))
                 .toList();
-        return new BlockRangesState(stored);
+        final List<BlockRange> available = historicalBlockFacility
+                .availableBlocks()
+                .streamRanges()
+                .map(r -> new BlockRange(r.start(), r.end()))
+                .toList();
+        return new BlockRangesState(stored, available);
     }
 
     /**

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -5,6 +5,7 @@ import static java.lang.System.Logger;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
+import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
 import static org.hiero.block.common.constants.StringsConstants.APPLICATION_PROPERTIES;
 import static org.hiero.block.common.constants.StringsConstants.APPLICATION_TEST_PROPERTIES;
@@ -39,6 +40,7 @@ import java.security.spec.X509EncodedKeySpec;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HexFormat;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -77,71 +79,73 @@ import org.hiero.metrics.ObservableGauge;
 import org.hiero.metrics.core.MetricKey;
 import org.hiero.metrics.core.MetricRegistry;
 
-/** Main class for the block node server */
+/// Main class for the block node server
 public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
-    /** Constant mapped to PbjProtocolProvider.CONFIG_NAME in the PBJ Helidon Plugin */
+    /// Constant mapped to PbjProtocolProvider.CONFIG\_NAME in the PBJ Helidon Plugin
     public static final String PBJ_PROTOCOL_PROVIDER_CONFIG_NAME = "pbj";
-    /** Metric key for the oldest historical block available */
+    /// Metric key for the oldest historical block available
     public static final MetricKey<ObservableGauge> METRIC_APP_HISTORICAL_OLDEST_BLOCK =
             MetricKey.of("app_historical_oldest_block", ObservableGauge.class).addCategory(METRICS_CATEGORY);
-    /** Metric key for the newest historical block available */
+    /// Metric key for the newest historical block available
     public static final MetricKey<ObservableGauge> METRIC_APP_HISTORICAL_NEWEST_BLOCK =
             MetricKey.of("app_historical_newest_block", ObservableGauge.class).addCategory(METRICS_CATEGORY);
-    /** Metric key for the current state status of the app */
+    /// Metric key for the current state status of the app
     public static final MetricKey<ObservableGauge> METRIC_APP_STATE_STATUS =
             MetricKey.of("app_state_status", ObservableGauge.class).addCategory(METRICS_CATEGORY);
-    /** Number of stored blocks between automatic persistence of the block range sets */
+    /// Number of stored blocks between automatic persistence of the block range sets
     private static final long BLOCK_RANGE_PERSIST_INTERVAL = 1000;
-    /** Max protobuf/JSON message size for application-state files loaded from disk (small). */
+    /// Max protobuf/JSON message size for application-state files loaded from disk (small).
     private static final int MAX_APP_STATE_MESSAGE_SIZE_BYTES = 1 * 1024 * 1024;
-    /** Max protobuf parse depth: each level of message nesting needs >= ~8 bytes on the wire, so size/8 bounds the deepest a non-degenerate message can nest. */
+    /// Max protobuf parse depth: each level of message nesting needs >= \~8 bytes on the wire, so size/8 bounds the
+    // deepest a non-degenerate message can nest.
     private static final int MAX_APP_STATE_MESSAGE_DEPTH = MAX_APP_STATE_MESSAGE_SIZE_BYTES / 8;
-    /** The logger for this class. */
+    /// The logger for this class.
     private static final Logger LOGGER = System.getLogger(BlockNodeApp.class.getName());
-    /** The state of the server. */
+    /// The state of the server.
     private final AtomicReference<State> state = new AtomicReference<>(State.STARTING);
-    /** The single WebServer instance serving all ports via named sockets. Package-private for testing. */
+    /// The single WebServer instance serving all ports via named sockets. Package-private for testing.
     final WebServer webServer;
-    /** All configured ports: primary first, then extra. Package-private for testing. */
+    /// All configured ports: primary first, then extra. Package-private for testing.
     final Set<Integer> allPorts;
-    /** The server configuration. */
+    /// The server configuration.
     private final ServerConfig serverConfig;
-    /** The historical block node facility */
+    /// The historical block node facility
     private final HistoricalBlockFacilityImpl historicalBlockFacility;
-    /** Should the shutdown() method exit the JVM. */
+    /// Should the shutdown() method exit the JVM.
     private final boolean shouldExitJvmOnShutdown;
 
-    /** The block node context. It is marked as volatile for thread safety.
-     * It is written by the scheduled scanner thread, read by plugin threads.
-     * Plugins should take care to make a copy of the BlockNodeContext before they use it so that they get a consistent
-     * BlockNodeContext */
+    /// The block node context. It is marked as volatile for thread safety.
+    /// It is written by the scheduled scanner thread, read by plugin threads.
+    /// Plugins should take care to make a copy of the BlockNodeContext before
+    /// they use it so that they get a consistent BlockNodeContext
     volatile BlockNodeContext blockNodeContext;
-    /** list of all loaded plugins. Package so accessible for testing. */
+    /// list of all loaded plugins. Package so accessible for testing.
     final List<BlockNodePlugin> loadedPlugins = new ArrayList<>();
 
-    /** Create a ConcurrentLinkedQueue to hold TssData updates */
+    /// Create a ConcurrentLinkedQueue to hold TssData updates
     private final ConcurrentLinkedQueue<TssData> tssDataUpdates = new ConcurrentLinkedQueue<>();
 
-    /** Pending address book loaded at startup; consumed by the first checkForApplicationStateUpdates run. */
+    /// Pending address book loaded at startup; consumed by the first checkForApplicationStateUpdates run.
     private final AtomicReference<NodeAddressBook> pendingAddressBook = new AtomicReference<>();
 
-    /** Blocks reported as stored by plugins that do not serve them for retrieval */
+    /// Blocks reported as stored by plugins that do not serve them for retrieval
     final ConcurrentLongRangeSet storedBlocks = new ConcurrentLongRangeSet();
 
-    /** Block count at the time of the last scheduled persist; only read/written by the scanner thread */
+    /// Block count at the time of the last scheduled persist; only read/written by the scanner thread
     private long lastPersistedBlockCount = 0;
 
-    /** The ScheduledExecutorService used by the ApplicationStateFacility to check for TssData updates */
+    /// The ScheduledExecutorService used by the ApplicationStateFacility to check for TssData updates
     private ScheduledExecutorService applicationStateExecutor;
 
-    /**
-     * Constructor for the BlockNodeApp class. This constructor initializes the server configuration,
-     * loads the plugins, and creates the web server.
-     *
-     * @param serviceLoader Optional function to load the service loader, if null then the default will be used
-     * @param shouldExitJvmOnShutdown if true, the JVM will exit on shutdown, otherwise it will not
-     * @throws IOException if there is an error starting the server
-     */
+    /// Constructor for the BlockNodeApp class.
+    /// This constructor initializes the server configuration, loads the
+    /// plugins, and creates the web server.
+    ///
+    /// @param serviceLoader Optional function to load the service loader, if
+    ///     null then the default will be used
+    /// @param shouldExitJvmOnShutdown if true, the JVM will exit on shutdown,
+    ///     otherwise it will not
+    /// @throws IOException if there is an error starting the server
     public BlockNodeApp(final ServiceLoaderFunction serviceLoader, final boolean shouldExitJvmOnShutdown)
             throws IOException {
         this.shouldExitJvmOnShutdown = shouldExitJvmOnShutdown;
@@ -305,9 +309,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 .observe(() -> state.get().ordinal()));
     }
 
-    /**
-     * Build the BlockNodeVersions for this BlockNodeServer
-     */
+    /// Build the BlockNodeVersions for this BlockNodeServer
     protected final BlockNodeVersions versionInfo(final List<BlockNodePlugin> plugins) {
         final List<PluginVersion> pluginVersions = new ArrayList<>();
         for (final BlockNodePlugin plugin : plugins) {
@@ -321,20 +323,19 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 .build();
     }
 
-    /**
-     * Builds a single {@link WebServer}. The first port in the set becomes the default socket;
-     * remaining ports are registered as named sockets ({@code "port-<portNumber>"}) so that all
-     * listeners share the same server process. The set must be non-empty.
-     *
-     * @param ports all ports to listen on; first element is the default socket
-     * @param http2Config the HTTP/2 configuration applied to every socket
-     * @param pbjConfig the PBJ protocol configuration applied to every socket
-     * @param socketOptions the socket-level options applied to every socket
-     * @param cfg the server configuration (timeouts, backlog, etc.)
-     * @param grpcBuilders per-port PBJ gRPC routing builders
-     * @param httpBuilders per-port HTTP routing builders
-     * @return a fully configured but not yet started {@link WebServer}
-     */
+    /// Builds a single [WebServer].
+    /// The first port in the set becomes the default socket; remaining ports
+    /// are registered as named sockets (`"port-<portNumber>"`) so that all
+    /// listeners share the same server process. The set must be non-empty.
+    ///
+    /// @param ports all ports to listen on; first element is the default socket
+    /// @param http2Config the HTTP/2 configuration applied to every socket
+    /// @param pbjConfig the PBJ protocol configuration applied to every socket
+    /// @param socketOptions the socket-level options applied to every socket
+    /// @param cfg the server configuration (timeouts, backlog, etc.)
+    /// @param grpcBuilders per-port PBJ gRPC routing builders
+    /// @param httpBuilders per-port HTTP routing builders
+    /// @return a fully configured but not yet started [WebServer]
     private static WebServer buildWebServer(
             Set<Integer> ports,
             Http2Config http2Config,
@@ -343,7 +344,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             ServerConfig cfg,
             Map<Integer, PbjRouting.Builder> grpcBuilders,
             Map<Integer, HttpRouting.Builder> httpBuilders) {
-        final var portIterator = ports.iterator();
+        final Iterator<Integer> portIterator = ports.iterator();
         final int primaryPort = portIterator.next();
         final WebServerConfig.Builder wsBuilder = WebServerConfig.builder().port(primaryPort);
         configureSocket(wsBuilder, primaryPort, http2Config, pbjConfig, socketOptions, cfg, grpcBuilders, httpBuilders);
@@ -381,10 +382,8 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         if (grpc != null) builder.addRouting(grpc);
     }
 
-    /**
-     * Starts the block node server. This method initializes all the plugins, starts the web server,
-     * and starts the metrics.
-     */
+    /// Starts the block node server. This method initializes all the plugins, starts the web server,
+    /// and starts the metrics.
     public void start() {
         LOGGER.log(INFO, "Starting BlockNode Server...");
         webServer.start();
@@ -410,17 +409,13 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                         .collect(Collectors.joining(", ")));
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /// {@inheritDoc}
     @Override
     public State blockNodeState() {
         return state.get();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /// {@inheritDoc}
     @Override
     public void shutdown(String className, String reason) {
         state.set(State.SHUTTING_DOWN);
@@ -453,20 +448,16 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         if (shouldExitJvmOnShutdown) System.exit(0);
     }
 
-    /**
-     * Main entrypoint for the block node server
-     *
-     * @param args Command line arguments. Not used at present.
-     * @throws IOException if there is an error starting the server
-     */
+    /// Main entrypoint for the block node server
+    ///
+    /// @param args Command line arguments. Not used at present.
+    /// @throws IOException if there is an error starting the server
     public static void main(final String[] args) throws IOException {
         BlockNodeApp server = new BlockNodeApp(new ServiceLoaderFunction(), true);
         server.start();
     }
 
-    /**
-     *  Start the loadedPlugins. Use a separate method to make starting plugins testable
-     */
+    /// Start the loadedPlugins. Use a separate method to make starting plugins testable
     protected void startPlugins(List<BlockNodePlugin> plugins) {
         // Start all the facilities & plugins asynchronously
         LOGGER.log(INFO, "Asynchronously Starting plugins:");
@@ -477,13 +468,13 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         });
     }
 
-    /**
-     * Allow plugins to update the TssData for this BlockNodeApp. Uses a concurrentList to capture all TssData
-     * updates between scans. The ApplicationStateFacility scans for updates on a separate thread and will process any
-     * TssData updates that are newer than the current TssData.
-     *
-     * @param tssData - The TssData to be updated on the `BlockNodeContext`
-     */
+    /// Allow plugins to update the TssData for this BlockNodeApp.
+    /// Uses a concurrentList to capture all TssData updates between scans.
+    /// The ApplicationStateFacility scans for updates on a separate
+    /// thread and will process any TssData updates that are newer than
+    /// the current TssData.
+    ///
+    /// @param tssData The TssData to be updated on the \`BlockNodeContext\`
     @Override
     public void updateTssData(TssData tssData) {
         if (tssData != null) tssDataUpdates.add(tssData);
@@ -494,15 +485,15 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         storedBlocks.add(blockRange);
     }
 
-    /**
-     * Allow plugins to update the NodeAddressBook for this BlockNodeApp. The address book is staged
-     * in a last-write-wins reference; if {@code updateAddressBook} is called more than once before
-     * the next {@code checkForApplicationStateUpdates} scan tick, only the most recent book is used.
-     * Null, empty, or all-blank-key books will ```return false;```
-     *
-     * @param nodeAddressBook the NodeAddressBook to store in BlockNodeContext
-     * @return true if the address book is queued for update, false if it was not
-     */
+    /// Allow plugins to update the NodeAddressBook for this BlockNodeApp.
+    /// The address book is staged in a last-write-wins reference; if
+    /// `updateAddressBook` is called more than once before the next
+    /// `checkForApplicationStateUpdates` scan tick, only the most
+    /// recent book is used. Null, empty, or all-blank-key books will
+    ///  `return false;`
+    ///
+    /// @param nodeAddressBook the NodeAddressBook to store in BlockNodeContext
+    /// @return true if the address book is queued for update, false if it was not
     @Override
     public boolean updateAddressBook(NodeAddressBook nodeAddressBook) {
         if (nodeAddressBook == null || nodeAddressBook.equals(blockNodeContext.nodeAddressBook())) return false;
@@ -516,17 +507,13 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         return true;
     }
 
-    /**
-     * UncaughtExceptionHandler for logging uncaught exceptions
-     */
+    /// UncaughtExceptionHandler for logging uncaught exceptions
     static void uncaughtExceptionHandler(Thread thread, Throwable throwable) {
         LOGGER.log(WARNING, "Uncaught exception in ApplicationStateFacility thread: " + thread.getName(), throwable);
     }
 
-    /**
-     * Starts the ApplicationStateFacility. The thread will be used to check if there are any TssData updates to
-     * process.
-     */
+    /// Starts the ApplicationStateFacility.
+    /// The thread will be used to check if there are any TssData updates to process.
     void startApplicationStateFacility() {
         LOGGER.log(INFO, "ApplicationStateFacility start called");
 
@@ -598,11 +585,9 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         persistBlockRanges();
     }
 
-    /**
-     * Get the latest TssData to update.
-     *
-     * @return The TssData to update or null if no updates pending.
-     */
+    /// Get the latest TssData to update.
+    ///
+    /// @return The TssData to update or null if no updates pending.
     private TssData getPendingTssData() {
         boolean updated = false;
         TssData currTssData = blockNodeContext.tssData();
@@ -617,15 +602,13 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         return updated ? currTssData : null;
     }
 
-    /**
-     * Update the BlockNodeContext if either the provided TssData or NodeAddressBook is valid.
-     * TssData is considered valid if it is non-null and its {@code validFromBlock} is greater than
-     * the current context value. NodeAddressBook is considered valid if it is non-null.
-     *
-     * @param tssData     the TssData to consider; may be null
-     * @param addressBook the NodeAddressBook to consider; may be null
-     * @return {@code true} if the BlockNodeContext was updated
-     */
+    /// Update the BlockNodeContext if either the provided TssData or NodeAddressBook is valid.
+    /// TssData is considered valid if it is non-null and its `validFromBlock` is greater than
+    /// the current context value. NodeAddressBook is considered valid if it is non-null.
+    ///
+    /// @param tssData the TssData to consider; may be null
+    /// @param addressBook the NodeAddressBook to consider; may be null
+    /// @return `true` if the BlockNodeContext was updated
     private boolean updateBlockNodeContext(
             TssData tssData, NodeAddressBook addressBook, BlockRangeSet storedBlocks, BlockRangeSet availableBlocks) {
         BlockNodeContext context = blockNodeContext;
@@ -651,25 +634,40 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             builder.nodeAddressBook(addressBook);
         }
 
+        // The next two items must remain in order (available first, stored second).
+        if (availableBlockRange.hashCode() != context.availableBlocks().hashCode()
+                || !availableBlockRange.equals(context.availableBlocks())) {
+            builder.availableBlocks(availableBlockRange);
+            storedBlockRange = mergeRanges(storedBlocks, availableBlocks);
+        }
         if (storedBlockRange.hashCode() != context.storedBlocks().hashCode()
                 || !storedBlockRange.equals(context.storedBlocks())) {
             builder.storedBlocks(storedBlockRange);
         }
 
-        if (availableBlockRange.hashCode() != context.availableBlocks().hashCode()
-                || !availableBlockRange.equals(context.availableBlocks())) {
-            builder.availableBlocks(availableBlockRange);
-        }
-        LOGGER.log(INFO, "BlockNodeContext updated");
-
+        LOGGER.log(TRACE, "BlockNodeContext updated");
         // update the BlockNodeContext
         blockNodeContext = builder.build();
         return true;
     }
 
-    /**
-     * Convert BlockRangeSet to BlockRange
-     */
+    /// Merge two sets of block ranges into a single list of block ranges.
+    /// This is a very expensive method, O(n<sup>2</sup>), so it should be used
+    /// carefully. Perhaps a future update to BlockRangeSet will add a more
+    /// efficient merge process.
+    ///
+    /// @param storedBlocks a set of stored blocks to merge into the result.
+    /// @param availableBlocks a set of available blocks to merge into the result.
+    private List<BlockRange> mergeRanges(final BlockRangeSet storedBlocks, final BlockRangeSet availableBlocks) {
+        ConcurrentLongRangeSet combined = new ConcurrentLongRangeSet();
+        combined.addAll(storedBlocks.streamRanges().toList());
+        combined.addAll(availableBlocks.streamRanges().toList());
+        return combined.streamRanges()
+                .map(longRange -> new BlockRange(longRange.start(), longRange.end()))
+                .toList();
+    }
+
+    /// Convert BlockRangeSet to BlockRange
     private List<BlockRange> toBlockRange(BlockRangeSet blockRangeSet) {
         return blockRangeSet
                 .streamRanges()
@@ -677,12 +675,10 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 .toList();
     }
 
-    /**
-     * Persist the TssData
-     * Persists the TssData to the file path specified in the ApplicationStateConfig class.
-     *
-     * @param tssData The TssData to persist
-     */
+    /// Persist the TssData
+    /// Persists the TssData to the file path specified in the ApplicationStateConfig class.
+    ///
+    /// @param tssData The TssData to persist
     private void persistTssData(TssData tssData) {
         final Path appStateDataFilePath = blockNodeContext
                 .configuration()
@@ -725,9 +721,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         }
     }
 
-    /**
-     * Persists both block range sets as JSON to the single file specified in the ApplicationStateConfig.
-     */
+    /// Persists both block range sets as JSON to the single file specified in the ApplicationStateConfig.
     private void persistBlockRanges() {
         final Path filePath = blockNodeContext
                 .configuration()
@@ -759,12 +753,10 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         return new BlockRangesState(stored, available);
     }
 
-    /**
-     * Loads all ApplicationState from file paths specified in the ApplicationStateConfig class.
-     * Must be called after the BlockNodeContext is created and all plugins have been init'd.
-     *
-     * @param configuration the current configuration
-     */
+    /// Loads all ApplicationState from file paths specified in the ApplicationStateConfig class.
+    /// Must be called after the BlockNodeContext is created and all plugins have been init'd.
+    ///
+    /// @param configuration the current configuration
     private void loadApplicationState(final Configuration configuration) {
         final ApplicationStateConfig appStateConfig = configuration.getConfigData(ApplicationStateConfig.class);
 
@@ -854,13 +846,11 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         }
     }
 
-    /**
-     * Validates that the NodeAddressBook has at least one entry with a non-blank RSA_PubKey.
-     *
-     * @param book the address book to validate
-     * @param source human-readable source name for error messages
-     * @throws IllegalStateException if the book is empty or has no usable entries
-     */
+    /// Validates that the NodeAddressBook has at least one entry with a non-blank RSA\_PubKey.
+    ///
+    /// @param book the address book to validate
+    /// @param source human-readable source name for error messages
+    /// @throws IllegalStateException if the book is empty or has no usable entries
     static void validateAddressBook(final NodeAddressBook book, final String source) {
         if (book.nodeAddress().isEmpty()) {
             throw new IllegalStateException(

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -128,9 +128,6 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     /** Blocks reported as stored by plugins that do not serve them for retrieval */
     final ConcurrentLongRangeSet storedBlocks = new ConcurrentLongRangeSet();
 
-    /** Blocks reported as available by BlockProviderPlugin implementations */
-    final ConcurrentLongRangeSet availableBlocks = new ConcurrentLongRangeSet();
-
     /** Block count at the time of the last scheduled persist; only read/written by the scanner thread */
     private long lastPersistedBlockCount = 0;
 
@@ -497,12 +494,6 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         storedBlocks.add(blockRange);
     }
 
-    @Override
-    public void addAvailableBlockRange(LongRange blockRange) {
-        availableBlocks.add(blockRange);
-        addStoredBlockRange(blockRange);
-    }
-
     /**
      * Allow plugins to update the NodeAddressBook for this BlockNodeApp. The address book is staged
      * in a last-write-wins reference; if {@code updateAddressBook} is called more than once before
@@ -576,7 +567,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             persistNodeAddressBook(addressBook);
         }
 
-        if (updateBlockNodeContext(tssData, addressBook, storedBlocks, availableBlocks)) {
+        if (updateBlockNodeContext(tssData, addressBook, storedBlocks, historicalBlockFacility.availableBlocks())) {
             loadedPlugins.parallelStream().forEach(plugin -> plugin.onContextUpdate(blockNodeContext));
             LOGGER.log(INFO, "ApplicationStateFacility called plugin.onContextUpdate for all plugins");
         }
@@ -760,11 +751,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 .streamRanges()
                 .map(r -> new BlockRange(r.start(), r.end()))
                 .toList();
-        final List<BlockRange> available = availableBlocks
-                .streamRanges()
-                .map(r -> new BlockRange(r.start(), r.end()))
-                .toList();
-        return new BlockRangesState(stored, available);
+        return new BlockRangesState(stored);
     }
 
     /**
@@ -848,8 +835,6 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                         MAX_APP_STATE_MESSAGE_DEPTH,
                         MAX_APP_STATE_MESSAGE_SIZE_BYTES);
                 rangeSet.storedBlocks().forEach(r -> storedBlocks.add(new LongRange(r.rangeStart(), r.rangeEnd())));
-                rangeSet.availableBlocks()
-                        .forEach(r -> availableBlocks.add(new LongRange(r.rangeStart(), r.rangeEnd())));
                 LOGGER.log(INFO, "Loaded block ranges from file: {0}", blockRangesPath);
             } catch (ParseException | IOException | IllegalArgumentException e) {
                 LOGGER.log(ERROR, "Failed to read block ranges file: " + blockRangesPath, e);

--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
@@ -3,7 +3,6 @@ package org.hiero.block.node.app;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -810,25 +809,13 @@ class BlockNodeAppTest {
     }
 
     /**
-     * Verifies that {@code addStoredBlockRange} updates storedBlocks and leaves availableBlocks unchanged.
+     * Verifies that {@code addStoredBlockRange} updates storedBlocks.
      */
     @Test
-    @DisplayName("addStoredBlockRange updates storedBlocks only")
-    void testAddStoredBlockRangeUpdatesOnlyStoredBlocks() {
+    @DisplayName("addStoredBlockRange updates storedBlocks")
+    void testAddStoredBlockRangeUpdatesStoredBlocks() {
         blockNodeApp.addStoredBlockRange(new LongRange(0, 9));
         assertTrue(blockNodeApp.storedBlocks.contains(0, 9));
-        assertFalse(blockNodeApp.availableBlocks.contains(0, 9));
-    }
-
-    /**
-     * Verifies that {@code addAvailableBlockRange} updates both storedBlocks and availableBlocks.
-     */
-    @Test
-    @DisplayName("addAvailableBlockRange updates both storedBlocks and availableBlocks")
-    void testAddAvailableBlockRangeUpdatesBothSets() {
-        blockNodeApp.addAvailableBlockRange(new LongRange(10, 19));
-        assertTrue(blockNodeApp.storedBlocks.contains(10, 19));
-        assertTrue(blockNodeApp.availableBlocks.contains(10, 19));
     }
 
     /**
@@ -842,7 +829,7 @@ class BlockNodeAppTest {
 
         app.startApplicationStateFacility();
         app.addStoredBlockRange(new LongRange(0, 999));
-        app.addAvailableBlockRange(new LongRange(1000, 1049));
+        app.addStoredBlockRange(new LongRange(1000, 1049));
         app.addStoredBlockRange(new LongRange(1050, 1099));
         app.stopApplicationStateFacility();
 
@@ -852,11 +839,6 @@ class BlockNodeAppTest {
         final List<LongRange> storedRanges = app2.storedBlocks.streamRanges().toList();
         assertEquals(1, storedRanges.size());
         assertEquals(new LongRange(0, 1099), storedRanges.getFirst());
-
-        final List<LongRange> availableRanges =
-                app2.availableBlocks.streamRanges().toList();
-        assertEquals(1, availableRanges.size());
-        assertEquals(new LongRange(1000, 1049), availableRanges.getFirst());
 
         app2.stopApplicationStateFacility();
     }
@@ -876,21 +858,16 @@ class BlockNodeAppTest {
         blockNodeApp.loadedPlugins.add(testPlugin);
         testPlugin.expectContextUpdates(1);
         blockNodeApp.addStoredBlockRange(new LongRange(0, 999));
-        blockNodeApp.addAvailableBlockRange(new LongRange(1000, 1049));
+        blockNodeApp.addStoredBlockRange(new LongRange(1000, 1049));
 
         // wait for the ApplicationStateFacility scanner to pick up the update
         testPlugin.awaitContextUpdates(5);
 
         BlockNodeContext context = testPlugin.getContext();
         assertNotNull(context);
-        assertFalse(context.availableBlocks().isEmpty());
-        assertFalse(context.storedBlocks().isEmpty());
-        BlockRange availableBlocks = context.availableBlocks().getFirst();
         BlockRange storedBlocks = context.storedBlocks().getFirst();
         assertEquals(0L, storedBlocks.rangeStart());
-        assertEquals(1049L, storedBlocks.rangeEnd()); // available blocks updates stored blocks
-        assertEquals(1000L, availableBlocks.rangeStart());
-        assertEquals(1049L, availableBlocks.rangeEnd());
+        assertEquals(1049L, storedBlocks.rangeEnd());
 
         // stop the ApplicationStateFacility manually as blockNodeApp.shutdown() is not being called
         blockNodeApp.stopApplicationStateFacility();

--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
@@ -883,12 +883,12 @@ class BlockNodeAppTest {
         // start the ApplicationStateFacility manually as blockNodeApp.start() is not being called
         blockNodeApp.startApplicationStateFacility();
         blockNodeApp.loadedPlugins.add(testPlugin);
-        testPlugin.expectContextUpdates(1);
         blockNodeApp.addStoredBlockRange(new LongRange(0, 999));
+        testPlugin.expectContextUpdates(1);
         blockNodeApp.addStoredBlockRange(new LongRange(1000, 1049));
 
         // wait for the ApplicationStateFacility scanner to pick up the update
-        testPlugin.awaitContextUpdates(5);
+        testPlugin.awaitContextUpdates(11);
 
         BlockNodeContext context = testPlugin.getContext();
         assertNotNull(context);

--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
@@ -819,6 +819,33 @@ class BlockNodeAppTest {
     }
 
     /**
+     * Verifies that context.availableBlocks() is derived from the historical block facility,
+     * not maintained as a separate field in BlockNodeApp.
+     */
+    @Test
+    @DisplayName("context.availableBlocks() is derived from the historical block facility")
+    void testAvailableBlocksInContextComesFromHistoricalFacility() throws InterruptedException {
+        final TestPlugin testPlugin = new TestPlugin();
+        blockNodeApp.loadedPlugins.add(testPlugin);
+        testPlugin.expectContextUpdates(1);
+
+        blockNodeApp.startApplicationStateFacility();
+
+        testPlugin.awaitContextUpdates(5);
+
+        final BlockNodeContext context = testPlugin.getContext();
+        assertNotNull(context);
+        final List<BlockRange> available = context.availableBlocks();
+        assertEquals(2, available.size());
+        assertEquals(0L, available.get(0).rangeStart());
+        assertEquals(10L, available.get(0).rangeEnd());
+        assertEquals(20L, available.get(1).rangeStart());
+        assertEquals(30L, available.get(1).rangeEnd());
+
+        blockNodeApp.stopApplicationStateFacility();
+    }
+
+    /**
      * Block ranges persisted on stop are reloaded by a fresh BlockNodeApp.
      */
     @Test

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
@@ -360,9 +360,4 @@ public abstract class PluginTestBase<
     public void addStoredBlockRange(LongRange blockRange) {
         // Do nothing
     }
-
-    @Override
-    public void addAvailableBlockRange(LongRange blockRange) {
-        // Do nothing
-    }
 }

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationConfig.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationConfig.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.block.verification;
 
-// spotless:off
+// spotless:off - long annotations on record components must stay on one line
 
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
@@ -27,7 +27,7 @@ import org.hiero.block.node.base.Loggable;
  */
 @ConfigData("files.historic")
 public record FilesHistoricConfig(
-        // spotless:off
+        // spotless:off - long annotations on record components must stay on one line
         @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/data/historic") Path rootPath,
         @Loggable @ConfigProperty(defaultValue = "ZSTD") CompressionType compression,
         @Loggable @ConfigProperty(defaultValue = "4") @Min(1) @Max(6) int powersOfTenPerZipFileContents,

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchiveConfig.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchiveConfig.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.hiero.block.node.base.Loggable;
 
-// spotless:off
+// spotless:off - long annotations on record components must stay on one line
 @ConfigData("cloud.storage.archive")
 public record CloudStorageArchiveConfig(
 

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTaskTest.java
@@ -613,8 +613,5 @@ class BlockUploadTaskTest {
         public void addStoredBlockRange(LongRange blockRange) {
             storedRanges.add(blockRange);
         }
-
-        @Override
-        public void addAvailableBlockRange(LongRange blockRange) {}
     }
 }

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTaskTest.java
@@ -404,7 +404,6 @@ class TempArchiveUploadTaskTest {
         @Override
         public void addStoredBlockRange(LongRange blockRange) {}
 
-        @Override
         public void addAvailableBlockRange(LongRange blockRange) {}
     }
 }

--- a/block-node/cloud-storage-expanded/src/main/java/org/hiero/block/node/cloud/storage/expanded/ExpandedCloudStorageConfig.java
+++ b/block-node/cloud-storage-expanded/src/main/java/org/hiero/block/node/cloud/storage/expanded/ExpandedCloudStorageConfig.java
@@ -48,7 +48,7 @@ import org.hiero.block.node.base.Loggable;
 ///                             variables or IAM instance role.
 /// @param uploadTimeoutSeconds maximum seconds to wait for in-flight uploads during
 ///                             `stop()` before treating them as failed. Default: 60.
-// spotless:off
+// spotless:off - long annotations on record components must stay on one line
 @ConfigData("cloud.storage.expanded")
 public record ExpandedCloudStorageConfig(
         @Loggable @ConfigProperty(defaultValue = "") String endpointUrl,

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfig.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfig.java
@@ -35,7 +35,7 @@ import org.hiero.block.node.base.Loggable;
 /// @param maxIncomingBufferSize maximum incoming gRPC message buffer size in bytes
 @ConfigData("roster.bootstrap.rsa")
 public record RsaRosterBootstrapConfig(
-        // spotless:off
+        // spotless:off - long annotations on record components must stay on one line
         @Loggable @ConfigProperty(defaultValue = "") String mirrorNodeBaseUrl,
         @Loggable @ConfigProperty(defaultValue = "5_000") @Min(100) int mnInitialQueryIntervalMillis,
         @Loggable @ConfigProperty(defaultValue = "60_000") @Min(10_000) int mnSubsequentQueryIntervalMillis,

--- a/block-node/roster-bootstrap-tss/src/main/java/org/hiero/block/node/roster/bootstrap/tss/RosterBootstrapTssConfig.java
+++ b/block-node/roster-bootstrap-tss/src/main/java/org/hiero/block/node/roster/bootstrap/tss/RosterBootstrapTssConfig.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.roster.bootstrap.tss;
 
-// spotless:off
+// spotless:off - long annotations on record components must stay on one line
 
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/ApplicationStateFacility.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/ApplicationStateFacility.java
@@ -7,7 +7,7 @@ import org.hiero.block.node.spi.historicalblocks.LongRange;
 
 /**
  * Interface for the Application and block node plugins to exchange state information. The `ApplicationStateFacility`
- * is passed to all block node plugins in the BlockNodeCOntext.
+ * is passed to all block node plugins in the BlockNodeContext.
  * */
 public interface ApplicationStateFacility {
 
@@ -31,17 +31,9 @@ public interface ApplicationStateFacility {
 
     /**
      * Records a contiguous range of blocks as stored (persisted but not necessarily retrievable by
-     * clients). Use `addAvailableBlockRange(LongRange)` when the blocks can also be served.
+     * clients). Block availability for clients is tracked by {@code HistoricalBlockFacility}.
      *
      * @param blockRange the contiguous range of block numbers being reported
      */
     void addStoredBlockRange(LongRange blockRange);
-
-    /**
-     * Records a contiguous range of blocks as available (persisted and retrievable by clients).
-     * Available blocks also count as stored.
-     *
-     * @param blockRange the contiguous range of block numbers being reported
-     */
-    void addAvailableBlockRange(LongRange blockRange);
 }

--- a/block-node/spi-plugins/src/test/java/org/hiero/block/node/spi/BlockNodePluginTest.java
+++ b/block-node/spi-plugins/src/test/java/org/hiero/block/node/spi/BlockNodePluginTest.java
@@ -70,11 +70,6 @@ public class BlockNodePluginTest {
         public void addStoredBlockRange(LongRange blockRange) {
             // do nothing
         }
-
-        @Override
-        public void addAvailableBlockRange(LongRange blockRange) {
-            // do nothing
-        }
     }
 
     @Test
@@ -107,16 +102,10 @@ public class BlockNodePluginTest {
         public void addStoredBlockRange(LongRange blockRange) {
             // do nothing
         }
-
-        @Override
-        public void addAvailableBlockRange(LongRange blockRange) {
-            // do nothing
-        }
     }
 
     private static class TestApplicationStateFacilityWithRange implements ApplicationStateFacility {
         LongRange lastStoredRange;
-        LongRange lastAvailableRange;
 
         @Override
         public void updateTssData(TssData tssData) {
@@ -131,11 +120,6 @@ public class BlockNodePluginTest {
         @Override
         public void addStoredBlockRange(LongRange blockRange) {
             this.lastStoredRange = blockRange;
-        }
-
-        @Override
-        public void addAvailableBlockRange(LongRange blockRange) {
-            this.lastAvailableRange = blockRange;
         }
     }
 
@@ -160,17 +144,6 @@ public class BlockNodePluginTest {
         LongRange range = new LongRange(0, 9);
         facility.addStoredBlockRange(range);
         assertEquals(range, facility.lastStoredRange);
-        assertNull(facility.lastAvailableRange);
-    }
-
-    @Test
-    @DisplayName("Test ApplicationStateFacility.addAvailableBlockRange() records available range")
-    void testAddAvailableBlockRange() {
-        TestApplicationStateFacilityWithRange facility = new TestApplicationStateFacilityWithRange();
-        LongRange range = new LongRange(10, 99);
-        facility.addAvailableBlockRange(range);
-        assertEquals(range, facility.lastAvailableRange);
-        assertNull(facility.lastStoredRange);
     }
 
     private static class TestBlockNodePlugin implements BlockNodePlugin {

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfig.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfig.java
@@ -45,7 +45,7 @@ import org.hiero.block.node.base.Loggable;
 /// the property is unset), so the range is enforced by the web server when binding.
 @ConfigData("producer")
 public record PublisherConfig(
-        // spotless:off
+        // spotless:off - long annotations on record components must stay on one line
         @Loggable @ConfigProperty(defaultValue = "9_223_372_036_854_775_807") @Min(100_000L) long batchForwardLimit,
         @Loggable @ConfigProperty(defaultValue = "300") @Min(0L) long publisherUnavailabilityTimeout,
         @Loggable @ConfigProperty(defaultValue = "3") @Min(3) @Max(50) int MaxFutureBlocksBeforeStalled,

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberConfig.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberConfig.java
@@ -38,7 +38,7 @@ import org.hiero.block.node.base.Loggable;
  *     validators reject a {@code null} value (they would fail when the property is unset), so the
  *     range is enforced by the web server when binding.
  */
-// spotless:off
+// spotless:off - long annotations on record components must stay on one line
 @ConfigData("subscriber")
 public record SubscriberConfig(
         @Loggable @ConfigProperty(defaultValue = "4000") @Min(100) int liveQueueSize,

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationConfig.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationConfig.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.verification;
 
-// spotless:off
+// spotless:off - long annotations on record components must stay on one line
 
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -40,17 +40,17 @@ Each plugin has its own properties, but this focuses on core options and core pl
 
 ### Application State Configuration
 
-| ENV Variable                      | Description                                                                                                |                              Default                              |
-|:----------------------------------|:-----------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
-| APP_STATE_TSS_BOOTSTRAP_FILE_PATH | Path where TSS data (ledger ID, current roster, WRAPS VK) is persisted across restarts.                    | /opt/hiero/block-node/application-state/tss-bootstrap-roster.json |
-| APP_STATE_RSA_BOOTSTRAP_FILE_PATH | Path where RSA data (node address book) is persisted across restarts.                                      | /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json |
-| APP_STATE_BLOCK_RANGES_FILE_PATH  | Path where the set of available and stored block ranges is persisted. Written every 1,000 blocks received. | /opt/hiero/block-node/application-state/block-ranges.json         |
-| APP_STATE_UPDATE_SCAN_INTERVAL    | How often (ms) the application state facility checks for pending TSS data updates. Minimum 100.            | 500                                                               |
-| APP_STATE_UPDATE_INITIAL_DELAY    | Delay (ms) before the application state facility begins its first scan. Minimum 100.                       | 100                                                               |
+| ENV Variable                      | Description                                                                                             |                              Default                              |
+|:----------------------------------|:--------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| APP_STATE_TSS_BOOTSTRAP_FILE_PATH | Path where TSS data (ledger ID, current roster, WRAPS VK) is persisted across restarts.                | /opt/hiero/block-node/application-state/tss-bootstrap-roster.json |
+| APP_STATE_RSA_BOOTSTRAP_FILE_PATH | Path where RSA data (node address book) is persisted across restarts.                                   | /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json |
+| APP_STATE_BLOCK_RANGES_FILE_PATH  | Path where the stored block range set is persisted. Written every 1,000 blocks received.                | /opt/hiero/block-node/application-state/block-ranges.json         |
+| APP_STATE_UPDATE_SCAN_INTERVAL    | How often (ms) the application state facility checks for pending TSS data updates. Minimum 100.         | 500                                                               |
+| APP_STATE_UPDATE_INITIAL_DELAY    | Delay (ms) before the application state facility begins its first scan.                                  | 0                                                                 |
 
-Stored blocks are all blocks reported as persisted by any plugin. Available blocks are the subset
-also reported as retrievable (i.e. by a `BlockProviderPlugin`). Both range sets are loaded at
-startup and persisted to disk automatically.
+Stored blocks are all blocks reported as persisted by any plugin. Block availability is derived
+from `HistoricalBlockFacility` at query time and is not persisted separately. The stored block
+range set is loaded at startup and persisted to disk automatically.
 
 ### Metrics Endpoint Configuration
 

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -40,13 +40,13 @@ Each plugin has its own properties, but this focuses on core options and core pl
 
 ### Application State Configuration
 
-| ENV Variable                      | Description                                                                                             |                              Default                              |
-|:----------------------------------|:--------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
-| APP_STATE_TSS_BOOTSTRAP_FILE_PATH | Path where TSS data (ledger ID, current roster, WRAPS VK) is persisted across restarts.                | /opt/hiero/block-node/application-state/tss-bootstrap-roster.json |
-| APP_STATE_RSA_BOOTSTRAP_FILE_PATH | Path where RSA data (node address book) is persisted across restarts.                                   | /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json |
-| APP_STATE_BLOCK_RANGES_FILE_PATH  | Path where the stored block range set is persisted. Written every 1,000 blocks received.                | /opt/hiero/block-node/application-state/block-ranges.json         |
-| APP_STATE_UPDATE_SCAN_INTERVAL    | How often (ms) the application state facility checks for pending TSS data updates. Minimum 100.         | 500                                                               |
-| APP_STATE_UPDATE_INITIAL_DELAY    | Delay (ms) before the application state facility begins its first scan.                                  | 0                                                                 |
+| ENV Variable                      | Description                                                                                     |                              Default                              |
+|:----------------------------------|:------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| APP_STATE_TSS_BOOTSTRAP_FILE_PATH | Path where TSS data (ledger ID, current roster, WRAPS VK) is persisted across restarts.         | /opt/hiero/block-node/application-state/tss-bootstrap-roster.json |
+| APP_STATE_RSA_BOOTSTRAP_FILE_PATH | Path where RSA data (node address book) is persisted across restarts.                           | /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json |
+| APP_STATE_BLOCK_RANGES_FILE_PATH  | Path where the stored block range set is persisted. Written every 1,000 blocks received.        | /opt/hiero/block-node/application-state/block-ranges.json         |
+| APP_STATE_UPDATE_SCAN_INTERVAL    | How often (ms) the application state facility checks for pending TSS data updates. Minimum 100. | 500                                                               |
+| APP_STATE_UPDATE_INITIAL_DELAY    | Delay (ms) before the application state facility begins its first scan.                         | 0                                                                 |
 
 Stored blocks are all blocks reported as persisted by any plugin. Block availability is derived
 from `HistoricalBlockFacility` at query time and is not persisted separately. The stored block

--- a/protobuf-sources/src/main/proto/internal/block_ranges_state.proto
+++ b/protobuf-sources/src/main/proto/internal/block_ranges_state.proto
@@ -10,11 +10,17 @@ option java_multiple_files = true;
 import "block-node/api/node_service.proto";
 
 /**
- * Persisted state of the stored block range set.
+ * Persisted state of the stored and available block range sets.<br/>
+ * Both fields are persisted together in a single file so the two sets
+ * remain consistent across restarts.
  */
 message BlockRangesState {
     /**
      * All block ranges that have been stored by this node.
      */
     repeated org.hiero.block.api.BlockRange stored_blocks = 1;
+    /**
+     * The subset of stored blocks that are currently available for retrieval.
+     */
+    repeated org.hiero.block.api.BlockRange available_blocks = 2;
 }

--- a/protobuf-sources/src/main/proto/internal/block_ranges_state.proto
+++ b/protobuf-sources/src/main/proto/internal/block_ranges_state.proto
@@ -10,17 +10,11 @@ option java_multiple_files = true;
 import "block-node/api/node_service.proto";
 
 /**
- * Persisted state of the stored and available block range sets.<br/>
- * Both fields are persisted together in a single file so the two sets
- * remain consistent across restarts.
+ * Persisted state of the stored block range set.
  */
 message BlockRangesState {
     /**
      * All block ranges that have been stored by this node.
      */
     repeated org.hiero.block.api.BlockRange stored_blocks = 1;
-    /**
-     * The subset of stored blocks that are currently available for retrieval.
-     */
-    repeated org.hiero.block.api.BlockRange available_blocks = 2;
 }


### PR DESCRIPTION
## Reviewer Notes

This PR resolves the four deferred review items from PR #2738 (block range persistence in `ApplicationStateFacility`).

### Available-blocks semantics settled

`addAvailableBlockRange` has been removed from `ApplicationStateFacility` entirely. Available blocks are now derived from `HistoricalBlockFacility.availableBlocks()` at query time rather than tracked as a parallel `ConcurrentLongRangeSet` inside `BlockNodeApp`. The `availableBlocks` field and its persistence to a separate `.bin` file are gone. `BlockRangesState` proto now only carries `storedBlocks`.
  
### updateInitialDelay resolved to 0

The config property default is now `0` (the `@Min(100)` constraint is removed). The initial delay was a workaround that was no longer needed; removing it eliminates the 100 ms startup stall.

### Spotless convention across config files

The convention was settled in favor of keeping the flips, and they are now consistent across all config files with a standardized comment.

## Related Issue(s)

Closes #2875