### PR TITLE
fix(solo-e2e): fix wrb-cli-wrapping-validation regressions (unsigned + oversized record files)

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/BlockReader.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/BlockReader.java
@@ -337,7 +337,7 @@ public class BlockReader {
                 final InputStream decompressedStream = compressionType.wrapStream(byteStream);
                 final ReadableStreamingData in = new ReadableStreamingData(decompressedStream)) {
             return Block.PROTOBUF.parse(
-                    in, false, false, Codec.DEFAULT_MAX_DEPTH, ProtobufParsingConstants.MAX_PARSE_SIZE);
+                    in, false, false, Codec.DEFAULT_MAX_DEPTH, ProtobufParsingConstants.MAX_MESSAGE_SIZE);
         } catch (ParseException e) {
             throw new IOException("Failed to parse block from bytes", e);
         }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/BlockZipsUtilities.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/BlockZipsUtilities.java
@@ -362,7 +362,7 @@ public final class BlockZipsUtilities {
             blockBytes = raw;
         }
         return Block.PROTOBUF.parse(
-                BufferedData.wrap(blockBytes), true, false, 1000, ProtobufParsingConstants.MAX_PARSE_SIZE);
+                BufferedData.wrap(blockBytes), true, false, 1000, ProtobufParsingConstants.MAX_MESSAGE_SIZE);
     }
     /**
      * Decompresses raw bytes and parses them as a {@link BlockUnparsed} protobuf. BlockUnparsed is shallow parsed so
@@ -389,7 +389,7 @@ public final class BlockZipsUtilities {
             blockBytes = raw;
         }
         return BlockUnparsed.PROTOBUF.parse(
-                BufferedData.wrap(blockBytes), true, false, 1000, ProtobufParsingConstants.MAX_PARSE_SIZE);
+                BufferedData.wrap(blockBytes), true, false, 1000, ProtobufParsingConstants.MAX_MESSAGE_SIZE);
     }
 
     /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/hashing/BlockStreamBlockHasher.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/model/hashing/BlockStreamBlockHasher.java
@@ -5,7 +5,7 @@ import static org.hiero.block.node.base.ParseHelper.standardParse;
 import static org.hiero.block.tools.blocks.model.hashing.HashingUtils.EMPTY_TREE_HASH;
 import static org.hiero.block.tools.blocks.model.hashing.HashingUtils.hashInternalNode;
 import static org.hiero.block.tools.blocks.model.hashing.HashingUtils.hashLeaf;
-import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_PARSE_SIZE;
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_MESSAGE_SIZE;
 
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.output.BlockFooter;
@@ -125,7 +125,7 @@ public class BlockStreamBlockHasher {
         try {
             Bytes bytes = Block.PROTOBUF.toBytes(block);
             BlockUnparsed unparsed = BlockUnparsed.PROTOBUF.parse(
-                    bytes.toReadableSequentialData(), false, false, Codec.DEFAULT_MAX_DEPTH, MAX_PARSE_SIZE);
+                    bytes.toReadableSequentialData(), false, false, Codec.DEFAULT_MAX_DEPTH, MAX_MESSAGE_SIZE);
             return hashBlockInternal(unparsed);
         } catch (Exception e) {
             throw new IllegalArgumentException("Failed to hash block", e);

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/AddressBookUpdateValidation.java
@@ -4,7 +4,7 @@ package org.hiero.block.tools.blocks.validation;
 import static org.hiero.block.tools.blocks.validation.BlockExtractionUtils.extractBlockInstant;
 import static org.hiero.block.tools.blocks.validation.BlockExtractionUtils.extractRecordFileBytes;
 import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_DEPTH;
-import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_RECORD_FILE_SIZE;
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_MESSAGE_SIZE;
 
 import com.hedera.hapi.block.stream.RecordFileItem;
 import com.hedera.hapi.node.base.Transaction;
@@ -115,7 +115,7 @@ public final class AddressBookUpdateValidation implements BlockValidation {
 
     private static List<Transaction> extractTransactions(final Bytes recordFileBytes) throws Exception {
         final RecordFileItem recordFileItem = RecordFileItem.PROTOBUF.parse(
-                recordFileBytes.toReadableSequentialData(), false, false, MAX_DEPTH, MAX_RECORD_FILE_SIZE);
+                recordFileBytes.toReadableSequentialData(), false, false, MAX_DEPTH, MAX_MESSAGE_SIZE);
         if (!recordFileItem.hasRecordFileContents()) {
             return List.of();
         }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/BlockExtractionUtils.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/BlockExtractionUtils.java
@@ -2,6 +2,7 @@
 package org.hiero.block.tools.blocks.validation;
 
 import static org.hiero.block.node.base.ParseHelper.standardParse;
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_MESSAGE_SIZE;
 
 import com.hedera.hapi.block.stream.output.BlockHeader;
 import com.hedera.hapi.node.base.Timestamp;
@@ -66,10 +67,11 @@ public final class BlockExtractionUtils {
         if (t.hasBody()) {
             return t.body();
         } else if (t.bodyBytes().length() > 0) {
-            return standardParse(TransactionBody.PROTOBUF, t.bodyBytes());
+            return standardParse(TransactionBody.PROTOBUF, t.bodyBytes(), MAX_MESSAGE_SIZE);
         } else if (t.signedTransactionBytes().length() > 0) {
-            final SignedTransaction st = standardParse(SignedTransaction.PROTOBUF, t.signedTransactionBytes());
-            return standardParse(TransactionBody.PROTOBUF, st.bodyBytes());
+            final SignedTransaction st =
+                    standardParse(SignedTransaction.PROTOBUF, t.signedTransactionBytes(), MAX_MESSAGE_SIZE);
+            return standardParse(TransactionBody.PROTOBUF, st.bodyBytes(), MAX_MESSAGE_SIZE);
         }
         return null;
     }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/HbarSupplyValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/HbarSupplyValidation.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.blocks.validation;
 
-import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_PARSE_SIZE;
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_MESSAGE_SIZE;
 
 import com.hedera.hapi.block.stream.output.MapChangeKey;
 import com.hedera.hapi.block.stream.output.MapChangeValue;
@@ -124,7 +124,7 @@ public final class HbarSupplyValidation implements BlockValidation {
                             false,
                             false,
                             Codec.DEFAULT_MAX_DEPTH,
-                            MAX_PARSE_SIZE));
+                            MAX_MESSAGE_SIZE));
                 } else if (item.hasRecordFile()) {
                     final Bytes recordFileBytes = item.recordFileOrThrow();
                     recordFileBytesList.add(recordFileBytes);

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/NodeStakeUpdateValidation.java
@@ -5,7 +5,7 @@ import static org.hiero.block.tools.blocks.validation.BlockExtractionUtils.extra
 import static org.hiero.block.tools.blocks.validation.BlockExtractionUtils.extractRecordFileBytes;
 import static org.hiero.block.tools.blocks.validation.BlockExtractionUtils.extractTransactionBody;
 import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_DEPTH;
-import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_RECORD_FILE_SIZE;
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_MESSAGE_SIZE;
 
 import com.hedera.hapi.block.stream.RecordFileItem;
 import com.hedera.hapi.node.base.Transaction;
@@ -114,7 +114,7 @@ public final class NodeStakeUpdateValidation implements BlockValidation {
     private void processNodeStakeUpdates(
             final Bytes recordFileBytes, final Instant blockInstant, final long blockNumber) throws Exception {
         final RecordFileItem recordFileItem = RecordFileItem.PROTOBUF.parse(
-                recordFileBytes.toReadableSequentialData(), false, false, MAX_DEPTH, MAX_RECORD_FILE_SIZE);
+                recordFileBytes.toReadableSequentialData(), false, false, MAX_DEPTH, MAX_MESSAGE_SIZE);
         if (!recordFileItem.hasRecordFileContents()) {
             return;
         }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/ProtobufParsingConstants.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/ProtobufParsingConstants.java
@@ -11,11 +11,10 @@ public final class ProtobufParsingConstants {
 
     /// Maximum size for parsing a whole record file, block, or other large message.
     ///
-    /// Set to [Integer#MAX_VALUE] (effectively unbounded): these parses consume trusted data the
-    /// tool itself produced or fetched, and message sizes are determined by network activity (e.g.
-    /// oversized blocks), not by a bound we choose. The cap only guards against runaway allocation
-    /// on corrupt input, which is not a concern here.
-    public static final int MAX_MESSAGE_SIZE = Integer.MAX_VALUE;
+    /// Set to 300 MB: large enough to comfortably accommodate the biggest record files and blocks
+    /// the tool handles, while still bounding allocation so a limit is encountered here rather than
+    /// later in the Block Node. This guards against runaway allocation on corrupt input.
+    public static final int MAX_MESSAGE_SIZE = 300 * 1024 * 1024;
 
     private ProtobufParsingConstants() {}
 }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/ProtobufParsingConstants.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/ProtobufParsingConstants.java
@@ -9,11 +9,13 @@ public final class ProtobufParsingConstants {
     /** Maximum protobuf nesting depth for parsing. */
     public static final int MAX_DEPTH = 512;
 
-    /** Maximum record file size for protobuf parsing (128 MB). */
-    public static final int MAX_RECORD_FILE_SIZE = 128 * 1024 * 1024;
-
-    /** Maximum parse size for protobuf messages (120 MB) to handle large blocks and StateChanges items. */
-    public static final int MAX_PARSE_SIZE = 120 * 1024 * 1024;
+    /// Maximum size for parsing a whole record file, block, or other large message.
+    ///
+    /// Set to [Integer#MAX_VALUE] (effectively unbounded): these parses consume trusted data the
+    /// tool itself produced or fetched, and message sizes are determined by network activity (e.g.
+    /// oversized blocks), not by a bound we choose. The cap only guards against runaway allocation
+    /// on corrupt input, which is not a concern here.
+    public static final int MAX_MESSAGE_SIZE = Integer.MAX_VALUE;
 
     private ProtobufParsingConstants() {}
 }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/TssEnablementValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/TssEnablementValidation.java
@@ -2,6 +2,7 @@
 package org.hiero.block.tools.blocks.validation;
 
 import static org.hiero.block.node.base.ParseHelper.standardParse;
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_MESSAGE_SIZE;
 
 import com.hedera.hapi.block.stream.RecordFileItem;
 import com.hedera.hapi.block.stream.output.BlockHeader;
@@ -35,7 +36,6 @@ public final class TssEnablementValidation implements BlockValidation {
 
     private static final String SAVE_FILE_NAME = "tssPublicationHistory.json";
     private static final int MAX_DEPTH = 512;
-    private static final int MAX_RECORD_FILE_SIZE = 128 * 1024 * 1024;
 
     private final TssEnablementRegistry tssRegistry;
     private final Path tssParametersBinPath;
@@ -90,7 +90,7 @@ public final class TssEnablementValidation implements BlockValidation {
             final Bytes recordFileBytes, final Instant blockInstant, final long blockNumber)
             throws ParseException, IOException {
         final RecordFileItem recordFileItem = RecordFileItem.PROTOBUF.parse(
-                recordFileBytes.toReadableSequentialData(), false, false, MAX_DEPTH, MAX_RECORD_FILE_SIZE);
+                recordFileBytes.toReadableSequentialData(), false, false, MAX_DEPTH, MAX_MESSAGE_SIZE);
         if (!recordFileItem.hasRecordFileContents()) {
             return;
         }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/capacity/NetworkCapacityClient.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/capacity/NetworkCapacityClient.java
@@ -183,7 +183,7 @@ public class NetworkCapacityClient {
                 false,
                 false,
                 Codec.DEFAULT_MAX_DEPTH,
-                ProtobufParsingConstants.MAX_PARSE_SIZE);
+                ProtobufParsingConstants.MAX_MESSAGE_SIZE);
 
         long blockNumber = block.items().getFirst().blockHeader().number();
         List<BlockItem> items = block.items();

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -1178,7 +1178,7 @@ public class LiveSequential implements Runnable {
                 false,
                 false,
                 Codec.DEFAULT_MAX_DEPTH,
-                ProtobufParsingConstants.MAX_PARSE_SIZE);
+                ProtobufParsingConstants.MAX_MESSAGE_SIZE);
 
         for (BlockValidation v : vc.sequentialValidations()) {
             try {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/RecordFileHasher.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/RecordFileHasher.java
@@ -2,6 +2,7 @@
 package org.hiero.block.tools.records;
 
 import static org.hiero.block.node.base.ParseHelper.standardParse;
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_MESSAGE_SIZE;
 import static org.hiero.block.tools.records.model.parsed.SerializationV5Utils.HASH_OBJECT_SIZE_BYTES;
 
 import com.hedera.hapi.node.base.SemanticVersion;
@@ -69,7 +70,7 @@ public class RecordFileHasher {
                 case 6 -> {
                     // V6 is nice and easy as it is all protobuf encoded after the first version integer
                     final RecordStreamFile recordStreamFile =
-                            standardParse(RecordStreamFile.PROTOBUF, new ReadableStreamingData(in));
+                            standardParse(RecordStreamFile.PROTOBUF, new ReadableStreamingData(in), MAX_MESSAGE_SIZE);
                     // For v6 the block hash is the end running hash which is accessed via endObjectRunningHash()
                     if (recordStreamFile.endObjectRunningHash() == null) {
                         throw new IllegalStateException("No end object running hash in record file");

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/parsed/ParsedRecordFile.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/parsed/ParsedRecordFile.java
@@ -2,6 +2,7 @@
 package org.hiero.block.tools.records.model.parsed;
 
 import static org.hiero.block.node.base.ParseHelper.standardParse;
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_MESSAGE_SIZE;
 import static org.hiero.block.tools.records.RecordFileDates.extractRecordFileTime;
 import static org.hiero.block.tools.records.RecordFileDates.instantToRecordFileName;
 import static org.hiero.block.tools.records.model.parsed.SerializationV5Utils.HASH_OBJECT_SIZE_BYTES;
@@ -347,7 +348,8 @@ public record ParsedRecordFile(
                     // compute the entire file hash used for signature verification
                     final byte[] fileHash = hashSha384(recordFileBytes);
                     // V6 is nice and easy as it is all protobuf encoded after the first version integer
-                    final RecordStreamFile recordStreamFile = standardParse(RecordStreamFile.PROTOBUF, in);
+                    final RecordStreamFile recordStreamFile =
+                            standardParse(RecordStreamFile.PROTOBUF, in, MAX_MESSAGE_SIZE);
                     // For v6 the block hash is the end-running-hash accessed via endObjectRunningHash()
                     if (recordStreamFile.endObjectRunningHash() == null) {
                         throw new IllegalStateException("No end object running hash in record file");

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/unparsed/UnparsedRecordBlockV6.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/unparsed/UnparsedRecordBlockV6.java
@@ -2,6 +2,7 @@
 package org.hiero.block.tools.records.model.unparsed;
 
 import static org.hiero.block.node.base.ParseHelper.standardParse;
+import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.MAX_MESSAGE_SIZE;
 import static org.hiero.block.tools.utils.Sha384.sha384Digest;
 
 import com.hedera.hapi.node.base.NodeAddressBook;
@@ -84,7 +85,8 @@ public class UnparsedRecordBlockV6 extends UnparsedRecordBlock {
             }
 
             // Parse protobuf portion
-            final RecordStreamFile rsf = standardParse(RecordStreamFile.PROTOBUF, new ReadableStreamingData(in));
+            final RecordStreamFile rsf =
+                    standardParse(RecordStreamFile.PROTOBUF, new ReadableStreamingData(in), MAX_MESSAGE_SIZE);
             final SemanticVersion hapiVersion = rsf.hapiProtoVersion();
 
             // Compute the entire file hash for signature validation


### PR DESCRIPTION

✅  Dry-Run test run: https://github.com/hiero-ledger/hiero-block-node/actions/runs/28400298918/job/84159984106

## Summary

The `wrb-cli-wrapping-validation` test in the `single` solo-e2e topology was failing repeatedly (3 attempts in a row on the scheduler, and again on `main`). After the OOM fix landed and the Block Node could stream past the previous crash point, the test reached the WRB CLI wrap step and exposed two separate, pre-existing problems. This PR fixes both.

Both failures surface in the `Run Test Definitions` step; the other tests (`smoke-test`, `tss-signature-transition`, `wrb-cli-hash-validation`) pass.

## Root causes

**1. Unsigned in-progress record file (intermittent)**

`wrb-cli-wrap-and-compare.sh` extracts the Consensus Node's record stream with `kubectl cp` while the CN is actively writing. That captures the newest record file mid-write: a truncated `.rcd.gz` whose `.rcd_sig` signature has not been flushed yet. The `blocks wrap` command hard-fails on any record file set missing its signature:

```
gzip: .../2026-..._..Z.rcd.gz: unexpected end of file
java.lang.RuntimeException: No signature files found for baseKey='2026-..._..Z' ...
Conversion complete. Blocks written: 0
```

**2. Oversized record file exceeds PBJ parse cap (deterministic)**

Once past the signature issue, wrap fails parsing the oversized "wraps transition" block (~30 MB) because the tools CLI parsed whole record files/blocks/transactions with PBJ's 2 MB default size:

```
com.hedera.pbj.runtime.ParseException: record_stream_items size 31570579 is greater than max 2097152
```

This was a latent regression from the PBJ 0.15.10 upgrade (#3080): call sites that previously used the 1-arg `Codec.parse(...)` were moved to `ParseHelper.standardParse(...)`, which defaults to `Codec.DEFAULT_MAX_SIZE` (2 MB). The block-node modules preserved their large parses with `Integer.MAX_VALUE`; the tools record-file paths were left at 2 MB.

## Changes

**Signature prune (`wrb-cli-wrap-and-compare.sh`)**
- Add `prune_incomplete_record_files`, called at the start of `generate_metadata_from_files` (the shared chokepoint for both the CN and MinIO extraction paths). It drops any `.rcd`/`.rcd.gz` lacking a matching `.rcd_sig`/`.rcd_sig.gz` before metadata generation and packaging. One rule covers both observed symptoms, since the truncated gz and the missing signature belong to the same in-progress file.

**Parse size cap consolidation (`tools` module)**
- Replace `MAX_RECORD_FILE_SIZE` (128 MB) and `MAX_PARSE_SIZE` (120 MB) in `ProtobufParsingConstants` with a single `MAX_MESSAGE_SIZE = Integer.MAX_VALUE`. Both were arbitrary bounded caps for the same purpose (parsing a whole trusted record file/block/transaction), and oversized blocks could exceed them. The cap only guards against runaway allocation on corrupt input, which is not a concern for data the tool itself produced or fetched.
- Route every whole-record/whole-block/transaction parse site through `MAX_MESSAGE_SIZE`: `ParsedRecordFile`, `RecordFileHasher`, `UnparsedRecordBlockV6`, `BlockExtractionUtils`, and the existing validation/model sites (`NodeStakeUpdateValidation`, `AddressBookUpdateValidation`, `TssEnablementValidation`, `HbarSupplyValidation`, `BlockReader`, `BlockZipsUtilities`, `BlockStreamBlockHasher`, `NetworkCapacityClient`, `LiveSequential`).
- Drop the duplicate local `MAX_RECORD_FILE_SIZE` constant in `TssEnablementValidation` in favor of the shared one.

## Test plan

- [x] `./gradlew :tools:spotlessApply :tools:compileJava :tools:test` — passes
- [x] Local solo-e2e `single` topology with the oversized ~30 MB record present: `wrb-cli-wrapping-validation` passes end-to-end — 16345 blocks wrapped, `VALIDATION PASSED`, 8/8 events, 3/3 assertions, 0 parse-size errors, 0 stake-data warnings
- [x] Confirmed the signature prune fires live (`Pruned 1 incomplete record file(s) lacking signatures`) and wrap progresses from 0 to all blocks
- [x] Solo E2E scheduler `single` job green in CI

## Reviewer Notes

This branch was cut before #3086 (the OOM/heap fix) merged, so it currently also carries that commit. Rebasing onto latest `main` drops it (already merged), leaving only the two fixes above.

## Related Issue(s)
