### PR TITLE
feat: BN followup items for historical address-book roster model

### DIFF
--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -10,14 +10,12 @@ import static org.hiero.block.common.constants.StringsConstants.APPLICATION_PROP
 import static org.hiero.block.common.constants.StringsConstants.APPLICATION_TEST_PROPERTIES;
 import static org.hiero.block.node.base.ParseHelper.standardParse;
 import static org.hiero.block.node.spi.BlockNodePlugin.METRICS_CATEGORY;
-import static org.hiero.block.node.spi.historicalblocks.BlockAccessor.MAX_PARSE_DEPTH;
 
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.node.base.NodeAddress;
 import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.pbj.grpc.helidon.PbjRouting;
 import com.hedera.pbj.grpc.helidon.config.PbjConfig;
-import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
@@ -856,28 +854,12 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         final Path historyFilePath = appStateConfig.rsaBootstrapFilePath();
         if (Files.exists(historyFilePath)) {
             try {
-                final RangedAddressBookHistory history = RangedAddressBookHistory.JSON.parse(
-                        Bytes.wrap(Files.readAllBytes(historyFilePath)).toReadableSequentialData(),
-                        true,
-                        false,
-                        MAX_PARSE_DEPTH,
-                        Codec.DEFAULT_MAX_SIZE);
+                final RangedAddressBookHistory history =
+                        standardParse(RangedAddressBookHistory.JSON, Bytes.wrap(Files.readAllBytes(historyFilePath)));
                 if (history.addressBooks().isEmpty()) {
-                    throw new IllegalStateException(
-                            "RSA address book history file contains no entries: " + historyFilePath);
-                }
-                pendingAddressBookHistory.set(history);
-            } catch (IOException e) {
-                throw new IllegalStateException("Failed to read RSA address book history file: " + historyFilePath, e);
-            } catch (ParseException e) {
-                // Revert back to the old bootstrap file format
-                try {
-                    final NodeAddressBook book = NodeAddressBook.JSON.parse(
-                            Bytes.wrap(Files.readAllBytes(historyFilePath)).toReadableSequentialData(),
-                            true,
-                            false,
-                            MAX_PARSE_DEPTH,
-                            Codec.DEFAULT_MAX_SIZE);
+                    // Try the old bootstrap file format, standard parse swallows it and returns an empty history
+                    final NodeAddressBook book =
+                            standardParse(NodeAddressBook.JSON, Bytes.wrap(Files.readAllBytes(historyFilePath)));
                     validateAddressBook(book, historyFilePath.toString());
                     final RangedAddressBookHistory wrapped = RangedAddressBookHistory.newBuilder()
                             .addressBooks(List.of(RangedNodeAddressBook.newBuilder()
@@ -887,15 +869,16 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                                     .build()))
                             .build();
                     pendingAddressBookHistory.set(wrapped);
-                } catch (ParseException ex) {
-                    final String message =
-                            "Corrupt RSA bootstrap file at %s — delete and restart to re-fetch from Mirror Node"
-                                    .formatted(historyFilePath);
-                    throw new IllegalStateException(message, ex);
-                } catch (IOException ex) {
-                    throw new IllegalStateException(
-                            "Failed to read RSA address book history file: " + historyFilePath, e);
+                } else {
+                    pendingAddressBookHistory.set(history);
                 }
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to read RSA address book history file: " + historyFilePath, e);
+            } catch (ParseException e) {
+                final String message =
+                        "Corrupt RSA bootstrap file at %s — delete and restart to re-fetch from Mirror Node"
+                                .formatted(historyFilePath);
+                throw new IllegalStateException(message, e);
             }
         } else {
             // History file absent — ensure parent directory exists for future writes.

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
@@ -237,7 +237,7 @@ public class TestBlockNodeServer {
                             List.of(buildRosterEntry(11, 22, Bytes.fromHex("03030303"))),
                             250))
                     .nodeAddressBook(buildAddressBook(4))
-                    .rangedAddressBookHistory(buildRangedHistory(4))
+                    .rangedAddressBookHistory(buildRangedHistory(5, 1000, 4))
                     .build();
         }
 
@@ -259,13 +259,35 @@ public class TestBlockNodeServer {
                     .build();
         }
 
-        private static RangedAddressBookHistory buildRangedHistory(final int count) {
+        /// builds a `RangedAddressBookHistory`
+        ///
+        /// @param ranges the number of `RangedNodeAddressBook` to generate
+        /// @param perRangeCount the number of blocks per `RangedNodeAddressBook`
+        /// @param addressBookCount the number of `NodeAddress` per `NodeAddressBook`
+        private static RangedAddressBookHistory buildRangedHistory(
+                final int ranges, final int perRangeCount, final int addressBookCount) {
+            ArrayList<RangedNodeAddressBook> addressBooks = new ArrayList<>(ranges);
+            for (int i = 0; i < ranges; i++) {
+                long startBlock = (long) i * perRangeCount;
+                long endBlock = i + 1 == ranges ? -1L : (long) (i + 1) * perRangeCount - 1;
+                addressBooks.add(buildRangedNodeAddressBook(startBlock, endBlock, addressBookCount));
+            }
             return RangedAddressBookHistory.newBuilder()
-                    .addressBooks(List.of(RangedNodeAddressBook.newBuilder()
-                            .addressBook(buildAddressBook(count))
-                            .startBlock(0L)
-                            .endBlock(-1L)
-                            .build()))
+                    .addressBooks(addressBooks)
+                    .build();
+        }
+
+        /// builds a `RangedNodeAddressBook`
+        ///
+        /// @param startBlock the starting block number for this `RangedNodeAddressBook`
+        /// @param endBlock the ending block number for this `RangedNodeAddressBook`
+        /// @param addressBookCount the number of `NodeAddress` per `NodeAddressBook`
+        private static RangedNodeAddressBook buildRangedNodeAddressBook(
+                final long startBlock, final long endBlock, final int addressBookCount) {
+            return RangedNodeAddressBook.newBuilder()
+                    .addressBook(buildAddressBook(addressBookCount))
+                    .startBlock(startBlock)
+                    .endBlock(endBlock)
                     .build();
         }
 

--- a/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
+++ b/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
@@ -916,7 +916,7 @@ class RsaRosterBootstrapPluginTest
 
             assertTrue(contextUpdated[0] > 0);
             assertNotNull(histories[0]);
-            assertEquals(1, histories[0].addressBooks().size());
+            assertEquals(5, histories[0].addressBooks().size());
 
             // These are magic numbers, yes. The {@link TestBlockNodeServer} does not yet have a way to pass in TssData
             // to


### PR DESCRIPTION
## Reviewer Notes

- revert RangedAddressbookHistory to using the standardParse helper.
- add NodeAddressBook parsing to the case of an empty RangedAddressbookHistory 
- improve the generation of test RangedAddressbookHistory

## Related Issue(s)
Closes: #3088
