### PR TITLE
feat: add blocks bulk-load command for historic plugin.

### DIFF
--- a/protobuf-sources/src/main/proto/internal/bulk_load_state.proto
+++ b/protobuf-sources/src/main/proto/internal/bulk_load_state.proto
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+syntax = "proto3";
+
+package org.hiero.block.internal;
+
+option java_package = "org.hiero.block.internal.protoc";
+// <<<pbj.java_package = "org.hiero.block.internal">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Resume state for the `blocks bulk-load` CLI command. Persisted as JSON next to the destination
+ * historic store. On re-run, the command reloads this state, skips already-copied files (via
+ * {@code copied_files}), and reports cumulative progress.
+ */
+message BulkLoadState {
+    /**
+     * Absolute path of the source directory the previous run was reading from. If the next run
+     * specifies a different source the operator is warned but the new source is honored.
+     */
+    string source_dir = 1;
+
+    /**
+     * Absolute path of the destination historic store directory the previous run was writing to.
+     */
+    string dest_dir = 2;
+
+    /**
+     * Relative paths (relative to {@code source_dir}) of zip files that have already been copied
+     * to the destination. Used at startup to skip already-copied files in O(1) via an in-memory
+     * HashSet.
+     */
+    repeated string copied_files = 3;
+
+    /**
+     * Highest block number known to have been copied so far. Used in combination with the
+     * {@code --start-block} CLI flag to skip whole zip files whose contents are entirely below
+     * this watermark.
+     */
+    int64 last_copied_block = 4;
+
+    /**
+     * Cumulative bytes copied across all runs. Reported in the progress summary; not used for
+     * skip decisions.
+     */
+    int64 total_bytes_copied = 5;
+
+    /**
+     * Cumulative file count copied across all runs. Reported in the progress summary; not used
+     * for skip decisions.
+     */
+    int64 total_files_copied = 6;
+}

--- a/tools-and-tests/tools/build.gradle.kts
+++ b/tools-and-tests/tools/build.gradle.kts
@@ -14,8 +14,6 @@ application { mainClass = "org.hiero.block.tools.BlockStreamTool" }
 mainModuleInfo {
     requires("org.hiero.block.protobuf.pbj")
     requires("org.hiero.block.node.base")
-    requires("com.fasterxml.jackson.annotation")
-    requires("com.fasterxml.jackson.databind")
     requires("com.hedera.pbj.runtime")
     requires("com.github.luben.zstd_jni")
     requires("com.google.api.gax")

--- a/tools-and-tests/tools/build.gradle.kts
+++ b/tools-and-tests/tools/build.gradle.kts
@@ -14,6 +14,8 @@ application { mainClass = "org.hiero.block.tools.BlockStreamTool" }
 mainModuleInfo {
     requires("org.hiero.block.protobuf.pbj")
     requires("org.hiero.block.node.base")
+    requires("com.fasterxml.jackson.annotation")
+    requires("com.fasterxml.jackson.databind")
     requires("com.hedera.pbj.runtime")
     requires("com.github.luben.zstd_jni")
     requires("com.google.api.gax")

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BlocksCommand.java
@@ -19,6 +19,7 @@ import picocli.CommandLine.Spec;
             ToWrappedBlocksCommand.class,
             FetchBalanceCheckpointsCommand.class,
             RepairZipsCommand.class,
+            BulkLoadBlocksCommand.class,
         },
         mixinStandardHelpOptions = true)
 public class BlocksCommand implements Runnable {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommand.java
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.blocks;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicLong;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Option;
+
+/**
+ * Bulk-load wrapped blocks from CLI output into a Block Node's historic storage.
+ *
+ * <p>This command copies wrapped block zip files from the CLI's output directory (as produced by
+ * the {@code wrap} command) directly into a Block Node's historic storage directory. The Block Node
+ * MUST be stopped before running this command.
+ *
+ * <p>On Block Node startup, the {@code BlockFileHistoricPlugin} will detect all copied blocks and
+ * make them available for serving.
+ *
+ * <h2>Storage Format Compatibility</h2>
+ * <p>Both the CLI's {@code wrap} command and the Block Node's {@code BlockFileHistoricPlugin} use
+ * the same storage format (as defined by {@code BlockWriter}), so zip files can be copied directly
+ * without any conversion or restructuring.
+ *
+ * <h2>Resumable</h2>
+ * <p>This command is resumable: if run multiple times, it will only copy files that don't already
+ * exist in the destination. Files are compared by path and size.
+ *
+ * <h2>Safety</h2>
+ * <p>The Block Node MUST be stopped before running this command to avoid concurrent writes to the
+ * same storage location.
+ *
+ * <h2>Example Usage</h2>
+ * <pre>
+ * # Stop the Block Node first!
+ * # systemctl stop hiero-block-node
+ *
+ * # Bulk-load wrapped blocks
+ * blocks bulk-load --source wrappedBlocks --dest /opt/hiero/block-node/data/historic
+ *
+ * # Start the Block Node
+ * # systemctl start hiero-block-node
+ * </pre>
+ *
+ * <h2>Directory Structure</h2>
+ * <p>The command copies the entire directory tree from the source to destination, preserving the
+ * nested directory structure required by the Block Node:
+ * <pre>
+ * source/
+ *   000/123/456/789/012/345/
+ *     60000s.zip
+ *     70000s.zip
+ *
+ * dest/
+ *   000/123/456/789/012/345/
+ *     60000s.zip  (copied)
+ *     70000s.zip  (copied)
+ * </pre>
+ */
+@Command(
+        name = "bulk-load",
+        description = "Bulk-load wrapped blocks from CLI output into Block Node historic storage (BN must be stopped)",
+        mixinStandardHelpOptions = true)
+public class BulkLoadBlocksCommand implements Callable<Integer> {
+
+    @Option(
+            names = {"-s", "--source"},
+            description = "Source directory containing wrapped block zip files (from CLI wrap command)",
+            required = true)
+    private Path sourceDir;
+
+    @Option(
+            names = {"-d", "--dest"},
+            description =
+                    "Destination directory (Block Node historic root path, e.g., /opt/hiero/block-node/data/historic)",
+            required = true)
+    private Path destDir;
+
+    @Option(
+            names = {"--dry-run"},
+            description = "Show what would be copied without actually copying")
+    private boolean dryRun = false;
+
+    @Option(
+            names = {"--start-block"},
+            description = "Start copying from this block number onwards (for resuming interrupted loads)")
+    private long startBlock = -1;
+
+    private static final String STATE_FILE_NAME = "historic-plugin-bulk-load-state.json";
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    /**
+     * State tracking for resume functionality.
+     */
+    public static class LoadState {
+        @JsonProperty
+        public String sourceDir;
+
+        @JsonProperty
+        public String destDir;
+
+        @JsonProperty
+        public List<String> copiedFiles = new ArrayList<>();
+
+        @JsonProperty
+        public long lastCopiedBlock = -1;
+
+        @JsonProperty
+        public long totalBytesCopied = 0;
+
+        @JsonProperty
+        public long totalFilesCopied = 0;
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        // Validate source directory
+        if (!Files.isDirectory(sourceDir)) {
+            System.err.println("Error: Source directory does not exist: " + sourceDir);
+            return 1;
+        }
+
+        // Warn if destination already exists
+        if (Files.exists(destDir)) {
+            System.out.println(
+                    Ansi.AUTO.string("@|yellow Warning:|@ Destination directory already exists: " + destDir));
+            System.out.println("This command will only copy files that don't exist in the destination.");
+            System.out.println();
+        } else {
+            // Create destination directory
+            try {
+                Files.createDirectories(destDir);
+                System.out.println(Ansi.AUTO.string("@|yellow Created destination directory:|@ " + destDir));
+            } catch (IOException e) {
+                System.err.println("Error: Failed to create destination directory: " + e.getMessage());
+                return 1;
+            }
+        }
+
+        // Load or create state file
+        Path stateFilePath = destDir.resolve(STATE_FILE_NAME);
+        LoadState state = loadState(stateFilePath);
+
+        // Check if resuming from a different source
+        if (state.sourceDir != null
+                && !state.sourceDir.equals(sourceDir.toAbsolutePath().toString())) {
+            System.out.println(
+                    Ansi.AUTO.string("@|yellow Warning:|@ State file indicates previous source: " + state.sourceDir));
+            System.out.println("Current source: " + sourceDir.toAbsolutePath());
+            System.out.println("Continuing with current source (state will be updated).");
+        }
+
+        // Update state with current run parameters
+        state.sourceDir = sourceDir.toAbsolutePath().toString();
+        state.destDir = destDir.toAbsolutePath().toString();
+
+        System.out.println(Ansi.AUTO.string("@|yellow Bulk-loading wrapped blocks:|@"));
+        System.out.println("  Source: " + sourceDir.toAbsolutePath());
+        System.out.println("  Destination: " + destDir.toAbsolutePath());
+        if (state.lastCopiedBlock >= 0) {
+            System.out.println(Ansi.AUTO.string("  @|yellow Resuming from block:|@ " + (state.lastCopiedBlock + 1)));
+            System.out.println("  Previously copied: " + state.totalFilesCopied + " files ("
+                    + formatBytes(state.totalBytesCopied) + ")");
+        }
+        if (startBlock >= 0) {
+            System.out.println("  Manual start block: " + startBlock);
+        }
+        if (dryRun) {
+            System.out.println(Ansi.AUTO.string("  @|yellow DRY RUN MODE - no files will be copied|@"));
+        }
+        System.out.println();
+
+        // Determine effective start block (use state's last copied block if higher)
+        long effectiveStartBlock = startBlock;
+        if (state.lastCopiedBlock >= 0) {
+            effectiveStartBlock = Math.max(effectiveStartBlock, state.lastCopiedBlock + 1);
+        }
+
+        // Copy files
+        AtomicLong copiedFiles = new AtomicLong(state.totalFilesCopied);
+        AtomicLong skippedFiles = new AtomicLong(0);
+        AtomicLong copiedBytes = new AtomicLong(state.totalBytesCopied);
+
+        try {
+            long finalEffectiveStartBlock = effectiveStartBlock;
+            Files.walkFileTree(sourceDir, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    // Only copy .zip files
+                    if (!file.toString().endsWith(".zip")) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    // Check if already copied (tracked in state)
+                    Path relativePath = sourceDir.relativize(file);
+                    if (state.copiedFiles.contains(relativePath.toString())) {
+                        skippedFiles.incrementAndGet();
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    // Check if this file is before our start block (for resume functionality)
+                    if (finalEffectiveStartBlock >= 0 && shouldSkipBasedOnBlockNumber(file, finalEffectiveStartBlock)) {
+                        skippedFiles.incrementAndGet();
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    // Compute destination path preserving directory structure
+                    Path destFile = destDir.resolve(relativePath);
+
+                    // Check if file already exists with same size
+                    if (Files.exists(destFile)) {
+                        long destSize = Files.size(destFile);
+                        long sourceSize = attrs.size();
+                        if (destSize == sourceSize) {
+                            skippedFiles.incrementAndGet();
+                            if (dryRun) {
+                                System.out.println("SKIP (exists): " + relativePath);
+                            }
+                            // Add to state even if skipped
+                            if (!dryRun) {
+                                state.copiedFiles.add(relativePath.toString());
+                                updateBlockNumber(state, file);
+                            }
+                            return FileVisitResult.CONTINUE;
+                        } else {
+                            System.out.println(Ansi.AUTO.string(
+                                    "@|yellow WARNING:|@ Size mismatch for " + relativePath + " (source: " + sourceSize
+                                            + " bytes, dest: " + destSize + " bytes) - will overwrite"));
+                        }
+                    }
+
+                    if (dryRun) {
+                        System.out.println("COPY: " + relativePath + " (" + formatBytes(attrs.size()) + ")");
+                    } else {
+                        // Create parent directories
+                        Files.createDirectories(destFile.getParent());
+
+                        // Copy file
+                        Files.copy(
+                                file,
+                                destFile,
+                                StandardCopyOption.REPLACE_EXISTING,
+                                StandardCopyOption.COPY_ATTRIBUTES);
+
+                        // Update state
+                        state.copiedFiles.add(relativePath.toString());
+                        state.totalFilesCopied++;
+                        state.totalBytesCopied += attrs.size();
+                        updateBlockNumber(state, file);
+
+                        // Save state periodically (every 10 files)
+                        if (state.totalFilesCopied % 10 == 0) {
+                            saveState(stateFilePath, state);
+                            System.out.printf(
+                                    "Copied %d files (%s), last block: %d%n",
+                                    state.totalFilesCopied, formatBytes(state.totalBytesCopied), state.lastCopiedBlock);
+                        }
+                    }
+
+                    copiedFiles.set(state.totalFilesCopied);
+                    copiedBytes.set(state.totalBytesCopied);
+
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    // Skip staging, links, and zipwork directories if they exist in source
+                    String dirName = dir.getFileName().toString();
+                    if (dirName.equals("staging") || dirName.equals("links") || dirName.equals("zipwork")) {
+                        System.out.println(Ansi.AUTO.string("@|yellow Skipping directory:|@ " + dirName));
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            System.err.println("Error during bulk load: " + e.getMessage());
+            e.printStackTrace();
+            return 1;
+        }
+
+        // Save final state
+        if (!dryRun) {
+            saveState(stateFilePath, state);
+        }
+
+        // Print summary
+        System.out.println();
+        System.out.println(Ansi.AUTO.string("@|yellow === Bulk Load Summary ===|@"));
+        System.out.println("Total files copied: " + state.totalFilesCopied);
+        System.out.println("Files skipped (already exist or before start block): " + skippedFiles.get());
+        System.out.println("Total bytes copied: " + formatBytes(state.totalBytesCopied));
+        System.out.println("Last copied block: " + state.lastCopiedBlock);
+        System.out.println("State file: " + stateFilePath);
+
+        if (dryRun) {
+            System.out.println();
+            System.out.println(Ansi.AUTO.string("@|yellow DRY RUN - No files were actually copied.|@"));
+            System.out.println("Re-run without --dry-run to perform the copy.");
+        } else {
+            System.out.println();
+            System.out.println(Ansi.AUTO.string("@|green Bulk load complete!|@"));
+            System.out.println();
+            System.out.println("Next steps:");
+            System.out.println("1. Start the Block Node");
+            System.out.println("2. The BlockFileHistoricPlugin will detect and serve the loaded blocks");
+            System.out.println();
+            System.out.println("To resume an interrupted load, simply run the same command again.");
+        }
+
+        return 0;
+    }
+
+    private LoadState loadState(Path stateFilePath) {
+        if (!Files.exists(stateFilePath)) {
+            return new LoadState();
+        }
+
+        try {
+            return JSON_MAPPER.readValue(stateFilePath.toFile(), LoadState.class);
+        } catch (IOException e) {
+            System.err.println("Warning: Failed to load state file, starting fresh: " + e.getMessage());
+            return new LoadState();
+        }
+    }
+
+    private void saveState(Path stateFilePath, LoadState state) {
+        try {
+            JSON_MAPPER.writeValue(stateFilePath.toFile(), state);
+        } catch (IOException e) {
+            System.err.println("Warning: Failed to save state file: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Update the lastCopiedBlock in the state based on the zip file being copied.
+     */
+    private void updateBlockNumber(LoadState state, Path zipFile) {
+        String fileName = zipFile.getFileName().toString();
+        if (!fileName.matches("\\d+s\\.zip")) {
+            return;
+        }
+
+        try {
+            // Extract the first block number from the zip file name
+            String numStr = fileName.substring(0, fileName.length() - 5); // Remove "s.zip"
+            long zipFirstBlock = Long.parseLong(numStr);
+
+            // Each zip contains 10,000 blocks
+            long zipLastBlock = zipFirstBlock + 10_000 - 1;
+
+            // Update last copied block
+            state.lastCopiedBlock = Math.max(state.lastCopiedBlock, zipLastBlock);
+        } catch (NumberFormatException e) {
+            // Invalid format, ignore
+        }
+    }
+
+    /**
+     * Check if a zip file should be skipped based on the start block number.
+     * Zip files are named like "00000s.zip", "10000s.zip", etc., where the number
+     * indicates the first block in that zip (for powersOfTen=4, each zip contains 10K blocks).
+     *
+     * @param zipFile the zip file path
+     * @param startBlock the starting block number
+     * @return true if this zip file contains only blocks before the start block
+     */
+    private boolean shouldSkipBasedOnBlockNumber(Path zipFile, long startBlock) {
+        String fileName = zipFile.getFileName().toString();
+        if (!fileName.matches("\\d+s\\.zip")) {
+            // Not a standard zip file name, don't skip
+            return false;
+        }
+
+        try {
+            // Extract the first block number from the zip file name
+            // e.g., "10000s.zip" -> 10000
+            String numStr = fileName.substring(0, fileName.length() - 5); // Remove "s.zip"
+            long zipFirstBlock = Long.parseLong(numStr);
+
+            // Determine the last block in this zip
+            // Assume powersOfTen=4 (10,000 blocks per zip) as that's the default
+            long blocksPerZip = 10_000;
+            long zipLastBlock = zipFirstBlock + blocksPerZip - 1;
+
+            // Skip if the entire zip is before the start block
+            return zipLastBlock < startBlock;
+        } catch (NumberFormatException e) {
+            // Invalid format, don't skip
+            return false;
+        }
+    }
+
+    private static String formatBytes(long bytes) {
+        if (bytes < 1024) {
+            return bytes + " B";
+        } else if (bytes < 1024 * 1024) {
+            return String.format("%.2f KB", bytes / 1024.0);
+        } else if (bytes < 1024 * 1024 * 1024) {
+            return String.format("%.2f MB", bytes / (1024.0 * 1024.0));
+        } else {
+            return String.format("%.2f GB", bytes / (1024.0 * 1024.0 * 1024.0));
+        }
+    }
+}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommand.java
@@ -188,10 +188,24 @@ public class BulkLoadBlocksCommand implements Callable<Integer> {
             effectiveStartBlock = Math.max(effectiveStartBlock, state.lastCopiedBlock + 1);
         }
 
+        // Pre-scan: count work remaining so we can render a real progress bar.
+        // Mirrors the filtering applied during the copy walk: zip files only,
+        // not in staging/links/zipwork, not already tracked in state, not before start block.
+        long scanStart = System.nanoTime();
+        ScanResult scan = scanWorkToDo(sourceDir, state, effectiveStartBlock);
+        long scanMs = (System.nanoTime() - scanStart) / 1_000_000L;
+        System.out.printf(
+                "  Scanned source: %,d file(s) to process (%s) in %dms%n",
+                scan.fileCount, formatBytes(scan.totalBytes), scanMs);
+        System.out.println();
+
         // Copy files
         AtomicLong copiedFiles = new AtomicLong(state.totalFilesCopied);
         AtomicLong skippedFiles = new AtomicLong(0);
         AtomicLong copiedBytes = new AtomicLong(state.totalBytesCopied);
+
+        ProgressTracker progress = new ProgressTracker(scan.fileCount, scan.totalBytes, dryRun);
+        progress.start();
 
         try {
             long finalEffectiveStartBlock = effectiveStartBlock;
@@ -233,6 +247,8 @@ public class BulkLoadBlocksCommand implements Callable<Integer> {
                                 state.copiedFiles.add(relativePath.toString());
                                 updateBlockNumber(state, file);
                             }
+                            // Pre-scan counted this file (it didn't check dest); keep the bar accurate.
+                            progress.advance(sourceSize);
                             return FileVisitResult.CONTINUE;
                         } else {
                             System.out.println(Ansi.AUTO.string(
@@ -263,14 +279,12 @@ public class BulkLoadBlocksCommand implements Callable<Integer> {
                         // Save state periodically (every 10 files)
                         if (state.totalFilesCopied % 10 == 0) {
                             saveState(stateFilePath, state);
-                            System.out.printf(
-                                    "Copied %d files (%s), last block: %d%n",
-                                    state.totalFilesCopied, formatBytes(state.totalBytesCopied), state.lastCopiedBlock);
                         }
                     }
 
                     copiedFiles.set(state.totalFilesCopied);
                     copiedBytes.set(state.totalBytesCopied);
+                    progress.advance(attrs.size());
 
                     return FileVisitResult.CONTINUE;
                 }
@@ -287,10 +301,13 @@ public class BulkLoadBlocksCommand implements Callable<Integer> {
                 }
             });
         } catch (IOException e) {
+            progress.finish();
             System.err.println("Error during bulk load: " + e.getMessage());
             e.printStackTrace();
             return 1;
         }
+
+        progress.finish();
 
         // Save final state
         if (!dryRun) {
@@ -298,6 +315,8 @@ public class BulkLoadBlocksCommand implements Callable<Integer> {
         }
 
         // Print summary
+        long elapsedMs = progress.elapsedMs();
+        long bytesThisRun = progress.bytesProcessedThisRun();
         System.out.println();
         System.out.println(Ansi.AUTO.string("@|yellow === Bulk Load Summary ===|@"));
         System.out.println("Total files copied: " + state.totalFilesCopied);
@@ -305,6 +324,10 @@ public class BulkLoadBlocksCommand implements Callable<Integer> {
         System.out.println("Total bytes copied: " + formatBytes(state.totalBytesCopied));
         System.out.println("Last copied block: " + state.lastCopiedBlock);
         System.out.println("State file: " + stateFilePath);
+        System.out.println("Elapsed: " + formatDuration(elapsedMs));
+        if (elapsedMs > 0 && bytesThisRun > 0) {
+            System.out.println("Average throughput: " + formatRate(bytesThisRun, elapsedMs));
+        }
 
         if (dryRun) {
             System.out.println();
@@ -413,6 +436,198 @@ public class BulkLoadBlocksCommand implements Callable<Integer> {
             return String.format("%.2f MB", bytes / (1024.0 * 1024.0));
         } else {
             return String.format("%.2f GB", bytes / (1024.0 * 1024.0 * 1024.0));
+        }
+    }
+
+    private static String formatDuration(long millis) {
+        if (millis < 1000) {
+            return millis + "ms";
+        }
+        long totalSeconds = millis / 1000;
+        long h = totalSeconds / 3600;
+        long m = (totalSeconds % 3600) / 60;
+        long s = totalSeconds % 60;
+        if (h > 0) {
+            return String.format("%dh %dm %ds", h, m, s);
+        } else if (m > 0) {
+            return String.format("%dm %ds", m, s);
+        } else {
+            return s + "s";
+        }
+    }
+
+    private static String formatRate(long bytes, long millis) {
+        if (millis <= 0) {
+            return "--";
+        }
+        double mbps = (bytes / (1024.0 * 1024.0)) / (millis / 1000.0);
+        return String.format("%.2f MB/s", mbps);
+    }
+
+    /** Result of the pre-scan: how many files and bytes are expected to be processed. */
+    private static class ScanResult {
+        final long fileCount;
+        final long totalBytes;
+
+        ScanResult(long fileCount, long totalBytes) {
+            this.fileCount = fileCount;
+            this.totalBytes = totalBytes;
+        }
+    }
+
+    /**
+     * Walk the source tree applying the same filters as the copy pass, but only counting
+     * files/bytes to be processed. This is a stat-only walk (no file reads) so it's cheap
+     * even on large trees.
+     */
+    private ScanResult scanWorkToDo(Path source, LoadState state, long effectiveStartBlock) throws IOException {
+        AtomicLong files = new AtomicLong();
+        AtomicLong bytes = new AtomicLong();
+        Files.walkFileTree(source, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                String name = dir.getFileName() == null ? "" : dir.getFileName().toString();
+                if (name.equals("staging") || name.equals("links") || name.equals("zipwork")) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                if (!file.toString().endsWith(".zip")) {
+                    return FileVisitResult.CONTINUE;
+                }
+                Path rel = source.relativize(file);
+                if (state.copiedFiles.contains(rel.toString())) {
+                    return FileVisitResult.CONTINUE;
+                }
+                if (effectiveStartBlock >= 0 && shouldSkipBasedOnBlockNumber(file, effectiveStartBlock)) {
+                    return FileVisitResult.CONTINUE;
+                }
+                files.incrementAndGet();
+                bytes.addAndGet(attrs.size());
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        return new ScanResult(files.get(), bytes.get());
+    }
+
+    /**
+     * Renders a single-line progress bar with files done, percent, throughput and ETA.
+     * Updates are throttled to at most one per {@link #UPDATE_INTERVAL_MS}. On a TTY the line
+     * is overwritten with carriage-return; off a TTY (logs, CI) each update gets its own line
+     * so the output stays readable when captured.
+     */
+    static final class ProgressTracker {
+        private static final long UPDATE_INTERVAL_MS = 200L;
+        private static final int BAR_WIDTH = 30;
+
+        private final long totalFiles;
+        private final long totalBytes;
+        private final boolean dryRun;
+        private final boolean isTty;
+
+        private long startNanos;
+        private long lastPrintMs;
+        private long filesDone;
+        private long bytesDone;
+
+        ProgressTracker(long totalFiles, long totalBytes, boolean dryRun) {
+            this.totalFiles = totalFiles;
+            this.totalBytes = totalBytes;
+            this.dryRun = dryRun;
+            this.isTty = System.console() != null;
+        }
+
+        void start() {
+            startNanos = System.nanoTime();
+            lastPrintMs = 0;
+            if (totalFiles > 0 && !dryRun) {
+                render(true);
+            }
+        }
+
+        synchronized void advance(long fileBytes) {
+            filesDone++;
+            bytesDone += Math.max(0L, fileBytes);
+            if (dryRun || totalFiles == 0) {
+                return;
+            }
+            long nowMs = elapsedMs();
+            if (nowMs - lastPrintMs >= UPDATE_INTERVAL_MS || filesDone == totalFiles) {
+                render(false);
+                lastPrintMs = nowMs;
+            }
+        }
+
+        void finish() {
+            if (dryRun || totalFiles == 0) {
+                return;
+            }
+            // Force a final render so the bar shows the end state even if we never hit the
+            // throttle window on the last file.
+            render(false);
+            // Move past the progress line so subsequent output starts on a fresh line.
+            System.out.println();
+        }
+
+        long elapsedMs() {
+            return (System.nanoTime() - startNanos) / 1_000_000L;
+        }
+
+        long bytesProcessedThisRun() {
+            return bytesDone;
+        }
+
+        private void render(boolean initial) {
+            long elapsed = elapsedMs();
+            double fraction = totalFiles == 0 ? 0.0 : Math.min(1.0, filesDone / (double) totalFiles);
+            int filled = (int) Math.round(fraction * BAR_WIDTH);
+            StringBuilder bar = new StringBuilder(BAR_WIDTH + 2);
+            bar.append('[');
+            for (int i = 0; i < BAR_WIDTH; i++) {
+                bar.append(i < filled ? '#' : '.');
+            }
+            bar.append(']');
+
+            String rate = (elapsed > 0 && bytesDone > 0) ? formatRate(bytesDone, elapsed) : "--";
+            String etaStr;
+            if (filesDone == 0 || elapsed == 0) {
+                etaStr = "--";
+            } else if (filesDone >= totalFiles) {
+                etaStr = "0s";
+            } else {
+                // ETA based on bytes-per-ms when we have meaningful byte progress; fall back
+                // to files-per-ms when files exist but every entry was zero-byte.
+                double remaining;
+                if (totalBytes > 0 && bytesDone > 0) {
+                    double bytesPerMs = bytesDone / (double) elapsed;
+                    remaining = (totalBytes - bytesDone) / bytesPerMs;
+                } else {
+                    double filesPerMs = filesDone / (double) elapsed;
+                    remaining = (totalFiles - filesDone) / filesPerMs;
+                }
+                etaStr = formatDuration((long) Math.max(0, remaining));
+            }
+
+            String line = String.format(
+                    "  %s %,d/%,d (%d%%) | %s/%s | %s | ETA %s",
+                    bar,
+                    filesDone,
+                    totalFiles,
+                    (int) Math.round(fraction * 100),
+                    formatBytes(bytesDone),
+                    formatBytes(totalBytes),
+                    rate,
+                    etaStr);
+
+            if (isTty && !initial) {
+                System.out.print('\r' + line);
+                System.out.flush();
+            } else {
+                System.out.println(line);
+            }
         }
     }
 }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommand.java
@@ -11,10 +11,11 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicLong;
+import org.hiero.block.tools.blocks.model.BlockZipsUtilities;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Option;
@@ -112,7 +113,7 @@ public class BulkLoadBlocksCommand implements Callable<Integer> {
         public String destDir;
 
         @JsonProperty
-        public List<String> copiedFiles = new ArrayList<>();
+        public Set<String> copiedFiles = new HashSet<>();
 
         @JsonProperty
         public long lastCopiedBlock = -1;
@@ -292,7 +293,8 @@ public class BulkLoadBlocksCommand implements Callable<Integer> {
                 @Override
                 public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
                     // Skip staging, links, and zipwork directories if they exist in source
-                    String dirName = dir.getFileName() == null ? "" : dir.getFileName().toString();
+                    String dirName =
+                            dir.getFileName() == null ? "" : dir.getFileName().toString();
                     if (dirName.equals("staging") || dirName.equals("links") || dirName.equals("zipwork")) {
                         System.out.println(Ansi.AUTO.string("@|yellow Skipping directory:|@ " + dirName));
                         return FileVisitResult.SKIP_SUBTREE;
@@ -414,10 +416,8 @@ public class BulkLoadBlocksCommand implements Callable<Integer> {
             String numStr = fileName.substring(0, fileName.length() - 5); // Remove "s.zip"
             long zipFirstBlock = Long.parseLong(numStr);
 
-            // Determine the last block in this zip
-            // Assume powersOfTen=4 (10,000 blocks per zip) as that's the default
-            long blocksPerZip = 10_000;
-            long zipLastBlock = zipFirstBlock + blocksPerZip - 1;
+            // Determine the last block in this zip using the configured zip size
+            long zipLastBlock = zipFirstBlock + BlockZipsUtilities.DEFAULT_BLOCKS_PER_ZIP - 1;
 
             // Skip if the entire zip is before the start block
             return zipLastBlock < startBlock;

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommand.java
@@ -292,7 +292,7 @@ public class BulkLoadBlocksCommand implements Callable<Integer> {
                 @Override
                 public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
                     // Skip staging, links, and zipwork directories if they exist in source
-                    String dirName = dir.getFileName().toString();
+                    String dirName = dir.getFileName() == null ? "" : dir.getFileName().toString();
                     if (dirName.equals("staging") || dirName.equals("links") || dirName.equals("zipwork")) {
                         System.out.println(Ansi.AUTO.string("@|yellow Skipping directory:|@ " + dirName));
                         return FileVisitResult.SKIP_SUBTREE;

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommand.java
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.blocks;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -12,9 +12,11 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicLong;
+import org.hiero.block.internal.BulkLoadState;
 import org.hiero.block.tools.blocks.model.BlockZipsUtilities;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
@@ -100,28 +102,19 @@ public class BulkLoadBlocksCommand implements Callable<Integer> {
     private long startBlock = -1;
 
     private static final String STATE_FILE_NAME = "historic-plugin-bulk-load-state.json";
-    private static final ObjectMapper JSON_MAPPER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
     /**
-     * State tracking for resume functionality.
+     * In-memory state tracking for resume functionality. Backed on disk by the PBJ-defined
+     * {@link BulkLoadState} message (JSON form) but kept mutable in-memory so we can incrementally
+     * record progress and rely on a {@link HashSet} for O(1) {@code copiedFiles.contains(...)}
+     * lookups during the file walk.
      */
     public static class LoadState {
-        @JsonProperty
         public String sourceDir;
-
-        @JsonProperty
         public String destDir;
-
-        @JsonProperty
         public Set<String> copiedFiles = new HashSet<>();
-
-        @JsonProperty
         public long lastCopiedBlock = -1;
-
-        @JsonProperty
         public long totalBytesCopied = 0;
-
-        @JsonProperty
         public long totalFilesCopied = 0;
     }
 
@@ -354,20 +347,44 @@ public class BulkLoadBlocksCommand implements Callable<Integer> {
             return new LoadState();
         }
 
-        try {
-            return JSON_MAPPER.readValue(stateFilePath.toFile(), LoadState.class);
-        } catch (IOException e) {
+        try (ReadableStreamingData in = new ReadableStreamingData(Files.newInputStream(stateFilePath))) {
+            return fromProto(BulkLoadState.JSON.parse(in));
+        } catch (IOException | ParseException e) {
             System.err.println("Warning: Failed to load state file, starting fresh: " + e.getMessage());
             return new LoadState();
         }
     }
 
     private void saveState(Path stateFilePath, LoadState state) {
-        try {
-            JSON_MAPPER.writeValue(stateFilePath.toFile(), state);
+        try (WritableStreamingData out = new WritableStreamingData(Files.newOutputStream(stateFilePath))) {
+            BulkLoadState.JSON.write(toProto(state), out);
         } catch (IOException e) {
             System.err.println("Warning: Failed to save state file: " + e.getMessage());
         }
+    }
+
+    /** Convert the on-disk PBJ-generated {@link BulkLoadState} to the mutable in-memory holder. */
+    static LoadState fromProto(BulkLoadState proto) {
+        LoadState state = new LoadState();
+        state.sourceDir = proto.sourceDir().isEmpty() ? null : proto.sourceDir();
+        state.destDir = proto.destDir().isEmpty() ? null : proto.destDir();
+        state.copiedFiles = new HashSet<>(proto.copiedFiles());
+        state.lastCopiedBlock = proto.lastCopiedBlock();
+        state.totalBytesCopied = proto.totalBytesCopied();
+        state.totalFilesCopied = proto.totalFilesCopied();
+        return state;
+    }
+
+    /** Convert the mutable in-memory holder back into a {@link BulkLoadState} for serialization. */
+    static BulkLoadState toProto(LoadState state) {
+        return BulkLoadState.newBuilder()
+                .sourceDir(state.sourceDir == null ? "" : state.sourceDir)
+                .destDir(state.destDir == null ? "" : state.destDir)
+                .copiedFiles(List.copyOf(state.copiedFiles))
+                .lastCopiedBlock(state.lastCopiedBlock)
+                .totalBytesCopied(state.totalBytesCopied)
+                .totalFilesCopied(state.totalFilesCopied)
+                .build();
     }
 
     /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommand.java
@@ -383,7 +383,7 @@ public class BulkLoadBlocksCommand implements Callable<Integer> {
             long zipFirstBlock = Long.parseLong(numStr);
 
             // Each zip contains 10,000 blocks
-            long zipLastBlock = zipFirstBlock + 10_000 - 1;
+            long zipLastBlock = zipFirstBlock + BlockZipsUtilities.DEFAULT_BLOCKS_PER_ZIP - 1;
 
             // Update last copied block
             state.lastCopiedBlock = Math.max(state.lastCopiedBlock, zipLastBlock);

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommandTest.java
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.blocks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+/** Unit tests for {@link BulkLoadBlocksCommand}. */
+class BulkLoadBlocksCommandTest {
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    @TempDir
+    Path tempDir;
+
+    Path sourceDir;
+    Path destDir;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        sourceDir = tempDir.resolve("source");
+        destDir = tempDir.resolve("dest");
+        Files.createDirectories(sourceDir);
+        Files.createDirectories(destDir);
+    }
+
+    @Nested
+    @DisplayName("Command Line Interface")
+    class CommandLineInterface {
+
+        @Test
+        @DisplayName("Should show help when --help is specified")
+        void helpOption() {
+            StringWriter out = new StringWriter();
+            CommandLine cmd = new CommandLine(new BulkLoadBlocksCommand());
+            cmd.setOut(new PrintWriter(out));
+
+            int exitCode = cmd.execute("--help");
+
+            assertEquals(0, exitCode);
+            String output = out.toString();
+            assertTrue(output.contains("bulk-load"));
+            assertTrue(output.contains("--source"));
+            assertTrue(output.contains("--dest"));
+        }
+
+        @Test
+        @DisplayName("Should fail when source directory is missing")
+        void missingSourceDirectory() {
+            Path nonExistent = tempDir.resolve("nonexistent");
+
+            int exitCode = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", nonExistent.toString(), "--dest", destDir.toString());
+
+            assertEquals(1, exitCode);
+        }
+
+        @Test
+        @DisplayName("Should create destination directory if it doesn't exist")
+        void createsDestinationDirectory() {
+            Path newDest = tempDir.resolve("newdest");
+
+            int exitCode = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", newDest.toString());
+
+            assertEquals(0, exitCode);
+            assertTrue(Files.isDirectory(newDest));
+        }
+    }
+
+    @Nested
+    @DisplayName("File Copying")
+    class FileCopying {
+
+        @Test
+        @DisplayName("Should copy zip files from source to destination")
+        void copiesZipFiles() throws IOException {
+            // Create test zip files with directory structure
+            Path srcSubdir = sourceDir.resolve("000/123");
+            Files.createDirectories(srcSubdir);
+            Path zipFile1 = srcSubdir.resolve("00000s.zip");
+            Path zipFile2 = srcSubdir.resolve("10000s.zip");
+            Files.writeString(zipFile1, "test content 1");
+            Files.writeString(zipFile2, "test content 2");
+
+            int exitCode = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", destDir.toString());
+
+            assertEquals(0, exitCode);
+
+            // Verify files were copied with same directory structure
+            Path destFile1 = destDir.resolve("000/123/00000s.zip");
+            Path destFile2 = destDir.resolve("000/123/10000s.zip");
+            assertTrue(Files.exists(destFile1));
+            assertTrue(Files.exists(destFile2));
+            assertEquals("test content 1", Files.readString(destFile1));
+            assertEquals("test content 2", Files.readString(destFile2));
+        }
+
+        @Test
+        @DisplayName("Should skip non-zip files")
+        void skipsNonZipFiles() throws IOException {
+            Path txtFile = sourceDir.resolve("test.txt");
+            Path jsonFile = sourceDir.resolve("test.json");
+            Files.writeString(txtFile, "text content");
+            Files.writeString(jsonFile, "json content");
+
+            int exitCode = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", destDir.toString());
+
+            assertEquals(0, exitCode);
+            assertFalse(Files.exists(destDir.resolve("test.txt")));
+            assertFalse(Files.exists(destDir.resolve("test.json")));
+        }
+
+        @Test
+        @DisplayName("Should skip staging, links, and zipwork directories")
+        void skipsInternalDirectories() throws IOException {
+            Path stagingDir = sourceDir.resolve("staging");
+            Path linksDir = sourceDir.resolve("links");
+            Path zipworkDir = sourceDir.resolve("zipwork");
+            Files.createDirectories(stagingDir);
+            Files.createDirectories(linksDir);
+            Files.createDirectories(zipworkDir);
+
+            Files.writeString(stagingDir.resolve("test.zip"), "staging content");
+            Files.writeString(linksDir.resolve("test.zip"), "links content");
+            Files.writeString(zipworkDir.resolve("test.zip"), "zipwork content");
+
+            int exitCode = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", destDir.toString());
+
+            assertEquals(0, exitCode);
+            assertFalse(Files.exists(destDir.resolve("staging")));
+            assertFalse(Files.exists(destDir.resolve("links")));
+            assertFalse(Files.exists(destDir.resolve("zipwork")));
+        }
+
+        @Test
+        @DisplayName("Should skip already-existing files with same size")
+        void skipsExistingFiles() throws IOException {
+            Path zipFile = sourceDir.resolve("00000s.zip");
+            Files.writeString(zipFile, "test content");
+
+            // First run - copy the file
+            int exitCode1 = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", destDir.toString());
+            assertEquals(0, exitCode1);
+
+            Path destFile = destDir.resolve("00000s.zip");
+            assertTrue(Files.exists(destFile));
+            long originalModifiedTime = Files.getLastModifiedTime(destFile).toMillis();
+
+            // Wait a bit to ensure modified time would change
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+
+            // Second run - should skip the file
+            int exitCode2 = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", destDir.toString());
+            assertEquals(0, exitCode2);
+
+            // File should not have been recopied (modified time unchanged)
+            long newModifiedTime = Files.getLastModifiedTime(destFile).toMillis();
+            assertEquals(originalModifiedTime, newModifiedTime);
+        }
+    }
+
+    @Nested
+    @DisplayName("State File Management")
+    class StateFileManagement {
+
+        @Test
+        @DisplayName("Should create state file after successful copy")
+        void createsStateFile() throws IOException {
+            Path zipFile = sourceDir.resolve("00000s.zip");
+            Files.writeString(zipFile, "test content");
+
+            int exitCode = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", destDir.toString());
+
+            assertEquals(0, exitCode);
+
+            Path stateFile = destDir.resolve("historic-plugin-bulk-load-state.json");
+            assertTrue(Files.exists(stateFile));
+
+            BulkLoadBlocksCommand.LoadState state =
+                    JSON_MAPPER.readValue(stateFile.toFile(), BulkLoadBlocksCommand.LoadState.class);
+            assertNotNull(state);
+            assertEquals(sourceDir.toAbsolutePath().toString(), state.sourceDir);
+            assertEquals(destDir.toAbsolutePath().toString(), state.destDir);
+            assertEquals(1, state.totalFilesCopied);
+            assertTrue(state.copiedFiles.contains("00000s.zip"));
+            assertEquals(9999, state.lastCopiedBlock); // 00000s.zip contains blocks 0-9999
+        }
+
+        @Test
+        @DisplayName("Should resume from state file on subsequent runs")
+        void resumesFromStateFile() throws IOException {
+            // Create multiple zip files
+            Files.writeString(sourceDir.resolve("00000s.zip"), "content 1");
+            Files.writeString(sourceDir.resolve("10000s.zip"), "content 2");
+            Files.writeString(sourceDir.resolve("20000s.zip"), "content 3");
+
+            // First run - copy first file only by manually creating state
+            BulkLoadBlocksCommand.LoadState initialState = new BulkLoadBlocksCommand.LoadState();
+            initialState.sourceDir = sourceDir.toAbsolutePath().toString();
+            initialState.destDir = destDir.toAbsolutePath().toString();
+            initialState.copiedFiles = List.of("00000s.zip");
+            initialState.lastCopiedBlock = 9999;
+            initialState.totalFilesCopied = 1;
+            initialState.totalBytesCopied = 100;
+
+            Path stateFile = destDir.resolve("historic-plugin-bulk-load-state.json");
+            JSON_MAPPER.writeValue(stateFile.toFile(), initialState);
+
+            // Also copy the first file to destination
+            Files.writeString(destDir.resolve("00000s.zip"), "content 1");
+
+            // Second run - should only copy remaining files
+            int exitCode = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", destDir.toString());
+
+            assertEquals(0, exitCode);
+
+            // Verify state was updated
+            BulkLoadBlocksCommand.LoadState finalState =
+                    JSON_MAPPER.readValue(stateFile.toFile(), BulkLoadBlocksCommand.LoadState.class);
+            assertEquals(3, finalState.totalFilesCopied);
+            assertTrue(finalState.copiedFiles.contains("10000s.zip"));
+            assertTrue(finalState.copiedFiles.contains("20000s.zip"));
+            assertEquals(29999, finalState.lastCopiedBlock); // 20000s.zip contains blocks 20000-29999
+        }
+
+        @Test
+        @DisplayName("Should track last copied block number correctly")
+        void tracksLastCopiedBlock() throws IOException {
+            Files.writeString(sourceDir.resolve("00000s.zip"), "content 0");
+            Files.writeString(sourceDir.resolve("50000s.zip"), "content 50k");
+            Files.writeString(sourceDir.resolve("100000s.zip"), "content 100k");
+
+            int exitCode = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", destDir.toString());
+
+            assertEquals(0, exitCode);
+
+            Path stateFile = destDir.resolve("historic-plugin-bulk-load-state.json");
+            BulkLoadBlocksCommand.LoadState state =
+                    JSON_MAPPER.readValue(stateFile.toFile(), BulkLoadBlocksCommand.LoadState.class);
+
+            // Last copied block should be the last block in 100000s.zip (100000 + 9999)
+            assertEquals(109999, state.lastCopiedBlock);
+        }
+    }
+
+    @Nested
+    @DisplayName("Start Block Filtering")
+    class StartBlockFiltering {
+
+        @Test
+        @DisplayName("Should skip zip files before start block")
+        void skipsFilesBeforeStartBlock() throws IOException {
+            // Create zip files for blocks 0-9999, 10000-19999, 20000-29999
+            Files.writeString(sourceDir.resolve("00000s.zip"), "content 0");
+            Files.writeString(sourceDir.resolve("10000s.zip"), "content 10k");
+            Files.writeString(sourceDir.resolve("20000s.zip"), "content 20k");
+
+            // Start from block 15000 (should skip 00000s.zip, copy others)
+            int exitCode = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", destDir.toString(), "--start-block", "15000");
+
+            assertEquals(0, exitCode);
+
+            assertFalse(Files.exists(destDir.resolve("00000s.zip")));
+            assertTrue(Files.exists(destDir.resolve("10000s.zip")));
+            assertTrue(Files.exists(destDir.resolve("20000s.zip")));
+        }
+
+        @Test
+        @DisplayName("Should use state's last block over manual start block if higher")
+        void usesHigherOfStateAndManualStartBlock() throws IOException {
+            Files.writeString(sourceDir.resolve("00000s.zip"), "content 0");
+            Files.writeString(sourceDir.resolve("10000s.zip"), "content 10k");
+            Files.writeString(sourceDir.resolve("20000s.zip"), "content 20k");
+
+            // Create state showing we've already copied up to block 19999
+            BulkLoadBlocksCommand.LoadState state = new BulkLoadBlocksCommand.LoadState();
+            state.sourceDir = sourceDir.toAbsolutePath().toString();
+            state.destDir = destDir.toAbsolutePath().toString();
+            state.copiedFiles = List.of("00000s.zip", "10000s.zip");
+            state.lastCopiedBlock = 19999;
+            state.totalFilesCopied = 2;
+
+            Path stateFile = destDir.resolve("historic-plugin-bulk-load-state.json");
+            JSON_MAPPER.writeValue(stateFile.toFile(), state);
+
+            // Try to start from block 5000 (state's 19999 is higher, so should start from 20000)
+            int exitCode = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", destDir.toString(), "--start-block", "5000");
+
+            assertEquals(0, exitCode);
+
+            // Should only copy the last zip
+            assertFalse(Files.exists(destDir.resolve("00000s.zip")));
+            assertFalse(Files.exists(destDir.resolve("10000s.zip")));
+            assertTrue(Files.exists(destDir.resolve("20000s.zip")));
+        }
+    }
+
+    @Nested
+    @DisplayName("Dry Run Mode")
+    class DryRunMode {
+
+        @Test
+        @DisplayName("Should not copy files in dry-run mode")
+        void doesNotCopyInDryRun() throws IOException {
+            Path zipFile = sourceDir.resolve("00000s.zip");
+            Files.writeString(zipFile, "test content");
+
+            int exitCode = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", destDir.toString(), "--dry-run");
+
+            assertEquals(0, exitCode);
+
+            // File should not have been copied
+            assertFalse(Files.exists(destDir.resolve("00000s.zip")));
+
+            // State file should not have been created
+            assertFalse(Files.exists(destDir.resolve("historic-plugin-bulk-load-state.json")));
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge Cases")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("Should handle empty source directory")
+        void handlesEmptySourceDirectory() {
+            int exitCode = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", destDir.toString());
+
+            assertEquals(0, exitCode);
+        }
+
+        @Test
+        @DisplayName("Should handle zip files with non-standard names")
+        void handlesNonStandardZipNames() throws IOException {
+            Path normalZip = sourceDir.resolve("00000s.zip");
+            Path weirdZip = sourceDir.resolve("weird-name.zip");
+            Files.writeString(normalZip, "normal content");
+            Files.writeString(weirdZip, "weird content");
+
+            int exitCode = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", destDir.toString());
+
+            assertEquals(0, exitCode);
+
+            // Both should be copied
+            assertTrue(Files.exists(destDir.resolve("00000s.zip")));
+            assertTrue(Files.exists(destDir.resolve("weird-name.zip")));
+
+            // But only the standard-named one should update lastCopiedBlock
+            Path stateFile = destDir.resolve("historic-plugin-bulk-load-state.json");
+            BulkLoadBlocksCommand.LoadState state =
+                    JSON_MAPPER.readValue(stateFile.toFile(), BulkLoadBlocksCommand.LoadState.class);
+            assertEquals(9999, state.lastCopiedBlock); // Only from 00000s.zip
+        }
+
+        @Test
+        @DisplayName("Should handle corrupt state file gracefully")
+        void handlesCorruptStateFile() throws IOException {
+            Path stateFile = destDir.resolve("historic-plugin-bulk-load-state.json");
+            Files.writeString(stateFile, "{ corrupt json");
+
+            Path zipFile = sourceDir.resolve("00000s.zip");
+            Files.writeString(zipFile, "test content");
+
+            // Should not fail, just start fresh
+            int exitCode = new CommandLine(new BulkLoadBlocksCommand())
+                    .execute("--source", sourceDir.toString(), "--dest", destDir.toString());
+
+            assertEquals(0, exitCode);
+            assertTrue(Files.exists(destDir.resolve("00000s.zip")));
+        }
+    }
+}

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommandTest.java
@@ -12,6 +12,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -223,7 +224,7 @@ class BulkLoadBlocksCommandTest {
             BulkLoadBlocksCommand.LoadState initialState = new BulkLoadBlocksCommand.LoadState();
             initialState.sourceDir = sourceDir.toAbsolutePath().toString();
             initialState.destDir = destDir.toAbsolutePath().toString();
-            initialState.copiedFiles = List.of("00000s.zip");
+            initialState.copiedFiles = new HashSet<>(List.of("00000s.zip"));
             initialState.lastCopiedBlock = 9999;
             initialState.totalFilesCopied = 1;
             initialState.totalBytesCopied = 100;
@@ -304,7 +305,7 @@ class BulkLoadBlocksCommandTest {
             BulkLoadBlocksCommand.LoadState state = new BulkLoadBlocksCommand.LoadState();
             state.sourceDir = sourceDir.toAbsolutePath().toString();
             state.destDir = destDir.toAbsolutePath().toString();
-            state.copiedFiles = List.of("00000s.zip", "10000s.zip");
+            state.copiedFiles = new HashSet<>(List.of("00000s.zip", "10000s.zip"));
             state.lastCopiedBlock = 19999;
             state.totalFilesCopied = 2;
 

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/BulkLoadBlocksCommandTest.java
@@ -6,7 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -14,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
+import org.hiero.block.internal.BulkLoadState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -23,7 +25,20 @@ import picocli.CommandLine;
 
 /** Unit tests for {@link BulkLoadBlocksCommand}. */
 class BulkLoadBlocksCommandTest {
-    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    private static BulkLoadBlocksCommand.LoadState readState(Path stateFile) throws IOException {
+        try (ReadableStreamingData in = new ReadableStreamingData(Files.newInputStream(stateFile))) {
+            return BulkLoadBlocksCommand.fromProto(BulkLoadState.JSON.parse(in));
+        } catch (Exception e) {
+            throw new IOException("Failed to parse state file: " + stateFile, e);
+        }
+    }
+
+    private static void writeState(Path stateFile, BulkLoadBlocksCommand.LoadState state) throws IOException {
+        try (WritableStreamingData out = new WritableStreamingData(Files.newOutputStream(stateFile))) {
+            BulkLoadState.JSON.write(BulkLoadBlocksCommand.toProto(state), out);
+        }
+    }
 
     @TempDir
     Path tempDir;
@@ -202,8 +217,7 @@ class BulkLoadBlocksCommandTest {
             Path stateFile = destDir.resolve("historic-plugin-bulk-load-state.json");
             assertTrue(Files.exists(stateFile));
 
-            BulkLoadBlocksCommand.LoadState state =
-                    JSON_MAPPER.readValue(stateFile.toFile(), BulkLoadBlocksCommand.LoadState.class);
+            BulkLoadBlocksCommand.LoadState state = readState(stateFile);
             assertNotNull(state);
             assertEquals(sourceDir.toAbsolutePath().toString(), state.sourceDir);
             assertEquals(destDir.toAbsolutePath().toString(), state.destDir);
@@ -230,7 +244,7 @@ class BulkLoadBlocksCommandTest {
             initialState.totalBytesCopied = 100;
 
             Path stateFile = destDir.resolve("historic-plugin-bulk-load-state.json");
-            JSON_MAPPER.writeValue(stateFile.toFile(), initialState);
+            writeState(stateFile, initialState);
 
             // Also copy the first file to destination
             Files.writeString(destDir.resolve("00000s.zip"), "content 1");
@@ -242,8 +256,7 @@ class BulkLoadBlocksCommandTest {
             assertEquals(0, exitCode);
 
             // Verify state was updated
-            BulkLoadBlocksCommand.LoadState finalState =
-                    JSON_MAPPER.readValue(stateFile.toFile(), BulkLoadBlocksCommand.LoadState.class);
+            BulkLoadBlocksCommand.LoadState finalState = readState(stateFile);
             assertEquals(3, finalState.totalFilesCopied);
             assertTrue(finalState.copiedFiles.contains("10000s.zip"));
             assertTrue(finalState.copiedFiles.contains("20000s.zip"));
@@ -263,8 +276,7 @@ class BulkLoadBlocksCommandTest {
             assertEquals(0, exitCode);
 
             Path stateFile = destDir.resolve("historic-plugin-bulk-load-state.json");
-            BulkLoadBlocksCommand.LoadState state =
-                    JSON_MAPPER.readValue(stateFile.toFile(), BulkLoadBlocksCommand.LoadState.class);
+            BulkLoadBlocksCommand.LoadState state = readState(stateFile);
 
             // Last copied block should be the last block in 100000s.zip (100000 + 9999)
             assertEquals(109999, state.lastCopiedBlock);
@@ -310,7 +322,7 @@ class BulkLoadBlocksCommandTest {
             state.totalFilesCopied = 2;
 
             Path stateFile = destDir.resolve("historic-plugin-bulk-load-state.json");
-            JSON_MAPPER.writeValue(stateFile.toFile(), state);
+            writeState(stateFile, state);
 
             // Try to start from block 5000 (state's 19999 is higher, so should start from 20000)
             int exitCode = new CommandLine(new BulkLoadBlocksCommand())
@@ -380,8 +392,7 @@ class BulkLoadBlocksCommandTest {
 
             // But only the standard-named one should update lastCopiedBlock
             Path stateFile = destDir.resolve("historic-plugin-bulk-load-state.json");
-            BulkLoadBlocksCommand.LoadState state =
-                    JSON_MAPPER.readValue(stateFile.toFile(), BulkLoadBlocksCommand.LoadState.class);
+            BulkLoadBlocksCommand.LoadState state = readState(stateFile);
             assertEquals(9999, state.lastCopiedBlock); // Only from 00000s.zip
         }
 


### PR DESCRIPTION
## Description

Implements CLI `blocks bulk-load` command to copy wrapped block zips from CLI output into Block Node historic storage for the BlockFileHistoricPlugin.

Closes #2955

## Features

- **Bulk copy**: Copies wrapped block zip files from source directory to Block Node historic storage directory
- **Resume support**: Tracks progress in `historic-plugin-bulk-load-state.json` and can resume from interruption
- **Filtering**: `--start-block` option to only copy blocks >= specified number
- **Dry-run mode**: Preview what would be copied without making changes
- **Progress tracking**: Shows copy progress every 10 files and saves state periodically

## Implementation

- `BulkLoadBlocksCommand.java`: Main command implementation with resume functionality
- `BulkLoadBlocksCommandTest.java`: Comprehensive test suite with 16 tests covering:
  - Command line interface (3 tests)
  - File copying (4 tests)
  - State file management (3 tests)
  - Start block filtering (2 tests)
  - Dry run mode (1 test)
  - Edge cases (3 tests)

## Usage

```bash
# Basic bulk load
blocks bulk-load --source-dir /path/to/cli/output --dest-dir /opt/hiero/block-node/data/historic

# Resume from previous run
blocks bulk-load --source-dir /path/to/cli/output --dest-dir /opt/hiero/block-node/data/historic --resume

# Copy only blocks >= 1000
blocks bulk-load --source-dir /path/to/cli/output --dest-dir /opt/hiero/block-node/data/historic --start-block 1000

# Dry run to preview
blocks bulk-load --source-dir /path/to/cli/output --dest-dir /opt/hiero/block-node/data/historic --dry-run
```
