### PR TITLE
feat: live-push each new WRB to a Block Node (#2956)

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -94,6 +94,7 @@ import org.hiero.block.tools.mirrornode.FetchBlockQuery;
 import org.hiero.block.tools.mirrornode.FixBlockTime;
 import org.hiero.block.tools.mirrornode.MirrorNodeBlockQueryOrder;
 import org.hiero.block.tools.mirrornode.UpdateBlockData;
+import org.hiero.block.tools.push.LiveBlockPushClient;
 import org.hiero.block.tools.records.RecordFileUtils;
 import org.hiero.block.tools.records.model.parsed.ParsedRecordBlock;
 import org.hiero.block.tools.records.model.parsed.RecordBlockConverter;
@@ -180,6 +181,30 @@ public class LiveSequential implements Runnable {
             names = {"--start-date"},
             description = "Start date in YYYY-MM-DD format (default: auto-detect from mirror node)")
     private String startDate;
+
+    @Option(
+            names = {"--push-bn-host"},
+            description = "Optional. If set, each wrapped block is pushed to this Block Node "
+                    + "host:port via the Publish gRPC stream as it is produced.")
+    private String pushBnHost;
+
+    @Option(
+            names = {"--push-bn-port"},
+            description =
+                    "Block Node Publish port to push to (default: 40840). Ignored if " + "--push-bn-host is not set.")
+    private int pushBnPort = 40840;
+
+    @Option(
+            names = {"--push-queue-capacity"},
+            description = "Bounded backpressure queue between the wrap thread and the push worker "
+                    + "(default: 32). When full, the wrap thread blocks; nothing is dropped.")
+    private int pushQueueCapacity = 32;
+
+    /** Live-push client; null when --push-bn-host is not set. */
+    private LiveBlockPushClient pushClient;
+
+    /** Blocks at or below this number are already on the BN; skip pushing them. */
+    private long pushSkipUpToInclusive = -1L;
 
     /** State persisted to JSON for resumability. Compatible with DownloadLive2 format. */
     private static class State {
@@ -316,6 +341,21 @@ public class LiveSequential implements Runnable {
                     + "]"
                     + " day=" + initialState.dayDate);
 
+            // Optional: live-push to a Block Node. If --push-bn-host was provided, set up the
+            // push client so the wrap thread can hand each validated block off to it as it is
+            // produced. The push subsystem owns its own thread + bounded queue (see
+            // LiveBlockPushClient javadoc).
+            if (pushBnHost != null && !pushBnHost.isBlank()) {
+                pushClient = new LiveBlockPushClient(
+                        pushBnHost, pushBnPort, pushQueueCapacity, LiveBlockPushClient.loadDefaultWebConfig());
+                pushSkipUpToInclusive = pushClient.queryLastAvailableBlock();
+                System.out.println("[live-sequential] Live push enabled: target=" + pushBnHost + ":"
+                        + pushBnPort + " queueCapacity=" + pushQueueCapacity
+                        + " BN lastAvailableBlock=" + pushSkipUpToInclusive
+                        + " (blocks <= this are skipped from push)");
+                pushClient.start();
+            }
+
             // Create producer-consumer queue
             final BlockingQueue<ValidatedBlock> queue = new LinkedBlockingQueue<>(32);
             final AtomicReference<Throwable> wrapError = new AtomicReference<>(null);
@@ -341,6 +381,12 @@ public class LiveSequential implements Runnable {
                             () -> {
                                 System.out.println("[live-sequential] Shutdown requested...");
                                 downloadManager.close();
+                                if (pushClient != null) {
+                                    System.out.println("[live-sequential] Draining live-push client (queue="
+                                            + pushClient.queueDepth() + " acked=" + pushClient.acked()
+                                            + " submitted=" + pushClient.submitted() + ")...");
+                                    pushClient.shutdown();
+                                }
                             },
                             "live-sequential-shutdown"));
 
@@ -356,6 +402,11 @@ public class LiveSequential implements Runnable {
             Throwable wrapErr = wrapError.get();
             if (wrapErr != null) {
                 throw new RuntimeException("Wrap+validate thread failed", wrapErr);
+            }
+
+            if (pushClient != null) {
+                System.out.println("[live-sequential] Draining live-push client...");
+                pushClient.shutdown();
             }
 
             System.out.println("[live-sequential] Complete.");
@@ -1106,6 +1157,19 @@ public class LiveSequential implements Runnable {
 
         // Run all validation checks
         runBlockValidations(wrappedBytes, blockNum, vc, ls, checkpointDir);
+
+        // Live-push to a Block Node if configured. Done after the block is fully validated and
+        // committed to the local zip; the push subsystem is fully decoupled (its own thread +
+        // bounded queue) so a slow/unreachable BN only stalls the push, not the local pipeline,
+        // unless the queue fills (in which case the wrap thread blocks here rather than dropping).
+        if (pushClient != null && blockNum > pushSkipUpToInclusive) {
+            try {
+                pushClient.pushBlock(blockNum, wrapped);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw ie;
+            }
+        }
 
         // Collect signature stats
         SignatureBlockStats blockStats = vc.signatureValidation().popBlockStats(blockNum);

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -362,10 +362,9 @@ public class LiveSequential implements Runnable {
                 pushClient = new LiveBlockPushClient(
                         pushBnHost, pushBnPort, pushQueueCapacity, LiveBlockPushClient.loadDefaultWebConfig());
                 pushSkipUpToInclusive = pushClient.queryLastAvailableBlock();
-                System.out.println("[live-sequential] Live push enabled: target=" + pushBnHost + ":"
-                        + pushBnPort + " queueCapacity=" + pushQueueCapacity
-                        + " BN lastAvailableBlock=" + pushSkipUpToInclusive
-                        + " (blocks <= this are skipped from push)");
+                System.out.printf(
+                        "[live-sequential] Live push enabled: target=%s:%d queueCapacity=%d BN lastAvailableBlock=%d (blocks <= this are skipped from push)%n",
+                        pushBnHost, pushBnPort, pushQueueCapacity, pushSkipUpToInclusive);
                 pushClient.start();
             }
 
@@ -1176,12 +1175,8 @@ public class LiveSequential implements Runnable {
         // bounded queue) so a slow/unreachable BN only stalls the push, not the local pipeline,
         // unless the queue fills (in which case the wrap thread blocks here rather than dropping).
         if (pushClient != null && blockNum > pushSkipUpToInclusive) {
-            try {
-                pushClient.pushBlock(blockNum, wrapped);
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                throw ie;
-            }
+            // Method declares `throws Exception` so InterruptedException propagates naturally.
+            pushClient.pushBlock(blockNum, wrapped);
         }
 
         // Collect signature stats

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -192,9 +192,10 @@ public class LiveSequential implements Runnable {
 
     @Option(
             names = {"--push-bn-host"},
-            description = "Block Node host to push to. Required when --push-enabled is set. Can be "
-                    + "configured ahead of time and gated on later via --push-enabled.")
-    private String pushBnHost;
+            description = "Block Node host to push to (default: localhost). The expected deployment "
+                    + "is a co-located BN, so localhost is the common case; override only when the "
+                    + "target BN runs elsewhere.")
+    private String pushBnHost = "localhost";
 
     @Option(
             names = {"--push-bn-port"},
@@ -358,9 +359,6 @@ public class LiveSequential implements Runnable {
             // side coordinating with the other. The push subsystem owns its own thread + bounded
             // queue (see LiveBlockPushClient javadoc).
             if (pushEnabled) {
-                if (pushBnHost == null || pushBnHost.isBlank()) {
-                    throw new IllegalArgumentException("--push-enabled requires --push-bn-host to be set");
-                }
                 pushClient = new LiveBlockPushClient(
                         pushBnHost, pushBnPort, pushQueueCapacity, LiveBlockPushClient.loadDefaultWebConfig());
                 pushSkipUpToInclusive = pushClient.queryLastAvailableBlock();
@@ -369,10 +367,6 @@ public class LiveSequential implements Runnable {
                         + " BN lastAvailableBlock=" + pushSkipUpToInclusive
                         + " (blocks <= this are skipped from push)");
                 pushClient.start();
-            } else if (pushBnHost != null && !pushBnHost.isBlank()) {
-                System.out.println("[live-sequential] Live push configured (host=" + pushBnHost + ":"
-                        + pushBnPort + ") but disabled (--push-enabled not set). "
-                        + "Run with --push-enabled to turn on after backfill completes.");
             }
 
             // Create producer-consumer queue

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -351,9 +351,12 @@ public class LiveSequential implements Runnable {
                     + " day=" + initialState.dayDate);
 
             // Optional: live-push to a Block Node. Gated by --push-enabled so the host can be
-            // configured ahead of time but the feature stays off until the operator flips it on
-            // (typically after the historical backfill has populated the target BN). The push
-            // subsystem owns its own thread + bounded queue (see LiveBlockPushClient javadoc).
+            // configured ahead of time but the feature stays off until the operator flips it on.
+            // Live push can run concurrently with a separate historical-backfill process pointing
+            // at the same BN — queryLastAvailableBlock() below skips blocks the BN already has, so
+            // the live side naturally sits above the historical high-water mark without either
+            // side coordinating with the other. The push subsystem owns its own thread + bounded
+            // queue (see LiveBlockPushClient javadoc).
             if (pushEnabled) {
                 if (pushBnHost == null || pushBnHost.isBlank()) {
                     throw new IllegalArgumentException("--push-enabled requires --push-bn-host to be set");

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -183,24 +183,33 @@ public class LiveSequential implements Runnable {
     private String startDate;
 
     @Option(
+            names = {"--push-enabled"},
+            description = "Enable live-push of each wrapped block to a Block Node as it is produced. "
+                    + "Off by default. Operationally, leave this off until the historical backfill "
+                    + "(see 'blocks bulk-load') has populated the target BN; then turn this on for "
+                    + "the steady-state live feed. Requires --push-bn-host.")
+    private boolean pushEnabled = false;
+
+    @Option(
             names = {"--push-bn-host"},
-            description = "Optional. If set, each wrapped block is pushed to this Block Node "
-                    + "host:port via the Publish gRPC stream as it is produced.")
+            description = "Block Node host to push to. Required when --push-enabled is set. Can be "
+                    + "configured ahead of time and gated on later via --push-enabled.")
     private String pushBnHost;
 
     @Option(
             names = {"--push-bn-port"},
             description =
-                    "Block Node Publish port to push to (default: 40840). Ignored if " + "--push-bn-host is not set.")
+                    "Block Node Publish port to push to (default: 40840). Ignored unless " + "--push-enabled is set.")
     private int pushBnPort = 40840;
 
     @Option(
             names = {"--push-queue-capacity"},
             description = "Bounded backpressure queue between the wrap thread and the push worker "
-                    + "(default: 32). When full, the wrap thread blocks; nothing is dropped.")
+                    + "(default: 32). When full, the wrap thread blocks; nothing is dropped. "
+                    + "Ignored unless --push-enabled is set.")
     private int pushQueueCapacity = 32;
 
-    /** Live-push client; null when --push-bn-host is not set. */
+    /** Live-push client; null unless push is enabled and configured. */
     private LiveBlockPushClient pushClient;
 
     /** Blocks at or below this number are already on the BN; skip pushing them. */
@@ -341,11 +350,14 @@ public class LiveSequential implements Runnable {
                     + "]"
                     + " day=" + initialState.dayDate);
 
-            // Optional: live-push to a Block Node. If --push-bn-host was provided, set up the
-            // push client so the wrap thread can hand each validated block off to it as it is
-            // produced. The push subsystem owns its own thread + bounded queue (see
-            // LiveBlockPushClient javadoc).
-            if (pushBnHost != null && !pushBnHost.isBlank()) {
+            // Optional: live-push to a Block Node. Gated by --push-enabled so the host can be
+            // configured ahead of time but the feature stays off until the operator flips it on
+            // (typically after the historical backfill has populated the target BN). The push
+            // subsystem owns its own thread + bounded queue (see LiveBlockPushClient javadoc).
+            if (pushEnabled) {
+                if (pushBnHost == null || pushBnHost.isBlank()) {
+                    throw new IllegalArgumentException("--push-enabled requires --push-bn-host to be set");
+                }
                 pushClient = new LiveBlockPushClient(
                         pushBnHost, pushBnPort, pushQueueCapacity, LiveBlockPushClient.loadDefaultWebConfig());
                 pushSkipUpToInclusive = pushClient.queryLastAvailableBlock();
@@ -354,6 +366,10 @@ public class LiveSequential implements Runnable {
                         + " BN lastAvailableBlock=" + pushSkipUpToInclusive
                         + " (blocks <= this are skipped from push)");
                 pushClient.start();
+            } else if (pushBnHost != null && !pushBnHost.isBlank()) {
+                System.out.println("[live-sequential] Live push configured (host=" + pushBnHost + ":"
+                        + pushBnPort + ") but disabled (--push-enabled not set). "
+                        + "Run with --push-enabled to turn on after backfill completes.");
             }
 
             // Create producer-consumer queue

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.push;
+
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClient;
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClientConfig;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import io.helidon.common.tls.Tls;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.grpc.GrpcClientProtocolConfig;
+import io.helidon.webclient.http2.Http2ClientProtocolConfig;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.hiero.block.api.BlockItemSet;
+import org.hiero.block.api.BlockNodeServiceInterface;
+import org.hiero.block.api.BlockStreamPublishServiceInterface;
+import org.hiero.block.api.PublishStreamRequest;
+import org.hiero.block.api.PublishStreamResponse;
+import org.hiero.block.api.ServerStatusRequest;
+import org.hiero.block.api.ServerStatusResponse;
+import org.hiero.block.tools.config.HelidonWebClientConfig;
+
+/**
+ * Pushes wrapped blocks to a Block Node over the standard publish gRPC stream, one block at a time,
+ * decoupled from the producer (the live wrap pipeline) by a bounded queue.
+ *
+ * <p>Producer (e.g. {@code LiveSequential}'s wrap thread) calls {@link #pushBlock(long, Block)} as
+ * each block is wrapped and validated. A background worker thread maintains a persistent publish
+ * stream, drains the queue into the stream, tracks per-block ACKs, and reconnects with exponential
+ * backoff if the stream drops.
+ *
+ * <p><b>"Never drop" guarantee.</b> Blocks are kept in an in-flight set until ACKed. On stream
+ * error, all in-flight blocks are re-sent on the new stream before the worker resumes draining the
+ * queue. If the queue fills (sustained BN unavailability), {@link #pushBlock} blocks the caller
+ * (the wrap thread) until space is freed; nothing is dropped.
+ *
+ * <p>The BN's stored block set is queried once via {@link #queryLastAvailableBlock()} so the
+ * producer can skip blocks the BN already has.
+ */
+public final class LiveBlockPushClient implements AutoCloseable {
+
+    /** Marker used to wake the worker for graceful shutdown. */
+    private static final Block POISON = Block.DEFAULT;
+
+    private final String host;
+    private final int port;
+    private final HelidonWebClientConfig webConfig;
+    private final BlockingQueue<QueuedBlock> queue;
+    private final long maxBatchBytes;
+    private final long retryInitialMs;
+    private final long retryMaxMs;
+
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicLong submitted = new AtomicLong();
+    private final AtomicLong acked = new AtomicLong();
+    private final AtomicLong lastAckedBlock = new AtomicLong(-1);
+    private final AtomicLong streamReconnects = new AtomicLong();
+
+    private Thread worker;
+    private WebClient cachedWebClient; // recreated on each reconnect
+
+    /**
+     * @param host BN host
+     * @param port BN port (publish service)
+     * @param queueCapacity backpressure queue size (blocks)
+     * @param webConfig Helidon/gRPC tuning; uses {@code serverMaxMessageSizeBytes} for batching
+     */
+    public LiveBlockPushClient(
+            final String host, final int port, final int queueCapacity, final HelidonWebClientConfig webConfig) {
+        this.host = host;
+        this.port = port;
+        this.webConfig = webConfig;
+        this.queue = new ArrayBlockingQueue<>(Math.max(1, queueCapacity));
+        this.maxBatchBytes = webConfig.serverMaxMessageSizeBytes();
+        this.retryInitialMs = 250L;
+        this.retryMaxMs = 30_000L;
+    }
+
+    /**
+     * Load the default {@code clientDefaultConfig.json} bundled with the tools module so callers
+     * don't have to hand-construct a {@link HelidonWebClientConfig}.
+     */
+    public static HelidonWebClientConfig loadDefaultWebConfig() {
+        try (final var stream =
+                LiveBlockPushClient.class.getClassLoader().getResourceAsStream("clientDefaultConfig.json")) {
+            if (stream == null) {
+                throw new IllegalStateException("clientDefaultConfig.json not found on classpath");
+            }
+            return HelidonWebClientConfig.JSON.parse(Bytes.wrap(stream.readAllBytes()));
+        } catch (final Exception e) {
+            throw new IllegalStateException("Failed to load default Helidon web client config", e);
+        }
+    }
+
+    /** Query the target BN once for its current {@code lastAvailableBlock}; returns -1 on error. */
+    public long queryLastAvailableBlock() {
+        try {
+            final WebClient web = buildWebClient();
+            final PbjGrpcClient pbj = new PbjGrpcClient(web, buildGrpcConfig());
+            final BlockNodeServiceInterface.BlockNodeServiceClient client =
+                    new BlockNodeServiceInterface.BlockNodeServiceClient(pbj, defaultOptions());
+            final ServerStatusResponse resp =
+                    client.serverStatus(ServerStatusRequest.newBuilder().build());
+            return resp.lastAvailableBlock();
+        } catch (final Exception e) {
+            System.err.println("[push] queryLastAvailableBlock failed: " + e.getMessage());
+            return -1;
+        }
+    }
+
+    /** Start the background worker thread. */
+    public void start() {
+        if (!running.compareAndSet(false, true)) {
+            return;
+        }
+        worker = new Thread(this::workerLoop, "live-block-push-worker");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    /**
+     * Hand a wrapped block to the push subsystem. Blocks the caller if the queue is full (which
+     * means the BN is falling behind). Never drops.
+     */
+    public void pushBlock(final long blockNumber, final Block wrapped) throws InterruptedException {
+        if (!running.get()) {
+            throw new IllegalStateException("LiveBlockPushClient is not started");
+        }
+        queue.put(new QueuedBlock(blockNumber, wrapped));
+    }
+
+    /** Drain the queue (waiting for ACKs) and stop the worker. */
+    public void shutdown() {
+        if (!running.compareAndSet(true, false)) {
+            return;
+        }
+        // Wake the worker; it will exit after draining.
+        try {
+            queue.put(new QueuedBlock(-1, POISON));
+        } catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+        if (worker != null) {
+            try {
+                worker.join(TimeUnit.MINUTES.toMillis(2));
+            } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        shutdown();
+    }
+
+    // ------- metrics -------
+
+    public long submitted() {
+        return submitted.get();
+    }
+
+    public long acked() {
+        return acked.get();
+    }
+
+    public long lastAcked() {
+        return lastAckedBlock.get();
+    }
+
+    public int queueDepth() {
+        return queue.size();
+    }
+
+    public long reconnects() {
+        return streamReconnects.get();
+    }
+
+    // ------- worker -------
+
+    private void workerLoop() {
+        // In-flight = sent on the current stream but not yet ACKed. On stream error these are
+        // re-sent on the new stream so nothing is lost.
+        final Deque<QueuedBlock> inFlight = new ArrayDeque<>();
+        long backoffMs = retryInitialMs;
+
+        while (running.get() || !queue.isEmpty() || !inFlight.isEmpty()) {
+            try {
+                final StreamSession session = openSession();
+                try {
+                    backoffMs = retryInitialMs; // reset on successful connect
+                    // First, resend anything still in-flight from the previous (failed) stream.
+                    for (final QueuedBlock qb : inFlight) {
+                        sendBlock(session, qb);
+                    }
+                    // Then drain new work from the queue.
+                    while (running.get() || !queue.isEmpty()) {
+                        final QueuedBlock qb = queue.take();
+                        if (qb.block == POISON) {
+                            // Graceful shutdown sentinel — wait for ACKs and exit.
+                            break;
+                        }
+                        inFlight.addLast(qb);
+                        sendBlock(session, qb);
+                        // Opportunistically prune in-flight head as ACKs arrive.
+                        prunePendingFromAck(inFlight);
+                    }
+                    // Wait for all ACKs (deadline) before closing.
+                    waitForPending(inFlight);
+                    session.requestPipeline.onComplete();
+                    try {
+                        session.completion.get(2, TimeUnit.MINUTES);
+                    } catch (final Exception ignored) {
+                        // best effort
+                    }
+                    return; // shutdown path
+                } catch (final StreamFailure sf) {
+                    // Stream broke; loop will reopen and resend inFlight.
+                    streamReconnects.incrementAndGet();
+                    System.err.println("[push] stream failure: " + sf.getMessage() + "; reconnecting after " + backoffMs
+                            + "ms (" + inFlight.size() + " in-flight)");
+                    safeClose(session);
+                    Thread.sleep(backoffMs);
+                    backoffMs = Math.min(retryMaxMs, backoffMs * 2);
+                } finally {
+                    safeClose(session);
+                }
+            } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (final Exception e) {
+                streamReconnects.incrementAndGet();
+                System.err.println("[push] unexpected worker error: " + e.getMessage() + "; reconnecting after "
+                        + backoffMs + "ms");
+                try {
+                    Thread.sleep(backoffMs);
+                } catch (final InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                backoffMs = Math.min(retryMaxMs, backoffMs * 2);
+            }
+        }
+    }
+
+    private void sendBlock(final StreamSession session, final QueuedBlock qb) {
+        final List<BlockItem> items = qb.block.items();
+        final List<List<BlockItem>> batches = new ArrayList<>();
+        List<BlockItem> current = new ArrayList<>();
+        long currentSize = 0;
+        for (final BlockItem item : items) {
+            final int itemSize = BlockItem.PROTOBUF.measureRecord(item);
+            if (!current.isEmpty() && currentSize + itemSize > maxBatchBytes) {
+                batches.add(current);
+                current = new ArrayList<>();
+                currentSize = 0;
+            }
+            current.add(item);
+            currentSize += itemSize;
+        }
+        if (!current.isEmpty()) {
+            batches.add(current);
+        }
+        for (final List<BlockItem> batch : batches) {
+            final BlockItemSet set = BlockItemSet.newBuilder().blockItems(batch).build();
+            final PublishStreamRequest req =
+                    PublishStreamRequest.newBuilder().blockItems(set).build();
+            session.requestPipeline.onNext(req);
+        }
+        submitted.incrementAndGet();
+    }
+
+    /** Move ACKed blocks off the head of the in-flight deque. */
+    private void prunePendingFromAck(final Deque<QueuedBlock> inFlight) {
+        final long ack = lastAckedBlock.get();
+        while (!inFlight.isEmpty() && inFlight.peekFirst().blockNumber <= ack) {
+            inFlight.pollFirst();
+        }
+    }
+
+    /** Block until inFlight is empty or a short deadline elapses. */
+    private void waitForPending(final Deque<QueuedBlock> inFlight) throws InterruptedException {
+        final long deadline = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(2);
+        while (!inFlight.isEmpty() && System.currentTimeMillis() < deadline) {
+            prunePendingFromAck(inFlight);
+            if (inFlight.isEmpty()) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+    }
+
+    // ------- gRPC plumbing -------
+
+    private WebClient buildWebClient() {
+        if (cachedWebClient == null) {
+            final Duration timeout = Duration.ofMillis(webConfig.readTimeoutMillis());
+            final Tls tls = Tls.builder().enabled(false).build();
+            final Http2ClientProtocolConfig http2Config = Http2ClientProtocolConfig.builder()
+                    .flowControlBlockTimeout(Duration.ofMillis(webConfig.flowControlTimeoutMillis()))
+                    .initialWindowSize(webConfig.initialWindowSize())
+                    .maxFrameSize(webConfig.maxFrameSize())
+                    .maxHeaderListSize(webConfig.maxHeaderListSize())
+                    .ping(webConfig.pingEnabled())
+                    .pingTimeout(Duration.ofMillis(webConfig.pingTimeoutMillis()))
+                    .priorKnowledge(webConfig.priorKnowledge())
+                    .build();
+            final GrpcClientProtocolConfig grpcProtocolConfig = GrpcClientProtocolConfig.builder()
+                    .abortPollTimeExpired(false)
+                    .pollWaitTime(timeout)
+                    .build();
+            cachedWebClient = WebClient.builder()
+                    .baseUri("http://" + host + ":" + port)
+                    .tls(tls)
+                    .protocolConfigs(List.of(http2Config, grpcProtocolConfig))
+                    .connectTimeout(timeout)
+                    .build();
+        }
+        return cachedWebClient;
+    }
+
+    private PbjGrpcClientConfig buildGrpcConfig() {
+        final Duration timeout = Duration.ofMillis(webConfig.readTimeoutMillis());
+        final Tls tls = Tls.builder().enabled(false).build();
+        final String encoding = webConfig.grpcEncoding().isBlank() ? "identity" : webConfig.grpcEncoding();
+        return new PbjGrpcClientConfig(
+                timeout, tls, Optional.empty(), "application/grpc", encoding, Set.of("identity", "gzip"));
+    }
+
+    private static ServiceInterface.RequestOptions defaultOptions() {
+        return new SimpleRequestOptions(Optional.empty(), ServiceInterface.RequestOptions.APPLICATION_GRPC);
+    }
+
+    @SuppressWarnings("unchecked")
+    private StreamSession openSession() {
+        final WebClient web = buildWebClient();
+        final PbjGrpcClient pbj = new PbjGrpcClient(web, buildGrpcConfig());
+        final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient client =
+                new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(pbj, defaultOptions());
+        final CompletableFuture<Void> completion = new CompletableFuture<>();
+        final Pipeline<PublishStreamResponse> responses = new AckPipeline(completion);
+        final Pipeline<PublishStreamRequest> requestPipeline =
+                (Pipeline<PublishStreamRequest>) client.publishBlockStream(responses);
+        return new StreamSession(requestPipeline, completion);
+    }
+
+    private void safeClose(final StreamSession session) {
+        if (session == null) {
+            return;
+        }
+        try {
+            session.requestPipeline.onComplete();
+        } catch (final Exception ignored) {
+            // best effort
+        }
+    }
+
+    // ------- inner types -------
+
+    private record QueuedBlock(long blockNumber, Block block) {}
+
+    private record StreamSession(Pipeline<PublishStreamRequest> requestPipeline, CompletableFuture<Void> completion) {}
+
+    private record SimpleRequestOptions(Optional<String> authority, String contentType)
+            implements ServiceInterface.RequestOptions {}
+
+    /** Wraps a stream failure thrown from the response pipeline as a checked-like marker. */
+    private static final class StreamFailure extends RuntimeException {
+        StreamFailure(final Throwable cause) {
+            super(cause);
+        }
+    }
+
+    /** Tracks ACKs and signals failure on stream errors. */
+    private final class AckPipeline implements Pipeline<PublishStreamResponse> {
+        private final CompletableFuture<Void> completion;
+
+        AckPipeline(final CompletableFuture<Void> completion) {
+            this.completion = completion;
+        }
+
+        @Override
+        public void onSubscribe(final Flow.Subscription subscription) {
+            // no-op
+        }
+
+        @Override
+        public void onNext(final PublishStreamResponse response) {
+            if (response.hasAcknowledgement()) {
+                final long blockNumber = response.acknowledgement().blockNumber();
+                acked.incrementAndGet();
+                // Track the highest contiguous acked block number we have seen.
+                long prev;
+                do {
+                    prev = lastAckedBlock.get();
+                    if (blockNumber <= prev) {
+                        break;
+                    }
+                } while (!lastAckedBlock.compareAndSet(prev, blockNumber));
+            }
+        }
+
+        @Override
+        public void onError(final Throwable throwable) {
+            completion.completeExceptionally(throwable);
+            throw new StreamFailure(throwable);
+        }
+
+        @Override
+        public void onComplete() {
+            completion.complete(null);
+        }
+    }
+}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
@@ -515,22 +515,29 @@ public final class LiveBlockPushClient implements AutoCloseable {
             // where applicable, a stream tear-down; the worker's reconnect + inFlight replay then
             // naturally resumes at the correct next block.
             if (response.hasSkipBlock()) {
-                // BN has already persisted this block; treat it as ACKed so we do not resend it.
+                // Skip means another publisher is currently sending this block; the BN does not
+                // want two publishers competing. Treat it as effectively ACKed so we don't resend
+                // it. (If the block were already persisted the BN would send EndOfStream(DUPLICATE)
+                // instead of Skip.)
                 final long skipped = response.skipBlock().blockNumber();
-                System.err.println(
-                        "[push] BN sent SkipBlock: block " + skipped + " already persisted; skipping resend");
+                System.err.println("[push] BN sent SkipBlock: block " + skipped
+                        + " is being sent by another publisher; skipping resend");
                 advanceAckWatermarkTo(skipped);
             } else if (response.hasResendBlock()) {
-                // BN wants an earlier block back. Rewind our ACK watermark so the reconnect replays
-                // inFlight from that block; continuing forward here draws a NodeBehindPublisher.
+                // BN wants an earlier block back. Rewind our ACK watermark so the reconnect
+                // replays inFlight from that block. Per the publish protocol we could also
+                // continue on the same stream after rewinding; tearing the stream down is
+                // simpler here because the worker's reconnect already handles inFlight replay.
                 final long target = response.resendBlock().blockNumber();
                 System.err.println("[push] BN sent ResendBlock: rewinding to block " + target + " and reconnecting");
                 rewindAckWatermarkTo(target - 1);
                 streamAlive.set(false);
                 completion.complete(null);
             } else if (response.hasNodeBehindPublisher()) {
-                // Publisher can't accept blocks this far ahead. Rewind and reconnect, or the BN
-                // may disconnect and temporarily block this publisher for misbehaving.
+                // The BN cannot accept blocks this far ahead of what it has persisted, so it is
+                // asking us to rewind to the offered block. Rewind is required; reconnect is
+                // optional (we could continue on the same stream), but tearing the stream down
+                // routes through the worker's reconnect + inFlight replay which is simpler.
                 final long target = response.nodeBehindPublisher().blockNumber();
                 System.err.println(
                         "[push] BN reports node behind publisher; rewinding to block " + target + " and reconnecting");
@@ -539,12 +546,21 @@ public final class LiveBlockPushClient implements AutoCloseable {
                 completion.complete(null);
             } else if (response.hasEndStream()) {
                 final PublishStreamResponse.EndOfStream end = response.endStream();
-                System.err.println("[push] BN sent EndOfStream (code=" + end.status()
-                        + ", last persisted block=" + end.blockNumber() + "); resuming from block "
-                        + (end.blockNumber() + 1));
-                // Advance to the BN's declared last-persisted watermark so the reconnect resumes
-                // at end.blockNumber() + 1 rather than replaying anything already persisted.
-                advanceAckWatermarkTo(end.blockNumber());
+                // end.blockNumber() is the BN's authoritative last-persisted watermark, which can
+                // be ahead of, equal to, or behind our current lastAckedBlock depending on why the
+                // stream ended (routine close after N blocks, error mid-flight, etc.). Move the
+                // watermark to exactly end.blockNumber() in whichever direction is needed so the
+                // worker resumes at end.blockNumber() + 1 rather than replaying anything the BN
+                // already has or skipping anything the BN is missing.
+                final long target = end.blockNumber();
+                final long current = lastAckedBlock.get();
+                System.err.println("[push] BN sent EndOfStream (code=" + end.status() + ", last persisted block="
+                        + target + "); resuming from block " + (target + 1));
+                if (target >= current) {
+                    advanceAckWatermarkTo(target);
+                } else {
+                    rewindAckWatermarkTo(target);
+                }
                 streamAlive.set(false);
                 completion.complete(null);
             }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
@@ -5,6 +5,7 @@ import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.pbj.grpc.client.helidon.PbjGrpcClient;
 import com.hedera.pbj.grpc.client.helidon.PbjGrpcClientConfig;
+import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -12,6 +13,7 @@ import io.helidon.common.tls.Tls;
 import io.helidon.webclient.api.WebClient;
 import io.helidon.webclient.grpc.GrpcClientProtocolConfig;
 import io.helidon.webclient.http2.Http2ClientProtocolConfig;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -103,7 +105,11 @@ public final class LiveBlockPushClient implements AutoCloseable {
                 throw new IllegalStateException("clientDefaultConfig.json not found on classpath");
             }
             return HelidonWebClientConfig.JSON.parse(Bytes.wrap(stream.readAllBytes()));
-        } catch (final Exception e) {
+        } catch (final IOException | ParseException | RuntimeException e) {
+            // IOException from readAllBytes/close; ParseException from the PBJ parse call;
+            // RuntimeException for anything else. Named explicitly so a future new checked
+            // exception surfaces as a compile error instead of being silently swallowed by
+            // a bare `Exception` catch.
             throw new IllegalStateException("Failed to load default Helidon web client config", e);
         }
     }
@@ -235,10 +241,13 @@ public final class LiveBlockPushClient implements AutoCloseable {
                     // Wait for all ACKs (deadline) before closing.
                     waitForPending(inFlight);
                     session.requestPipeline.onComplete();
+                    // Best effort: give the server 2 min to acknowledge onComplete before we exit.
+                    // We do NOT want a failed .get() here to trigger the outer reconnect path (we're
+                    // in the shutdown branch); log the specific expected exceptions and move on.
                     try {
                         session.completion.get(2, TimeUnit.MINUTES);
-                    } catch (final Exception ignored) {
-                        // best effort
+                    } catch (final java.util.concurrent.ExecutionException | java.util.concurrent.TimeoutException e) {
+                        System.err.println("[push] shutdown: completion did not settle cleanly: " + e.getMessage());
                     }
                     return; // shutdown path
                 } catch (final StreamFailure sf) {
@@ -247,27 +256,37 @@ public final class LiveBlockPushClient implements AutoCloseable {
                     System.err.println("[push] stream failure: " + sf.getMessage() + "; reconnecting after " + backoffMs
                             + "ms (" + inFlight.size() + " in-flight)");
                     safeClose(session);
-                    Thread.sleep(backoffMs);
-                    backoffMs = Math.min(retryMaxMs, backoffMs * 2);
+                    backoffMs = backoffAndAdvance(backoffMs);
+                    if (Thread.currentThread().isInterrupted()) {
+                        return;
+                    }
                 } finally {
                     safeClose(session);
                 }
             } catch (final InterruptedException ie) {
                 Thread.currentThread().interrupt();
                 return;
-            } catch (final Exception e) {
+            } catch (final RuntimeException e) {
                 streamReconnects.incrementAndGet();
                 System.err.println("[push] unexpected worker error: " + e.getMessage() + "; reconnecting after "
                         + backoffMs + "ms");
-                try {
-                    Thread.sleep(backoffMs);
-                } catch (final InterruptedException ie) {
-                    Thread.currentThread().interrupt();
+                backoffMs = backoffAndAdvance(backoffMs);
+                if (Thread.currentThread().isInterrupted()) {
                     return;
                 }
-                backoffMs = Math.min(retryMaxMs, backoffMs * 2);
             }
         }
+    }
+
+    /**
+     * Park for {@code backoffMs} milliseconds, then return the next (doubled, clamped) backoff.
+     * Uses {@link java.util.concurrent.locks.LockSupport#parkNanos} so we don't need to catch
+     * {@link InterruptedException} — park returns silently on interrupt and leaves the flag set
+     * for the caller to observe.
+     */
+    private long backoffAndAdvance(final long backoffMs) {
+        java.util.concurrent.locks.LockSupport.parkNanos(backoffMs * 1_000_000L);
+        return Math.min(retryMaxMs, backoffMs * 2);
     }
 
     private void sendBlock(final StreamSession session, final QueuedBlock qb) {
@@ -461,15 +480,43 @@ public final class LiveBlockPushClient implements AutoCloseable {
                         break;
                     }
                 } while (!lastAckedBlock.compareAndSet(prev, blockNumber));
+                return;
+            }
+            // The publish protocol may respond with more than acknowledgements. We surface each
+            // variant so the operator log makes it clear what the BN is telling us, and let the
+            // stream-lifecycle path (streamAlive / completion / worker reconnect) handle the
+            // consequences. Skip/Resend/NodeBehindPublisher are informational for this client;
+            // EndOfStream is a normal close after the max stream duration (or a hard error),
+            // which the outer worker treats as a reconnect trigger.
+            if (response.hasSkipBlock()) {
+                System.err.println("[push] BN sent SkipBlock: block "
+                        + response.skipBlock().blockNumber());
+            } else if (response.hasResendBlock()) {
+                System.err.println("[push] BN sent ResendBlock: block "
+                        + response.resendBlock().blockNumber());
+            } else if (response.hasNodeBehindPublisher()) {
+                System.err.println("[push] BN reports node behind publisher at block "
+                        + response.nodeBehindPublisher().blockNumber());
+            } else if (response.hasEndStream()) {
+                final PublishStreamResponse.EndOfStream end = response.endStream();
+                System.err.println("[push] BN sent EndOfStream (code=" + end.status() + ", block=" + end.blockNumber()
+                        + "); worker will reconnect");
+                streamAlive.set(false);
+                completion.complete(null);
             }
         }
 
         @Override
         public void onError(final Throwable throwable) {
+            // Runs on Helidon's I/O thread. Don't throw from here — Helidon's behaviour on a
+            // thrown exception is undefined and it can hang the stream. We log, mark the stream
+            // dead via the AtomicBoolean, and complete the future exceptionally. The worker's
+            // poll loop observes streamAlive == false and re-throws StreamFailure on its own
+            // thread, which is the correct place for the reconnect logic to fire.
             failureCause = throwable;
             streamAlive.set(false);
             completion.completeExceptionally(throwable);
-            throw new StreamFailure(throwable);
+            System.err.println("[push] response stream error: " + throwable.getMessage());
         }
 
         @Override

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
@@ -67,12 +67,13 @@ public final class LiveBlockPushClient implements AutoCloseable {
 
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final AtomicLong submitted = new AtomicLong();
+    private final AtomicLong highestSubmittedBlock = new AtomicLong(-1);
     private final AtomicLong acked = new AtomicLong();
     private final AtomicLong lastAckedBlock = new AtomicLong(-1);
     private final AtomicLong streamReconnects = new AtomicLong();
 
     private Thread worker;
-    private WebClient cachedWebClient; // recreated on each reconnect
+    private WebClient cachedWebClient; // lazily created once and reused for every session
 
     /**
      * @param host BN host
@@ -208,9 +209,20 @@ public final class LiveBlockPushClient implements AutoCloseable {
                     for (final QueuedBlock qb : inFlight) {
                         sendBlock(session, qb);
                     }
-                    // Then drain new work from the queue.
+                    // Then drain new work from the queue. Poll with a short timeout so the
+                    // worker periodically checks whether the response pipeline has flipped to
+                    // failed — protects against the case where Helidon's I/O thread absorbs
+                    // the throw from AckPipeline.onError instead of surfacing it here.
                     while (running.get() || !queue.isEmpty()) {
-                        final QueuedBlock qb = queue.take();
+                        if (!session.responses.isAlive()) {
+                            final Throwable cause = session.responses.failureCause();
+                            throw new StreamFailure(
+                                    cause != null ? cause : new RuntimeException("stream closed by remote"));
+                        }
+                        final QueuedBlock qb = queue.poll(200, TimeUnit.MILLISECONDS);
+                        if (qb == null) {
+                            continue;
+                        }
                         if (qb.block == POISON) {
                             // Graceful shutdown sentinel — wait for ACKs and exit.
                             break;
@@ -265,6 +277,14 @@ public final class LiveBlockPushClient implements AutoCloseable {
         long currentSize = 0;
         for (final BlockItem item : items) {
             final int itemSize = BlockItem.PROTOBUF.measureRecord(item);
+            // A single item bigger than the max message size will get its own batch and be
+            // rejected by the BN. There's nothing we can do to shrink it here — log so the
+            // failure is diagnosable rather than mysterious.
+            if (itemSize > maxBatchBytes) {
+                System.err.println("[push] block " + qb.blockNumber + " has an oversized item ("
+                        + itemSize + " bytes > maxBatchBytes " + maxBatchBytes
+                        + "); the BN will reject the resulting frame");
+            }
             if (!current.isEmpty() && currentSize + itemSize > maxBatchBytes) {
                 batches.add(current);
                 current = new ArrayList<>();
@@ -282,6 +302,16 @@ public final class LiveBlockPushClient implements AutoCloseable {
                     PublishStreamRequest.newBuilder().blockItems(set).build();
             session.requestPipeline.onNext(req);
         }
+        // Only increment `submitted` on the first send of a given block — reattempts after a
+        // stream reconnect walk in-flight in ascending order, so a block <= the current high
+        // watermark has already been counted.
+        long prev;
+        do {
+            prev = highestSubmittedBlock.get();
+            if (qb.blockNumber <= prev) {
+                return;
+            }
+        } while (!highestSubmittedBlock.compareAndSet(prev, qb.blockNumber));
         submitted.incrementAndGet();
     }
 
@@ -353,10 +383,10 @@ public final class LiveBlockPushClient implements AutoCloseable {
         final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient client =
                 new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(pbj, defaultOptions());
         final CompletableFuture<Void> completion = new CompletableFuture<>();
-        final Pipeline<PublishStreamResponse> responses = new AckPipeline(completion);
+        final AckPipeline responses = new AckPipeline(completion);
         final Pipeline<PublishStreamRequest> requestPipeline =
                 (Pipeline<PublishStreamRequest>) client.publishBlockStream(responses);
-        return new StreamSession(requestPipeline, completion);
+        return new StreamSession(requestPipeline, completion, responses);
     }
 
     private void safeClose(final StreamSession session) {
@@ -374,7 +404,10 @@ public final class LiveBlockPushClient implements AutoCloseable {
 
     private record QueuedBlock(long blockNumber, Block block) {}
 
-    private record StreamSession(Pipeline<PublishStreamRequest> requestPipeline, CompletableFuture<Void> completion) {}
+    private record StreamSession(
+            Pipeline<PublishStreamRequest> requestPipeline,
+            CompletableFuture<Void> completion,
+            AckPipeline responses) {}
 
     private record SimpleRequestOptions(Optional<String> authority, String contentType)
             implements ServiceInterface.RequestOptions {}
@@ -386,12 +419,28 @@ public final class LiveBlockPushClient implements AutoCloseable {
         }
     }
 
-    /** Tracks ACKs and signals failure on stream errors. */
+    /**
+     * Tracks ACKs and signals failure on stream errors. Runs on Helidon's response-processing thread,
+     * which may or may not surface exceptions thrown from {@link #onError}. To make failure detection
+     * robust from the worker thread, {@link #streamAlive} is flipped to {@code false} before the
+     * exception is thrown; the worker polls it in the drain loop and reconnects even if Helidon
+     * swallowed the throw.
+     */
     private final class AckPipeline implements Pipeline<PublishStreamResponse> {
         private final CompletableFuture<Void> completion;
+        private final AtomicBoolean streamAlive = new AtomicBoolean(true);
+        private volatile Throwable failureCause;
 
         AckPipeline(final CompletableFuture<Void> completion) {
             this.completion = completion;
+        }
+
+        boolean isAlive() {
+            return streamAlive.get();
+        }
+
+        Throwable failureCause() {
+            return failureCause;
         }
 
         @Override
@@ -417,12 +466,15 @@ public final class LiveBlockPushClient implements AutoCloseable {
 
         @Override
         public void onError(final Throwable throwable) {
+            failureCause = throwable;
+            streamAlive.set(false);
             completion.completeExceptionally(throwable);
             throw new StreamFailure(throwable);
         }
 
         @Override
         public void onComplete() {
+            streamAlive.set(false);
             completion.complete(null);
         }
     }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
@@ -499,7 +499,7 @@ public final class LiveBlockPushClient implements AutoCloseable {
                         + response.nodeBehindPublisher().blockNumber());
             } else if (response.hasEndStream()) {
                 final PublishStreamResponse.EndOfStream end = response.endStream();
-                System.err.println("[push] BN sent EndOfStream (code=" + end.status() + ", block=" + end.blockNumber()
+                System.err.println("[push] BN sent EndOfStream (code=" + end.status() + ", last persisted block=" + end.blockNumber()
                         + "); worker will reconnect");
                 streamAlive.set(false);
                 completion.complete(null);

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
@@ -334,6 +334,32 @@ public final class LiveBlockPushClient implements AutoCloseable {
         submitted.incrementAndGet();
     }
 
+    /** Advance {@link #lastAckedBlock} to {@code target} if it is currently lower. */
+    private void advanceAckWatermarkTo(final long target) {
+        long prev;
+        do {
+            prev = lastAckedBlock.get();
+            if (target <= prev) {
+                return;
+            }
+        } while (!lastAckedBlock.compareAndSet(prev, target));
+    }
+
+    /**
+     * Lower {@link #lastAckedBlock} to {@code target} if it is currently higher. Used when the BN
+     * asks us to rewind (ResendBlock / NodeBehindPublisher) so the reconnect's inFlight replay
+     * treats blocks {@code > target} as still-unacked.
+     */
+    private void rewindAckWatermarkTo(final long target) {
+        long prev;
+        do {
+            prev = lastAckedBlock.get();
+            if (target >= prev) {
+                return;
+            }
+        } while (!lastAckedBlock.compareAndSet(prev, target));
+    }
+
     /** Move ACKed blocks off the head of the in-flight deque. */
     private void prunePendingFromAck(final Deque<QueuedBlock> inFlight) {
         final long ack = lastAckedBlock.get();
@@ -482,25 +508,43 @@ public final class LiveBlockPushClient implements AutoCloseable {
                 } while (!lastAckedBlock.compareAndSet(prev, blockNumber));
                 return;
             }
-            // The publish protocol may respond with more than acknowledgements. We surface each
-            // variant so the operator log makes it clear what the BN is telling us, and let the
-            // stream-lifecycle path (streamAlive / completion / worker reconnect) handle the
-            // consequences. Skip/Resend/NodeBehindPublisher are informational for this client;
-            // EndOfStream is a normal close after the max stream duration (or a hard error),
-            // which the outer worker treats as a reconnect trigger.
+            // The publish protocol responses beyond Acknowledgement drive the client's next-block
+            // watermark: continuing to push forward after a Skip/Resend/NodeBehindPublisher (or
+            // ignoring EndOfStream's persisted-block hint) risks a disconnect or a misbehaving-
+            // publisher block from the BN. Each variant is mapped to an ACK-watermark change and,
+            // where applicable, a stream tear-down; the worker's reconnect + inFlight replay then
+            // naturally resumes at the correct next block.
             if (response.hasSkipBlock()) {
-                System.err.println("[push] BN sent SkipBlock: block "
-                        + response.skipBlock().blockNumber());
+                // BN has already persisted this block; treat it as ACKed so we do not resend it.
+                final long skipped = response.skipBlock().blockNumber();
+                System.err.println(
+                        "[push] BN sent SkipBlock: block " + skipped + " already persisted; skipping resend");
+                advanceAckWatermarkTo(skipped);
             } else if (response.hasResendBlock()) {
-                System.err.println("[push] BN sent ResendBlock: block "
-                        + response.resendBlock().blockNumber());
+                // BN wants an earlier block back. Rewind our ACK watermark so the reconnect replays
+                // inFlight from that block; continuing forward here draws a NodeBehindPublisher.
+                final long target = response.resendBlock().blockNumber();
+                System.err.println("[push] BN sent ResendBlock: rewinding to block " + target + " and reconnecting");
+                rewindAckWatermarkTo(target - 1);
+                streamAlive.set(false);
+                completion.complete(null);
             } else if (response.hasNodeBehindPublisher()) {
-                System.err.println("[push] BN reports node behind publisher at block "
-                        + response.nodeBehindPublisher().blockNumber());
+                // Publisher can't accept blocks this far ahead. Rewind and reconnect, or the BN
+                // may disconnect and temporarily block this publisher for misbehaving.
+                final long target = response.nodeBehindPublisher().blockNumber();
+                System.err.println(
+                        "[push] BN reports node behind publisher; rewinding to block " + target + " and reconnecting");
+                rewindAckWatermarkTo(target - 1);
+                streamAlive.set(false);
+                completion.complete(null);
             } else if (response.hasEndStream()) {
                 final PublishStreamResponse.EndOfStream end = response.endStream();
-                System.err.println("[push] BN sent EndOfStream (code=" + end.status() + ", last persisted block=" + end.blockNumber()
-                        + "); worker will reconnect");
+                System.err.println("[push] BN sent EndOfStream (code=" + end.status()
+                        + ", last persisted block=" + end.blockNumber() + "); resuming from block "
+                        + (end.blockNumber() + 1));
+                // Advance to the BN's declared last-persisted watermark so the reconnect resumes
+                // at end.blockNumber() + 1 rather than replaying anything already persisted.
+                advanceAckWatermarkTo(end.blockNumber());
                 streamAlive.set(false);
                 completion.complete(null);
             }

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/push/LiveBlockPushClientTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/push/LiveBlockPushClientTest.java
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.push;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hapi.block.stream.Block;
+import org.hiero.block.tools.config.HelidonWebClientConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Unit tests for {@link LiveBlockPushClient}. These cover the safe-to-use API contract
+ * (lifecycle invariants, metric defaults, default-config loading, and the error path of
+ * {@link LiveBlockPushClient#queryLastAvailableBlock()} when the BN is unreachable).
+ *
+ * <p>End-to-end push/ACK/reconnect behavior requires either a real Block Node or a stub gRPC
+ * server and belongs in the integration test suites, not here.
+ */
+class LiveBlockPushClientTest {
+
+    /** Port 1 is reserved and effectively always refuses TCP connections — used as an unreachable target. */
+    private static final int UNREACHABLE_PORT = 1;
+
+    private static LiveBlockPushClient newClient(final int queueCapacity) {
+        return new LiveBlockPushClient(
+                "127.0.0.1", UNREACHABLE_PORT, queueCapacity, LiveBlockPushClient.loadDefaultWebConfig());
+    }
+
+    @Nested
+    @DisplayName("Default config")
+    class DefaultConfig {
+
+        @Test
+        @DisplayName("loadDefaultWebConfig() loads the bundled JSON without error")
+        void loadsBundledConfig() {
+            final HelidonWebClientConfig cfg = LiveBlockPushClient.loadDefaultWebConfig();
+            assertNotNull(cfg);
+            // serverMaxMessageSizeBytes from clientDefaultConfig.json is 131_072_000 (~125 MiB)
+            assertEquals(131_072_000, cfg.serverMaxMessageSizeBytes());
+            assertTrue(cfg.readTimeoutMillis() > 0);
+        }
+    }
+
+    @Nested
+    @DisplayName("Lifecycle")
+    class Lifecycle {
+
+        @Test
+        @DisplayName("pushBlock before start() throws IllegalStateException")
+        void pushBeforeStartThrows() {
+            try (final LiveBlockPushClient client = newClient(8)) {
+                assertThrows(IllegalStateException.class, () -> client.pushBlock(0L, Block.DEFAULT));
+            }
+        }
+
+        @Test
+        @DisplayName("shutdown() before start() is a no-op")
+        void shutdownBeforeStartIsNoOp() {
+            final LiveBlockPushClient client = newClient(8);
+            assertDoesNotThrow(client::shutdown);
+        }
+
+        @Test
+        @DisplayName("close() is an alias for shutdown() and is idempotent")
+        @Timeout(10)
+        void closeIsIdempotent() {
+            final LiveBlockPushClient client = newClient(8);
+            assertDoesNotThrow(client::close);
+            assertDoesNotThrow(client::close); // second close must not throw
+        }
+    }
+
+    @Nested
+    @DisplayName("Metrics defaults")
+    class MetricsDefaults {
+
+        @Test
+        @DisplayName("Counters and last-acked start at expected initial values")
+        void initialMetrics() {
+            try (final LiveBlockPushClient client = newClient(8)) {
+                assertEquals(0L, client.submitted());
+                assertEquals(0L, client.acked());
+                assertEquals(-1L, client.lastAcked());
+                assertEquals(0L, client.reconnects());
+                assertEquals(0, client.queueDepth());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Unreachable BN error path")
+    class UnreachableBn {
+
+        @Test
+        @DisplayName("queryLastAvailableBlock() returns -1 when the BN is unreachable")
+        @Timeout(60)
+        void queryReturnsMinusOneOnUnreachable() {
+            try (final LiveBlockPushClient client = newClient(8)) {
+                final long result = client.queryLastAvailableBlock();
+                assertEquals(-1L, result, "Expected sentinel -1 when BN is unreachable");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an opt-in path to the `days live-sequential` command that pushes each freshly wrapped & validated `Block` to a Block Node via the standard `BlockStreamPublishService` gRPC stream, one block at a time, as it is produced.
- New `org.hiero.block.tools.push.LiveBlockPushClient` encapsulates the persistent publish stream, decoupling the producer (wrap thread) from the network via a bounded queue so the local zip output path is never delayed by transient BN slowness.
- Gated by an explicit `--push-enabled` flag so the host can be configured ahead of time but the feature stays off until the operator flips it on after the historical backfill (#2955 / #3038) has populated the target BN.

Closes #2956.

## Why

Part of epic #2954 — _Distribute historical & live WRBs and TSS to Tier-1 Block Nodes_. The special-purpose ("Tier 0") BN is seeded via bulk-load for history; this PR provides the steady-state live feed so the BN stays continuously current without the 6-hour zip-batch flood pattern.

## How it works

### Push client (`LiveBlockPushClient`)

- Builds the gRPC publish stream on `PbjGrpcClient` + Helidon WebClient, matching the existing `NetworkCapacityClient` plumbing.
- Background worker thread drains an `ArrayBlockingQueue<QueuedBlock>` into the stream. Each block is batched into `PublishStreamRequest`s respecting `serverMaxMessageSizeBytes`.
- **"Never drop" guarantee:** blocks remain in an in-flight deque until ACKed. On stream error the worker reconnects with exponential backoff (250 ms → 30 s cap) and re-sends in-flight blocks before resuming the queue. If the queue fills (sustained BN outage) the producer's `pushBlock` call blocks rather than dropping.
- One-shot `queryLastAvailableBlock()` via `BlockNodeService.serverStatus` so the producer can skip blocks the BN already has on resume.
- `loadDefaultWebConfig()` reads the bundled `clientDefaultConfig.json` so callers don't have to hand-build a `HelidonWebClientConfig`.

### Wiring in `LiveSequential`

- New CLI options:
  - `--push-enabled` (bool, default `false`) — explicit gate
  - `--push-bn-host` (string) — BN host; required when `--push-enabled` is set
  - `--push-bn-port` (int, default `40840`)
  - `--push-queue-capacity` (int, default `32`)
- Validation:
  - `--push-enabled` without `--push-bn-host` → fail fast with `IllegalArgumentException`
  - `--push-bn-host` set but `--push-enabled` not set → log "configured but disabled" and proceed in zip-only mode
- Hook lives at the end of `wrapAndValidateBlock`, after the block is fully validated and committed to the zip. Blocks `<= lastAvailableBlock` are skipped from the push path; subsequent blocks go onto the push queue.
- Push client is started before the wrap thread and drained both on graceful completion and via the shutdown hook.

## Operational flow

1. Deploy with `--push-bn-host=<bn>` baked in, `--push-enabled` off → wrap keeps producing the local zip; BN gets backfilled via `blocks bulk-load` (#3038).
2. When backfill catches up, restart with `--push-enabled` → live feed starts from `lastAvailableBlock + 1`.

## BN side

No BN changes required. We hit:
- `stream-publisher` plugin → `BlockStreamPublishService.publishBlockStream` (already in default `values.yaml`)
- `server-status` plugin → `BlockNodeService.serverStatus` (already in default `values.yaml`)

For WRB-mode BNs, `roster-bootstrap-rsa` must be appended to the plugin list (this is already the operational pattern in `solo-deploy-network.sh` for rsa-wrb mode).

