### PR TITLE
fix(roster-bootstrap-rsa): resolve genesis era without the blocks API

### DIFF
--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
@@ -437,12 +437,12 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
     /// Converts a (from, to) timestamp pair to a [startBlock, endBlock] pair by querying the
     /// Mirror Node blocks API. Returns {@code null} if the block range cannot be determined.
     ///
-    /// Blank timestamps are treated as sentinels: blank {@code from} means genesis (startBlock=0)
-    /// with no API call; blank {@code to} means open-ended (endBlock=-1) with no API call.
+    /// Sentinels are resolved without an API call: a genesis {@code from} (see [#isGenesisFrom])
+    /// means startBlock=0; a blank {@code to} means open-ended (endBlock=-1).
     private long[] fetchBlockRange(final HttpClient client, final String from, final String to) {
         final long startBlock, endBlock;
-        if (from == null || from.isBlank()) {
-            startBlock = 0L; // no from-timestamp → treat as genesis
+        if (isGenesisFrom(from)) {
+            startBlock = 0L; // genesis address book → block 0, no blocks API call needed
             endBlock = -1L;
         } else {
             String query = to == null || to.isBlank()
@@ -460,6 +460,24 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
         }
 
         return new long[] {startBlock, endBlock};
+    }
+
+    /// Returns true if {@code from} denotes the genesis address book — either blank, or the Mirror
+    /// Node's near-epoch sentinel (e.g. "0.000000001") marking validity "from the beginning". Real
+    /// consensus timestamps are ~1.7e9 s, so any value below 1 s is treated as genesis.
+    ///
+    /// This lets the genesis era resolve to block 0 without the blocks API, which is required on
+    /// networks (e.g. solo) where the Mirror Node has no blocks until the Block Node — which needs
+    /// this roster to verify them — starts storing them.
+    private static boolean isGenesisFrom(final String from) {
+        if (from == null || from.isBlank()) {
+            return true;
+        }
+        try {
+            return Double.parseDouble(from) < 1.0;
+        } catch (final NumberFormatException e) {
+            return false;
+        }
     }
 
     private MirrorNodeBlocksResponse fetchAndParseBlocks(final HttpClient client, final String url) {

--- a/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
+++ b/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
@@ -2,6 +2,7 @@
 package org.hiero.block.node.roster.bootstrap.rsa;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hiero.block.api.RangedAddressBookHistory;
 import org.hiero.block.api.RangedNodeAddressBook;
@@ -322,6 +324,43 @@ class RsaRosterBootstrapPluginTest
             assertEquals("aabbcc", era0.nodeAddress().getFirst().rsaPubKey());
             assertEquals(0L, history.addressBooks().get(0).startBlock());
             assertEquals(-1L, history.addressBooks().get(0).endBlock()); // open-ended
+        }
+
+        @Test
+        @DisplayName("Genesis sentinel timestamp resolves to block 0 without calling the blocks API")
+        void genesisSentinelResolvesWithoutBlocksApi() {
+            // The Mirror Node reports the genesis address book's validity start as a near-epoch
+            // sentinel ("0.000000001"), not a blank timestamp. The genesis era must still resolve to
+            // startBlock=0 without the blocks API: on a fresh network /api/v1/blocks has no data until
+            // the Block Node — which needs this roster to verify blocks — starts storing them. Calling
+            // the blocks API here would skip the era and leave the roster empty (the regression).
+            final AtomicBoolean blocksApiCalled = new AtomicBoolean(false);
+            server.createContext("/api/v1/blocks", exchange -> {
+                blocksApiCalled.set(true);
+                final byte[] bytes = "{\"blocks\":[],\"links\":{\"next\":null}}".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, bytes.length);
+                try (var out = exchange.getResponseBody()) {
+                    out.write(bytes);
+                }
+            });
+            registerStaticHandler(
+                    "/api/v1/network/nodes",
+                    200,
+                    "{\"nodes\":[{\"node_id\":0,\"public_key\":\"aabbcc\",\"timestamp\":{\"from\":\"0.000000001\",\"to\":null}}],\"links\":{\"next\":null}}");
+
+            start(new RsaRosterBootstrapPlugin(), new SimpleInMemoryHistoricalBlockFacility(), serverConfig());
+            testThreadPoolManager.scheduledExecutor().executeSerially();
+
+            final RangedAddressBookHistory history = blockNodeContext.rangedAddressBookHistory();
+            assertNotNull(history);
+            assertEquals(1, history.addressBooks().size());
+            assertEquals(0L, history.addressBooks().getFirst().startBlock());
+            assertEquals(-1L, history.addressBooks().getFirst().endBlock()); // open-ended genesis
+            final NodeAddressBook era0 = history.addressBooks().getFirst().addressBook();
+            assertEquals(1, era0.nodeAddress().size());
+            assertEquals(0L, era0.nodeAddress().getFirst().nodeId());
+            assertEquals("aabbcc", era0.nodeAddress().getFirst().rsaPubKey());
+            assertFalse(blocksApiCalled.get(), "blocks API must not be called for the genesis era");
         }
 
         @Test


### PR DESCRIPTION

## Summary

The `single-wrb-rsa` solo-e2e job (`rsa-roster-verification`) has failed since #3070 with `roster_entries_loaded=0` — the Block Node verifies no blocks because the RSA roster never loads.

#3070's historical-era bootstrap resolves each era's block range via `/api/v1/blocks`. For the genesis era the Mirror Node reports `timestamp.from` as a near-epoch sentinel (`0.000000001`) rather than blank, so it isn't recognized as genesis and the plugin calls `/api/v1/blocks`. On a fresh network that endpoint is empty until the Block Node stores blocks — but the Block Node can't store blocks without the roster. The era is skipped, the roster stays empty, and every block fails RSA verification.

Fixes #3107 

## Test plan

- [x] Unit test: genesis sentinel builds a one-era roster at block 0 and never calls the blocks API (fails without the fix)
- [x] Local solo-e2e `single-wrb-rsa`, fixed plugin injected manually (the published SNAPSHOT lacks the fix, so it can't ride the normal deploy): roster loads — `roster_entries_loaded` 0 → 1, "RSA key map updated: 1/1 nodes loaded", zero `/blocks` calls
- [ ] Full green `rsa-roster-verification` on CI after merge republishes the `main` SNAPSHOT with the fix