### PR TITLE
chore: Allow Out of Order Verification for Sources Other Than Publisher

### DIFF
--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationConfig.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationConfig.java
@@ -20,6 +20,9 @@ import org.hiero.block.node.base.Loggable;
 ///     Written when block 0 is processed. Loaded on startup to restore full TSS state.
 /// @param activeSessionsBufferSize size of maximum allowed active sessions. When full and a new session needs to
 ///     start, room will be made for it by canceling the longest running one. todo(2528) could be lowest block nubmer
+/// @param allSourcesRequireOrdering if true, strict ordering of the next expected block to verify will be enforced
+///     for blocks received from any source. If false, only
+///     [org.hiero.block.node.spi.blockmessaging.BlockSource#PUBLISHER] will be strictly ordered.
 @ConfigData("verification")
 public record VerificationConfig(
     @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/rootHashOfAllPreviousBlocks.bin") Path allBlocksHasherFilePath,
@@ -27,6 +30,7 @@ public record VerificationConfig(
     @Loggable @ConfigProperty(defaultValue = "false") boolean rebuildAllBlocksHasherFromStore,
     @Loggable @ConfigProperty(defaultValue = "100") int allBlocksHasherPersistenceInterval,
     @Loggable @ConfigProperty(defaultValue = "/opt/hiero/block-node/application-state/tss-parameters.bin") Path tssParametersFilePath,
-    @Loggable @ConfigProperty(defaultValue = "100") int activeSessionsBufferSize){}
+    @Loggable @ConfigProperty(defaultValue = "100") int activeSessionsBufferSize,
+    @Loggable @ConfigProperty(defaultValue = "true") boolean allSourcesRequireOrdering){}
 
 // spotless:on

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/BlockSessionHandler.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/BlockSessionHandler.java
@@ -146,6 +146,7 @@ public final class BlockSessionHandler {
                 recentlyVerifiedBlocks,
                 executor,
                 context,
+                verificationConfig,
                 finishedSessions);
     }
 

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/CompletableVerificationSession.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/CompletableVerificationSession.java
@@ -10,6 +10,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import org.hiero.block.node.block.verification.VerificationConfig;
 import org.hiero.block.node.block.verification.VerificationDataProvider;
 import org.hiero.block.node.block.verification.hasher.BlockHasher;
 import org.hiero.block.node.block.verification.metrics.MetricsHolder;
@@ -34,6 +35,7 @@ public final class CompletableVerificationSession implements BlockVerificationSe
     private final VerificationDataProvider verificationDataProvider;
     private final ConcurrentLinkedDeque<BlockItems> blockItemsDeque;
     private final ConcurrentSkipListSet<SessionKey> finishedSessions;
+    private final VerificationConfig verificationConfig;
     private volatile CompletableFuture<BlockVerificationResult> sessionCompletionChain;
 
     /// Constructor.
@@ -47,6 +49,7 @@ public final class CompletableVerificationSession implements BlockVerificationSe
             final ConcurrentSkipListSet<Long> recentlyVerifiedBlocks,
             final ExecutorService executor,
             final BlockNodeContext context,
+            final VerificationConfig verificationConfig,
             final ConcurrentSkipListSet<SessionKey> finishedSessions) {
         if (blockNumber < 0) {
             throw new IllegalArgumentException("Block number must be non-negative");
@@ -62,6 +65,7 @@ public final class CompletableVerificationSession implements BlockVerificationSe
         this.executor = Objects.requireNonNull(executor);
         this.isCancelled = new AtomicBoolean(false);
         this.blockItemsDeque = new ConcurrentLinkedDeque<>();
+        this.verificationConfig = Objects.requireNonNull(verificationConfig);
         this.finishedSessions = Objects.requireNonNull(finishedSessions);
     }
 
@@ -97,7 +101,8 @@ public final class CompletableVerificationSession implements BlockVerificationSe
                 verificationDataProvider);
         final BlockVerifier verifier = new BlockVerifier(
                 isCancelled, metricsHolder.proofVerificationMetrics(), System.nanoTime(), verificationDataProvider);
-        final ResultOrderingManager resultOrderManager = new ResultOrderingManager(isCancelled, lastVerifiedBlock);
+        final ResultOrderingManager resultOrderManager =
+                new ResultOrderingManager(isCancelled, lastVerifiedBlock, verificationConfig);
         final SessionResultHandler sessionResultHandler = new SessionResultHandler(
                 context,
                 metricsHolder.sessionResultMetrics(),

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/ResultOrderingManager.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/ResultOrderingManager.java
@@ -7,18 +7,25 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Function;
+import org.hiero.block.node.block.verification.VerificationConfig;
 import org.hiero.block.node.block.verification.verifier.BlockVerificationResult;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
 
 /// The third stage of a [org.hiero.block.node.block.verification.session.CompletableVerificationSession].
 /// This stage simply awaits the right turn of the successful block verification's result propagation.
 public final class ResultOrderingManager implements Function<BlockVerificationResult, BlockVerificationResult> {
     private final AtomicLong lastVerifiedBlock;
+    private final VerificationConfig verificationConfig;
     private final AtomicBoolean isCanceled;
 
     /// Constructor.
-    public ResultOrderingManager(final AtomicBoolean isCanceled, final AtomicLong lastVerifiedBlock) {
+    public ResultOrderingManager(
+            final AtomicBoolean isCanceled,
+            final AtomicLong lastVerifiedBlock,
+            final VerificationConfig verificationConfig) {
         this.isCanceled = Objects.requireNonNull(isCanceled);
         this.lastVerifiedBlock = Objects.requireNonNull(lastVerifiedBlock);
+        this.verificationConfig = Objects.requireNonNull(verificationConfig);
     }
 
     /// Accept a successful [BlockVerificationResult].
@@ -26,11 +33,13 @@ public final class ResultOrderingManager implements Function<BlockVerificationRe
     /// We follow the last verified block value. If we are below or equal to that, we do not enforce ordering
     /// and simply continue to the next stage. If we are higher than the next expected block to verify successfully,
     /// we have to wait until our turn arrives.
+    /// _NOTE_: strict ordering is always required for [BlockSource#PUBLISHER], but based on the
+    /// [VerificationConfig#allSourcesRequireOrdering()] setting, we can disable ordering for other sources.
     @Override
     public BlockVerificationResult apply(final BlockVerificationResult blockVerificationResult) {
         while (!isCanceled()) {
             final long nextExpectedBlock = lastVerifiedBlock.get() + 1;
-            if (blockVerificationResult.blockNumber() > nextExpectedBlock) {
+            if (shouldPark(blockVerificationResult, nextExpectedBlock)) {
                 // Shortly park to avoid busy-waiting
                 LockSupport.parkNanos(TimeUnit.MICROSECONDS.toNanos(500));
             } else {
@@ -39,6 +48,13 @@ public final class ResultOrderingManager implements Function<BlockVerificationRe
         }
         throw new VerificationSessionFailedException(
                 blockVerificationResult.blockNumber(), SessionFailureType.CANCELLED, blockVerificationResult.source());
+    }
+
+    private boolean shouldPark(final BlockVerificationResult verificationResult, final long nextExpectedBlock) {
+        // spotless:off
+        return (verificationResult.blockNumber() > nextExpectedBlock)
+            && (verificationResult.source() == BlockSource.PUBLISHER || verificationConfig.allSourcesRequireOrdering());
+        // spotless:on
     }
 
     private boolean isCanceled() {


### PR DESCRIPTION
* Added a new config that will allow enabling/disabling strict ordering for blocks with sources other than Publisher
* Order Manager uses that config