### PR TITLE
feat: Defer ASF stored-block registration in TempArchiveUploadTask until multipart upload completes

### DIFF
--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/ArchiveKey.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/ArchiveKey.java
@@ -13,6 +13,14 @@ import java.util.List;
 /// round-trip `parse(format(groupStart, level), level) == groupStart` always holds.
 final class ArchiveKey {
 
+    /// Width, in characters, of each `/`-delimited path segment produced by [format] and consumed
+    /// by [parse] (and, for the segment count alone, by [StartupRecoveryTask#directoryDepth]).
+    static final int PATH_SEGMENT_WIDTH = 4;
+
+    /// Number of decimal digits `groupStart` is zero-padded to in [format]; `Long.MAX_VALUE` has 19
+    /// digits, so this fits any `long` block number and keeps S3's key ordering numeric.
+    static final int MAX_LONG_DIGITS = 19;
+
     private ArchiveKey() {}
 
     /// Formats the S3 object key for the tar group whose first block number is `groupStart`,
@@ -27,10 +35,11 @@ final class ArchiveKey {
     ///
     /// When `objectKeyPrefix` is non-empty the returned key is `{prefix}/{block-path}.tar`.
     static @NonNull String format(long groupStart, int groupingLevel, @NonNull String objectKeyPrefix) {
-        final String truncated = String.format("%019d", groupStart).substring(0, 19 - groupingLevel);
+        final String truncated =
+                String.format("%0" + MAX_LONG_DIGITS + "d", groupStart).substring(0, MAX_LONG_DIGITS - groupingLevel);
         final List<String> parts = new ArrayList<>();
-        for (int i = 0; i < truncated.length(); i += 4) {
-            parts.add(truncated.substring(i, Math.min(i + 4, truncated.length())));
+        for (int i = 0; i < truncated.length(); i += PATH_SEGMENT_WIDTH) {
+            parts.add(truncated.substring(i, Math.min(i + PATH_SEGMENT_WIDTH, truncated.length())));
         }
         parts.set(parts.size() - 1, String.valueOf(Long.parseLong(parts.getLast())));
         final String blockPath = String.join("/", parts) + ".tar";
@@ -75,7 +84,7 @@ final class ArchiveKey {
 
     /// Returns the width (number of characters) of the last path segment for a given grouping level.
     private static int lastSegmentWidth(int groupingLevel) {
-        final int width = (19 - groupingLevel) % 4;
-        return width == 0 ? 4 : width;
+        final int width = (MAX_LONG_DIGITS - groupingLevel) % PATH_SEGMENT_WIDTH;
+        return width == 0 ? PATH_SEGMENT_WIDTH : width;
     }
 }

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/ArchiveKey.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/ArchiveKey.java
@@ -17,9 +17,9 @@ final class ArchiveKey {
     /// by [parse] (and, for the segment count alone, by [StartupRecoveryTask#directoryDepth]).
     static final int PATH_SEGMENT_WIDTH = 4;
 
-    /// Number of decimal digits `groupStart` is zero-padded to in [format]; `Long.MAX_VALUE` has 19
-    /// digits, so this fits any `long` block number and keeps S3's key ordering numeric.
-    static final int MAX_LONG_DIGITS = 19;
+    /// Number of decimal digits `groupStart` is zero-padded to in [format]; this fits any `long`
+    /// block number and keeps S3's key ordering numeric.
+    static final int MAX_LONG_DIGITS = Long.toString(Long.MAX_VALUE).length();
 
     private ArchiveKey() {}
 

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
@@ -290,8 +290,9 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
 
     /// Drains completed [TempArchiveUploadTask] futures and updates the tracker.
     ///
-    /// [TempArchiveUploadTask] already calls `ApplicationStateFacility.addStoredBlockRange()` per
-    /// part, so no additional range registration is needed here.
+    /// [TempArchiveUploadTask] calls `ApplicationStateFacility.addStoredBlockRange()` once after
+    /// both the multipart upload and the meta file write succeed, so no additional range
+    /// registration is needed here.
     private void checkAndDrainTempUploadResults() {
         final Iterator<Map.Entry<Long, Future<TempArchiveEntry>>> it =
                 tempUploadFutures.entrySet().iterator();
@@ -470,7 +471,12 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                 if (result.currentGroupStart() != -1) {
                     currentGroupStart = result.currentGroupStart();
                     nextBlockToQueue = result.uploadId() != null ? result.nextBlockNumber() : currentGroupStart;
-                    if (nextBlockToQueue > 0) {
+                    if (result.completedRanges() != null) {
+                        for (final LongRange range : result.completedRanges()) {
+                            context.applicationStateFacility().addStoredBlockRange(range);
+                        }
+                    } else if (nextBlockToQueue > 0) {
+                        // Case 2 (resume): completed archives unknown; fall back to broad range
                         context.applicationStateFacility().addStoredBlockRange(new LongRange(0, nextBlockToQueue - 1));
                     }
                     currentBlockQueue = new LinkedBlockingQueue<>();

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
@@ -472,9 +472,8 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                     currentGroupStart = result.currentGroupStart();
                     nextBlockToQueue = result.uploadId() != null ? result.nextBlockNumber() : currentGroupStart;
                     if (result.completedRanges() != null) {
-                        for (final LongRange range : result.completedRanges()) {
-                            context.applicationStateFacility().addStoredBlockRange(range);
-                        }
+                        result.completedRanges().streamRanges().forEach(range -> context.applicationStateFacility()
+                                .addStoredBlockRange(range));
                     } else if (nextBlockToQueue > 0) {
                         // Case 2 (resume): completed archives unknown; fall back to broad range
                         context.applicationStateFacility().addStoredBlockRange(new LongRange(0, nextBlockToQueue - 1));

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/RecoveryResult.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/RecoveryResult.java
@@ -2,6 +2,7 @@
 package org.hiero.block.node.cloud.storage.archive;
 
 import java.util.List;
+import org.hiero.block.node.spi.historicalblocks.LongRange;
 
 /// The outcome of a [StartupRecoveryTask] run.
 ///
@@ -32,6 +33,11 @@ import java.util.List;
 ///                          recovery paths that skip the temporary-archive scan
 /// @param lastHandedOffBlock the last block number handed off to any upload task before the
 ///                           restart, or `-1` when nothing was archived yet (fresh start)
+/// @param completedRanges   one [LongRange] per completed tar archive found during startup, so
+///                          that [CloudStorageArchivePlugin] can register them individually
+///                          instead of a single broad `[0, nextBlockToQueue-1]` range;
+///                          `null` when the recovery path does not enumerate completed archives
+///                          (Case 2 resume path)
 record RecoveryResult(
         long currentGroupStart,
         String uploadId,
@@ -39,4 +45,5 @@ record RecoveryResult(
         long nextBlockNumber,
         byte[] trailingBytes,
         List<TempArchiveEntry> tempArchives,
-        long lastHandedOffBlock) {}
+        long lastHandedOffBlock,
+        List<LongRange> completedRanges) {}

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/RecoveryResult.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/RecoveryResult.java
@@ -2,7 +2,7 @@
 package org.hiero.block.node.cloud.storage.archive;
 
 import java.util.List;
-import org.hiero.block.node.spi.historicalblocks.LongRange;
+import org.hiero.block.node.base.ranges.ConcurrentLongRangeSet;
 
 /// The outcome of a [StartupRecoveryTask] run.
 ///
@@ -33,11 +33,11 @@ import org.hiero.block.node.spi.historicalblocks.LongRange;
 ///                          recovery paths that skip the temporary-archive scan
 /// @param lastHandedOffBlock the last block number handed off to any upload task before the
 ///                           restart, or `-1` when nothing was archived yet (fresh start)
-/// @param completedRanges   one [LongRange] per completed tar archive found during startup, so
-///                          that [CloudStorageArchivePlugin] can register them individually
-///                          instead of a single broad `[0, nextBlockToQueue-1]` range;
-///                          `null` when the recovery path does not enumerate completed archives
-///                          (Case 2 resume path)
+/// @param completedRanges   the ranges of completed tar archives found during startup, so that
+///                          [CloudStorageArchivePlugin] can register the actual coverage
+///                          (including any gaps) instead of a single broad
+///                          `[0, nextBlockToQueue-1]` range; `null` when the recovery path does
+///                          not enumerate completed archives (Case 2 resume path)
 record RecoveryResult(
         long currentGroupStart,
         String uploadId,
@@ -46,4 +46,4 @@ record RecoveryResult(
         byte[] trailingBytes,
         List<TempArchiveEntry> tempArchives,
         long lastHandedOffBlock,
-        List<LongRange> completedRanges) {}
+        ConcurrentLongRangeSet completedRanges) {}

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTask.java
@@ -154,31 +154,59 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
         return recoveryResult;
     }
 
-    /// Pages through ALL objects under the configured prefix (excluding `tmp/`) and returns
-    /// the sorted list of final tar keys -- those that do not end with `.tmp` or `.meta`.
+    /// Walks the `/`-delimited directory hierarchy under the configured prefix (excluding `tmp/`)
+    /// and returns the list of all final tar keys.
     ///
-    /// O(N/1000) list calls for N completed archives. The full list is required to populate
-    /// [RecoveryResult#completedRanges()]; a faster O(depth) last-key traversal using
-    /// delimiter listing would suffice for `currentGroupStart` alone but not for per-range
-    /// accuracy.
+    /// [ArchiveKey#format] lays out each group as `directoryDepth` path segments followed by a
+    /// leaf segment folded into the object name (e.g. `0000/0000/0000/0001/23.tar`). This walks
+    /// [directoryDepth] delimiter listings (returning `CommonPrefixes`, one per branch) before
+    /// issuing a single flat listing per leaf directory to read the actual tar keys, bounding the
+    /// list-call count by O(levels x branches) rather than the total number of completed archives,
+    /// with no loss of per-range accuracy since every tar key is still read from a leaf listing.
     private List<String> findAllTarKeys(S3Client s3) throws S3ResponseException, IOException {
         final String objectKeyPrefix = config.objectKeyPrefix();
         final String excludedPrefix = TempArchiveKey.tmpPrefix(objectKeyPrefix);
         final String rootPrefix = objectKeyPrefix.isEmpty() ? "" : objectKeyPrefix + "/";
         final List<String> tarKeys = new ArrayList<>();
+        collectTarKeys(s3, rootPrefix, directoryDepth(), excludedPrefix, tarKeys);
+        return tarKeys;
+    }
+
+    /// Number of `/`-delimited directory levels [ArchiveKey#format] emits before the leaf segment
+    /// that is folded into the object name, for the configured [CloudStorageArchiveConfig#groupingLevel()].
+    private int directoryDepth() {
+        final int digitCount = 19 - config.groupingLevel();
+        final int segmentCount = (digitCount + 3) / 4;
+        return segmentCount - 1;
+    }
+
+    /// Recursively descends `remainingDepth` levels of `/`-delimited directories starting at
+    /// [prefix], collecting completed tar keys into [out]. At `remainingDepth == 0`, [prefix] is a
+    /// leaf directory: a flat (non-delimited) listing reads its objects directly, giving the exact
+    /// tar keys without ever walking sibling leaf directories.
+    private void collectTarKeys(S3Client s3, String prefix, int remainingDepth, String excludedPrefix, List<String> out)
+            throws S3ResponseException, IOException {
+        final String delimiter = remainingDepth == 0 ? null : "/";
         String token = null;
         boolean hasMore = true;
         while (hasMore) {
-            final S3Client.ListPage page = s3.listObjectsPage(rootPrefix, token, null, MAX_LIST_RESULTS);
-            for (final String key : page.keys()) {
-                if (!key.startsWith(excludedPrefix) && !key.endsWith(".tmp") && !key.endsWith(".meta")) {
-                    tarKeys.add(key);
+            final S3Client.ListPage page = s3.listObjectsPage(prefix, token, delimiter, MAX_LIST_RESULTS);
+            if (remainingDepth == 0) {
+                for (final String key : page.keys()) {
+                    if (key.endsWith(".tar")) {
+                        out.add(key);
+                    }
+                }
+            } else {
+                for (final String childPrefix : page.keys()) {
+                    if (!childPrefix.equals(excludedPrefix)) {
+                        collectTarKeys(s3, childPrefix, remainingDepth - 1, excludedPrefix, out);
+                    }
                 }
             }
             token = page.continuationToken();
             hasMore = token != null;
         }
-        return tarKeys;
     }
 
     /// Case 2: one hanging upload — complete it to materialize a readable S3 object, start a fresh

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTask.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
+import org.hiero.block.node.spi.historicalblocks.LongRange;
 
 /// Determines where [CloudStorageArchivePlugin] should resume uploading after a restart.
 ///
@@ -103,7 +104,8 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
                 result.nextBlockNumber(),
                 result.trailingBytes(),
                 tempArchives,
-                lastHandedOffBlock);
+                lastHandedOffBlock,
+                result.completedRanges());
     }
 
     /// Filters a raw [S3Client#listMultipartUploads] result to only the **regular** (non-temp)
@@ -122,84 +124,61 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
                 .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    /// Case 1: no hanging uploads — find the last completed tar and return the start of the next group.
+    /// Case 1: no hanging uploads — enumerate all completed tar archives and return the start of
+    /// the next group after the last one.
     private RecoveryResult recoverFromCompletedObjects(S3Client s3) throws S3ResponseException, IOException {
         final RecoveryResult recoveryResult;
-        final String lastKey = findLastKey(s3);
-        if (lastKey == null) {
+        final List<String> allTarKeys = findAllTarKeys(s3);
+        if (allTarKeys.isEmpty()) {
             LOGGER.log(TRACE, "No prior state found in S3 bucket, starting fresh");
-            recoveryResult = new RecoveryResult(-1, null, null, 0, null, null, -1);
+            recoveryResult = new RecoveryResult(-1, null, null, 0, null, null, -1, List.of());
         } else {
             final long groupSize = Math.powExact(10, config.groupingLevel());
-            final long groupStart = ArchiveKey.parse(lastKey, config.groupingLevel(), config.objectKeyPrefix());
+            final List<LongRange> completedRanges = new ArrayList<>(allTarKeys.size());
+            long maxGroupStart = -1;
+            for (final String key : allTarKeys) {
+                final long groupStart = ArchiveKey.parse(key, config.groupingLevel(), config.objectKeyPrefix());
+                completedRanges.add(new LongRange(groupStart, groupStart + groupSize - 1));
+                if (groupStart > maxGroupStart) {
+                    maxGroupStart = groupStart;
+                }
+            }
             LOGGER.log(
                     TRACE,
                     "Last completed tar group starts at {0}, resuming from {1}",
-                    groupStart,
-                    groupStart + groupSize);
-            recoveryResult = new RecoveryResult(groupStart + groupSize, null, null, 0, null, null, -1);
+                    maxGroupStart,
+                    maxGroupStart + groupSize);
+            recoveryResult =
+                    new RecoveryResult(maxGroupStart + groupSize, null, null, 0, null, null, -1, completedRanges);
         }
         return recoveryResult;
     }
 
-    /// Right-hand path traversal: descends the virtual S3 directory tree by always following
-    /// the alphabetically last common prefix at each level, skipping the `tmp/` virtual directory,
-    /// then pages through the leaf objects to return the key of the last one, or `null` if the
-    /// bucket is empty.
+    /// Pages through ALL objects under the configured prefix (excluding `tmp/`) and returns
+    /// the sorted list of final tar keys -- those that do not end with `.tmp` or `.meta`.
     ///
-    /// When [CloudStorageArchiveConfig#objectKeyPrefix()] is configured the traversal is rooted
-    /// at `{prefix}/` so that sibling prefixes in the same bucket are never visited.
-    private String findLastKey(S3Client s3) throws S3ResponseException, IOException {
+    /// O(N/1000) list calls for N completed archives. The full list is required to populate
+    /// [RecoveryResult#completedRanges()]; a faster O(depth) last-key traversal using
+    /// delimiter listing would suffice for `currentGroupStart` alone but not for per-range
+    /// accuracy.
+    private List<String> findAllTarKeys(S3Client s3) throws S3ResponseException, IOException {
         final String objectKeyPrefix = config.objectKeyPrefix();
         final String excludedPrefix = TempArchiveKey.tmpPrefix(objectKeyPrefix);
-        String currentPrefix = objectKeyPrefix.isEmpty() ? "" : objectKeyPrefix + "/";
-        String lastPrefix = findLastCommonPrefixExcluding(s3, currentPrefix, excludedPrefix);
-        while (lastPrefix != null) {
-            currentPrefix = lastPrefix;
-            lastPrefix = findLastCommonPrefixExcluding(s3, currentPrefix, excludedPrefix);
-        }
-        return findLastObject(s3, currentPrefix);
-    }
-
-    /// Pages through all common prefixes under [prefix] and returns the alphabetically last one
-    /// that is not equal to [excluded], or `null` if there are no qualifying common prefixes.
-    private String findLastCommonPrefixExcluding(S3Client s3, String prefix, String excluded)
-            throws S3ResponseException, IOException {
-        String lastPrefix = null;
+        final String rootPrefix = objectKeyPrefix.isEmpty() ? "" : objectKeyPrefix + "/";
+        final List<String> tarKeys = new ArrayList<>();
         String token = null;
         boolean hasMore = true;
         while (hasMore) {
-            final S3Client.ListPage page = s3.listObjectsPage(prefix, token, "/", MAX_LIST_RESULTS);
-            for (final String candidate : page.keys()) {
-                if (!candidate.equals(excluded)) {
-                    lastPrefix = candidate;
+            final S3Client.ListPage page = s3.listObjectsPage(rootPrefix, token, null, MAX_LIST_RESULTS);
+            for (final String key : page.keys()) {
+                if (!key.startsWith(excludedPrefix) && !key.endsWith(".tmp") && !key.endsWith(".meta")) {
+                    tarKeys.add(key);
                 }
             }
             token = page.continuationToken();
             hasMore = token != null;
         }
-        return lastPrefix;
-    }
-
-    /// Pages through all objects under [prefix] and returns the key of the alphabetically last one,
-    /// or `null` if the prefix contains no objects.
-    private String findLastObject(S3Client s3, String prefix) throws S3ResponseException, IOException {
-        String lastKey = null;
-        String token = null;
-        boolean hasMore = true;
-        while (hasMore) {
-            final S3Client.ListPage page = s3.listObjectsPage(prefix, token, null, MAX_LIST_RESULTS);
-            if (!page.keys().isEmpty()) {
-                final String candidate = page.keys().getLast();
-                // Filter out any .tmp or .meta objects that might appear at the leaf level
-                if (!candidate.endsWith(".tmp") && !candidate.endsWith(".meta")) {
-                    lastKey = candidate;
-                }
-            }
-            token = page.continuationToken();
-            hasMore = token != null;
-        }
-        return lastKey;
+        return tarKeys;
     }
 
     /// Case 2: one hanging upload — complete it to materialize a readable S3 object, start a fresh
@@ -235,7 +214,8 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
                         scanResult.blockNumber(),
                         scanResult.trailingBytes(),
                         null,
-                        -1);
+                        -1,
+                        null);
             } else {
                 LOGGER.log(DEBUG, "No block start found in any part for key {0}; aborting", key);
                 s3.abortMultipartUpload(key, newUploadId);

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTask.java
@@ -175,8 +175,8 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
     /// Number of `/`-delimited directory levels [ArchiveKey#format] emits before the leaf segment
     /// that is folded into the object name, for the configured [CloudStorageArchiveConfig#groupingLevel()].
     private int directoryDepth() {
-        final int digitCount = 19 - config.groupingLevel();
-        final int segmentCount = (digitCount + 3) / 4;
+        final int digitCount = ArchiveKey.MAX_LONG_DIGITS - config.groupingLevel();
+        final int segmentCount = (digitCount + ArchiveKey.PATH_SEGMENT_WIDTH - 1) / ArchiveKey.PATH_SEGMENT_WIDTH;
         return segmentCount - 1;
     }
 

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTask.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
-import org.hiero.block.node.spi.historicalblocks.LongRange;
+import org.hiero.block.node.base.ranges.ConcurrentLongRangeSet;
 
 /// Determines where [CloudStorageArchivePlugin] should resume uploading after a restart.
 ///
@@ -131,14 +131,14 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
         final List<String> allTarKeys = findAllTarKeys(s3);
         if (allTarKeys.isEmpty()) {
             LOGGER.log(TRACE, "No prior state found in S3 bucket, starting fresh");
-            recoveryResult = new RecoveryResult(-1, null, null, 0, null, null, -1, List.of());
+            recoveryResult = new RecoveryResult(-1, null, null, 0, null, null, -1, new ConcurrentLongRangeSet());
         } else {
             final long groupSize = Math.powExact(10, config.groupingLevel());
-            final List<LongRange> completedRanges = new ArrayList<>(allTarKeys.size());
+            final ConcurrentLongRangeSet completedRanges = new ConcurrentLongRangeSet();
             long maxGroupStart = -1;
             for (final String key : allTarKeys) {
                 final long groupStart = ArchiveKey.parse(key, config.groupingLevel(), config.objectKeyPrefix());
-                completedRanges.add(new LongRange(groupStart, groupStart + groupSize - 1));
+                completedRanges.add(groupStart, groupStart + groupSize - 1);
                 if (groupStart > maxGroupStart) {
                     maxGroupStart = groupStart;
                 }

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/TempArchiveKey.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/TempArchiveKey.java
@@ -5,9 +5,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 /// Encodes and decodes S3 object keys for temporary tar archives.
 ///
-/// Temporary archives live under a `tmp/` virtual directory so that [StartupRecoveryTask]'s
-/// [StartupRecoveryTask#findLastKey] traversal can exclude them by skipping the `tmp/` common
-/// prefix.  Two companion objects are created per archive segment:
+/// Temporary archives live under a `tmp/` virtual directory so that [StartupRecoveryTask]
+/// can exclude them by skipping the `tmp/` common prefix.  Two companion objects are created per archive segment:
 ///
 /// - **Tar object** — `{prefix}/tmp/{firstBlock:019d}.tmp` — the raw tar content.
 /// - **Meta object** — `{prefix}/tmp/{firstBlock:019d}.meta` — a single-line text file whose

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTask.java
@@ -86,7 +86,7 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
                     s3.createMultipartUpload(s3Key, config.storageClass().name(), S3UploadUtils.CONTENT_TYPE);
             final List<String> etags = new ArrayList<>();
             byte[] buffer = new byte[0];
-            long lastNotifiedBlock = firstBlock - 1;
+            long totalBytes = 0;
             long currentBlock = firstBlock;
             long lastProcessedBlock = firstBlock - 1;
             BlockSource lastSource = BlockSource.UNKNOWN;
@@ -107,17 +107,7 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
                         final S3UploadUtils.SplitBuffer split = S3UploadUtils.splitAtPartSize(buffer, partSizeBytes);
                         doUploadPart(split.part(), s3, uploadId, etags);
                         buffer = split.remainder();
-                        // Design assumption (matches BlockUploadTask): notifications are sent per
-                        // S3 part, not per completed archive. If lastProcessedBlock's tar bytes
-                        // straddle a part boundary, the trailing portion is still in the buffer
-                        // and will be uploaded later — but the block is declared persisted here.
-                        blockMessaging.sendBlockPersisted(
-                                new PersistedNotification(lastProcessedBlock, true, 1_000, lastSource));
-                        applicationStateFacility.addStoredBlockRange(
-                                new LongRange(lastNotifiedBlock + 1, lastProcessedBlock));
-                        metricsHolder.blocksWritten().increment(lastProcessedBlock - lastNotifiedBlock);
-                        metricsHolder.storedBytes().increment(partSizeBytes);
-                        lastNotifiedBlock = lastProcessedBlock;
+                        totalBytes += partSizeBytes;
                     }
                 } catch (InterruptedException e) {
                     LOGGER.log(TRACE, "Temp archive upload task interrupted for key {0}", s3Key, e);
@@ -132,27 +122,26 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
 
             final long lastBlock = lastProcessedBlock;
 
-            // When buffer is empty, the last block's bytes landed exactly on a part boundary and
-            // were already notified and range-registered inside the loop above — nothing to do.
             if (buffer.length > 0) {
                 try {
                     doUploadPart(buffer, s3, uploadId, etags);
-                    blockMessaging.sendBlockPersisted(new PersistedNotification(lastBlock, true, 1_000, lastSource));
-                    applicationStateFacility.addStoredBlockRange(new LongRange(lastNotifiedBlock + 1, lastBlock));
-                    metricsHolder.blocksWritten().increment(lastBlock - lastNotifiedBlock);
-                    metricsHolder.storedBytes().increment(buffer.length);
+                    totalBytes += buffer.length;
                 } catch (S3ResponseException | IOException e) {
                     S3UploadUtils.abortQuietly(s3, s3Key, uploadId);
-                    blockMessaging.sendBlockPersisted(
-                            new PersistedNotification(lastNotifiedBlock + 1, false, 1_000, lastSource));
+                    blockMessaging.sendBlockPersisted(new PersistedNotification(firstBlock, false, 1_000, lastSource));
                     LOGGER.log(INFO, "Failed to upload final temp archive part for key {0}", s3Key, e);
                     throw e;
                 }
             }
 
-            // If this throws after the success notification above, the result is a false-persisted block; accepted by
-            // design, same as BlockUploadTask.
-            doCompleteMultipartUpload(s3, s3Key, uploadId, etags);
+            try {
+                doCompleteMultipartUpload(s3, s3Key, uploadId, etags);
+            } catch (S3ResponseException | IOException e) {
+                S3UploadUtils.abortQuietly(s3, s3Key, uploadId);
+                blockMessaging.sendBlockPersisted(new PersistedNotification(firstBlock, false, 1_000, lastSource));
+                LOGGER.log(INFO, "Failed to complete temp archive multipart upload for key {0}", s3Key, e);
+                throw e;
+            }
             LOGGER.log(
                     TRACE,
                     "Completed temp archive upload for key {0}, blocks [{1}, {2}]",
@@ -161,8 +150,22 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
                     lastBlock);
 
             final String metaKey = TempArchiveKey.formatMeta(firstBlock, config.objectKeyPrefix());
-            doUploadTextFile(s3, metaKey, config.storageClass().name(), String.valueOf(lastBlock));
+            try {
+                doUploadTextFile(s3, metaKey, config.storageClass().name(), String.valueOf(lastBlock));
+            } catch (S3ResponseException | IOException e) {
+                LOGGER.log(INFO, "Failed to write temp archive meta {0}, tar is already committed", metaKey, e);
+                blockMessaging.sendBlockPersisted(new PersistedNotification(lastBlock, true, 1_000, lastSource));
+                applicationStateFacility.addStoredBlockRange(new LongRange(firstBlock, lastBlock));
+                metricsHolder.blocksWritten().increment(lastBlock - firstBlock + 1);
+                metricsHolder.storedBytes().increment(totalBytes);
+                throw e;
+            }
             LOGGER.log(TRACE, "Wrote temp archive meta {0}", metaKey);
+
+            blockMessaging.sendBlockPersisted(new PersistedNotification(lastBlock, true, 1_000, lastSource));
+            applicationStateFacility.addStoredBlockRange(new LongRange(firstBlock, lastBlock));
+            metricsHolder.blocksWritten().increment(lastBlock - firstBlock + 1);
+            metricsHolder.storedBytes().increment(totalBytes);
 
             return new TempArchiveEntry(s3Key, firstBlock, lastBlock, null);
         }

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTaskTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import org.hiero.block.node.app.fixtures.blocks.TestBlock;
 import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
+import org.hiero.block.node.spi.historicalblocks.LongRange;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -132,6 +133,8 @@ class StartupRecoveryTaskTest {
         assertThat(result.uploadId()).isNull();
         assertThat(result.trailingBytes()).isNull();
         assertThat(result.lastHandedOffBlock()).isEqualTo(-1L);
+        assertThat(result.completedRanges()).isNotNull();
+        assertThat(result.completedRanges()).isEmpty();
     }
 
     /// Verifies that a completed tar for the first group causes recovery to return the start of
@@ -185,9 +188,46 @@ class StartupRecoveryTaskTest {
         assertThat(result.lastHandedOffBlock()).isEqualTo(groupSize * 3 - 1);
     }
 
+    /// Verifies that recovery returns the correct next group start when more than ten groups are
+    /// completed in the same S3 "folder", exercising the case where [ArchiveKey#format] strips
+    /// leading zeros from the last path segment so that lexicographic order diverges from numeric
+    /// order (e.g. `10.tar` sorts before `2.tar` through `9.tar` in S3's UTF-8 binary ordering).
+    ///
+    /// With [GROUPING_LEVEL] = 1 and groupSize = 10, eleven completed groups span
+    /// groupStart = 0, 10, 20, ..., 100.  The 11th key is `...0000/10.tar` which S3 places between
+    /// `...0000/1.tar` and `...0000/2.tar`, so naively calling `List#getLast()` on the S3-sorted
+    /// list would return `...0000/9.tar` (groupStart 90) and yield the wrong `currentGroupStart`
+    /// of 100 instead of 110.
+    @Test
+    @DisplayName("Eleven completed tar groups: recovery uses numeric max, not S3 lexicographic last")
+    void elevenCompletedTarGroupsReturnNextGroupStart() throws Exception {
+        final long groupSize = Math.powExact(10, GROUPING_LEVEL);
+        final int groupCount = 11;
+        try (S3Client s3 = openS3Client()) {
+            for (int g = 0; g < groupCount; g++) {
+                final long groupStart = (long) g * groupSize;
+                final String key = ArchiveKey.format(groupStart, GROUPING_LEVEL, "");
+                final List<TestBlock> blocks =
+                        TestBlockBuilder.generateBlocksInRange((int) groupStart, (int) (groupStart + groupSize - 1));
+                final String uploadId =
+                        s3.createMultipartUpload(key, config.storageClass().name(), CONTENT_TYPE);
+                final String etag = s3.multipartUploadPart(key, uploadId, 1, buildTarBytes(blocks));
+                s3.completeMultipartUpload(key, uploadId, List.of(etag));
+            }
+        }
+
+        final RecoveryResult result = new StartupRecoveryTask(config).call();
+
+        assertThat(result.currentGroupStart()).isEqualTo(groupSize * groupCount);
+        assertThat(result.uploadId()).isNull();
+        assertThat(result.trailingBytes()).isNull();
+        assertThat(result.lastHandedOffBlock()).isEqualTo(groupSize * groupCount - 1);
+        assertThat(result.completedRanges()).hasSize(groupCount);
+    }
+
     /// Verifies that when completed tars live in two different 4th-level S3 "folders"
-    /// (i.e. the key prefix before the last segment differs), [findLastKey] still correctly
-    /// navigates to the alphabetically last prefix and returns the right group start.
+    /// (i.e. the key prefix before the last segment differs), recovery still correctly
+    /// identifies the alphabetically last object and returns the right group start.
     ///
     /// With [GROUPING_LEVEL] = 1 and groupSize = 10:
     ///  - `start = 0`    → key `"0000/0000/0000/0000/0.tar"` (4th segment `0000`)
@@ -233,7 +273,7 @@ class StartupRecoveryTaskTest {
     /// configured one (simulating a shared bucket with e.g. `hiero/mainnet` and `hiero/testnet`):
     ///
     /// - The completed-object traversal stays inside the configured prefix and returns the correct
-    ///   [RecoveryResult#currentGroupStart()] (fixing the `findLastKey` bug).
+    ///   [RecoveryResult#currentGroupStart()] (the completed-object traversal stays inside the configured prefix).
     /// - The sibling's hanging upload is not counted in `totalUploads` and is not aborted (fixing
     ///   the `listMultipartUploads` bucket-wide scan bug).
     @Test
@@ -318,7 +358,7 @@ class StartupRecoveryTaskTest {
     /// value and the bucket contains a completed tar only under that prefix, recovery correctly
     /// traverses the prefixed path and returns the start of the next group.
     ///
-    /// This is the simplest end-to-end exercise of [StartupRecoveryTask#findLastKey] with a prefix:
+    /// This is the simplest end-to-end exercise of prefixed recovery:
     /// no sibling, just one completed tar and an assertion on [RecoveryResult#currentGroupStart()].
     @Test
     @DisplayName("Completed tar under configured prefix: recovery returns the start of the next group")
@@ -685,15 +725,15 @@ class StartupRecoveryTaskTest {
     }
 
     /// Verifies that when the bucket contains both a completed regular `.tar` and objects under
-    /// `tmp/`, [findLastKey] excludes the `tmp/` virtual directory and returns the correct
+    /// `tmp/`, recovery excludes the `tmp/` virtual directory and returns the correct
     /// [RecoveryResult#currentGroupStart()] based on the completed regular tar.
     ///
-    /// With groupSize=10, a completed tar for group 0 (blocks 0–9) produces
+    /// With groupSize=10, a completed tar for group 0 (blocks 0-9) produces
     /// [RecoveryResult#currentGroupStart()] == 10.  The presence of `.meta` objects under `tmp/`
-    /// must not distract [findLastKey] into the `tmp/` subtree and produce a wrong group start.
+    /// must not cause recovery to return a wrong group start.
     @Test
-    @DisplayName("findLastKey excludes the tmp/ directory: regular tar still found correctly")
-    void findLastKeyIgnoresTmpDirectory() throws Exception {
+    @DisplayName("Recovery ignores tmp/ objects: regular tar still found correctly")
+    void recoveryIgnoresTmpObjects() throws Exception {
         final long groupSize = Math.powExact(10, GROUPING_LEVEL);
         final String regularKey = ArchiveKey.format(0, GROUPING_LEVEL, "");
 
@@ -708,7 +748,7 @@ class StartupRecoveryTaskTest {
                     buildTarBytes(TestBlockBuilder.generateBlocksInRange(0, (int) groupSize - 1)));
             s3.completeMultipartUpload(regularKey, uploadId, List.of(etag));
 
-            // Some objects under tmp/ — these must not influence findLastKey.
+            // Some objects under tmp/ — these must not influence recovery.
             final String metaKey = TempArchiveKey.formatMeta(0, config.objectKeyPrefix());
             final String tarKey = TempArchiveKey.formatTar(0, config.objectKeyPrefix());
             s3.uploadTextFile(tarKey, config.storageClass().name(), "dummy");
@@ -726,6 +766,58 @@ class StartupRecoveryTaskTest {
         assertThat(result.tempArchives().getFirst().lastBlock()).isEqualTo(9L);
         // base = groupSize - 1 = 9; temp archive lastBlock = 9 → max = 9.
         assertThat(result.lastHandedOffBlock()).isEqualTo(groupSize - 1);
+    }
+
+    /// Verifies that [StartupRecoveryTask] enumerates all completed tar archives and returns a
+    /// [RecoveryResult#completedRanges()] list with one [LongRange] per archive.
+    ///
+    /// Two distinct completed tar archives are planted (groups 0 and 1).  After recovery,
+    /// [RecoveryResult#completedRanges()] must contain exactly two entries with the correct
+    /// `[groupStart, groupStart + groupSize - 1]` ranges.
+    @Test
+    @DisplayName("Multiple completed archives: completedRanges contains one LongRange per archive")
+    void multipleCompletedArchivesReturnCompletedRanges() throws Exception {
+        final long groupSize = Math.powExact(10, GROUPING_LEVEL);
+        try (S3Client s3 = openS3Client()) {
+            for (int g = 0; g < 2; g++) {
+                final long groupStart = (long) g * groupSize;
+                final String key = ArchiveKey.format(groupStart, GROUPING_LEVEL, "");
+                final List<TestBlock> blocks =
+                        TestBlockBuilder.generateBlocksInRange((int) groupStart, (int) (groupStart + groupSize - 1));
+                final String uploadId =
+                        s3.createMultipartUpload(key, config.storageClass().name(), CONTENT_TYPE);
+                final String etag = s3.multipartUploadPart(key, uploadId, 1, buildTarBytes(blocks));
+                s3.completeMultipartUpload(key, uploadId, List.of(etag));
+            }
+        }
+
+        final RecoveryResult result = new StartupRecoveryTask(config).call();
+
+        assertThat(result.completedRanges()).isNotNull();
+        assertThat(result.completedRanges()).hasSize(2);
+        assertThat(result.completedRanges())
+                .containsExactlyInAnyOrder(
+                        new LongRange(0, groupSize - 1), new LongRange(groupSize, groupSize * 2 - 1));
+    }
+
+    /// Verifies that a single hanging multipart upload (Case 2) returns [RecoveryResult#completedRanges()]
+    /// == `null`, since completed archives are not enumerated on the resume path.
+    @Test
+    @DisplayName("Single hanging upload (Case 2): completedRanges is null")
+    void singleHangingUploadReturnsNullCompletedRanges() throws Exception {
+        final List<TestBlock> blocks = TestBlockBuilder.generateBlocksInRange(0, 4);
+        final String key = ArchiveKey.format(0, GROUPING_LEVEL, "");
+        final byte[] partBytes = buildTarBytes(blocks);
+        try (S3Client s3 = openS3Client()) {
+            final String uploadId =
+                    s3.createMultipartUpload(key, config.storageClass().name(), CONTENT_TYPE);
+            s3.multipartUploadPart(key, uploadId, 1, partBytes);
+        }
+
+        final RecoveryResult result = new StartupRecoveryTask(config).call();
+
+        assertThat(result.uploadId()).isNotNull();
+        assertThat(result.completedRanges()).isNull();
     }
 
     private S3Client openS3Client() throws Exception {

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTaskTest.java
@@ -134,7 +134,7 @@ class StartupRecoveryTaskTest {
         assertThat(result.trailingBytes()).isNull();
         assertThat(result.lastHandedOffBlock()).isEqualTo(-1L);
         assertThat(result.completedRanges()).isNotNull();
-        assertThat(result.completedRanges()).isEmpty();
+        assertThat(result.completedRanges().streamRanges()).isEmpty();
     }
 
     /// Verifies that a completed tar for the first group causes recovery to return the start of
@@ -222,7 +222,9 @@ class StartupRecoveryTaskTest {
         assertThat(result.uploadId()).isNull();
         assertThat(result.trailingBytes()).isNull();
         assertThat(result.lastHandedOffBlock()).isEqualTo(groupSize * groupCount - 1);
-        assertThat(result.completedRanges()).hasSize(groupCount);
+        // The eleven groups are contiguous, so ConcurrentLongRangeSet merges them into one range.
+        assertThat(result.completedRanges().streamRanges())
+                .containsExactly(new LongRange(0, groupSize * groupCount - 1));
     }
 
     /// Verifies that when completed tars live in two different 4th-level S3 "folders"
@@ -769,13 +771,12 @@ class StartupRecoveryTaskTest {
     }
 
     /// Verifies that [StartupRecoveryTask] enumerates all completed tar archives and returns a
-    /// [RecoveryResult#completedRanges()] list with one [LongRange] per archive.
+    /// [RecoveryResult#completedRanges()] covering exactly the completed blocks.
     ///
-    /// Two distinct completed tar archives are planted (groups 0 and 1).  After recovery,
-    /// [RecoveryResult#completedRanges()] must contain exactly two entries with the correct
-    /// `[groupStart, groupStart + groupSize - 1]` ranges.
+    /// Two distinct completed tar archives are planted (groups 0 and 1).  Since the two groups
+    /// are contiguous, [ConcurrentLongRangeSet] merges them into a single range spanning both.
     @Test
-    @DisplayName("Multiple completed archives: completedRanges contains one LongRange per archive")
+    @DisplayName("Multiple completed archives: completedRanges covers both archives")
     void multipleCompletedArchivesReturnCompletedRanges() throws Exception {
         final long groupSize = Math.powExact(10, GROUPING_LEVEL);
         try (S3Client s3 = openS3Client()) {
@@ -794,10 +795,7 @@ class StartupRecoveryTaskTest {
         final RecoveryResult result = new StartupRecoveryTask(config).call();
 
         assertThat(result.completedRanges()).isNotNull();
-        assertThat(result.completedRanges()).hasSize(2);
-        assertThat(result.completedRanges())
-                .containsExactlyInAnyOrder(
-                        new LongRange(0, groupSize - 1), new LongRange(groupSize, groupSize * 2 - 1));
+        assertThat(result.completedRanges().streamRanges()).containsExactly(new LongRange(0, groupSize * 2 - 1));
     }
 
     /// Verifies that a single hanging multipart upload (Case 2) returns [RecoveryResult#completedRanges()]

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTaskTest.java
@@ -19,6 +19,7 @@ import io.minio.errors.MinioException;
 import io.minio.messages.Item;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -56,7 +57,7 @@ class TempArchiveUploadTaskTest {
     private static final String BUCKET_NAME = "test-bucket";
     private static final int GROUPING_LEVEL = 1;
     private static final int PART_SIZE_MB = 5;
-    /// ~600 KB per block; two blocks exceed the 5 MB part threshold, triggering a mid-loop flush.
+    /// ~600 KiB per block; nine or more blocks exceed the 5 MiB part threshold, triggering a mid-loop flush.
     private static final int BLOCK_DATA_BYTES = 600 * 1024;
 
     // @todo(2013) we should remove that and use another approach
@@ -154,9 +155,12 @@ class TempArchiveUploadTaskTest {
     }
 
     private TempArchiveUploadTask buildTask(
-            String s3Key, long firstBlock, BlockingQueue<BlockWithSource> queue, TestBlockMessagingFacility messaging) {
-        return new TempArchiveUploadTask(
-                config, messaging, new NoOpApplicationStateFacility(), createMetricsHolder(), s3Key, firstBlock, queue);
+            String s3Key,
+            long firstBlock,
+            BlockingQueue<BlockWithSource> queue,
+            TestBlockMessagingFacility messaging,
+            TrackingApplicationStateFacility asf) {
+        return new TempArchiveUploadTask(config, messaging, asf, createMetricsHolder(), s3Key, firstBlock, queue);
     }
 
     /// Verifies the happy path: blocks queued followed by SEGMENT_END produce a completed `.tmp`
@@ -170,13 +174,15 @@ class TempArchiveUploadTaskTest {
         final String metaKey = TempArchiveKey.formatMeta(0, "");
         final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
         final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
+        final TrackingApplicationStateFacility asf = new TrackingApplicationStateFacility();
 
         for (int i = 0; i < 3; i++) {
             queue.put(makeBlock(100));
         }
         queue.put(TempArchiveUploadTask.SEGMENT_END);
 
-        final TempArchiveEntry entry = buildTask(s3Key, 0, queue, messaging).call();
+        final TempArchiveEntry entry =
+                buildTask(s3Key, 0, queue, messaging, asf).call();
 
         assertThat(entry.s3Key()).isEqualTo(s3Key);
         assertThat(entry.firstBlock()).isZero();
@@ -191,23 +197,27 @@ class TempArchiveUploadTaskTest {
         assertThat(notifications.getFirst().blockNumber()).isEqualTo(2L);
         assertThat(notifications.getFirst().succeeded()).isTrue();
         assertThat(notifications.getFirst().blockSource()).isEqualTo(BlockSource.PUBLISHER);
+        assertThat(asf.addedRanges).hasSize(1);
+        assertThat(asf.addedRanges.getFirst()).isEqualTo(new LongRange(0, 2));
     }
 
-    /// Verifies that when [doCompleteMultipartUpload] throws, [call()] rethrows the exception and
-    /// neither the `.tmp` key (not yet committed) nor the `.meta` key is present in S3.
+    /// Verifies that when [doCompleteMultipartUpload] throws, [call()] rethrows the exception,
+    /// neither the `.tmp` key (not yet committed) nor the `.meta` key is present in S3, and a
+    /// failed [PersistedNotification] is sent so downstream subscribers are not left dangling.
     @Test
-    @DisplayName("completeMultipartUpload failure: exception rethrown; no keys committed")
+    @DisplayName("completeMultipartUpload failure: exception rethrown; no keys committed; failed notification sent")
     void completeFailureThrowsAndLeavesNoKeys() throws Exception {
         final String s3Key = TempArchiveKey.formatTar(0, "");
         final String metaKey = TempArchiveKey.formatMeta(0, "");
         final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
         final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
+        final TrackingApplicationStateFacility asf = new TrackingApplicationStateFacility();
 
         queue.put(makeBlock(100));
         queue.put(TempArchiveUploadTask.SEGMENT_END);
 
-        final TempArchiveUploadTask task = new FailingCompleteTask(
-                config, messaging, new NoOpApplicationStateFacility(), createMetricsHolder(), s3Key, 0, queue);
+        final TempArchiveUploadTask task =
+                new FailingCompleteTask(config, messaging, asf, createMetricsHolder(), s3Key, 0, queue);
 
         assertThatThrownBy(task::call).isInstanceOf(IOException.class);
         try (S3Client s3 = openS3Client()) {
@@ -215,30 +225,45 @@ class TempArchiveUploadTaskTest {
             assertThat(s3.listObjects(s3Key, 1)).doesNotContain(s3Key);
             assertThat(s3.listObjects(metaKey, 1)).doesNotContain(metaKey);
         }
+        assertThat(asf.addedRanges).isEmpty();
+        final List<PersistedNotification> notifications = messaging.getSentPersistedNotifications();
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications.getFirst().succeeded()).isFalse();
+        assertThat(notifications.getFirst().blockNumber()).isZero();
+        assertThat(notifications.getFirst().blockSource()).isEqualTo(BlockSource.PUBLISHER);
     }
 
     /// Verifies that when [doUploadTextFile] (the meta companion write) throws, [call()] rethrows
     /// the exception.  The `.tmp` key was already committed by [doCompleteMultipartUpload], so it
-    /// IS present; only the `.meta` key is absent.
+    /// IS present; only the `.meta` key is absent.  Because the tar is durable, a success
+    /// [PersistedNotification] and range registration are still sent before rethrowing.
     @Test
-    @DisplayName("Meta file write failure: exception rethrown; .tmp exists but .meta absent")
+    @DisplayName("Meta file write failure: exception rethrown; .tmp exists but .meta absent; success notification sent")
     void metaWriteFailureThrowsAndLeavesTmpButNoMeta() throws Exception {
         final String s3Key = TempArchiveKey.formatTar(0, "");
         final String metaKey = TempArchiveKey.formatMeta(0, "");
         final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
         final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
+        final TrackingApplicationStateFacility asf = new TrackingApplicationStateFacility();
 
         queue.put(makeBlock(100));
         queue.put(TempArchiveUploadTask.SEGMENT_END);
 
-        final TempArchiveUploadTask task = new FailingMetaTask(
-                config, messaging, new NoOpApplicationStateFacility(), createMetricsHolder(), s3Key, 0, queue);
+        final TempArchiveUploadTask task =
+                new FailingMetaTask(config, messaging, asf, createMetricsHolder(), s3Key, 0, queue);
 
         assertThatThrownBy(task::call).isInstanceOf(IOException.class);
         try (S3Client s3 = openS3Client()) {
             assertThat(s3.listObjects(s3Key, 1)).contains(s3Key);
             assertThat(s3.listObjects(metaKey, 1)).doesNotContain(metaKey);
         }
+        assertThat(asf.addedRanges).hasSize(1);
+        assertThat(asf.addedRanges.getFirst()).isEqualTo(new LongRange(0, 0));
+        final List<PersistedNotification> notifications = messaging.getSentPersistedNotifications();
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications.getFirst().succeeded()).isTrue();
+        assertThat(notifications.getFirst().blockNumber()).isZero();
+        assertThat(notifications.getFirst().blockSource()).isEqualTo(BlockSource.PUBLISHER);
     }
 
     /// Verifies that interrupting the virtual thread while it is blocked on [BlockingQueue#take]
@@ -249,7 +274,8 @@ class TempArchiveUploadTaskTest {
         final String s3Key = TempArchiveKey.formatTar(0, "");
         final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
         final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
-        final TempArchiveUploadTask task = buildTask(s3Key, 0, queue, messaging);
+        final TrackingApplicationStateFacility asf = new TrackingApplicationStateFacility();
+        final TempArchiveUploadTask task = buildTask(s3Key, 0, queue, messaging, asf);
 
         final InterruptedException[] caught = {null};
         final Thread thread = new Thread(() -> {
@@ -281,6 +307,7 @@ class TempArchiveUploadTaskTest {
         final String s3Key = TempArchiveKey.formatTar(0, "");
         final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
         final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
+        final TrackingApplicationStateFacility asf = new TrackingApplicationStateFacility();
 
         // Large blocks so the cumulative buffer exceeds PART_SIZE_MB before SEGMENT_END,
         // triggering the mid-loop doUploadPart call.
@@ -289,11 +316,12 @@ class TempArchiveUploadTaskTest {
         }
         queue.put(TempArchiveUploadTask.SEGMENT_END);
 
-        final TempArchiveUploadTask task = new FailingUploadPartTask(
-                config, messaging, new NoOpApplicationStateFacility(), createMetricsHolder(), s3Key, 0, queue);
+        final TempArchiveUploadTask task =
+                new FailingUploadPartTask(config, messaging, asf, createMetricsHolder(), s3Key, 0, queue);
 
         assertThatThrownBy(task::call).isInstanceOf(IOException.class);
         assertThat(messaging.getSentPersistedNotifications()).isEmpty();
+        assertThat(asf.addedRanges).isEmpty();
         try (S3Client s3 = openS3Client()) {
             assertThat(s3.listMultipartUploads()).doesNotContainKey(s3Key);
         }
@@ -308,6 +336,7 @@ class TempArchiveUploadTaskTest {
         final String s3Key = TempArchiveKey.formatTar(0, "");
         final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
         final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
+        final TrackingApplicationStateFacility asf = new TrackingApplicationStateFacility();
 
         // Small blocks so the buffer stays below PART_SIZE_MB throughout the loop;
         // doUploadPart is only called for the final partial buffer.
@@ -316,8 +345,8 @@ class TempArchiveUploadTaskTest {
         }
         queue.put(TempArchiveUploadTask.SEGMENT_END);
 
-        final TempArchiveUploadTask task = new FailingUploadPartTask(
-                config, messaging, new NoOpApplicationStateFacility(), createMetricsHolder(), s3Key, 0, queue);
+        final TempArchiveUploadTask task =
+                new FailingUploadPartTask(config, messaging, asf, createMetricsHolder(), s3Key, 0, queue);
 
         assertThatThrownBy(task::call).isInstanceOf(IOException.class);
         final List<PersistedNotification> notifications = messaging.getSentPersistedNotifications();
@@ -325,9 +354,42 @@ class TempArchiveUploadTaskTest {
         assertThat(notifications.getFirst().succeeded()).isFalse();
         assertThat(notifications.getFirst().blockNumber()).isZero();
         assertThat(notifications.getFirst().blockSource()).isEqualTo(BlockSource.PUBLISHER);
+        assertThat(asf.addedRanges).isEmpty();
         try (S3Client s3 = openS3Client()) {
             assertThat(s3.listMultipartUploads()).doesNotContainKey(s3Key);
         }
+    }
+
+    /// Verifies the multi-part success path: blocks large enough to trigger a mid-loop flush
+    /// produce a single [applicationStateFacility.addStoredBlockRange] call covering the full
+    /// range after both the multipart complete and the meta write succeed.
+    @Test
+    @DisplayName("Multi-part success: single addStoredBlockRange covering full range after completion")
+    void multiPartSuccessRegistersFullRangeAfterCompletion() throws Exception {
+        final String s3Key = TempArchiveKey.formatTar(0, "");
+        final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
+        final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
+        final TrackingApplicationStateFacility asf = new TrackingApplicationStateFacility();
+
+        // ~600 KB per block; 10 blocks = ~6 MB, exceeding the 5 MB part threshold so at least
+        // one mid-loop flush occurs before SEGMENT_END.
+        final int numBlocks = 10;
+        for (int i = 0; i < numBlocks; i++) {
+            queue.put(makeBlock(BLOCK_DATA_BYTES));
+        }
+        queue.put(TempArchiveUploadTask.SEGMENT_END);
+
+        final TempArchiveEntry entry =
+                buildTask(s3Key, 0, queue, messaging, asf).call();
+
+        assertThat(entry.firstBlock()).isZero();
+        assertThat(entry.lastBlock()).isEqualTo(numBlocks - 1L);
+        assertThat(asf.addedRanges).hasSize(1);
+        assertThat(asf.addedRanges.getFirst()).isEqualTo(new LongRange(0, numBlocks - 1L));
+        final List<PersistedNotification> notifications = messaging.getSentPersistedNotifications();
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications.getFirst().blockNumber()).isEqualTo(numBlocks - 1L);
+        assertThat(notifications.getFirst().succeeded()).isTrue();
     }
 
     /// [TempArchiveUploadTask] subclass that always throws from [doUploadPart].
@@ -391,12 +453,16 @@ class TempArchiveUploadTaskTest {
         }
     }
 
-    private static final class NoOpApplicationStateFacility implements ApplicationStateFacility {
+    private static final class TrackingApplicationStateFacility implements ApplicationStateFacility {
+        final List<LongRange> addedRanges = new ArrayList<>();
+
         @Override
         public void updateTssData(TssData tssData) {}
 
         @Override
-        public void addStoredBlockRange(LongRange blockRange) {}
+        public void addStoredBlockRange(LongRange blockRange) {
+            addedRanges.add(blockRange);
+        }
 
         @Override
         public NetworkData knownPublishers() {


### PR DESCRIPTION
## Reviewer Notes

### Deferred ASF registration and persisted notification in `TempArchiveUploadTask`                                                                                                   
                                                                                                                                                                                      
Previously `TempArchiveUploadTask` called `addStoredBlockRange` and sent a `PersistedNotification(success=true)` after each flushed S3 part, before the multipart upload was  complete. If `completeMultipartUpload` or the subsequent `.meta` write failed, `abortQuietly` removed the data from S3 but the ASF registrations were not reverted.                                                                        
                                                                                                                                                                                      
The fix removes all per-part ASF and notification calls from the while loop and the final-buffer block. A single `addStoredBlockRange(new LongRange(firstBlock, lastBlock))` and `PersistedNotification(success=true)` are now emitted only after both `doCompleteMultipartUpload` and the `.meta` write succeed. Each failure site is wrapped in its own try-catch. Metric increments are consolidated to the same point. The `lastNotifiedBlock` tracking variable is replaced by `totalBytes`, which accumulates part sizes for the deferred metrics call.
                                                        
### Per-archive range registration during startup recovery                                                                                                                          
                                                                                                                                                                                      
`StartupRecoveryTask.recoverFromCompletedObjects` previously used a right-hand-path traversal (`findLastKey`) that only located the alphabetically last completed tar and returned a single broad `[0, nextBlockToQueue-1]` range to `CloudStorageArchivePlugin`. This over-reported stored blocks when the node had gaps in its archive history.                        
                                                                                                                                                                                      
`findLastKey` is replaced by `findAllTarKeys`, which pages through all objects under the configured prefix (excluding `tmp/`) and collects every final tar key (filtering out `.tmp` and `.meta` by suffix). The new `RecoveryResult.completedRanges` field carries one `LongRange` per completed archive back to `CloudStorageArchivePlugin`. During startup, if  `completedRanges` is non-null (Case 1), the plugin registers each range individually via `addStoredBlockRange` instead of the broad fallback. Case 2 (resume path, where completed archives are not enumerated) continues to use the broad `[0, nextBlockToQueue-1]` range and sets `completedRanges` to `null` to signal this. 

## Related Issue(s)

Closes #3041 