### PR TITLE
feat(solo-e2e): per-plugin port support and deployment lock fix

### DIFF
--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -189,12 +189,16 @@ jobs:
           MATRIX_COUNT=$(echo "${MATRIX_JSON}" | jq '. | length')
           echo "matrix_count=${MATRIX_COUNT}" >> "$GITHUB_OUTPUT"
 
+          # MN pinned: v0.157.0+ (HIP-1137) broke Solo CLI's block node env var injection.
+          # Track https://github.com/hiero-ledger/solo/issues/4863 to unpin MN_PINNED.
+          MN_PINNED="v0.156.0"
+
           # Configure versions based on run type and trigger
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
             # TAG release: use the tag for BN, latest GA for CN/MN
             BN_VERSION="${{ github.ref_name }}"
             CN_VERSION="latest"
-            MN_VERSION="latest"
+            MN_VERSION="${MN_PINNED}"
           elif [[ "${RUN_TYPE}" == "rc" ]]; then
             # RC run: use SNAPSHOT BN against RC versions of CN/MN
             BN_VERSION="${{ inputs.block-node-version }}"
@@ -202,7 +206,7 @@ jobs:
             CN_VERSION="${{ inputs.consensus-node-version }}"
             CN_VERSION="${CN_VERSION:-rc}"
             MN_VERSION="${{ inputs.mirror-node-version }}"
-            MN_VERSION="${MN_VERSION:-rc}"
+            MN_VERSION="${MN_VERSION:-${MN_PINNED}}"
           elif [[ -n "${{ inputs.block-node-version }}" ]]; then
             # Manual override with explicit versions
             BN_VERSION="${{ inputs.block-node-version }}"
@@ -214,7 +218,7 @@ jobs:
             # Scheduled runs (daily/weekend): use SNAPSHOT BN against GA stable CN/MN
             BN_VERSION="main"
             CN_VERSION="latest"
-            MN_VERSION="latest"
+            MN_VERSION="${MN_PINNED}"
           fi
 
           # Solo CLI version: use input if provided, otherwise default to latest stable

--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -217,11 +217,11 @@ jobs:
             MN_VERSION="latest"
           fi
 
-          # Solo CLI version: use input if provided, otherwise default to 0.72.0 (as latest stable tested)
+          # Solo CLI version: use input if provided, otherwise default to latest stable
           if [[ -n "${{ inputs.solo-version }}" ]]; then
             SOLO_VERSION="${{ inputs.solo-version }}"
           else
-            SOLO_VERSION="0.72.0"
+            SOLO_VERSION="0.79.0"
           fi
 
           # Relay version: use input if provided, otherwise default to latest

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -36,7 +36,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         type: string
-        default: "0.72.0"
+        default: "0.79.0"
       tss-enabled:
         description: "Enable TSS/WRAPS on consensus nodes"
         type: boolean
@@ -128,7 +128,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         required: false
-        default: "0.72.0"
+        default: "0.79.0"
       tss-enabled:
         description: "Enable TSS (Threshold Signature Scheme) on consensus nodes"
         required: false

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -18,9 +18,11 @@ on:
         type: string
         default: "latest"
       mirror-node-version:
+        # Pinned: MN v0.157.0+ (HIP-1137) broke Solo CLI's block node env var injection.
+        # Track https://github.com/hiero-ledger/solo/issues/4863 to unpin.
         description: "Mirror Node version ('latest', 'rc', or tag like 'v0.146.0')"
         type: string
-        default: "latest"
+        default: "v0.156.0"
       relay-version:
         description: "Relay version ('latest' or tag like 'v0.75.0')"
         type: string
@@ -110,9 +112,11 @@ on:
         required: false
         default: "latest"
       mirror-node-version:
+        # Pinned: MN v0.157.0+ (HIP-1137) broke Solo CLI's block node env var injection.
+        # Track https://github.com/hiero-ledger/solo/issues/4863 to unpin.
         description: "Mirror Node version ('latest', 'rc' or tag like 'v0.150.0')"
         required: false
-        default: "latest"
+        default: "v0.156.0"
       relay-version:
         description: "Relay version ('latest' or tag like 'v0.75.0')"
         required: false

--- a/block-node/app/build.gradle.kts
+++ b/block-node/app/build.gradle.kts
@@ -137,8 +137,9 @@ dependencies {
 
     // Extended functionality
     blockNodePlugins(project(":backfill"))
-    blockNodePlugins(project(":s3-archive"))
-    blockNodePlugins(project(":cloud-storage-expanded"))
+    // when running the BN locally, we don't need or want to have the S3 plugins by default
+    // blockNodePlugins(project(":cloud-storage-expanded"))
+    // blockNodePlugins(project(":cloud-storage-archive"))
 }
 
 /** Sets block node storage environment variables for the given data directory. */

--- a/block-node/app/build.gradle.kts
+++ b/block-node/app/build.gradle.kts
@@ -91,10 +91,10 @@ application {
 // Core runtime dependencies only - NO plugins
 // Plugins are loaded dynamically from the plugins directory at runtime
 mainModuleInfo {
-    runtimeOnly("com.swirlds.config.impl")
-    runtimeOnly("io.helidon.logging.jul")
     runtimeOnly("com.hedera.pbj.grpc.helidon.config")
+    runtimeOnly("com.swirlds.config.impl")
     runtimeOnly("org.hiero.metrics.openmetrics.httpserver")
+    runtimeOnly("io.helidon.logging.jul")
 }
 
 // Authoritative list of block node plugins. When adding a new plugin, add it here
@@ -193,29 +193,28 @@ tasks.register<JavaExec>("runWithCleanStorage") {
 
 testModuleInfo {
     requires("org.hiero.block.node.app.test.fixtures")
-
+    requires("org.assertj.core")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
     requires("org.mockito")
-    requires("org.assertj.core")
 
-    // Plugins needed for integration tests (e.g., testMain which starts the full app)
-    runtimeOnly("org.hiero.block.node.messaging")
+    runtimeOnly("org.hiero.block.node.access.service")
+    runtimeOnly("org.hiero.block.node.archive.s3cloud")
+    runtimeOnly("org.hiero.block.node.backfill")
+    runtimeOnly("org.hiero.block.node.blocks.files.historic")
+    runtimeOnly("org.hiero.block.node.blocks.files.recent")
+    runtimeOnly("org.hiero.block.node.cloud.storage.archive")
+    runtimeOnly("org.hiero.block.node.cloud.storage.expanded")
     runtimeOnly("org.hiero.block.node.health")
+    runtimeOnly("org.hiero.block.node.messaging")
+    runtimeOnly("org.hiero.block.node.roster.bootstrap.rsa")
+    runtimeOnly("org.hiero.block.node.roster.bootstrap.tss")
     runtimeOnly("org.hiero.block.node.server.status")
     runtimeOnly("org.hiero.block.node.stream.publisher")
     runtimeOnly("org.hiero.block.node.stream.subscriber")
-    runtimeOnly("org.hiero.block.node.roster.bootstrap.tss")
-    runtimeOnly("org.hiero.block.node.roster.bootstrap.rsa")
     runtimeOnly("org.hiero.block.node.verification")
-    runtimeOnly("org.hiero.block.node.blocks.files.recent")
-    runtimeOnly("org.hiero.block.node.blocks.files.historic")
-    runtimeOnly("org.hiero.block.node.access.service")
-    runtimeOnly("org.hiero.block.node.backfill")
-    runtimeOnly("org.hiero.block.node.archive.s3cloud")
-    runtimeOnly("org.hiero.block.node.cloud.storage.archive")
-    runtimeOnly("org.hiero.block.node.cloud.storage.expanded")
 
+    // Plugins needed for integration tests (e.g., testMain which starts the full app)
     exportsTo("com.swirlds.config.impl")
 }
 

--- a/charts/block-node-server/templates/_helpers.tpl
+++ b/charts/block-node-server/templates/_helpers.tpl
@@ -119,90 +119,58 @@ Usage: include "hiero-block-node.pluginPortEnvVars" .
 
 {{/*
 Emit Service port entries for each non-null plugin port in blockNode.ports.
+Multiple plugins that share the same port number emit only one Service port entry
+(Kubernetes rejects duplicate port numbers within a Service).
 Usage: include "hiero-block-node.pluginServicePorts" . | nindent 4
 */}}
 {{- define "hiero-block-node.pluginServicePorts" -}}
+{{- $seen := dict -}}
 {{- with .Values.blockNode.ports -}}
-{{- if .publisher }}
-- name: publisher
-  port: {{ .publisher }}
-  targetPort: publisher
+{{- $entries := list (list "publisher" .publisher) (list "subscriber" .subscriber) (list "block-access" .blockAccess) (list "health" .health) (list "server-status" .serverStatus) -}}
+{{- range $entries -}}
+{{- $name := index . 0 -}}
+{{- $port := index . 1 -}}
+{{- if $port -}}
+{{- $key := toString $port -}}
+{{- if not (hasKey $seen $key) -}}
+{{- $_ := set $seen $key true }}
+- name: {{ $name }}
+  port: {{ $port }}
+  targetPort: {{ $port }}
   protocol: TCP
 {{- end -}}
-{{- if .subscriber }}
-- name: subscriber
-  port: {{ .subscriber }}
-  targetPort: subscriber
-  protocol: TCP
 {{- end -}}
-{{- if .blockAccess }}
-- name: block-access
-  port: {{ .blockAccess }}
-  targetPort: block-access
-  protocol: TCP
-{{- end -}}
-{{- if .health }}
-- name: health
-  port: {{ .health }}
-  targetPort: health
-  protocol: TCP
-{{- end -}}
-{{- if .serverStatus }}
-- name: server-status
-  port: {{ .serverStatus }}
-  targetPort: server-status
-  protocol: TCP
 {{- end -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
 Emit container port entries for each non-null plugin port in blockNode.ports.
+Multiple plugins that share the same port number emit only one container port entry
+(Kubernetes rejects duplicate containerPort numbers within a container).
 Accepts a dict context: (dict "Values" .Values "hostPorts" $hostPorts)
 Usage: include "hiero-block-node.pluginContainerPorts" (dict "Values" .Values "hostPorts" $hostPorts) | nindent 10
 */}}
 {{- define "hiero-block-node.pluginContainerPorts" -}}
+{{- $seen := dict -}}
 {{- $hp := .hostPorts -}}
 {{- with .Values.blockNode.ports -}}
-{{- if .publisher }}
-- name: publisher
-  containerPort: {{ .publisher }}
-  {{- if hasKey $hp "publisher" }}
-  hostPort: {{ index $hp "publisher" }}
+{{- $entries := list (list "publisher" .publisher) (list "subscriber" .subscriber) (list "block-access" .blockAccess) (list "health" .health) (list "server-status" .serverStatus) -}}
+{{- range $entries -}}
+{{- $name := index . 0 -}}
+{{- $port := index . 1 -}}
+{{- if $port -}}
+{{- $key := toString $port -}}
+{{- if not (hasKey $seen $key) -}}
+{{- $_ := set $seen $key true }}
+- name: {{ $name }}
+  containerPort: {{ $port }}
+  {{- if hasKey $hp $name }}
+  hostPort: {{ index $hp $name }}
   {{- end }}
   protocol: TCP
 {{- end -}}
-{{- if .subscriber }}
-- name: subscriber
-  containerPort: {{ .subscriber }}
-  {{- if hasKey $hp "subscriber" }}
-  hostPort: {{ index $hp "subscriber" }}
-  {{- end }}
-  protocol: TCP
 {{- end -}}
-{{- if .blockAccess }}
-- name: block-access
-  containerPort: {{ .blockAccess }}
-  {{- if hasKey $hp "block-access" }}
-  hostPort: {{ index $hp "block-access" }}
-  {{- end }}
-  protocol: TCP
-{{- end -}}
-{{- if .health }}
-- name: health
-  containerPort: {{ .health }}
-  {{- if hasKey $hp "health" }}
-  hostPort: {{ index $hp "health" }}
-  {{- end }}
-  protocol: TCP
-{{- end -}}
-{{- if .serverStatus }}
-- name: server-status
-  containerPort: {{ .serverStatus }}
-  {{- if hasKey $hp "server-status" }}
-  hostPort: {{ index $hp "server-status" }}
-  {{- end }}
-  protocol: TCP
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/tools-and-tests/scripts/network-topology-tool/generate-chart-values-config-overlays.sh
+++ b/tools-and-tests/scripts/network-topology-tool/generate-chart-values-config-overlays.sh
@@ -311,18 +311,17 @@ function generate_mn_overlay {
     bn_dns=$(get_service_dns "${bn}" "${NAMESPACE}")
 
     nodes_config="${nodes_config}
-              - host: ${bn_dns}
-                port: ${bn_port}"
+              - endpoints:
+                  - host: ${bn_dns}
+                    port: ${bn_port}"
   done <<< "${block_node_names}"
 
   # Image overrides (workaround, ALL topologies): the default GraalVM-native Mirror Node
-  # images crash on startup in MN 0.155.x/0.156.x. importer fails on missing reflection hints
-  # for RecordFileConsensusTimestampsRecalculateMigration records; grpc fails binding
-  # CommonProperties (Hibernate DurationMaxValidator no-arg ctor); rest-java fails the same
-  # class of native-image gap on amd64 (CI). Override these native modules to the JVM images
-  # (gcr.io/mirrornode/*); their native-sized memory limits are too small for the JVM, so bump
-  # them. web3 native and pinger (already JVM) are fine and left as-is.
-  # TODO: remove these overrides once MN ships fixed native images.
+  # images crash on startup due to missing reflection hints for several classes. Override
+  # the affected modules to the JVM images (gcr.io/mirrornode/*); their native-sized memory
+  # limits are too small for the JVM, so bump them. web3 native and pinger (already JVM)
+  # are fine and left as-is.
+  # TODO: remove these overrides once MN ships fully fixed native images.
   local importer_jvm_override="  image:
     registry: gcr.io
     repository: mirrornode/hedera-mirror-importer

--- a/tools-and-tests/scripts/network-topology-tool/generate-chart-values-config-overlays.sh
+++ b/tools-and-tests/scripts/network-topology-tool/generate-chart-values-config-overlays.sh
@@ -160,102 +160,121 @@ function get_service_dns {
   echo "${service_name}.${namespace}.svc.cluster.local"
 }
 
-# Generate Block Node overlay for a block node with peers
-# Only generates overlay if the block node has peers configured
+# Generate Block Node overlay for a block node with peers and/or plugin_ports.
+# Only generates the overlay file when there is something to emit.
 function generate_bn_overlay {
   local bn_name="${1}"
   local output_file="${2}"
 
-  # Check if this block node has peers (yq returns "null" string if not present)
+  # Determine if this block node has peers
   local has_peers
   has_peers=$(yq ".block_nodes[\"${bn_name}\"].peers // \"\"" "${TOPOLOGY_FILE}" 2>/dev/null)
-
-  if [[ -z "${has_peers}" ]] || [[ "${has_peers}" == "null" ]]; then
-    return 0  # No peers, no overlay needed
+  local peer_count=0
+  if [[ -n "${has_peers}" ]] && [[ "${has_peers}" != "null" ]]; then
+    peer_count=$(yq ".block_nodes[\"${bn_name}\"].peers | length" "${TOPOLOGY_FILE}" 2>/dev/null)
   fi
 
-  # Get peer count
-  local peer_count
-  peer_count=$(yq ".block_nodes[\"${bn_name}\"].peers | length" "${TOPOLOGY_FILE}" 2>/dev/null)
-
-  if [[ "${peer_count}" -eq 0 ]]; then
-    return 0  # No peers found
+  # Determine if this block node has plugin_ports
+  local raw_plugin_ports
+  raw_plugin_ports=$(yq ".block_nodes[\"${bn_name}\"].plugin_ports // \"\"" "${TOPOLOGY_FILE}" 2>/dev/null)
+  local has_plugin_ports="false"
+  if [[ -n "${raw_plugin_ports}" ]] && [[ "${raw_plugin_ports}" != "null" ]]; then
+    has_plugin_ports="true"
   fi
 
-  # Get peer names - simple extraction (handles string array)
-  local peer_names
-  peer_names=$(yq -r ".block_nodes[\"${bn_name}\"].peers[]" "${TOPOLOGY_FILE}" 2>/dev/null)
-
-  if [[ -z "${peer_names}" ]]; then
-    return 0  # No peers found
+  # Nothing to generate
+  if [[ "${peer_count}" -eq 0 ]] && [[ "${has_plugin_ports}" == "false" ]]; then
+    return 0
   fi
 
-  # Build sources array
+  # Build backfill sources array (only when peers are configured)
   local sources=""
-  local priority=1
-  while IFS= read -r peer; do
-    [[ -z "${peer}" ]] && continue
+  local greedy_mode="false"
 
-    local peer_port
-    peer_port=$(yq ".block_nodes[\"${peer}\"].port // 40840" "${TOPOLOGY_FILE}")
-    local peer_dns
-    peer_dns=$(get_service_dns "${peer}" "${NAMESPACE}")
+  if [[ "${peer_count}" -gt 0 ]]; then
+    local peer_names
+    peer_names=$(yq -r ".block_nodes[\"${bn_name}\"].peers[]" "${TOPOLOGY_FILE}" 2>/dev/null)
 
-    # Read gRPC tuning from the peer node (if configured)
-    local grpc_tuning=""
-    local max_frame_size
-    max_frame_size=$(yq ".block_nodes[\"${peer}\"].grpc_tuning.max_frame_size // 0" "${TOPOLOGY_FILE}" 2>/dev/null)
-    local initial_window_size
-    initial_window_size=$(yq ".block_nodes[\"${peer}\"].grpc_tuning.initial_window_size // 0" "${TOPOLOGY_FILE}" 2>/dev/null)
-    local initial_buffer_size
-    initial_buffer_size=$(yq ".block_nodes[\"${peer}\"].grpc_tuning.initial_buffer_size // 0" "${TOPOLOGY_FILE}" 2>/dev/null)
-    local connect_timeout
-    connect_timeout=$(yq ".block_nodes[\"${peer}\"].grpc_tuning.connect_timeout // 0" "${TOPOLOGY_FILE}" 2>/dev/null)
-    local read_timeout
-    read_timeout=$(yq ".block_nodes[\"${peer}\"].grpc_tuning.read_timeout // 0" "${TOPOLOGY_FILE}" 2>/dev/null)
+    if [[ -z "${peer_names}" ]]; then
+      peer_count=0  # Treat as no peers if names could not be read
+    else
+      local priority=1
+      while IFS= read -r peer; do
+        [[ -z "${peer}" ]] && continue
 
-    # Build grpc_webclient_tuning block if any tuning is configured
-    if [[ "${max_frame_size}" -gt 0 ]] || [[ "${initial_window_size}" -gt 0 ]] || \
-       [[ "${initial_buffer_size}" -gt 0 ]] || [[ "${connect_timeout}" -gt 0 ]] || \
-       [[ "${read_timeout}" -gt 0 ]]; then
-      grpc_tuning="
+        local peer_port
+        peer_port=$(yq ".block_nodes[\"${peer}\"].port // 40840" "${TOPOLOGY_FILE}")
+        local peer_dns
+        peer_dns=$(get_service_dns "${peer}" "${NAMESPACE}")
+
+        # Read gRPC tuning from the peer node (if configured)
+        local grpc_tuning=""
+        local max_frame_size
+        max_frame_size=$(yq ".block_nodes[\"${peer}\"].grpc_tuning.max_frame_size // 0" "${TOPOLOGY_FILE}" 2>/dev/null)
+        local initial_window_size
+        initial_window_size=$(yq ".block_nodes[\"${peer}\"].grpc_tuning.initial_window_size // 0" "${TOPOLOGY_FILE}" 2>/dev/null)
+        local initial_buffer_size
+        initial_buffer_size=$(yq ".block_nodes[\"${peer}\"].grpc_tuning.initial_buffer_size // 0" "${TOPOLOGY_FILE}" 2>/dev/null)
+        local connect_timeout
+        connect_timeout=$(yq ".block_nodes[\"${peer}\"].grpc_tuning.connect_timeout // 0" "${TOPOLOGY_FILE}" 2>/dev/null)
+        local read_timeout
+        read_timeout=$(yq ".block_nodes[\"${peer}\"].grpc_tuning.read_timeout // 0" "${TOPOLOGY_FILE}" 2>/dev/null)
+
+        if [[ "${max_frame_size}" -gt 0 ]] || [[ "${initial_window_size}" -gt 0 ]] || \
+           [[ "${initial_buffer_size}" -gt 0 ]] || [[ "${connect_timeout}" -gt 0 ]] || \
+           [[ "${read_timeout}" -gt 0 ]]; then
+          grpc_tuning="
         grpc_webclient_tuning:"
-      [[ "${max_frame_size}" -gt 0 ]] && grpc_tuning="${grpc_tuning}
+          [[ "${max_frame_size}" -gt 0 ]] && grpc_tuning="${grpc_tuning}
           max_frame_size: ${max_frame_size}"
-      [[ "${initial_window_size}" -gt 0 ]] && grpc_tuning="${grpc_tuning}
+          [[ "${initial_window_size}" -gt 0 ]] && grpc_tuning="${grpc_tuning}
           initial_window_size: ${initial_window_size}"
-      [[ "${initial_buffer_size}" -gt 0 ]] && grpc_tuning="${grpc_tuning}
+          [[ "${initial_buffer_size}" -gt 0 ]] && grpc_tuning="${grpc_tuning}
           initial_buffer_size: ${initial_buffer_size}"
-      [[ "${connect_timeout}" -gt 0 ]] && grpc_tuning="${grpc_tuning}
+          [[ "${connect_timeout}" -gt 0 ]] && grpc_tuning="${grpc_tuning}
           connect_timeout: ${connect_timeout}"
-      [[ "${read_timeout}" -gt 0 ]] && grpc_tuning="${grpc_tuning}
+          [[ "${read_timeout}" -gt 0 ]] && grpc_tuning="${grpc_tuning}
           read_timeout: ${read_timeout}"
-    fi
+        fi
 
-    sources="${sources}
+        sources="${sources}
       - address: \"${peer_dns}\"
         port: ${peer_port}
         priority: ${priority}${grpc_tuning}"
-    priority=$((priority + 1))
-  done <<< "${peer_names}"
+        priority=$((priority + 1))
+      done <<< "${peer_names}"
 
-  # Read greedy mode from topology (defaults to false if not specified)
-  local greedy_mode
-  greedy_mode=$(yq ".block_nodes[\"${bn_name}\"].greedy // false" "${TOPOLOGY_FILE}" 2>/dev/null)
+      greedy_mode=$(yq ".block_nodes[\"${bn_name}\"].greedy // false" "${TOPOLOGY_FILE}" 2>/dev/null)
+    fi
+  fi
 
-  # Write the overlay
-  cat > "${output_file}" << EOF
-# Generated by generate-chart-values-config-overlays.sh from topology: ${TOPOLOGY_NAME}
-# Block Node: ${bn_name}
-blockNode:
-  config:
-    BACKFILL_BLOCK_NODE_SOURCES_PATH: "/opt/hiero/block-node/backfill/block-node-sources.json"
-    BACKFILL_GREEDY: "${greedy_mode}"
-  backfill:
-    path: "/opt/hiero/block-node/backfill"
-    filename: "block-node-sources.json"
-    sources:${sources}
-EOF
+  # Write the overlay with a single blockNode: root (avoids duplicate-key issues in YAML)
+  {
+    echo "# Generated by generate-chart-values-config-overlays.sh from topology: ${TOPOLOGY_NAME}"
+    echo "# Block Node: ${bn_name}"
+    echo "blockNode:"
+
+    # Per-plugin port overrides (blockNode.ports). Keys are passed through as-is — use
+    # camelCase to match the Helm chart (publisher, subscriber, blockAccess, health, serverStatus).
+    if [[ "${has_plugin_ports}" == "true" ]]; then
+      echo "  ports:"
+      while IFS="=" read -r key value; do
+        [[ -z "${key}" ]] && continue
+        echo "    ${key}: ${value}"
+      done < <(yq -r ".block_nodes[\"${bn_name}\"].plugin_ports | to_entries[] | .key + \"=\" + (.value | tostring)" "${TOPOLOGY_FILE}" 2>/dev/null)
+    fi
+
+    # Backfill config (blockNode.config + blockNode.backfill)
+    if [[ "${peer_count}" -gt 0 ]]; then
+      echo "  config:"
+      echo "    BACKFILL_BLOCK_NODE_SOURCES_PATH: \"/opt/hiero/block-node/backfill/block-node-sources.json\""
+      echo "    BACKFILL_GREEDY: \"${greedy_mode}\""
+      echo "  backfill:"
+      echo "    path: \"/opt/hiero/block-node/backfill\""
+      echo "    filename: \"block-node-sources.json\""
+      echo "    sources:${sources}"
+    fi
+  } > "${output_file}"
 
   log_line "Generated BN overlay: %s" "${output_file}"
 }
@@ -444,6 +463,78 @@ function generate_bn_priority_mappings {
   done <<< "${bn_names}"
 }
 
+# Generate CN block-nodes.json files for consensus nodes whose block nodes have non-default
+# publisher (streamingPort) or serverStatus (servicePort) plugin ports.
+# streamingPort = plugin_ports.publisher // topology port // 40840
+# servicePort   = plugin_ports.serverStatus // topology port // 40840
+function generate_cn_block_nodes_json {
+  local output_dir="${1}"
+
+  local has_cn_section
+  has_cn_section=$(yq '.consensus_nodes | keys | length // 0' "${TOPOLOGY_FILE}" 2>/dev/null)
+  [[ "${has_cn_section}" -eq 0 ]] && return 0
+
+  local cn_names
+  cn_names=$(yq -r '.consensus_nodes | keys[]' "${TOPOLOGY_FILE}" 2>/dev/null)
+  [[ -z "${cn_names}" ]] && return 0
+
+  while IFS= read -r cn_name; do
+    [[ -z "${cn_name}" ]] && continue
+
+    local bn_list
+    bn_list=$(yq -r ".consensus_nodes[\"${cn_name}\"].block_nodes[]" "${TOPOLOGY_FILE}" 2>/dev/null)
+    [[ -z "${bn_list}" ]] && continue
+
+    # Only generate if at least one BN in this CN's list has a non-default publisher or serverStatus port
+    local needs_custom_config="false"
+    while IFS= read -r bn_name; do
+      [[ -z "${bn_name}" ]] && continue
+      local pub_port ss_port
+      pub_port=$(yq ".block_nodes[\"${bn_name}\"].plugin_ports.publisher // \"\"" "${TOPOLOGY_FILE}" 2>/dev/null)
+      ss_port=$(yq ".block_nodes[\"${bn_name}\"].plugin_ports.serverStatus // \"\"" "${TOPOLOGY_FILE}" 2>/dev/null)
+      if [[ -n "${pub_port}" && "${pub_port}" != "null" ]] || \
+         [[ -n "${ss_port}" && "${ss_port}" != "null" ]]; then
+        needs_custom_config="true"
+        break
+      fi
+    done <<< "${bn_list}"
+    [[ "${needs_custom_config}" == "false" ]] && continue
+
+    local nodes_json=""
+    local priority=1
+    local first="true"
+
+    while IFS= read -r bn_name; do
+      [[ -z "${bn_name}" ]] && continue
+
+      local bn_dns
+      bn_dns=$(get_service_dns "${bn_name}" "${NAMESPACE}")
+
+      local default_port
+      default_port=$(yq ".block_nodes[\"${bn_name}\"].port // 40840" "${TOPOLOGY_FILE}" 2>/dev/null)
+
+      local streaming_port service_port
+      streaming_port=$(yq ".block_nodes[\"${bn_name}\"].plugin_ports.publisher // ${default_port}" "${TOPOLOGY_FILE}" 2>/dev/null)
+      service_port=$(yq ".block_nodes[\"${bn_name}\"].plugin_ports.serverStatus // ${default_port}" "${TOPOLOGY_FILE}" 2>/dev/null)
+
+      [[ "${first}" != "true" ]] && nodes_json="${nodes_json},"
+      nodes_json="${nodes_json}
+    {
+      \"address\": \"${bn_dns}\",
+      \"streamingPort\": ${streaming_port},
+      \"servicePort\": ${service_port},
+      \"priority\": ${priority}
+    }"
+      first="false"
+      priority=$((priority + 1))
+    done <<< "${bn_list}"
+
+    local output_file="${output_dir}/cn-${cn_name}-block-nodes.json"
+    printf '{\n  "nodes": [%s\n  ],\n  "blockItemBatchSize": 256\n}\n' "${nodes_json}" > "${output_file}"
+    log_line "Generated CN block-nodes.json: %s" "${output_file}"
+  done <<< "${cn_names}"
+}
+
 function validate_prerequisites {
   if ! command -v yq >/dev/null 2>&1; then
     fail "ERROR: yq is required but not found. Install from: https://github.com/mikefarah/yq" 1
@@ -496,6 +587,9 @@ function main {
 
   # Generate BN priority mappings for Solo --priority-mapping
   generate_bn_priority_mappings "${OUTPUT_DIR}"
+
+  # Generate CN block-nodes.json overrides when publisher/serverStatus use non-default ports
+  generate_cn_block_nodes_json "${OUTPUT_DIR}"
 
   # Count priority mapping files
   local mapping_count

--- a/tools-and-tests/scripts/network-topology-tool/generate-chart-values-config-overlays.sh
+++ b/tools-and-tests/scripts/network-topology-tool/generate-chart-values-config-overlays.sh
@@ -311,9 +311,8 @@ function generate_mn_overlay {
     bn_dns=$(get_service_dns "${bn}" "${NAMESPACE}")
 
     nodes_config="${nodes_config}
-              - endpoints:
-                  - host: ${bn_dns}
-                    port: ${bn_port}"
+              - host: ${bn_dns}
+                port: ${bn_port}"
   done <<< "${block_node_names}"
 
   # Image overrides (workaround, ALL topologies): the default GraalVM-native Mirror Node

--- a/tools-and-tests/scripts/network-topology-tool/network-topology.schema.yaml
+++ b/tools-and-tests/scripts/network-topology-tool/network-topology.schema.yaml
@@ -104,6 +104,10 @@ properties:
             description: "Enable greedy backfill mode (defaults to false)"
           grpc_tuning:
             $ref: "#/$defs/grpcTuning"
+          plugin_ports:
+            type: object
+            description: "Per-plugin port overrides. Keys match blockNode.ports in the Helm chart (camelCase: publisher, subscriber, blockAccess, health, serverStatus). publisher defaults to service.port (40840) when unset."
+            additionalProperties: { $ref: "#/$defs/port" }
 
   consensus_nodes:
     type: object

--- a/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
+++ b/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
@@ -112,6 +112,12 @@ tasks:
     desc: Destroy Kind cluster and clean up Solo config
     cmds:
       - |
+        # Kill any orphaned Solo processes holding the deployment lock, then release the
+        # K8s Lease. A background 'solo block node add' can survive cluster teardown and
+        # actively renew the Lease in the new cluster, blocking the next deployment.
+        pkill -f "solo block node" 2>/dev/null || true
+        kubectl delete lease solo-network -n "{{.NAMESPACE}}" --ignore-not-found=true 2>/dev/null || true
+
         echo "Cleaning up Solo local config..."
         if solo deployment config delete -d "{{.DEPLOYMENT}}" -q 2>/dev/null; then
           echo "  Solo deployment config deleted"

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
@@ -308,7 +308,8 @@ function generate_overlays {
 
   # Clean output directory to avoid stale overlays from previous topology runs
   rm -f "${overlay_dir}"/bn-*.yaml "${overlay_dir}"/mn-*.yaml \
-        "${overlay_dir}"/bn-*-priority-mapping.txt 2>/dev/null
+        "${overlay_dir}"/bn-*-priority-mapping.txt \
+        "${overlay_dir}"/cn-*-block-nodes.json 2>/dev/null
 
   start_task "Generating Helm overlays from topology"
   local generator_output
@@ -417,6 +418,12 @@ function deploy_block_nodes {
   log_line "Deploying Block Nodes"
   log_line "---------------------"
 
+  # Kill any orphaned Solo processes that may be holding the deployment lock, then release
+  # the K8s Lease. A stale 'solo block node add' from a prior run actively renews the Lease
+  # across cluster teardown/recreate, blocking the next deployment attempt.
+  pkill -f "solo block node" 2>/dev/null || true
+  kubectl delete lease solo-network -n "${NAMESPACE}" --ignore-not-found=true 2>/dev/null || true
+
   local bn_args=""
   if [[ -n "${BN_VERSION}" ]]; then
     bn_args="--chart-version ${BN_VERSION}"
@@ -447,7 +454,7 @@ function deploy_block_nodes {
 
     if [[ -f "${bn_overlay}" ]]; then
       overlay_args="${overlay_args} -f ${bn_overlay}"
-      log_line "  Using backfill overlay for block-node-${i}"
+      log_line "  Using generated overlay for block-node-${i}"
     fi
 
     # rsa-wrb: append the shared WRB overlay enabling the roster-bootstrap-rsa plugin.
@@ -641,6 +648,54 @@ function deploy_consensus_nodes {
     --deployment "${DEPLOYMENT}" \
     --node-aliases "${NODE_ALIASES}" || fail "ERROR: Failed to start consensus nodes" 1
   end_task
+}
+
+# Apply generated CN block-nodes.json files to CN pods when the topology sets
+# non-default publisher (streamingPort) or serverStatus (servicePort) ports.
+# Solo's block node add always writes block-nodes.json with port 40840 for both fields;
+# this step overwrites that file when the topology specifies different ports.
+function apply_cn_block_nodes_configs {
+  local overlay_dir="${OVERLAY_DIR}"
+
+  local config_files
+  config_files=$(find "${overlay_dir}" -maxdepth 1 -name "cn-*-block-nodes.json" -type f 2>/dev/null)
+  [[ -z "${config_files}" ]] && return 0
+
+  log_line ""
+  log_line "Applying CN block-nodes.json port overrides"
+  log_line "--------------------------------------------"
+
+  local config_path="/opt/hgcapp/services-hedera/HapiApp2.0/data/config/block-nodes.json"
+
+  while IFS= read -r config_file; do
+    [[ -z "${config_file}" ]] && continue
+
+    local cn_name
+    cn_name=$(basename "${config_file}" | sed 's/^cn-//' | sed 's/-block-nodes\.json$//')
+    local cn_pod="network-${cn_name}-0"
+
+    start_task "Applying block-nodes.json to %s" "${cn_pod}"
+
+    local attempts=0
+    until kubectl exec "${cn_pod}" -n "${NAMESPACE}" -c root-container -- true 2>/dev/null; do
+      attempts=$((attempts + 1))
+      if [[ "${attempts}" -ge 30 ]]; then
+        end_task "TIMEOUT (pod not ready after 30s)"
+        break
+      fi
+      sleep 1
+    done
+    if [[ "${attempts}" -ge 30 ]]; then
+      continue
+    fi
+
+    if kubectl exec -i "${cn_pod}" -n "${NAMESPACE}" -c root-container -- \
+        bash -c "cat > ${config_path}" < "${config_file}"; then
+      end_task
+    else
+      end_task "FAILED"
+    fi
+  done <<< "${config_files}"
 }
 
 function deploy_mirror_node {
@@ -853,6 +908,7 @@ function main {
   # polls the Mirror Node indefinitely, so it tolerates the MN starting later.
   deploy_block_nodes
   deploy_consensus_nodes
+  apply_cn_block_nodes_configs
   deploy_mirror_node
   deploy_relay
   deploy_explorer

--- a/tools-and-tests/scripts/solo-e2e-test/topologies/single.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/topologies/single.yaml
@@ -15,6 +15,7 @@ block_nodes:
     address: block-node-1
     port: 40840
 
+
 consensus_nodes:
   node1:
     block_nodes: [block-node-1]


### PR DESCRIPTION
## Summary

- **Helm chart dedup**: `pluginServicePorts` / `pluginContainerPorts` helpers now skip duplicate port entries (Kubernetes rejects Services/containers with the same port number declared twice).
- **Topology-driven plugin ports**: `generate_bn_overlay` now emits `blockNode.ports` from the topology `plugin_ports` map, and a new `generate_cn_block_nodes_json` function produces per-CN `block-nodes.json` overrides with separate `streamingPort` (publisher) and `servicePort` (serverStatus) — applied to CN pods after deployment to replace Solo's hardcoded port 40840 entries.
- **Solo deployment lock fix**: a background `solo block node add` process from a prior run can survive cluster teardown and continue renewing the K8s `solo-network` Lease in a newly created cluster, blocking the next deployment. Fixed by killing matching processes and deleting the Lease at both `cluster:destroy` time and at the start of `deploy_block_nodes`.

## Changes

**`charts/block-node-server/templates/_helpers.tpl`**
- `pluginServicePorts` and `pluginContainerPorts` iterate a single ordered list and track seen port numbers with a `$seen` dict, emitting only the first plugin entry per unique port number.

**`tools-and-tests/scripts/network-topology-tool/generate-chart-values-config-overlays.sh`**
- `generate_bn_overlay`: extended to emit `blockNode.ports.*` from `plugin_ports` topology keys in addition to backfill config; both sections are written under a single `blockNode:` root using a `{ } > file` block to prevent duplicate YAML top-level keys.
- New `generate_cn_block_nodes_json`: for any CN whose BNs declare non-default `plugin_ports.publisher` or `plugin_ports.serverStatus`, generates `cn-<name>-block-nodes.json` with explicit `streamingPort` and `servicePort` fields. Falls back to `topology port // 40840` when a plugin port is not overridden.

**`tools-and-tests/scripts/network-topology-tool/network-topology.schema.yaml`**
- Added `plugin_ports` (map of camelCase plugin name → port number) to the block node schema.

**`tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh`**
- `deploy_block_nodes`: kill orphaned `solo block node` processes + delete K8s Lease before iterating BNs.
- New `apply_cn_block_nodes_configs`: finds `cn-*-block-nodes.json` overlay files and copies them into each CN pod's `data/config/block-nodes.json`, replacing Solo's auto-generated version.
- `apply_cn_block_nodes_configs` called in `main` after `deploy_consensus_nodes`.
- Overlay cleanup now includes `cn-*-block-nodes.json`.

**`tools-and-tests/scripts/solo-e2e-test/Taskfile.yml`**
- `cluster:destroy`: kill orphaned processes + delete Lease before running Solo CLI teardown.

## Known Limitation

Solo's own "Check block node readiness" step in `solo block node add` hardcodes port 40840 for both the HTTP health probe and the gRPC `serverStatus` probe. Per-plugin port overrides for `health` or `serverStatus` will cause Solo's deployment to hang at this step, even though the K8s pod becomes `Ready` correctly. A separate issue has been filed with the Solo team to fix this in their readiness check flow.

## Test Plan

- [x] `task up` with default `single` topology (no `plugin_ports`) completes without lock errors
- [x] `task down` followed immediately by `task up` does not hit "lock already acquired" error
- [x] `task up` with a topology using `plugin_ports.publisher` / `plugin_ports.serverStatus` — verify `cn-node1-block-nodes.json` is generated with the expected `streamingPort` / `servicePort` and is applied to the CN pod
- [x] Helm template dry-run with two plugins sharing a port produces no duplicate Service or container port entries
