### PR TITLE
fix: Enable Subscriber to detect when messaging subscription is ended and re-register if needed.

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/SimpleInMemoryHistoricalBlockFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/SimpleInMemoryHistoricalBlockFacility.java
@@ -51,6 +51,10 @@ public class SimpleInMemoryHistoricalBlockFacility implements HistoricalBlockFac
         handleBlockItemsReceived(blockItems, true);
     }
 
+    public void handleBlockItemsReceived(BlockItems blockItems, final boolean sendNotification) {
+        handleBlockItemsReceived(blockItems, sendNotification, 2000, BlockSource.UNKNOWN);
+    }
+
     public void handleBlockItemsReceived(
             BlockItems blockItems, final boolean sendNotification, int priority, BlockSource source) {
         if (!disablePlugin.get()) {
@@ -83,9 +87,6 @@ public class SimpleInMemoryHistoricalBlockFacility implements HistoricalBlockFac
         }
     }
 
-    public void handleBlockItemsReceived(BlockItems blockItems, final boolean sendNotification) {
-        handleBlockItemsReceived(blockItems, sendNotification, 2000, BlockSource.UNKNOWN);
-    }
     /**
      * {@inheritDoc}
      */

--- a/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/DynamicBlockItemTest.java
+++ b/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/DynamicBlockItemTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
 import java.util.stream.IntStream;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockItemUnparsed.ItemOneOfType;
@@ -544,15 +545,15 @@ public class DynamicBlockItemTest {
                     true,
                     false));
         }
-
+        // Pause for 100 microseconds to let blocks get sent.
+        LockSupport.parkNanos(100_000L);
+        messagingService.stop();
         assertTrue(
                 allReceived.await(20, TimeUnit.SECONDS),
                 "No-backpressure handler did not receive all " + totalItems + " items");
         assertEquals(totalItems, receiveCount.get(), "Item count mismatch");
         assertEquals(
                 IntStream.range(0, totalItems).sum(), receiveSum.get(), "Item sum mismatch — some items were lost");
-
-        messagingService.stop();
     }
 
     /**

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
@@ -540,6 +540,13 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
         // Need to park here waiting for at least one entry on the queue, otherwise
         // we'll spin in the caller thread in an extreme form of spin wait.
         if (liveBlockQueue.isEmpty()) {
+            // Re-register the messaging handler if necessary.
+            // Use a CAS check to determine if we reregister
+            if (liveBlockHandler.canReregister()) {
+                blockNodeContext
+                        .blockMessaging()
+                        .registerNoBackpressureBlockItemHandler(liveBlockHandler, false, sessionContext.handlerName);
+            }
             // Wait briefly for a live block to be available.
             awaitNewLiveEntries();
         }
@@ -866,6 +873,7 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
 
         private final BlockingQueue<BlockItems> liveBlockQueue;
         private final AtomicLong latestLiveStreamBlock;
+        private final AtomicBoolean isRegisteredFlag;
         private final String clientId;
 
         private LiveBlockHandler(
@@ -875,24 +883,24 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
             this.liveBlockQueue = requireNonNull(liveBlockQueue);
             this.latestLiveStreamBlock = requireNonNull(latestLiveStreamBlock);
             this.clientId = clientId;
+            isRegisteredFlag = new AtomicBoolean(true);
+        }
+
+        public boolean canReregister() {
+            return isRegisteredFlag.compareAndSet(false, true);
         }
 
         @Override
         public void onTooFarBehindError() {
-            // Insert a signal to the session that it is "too far behind" live.
-            // Should not ever happen with this design.
-            LOGGER.log(Level.INFO, "Handler for {0} has fallen behind.", clientId);
+            // Mark this handler to be re-registered when the session is ready
+            // to swtich back to "live".
+            if (isRegisteredFlag.compareAndSet(true, false)) {
+                LOGGER.log(Level.INFO, "Handler for {0} has fallen behind.", clientId);
+            }
         }
 
         @Override
         public void handleBlockItemsReceived(@NonNull final BlockItems blockItems) {
-            // @todo(1673) consider to also add a check for:
-            //    blockItems.blockNumber() > latestLiveStreamBlock.get() && blockItems.isStartOfNewBlock()
-            //    because if this is not the start of a new block, the queue will be trimmed
-            //    this should improve accuracy when determining if we can fulfill the request, but
-            //    we should also be careful and think about how this change would affect the session
-            //    as a whole and we need to ensure that such a check is correct and make amends
-            //    elsewhere if needed.
             if (blockItems.blockNumber() > latestLiveStreamBlock.get()) {
                 latestLiveStreamBlock.set(blockItems.blockNumber());
             }

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberServicePluginTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberServicePluginTest.java
@@ -29,7 +29,6 @@ import org.hiero.block.node.app.fixtures.plugintest.GrpcPluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -851,8 +850,6 @@ class SubscriberServicePluginTest {
                      */
                     @Test
                     @DisplayName("Test Subscriber: Valid Request Live Stream From Live Then History")
-                    @Disabled(
-                            "@todo(1673) should not be failing, we fail because history not permitted, we think we jump ahead")
                     void testSuccessfulRequestLiveStreamFromLiveThenHistory() {
                         // First we create the blocks
                         final List<TestBlock> blocksZeroToTwo = TestBlockBuilder.generateBlocksInRange(0, 2);
@@ -876,8 +873,8 @@ class SubscriberServicePluginTest {
                         // now we need to stop the plugin to end the live stream request and
                         // receive the success status response
                         plugin.stop();
-                        final int expectedResponses = (2 * blocksZeroToTwo.size())
-                                + 1; // three with items and end of block, one with success status
+                        // two with items (because we start from block 1), one with success status
+                        final int expectedResponses = (blocksZeroToTwo.size() - 1) + 1;
                         // Assert responses count and status success
                         assertThat(fromPluginBytes)
                                 .hasSize(expectedResponses)
@@ -1219,6 +1216,9 @@ class SubscriberServicePluginTest {
                 final BlockItem last = actual.getLast();
             } else if (subscribeResponse.hasEndOfBlock()) {
                 assertEndOfBlock(subscribeResponse, currentBlockNumber);
+                currentBlockNumber = -1;
+            } else if (subscribeResponse.hasStatus()) {
+                // skip "Status" responses.
                 currentBlockNumber = -1;
             } else {
                 fail("Unexpected response type %s."


### PR DESCRIPTION
## Reviewer Notes
* Added functional code for onTooFarBehindError to record de-registration.
* Added code to re-register when needed, gated by a CAS check.
* Fixed a disabled test and re-enabled it.

## Related Issue(s)
 Fixes #1715
