### PR TITLE
fix: fix k6 Tests

### DIFF
--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew --no-daemon
-  SOLO_VERSION: "0.72.0"
+  SOLO_VERSION: "0.73.0"
 
 jobs:
   k6-tests:

--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew --no-daemon
-  SOLO_VERSION: "0.73.0"
+  SOLO_VERSION: "0.72.0"
 
 jobs:
   k6-tests:
@@ -57,6 +57,10 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          # Pin to Helm 3.x: Solo cannot parse Helm 4.x install output
+          # ("Failed to deserialize the output into the specified class: Release").
+          version: v3.14.4
 
       - name: Setup Kind
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -36,7 +36,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         type: string
-        default: "0.72.0"
+        default: "0.73.0"
       tss-enabled:
         description: "Enable TSS/WRAPS on consensus nodes"
         type: boolean
@@ -128,7 +128,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         required: false
-        default: "0.72.0"
+        default: "0.73.0"
       tss-enabled:
         description: "Enable TSS (Threshold Signature Scheme) on consensus nodes"
         required: false
@@ -227,10 +227,6 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-        with:
-          # Pin to Helm 3.x: Solo cannot parse Helm 4.x install output
-          # ("Failed to deserialize the output into the specified class: Release").
-          version: v3.14.4
 
       - name: Setup Kind
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -36,7 +36,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         type: string
-        default: "0.73.0"
+        default: "0.72.0"
       tss-enabled:
         description: "Enable TSS/WRAPS on consensus nodes"
         type: boolean
@@ -128,7 +128,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         required: false
-        default: "0.73.0"
+        default: "0.72.0"
       tss-enabled:
         description: "Enable TSS (Threshold Signature Scheme) on consensus nodes"
         required: false
@@ -227,6 +227,10 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          # Pin to Helm 3.x: Solo cannot parse Helm 4.x install output
+          # ("Failed to deserialize the output into the specified class: Release").
+          version: v3.14.4
 
       - name: Setup Kind
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0


### PR DESCRIPTION
## Reviewer Notes
upgrade K6RunTests to use solo 0.73.0
change K6 Tests helm version to 3.14.4

## Related Issue(s)
Closes: #3061