### PR TITLE
feat: Add statusz inbound and outbound network data to Health plugin.

### DIFF
--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/state/ApplicationStateConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/state/ApplicationStateConfig.java
@@ -22,6 +22,12 @@ import org.hiero.block.node.base.Loggable;
  *     The file is written automatically every {@code BLOCK_RANGE_PERSIST_INTERVAL} blocks and on
  *     shutdown, then loaded on startup. Block availability is derived from
  *     {@code HistoricalBlockFacility} at query time and is not persisted here.
+ * @param knownPublishersFilePath path to the JSON file (a serialized {@code NetworkData}) describing the
+ *     known inbound publishers, loaded on startup and exposed for the {@code /statusz/inbound} endpoint.
+ * @param inboundPartnersFilePath path to the JSON file (a serialized {@code NetworkData}) describing the
+ *     designated inbound partners, loaded on startup and exposed for the {@code /statusz/inbound} endpoint.
+ * @param outboundPartnersFilePath path to the JSON file (a serialized {@code NetworkData}) describing the
+ *     designated outbound partners, loaded on startup and exposed for the {@code /statusz/outbound} endpoint.
  * @param updateScanInterval The amount of milliseconds that the {@code ApplicationStateFacility} waits between
  *     checking to see if there are any {@code TssData} updates to process.
  * @param updateInitialDelay The amount of milliseconds before the first scheduled scan. Defaults to {@code 0}
@@ -33,6 +39,9 @@ public record ApplicationStateConfig(
         @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/tss-bootstrap-roster.json") Path tssBootstrapFilePath,
         @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json") Path rsaBootstrapFilePath,
         @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/block-ranges.json") Path blockRangesFilePath,
+        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/known-publishers.json") Path knownPublishersFilePath,
+        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/inbound-partners.json") Path inboundPartnersFilePath,
+        @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/outbound-partners.json") Path outboundPartnersFilePath,
         @Loggable @ConfigProperty(defaultValue = "500") @Min(100) long updateScanInterval,
         @Loggable @ConfigProperty(defaultValue = "0") @Min(0) int updateInitialDelay) {
         // spotless:on

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -55,6 +55,7 @@ import java.util.stream.Collectors;
 import org.hiero.block.api.BlockNodeVersions;
 import org.hiero.block.api.BlockNodeVersions.PluginVersion;
 import org.hiero.block.api.BlockRange;
+import org.hiero.block.api.NetworkData;
 import org.hiero.block.api.TssData;
 import org.hiero.block.internal.BlockRangesState;
 import org.hiero.block.node.app.config.AutomaticEnvironmentVariableConfigSource;
@@ -129,6 +130,18 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     /// Blocks reported as stored by plugins that do not serve them for retrieval
     final ConcurrentLongRangeSet storedBlocks = new ConcurrentLongRangeSet();
 
+    /// Known inbound publishers loaded from configuration on startup; exposed for /statusz/inbound.
+    private final AtomicReference<NetworkData> knownPublishers = new AtomicReference<>(NetworkData.DEFAULT);
+
+    /// Designated inbound partners loaded from configuration on startup; exposed for /statusz/inbound.
+    private final AtomicReference<NetworkData> inboundPartners = new AtomicReference<>(NetworkData.DEFAULT);
+
+    /// Designated outbound partners loaded from configuration on startup; exposed for /statusz/outbound.
+    private final AtomicReference<NetworkData> outboundPartners = new AtomicReference<>(NetworkData.DEFAULT);
+
+    /// Backfill source connections reported by the backfill plugin; exposed for both /statusz endpoints.
+    private final AtomicReference<NetworkData> backfillSources = new AtomicReference<>(NetworkData.DEFAULT);
+
     /// Block count at the time of the last scheduled persist; only read/written by the scanner thread
     private long lastPersistedBlockCount = 0;
 
@@ -150,7 +163,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         // ==== LOAD LOGGING CONFIG ====================================================================================
         final boolean externalLogging = System.getProperty("java.util.logging.config.file") != null;
         if (externalLogging) {
-            LOGGER.log(INFO, "External logging configuration found");
+            LOGGER.log(DEBUG, "External logging configuration found");
         } else {
             // load the logging configuration from the classpath and make it colorful
             try (var loggingConfigIn = BlockNodeApp.class.getClassLoader().getResourceAsStream("logging.properties")) {
@@ -163,7 +176,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 LOGGER.log(INFO, "Failed to load logging configuration", e);
             }
             CleanColorfulFormatter.makeLoggingColorful();
-            LOGGER.log(INFO, "Using default logging configuration");
+            LOGGER.log(DEBUG, "Using default logging configuration");
         }
         // tell helidon to use the same logging configuration
         System.setProperty("io.helidon.logging.config.disabled", "true");
@@ -177,7 +190,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             final String[] moduleClassPathArray = moduleClassPath.split(":");
             for (String module : moduleClassPathArray) {
                 if (module.contains("hiero")) {
-                    LOGGER.log(INFO, "    " + module);
+                    LOGGER.log(INFO, "    {0}", module);
                 }
             }
         }
@@ -248,9 +261,8 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         final ServiceBuilderImpl serviceBuilder = new ServiceBuilderImpl(serverConfig.port());
         // ==== INITIALIZE PLUGINS =====================================================================================
         // Initialize all the facilities & plugins, adding routing for each plugin
-        LOGGER.log(INFO, "Initializing plugins:");
         for (BlockNodePlugin plugin : loadedPlugins) {
-            LOGGER.log(INFO, "    " + plugin.name());
+            LOGGER.log(INFO, "    {0}", plugin.name());
             plugin.init(blockNodeContext, serviceBuilder);
         }
         // ==== LOAD & CONFIGURE WEB SERVER ============================================================================
@@ -383,7 +395,6 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     /// Starts the block node server. This method initializes all the plugins, starts the web server,
     /// and starts the metrics.
     public void start() {
-        LOGGER.log(INFO, "Starting BlockNode Server...");
         webServer.start();
         LOGGER.log(
                 INFO,
@@ -431,7 +442,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         webServer.stop();
         // Stop all the facilities &  plugins
         for (BlockNodePlugin plugin : loadedPlugins) {
-            LOGGER.log(INFO, "Stopping plugin: {0}", plugin.name());
+            LOGGER.log(INFO, "    {0}", plugin.name());
             plugin.stop();
         }
         // Stop metrics
@@ -442,7 +453,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             LOGGER.log(DEBUG, "Could not properly close metric registry.", e);
         }
         // finally exit
-        LOGGER.log(INFO, "Bye bye");
+        LOGGER.log(INFO, "System Exiting");
         if (shouldExitJvmOnShutdown) System.exit(0);
     }
 
@@ -458,10 +469,8 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     /// Start the loadedPlugins. Use a separate method to make starting plugins testable
     protected void startPlugins(List<BlockNodePlugin> plugins) {
         // Start all the facilities & plugins asynchronously
-        LOGGER.log(INFO, "Asynchronously Starting plugins:");
         // Asynchronously start the plugins
         plugins.parallelStream().forEach(plugin -> {
-            LOGGER.log(INFO, "    " + plugin.name());
             plugin.start();
         });
     }
@@ -483,6 +492,31 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         storedBlocks.add(blockRange);
     }
 
+    @Override
+    public NetworkData knownPublishers() {
+        return knownPublishers.get();
+    }
+
+    @Override
+    public NetworkData inboundPartners() {
+        return inboundPartners.get();
+    }
+
+    @Override
+    public NetworkData outboundPartners() {
+        return outboundPartners.get();
+    }
+
+    @Override
+    public NetworkData backfillSources() {
+        return backfillSources.get();
+    }
+
+    @Override
+    public void updateBackfillSources(NetworkData sources) {
+        backfillSources.set(sources != null ? sources : NetworkData.DEFAULT);
+    }
+
     /// Allow plugins to update the NodeAddressBook for this BlockNodeApp.
     /// The address book is staged in a last-write-wins reference; if
     /// `updateAddressBook` is called more than once before the next
@@ -498,7 +532,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         try {
             validateAddressBook(nodeAddressBook, "runtime update");
         } catch (IllegalStateException e) {
-            LOGGER.log(WARNING, "Rejecting invalid address book update: {0}", e.getMessage());
+            LOGGER.log(INFO, "Rejecting invalid address book update: {0}", e);
             return false;
         }
         pendingAddressBook.set(nodeAddressBook);
@@ -513,8 +547,6 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     /// Starts the ApplicationStateFacility.
     /// The thread will be used to check if there are any TssData updates to process.
     void startApplicationStateFacility() {
-        LOGGER.log(INFO, "ApplicationStateFacility start called");
-
         // ==== LOAD APPLICATION STATE =================================================================================
         loadApplicationState(blockNodeContext.configuration());
 
@@ -554,7 +586,6 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
 
         if (updateBlockNodeContext(tssData, addressBook, storedBlocks, historicalBlockFacility.availableBlocks())) {
             loadedPlugins.parallelStream().forEach(plugin -> plugin.onContextUpdate(blockNodeContext));
-            LOGGER.log(INFO, "ApplicationStateFacility called plugin.onContextUpdate for all plugins");
         }
 
         // Persist block ranges whenever the running total crosses a BLOCK_RANGE_PERSIST_INTERVAL boundary.
@@ -685,7 +716,6 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         try {
             Bytes serialized = TssData.JSON.toBytes(tssData);
             Files.write(appStateDataFilePath, serialized.toByteArray());
-            LOGGER.log(INFO, "Persisted TssData to file: {0}", appStateDataFilePath);
         } catch (IOException e) {
             LOGGER.log(WARNING, "Failed to persist TssData to %s: %s".formatted(appStateDataFilePath, e), e);
         }
@@ -704,18 +734,17 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 Files.move(tmp, filePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
             } catch (AtomicMoveNotSupportedException e) {
                 LOGGER.log(
-                        WARNING,
+                        DEBUG,
                         "Atomic move not supported on this filesystem for {0}; falling back to non-atomic replace",
                         filePath);
                 Files.move(tmp, filePath, StandardCopyOption.REPLACE_EXISTING);
             }
-            LOGGER.log(INFO, "Persisted RSA address book to file: {0}", filePath);
         } catch (IOException e) {
             LOGGER.log(
-                    WARNING,
+                    INFO,
                     "Failed to persist RSA address book to {0}: {1} — will re-fetch on next startup",
                     filePath,
-                    e.getMessage());
+                    e);
         }
     }
 
@@ -732,7 +761,6 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             Files.deleteIfExists(filePath);
             Files.createLink(filePath, tmp);
             Files.deleteIfExists(tmp);
-            LOGGER.log(INFO, "Persisted block ranges to file: {0}", filePath);
         } catch (IOException e) {
             LOGGER.log(WARNING, "Failed to persist block ranges to %s".formatted(filePath), e);
         }
@@ -764,9 +792,8 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             try {
                 TssData tssData = standardParse(TssData.JSON, Bytes.wrap(Files.readAllBytes(tssDataJsonPath)));
                 updateTssData(tssData);
-                LOGGER.log(INFO, "Loaded TssData from file: {0}", tssDataJsonPath);
             } catch (ParseException | IOException e) {
-                LOGGER.log(ERROR, "Failed to read TssData file: " + tssDataJsonPath, e);
+                LOGGER.log(WARNING, "Failed to read TssData file: " + tssDataJsonPath, e);
             }
         } else {
             // make sure the directory is created for the writes
@@ -774,7 +801,7 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             try {
                 Files.createDirectories(parent);
             } catch (IOException e) {
-                LOGGER.log(ERROR, "Failed to create TssData directory: " + parent, e);
+                LOGGER.log(WARNING, "Failed to create TssData directory: " + parent, e);
             }
         }
 
@@ -786,18 +813,13 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 final NodeAddressBook book = standardParse(NodeAddressBook.JSON, Bytes.wrap(raw));
                 validateAddressBook(book, rsaFilePath.toString());
                 pendingAddressBook.set(book);
-                LOGGER.log(
-                        INFO,
-                        "Loaded RSA address book from file: {0} ({1} entries)",
-                        rsaFilePath,
-                        book.nodeAddress().size());
             } catch (IOException e) {
                 throw new IllegalStateException("Failed to read RSA bootstrap file: " + rsaFilePath, e);
             } catch (ParseException e) {
-                throw new IllegalStateException(
-                        "Corrupt RSA bootstrap file at " + rsaFilePath
-                                + " — delete and restart to re-fetch from Mirror Node",
-                        e);
+                final String message =
+                        "Corrupt RSA bootstrap file at %s — delete and restart to re-fetch from Mirror Node"
+                                .formatted(rsaFilePath);
+                throw new IllegalStateException(message, e);
             }
         } else {
             // make sure the directory is created for the writes
@@ -818,15 +840,44 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 rangeSet.storedBlocks().forEach(r -> storedBlocks.add(new LongRange(r.rangeStart(), r.rangeEnd())));
                 LOGGER.log(INFO, "Loaded block ranges from file: {0}", blockRangesPath);
             } catch (ParseException | IOException | IllegalArgumentException e) {
-                LOGGER.log(ERROR, "Failed to read block ranges file: " + blockRangesPath, e);
+                LOGGER.log(WARNING, "Failed to read block ranges file: " + blockRangesPath, e);
             }
         } else {
             Path parent = blockRangesPath.getParent();
             try {
                 Files.createDirectories(parent);
             } catch (IOException e) {
-                LOGGER.log(ERROR, "Failed to create block ranges directory: " + parent, e);
+                LOGGER.log(WARNING, "Failed to create block ranges directory: " + parent, e);
             }
+        }
+
+        // Load the connection-information sets (JSON-serialized NetworkData) used by the /statusz endpoints.
+        // These are read-only configuration; absent or unreadable files yield an empty set.
+        knownPublishers.set(loadNetworkData(appStateConfig.knownPublishersFilePath()));
+        inboundPartners.set(loadNetworkData(appStateConfig.inboundPartnersFilePath()));
+        outboundPartners.set(loadNetworkData(appStateConfig.outboundPartnersFilePath()));
+    }
+
+    /// Loads a [NetworkData] document from the given JSON file.
+    /// Missing files and parse failures are logged and yield
+    /// [NetworkData#DEFAULT] (an empty set) rather than throwing, mirroring
+    /// the lenient handling used for other optional application-state files.
+    ///
+    /// @param path the JSON file to read
+    /// @return the parsed NetworkData, or [NetworkData#DEFAULT] if
+    ///     absent or unreadable
+    static NetworkData loadNetworkData(final Path path) {
+        if (path == null || !Files.exists(path)) {
+            LOGGER.log(DEBUG, "Network data file not present, using empty set: {0}", path);
+            return NetworkData.DEFAULT;
+        }
+        try {
+            final NetworkData data = standardParse(
+                    NetworkData.JSON, Bytes.wrap(Files.readAllBytes(path)), MAX_APP_STATE_MESSAGE_SIZE_BYTES);
+            return data;
+        } catch (ParseException | IOException e) {
+            LOGGER.log(INFO, "Failed to read network data file %s.".formatted(path), e);
+            return NetworkData.DEFAULT;
         }
     }
 
@@ -838,14 +889,15 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     static void validateAddressBook(final NodeAddressBook book, final String source) {
         if (book.nodeAddress().isEmpty()) {
             throw new IllegalStateException(
-                    "RSA address book from " + source + " contains no entries — cannot verify WRB proofs");
+                    "RSA address book from %s contains no entries — cannot verify WRB proofs".formatted(source));
         }
         final long declared = book.nodeAddress().stream()
                 .filter(a -> !a.rsaPubKey().isBlank())
                 .count();
+        final String noValidKeyMessage =
+                "RSA address book from %s has %s entries but none have a valid RSA_PubKey".formatted(source, declared);
         if (declared == 0) {
-            throw new IllegalStateException("RSA address book from " + source + " has "
-                    + book.nodeAddress().size() + " entries but none have a non-blank RSA_PubKey");
+            throw new IllegalStateException(noValidKeyMessage);
         }
         long usable = 0;
         final HexFormat hex = HexFormat.of();
@@ -866,12 +918,11 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 kf.generatePublic(new X509EncodedKeySpec(keyBytes));
                 usable++;
             } catch (InvalidKeySpecException | IllegalArgumentException e) {
-                LOGGER.log(WARNING, "Malformed RSA_PubKey for node {0} — skipped: {1}", addr.nodeId(), e.getMessage());
+                LOGGER.log(INFO, "Malformed RSA_PubKey for node {0} — skipped: {1}", addr.nodeId(), e);
             }
         }
         if (usable == 0) {
-            throw new IllegalStateException("RSA address book from " + source + " has "
-                    + book.nodeAddress().size() + " entries but none have a valid RSA_PubKey");
+            throw new IllegalStateException(noValidKeyMessage);
         }
     }
 }

--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppNetworkDataLoadTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppNetworkDataLoadTest.java
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.app;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hiero.block.api.NetworkConnection;
+import org.hiero.block.api.NetworkConnection.ConnectionReference;
+import org.hiero.block.api.NetworkConnection.IpProtocol;
+import org.hiero.block.api.NetworkData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link BlockNodeApp#loadNetworkData(Path)}. */
+class BlockNodeAppNetworkDataLoadTest {
+
+    @Test
+    @DisplayName("A valid NetworkData JSON file is parsed")
+    void loadsNetworkDataFromFile(@TempDir final Path dir) throws IOException {
+        final NetworkData data = NetworkData.newBuilder()
+                .activeEndpoints(NetworkConnection.newBuilder()
+                        .local(new ConnectionReference("$", "*"))
+                        .remote(new ConnectionReference("pub.example.com", "40840"))
+                        .category("publisher")
+                        .scheme("https")
+                        .protocol(IpProtocol.TCP)
+                        .tlsRequired(true)
+                        .certificate(Bytes.EMPTY)
+                        .build())
+                .build();
+        final Path file = dir.resolve("known-publishers.json");
+        Files.writeString(file, NetworkData.JSON.toJSON(data));
+
+        final NetworkData loaded = BlockNodeApp.loadNetworkData(file);
+
+        assertEquals(1, loaded.activeEndpoints().size());
+        assertEquals("pub.example.com", loaded.activeEndpoints().get(0).remote().address());
+    }
+
+    @Test
+    @DisplayName("A missing file yields an empty NetworkData")
+    void missingFileReturnsEmpty(@TempDir final Path dir) {
+        assertTrue(BlockNodeApp.loadNetworkData(dir.resolve("does-not-exist.json"))
+                .activeEndpoints()
+                .isEmpty());
+    }
+
+    @Test
+    @DisplayName("A null path yields an empty NetworkData")
+    void nullPathReturnsEmpty() {
+        assertTrue(BlockNodeApp.loadNetworkData(null).activeEndpoints().isEmpty());
+    }
+}

--- a/block-node/app/src/testFixtures/java/module-info.java
+++ b/block-node/app/src/testFixtures/java/module-info.java
@@ -19,7 +19,12 @@ module org.hiero.block.node.app.test.fixtures {
     requires org.hiero.block.protobuf.pbj;
     requires org.hiero.metrics;
     requires com.github.luben.zstd_jni;
+    requires io.helidon.common.context;
+    requires io.helidon.common.parameters;
     requires io.helidon.common.socket;
+    requires io.helidon.common.uri;
+    requires io.helidon.http.media;
+    requires io.helidon.http;
     requires io.helidon.webserver;
     requires java.logging;
     requires org.junit.jupiter.api;

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 import org.hiero.block.api.BlockNodeVersions;
 import org.hiero.block.api.BlockNodeVersions.PluginVersion;
 import org.hiero.block.api.BlockRange;
+import org.hiero.block.api.NetworkData;
 import org.hiero.block.api.TssData;
 import org.hiero.block.node.app.fixtures.TestMetricsExporter;
 import org.hiero.block.node.app.fixtures.async.TestThreadPoolManager;
@@ -358,6 +359,31 @@ public abstract class PluginTestBase<
 
     @Override
     public void addStoredBlockRange(LongRange blockRange) {
+        // Do nothing
+    }
+
+    @Override
+    public NetworkData knownPublishers() {
+        return TestApplicationStateFacility.DEFAULT_NETWORK_DATA;
+    }
+
+    @Override
+    public NetworkData inboundPartners() {
+        return TestApplicationStateFacility.DEFAULT_NETWORK_DATA;
+    }
+
+    @Override
+    public NetworkData outboundPartners() {
+        return TestApplicationStateFacility.DEFAULT_NETWORK_DATA;
+    }
+
+    @Override
+    public NetworkData backfillSources() {
+        return TestApplicationStateFacility.DEFAULT_NETWORK_DATA;
+    }
+
+    @Override
+    public void updateBackfillSources(NetworkData sources) {
         // Do nothing
     }
 }

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestApplicationStateFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestApplicationStateFacility.java
@@ -2,19 +2,72 @@
 package org.hiero.block.node.app.fixtures.plugintest;
 
 import com.hedera.hapi.node.base.NodeAddressBook;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.util.Deque;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import org.hiero.block.api.NetworkConnection;
+import org.hiero.block.api.NetworkConnection.ConnectionReference;
+import org.hiero.block.api.NetworkConnection.IpProtocol;
+import org.hiero.block.api.NetworkData;
 import org.hiero.block.api.TssData;
 import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.historicalblocks.LongRange;
 
+/**
+ * A configurable {@link ApplicationStateFacility} test fixture. The connection sets
+ * ({@code knownPublishers}, {@code inboundPartners}, {@code outboundPartners}, {@code backfillSources})
+ * default to {@link #DEFAULT_NETWORK_DATA} — non-empty sample data — and can be overridden via the
+ * setters. The block-range and TSS/address-book mutators are no-ops.
+ */
 public class TestApplicationStateFacility implements ApplicationStateFacility {
     private final Deque<TssData> tssDataUpdates;
     private final Deque<NodeAddressBook> nodeAddressBookUpdates;
 
+    /** Non-empty sample network data used as the default for every connection set. */
+    public static final NetworkData DEFAULT_NETWORK_DATA = NetworkData.newBuilder()
+            .activeEndpoints(NetworkConnection.newBuilder()
+                    .local(new ConnectionReference("$", "*"))
+                    .remote(new ConnectionReference("test.example.com", "40840"))
+                    .category("partner")
+                    .scheme("https")
+                    .protocol(IpProtocol.TCP)
+                    .tlsRequired(true)
+                    .certificate(Bytes.EMPTY)
+                    .build())
+            .build();
+
+    private NetworkData knownPublishers = DEFAULT_NETWORK_DATA;
+    private NetworkData inboundPartners = DEFAULT_NETWORK_DATA;
+    private NetworkData outboundPartners = DEFAULT_NETWORK_DATA;
+    private NetworkData backfillSources = DEFAULT_NETWORK_DATA;
+
     public TestApplicationStateFacility() {
         this.tssDataUpdates = new ConcurrentLinkedDeque<>();
         this.nodeAddressBookUpdates = new ConcurrentLinkedDeque<>();
+    }
+
+    public Deque<TssData> getTssDataUpdates() {
+        return tssDataUpdates;
+    }
+
+    public Deque<NodeAddressBook> getNodeAddressBookUpdates() {
+        return nodeAddressBookUpdates;
+    }
+
+    public void setKnownPublishers(NetworkData value) {
+        this.knownPublishers = value;
+    }
+
+    public void setInboundPartners(NetworkData value) {
+        this.inboundPartners = value;
+    }
+
+    public void setOutboundPartners(NetworkData value) {
+        this.outboundPartners = value;
+    }
+
+    public void setBackfillSources(NetworkData value) {
+        this.backfillSources = value;
     }
 
     @Override
@@ -30,11 +83,28 @@ public class TestApplicationStateFacility implements ApplicationStateFacility {
     @Override
     public void addStoredBlockRange(final LongRange blockRange) {}
 
-    public Deque<TssData> getTssDataUpdates() {
-        return tssDataUpdates;
+    @Override
+    public NetworkData knownPublishers() {
+        return knownPublishers;
     }
 
-    public Deque<NodeAddressBook> getNodeAddressBookUpdates() {
-        return nodeAddressBookUpdates;
+    @Override
+    public NetworkData inboundPartners() {
+        return inboundPartners;
+    }
+
+    @Override
+    public NetworkData outboundPartners() {
+        return outboundPartners;
+    }
+
+    @Override
+    public NetworkData backfillSources() {
+        return backfillSources;
+    }
+
+    @Override
+    public void updateBackfillSources(NetworkData sources) {
+        this.backfillSources = sources;
     }
 }

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestServerRequest.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestServerRequest.java
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.app.fixtures.plugintest;
+
+import io.helidon.common.context.Context;
+import io.helidon.common.parameters.Parameters;
+import io.helidon.common.socket.PeerInfo;
+import io.helidon.common.uri.UriInfo;
+import io.helidon.common.uri.UriQuery;
+import io.helidon.http.Header;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.RoutedPath;
+import io.helidon.http.ServerRequestHeaders;
+import io.helidon.http.media.ReadableEntity;
+import io.helidon.webserver.ListenerContext;
+import io.helidon.webserver.ProxyProtocolData;
+import io.helidon.webserver.http.HttpSecurity;
+import io.helidon.webserver.http.ServerRequest;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
+/**
+ * Minimal {@link ServerRequest} test double that exposes only a settable request path (via
+ * {@link #path()}). All other operations are unsupported.
+ */
+public class TestServerRequest implements ServerRequest {
+    private final String path;
+
+    public TestServerRequest(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public RoutedPath path() {
+        return new TestRoutedPath(path);
+    }
+
+    @Override
+    public void reset() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSecure() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ReadableEntity content() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String socketId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String serverSocketId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Context context() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ListenerContext listenerContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpSecurity security() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean continueSent() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void streamFilter(UnaryOperator<InputStream> filterFunction) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<ProxyProtocolData> proxyProtocolData() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpPrologue prologue() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServerRequestHeaders headers() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public UriQuery query() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PeerInfo remotePeer() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PeerInfo localPeer() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String authority() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void header(Header header) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int id() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public UriInfo requestedUri() {
+        throw new UnsupportedOperationException();
+    }
+
+    /** Minimal {@link RoutedPath} returning the configured path string. */
+    private record TestRoutedPath(String path) implements RoutedPath {
+        @Override
+        public String rawPath() {
+            return path;
+        }
+
+        @Override
+        public String rawPathNoParams() {
+            return path;
+        }
+
+        @Override
+        public Parameters matrixParameters() {
+            return Parameters.empty("matrix");
+        }
+
+        @Override
+        public Parameters pathParameters() {
+            return Parameters.empty("path");
+        }
+
+        @Override
+        public RoutedPath absolute() {
+            return this;
+        }
+
+        @Override
+        public void validate() {
+            // no-op
+        }
+    }
+}

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestServerResponse.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestServerResponse.java
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.app.fixtures.plugintest;
+
+import io.helidon.common.uri.UriQuery;
+import io.helidon.http.Header;
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.ServerResponseHeaders;
+import io.helidon.http.ServerResponseTrailers;
+import io.helidon.http.Status;
+import io.helidon.webserver.http.ServerResponse;
+import java.io.OutputStream;
+import java.util.function.UnaryOperator;
+
+/**
+ * Minimal {@link ServerResponse} test double that records the status code, the {@code Content-Type}
+ * header, and the sent entity, exposing them via accessors. All other operations are unsupported.
+ */
+public class TestServerResponse implements ServerResponse {
+    private int statusCode = -1;
+    private String contentType;
+    private Object sentEntity;
+    private boolean sent;
+
+    /** @return the status code passed to {@code status(...)}, or {@code -1} if unset */
+    public int sentStatus() {
+        return statusCode;
+    }
+
+    /** @return the value of the {@code Content-Type} header, or {@code null} if unset */
+    public String contentType() {
+        return contentType;
+    }
+
+    /** @return the entity passed to {@code send(...)}, or {@code null} if nothing was sent */
+    public Object sentEntity() {
+        return sentEntity;
+    }
+
+    @Override
+    public ServerResponse status(int statusCode) {
+        this.statusCode = statusCode;
+        return this;
+    }
+
+    @Override
+    public ServerResponse status(Status status) {
+        this.statusCode = status.code();
+        return this;
+    }
+
+    @Override
+    public Status status() {
+        return Status.create(statusCode);
+    }
+
+    @Override
+    public ServerResponse header(HeaderName name, String... values) {
+        if (name.equals(HeaderNames.CONTENT_TYPE) && values.length > 0) {
+            this.contentType = values[0];
+        }
+        return this;
+    }
+
+    @Override
+    public ServerResponse header(Header header) {
+        if (header.headerName().equals(HeaderNames.CONTENT_TYPE)) {
+            this.contentType = header.values();
+        }
+        return this;
+    }
+
+    @Override
+    public void send(Object entity) {
+        this.sentEntity = entity;
+        this.sent = true;
+    }
+
+    @Override
+    public void send() {
+        this.sent = true;
+    }
+
+    @Override
+    public void send(byte[] bytes) {
+        this.sentEntity = bytes;
+        this.sent = true;
+    }
+
+    @Override
+    public boolean isSent() {
+        return sent;
+    }
+
+    @Override
+    public OutputStream outputStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long bytesWritten() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServerResponse whenSent(Runnable listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServerResponse reroute(String newPath) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServerResponse reroute(String path, UriQuery query) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServerResponse next() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServerResponseHeaders headers() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServerResponseTrailers trailers() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void streamResult(String result) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void streamFilter(UnaryOperator<OutputStream> filterFunction) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillNetworkData.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillNetworkData.java
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.backfill;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.List;
+import org.hiero.block.api.NetworkConnection;
+import org.hiero.block.api.NetworkConnection.ConnectionReference;
+import org.hiero.block.api.NetworkConnection.IpProtocol;
+import org.hiero.block.api.NetworkData;
+import org.hiero.block.internal.BlockNodeSource;
+import org.hiero.block.internal.BlockNodeSourceConfig;
+
+/**
+ * Utility for converting configured backfill sources into the {@link NetworkData} representation that is
+ * published to the Application State facility (and reported by the {@code /statusz} endpoints).
+ *
+ * <p>Each backfill source becomes a {@link NetworkConnection} whose {@code remote} is the source endpoint,
+ * whose {@code local} is the wildcard self endpoint {@code $:*}, whose {@code category} is {@code partner},
+ * and which carries no certificate.
+ */
+final class BackfillNetworkData {
+    private static final String BACKFILL_DEFAULT_CATEGORY = "partner";
+    private static final String DEFAULT_TLS_SCHEME = "grpcs";
+    private static final String DEFAULT_NON_TLS_SCHEME = "grpc";
+
+    private BackfillNetworkData() {
+        // utility class; not instantiable
+    }
+
+    /**
+     * Converts the configured backfill sources into a {@link NetworkData}.
+     *
+     * @param sources the parsed backfill sources
+     * @param tlsEnabled whether TLS is required (from backfill configuration)
+     * @return the equivalent NetworkData
+     */
+    static NetworkData toNetworkData(@NonNull final BlockNodeSource sources, final boolean tlsEnabled) {
+        final List<NetworkConnection> connections =
+                new ArrayList<>(sources.nodes().size());
+        for (final BlockNodeSourceConfig node : sources.nodes()) {
+            connections.add(toNetworkConnection(node, tlsEnabled));
+        }
+        return NetworkData.newBuilder().activeEndpoints(connections).build();
+    }
+
+    /**
+     * Converts a single backfill source into a {@link NetworkConnection}. The {@code scheme} and
+     * {@code protocol} come from the source configuration, falling back to {@code http(s)} (per the backfill
+     * TLS setting) and {@code TCP} respectively when unset.
+     *
+     * @param node the backfill source configuration
+     * @param tls whether TLS is required (from backfill configuration)
+     * @return the equivalent NetworkConnection
+     */
+    static NetworkConnection toNetworkConnection(@NonNull final BlockNodeSourceConfig node, final boolean tls) {
+        final String scheme =
+                node.scheme().isBlank() ? (tls ? DEFAULT_TLS_SCHEME : DEFAULT_NON_TLS_SCHEME) : node.scheme();
+        final IpProtocol protocol = node.protocol() == IpProtocol.UNIDENTIFIED ? IpProtocol.TCP : node.protocol();
+        return NetworkConnection.newBuilder()
+                .remote(new ConnectionReference(node.address(), Integer.toString(node.port())))
+                .local(new ConnectionReference("$", "*"))
+                .category(BACKFILL_DEFAULT_CATEGORY)
+                .scheme(scheme)
+                .protocol(protocol)
+                .tlsRequired(tls)
+                .certificate(Bytes.EMPTY)
+                .build();
+    }
+}

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -159,6 +159,12 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
         // ready for backfill.
         hasBNSourcesPath = true;
 
+        // Publish the source connections to the Application State facility so the /statusz endpoints
+        // can report them. All connection information is owned by the Application State facility.
+        context.applicationStateFacility()
+                .updateBackfillSources(
+                        BackfillNetworkData.toNetworkData(blockNodeSources, backfillConfiguration.enableTLS()));
+
         // Register the service
         context.blockMessaging().registerBlockNotificationHandler(this, false, "BackfillPlugin");
     }

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillNetworkDataTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillNetworkDataTest.java
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.backfill;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.List;
+import org.hiero.block.api.NetworkConnection;
+import org.hiero.block.api.NetworkConnection.IpProtocol;
+import org.hiero.block.api.NetworkData;
+import org.hiero.block.internal.BlockNodeSource;
+import org.hiero.block.internal.BlockNodeSourceConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link BackfillNetworkData} conversion of backfill sources to {@link NetworkData}. */
+class BackfillNetworkDataTest {
+
+    @Test
+    @DisplayName("Source maps to remote endpoint, wildcard self local, partner category, and empty certificate")
+    void mapsSourceToConnection() {
+        final BlockNodeSourceConfig node = BlockNodeSourceConfig.newBuilder()
+                .address("source.example.com")
+                .port(40840)
+                .scheme("grpc")
+                .protocol(IpProtocol.UDP)
+                .build();
+
+        final NetworkConnection connection = BackfillNetworkData.toNetworkConnection(node, true);
+
+        assertEquals("source.example.com", connection.remote().address());
+        assertEquals("40840", connection.remote().port());
+        assertEquals("$", connection.local().address());
+        assertEquals("*", connection.local().port());
+        assertEquals("partner", connection.category());
+        assertEquals("grpc", connection.scheme());
+        assertEquals(IpProtocol.UDP, connection.protocol());
+        assertTrue(connection.tlsRequired());
+        assertEquals(Bytes.EMPTY, connection.certificate());
+    }
+
+    @Test
+    @DisplayName("Blank scheme and unidentified protocol fall back to https/TCP when TLS is enabled")
+    void defaultsWithTls() {
+        final BlockNodeSourceConfig node =
+                BlockNodeSourceConfig.newBuilder().address("a").port(1).build();
+
+        final NetworkConnection connection = BackfillNetworkData.toNetworkConnection(node, true);
+
+        assertEquals("grpcs", connection.scheme());
+        assertEquals(IpProtocol.TCP, connection.protocol());
+        assertTrue(connection.tlsRequired());
+    }
+
+    @Test
+    @DisplayName("Blank scheme falls back to http when TLS is disabled")
+    void defaultsWithoutTls() {
+        final BlockNodeSourceConfig node =
+                BlockNodeSourceConfig.newBuilder().address("a").port(1).build();
+
+        final NetworkConnection connection = BackfillNetworkData.toNetworkConnection(node, false);
+
+        assertEquals("grpc", connection.scheme());
+        assertFalse(connection.tlsRequired());
+    }
+
+    @Test
+    @DisplayName("toNetworkData converts every configured source")
+    void convertsAllSources() {
+        final BlockNodeSource sources = BlockNodeSource.newBuilder()
+                .nodes(List.of(
+                        BlockNodeSourceConfig.newBuilder().address("a").port(1).build(),
+                        BlockNodeSourceConfig.newBuilder().address("b").port(2).build()))
+                .build();
+
+        final NetworkData data = BackfillNetworkData.toNetworkData(sources, false);
+
+        assertEquals(2, data.activeEndpoints().size());
+        assertEquals("a", data.activeEndpoints().get(0).remote().address());
+        assertEquals("b", data.activeEndpoints().get(1).remote().address());
+    }
+}

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTaskTest.java
@@ -27,6 +27,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import org.hiero.block.api.NetworkData;
 import org.hiero.block.api.TssData;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
@@ -613,5 +614,28 @@ class BlockUploadTaskTest {
         public void addStoredBlockRange(LongRange blockRange) {
             storedRanges.add(blockRange);
         }
+
+        @Override
+        public NetworkData knownPublishers() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public NetworkData inboundPartners() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public NetworkData outboundPartners() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public NetworkData backfillSources() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public void updateBackfillSources(NetworkData sources) {}
     }
 }

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTaskTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import org.hiero.block.api.NetworkData;
 import org.hiero.block.api.TssData;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
@@ -89,6 +90,18 @@ class TempArchiveUploadTaskTest {
         MINIO_CONTAINER.stop();
     }
 
+    private static BlockWithSource makeBlock(int dataSize) {
+        final byte[] data = new byte[dataSize];
+        new Random(0).nextBytes(data);
+        final BlockItemUnparsed item = new BlockItemUnparsed(
+                new OneOf<>(BlockItemUnparsed.ItemOneOfType.SIGNED_TRANSACTION, Bytes.wrap(data)));
+        return new BlockWithSource(
+                BlockUnparsed.newBuilder()
+                        .blockItems(new BlockItemUnparsed[] {item})
+                        .build(),
+                BlockSource.PUBLISHER);
+    }
+
     @BeforeEach
     void setUp() throws Exception {
         final ConfigurationBuilder builder =
@@ -139,18 +152,6 @@ class TempArchiveUploadTaskTest {
         return CloudStorageArchivePlugin.MetricsHolder.createMetrics(MetricRegistry.builder()
                 .setMetricsExporter(new TestMetricsExporter())
                 .build());
-    }
-
-    private static BlockWithSource makeBlock(int dataSize) {
-        final byte[] data = new byte[dataSize];
-        new Random(0).nextBytes(data);
-        final BlockItemUnparsed item = new BlockItemUnparsed(
-                new OneOf<>(BlockItemUnparsed.ItemOneOfType.SIGNED_TRANSACTION, Bytes.wrap(data)));
-        return new BlockWithSource(
-                BlockUnparsed.newBuilder()
-                        .blockItems(new BlockItemUnparsed[] {item})
-                        .build(),
-                BlockSource.PUBLISHER);
     }
 
     private TempArchiveUploadTask buildTask(
@@ -392,7 +393,6 @@ class TempArchiveUploadTaskTest {
     }
 
     private static final class NoOpApplicationStateFacility implements ApplicationStateFacility {
-
         @Override
         public void updateTssData(TssData tssData) {}
 
@@ -404,6 +404,27 @@ class TempArchiveUploadTaskTest {
         @Override
         public void addStoredBlockRange(LongRange blockRange) {}
 
-        public void addAvailableBlockRange(LongRange blockRange) {}
+        @Override
+        public NetworkData knownPublishers() {
+            return null;
+        }
+
+        @Override
+        public NetworkData inboundPartners() {
+            return null;
+        }
+
+        @Override
+        public NetworkData outboundPartners() {
+            return null;
+        }
+
+        @Override
+        public NetworkData backfillSources() {
+            return null;
+        }
+
+        @Override
+        public void updateBackfillSources(final NetworkData sources) {}
     }
 }

--- a/block-node/health/build.gradle.kts
+++ b/block-node/health/build.gradle.kts
@@ -8,13 +8,14 @@ description = "Hiero Block Node Health Service"
 tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
 
 mainModuleInfo {
-    runtimeOnly("com.swirlds.config.impl")
-    runtimeOnly("org.apache.logging.log4j.slf4j2.impl")
-    runtimeOnly("io.helidon.logging.jul")
     runtimeOnly("com.hedera.pbj.grpc.helidon.config")
+    runtimeOnly("com.swirlds.config.impl")
+    runtimeOnly("io.helidon.logging.jul")
+    runtimeOnly("org.apache.logging.log4j.slf4j2.impl")
 }
 
 testModuleInfo {
+    requires("org.hiero.block.node.app.test.fixtures")
     requires("org.junit.jupiter.api")
     requires("org.mockito")
     requires("org.mockito.junit.jupiter")

--- a/block-node/health/src/main/java/module-info.java
+++ b/block-node/health/src/main/java/module-info.java
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import org.hiero.block.node.health.HealthServicePlugin;
 
-// SPDX-License-Identifier: Apache-2.0
 module org.hiero.block.node.health {
-    uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
-
-    // export configuration classes to the config module and app
     exports org.hiero.block.node.health to
             com.swirlds.config.impl,
             com.swirlds.config.extensions,
@@ -14,9 +10,15 @@ module org.hiero.block.node.health {
     requires transitive com.swirlds.config.api;
     requires transitive org.hiero.block.node.spi;
     requires transitive io.helidon.webserver;
+    requires com.hedera.pbj.runtime;
     requires org.hiero.block.node.base;
+    requires org.hiero.block.protobuf.pbj;
     requires com.github.spotbugs.annotations;
+    requires io.helidon.http;
 
+    // spotless:off Spotless is broken at the moment, wants to both add and remove the same line.
+    uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
     provides org.hiero.block.node.spi.BlockNodePlugin with
             HealthServicePlugin;
+    // spotless:on
 }

--- a/block-node/health/src/main/java/org/hiero/block/node/health/HealthConfig.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/HealthConfig.java
@@ -16,5 +16,7 @@ import org.hiero.block.node.base.Loggable;
  */
 @ConfigData("health")
 public record HealthConfig(
-        @Loggable @ConfigProperty(defaultValue = ConfigProperty.NULL_DEFAULT_VALUE)
-        Integer port) {}
+        // spotless:off
+        @Loggable @ConfigProperty(defaultValue = ConfigProperty.NULL_DEFAULT_VALUE) Integer port) {
+        // spotless:on
+}

--- a/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
@@ -11,51 +11,57 @@ import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 import java.lang.System.Logger;
 import java.util.List;
+import org.hiero.block.api.NetworkData;
+import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.health.HealthFacility;
 
-/** Provides implementation for the health endpoints of the server. */
+/// Provides implementation for the health endpoints of the server.
 public class HealthServicePlugin implements BlockNodePlugin {
     private final Logger LOGGER = System.getLogger(getClass().getName());
     protected static final String HEALTHZ_PATH = "/healthz";
     protected static final String LIVEZ_PATH = "/livez";
     protected static final String READYZ_PATH = "/readyz";
+    protected static final String STATUSZ_PATH = "/statusz";
+    protected static final String INBOUND_PATH = STATUSZ_PATH + "/inbound";
+    protected static final String OUTBOUND_PATH = STATUSZ_PATH + "/outbound";
 
-    /** The health facility, used for getting server status */
+    /// The health facility, used for getting server status
     private HealthFacility healthFacility;
 
-    /**
-     * {@inheritDoc}
-     */
+    /// The application state facility, used to obtain connection information
+    /// for the statusz endpoints
+    private ApplicationStateFacility applicationStateFacility;
+
+    /// {@inheritDoc}
     @Override
     public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
         healthFacility = context.serverHealth();
+        applicationStateFacility = context.applicationStateFacility();
         // A null port (the default) shares server.port
         final Integer port =
                 context.configuration().getConfigData(HealthConfig.class).port();
         serviceBuilder.registerHttpService(HEALTHZ_PATH, port, httpRules -> httpRules
                 .get(LIVEZ_PATH, this::handleLivez)
                 .get(READYZ_PATH, this::handleReadyz));
+        serviceBuilder.registerHttpService(STATUSZ_PATH, port, httpRules -> httpRules.get("*", this::handleStatusz));
         LOGGER.log(DEBUG, "Completed health facility initialization");
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /// {@inheritDoc}
     @Override
     @NonNull
     public List<Class<? extends Record>> configDataTypes() {
         return List.of(HealthConfig.class);
     }
 
-    /**
-     * Handles the request for liveness endpoint, that it most be defined on routing implementation.
-     *
-     * @param req the server request
-     * @param res the server response
-     */
+    /// Handles the request for liveness endpoint, that must be defined
+    /// in the routing implementation.
+    ///
+    /// @param req the server request
+    /// @param res the server response
     public final void handleLivez(@NonNull final ServerRequest req, @NonNull final ServerResponse res) {
         try {
             if (healthFacility.isRunning()) {
@@ -70,13 +76,11 @@ public class HealthServicePlugin implements BlockNodePlugin {
         }
     }
 
-    /**
-     * Handles the request for readiness endpoint, that it most be defined on routing
-     * implementation.
-     *
-     * @param req the server request
-     * @param res the server response
-     */
+    /// Handles the request for readiness endpoint, that must be defined
+    /// in the routing implementation.
+    ///
+    /// @param req the server request
+    /// @param res the server response
     public final void handleReadyz(@NonNull final ServerRequest req, @NonNull final ServerResponse res) {
         try {
             if (healthFacility.isRunning()) {
@@ -88,6 +92,30 @@ public class HealthServicePlugin implements BlockNodePlugin {
             }
         } catch (final RuntimeException e) {
             LOGGER.log(WARNING, "Failed to respond to readiness check due to %s".formatted(e), e);
+        }
+    }
+
+    /// Handles requests for the `/statusz` endpoints. The request subpath
+    /// selects which handler runs. The matching handler builds and sends its
+    /// [NetworkData] response synchronously on the request thread.
+    ///
+    /// @param req the server request
+    /// @param res the server response
+    public final void handleStatusz(@NonNull final ServerRequest req, @NonNull final ServerResponse res) {
+        try {
+            final String path = req.path().path();
+            NetworkData temp;
+            if (path.endsWith(INBOUND_PATH)) {
+                new InboundStatusHandler(req, res, applicationStateFacility).createAndSendResponse();
+            } else if (path.endsWith(OUTBOUND_PATH)) {
+                new OutboundStatusHandler(req, res, applicationStateFacility).createAndSendResponse();
+            } else {
+                LOGGER.log(INFO, "Responded code 404 (Unknown statusz subpath) for {0}", path);
+                res.status(404).send("Unknown statusz subpath");
+            }
+        } catch (final RuntimeException e) {
+            LOGGER.log(WARNING, "Failed to respond to statusz check due to %s".formatted(e), e);
+            res.status(500).send();
         }
     }
 }

--- a/block-node/health/src/main/java/org/hiero/block/node/health/InboundStatusHandler.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/InboundStatusHandler.java
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.health;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.helidon.http.HeaderNames;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import java.lang.System.Logger;
+import java.util.ArrayList;
+import java.util.List;
+import org.hiero.block.api.NetworkConnection;
+import org.hiero.block.api.NetworkData;
+import org.hiero.block.node.spi.ApplicationStateFacility;
+
+/// Builds and sends the `/statusz/inbound` response: the merge of the known
+/// publishers, the inbound designated partners, and the backfill sources,
+/// serialized as [NetworkData] JSON.
+///
+/// This is an independent, `final` class with no shared base or interface
+/// (to avoid virtual-call overhead). Its single [#createAndSendResponse()]
+/// entry point is invoked synchronously on the (virtual) request thread
+/// by [HealthServicePlugin].
+final class InboundStatusHandler {
+    private final Logger LOGGER = System.getLogger(getClass().getName());
+    private final ServerRequest request;
+    private final ServerResponse response;
+    private final ApplicationStateFacility appState;
+
+    InboundStatusHandler(
+            @NonNull final ServerRequest request,
+            @NonNull final ServerResponse response,
+            @NonNull final ApplicationStateFacility appState) {
+        this.request = request;
+        this.response = response;
+        this.appState = appState;
+    }
+
+    /// Builds the inbound [NetworkData] and sends it as
+    /// an `application/json` response.
+    void createAndSendResponse() {
+        final List<NetworkConnection> endpoints = new ArrayList<>();
+        endpoints.addAll(appState.knownPublishers().activeEndpoints());
+        endpoints.addAll(appState.inboundPartners().activeEndpoints());
+        endpoints.addAll(appState.backfillSources().activeEndpoints());
+        final NetworkData data =
+                NetworkData.newBuilder().activeEndpoints(endpoints).build();
+        response.status(200)
+                .header(HeaderNames.CONTENT_TYPE, "application/json")
+                .send(NetworkData.JSON.toJSON(data));
+    }
+}

--- a/block-node/health/src/main/java/org/hiero/block/node/health/OutboundStatusHandler.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/OutboundStatusHandler.java
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.health;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.helidon.http.HeaderNames;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import java.lang.System.Logger;
+import java.util.ArrayList;
+import java.util.List;
+import org.hiero.block.api.NetworkConnection;
+import org.hiero.block.api.NetworkData;
+import org.hiero.block.node.spi.ApplicationStateFacility;
+
+/// Builds and sends the `/statusz/outbound` response: the merge of the
+/// outbound designated partners and the backfill sources, serialized
+/// as [NetworkData] JSON.
+///
+/// This is an independent, `final` class with no shared base or interface (to
+/// avoid virtual-call overhead). Its single [#createAndSendResponse()] entry
+/// point is invoked synchronously on the (virtual) request
+/// thread by [HealthServicePlugin].
+final class OutboundStatusHandler {
+    private final Logger LOGGER = System.getLogger(getClass().getName());
+    private final ServerRequest request;
+    private final ServerResponse response;
+    private final ApplicationStateFacility appState;
+
+    OutboundStatusHandler(
+            @NonNull final ServerRequest request,
+            @NonNull final ServerResponse response,
+            @NonNull final ApplicationStateFacility appState) {
+        this.request = request;
+        this.response = response;
+        this.appState = appState;
+    }
+
+    /// Builds the outbound {@link NetworkData} and sends it as
+    /// an `application/json` response.
+    void createAndSendResponse() {
+        final List<NetworkConnection> endpoints = new ArrayList<>();
+        endpoints.addAll(appState.outboundPartners().activeEndpoints());
+        endpoints.addAll(appState.backfillSources().activeEndpoints());
+        final NetworkData data =
+                NetworkData.newBuilder().activeEndpoints(endpoints).build();
+        response.status(200)
+                .header(HeaderNames.CONTENT_TYPE, "application/json")
+                .send(NetworkData.JSON.toJSON(data));
+    }
+}

--- a/block-node/health/src/test/java/org/hiero/block/node/health/HealthServiceTest.java
+++ b/block-node/health/src/test/java/org/hiero/block/node/health/HealthServiceTest.java
@@ -2,19 +2,31 @@
 package org.hiero.block.node.health;
 
 import static org.hiero.block.node.health.HealthServicePlugin.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
+import java.nio.charset.StandardCharsets;
+import org.hiero.block.api.NetworkData;
+import org.hiero.block.node.app.fixtures.plugintest.TestApplicationStateFacility;
+import org.hiero.block.node.app.fixtures.plugintest.TestServerRequest;
+import org.hiero.block.node.app.fixtures.plugintest.TestServerResponse;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.health.HealthFacility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -151,5 +163,82 @@ class HealthServiceTest {
         httpService.routing(httpRules);
         Mockito.verify(httpRules, Mockito.times(1)).get(ArgumentMatchers.eq(READYZ_PATH), ArgumentMatchers.any());
         Mockito.verify(httpRules, Mockito.times(1)).get(ArgumentMatchers.eq(LIVEZ_PATH), ArgumentMatchers.any());
+    }
+
+    @Test
+    public void testStatuszRouting() {
+        ArgumentCaptor<HttpService> httpServiceArgumentCaptor = ArgumentCaptor.forClass(HttpService.class);
+        HttpRules httpRules = Mockito.mock(HttpRules.class);
+        Mockito.when(httpRules.get(ArgumentMatchers.anyString(), ArgumentMatchers.any()))
+                .thenReturn(httpRules);
+        BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
+        setupContextConfig(context);
+
+        HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
+        healthServicePlugin.init(context, serviceBuilder);
+
+        // the /statusz service is registered as a second HTTP service with * route
+        Mockito.verify(serviceBuilder, Mockito.times(1))
+                .registerHttpService(
+                        ArgumentMatchers.eq(STATUSZ_PATH),
+                        ArgumentMatchers.isNull(),
+                        httpServiceArgumentCaptor.capture());
+        HttpService httpService = httpServiceArgumentCaptor.getValue();
+        assertNotNull(httpService);
+        httpService.routing(httpRules);
+        Mockito.verify(httpRules, Mockito.times(1)).get(ArgumentMatchers.eq("*"), ArgumentMatchers.any());
+    }
+
+    @Test
+    public void testHandleStatuszInbound() throws ParseException {
+        BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
+        Mockito.when(context.applicationStateFacility()).thenReturn(new TestApplicationStateFacility());
+        setupContextConfig(context);
+
+        HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
+        healthServicePlugin.init(context, serviceBuilder);
+
+        TestServerResponse response = new TestServerResponse();
+        healthServicePlugin.handleStatusz(new TestServerRequest("/statusz/inbound"), response);
+
+        assertEquals(200, response.sentStatus());
+        assertEquals("application/json", response.contentType());
+        NetworkData sent =
+                NetworkData.JSON.parse(Bytes.wrap(((String) response.sentEntity()).getBytes(StandardCharsets.UTF_8)));
+        assertFalse(sent.activeEndpoints().isEmpty());
+    }
+
+    @Test
+    public void testHandleStatuszOutbound() throws ParseException {
+        BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
+        Mockito.when(context.applicationStateFacility()).thenReturn(new TestApplicationStateFacility());
+        setupContextConfig(context);
+
+        HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
+        healthServicePlugin.init(context, serviceBuilder);
+
+        TestServerResponse response = new TestServerResponse();
+        healthServicePlugin.handleStatusz(new TestServerRequest("/statusz/outbound"), response);
+
+        assertEquals(200, response.sentStatus());
+        assertEquals("application/json", response.contentType());
+        NetworkData sent =
+                NetworkData.JSON.parse(Bytes.wrap(((String) response.sentEntity()).getBytes(StandardCharsets.UTF_8)));
+        assertFalse(sent.activeEndpoints().isEmpty());
+    }
+
+    @Test
+    public void testHandleStatuszUnknownSubpath() {
+        BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
+        Mockito.when(context.applicationStateFacility()).thenReturn(new TestApplicationStateFacility());
+        setupContextConfig(context);
+
+        HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
+        healthServicePlugin.init(context, serviceBuilder);
+
+        TestServerResponse response = new TestServerResponse();
+        healthServicePlugin.handleStatusz(new TestServerRequest("/statusz/bogus"), response);
+
+        assertEquals(404, response.sentStatus());
     }
 }

--- a/block-node/health/src/test/java/org/hiero/block/node/health/InboundStatusHandlerTest.java
+++ b/block-node/health/src/test/java/org/hiero/block/node/health/InboundStatusHandlerTest.java
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.health;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.nio.charset.StandardCharsets;
+import org.hiero.block.api.NetworkConnection;
+import org.hiero.block.api.NetworkConnection.ConnectionReference;
+import org.hiero.block.api.NetworkConnection.IpProtocol;
+import org.hiero.block.api.NetworkData;
+import org.hiero.block.node.app.fixtures.plugintest.TestApplicationStateFacility;
+import org.hiero.block.node.app.fixtures.plugintest.TestServerRequest;
+import org.hiero.block.node.app.fixtures.plugintest.TestServerResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class InboundStatusHandlerTest {
+
+    private static NetworkData singleEndpoint(final String category, final String remoteAddress) {
+        return NetworkData.newBuilder()
+                .activeEndpoints(NetworkConnection.newBuilder()
+                        .local(new ConnectionReference("$", "*"))
+                        .remote(new ConnectionReference(remoteAddress, "40840"))
+                        .category(category)
+                        .scheme("grpcs")
+                        .protocol(IpProtocol.TCP)
+                        .tlsRequired(true)
+                        .certificate(Bytes.EMPTY)
+                        .build())
+                .build();
+    }
+
+    private static NetworkData parse(final TestServerResponse response) throws Exception {
+        return NetworkData.JSON.parse(Bytes.wrap(((String) response.sentEntity()).getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static boolean containsRemote(final NetworkData data, final String address) {
+        return data.activeEndpoints().stream()
+                .anyMatch(c -> c.remote().address().equals(address));
+    }
+
+    @Test
+    @DisplayName("Inbound merges publishers, inbound partners and backfill sources (but not outbound partners)")
+    void mergesInboundSets() throws Exception {
+        final TestApplicationStateFacility appState = new TestApplicationStateFacility();
+        appState.setKnownPublishers(singleEndpoint("publisher", "pub.example.com"));
+        appState.setInboundPartners(singleEndpoint("partner", "inpartner.example.com"));
+        appState.setBackfillSources(singleEndpoint("partner", "backfill.example.com"));
+        appState.setOutboundPartners(singleEndpoint("partner", "outpartner.example.com"));
+
+        final TestServerResponse response = new TestServerResponse();
+        new InboundStatusHandler(new TestServerRequest("/statusz/inbound"), response, appState).createAndSendResponse();
+
+        assertEquals(200, response.sentStatus());
+        assertEquals("application/json", response.contentType());
+
+        final NetworkData sent = parse(response);
+        assertEquals(3, sent.activeEndpoints().size());
+        assertTrue(containsRemote(sent, "pub.example.com"));
+        assertTrue(containsRemote(sent, "inpartner.example.com"));
+        assertTrue(containsRemote(sent, "backfill.example.com"));
+        assertFalse(containsRemote(sent, "outpartner.example.com"));
+    }
+
+    @Test
+    @DisplayName("Inbound with all-empty sets returns an empty NetworkData")
+    void emptyWhenNoConnections() throws Exception {
+        final TestApplicationStateFacility appState = new TestApplicationStateFacility();
+        appState.setKnownPublishers(NetworkData.DEFAULT);
+        appState.setInboundPartners(NetworkData.DEFAULT);
+        appState.setBackfillSources(NetworkData.DEFAULT);
+
+        final TestServerResponse response = new TestServerResponse();
+        new InboundStatusHandler(new TestServerRequest("/statusz/inbound"), response, appState).createAndSendResponse();
+
+        assertEquals(200, response.sentStatus());
+        assertTrue(parse(response).activeEndpoints().isEmpty());
+    }
+}

--- a/block-node/health/src/test/java/org/hiero/block/node/health/OutboundStatusHandlerTest.java
+++ b/block-node/health/src/test/java/org/hiero/block/node/health/OutboundStatusHandlerTest.java
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.health;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.nio.charset.StandardCharsets;
+import org.hiero.block.api.NetworkConnection;
+import org.hiero.block.api.NetworkConnection.ConnectionReference;
+import org.hiero.block.api.NetworkConnection.IpProtocol;
+import org.hiero.block.api.NetworkData;
+import org.hiero.block.node.app.fixtures.plugintest.TestApplicationStateFacility;
+import org.hiero.block.node.app.fixtures.plugintest.TestServerRequest;
+import org.hiero.block.node.app.fixtures.plugintest.TestServerResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OutboundStatusHandlerTest {
+
+    private static NetworkData singleEndpoint(final String category, final String remoteAddress) {
+        return NetworkData.newBuilder()
+                .activeEndpoints(NetworkConnection.newBuilder()
+                        .local(new ConnectionReference("$", "*"))
+                        .remote(new ConnectionReference(remoteAddress, "40840"))
+                        .category(category)
+                        .scheme("https")
+                        .protocol(IpProtocol.TCP)
+                        .tlsRequired(true)
+                        .certificate(Bytes.EMPTY)
+                        .build())
+                .build();
+    }
+
+    private static NetworkData parse(final TestServerResponse response) throws Exception {
+        return NetworkData.JSON.parse(Bytes.wrap(((String) response.sentEntity()).getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static boolean containsRemote(final NetworkData data, final String address) {
+        return data.activeEndpoints().stream()
+                .anyMatch(c -> c.remote().address().equals(address));
+    }
+
+    @Test
+    @DisplayName("Outbound merges outbound partners and backfill sources (but not publishers or inbound partners)")
+    void mergesOutboundSets() throws Exception {
+        final TestApplicationStateFacility appState = new TestApplicationStateFacility();
+        appState.setOutboundPartners(singleEndpoint("partner", "outpartner.example.com"));
+        appState.setBackfillSources(singleEndpoint("partner", "backfill.example.com"));
+        appState.setKnownPublishers(singleEndpoint("publisher", "pub.example.com"));
+        appState.setInboundPartners(singleEndpoint("partner", "inpartner.example.com"));
+
+        final TestServerResponse response = new TestServerResponse();
+        new OutboundStatusHandler(new TestServerRequest("/statusz/outbound"), response, appState)
+                .createAndSendResponse();
+
+        assertEquals(200, response.sentStatus());
+        assertEquals("application/json", response.contentType());
+
+        final NetworkData sent = parse(response);
+        assertEquals(2, sent.activeEndpoints().size());
+        assertTrue(containsRemote(sent, "outpartner.example.com"));
+        assertTrue(containsRemote(sent, "backfill.example.com"));
+        assertFalse(containsRemote(sent, "pub.example.com"));
+        assertFalse(containsRemote(sent, "inpartner.example.com"));
+    }
+
+    @Test
+    @DisplayName("Outbound with all-empty sets returns an empty NetworkData")
+    void emptyWhenNoConnections() throws Exception {
+        final TestApplicationStateFacility appState = new TestApplicationStateFacility();
+        appState.setOutboundPartners(NetworkData.DEFAULT);
+        appState.setBackfillSources(NetworkData.DEFAULT);
+
+        final TestServerResponse response = new TestServerResponse();
+        new OutboundStatusHandler(new TestServerRequest("/statusz/outbound"), response, appState)
+                .createAndSendResponse();
+
+        assertEquals(200, response.sentStatus());
+        assertTrue(parse(response).activeEndpoints().isEmpty());
+    }
+}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/ApplicationStateFacility.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/ApplicationStateFacility.java
@@ -2,6 +2,7 @@
 package org.hiero.block.node.spi;
 
 import com.hedera.hapi.node.base.NodeAddressBook;
+import org.hiero.block.api.NetworkData;
 import org.hiero.block.api.TssData;
 import org.hiero.block.node.spi.historicalblocks.LongRange;
 
@@ -36,4 +37,46 @@ public interface ApplicationStateFacility {
      * @param blockRange the contiguous range of block numbers being reported
      */
     void addStoredBlockRange(LongRange blockRange);
+
+    /**
+     * The set of known inbound publishers, loaded from configuration on startup. Reported by the
+     * {@code /statusz/inbound} endpoint.
+     *
+     * @return the known publishers; never {@code null} (empty when none are configured)
+     */
+    NetworkData knownPublishers();
+
+    /**
+     * The set of designated inbound partners, loaded from configuration on startup. Reported by the
+     * {@code /statusz/inbound} endpoint.
+     *
+     * @return the inbound partners; never {@code null} (empty when none are configured)
+     */
+    NetworkData inboundPartners();
+
+    /**
+     * The set of designated outbound partners, loaded from configuration on startup. Reported by the
+     * {@code /statusz/outbound} endpoint.
+     *
+     * @return the outbound partners; never {@code null} (empty when none are configured)
+     */
+    NetworkData outboundPartners();
+
+    /**
+     * The set of backfill source connections most recently reported by the backfill plugin. Backfill
+     * sources are reported by <b>both</b> the {@code /statusz/inbound} and {@code /statusz/outbound}
+     * endpoints, because every backfill source may also backfill from this node.
+     *
+     * @return the backfill sources; never {@code null} (empty when none are configured)
+     */
+    NetworkData backfillSources();
+
+    /**
+     * Registers (or replaces) the set of backfill source connections. Called by the backfill plugin
+     * when it loads its sources, so that all connection information is owned by the Application State
+     * facility rather than read directly from backfill configuration.
+     *
+     * @param sources the backfill source connections to publish
+     */
+    void updateBackfillSources(NetworkData sources);
 }

--- a/block-node/spi-plugins/src/test/java/org/hiero/block/node/spi/BlockNodePluginTest.java
+++ b/block-node/spi-plugins/src/test/java/org/hiero/block/node/spi/BlockNodePluginTest.java
@@ -16,6 +16,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import io.helidon.webserver.http.HttpService;
 import java.util.ArrayList;
 import java.util.List;
+import org.hiero.block.api.NetworkData;
 import org.hiero.block.api.TssData;
 import org.hiero.block.node.spi.historicalblocks.LongRange;
 import org.junit.jupiter.api.DisplayName;
@@ -70,6 +71,31 @@ public class BlockNodePluginTest {
         public void addStoredBlockRange(LongRange blockRange) {
             // do nothing
         }
+
+        @Override
+        public NetworkData knownPublishers() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public NetworkData inboundPartners() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public NetworkData outboundPartners() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public NetworkData backfillSources() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public void updateBackfillSources(NetworkData sources) {
+            // do nothing
+        }
     }
 
     @Test
@@ -102,6 +128,31 @@ public class BlockNodePluginTest {
         public void addStoredBlockRange(LongRange blockRange) {
             // do nothing
         }
+
+        @Override
+        public NetworkData knownPublishers() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public NetworkData inboundPartners() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public NetworkData outboundPartners() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public NetworkData backfillSources() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public void updateBackfillSources(NetworkData sources) {
+            // do nothing
+        }
     }
 
     private static class TestApplicationStateFacilityWithRange implements ApplicationStateFacility {
@@ -120,6 +171,31 @@ public class BlockNodePluginTest {
         @Override
         public void addStoredBlockRange(LongRange blockRange) {
             this.lastStoredRange = blockRange;
+        }
+
+        @Override
+        public NetworkData knownPublishers() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public NetworkData inboundPartners() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public NetworkData outboundPartners() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public NetworkData backfillSources() {
+            return NetworkData.DEFAULT;
+        }
+
+        @Override
+        public void updateBackfillSources(NetworkData sources) {
+            // do nothing
         }
     }
 

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -45,6 +45,9 @@ Each plugin has its own properties, but this focuses on core options and core pl
 | APP_STATE_TSS_BOOTSTRAP_FILE_PATH | Path where TSS data (ledger ID, current roster, WRAPS VK) is persisted across restarts.         | /opt/hiero/block-node/application-state/tss-bootstrap-roster.json |
 | APP_STATE_RSA_BOOTSTRAP_FILE_PATH | Path where RSA data (node address book) is persisted across restarts.                           | /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json |
 | APP_STATE_BLOCK_RANGES_FILE_PATH  | Path where the stored block range set is persisted. Written every 1,000 blocks received.        | /opt/hiero/block-node/application-state/block-ranges.json         |
+| KNOWN_PUBLISHERS_FILE_PATH        | Path where connections for known publisher are persisted. Read only on start.                   | /opt/hiero/block-node/application-state/known-publishers.json     |
+| INBOUND_PARTNERS_FILE_PATH        | Path where connections for designated inbound partners are persisted. Read only on start.       | /opt/hiero/block-node/application-state/inbound-partners.json     |
+| OUTBOUND_PARTNERS_FILE_PATH       | Path where connections for designated outbound partners are persisted. Read only on start.      | /opt/hiero/block-node/application-state/outbound-partners.json    |
 | APP_STATE_UPDATE_SCAN_INTERVAL    | How often (ms) the application state facility checks for pending TSS data updates. Minimum 100. | 500                                                               |
 | APP_STATE_UPDATE_INITIAL_DELAY    | Delay (ms) before the application state facility begins its first scan.                         | 0                                                                 |
 

--- a/protobuf-sources/src/main/proto/block-node/api/network-data.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/network-data.proto
@@ -44,7 +44,11 @@ message NetworkConnection {
     ///
     /// Categories are defined by the producing system, but MUST match agreed
     /// quality of service tags for the management system that consumes
-    /// this API.
+    /// this API.<br/>
+    /// This value SHALL NOT be modified or transformed by the block node; it
+    /// should be passed through from configuration to output unchanged.
+    /// If not read from configuration, this value SHALL be set to a
+    /// configurable default based on the source of connection information.
     string category = 3;
 
     /// The connection scheme as defined in

--- a/protobuf-sources/src/main/proto/internal/block_node_source.proto
+++ b/protobuf-sources/src/main/proto/internal/block_node_source.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 
 package org.hiero.block.internal;
 
+import "block-node/api/network-data.proto";
+
 option java_package = "org.hiero.block.internal.protoc";
 // <<<pbj.java_package = "org.hiero.block.internal">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
@@ -39,6 +41,18 @@ message BlockNodeSourceConfig {
    * All tuning parameters are in this sub-message for cleaner organization
    */
   GrpcWebClientTuning grpc_webclient_tuning = 6;
+
+  /**
+   * RFC 3986 connection scheme for this source (e.g. "grpc" or "grpcs").
+   * When empty, the scheme is derived from the source TLS setting, using
+   * `grpc` if TLS is not enabled and `grpcs` if TLS is enabled.
+   */
+  string scheme = 7;
+
+  /**
+   * IP protocol for this source connection.
+   */
+  org.hiero.block.api.NetworkConnection.IpProtocol protocol = 8;
 }
 
 /**


### PR DESCRIPTION
## Reviewer Notes
* Added configuration for baseline network data for publisher, inbound partners, and outbound partners
   * The publisher data will be replaced with roster data in future work.
* Adjusted the Backfill plugin to fill in Backfill connections when loading backfill configuration.
   * This may also be modified in future work to use HIP-1137 RegisteredNode data.
* Modified the backfill plugin configuration data schema to include missing values needed to fill in NetworkData connections.
* Adjusted Application State Facility to manage network data
* Added endpoints to the Health plugin for inbound and outbound network data
* Added initial tests for all new functionality.

## Related Issue(s)
 Resolves #2992 
