### PR TITLE
feat: Update helm charts for ApplicationStateFacility volume mounts.

### DIFF
--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/state/ApplicationStateConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/state/ApplicationStateConfig.java
@@ -17,7 +17,7 @@ import org.hiero.block.node.base.Loggable;
  *     are persisted across restarts as a serialized {@code TssData}.
  * @param rsaBootstrapFilePath path to the RSA roster bootstrap file (JSON-encoded {@code NodeAddressBook}).
  *     Configured via {@code app.state.rsaBootstrapFilePath}.
- *     Defaults to {@code /opt/hiero/block-node/node/rsa-bootstrap-roster.json}.
+ *     Defaults to {@code /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json}.
  * @param blockRangesFilePath path to the JSON file where both the stored and available block range sets are
  *     persisted together. The file is written automatically every {@code BLOCK_RANGE_PERSIST_INTERVAL}
  *     blocks and on shutdown, then loaded on startup.
@@ -27,9 +27,9 @@ import org.hiero.block.node.base.Loggable;
 @ConfigData("app.state")
 public record ApplicationStateConfig(
         // spotless:off
-        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/node/tss-bootstrap-roster.json") Path tssBootstrapFilePath,
-        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/node/rsa-bootstrap-roster.json") Path rsaBootstrapFilePath,
-        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/node/block-ranges.json") Path blockRangesFilePath,
+        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/tss-bootstrap-roster.json") Path tssBootstrapFilePath,
+        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json") Path rsaBootstrapFilePath,
+        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/block-ranges.json") Path blockRangesFilePath,
         @Loggable @ConfigProperty(defaultValue = "500") @Min(100) long updateScanInterval,
         @Loggable @ConfigProperty(defaultValue = "100") @Min(100) int updateInitialDelay) {
         // spotless:on

--- a/block-node/app/docker/update-env.sh
+++ b/block-node/app/docker/update-env.sh
@@ -50,8 +50,9 @@ echo "CLOUD_STORAGE_ARCHIVE_BUCKET_NAME=${CLOUD_STORAGE_ARCHIVE_BUCKET_NAME}" >>
 echo "CLOUD_STORAGE_ARCHIVE_REGION_NAME=${CLOUD_STORAGE_REGION_NAME}" >> .env
 echo "CLOUD_STORAGE_ARCHIVE_ACCESS_KEY=${CLOUD_STORAGE_ACCESS_KEY}" >> .env
 echo "CLOUD_STORAGE_ARCHIVE_SECRET_KEY=${CLOUD_STORAGE_SECRET_KEY}" >> .env
-echo "APP_STATE_DATA_FILE_PATH=/tmp/hiero/block-node/node/app-state-data.json" >> .env
-echo "APP_STATE_RSA_BOOTSTRAP_FILE_PATH=/tmp/hiero/block-node/node/rsa-bootstrap-roster.json" >> .env
+echo "APP_STATE_TSS_BOOTSTRAP_FILE_PATH=/tmp/hiero/block-node/application-state/tss-bootstrap-roster.json" >> .env
+echo "APP_STATE_RSA_BOOTSTRAP_FILE_PATH=/tmp/hiero/block-node/application-state/rsa-bootstrap-roster.json" >> .env
+echo "APP_STATE_BLOCK_RANGES_FILE_PATH=/tmp/hiero/block-node/application-state/block-ranges.json" >> .env
 
 # Output the values
 echo ".env properties:"

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationConfig.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationConfig.java
@@ -22,11 +22,11 @@ import org.hiero.block.node.base.Loggable;
 ///     start, room will be made for it by canceling the longest running one. todo(2528) could be lowest block nubmer
 @ConfigData("verification")
 public record VerificationConfig(
-    @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/verification/rootHashOfAllPreviousBlocks.bin") Path allBlocksHasherFilePath,
+    @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/rootHashOfAllPreviousBlocks.bin") Path allBlocksHasherFilePath,
     @Loggable @ConfigProperty(defaultValue = "false") boolean allBlocksHasherEnabled,
     @Loggable @ConfigProperty(defaultValue = "false") boolean rebuildAllBlocksHasherFromStore,
     @Loggable @ConfigProperty(defaultValue = "100") int allBlocksHasherPersistenceInterval,
-    @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/verification/tss-parameters.bin") Path tssParametersFilePath,
+    @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/tss-parameters.bin") Path tssParametersFilePath,
     @Loggable @ConfigProperty(defaultValue = "100") int activeSessionsBufferSize){}
 
 // spotless:on

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationDataProvider.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationDataProvider.java
@@ -155,7 +155,7 @@ public final class VerificationDataProvider {
     /// certificate bytes, **without** a `0x` prefix.
     /// This logic mirrors `SigFileUtils.decodePublicKey` in `tools-and-tests/tools`
     /// but is inlined here because that module cannot be imported from
-    /// `block-node/verification`.
+    /// `block-node/application-state`.
     /// ---
     /// Builds an immutable `node_id → PublicKey` map from the given address book.
     /// Entries where `rsaPubKey()` is blank or whose key bytes cannot be decoded

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/hasher/BlockHasher.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/hasher/BlockHasher.java
@@ -359,7 +359,7 @@ public final class BlockHasher implements Supplier<HashingResult> {
     ///
     /// This matches `SignatureDataExtractor.computeSignedHash(6, ...)` in
     /// `tools-and-tests/tools`. Inlined here because that module cannot be imported from
-    /// `block-node/verification`.
+    /// `block-node/application-state`.
     ///
     /// @param rawRecordStreamFileBytes raw bytes of the `record_file_contents` field
     /// @return 48-byte SHA-384 digest

--- a/block-node/roster-bootstrap-rsa/README.md
+++ b/block-node/roster-bootstrap-rsa/README.md
@@ -24,7 +24,7 @@ the roster cannot be loaded.
 ## How it works
 
 1. **File-first:** On startup `BlockNodeApp.loadApplicationState()` checks for a local bootstrap file at
-   `app.state.rsaBootstrapFilePath` (default `/opt/hiero/block-node/node/rsa-bootstrap-roster.json`). If found,
+   `app.state.rsaBootstrapFilePath` (default `/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json`). If found,
    the roster is parsed and made available in `BlockNodeContext` before any plugin is started.
 2. **Mirror Node fallback:** If no local file is present, the plugin queries the Hedera Mirror Node REST API
    (`GET /api/v1/network/nodes`, paginated, `order=desc`). The result is written to the bootstrap file via
@@ -52,7 +52,7 @@ Only two fields from each `NodeAddress` entry are populated:
 No metadata fields (network name, generation timestamp, schema version) are embedded.
 Operators wishing to annotate the file should maintain a separate sidecar.
 
-**Default file path:** `/opt/hiero/block-node/node/rsa-bootstrap-roster.json`
+**Default file path:** `/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json`
 (Configured via `app.state.rsaBootstrapFilePath`.)
 
 Generate this file before Phase 2a cutover using the operator script:
@@ -60,7 +60,7 @@ Generate this file before Phase 2a cutover using the operator script:
 ```bash
 tools-and-tests/scripts/node-operations/generate-roster-bootstrap.sh \
   --network mainnet \
-  --output /opt/hiero/block-node/node/rsa-bootstrap-roster.json
+  --output /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json
 ```
 
 ---
@@ -69,9 +69,9 @@ tools-and-tests/scripts/node-operations/generate-roster-bootstrap.sh \
 
 Bootstrap file path is configured in the `app.state` namespace (shared with other application state):
 
-|             Property             |                        Default                         |                              Description                              |
-|----------------------------------|--------------------------------------------------------|-----------------------------------------------------------------------|
-| `app.state.rsaBootstrapFilePath` | `/opt/hiero/block-node/node/rsa-bootstrap-roster.json` | Path to the local bootstrap file (JSON-serialized `NodeAddressBook`). |
+|             Property             |                               Default                               |                              Description                              |
+|----------------------------------|---------------------------------------------------------------------|-----------------------------------------------------------------------|
+| `app.state.rsaBootstrapFilePath` | `/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json` | Path to the local bootstrap file (JSON-serialized `NodeAddressBook`). |
 
 Mirror Node fallback is configured in the `roster.bootstrap.rsa` namespace:
 

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/RsaKeyDecoder.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/RsaKeyDecoder.java
@@ -24,7 +24,7 @@ import java.util.Map;
  *
  * This logic mirrors `SigFileUtils.decodePublicKey` in `tools-and-tests/tools`
  * but is inlined here because that module cannot be imported from
- * `block-node/verification`.
+ * `block-node/application-state`.
  *
  * TODO: reconcile with `SigFileUtils.decodePublicKey` and `AddressBookRegistry`
  * which store `rsaPubKey` as hex-encoded *certificate* DER (cert wrapping the

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationConfig.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationConfig.java
@@ -20,9 +20,9 @@ import org.hiero.block.node.base.Loggable;
  */
 @ConfigData("verification")
 public record VerificationConfig(
-        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/verification/rootHashOfAllPreviousBlocks.bin") Path allBlocksHasherFilePath,
+        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/rootHashOfAllPreviousBlocks.bin") Path allBlocksHasherFilePath,
         @Loggable @ConfigProperty(defaultValue = "false") boolean allBlocksHasherEnabled,
         @Loggable @ConfigProperty(defaultValue = "10") int allBlocksHasherPersistenceInterval,
-        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/verification/tss-parameters.bin") Path tssParametersFilePath) {}
+        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/tss-parameters.bin") Path tssParametersFilePath) {}
 
 // spotless:on

--- a/charts/block-node-server/templates/statefulset.yaml
+++ b/charts/block-node-server/templates/statefulset.yaml
@@ -67,6 +67,11 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.blockNode.persistence.verification.existingClaim }}
         {{- end }}
+        {{- if .Values.blockNode.persistence.applicationStateFacility.existingClaim }}
+        - name: {{ default "application-state-storage" .Values.blockNode.persistence.applicationStateFacility.volumeName }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.blockNode.persistence.applicationStateFacility.existingClaim }}
+        {{- end }}
         {{- if .Values.blockNode.persistence.plugins.existingClaim }}
         - name: {{ default "plugins-storage" .Values.blockNode.persistence.plugins.volumeName }}
           persistentVolumeClaim:
@@ -242,6 +247,8 @@ spec:
             subPath: {{ .Values.blockNode.persistence.live.subPath }}
           - name: {{ default "verification-storage" .Values.blockNode.persistence.verification.volumeName }}
             mountPath: {{ .Values.blockNode.persistence.verification.mountPath }}
+          - name: {{ default "application-state-storage" .Values.blockNode.persistence.applicationStateFacility.volumeName }}
+            mountPath: {{ .Values.blockNode.persistence.applicationStateFacility.mountPath }}
           {{- if and .Values.blockNode.backfill .Values.blockNode.backfill.sources }}
           - name: block-node-sources
             mountPath: {{ .Values.blockNode.backfill.path }}
@@ -338,6 +345,19 @@ spec:
             storage: {{ .Values.blockNode.persistence.verification.size }}
         {{- if .Values.blockNode.persistence.verification.storageClass }}
         storageClassName: {{ .Values.blockNode.persistence.verification.storageClass }}
+        {{- end }}
+    {{- end }}
+    {{- if not .Values.blockNode.persistence.applicationStateFacility.existingClaim }}
+    - metadata:
+        name: {{ default "application-state-storage" .Values.blockNode.persistence.applicationStateFacility.volumeName }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.blockNode.persistence.applicationStateFacility.size }}
+        {{- if .Values.blockNode.persistence.applicationStateFacility.storageClass }}
+        storageClassName: {{ .Values.blockNode.persistence.applicationStateFacility.storageClass }}
         {{- end }}
     {{- end }}
     {{- if and .Values.plugins.names (not .Values.blockNode.persistence.plugins.existingClaim) }}

--- a/charts/block-node-server/templates/statefulset.yaml
+++ b/charts/block-node-server/templates/statefulset.yaml
@@ -62,10 +62,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.blockNode.persistence.live.existingClaim }}
         {{- end }}
-        {{- if .Values.blockNode.persistence.applicationStateFacility.existingClaim }}
-        - name: {{ default "application-state-storage" .Values.blockNode.persistence.applicationStateFacility.volumeName }}
+        {{- if .Values.blockNode.persistence.applicationState.existingClaim }}
+        - name: {{ default "application-state-storage" .Values.blockNode.persistence.applicationState.volumeName }}
           persistentVolumeClaim:
-            claimName: {{ .Values.blockNode.persistence.applicationStateFacility.existingClaim }}
+            claimName: {{ .Values.blockNode.persistence.applicationState.existingClaim }}
         {{- end }}
         {{- if .Values.blockNode.persistence.plugins.existingClaim }}
         - name: {{ default "plugins-storage" .Values.blockNode.persistence.plugins.volumeName }}
@@ -240,8 +240,8 @@ spec:
           - name: {{ default "live-storage" .Values.blockNode.persistence.live.volumeName }}
             mountPath: {{ .Values.blockNode.persistence.live.mountPath }}
             subPath: {{ .Values.blockNode.persistence.live.subPath }}
-          - name: {{ default "application-state-storage" .Values.blockNode.persistence.applicationStateFacility.volumeName }}
-            mountPath: {{ .Values.blockNode.persistence.applicationStateFacility.mountPath }}
+          - name: {{ default "application-state-storage" .Values.blockNode.persistence.applicationState.volumeName }}
+            mountPath: {{ .Values.blockNode.persistence.applicationState.mountPath }}
           {{- if and .Values.blockNode.backfill .Values.blockNode.backfill.sources }}
           - name: block-node-sources
             mountPath: {{ .Values.blockNode.backfill.path }}
@@ -327,17 +327,17 @@ spec:
         storageClassName: {{ .Values.blockNode.persistence.live.storageClass }}
         {{- end }}
     {{- end }}
-    {{- if not .Values.blockNode.persistence.applicationStateFacility.existingClaim }}
+    {{- if not .Values.blockNode.persistence.applicationState.existingClaim }}
     - metadata:
-        name: {{ default "application-state-storage" .Values.blockNode.persistence.applicationStateFacility.volumeName }}
+        name: {{ default "application-state-storage" .Values.blockNode.persistence.applicationState.volumeName }}
       spec:
         accessModes:
           - ReadWriteOnce
         resources:
           requests:
-            storage: {{ .Values.blockNode.persistence.applicationStateFacility.size }}
-        {{- if .Values.blockNode.persistence.applicationStateFacility.storageClass }}
-        storageClassName: {{ .Values.blockNode.persistence.applicationStateFacility.storageClass }}
+            storage: {{ .Values.blockNode.persistence.applicationState.size }}
+        {{- if .Values.blockNode.persistence.applicationState.storageClass }}
+        storageClassName: {{ .Values.blockNode.persistence.applicationState.storageClass }}
         {{- end }}
     {{- end }}
     {{- if and .Values.plugins.names (not .Values.blockNode.persistence.plugins.existingClaim) }}

--- a/charts/block-node-server/templates/statefulset.yaml
+++ b/charts/block-node-server/templates/statefulset.yaml
@@ -62,11 +62,6 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.blockNode.persistence.live.existingClaim }}
         {{- end }}
-        {{- if .Values.blockNode.persistence.verification.existingClaim }}
-        - name: {{ default "verification-storage" .Values.blockNode.persistence.verification.volumeName }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.blockNode.persistence.verification.existingClaim }}
-        {{- end }}
         {{- if .Values.blockNode.persistence.applicationStateFacility.existingClaim }}
         - name: {{ default "application-state-storage" .Values.blockNode.persistence.applicationStateFacility.volumeName }}
           persistentVolumeClaim:
@@ -245,8 +240,6 @@ spec:
           - name: {{ default "live-storage" .Values.blockNode.persistence.live.volumeName }}
             mountPath: {{ .Values.blockNode.persistence.live.mountPath }}
             subPath: {{ .Values.blockNode.persistence.live.subPath }}
-          - name: {{ default "verification-storage" .Values.blockNode.persistence.verification.volumeName }}
-            mountPath: {{ .Values.blockNode.persistence.verification.mountPath }}
           - name: {{ default "application-state-storage" .Values.blockNode.persistence.applicationStateFacility.volumeName }}
             mountPath: {{ .Values.blockNode.persistence.applicationStateFacility.mountPath }}
           {{- if and .Values.blockNode.backfill .Values.blockNode.backfill.sources }}
@@ -332,19 +325,6 @@ spec:
             storage: {{ .Values.blockNode.persistence.live.size }}
         {{- if .Values.blockNode.persistence.live.storageClass }}
         storageClassName: {{ .Values.blockNode.persistence.live.storageClass }}
-        {{- end }}
-    {{- end }}
-    {{- if not .Values.blockNode.persistence.verification.existingClaim }}
-    - metadata:
-        name: {{ default "verification-storage" .Values.blockNode.persistence.verification.volumeName }}
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: {{ .Values.blockNode.persistence.verification.size }}
-        {{- if .Values.blockNode.persistence.verification.storageClass }}
-        storageClassName: {{ .Values.blockNode.persistence.verification.storageClass }}
         {{- end }}
     {{- end }}
     {{- if not .Values.blockNode.persistence.applicationStateFacility.existingClaim }}

--- a/charts/block-node-server/values-overrides/host-paths.yaml
+++ b/charts/block-node-server/values-overrides/host-paths.yaml
@@ -106,3 +106,30 @@ spec:
     requests:
       storage: 1Gi
   volumeName: verification-storage-pv
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: application-state-storage-pv
+  namespace: <NAMESPACE>
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  hostPath:
+    path: /mnt/fast-storage/application-state
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: application-state-storage-pvc
+  namespace: <NAMESPACE>
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  volumeName: application-state-storage-pv

--- a/charts/block-node-server/values-overrides/host-paths.yaml
+++ b/charts/block-node-server/values-overrides/host-paths.yaml
@@ -83,33 +83,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: verification-storage-pv
-  namespace: <NAMESPACE>
-spec:
-  accessModes:
-    - ReadWriteOnce
-  capacity:
-    storage: 1Gi
-  hostPath:
-    path: /mnt/fast-storage/verification
-    type: DirectoryOrCreate
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: verification-storage-pvc
-  namespace: <NAMESPACE>
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
-  volumeName: verification-storage-pv
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
   name: application-state-storage-pv
   namespace: <NAMESPACE>
 spec:

--- a/charts/block-node-server/values-overrides/lfh-values.yaml
+++ b/charts/block-node-server/values-overrides/lfh-values.yaml
@@ -32,8 +32,6 @@ blockNode:
                     mountPath: /archive-pvc
                   - name: logging-storage
                     mountPath: /logging-pvc
-                  - name: verification-storage
-                    mountPath: /verification-pvc
                   - name: application-state-storage
                     mountPath: /application-state-pvc
         persistence:
@@ -49,9 +47,6 @@ blockNode:
                 create: false
                 existingClaim: logging-storage-pvc
                 subPath: ""
-            verification:
-                create: false
-                existingClaim: verification-storage-pvc
             applicationStateFacility:
                 create: false
                 existingClaim: application-state-storage-pvc

--- a/charts/block-node-server/values-overrides/lfh-values.yaml
+++ b/charts/block-node-server/values-overrides/lfh-values.yaml
@@ -22,7 +22,9 @@ blockNode:
                       chown 2000:2000 /logging-pvc && \
                       chmod 700 /logging-pvc && \
                       chown 2000:2000 /verification-pvc && \
-                      chmod 700 /verification-pvc
+                      chmod 700 /verification-pvc && \
+                      chown 2000:2000 /application-state-pvc && \
+                      chmod 700 /application-state-pvc
               volumeMounts:
                   - name: live-storage
                     mountPath: /live-pvc
@@ -32,6 +34,8 @@ blockNode:
                     mountPath: /logging-pvc
                   - name: verification-storage
                     mountPath: /verification-pvc
+                  - name: application-state-storage
+                    mountPath: /application-state-pvc
         persistence:
             live:
                 create: false
@@ -48,6 +52,9 @@ blockNode:
             verification:
                 create: false
                 existingClaim: verification-storage-pvc
+            applicationStateFacility:
+                create: false
+                existingClaim: application-state-storage-pvc
 
 service:
     type: LoadBalancer

--- a/charts/block-node-server/values-overrides/lfh-values.yaml
+++ b/charts/block-node-server/values-overrides/lfh-values.yaml
@@ -47,7 +47,7 @@ blockNode:
                 create: false
                 existingClaim: logging-storage-pvc
                 subPath: ""
-            applicationStateFacility:
+            applicationState:
                 create: false
                 existingClaim: application-state-storage-pvc
 

--- a/charts/block-node-server/values-overrides/mid-size.yaml
+++ b/charts/block-node-server/values-overrides/mid-size.yaml
@@ -16,7 +16,7 @@ blockNode:
       size: 4Gi
     logging:
       size: 2Gi
-    applicationStateFacility:
+    applicationState:
       size: 500Mi
   health:
     readiness:

--- a/charts/block-node-server/values-overrides/mid-size.yaml
+++ b/charts/block-node-server/values-overrides/mid-size.yaml
@@ -18,6 +18,8 @@ blockNode:
       size: 2Gi
     verification:
       size: 500Mi
+    applicationStateFacility:
+      size: 500Mi
   health:
     readiness:
       initialDelaySeconds: 10

--- a/charts/block-node-server/values-overrides/mid-size.yaml
+++ b/charts/block-node-server/values-overrides/mid-size.yaml
@@ -16,8 +16,6 @@ blockNode:
       size: 4Gi
     logging:
       size: 2Gi
-    verification:
-      size: 500Mi
     applicationStateFacility:
       size: 500Mi
   health:

--- a/charts/block-node-server/values-overrides/mini.yaml
+++ b/charts/block-node-server/values-overrides/mini.yaml
@@ -27,6 +27,8 @@ blockNode:
       size: 1Gi
     verification:
       size: 100Mi
+    applicationStateFacility:
+      size: 100Mi
   health:
     readiness:
       initialDelaySeconds: 20

--- a/charts/block-node-server/values-overrides/mini.yaml
+++ b/charts/block-node-server/values-overrides/mini.yaml
@@ -25,8 +25,6 @@ blockNode:
       size: 1Gi
     logging:
       size: 1Gi
-    verification:
-      size: 100Mi
     applicationStateFacility:
       size: 100Mi
   health:

--- a/charts/block-node-server/values-overrides/mini.yaml
+++ b/charts/block-node-server/values-overrides/mini.yaml
@@ -25,7 +25,7 @@ blockNode:
       size: 1Gi
     logging:
       size: 1Gi
-    applicationStateFacility:
+    applicationState:
       size: 100Mi
   health:
     readiness:

--- a/charts/block-node-server/values-overrides/nano.yaml
+++ b/charts/block-node-server/values-overrides/nano.yaml
@@ -35,6 +35,10 @@ blockNode:
       size: 100Mi
       # Optionally specify an existing PVC name instead of creating via volumeClaimTemplate
       # existingClaim: "nano-verification-pvc"
+    applicationStateFacility:
+      size: 100Mi
+      # Optionally specify an existing PVC name instead of creating via volumeClaimTemplate
+      # existingClaim: "nano-application-state-pvc"
   health:
     readiness:
       initialDelaySeconds: 30

--- a/charts/block-node-server/values-overrides/nano.yaml
+++ b/charts/block-node-server/values-overrides/nano.yaml
@@ -31,10 +31,6 @@ blockNode:
       size: 1Gi
       # Optionally specify an existing PVC name instead of creating via volumeClaimTemplate
       # existingClaim: "nano-logging-pvc"
-    verification:
-      size: 100Mi
-      # Optionally specify an existing PVC name instead of creating via volumeClaimTemplate
-      # existingClaim: "nano-verification-pvc"
     applicationStateFacility:
       size: 100Mi
       # Optionally specify an existing PVC name instead of creating via volumeClaimTemplate

--- a/charts/block-node-server/values-overrides/nano.yaml
+++ b/charts/block-node-server/values-overrides/nano.yaml
@@ -31,7 +31,7 @@ blockNode:
       size: 1Gi
       # Optionally specify an existing PVC name instead of creating via volumeClaimTemplate
       # existingClaim: "nano-logging-pvc"
-    applicationStateFacility:
+    applicationState:
       size: 100Mi
       # Optionally specify an existing PVC name instead of creating via volumeClaimTemplate
       # existingClaim: "nano-application-state-pvc"

--- a/charts/block-node-server/values-overrides/rfh-values.yaml
+++ b/charts/block-node-server/values-overrides/rfh-values.yaml
@@ -24,7 +24,5 @@ blockNode:
             size: 10Gi
         logging:
             size: 2Gi
-        verification:
-            size: 500Mi
         applicationStateFacility:
             size: 500Mi

--- a/charts/block-node-server/values-overrides/rfh-values.yaml
+++ b/charts/block-node-server/values-overrides/rfh-values.yaml
@@ -26,3 +26,5 @@ blockNode:
             size: 2Gi
         verification:
             size: 500Mi
+        applicationStateFacility:
+            size: 500Mi

--- a/charts/block-node-server/values-overrides/rfh-values.yaml
+++ b/charts/block-node-server/values-overrides/rfh-values.yaml
@@ -24,5 +24,5 @@ blockNode:
             size: 10Gi
         logging:
             size: 2Gi
-        applicationStateFacility:
+        applicationState:
             size: 500Mi

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -133,8 +133,6 @@ blockNode:
           mkdir -p /archive-pvc/archive-data && \
           chown 2000:2000 /archive-pvc/archive-data && \
           chmod 700 /archive-pvc/archive-data && \
-          chown 2000:2000 /verification-pvc && \
-          chmod 700 /verification-pvc
           chown 2000:2000 /application-state-pvc && \
           chmod 700 /application-state-pvc
       volumeMounts:
@@ -142,8 +140,6 @@ blockNode:
           mountPath: /live-pvc
         - name: archive-storage
           mountPath: /archive-pvc
-        - name: verification-storage
-          mountPath: /verification-pvc
         - name: application-state-storage
           mountPath: /application-state-pvc
   # To add plugins not available in Maven (e.g. download from a URL at pod start).
@@ -230,22 +226,12 @@ blockNode:
       # storageClass: "your-storage-class"
       # Optionally specify an existing PVC name instead of creating via volumeClaimTemplate
       # existingClaim: "my-live-pvc"
-    verification:
-      # name of the volume within the statefulset
-      volumeName: "verification-storage"
-      # should match VERIFICATION_ALL_BLOCKS_HASHER_FILE_PATH parent directory
-      mountPath: "/opt/hiero/block-node/verification"
-      size: 1Gi
-      # Optionally add a storage class name if needed
-      # storageClass: "your-storage-class"
-      # Optionally specify an existing PVC name instead of creating via volumeClaimTemplate
-      # existingClaim: "my-verification-pvc"
     applicationStateFacility:
       # name of the volume within the statefulset
       volumeName: "application-state-storage"
       # should match APP_STATE_TSS_DATA_FILE_PATH, APP_STATE_STORED_BLOCKS_FILE_PATH,
       # APP_STATE_AVAILABLE_BLOCKS_FILE_PATH parent directory
-      mountPath: "/opt/hiero/block-node/node"
+      mountPath: "/opt/hiero/block-node/application-state"
       size: 1Gi
       # Optionally add a storage class name if needed
       # storageClass: "your-storage-class"

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -226,7 +226,7 @@ blockNode:
       # storageClass: "your-storage-class"
       # Optionally specify an existing PVC name instead of creating via volumeClaimTemplate
       # existingClaim: "my-live-pvc"
-    applicationStateFacility:
+    applicationState:
       # name of the volume within the statefulset
       volumeName: "application-state-storage"
       # should match APP_STATE_TSS_DATA_FILE_PATH, APP_STATE_STORED_BLOCKS_FILE_PATH,

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -135,6 +135,8 @@ blockNode:
           chmod 700 /archive-pvc/archive-data && \
           chown 2000:2000 /verification-pvc && \
           chmod 700 /verification-pvc
+          chown 2000:2000 /application-state-pvc && \
+          chmod 700 /application-state-pvc
       volumeMounts:
         - name: live-storage
           mountPath: /live-pvc
@@ -142,6 +144,8 @@ blockNode:
           mountPath: /archive-pvc
         - name: verification-storage
           mountPath: /verification-pvc
+        - name: application-state-storage
+          mountPath: /application-state-pvc
   # To add plugins not available in Maven (e.g. download from a URL at pod start).
   # Note: for non-Maven plugins, dependencies are NOT auto-resolved.
   # You must include the plugin JAR and all of its transitive dependencies.
@@ -231,6 +235,17 @@ blockNode:
       volumeName: "verification-storage"
       # should match VERIFICATION_ALL_BLOCKS_HASHER_FILE_PATH parent directory
       mountPath: "/opt/hiero/block-node/verification"
+      size: 1Gi
+      # Optionally add a storage class name if needed
+      # storageClass: "your-storage-class"
+      # Optionally specify an existing PVC name instead of creating via volumeClaimTemplate
+      # existingClaim: "my-verification-pvc"
+    applicationStateFacility:
+      # name of the volume within the statefulset
+      volumeName: "application-state-storage"
+      # should match APP_STATE_TSS_DATA_FILE_PATH, APP_STATE_STORED_BLOCKS_FILE_PATH,
+      # APP_STATE_AVAILABLE_BLOCKS_FILE_PATH parent directory
+      mountPath: "/opt/hiero/block-node/node"
       size: 1Gi
       # Optionally add a storage class name if needed
       # storageClass: "your-storage-class"

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -40,13 +40,13 @@ Each plugin has its own properties, but this focuses on core options and core pl
 
 ### Application State Configuration
 
-| ENV Variable                         | Description                                                                                     |                       Default                        |
-|:-------------------------------------|:------------------------------------------------------------------------------------------------|------------------------------------------------------|
-| APP_STATE_TSS_DATA_FILE_PATH         | Path where TSS data (ledger ID, address book, WRAPS VK) is persisted across restarts.           | /opt/hiero/block-node/node/app-state-data.bin        |
-| APP_STATE_STORED_BLOCKS_FILE_PATH    | Path where the set of stored block ranges is persisted. Written every 1,000 blocks received.    | /opt/hiero/block-node/node/stored-blocks-data.bin    |
-| APP_STATE_AVAILABLE_BLOCKS_FILE_PATH | Path where the set of available block ranges is persisted. Written every 1,000 blocks received. | /opt/hiero/block-node/node/available-blocks-data.bin |
-| APP_STATE_UPDATE_SCAN_INTERVAL       | How often (ms) the application state facility checks for pending TSS data updates. Minimum 100. | 500                                                  |
-| APP_STATE_UPDATE_INITIAL_DELAY       | Delay (ms) before the application state facility begins its first scan. Minimum 100.            | 100                                                  |
+| ENV Variable                      | Description                                                                                                |                              Default                              |
+|:----------------------------------|:-----------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| APP_STATE_TSS_BOOTSTRAP_FILE_PATH | Path where TSS data (ledger ID, current roster, WRAPS VK) is persisted across restarts.                    | /opt/hiero/block-node/application-state/tss-bootstrap-roster.json |
+| APP_STATE_RSA_BOOTSTRAP_FILE_PATH | Path where RSA data (node address book) is persisted across restarts.                                      | /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json |
+| APP_STATE_BLOCK_RANGES_FILE_PATH  | Path where the set of available and stored block ranges is persisted. Written every 1,000 blocks received. | /opt/hiero/block-node/application-state/block-ranges.json         |
+| APP_STATE_UPDATE_SCAN_INTERVAL    | How often (ms) the application state facility checks for pending TSS data updates. Minimum 100.            | 500                                                               |
+| APP_STATE_UPDATE_INITIAL_DELAY    | Delay (ms) before the application state facility begins its first scan. Minimum 100.                       | 100                                                               |
 
 Stored blocks are all blocks reported as persisted by any plugin. Available blocks are the subset
 also reported as retrievable (i.e. by a `BlockProviderPlugin`). Both range sets are loaded at
@@ -270,12 +270,12 @@ for the JSON schema.
 
 ### Verification Plugin Configuration
 
-| ENV Variable                                        | Description                                                                    |                                                            Default |
-|:----------------------------------------------------|:-------------------------------------------------------------------------------|-------------------------------------------------------------------:|
-| VERIFICATION_ALL_BLOCKS_HASHER_ENABLED              | Enable the all-blocks hasher to compute and verify a rolling root hash.        |                                                              false |
-| VERIFICATION_ALL_BLOCKS_HASHER_FILE_PATH            | Path to the persisted root hash file for all previous blocks.                  | /opt/hiero/block-node/verification/rootHashOfAllPreviousBlocks.bin |
-| VERIFICATION_ALL_BLOCKS_HASHER_PERSISTENCE_INTERVAL | How often (in blocks) the hasher persists its state to disk.                   |                                                                 10 |
-| VERIFICATION_TSS_PARAMETERS_FILE_PATH               | Path to the persisted TSS parameters file (ledger ID, address book, WRAPS VK). |              /opt/hiero/block-node/verification/tss-parameters.bin |
+| ENV Variable                                        | Description                                                                    |                                                                 Default |
+|:----------------------------------------------------|:-------------------------------------------------------------------------------|------------------------------------------------------------------------:|
+| VERIFICATION_ALL_BLOCKS_HASHER_ENABLED              | Enable the all-blocks hasher to compute and verify a rolling root hash.        |                                                                   false |
+| VERIFICATION_ALL_BLOCKS_HASHER_FILE_PATH            | Path to the persisted root hash file for all previous blocks.                  | /opt/hiero/block-node/application-state/rootHashOfAllPreviousBlocks.bin |
+| VERIFICATION_ALL_BLOCKS_HASHER_PERSISTENCE_INTERVAL | How often (in blocks) the hasher persists its state to disk.                   |                                                                      10 |
+| VERIFICATION_TSS_PARAMETERS_FILE_PATH               | Path to the persisted TSS parameters file (ledger ID, address book, WRAPS VK). |              /opt/hiero/block-node/application-state/tss-parameters.bin |
 
 > **Note:** `VERIFICATION_ALL_BLOCKS_HASHER_ENABLED` must remain `false` (the default).
 > The all-blocks hasher requires a strictly sequential block stream; out-of-order or

--- a/docs/design/block-verification.md
+++ b/docs/design/block-verification.md
@@ -286,11 +286,11 @@ sequenceDiagram
 
 Configuration class: `VerificationConfig`
 
-|               Property               |                               Default                                |                      Description                       |
-|--------------------------------------|----------------------------------------------------------------------|--------------------------------------------------------|
-| `allBlocksHasherFilePath`            | `/opt/hiero/block-node/verification/rootHashOfAllPreviousBlocks.bin` | Path for the persistent hasher snapshot                |
-| `allBlocksHasherEnabled`             | `true`                                                               | Enable or disable the all-blocks root hash computation |
-| `allBlocksHasherPersistenceInterval` | `10` (blocks)                                                        | How often the hasher snapshot is written to disk       |
+|               Property               |                                  Default                                  |                      Description                       |
+|--------------------------------------|---------------------------------------------------------------------------|--------------------------------------------------------|
+| `allBlocksHasherFilePath`            | `/opt/hiero/block-node/application-state/rootHashOfAllPreviousBlocks.bin` | Path for the persistent hasher snapshot                |
+| `allBlocksHasherEnabled`             | `true`                                                                    | Enable or disable the all-blocks root hash computation |
+| `allBlocksHasherPersistenceInterval` | `10` (blocks)                                                             | How often the hasher snapshot is written to disk       |
 
 ## Metrics
 

--- a/docs/design/tss-block-proof-verification.md
+++ b/docs/design/tss-block-proof-verification.md
@@ -63,6 +63,6 @@ file can be placed manually into the volume.
 
 ## Configuration
 
-|               Property               |                         Default                         |           Description           |
-|--------------------------------------|---------------------------------------------------------|---------------------------------|
-| `verification.tssParametersFilePath` | `/opt/hiero/block-node/verification/tss-parameters.bin` | TSS parameters persistence path |
+|               Property               |                           Default                            |           Description           |
+|--------------------------------------|--------------------------------------------------------------|---------------------------------|
+| `verification.tssParametersFilePath` | `/opt/hiero/block-node/application-state/tss-parameters.bin` | TSS parameters persistence path |

--- a/docs/design/wrb-streaming/bootstrap-roster-plugin.md
+++ b/docs/design/wrb-streaming/bootstrap-roster-plugin.md
@@ -255,7 +255,7 @@ final NodeAddressBook nodeAddressBook =
         NodeAddressBook.JSON.parse(Bytes.wrap(Files.readAllBytes(filePath)));
 ```
 
-**Default file path:** `/opt/hiero/block-node/node/rsa-bootstrap-roster.json`
+**Default file path:** `/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json`
 (Configured via `app.state.rsaBootstrapFilePath`.)
 
 ---
@@ -598,9 +598,9 @@ sequenceDiagram
 
 Bootstrap file path is in the `app.state` namespace (shared application state config):
 
-|             Property             |  Type  |                        Default                         |                          Description                          |
-|----------------------------------|--------|--------------------------------------------------------|---------------------------------------------------------------|
-| `app.state.rsaBootstrapFilePath` | string | `/opt/hiero/block-node/node/rsa-bootstrap-roster.json` | Path to the JSON-serialized `NodeAddressBook` bootstrap file. |
+|             Property             |  Type  |                               Default                               |                          Description                          |
+|----------------------------------|--------|---------------------------------------------------------------------|---------------------------------------------------------------|
+| `app.state.rsaBootstrapFilePath` | string | `/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json` | Path to the JSON-serialized `NodeAddressBook` bootstrap file. |
 
 All plugin properties are in the `roster.bootstrap.rsa` namespace:
 
@@ -697,7 +697,7 @@ A script `tools-and-tests/scripts/node-operations/generate-roster-rsa-bootstrap.
 **Expected usage before a Phase 2a cutover:**
 
 ```bash
-generate-rsa-roster-bootstrap.sh --network mainnet --output /opt/hiero/block-node/node/rsa-bootstrap-roster.json
+generate-rsa-roster-bootstrap.sh --network mainnet --output /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json
 ```
 
 Because the plugin polls both the peer BN and Mirror Node at configurable intervals and updates the address book in

--- a/docs/design/wrb-streaming/sp-wrb-bn-design.md
+++ b/docs/design/wrb-streaming/sp-wrb-bn-design.md
@@ -118,7 +118,7 @@ that era's node RSA keys. A block with no available address book fails verificat
 Tier-1 retrieval already exists via `RosterBootstrapTssPlugin.queryPeerTssData()` against the
 special-purpose BN's status API. The only operational step is moving the CLI-produced
 `/mnt/wrb-operations/wrappedBlocks/tss-bootstrap-roster.json` to the BN's
-`/opt/hiero/block-node/node/` — a documented operator/script action, **not** an engineering change.
+`/opt/hiero/block-node/application-state/` — a documented operator/script action, **not** an engineering change.
 Stop the Block Node before copying the file into place and restart after — this avoids concurrent writes to the same location.
 
 ### Reuse summary
@@ -136,7 +136,7 @@ Stop the Block Node before copying the file into place and restart after — thi
 flowchart LR
     subgraph WRBS [WRB server]
         CLI[CLI tools<br/>wrap + push] -->|"bulk-load (historical) / publish (live)"| SP[Special-purpose BN<br/>Tier 0]
-        TSSJSON[tss-bootstrap-roster.json] -. operator copy .-> SPCFG[(BN config<br/>/opt/hiero/block-node/node)]
+        TSSJSON[tss-bootstrap-roster.json] -. operator copy .-> SPCFG[(BN config<br/>/opt/hiero/block-node/application-state)]
     end
     MN[Mirror Node] -->|address-book changes| SP
     ABH[CLI address-book history JSON] -. convert + bootstrap .-> SP
@@ -157,7 +157,7 @@ New / affected configuration (final keys decided per ticket; plugins own their o
 - **CLI live-push**: target BN publish endpoint (and enable/disable of the live distribution path).
 - **TSS (operator step, no config change):** copy
   `/mnt/wrb-operations/wrappedBlocks/tss-bootstrap-roster.json` →
-  `/opt/hiero/block-node/node/`.
+  `/opt/hiero/block-node/application-state/`.
 
 ## Metrics
 

--- a/tools-and-tests/scripts/node-operations/generate-rsa-roster-bootstrap.sh
+++ b/tools-and-tests/scripts/node-operations/generate-rsa-roster-bootstrap.sh
@@ -39,15 +39,15 @@
 #
 #   1. Pick the network (or an explicit MN URL):
 #        generate-rsa-roster-bootstrap.sh --network mainnet \
-#          --output /opt/hiero/block-node/node/rsa-bootstrap-roster.json
+#          --output /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json
 #
 #      or point at a specific Mirror Node:
 #        generate-rsa-roster-bootstrap.sh \
 #          --mirror-node-url https://mainnet-public.mirrornode.hedera.com \
-#          --output /opt/hiero/block-node/node/rsa-bootstrap-roster.json
+#          --output /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json
 #
 #   2. Inspect the result:
-#        python3 -m json.tool < /opt/hiero/block-node/node/rsa-bootstrap-roster.json | head -40
+#        python3 -m json.tool < /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json | head -40
 #      Confirm the entry count matches the expected number of active nodes.
 #
 #   3. Deploy the file to the configured bootstrap path
@@ -99,7 +99,7 @@ Output shape:
 
 Examples:
   generate-rsa-roster-bootstrap.sh --network mainnet \
-    --output /opt/hiero/block-node/node/rsa-bootstrap-roster.json
+    --output /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json
 
   generate-rsa-roster-bootstrap.sh \
     --mirror-node-url https://testnet.mirrornode.hedera.com > roster.json

--- a/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
+++ b/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
@@ -339,7 +339,7 @@ tasks:
     cmds:
       - |
         POD_NAME="block-node-{{.NODE}}-0"
-        VERIFICATION_FILE="/opt/hiero/block-node/verification/rootHashOfAllPreviousBlocks.bin"
+        VERIFICATION_FILE="/opt/hiero/block-node/application-state/rootHashOfAllPreviousBlocks.bin"
 
         echo "Resetting Block Node {{.NODE}}..."
 


### PR DESCRIPTION
## Reviewer Notes
State files get written to the block-node/node directory. This directory was not on a volume mount so that state was ephemeral across restarts. Added a volume specifically for application state. 

Initial Files modified:

- [statefulset.yaml](charts/block-node-server/templates/statefulset.yaml) - Added `existingClaim` volume block, main container volume mount, and `volumeClaimTemplate`
- [host-paths.yaml](charts/block-node-server/values-overrides/host-paths.yaml) - Added `application-state-storage-pv` PV and `application-state-storage-pvc` PVC
- [lfh-values.yaml](charts/block-node-server/values-overrides/lfh-values.yaml) - Added init container chown/chmod command, volumeMount, and `applicationStateFacility.existingClaim` in persistence
- [mid-size.yaml](charts/block-node-server/values-overrides/mid-size.yaml) - Added `applicationStateFacility.size: 500Mi` | | 
- [mini.yaml](charts/block-node-server/values-overrides/mini.yaml) - Added `applicationStateFacility.size: 100Mi`
- [nano.yaml](charts/block-node-server/values-overrides/nano.yaml) - Added `applicationStateFacility.size: 100Mi` with commented `existingClaim`
- [rfh-values.yaml](charts/block-node-server/values-overrides/rfh-values.yaml) -Added `applicationStateFacility.size: 500Mi`

## Related Issue(s)
Closes: #3020 
