### PR TITLE
feat: add block-verification to published projects in build.gradle.kts

### DIFF
--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     published(project(":roster-bootstrap-rsa"))
     published(project(":roster-bootstrap-tss"))
     published(project(":verification"))
+    published(project(":block-verification"))
 
     implementation(project(":app"))
     implementation(project(":simulator"))


### PR DESCRIPTION
## Reviewer Notes

This is needed so the plugin can be published to Maven and used by the deployment flow.

Fixes #3110 