### PR TITLE
feat(messaging): generic block notifications via BlockNotification marker interface

### DIFF
--- a/block-node/app/docker/metrics/dashboards/Hiero-Block-Node-Plugins/messaging-facility.json
+++ b/block-node/app/docker/metrics/dashboards/Hiero-Block-Node-Plugins/messaging-facility.json
@@ -208,7 +208,7 @@
       "pluginVersion": "11.4.0",
       "targets": [
         {
-          "expr": "rate(blocknode_messaging_block_verification_notifications_total[$__rate_interval])",
+          "expr": "rate(blocknode_messaging_block_notifications_sent_total{notification_type=\"VerificationNotification\"}[$__rate_interval])",
           "legendFormat": "verifications/s",
           "refId": "A"
         }
@@ -299,7 +299,7 @@
       "pluginVersion": "11.4.0",
       "targets": [
         {
-          "expr": "rate(blocknode_messaging_block_persisted_notifications_total[$__rate_interval])",
+          "expr": "rate(blocknode_messaging_block_notifications_sent_total{notification_type=\"PersistedNotification\"}[$__rate_interval])",
           "legendFormat": "persisted/s",
           "refId": "A"
         }
@@ -391,7 +391,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(blocknode_messaging_block_backfilled_notifications_total[$__rate_interval])",
+          "expr": "rate(blocknode_messaging_block_notifications_sent_total{notification_type=\"BackfilledBlockNotification\"}[$__rate_interval])",
           "legendFormat": "persisted/s",
           "range": true,
           "refId": "A"
@@ -484,7 +484,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(blocknode_messaging_newest_block_known_to_network_notifications_total[$__rate_interval])",
+          "expr": "rate(blocknode_messaging_block_notifications_sent_total{notification_type=\"NewestBlockKnownToNetworkNotification\"}[$__rate_interval])",
           "legendFormat": "persisted/s",
           "range": true,
           "refId": "A"

--- a/block-node/app/docker/metrics/dashboards/block-node-server.json
+++ b/block-node/app/docker/metrics/dashboards/block-node-server.json
@@ -435,7 +435,7 @@
           "refId": "B"
         },
         {
-          "expr": "rate(blocknode_messaging_block_persisted_notifications_total[$__rate_interval])",
+          "expr": "rate(blocknode_messaging_block_notifications_sent_total{notification_type=\"PersistedNotification\"}[$__rate_interval])",
           "legendFormat": "Blocks Persisted/s",
           "refId": "C"
         }

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/SimpleInMemoryHistoricalBlockFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/SimpleInMemoryHistoricalBlockFacility.java
@@ -77,7 +77,7 @@ public class SimpleInMemoryHistoricalBlockFacility implements HistoricalBlockFac
                 if (sendNotification) {
                     blockNodeContext
                             .blockMessaging()
-                            .sendBlockPersisted(new PersistedNotification(blockNumber, true, priority, source));
+                            .sendBlockNotification(new PersistedNotification(blockNumber, true, priority, source));
                 }
             }
         }

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
@@ -14,6 +14,7 @@ import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.NoBackPressureBlockItemHandler;
@@ -237,52 +238,19 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
      * {@inheritDoc}
      */
     @Override
-    public void sendBlockVerification(final VerificationNotification notification) {
+    public void sendBlockNotification(final BlockNotification notification) {
         logNotification(notification);
-        sentVerificationNotifications.add(notification);
-        for (final BlockNotificationHandler handler : blockNotificationHandlers) {
-            handler.handleVerification(notification);
+        switch (notification) {
+            case VerificationNotification v -> sentVerificationNotifications.add(v);
+            case PersistedNotification p -> sentPersistedNotifications.add(p);
+            case NewestBlockKnownToNetworkNotification n -> sentNewestBlockKnownToNetworkNotifications.add(n);
+            case PublisherStatusUpdateNotification s -> sentPublisherStatusUpdateNotifications.add(s);
+            default -> {
+                /* not tracked in a dedicated sent list */
+            }
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void sendBlockPersisted(final PersistedNotification notification) {
-        logNotification(notification);
-        sentPersistedNotifications.add(notification);
         for (final BlockNotificationHandler handler : blockNotificationHandlers) {
-            handler.handlePersisted(notification);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void sendBackfilledBlockNotification(final BackfilledBlockNotification notification) {
-        logNotification(notification);
-        for (final BlockNotificationHandler handler : blockNotificationHandlers) {
-            handler.handleBackfilled(notification);
-        }
-    }
-
-    @Override
-    public void sendNewestBlockKnownToNetwork(final NewestBlockKnownToNetworkNotification notification) {
-        logNotification(notification);
-        sentNewestBlockKnownToNetworkNotifications.add(notification);
-        for (final BlockNotificationHandler handler : blockNotificationHandlers) {
-            handler.handleNewestBlockKnownToNetwork(notification);
-        }
-    }
-
-    @Override
-    public void sendPublisherStatusUpdate(final PublisherStatusUpdateNotification notification) {
-        logNotification(notification);
-        sentPublisherStatusUpdateNotifications.add(notification);
-        for (final BlockNotificationHandler handler : blockNotificationHandlers) {
-            handler.handlePublisherStatusUpdate(notification);
+            handler.handleNotification(notification);
         }
     }
 
@@ -303,7 +271,7 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
         blockNotificationHandlers.remove(handler);
     }
 
-    private void logNotification(final Record notification) {
+    private void logNotification(final BlockNotification notification) {
         switch (notification) {
             case BackfilledBlockNotification backfilled ->
                 LOGGER.log(

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestVerificationPlugin.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestVerificationPlugin.java
@@ -17,6 +17,7 @@ import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.blockmessaging.BlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
@@ -57,7 +58,7 @@ public class TestVerificationPlugin implements BlockNodePlugin, BlockNotificatio
         }
         if (currentSession.processBlockItems(blockItems)) {
             // first send the notification, most likely it will be handled on the same thread
-            context.blockMessaging().sendBlockVerification(currentSession.completeSession());
+            context.blockMessaging().sendBlockNotification(currentSession.completeSession());
             // then mark as a failure
             if (currentSession.shouldFail) {
                 final long blockNumber = currentSession.blockNumber;
@@ -70,6 +71,11 @@ public class TestVerificationPlugin implements BlockNodePlugin, BlockNotificatio
     public void stop() {
         context.blockMessaging().unregisterBlockNotificationHandler(this);
         context.blockMessaging().unregisterBlockItemHandler(this);
+    }
+
+    @Override
+    public void handleNotification(final BlockNotification notification) {
+        // this plugin only emits verification notifications; it does not react to any notification
     }
 
     public void setBlockSource(final BlockSource blockSource) {

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/VerificationHandlingHistoricalBlockFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/VerificationHandlingHistoricalBlockFacility.java
@@ -8,6 +8,7 @@ import org.hiero.block.node.app.fixtures.blocks.BlockUtils;
 import org.hiero.block.node.app.fixtures.blocks.MinimalBlockAccessor;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
@@ -41,12 +42,18 @@ public class VerificationHandlingHistoricalBlockFacility implements HistoricalBl
     }
 
     @Override
-    public void handleVerification(final VerificationNotification notification) {
+    public void handleNotification(final BlockNotification notification) {
+        if (notification instanceof VerificationNotification verification) {
+            handleVerification(verification);
+        }
+    }
+
+    private void handleVerification(final VerificationNotification notification) {
         if (notification.success()) {
             blockStorage.put(notification.blockNumber(), BlockUtils.toBlock(notification.block()));
             availableBlocks.add(notification.blockNumber());
             context.blockMessaging()
-                    .sendBlockPersisted(
+                    .sendBlockNotification(
                             new PersistedNotification(notification.blockNumber(), true, 2_000, notification.source()));
         }
     }

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPersistenceAwaiter.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPersistenceAwaiter.java
@@ -9,6 +9,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
@@ -95,8 +96,7 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
      *
      * @param notification the persistence notification
      */
-    @Override
-    public void handlePersisted(@NonNull PersistedNotification notification) {
+    void handlePersisted(@NonNull PersistedNotification notification) {
         // we only care for backfilled blocks
         if (notification.blockSource() != BlockSource.BACKFILL) {
             return;
@@ -123,8 +123,7 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
      *
      * @param notification the verification notification
      */
-    @Override
-    public void handleVerification(@NonNull VerificationNotification notification) {
+    void handleVerification(@NonNull VerificationNotification notification) {
         // we only care for backfilled blocks
         if (notification.source() != BlockSource.BACKFILL) {
             return;
@@ -139,6 +138,15 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
                 LOGGER.log(INFO, verificationFailedMsg, blockNumber);
                 latch.countDown();
             }
+        }
+    }
+
+    @Override
+    public void handleNotification(final BlockNotification notification) {
+        switch (notification) {
+            case VerificationNotification v -> handleVerification(v);
+            case PersistedNotification p -> handlePersisted(p);
+            default -> {}
         }
     }
 

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -26,6 +26,7 @@ import org.hiero.block.node.app.config.node.NodeConfig;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
@@ -434,8 +435,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
     /**
      * {@inheritDoc}
      */
-    @Override
-    public void handlePersisted(PersistedNotification notification) {
+    void handlePersisted(PersistedNotification notification) {
         if (notification.blockSource() == BlockSource.BACKFILL) {
             // Add more detailed logging for persistence notifications
             final String backfillPersistedMsg = "Received backfill persisted notification for block=[{0}]";
@@ -452,8 +452,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
     /**
      * {@inheritDoc}
      */
-    @Override
-    public void handleVerification(VerificationNotification notification) {
+    void handleVerification(VerificationNotification notification) {
         if (notification.source() == BlockSource.BACKFILL) {
             final String verificationNotificationMsg = "Received verification notification for block [{0}]";
             LOGGER.log(TRACE, verificationNotificationMsg, notification.blockNumber());
@@ -467,8 +466,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
         }
     }
 
-    @Override
-    public void handleNewestBlockKnownToNetwork(NewestBlockKnownToNetworkNotification notification) {
+    void handleNewestBlockKnownToNetwork(NewestBlockKnownToNetworkNotification notification) {
         if (!hasBNSourcesPath) {
             LOGGER.log(DEBUG, "No block node sources path configured, skipping on-demand backfill");
             return;
@@ -488,6 +486,16 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
             return;
         }
         scheduleGap(new GapDetector.Gap(new LongRange(startBackfillFrom, cappedEnd), GapDetector.Type.LIVE_TAIL));
+    }
+
+    @Override
+    public void handleNotification(final BlockNotification notification) {
+        switch (notification) {
+            case VerificationNotification v -> handleVerification(v);
+            case PersistedNotification p -> handlePersisted(p);
+            case NewestBlockKnownToNetworkNotification n -> handleNewestBlockKnownToNetwork(n);
+            default -> {}
+        }
     }
 
     /**

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -433,7 +433,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
     }
 
     /**
-     * {@inheritDoc}
+     * Handles a persisted notification, dispatched from {@link #handleNotification}.
      */
     void handlePersisted(PersistedNotification notification) {
         if (notification.blockSource() == BlockSource.BACKFILL) {
@@ -450,7 +450,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
     }
 
     /**
-     * {@inheritDoc}
+     * Handles a verification notification, dispatched from {@link #handleNotification}.
      */
     void handleVerification(VerificationNotification notification) {
         if (notification.source() == BlockSource.BACKFILL) {

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillRunner.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillRunner.java
@@ -261,7 +261,7 @@ final class BackfillRunner {
             metricsHolder.backfillFetchedBlocks().increment();
             // always track persistence before sending backfill notification to avoid race conditions
             persistenceAwaiter.trackBlock(blockNumber);
-            messaging.sendBackfilledBlockNotification(new BackfilledBlockNotification(blockNumber, blockUnparsed));
+            messaging.sendBlockNotification(new BackfilledBlockNotification(blockNumber, blockUnparsed));
             final String backfillingBlockMsg = "Backfilling block [{0}]";
             logger.log(TRACE, backfillingBlockMsg, blockNumber);
             pendingBackfillBlocks.incrementAndGet();

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
@@ -31,6 +31,7 @@ import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBloc
 import org.hiero.block.node.app.fixtures.server.TestBlockNodeServer;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
@@ -628,7 +629,7 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         // Trigger the backfill on-demand by sending a NewestBlockKnownToNetworkNotification
         // to the block messaging system
         NewestBlockKnownToNetworkNotification newestBlockNotification = new NewestBlockKnownToNetworkNotification(50L);
-        this.blockMessaging.sendNewestBlockKnownToNetwork(newestBlockNotification);
+        this.blockMessaging.sendBlockNotification(newestBlockNotification);
         // Wait for the backfill to complete
 
         countDownLatch.await(1, TimeUnit.MINUTES); // Wait until countDownLatch.countDown() is called
@@ -683,7 +684,7 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         registerDefaultTestBackfillHandler();
         registerDefaultTestVerificationHandler(countDownLatch);
 
-        blockMessaging.sendNewestBlockKnownToNetwork(new NewestBlockKnownToNetworkNotification(466L));
+        blockMessaging.sendBlockNotification(new NewestBlockKnownToNetworkNotification(466L));
 
         countDownLatch.await(1, TimeUnit.MINUTES);
 
@@ -729,7 +730,7 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         // Trigger the backfill on-demand by sending a NewestBlockKnownToNetworkNotification
         // to the block messaging system
         NewestBlockKnownToNetworkNotification newestBlockNotification = new NewestBlockKnownToNetworkNotification(20L);
-        this.blockMessaging.sendNewestBlockKnownToNetwork(newestBlockNotification);
+        this.blockMessaging.sendBlockNotification(newestBlockNotification);
         // Wait for the backfill to complete
 
         countDownLatch.await(1, TimeUnit.MINUTES); // Wait until countDownLatch.countDown() is called
@@ -775,7 +776,7 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         // Trigger the backfill on-demand by sending a NewestBlockKnownToNetworkNotification
         // to the block messaging system
         NewestBlockKnownToNetworkNotification newestBlockNotification = new NewestBlockKnownToNetworkNotification(20L);
-        this.blockMessaging.sendNewestBlockKnownToNetwork(newestBlockNotification);
+        this.blockMessaging.sendBlockNotification(newestBlockNotification);
         // Wait for the backfill to complete
 
         // allow some time for the backfill process to run
@@ -830,7 +831,7 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
 
         // Trigger the on-demand backfill by sending a NewestBlockKnownToNetworkNotification
         NewestBlockKnownToNetworkNotification newestBlockNotification = new NewestBlockKnownToNetworkNotification(50L);
-        this.blockMessaging.sendNewestBlockKnownToNetwork(newestBlockNotification);
+        this.blockMessaging.sendBlockNotification(newestBlockNotification);
 
         // LiveStreamPublisherManager
         countDownLatch.await(1, TimeUnit.MINUTES); // Wait until countDownLatch.countDown() is called
@@ -893,17 +894,24 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         // register the verification handler
         this.blockMessaging.registerBlockNotificationHandler(
                 new BlockNotificationHandler() {
-                    @Override
-                    public void handleVerification(VerificationNotification notification) {
+                    private void handleVerification(VerificationNotification notification) {
                         blockNodeContext
                                 .blockMessaging()
-                                .sendBlockPersisted(new PersistedNotification(
+                                .sendBlockNotification(new PersistedNotification(
                                         notification.blockNumber(), true, 10, notification.source()));
                         latch1.countDown();
                         if (notification.blockNumber() < 50) {
                             latchHistorical.countDown(); // Count down for historical blocks
                         } else if (notification.blockNumber() >= 100) {
                             latchLive.countDown(); // Count down for live blocks
+                        }
+                    }
+
+                    @Override
+                    public void handleNotification(BlockNotification notification) {
+                        switch (notification) {
+                            case VerificationNotification n -> handleVerification(n);
+                            default -> {}
                         }
                     }
                 },
@@ -915,7 +923,7 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
 
         // Trigger the on-demand backfill by sending a NewestBlockKnownToNetworkNotification
         NewestBlockKnownToNetworkNotification newestBlockNotification = new NewestBlockKnownToNetworkNotification(200L);
-        this.blockMessaging.sendNewestBlockKnownToNetwork(newestBlockNotification);
+        this.blockMessaging.sendBlockNotification(newestBlockNotification);
 
         // Wait for the backfill to complete
         latchHistorical.await(1, TimeUnit.MINUTES); // Wait until latch2.countDown() is called
@@ -981,17 +989,24 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         // register the verification handler
         this.blockMessaging.registerBlockNotificationHandler(
                 new BlockNotificationHandler() {
-                    @Override
-                    public void handleVerification(VerificationNotification notification) {
+                    private void handleVerification(VerificationNotification notification) {
                         blockNodeContext
                                 .blockMessaging()
-                                .sendBlockPersisted(new PersistedNotification(
+                                .sendBlockNotification(new PersistedNotification(
                                         notification.blockNumber(), true, 10, notification.source()));
                         latch1.countDown();
                         if (notification.blockNumber() < 50) {
                             latchHistorical.countDown(); // Count down for historical blocks
                         } else if (notification.blockNumber() >= 100) {
                             latchLive.countDown(); // Count down for live blocks
+                        }
+                    }
+
+                    @Override
+                    public void handleNotification(BlockNotification notification) {
+                        switch (notification) {
+                            case VerificationNotification n -> handleVerification(n);
+                            default -> {}
                         }
                     }
                 },
@@ -1004,7 +1019,7 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         // No external trigger the backfill on-demand should receive NewestBlockKnownToNetworkNotification from
         // LiveStreamPublisherManager
         NewestBlockKnownToNetworkNotification newestBlockNotification = new NewestBlockKnownToNetworkNotification(101L);
-        this.blockMessaging.sendNewestBlockKnownToNetwork(newestBlockNotification);
+        this.blockMessaging.sendBlockNotification(newestBlockNotification);
 
         // Wait for the backfill to complete
         latchHistorical.await(1, TimeUnit.MINUTES); // Wait until latch2.countDown() is called
@@ -1076,11 +1091,10 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         // register the verification handler
         this.blockMessaging.registerBlockNotificationHandler(
                 new BlockNotificationHandler() {
-                    @Override
-                    public void handleVerification(VerificationNotification notification) {
+                    private void handleVerification(VerificationNotification notification) {
                         blockNodeContext
                                 .blockMessaging()
-                                .sendBlockPersisted(new PersistedNotification(
+                                .sendBlockNotification(new PersistedNotification(
                                         notification.blockNumber(), true, 10, notification.source()));
                         backfillLatch.countDown();
 
@@ -1090,6 +1104,14 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
                                 ((SimpleBlockRangeSet) historicalBlockFacility.availableBlocks());
                         newRange.add(notification.blockNumber());
                         historicalBlockFacility.setTemporaryAvailableBlocks(newRange);
+                    }
+
+                    @Override
+                    public void handleNotification(BlockNotification notification) {
+                        switch (notification) {
+                            case VerificationNotification n -> handleVerification(n);
+                            default -> {}
+                        }
                     }
                 },
                 false,
@@ -1170,11 +1192,10 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         // register the verification handler
         this.blockMessaging.registerBlockNotificationHandler(
                 new BlockNotificationHandler() {
-                    @Override
-                    public void handleVerification(VerificationNotification notification) {
+                    private void handleVerification(VerificationNotification notification) {
                         blockNodeContext
                                 .blockMessaging()
-                                .sendBlockPersisted(new PersistedNotification(
+                                .sendBlockNotification(new PersistedNotification(
                                         notification.blockNumber(), true, 10, notification.source()));
                         backfillLatch.countDown();
                         if (notification.blockNumber() < localBNEarliestBlock) {
@@ -1190,6 +1211,14 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
                         newRange.add(notification.blockNumber());
                         historicalBlockFacility.setTemporaryAvailableBlocks(newRange);
                     }
+
+                    @Override
+                    public void handleNotification(BlockNotification notification) {
+                        switch (notification) {
+                            case VerificationNotification n -> handleVerification(n);
+                            default -> {}
+                        }
+                    }
                 },
                 false,
                 "test-backfill-handler");
@@ -1197,7 +1226,7 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         // Trigger the backfill on-demand by sending a NewestBlockKnownToNetworkNotification
         // to the block messaging system
         NewestBlockKnownToNetworkNotification newestBlockNotification = new NewestBlockKnownToNetworkNotification(120L);
-        this.blockMessaging.sendNewestBlockKnownToNetwork(newestBlockNotification);
+        this.blockMessaging.sendBlockNotification(newestBlockNotification);
 
         // Wait for the backfill to complete
         boolean autonomousSuccess =
@@ -1262,17 +1291,24 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         registerDefaultTestBackfillHandler();
         this.blockMessaging.registerBlockNotificationHandler(
                 new BlockNotificationHandler() {
-                    @Override
-                    public void handleVerification(VerificationNotification notification) {
+                    private void handleVerification(VerificationNotification notification) {
                         blockNodeContext
                                 .blockMessaging()
-                                .sendBlockPersisted(new PersistedNotification(
+                                .sendBlockNotification(new PersistedNotification(
                                         notification.blockNumber(), true, 10, notification.source()));
                         latch.countDown();
                         // Update the store so next scan sees progress
                         SimpleBlockRangeSet newRange = ((SimpleBlockRangeSet) pluginStore.availableBlocks());
                         newRange.add(notification.blockNumber());
                         pluginStore.setTemporaryAvailableBlocks(newRange);
+                    }
+
+                    @Override
+                    public void handleNotification(BlockNotification notification) {
+                        switch (notification) {
+                            case VerificationNotification n -> handleVerification(n);
+                            default -> {}
+                        }
                     }
                 },
                 false,
@@ -1424,17 +1460,24 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
     private void registerDefaultTestBackfillHandler() {
         this.blockMessaging.registerBlockNotificationHandler(
                 new BlockNotificationHandler() {
-                    @Override
-                    public void handleBackfilled(BackfilledBlockNotification notification) {
+                    private void handleBackfilled(BackfilledBlockNotification notification) {
                         blockNodeContext
                                 .blockMessaging()
-                                .sendBlockVerification(new VerificationNotification(
+                                .sendBlockNotification(new VerificationNotification(
                                         true,
                                         null,
                                         notification.blockNumber(),
                                         Bytes.wrap("123"),
                                         notification.block(),
                                         BlockSource.BACKFILL));
+                    }
+
+                    @Override
+                    public void handleNotification(BlockNotification notification) {
+                        switch (notification) {
+                            case BackfilledBlockNotification n -> handleBackfilled(n);
+                            default -> {}
+                        }
                     }
                 },
                 false,
@@ -1444,13 +1487,20 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
     private void registerDefaultTestVerificationHandler(CountDownLatch countDownLatch) {
         this.blockMessaging.registerBlockNotificationHandler(
                 new BlockNotificationHandler() {
-                    @Override
-                    public void handleVerification(VerificationNotification notification) {
+                    private void handleVerification(VerificationNotification notification) {
                         blockNodeContext
                                 .blockMessaging()
-                                .sendBlockPersisted(new PersistedNotification(
+                                .sendBlockNotification(new PersistedNotification(
                                         notification.blockNumber(), true, 10, notification.source()));
                         countDownLatch.countDown();
+                    }
+
+                    @Override
+                    public void handleNotification(BlockNotification notification) {
+                        switch (notification) {
+                            case VerificationNotification n -> handleVerification(n);
+                            default -> {}
+                        }
                     }
                 },
                 false,

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillRunnerTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillRunnerTest.java
@@ -308,11 +308,20 @@ class BackfillRunnerTest {
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
                     new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
-                        @Override
-                        public void handleBackfilled(
+                        private void handleBackfilled(
                                 org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
-                            messaging.sendBlockPersisted(new PersistedNotification(
+                            messaging.sendBlockNotification(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
+                        }
+
+                        @Override
+                        public void handleNotification(
+                                org.hiero.block.node.spi.blockmessaging.BlockNotification notification) {
+                            switch (notification) {
+                                case org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification b ->
+                                    handleBackfilled(b);
+                                default -> {}
+                            }
                         }
                     },
                     false,
@@ -354,11 +363,20 @@ class BackfillRunnerTest {
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
                     new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
-                        @Override
-                        public void handleBackfilled(
+                        private void handleBackfilled(
                                 org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
-                            messaging.sendBlockPersisted(new PersistedNotification(
+                            messaging.sendBlockNotification(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
+                        }
+
+                        @Override
+                        public void handleNotification(
+                                org.hiero.block.node.spi.blockmessaging.BlockNotification notification) {
+                            switch (notification) {
+                                case org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification b ->
+                                    handleBackfilled(b);
+                                default -> {}
+                            }
                         }
                     },
                     false,
@@ -401,11 +419,20 @@ class BackfillRunnerTest {
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
                     new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
-                        @Override
-                        public void handleBackfilled(
+                        private void handleBackfilled(
                                 org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
-                            messaging.sendBlockPersisted(new PersistedNotification(
+                            messaging.sendBlockNotification(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
+                        }
+
+                        @Override
+                        public void handleNotification(
+                                org.hiero.block.node.spi.blockmessaging.BlockNotification notification) {
+                            switch (notification) {
+                                case org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification b ->
+                                    handleBackfilled(b);
+                                default -> {}
+                            }
                         }
                     },
                     false,
@@ -469,12 +496,21 @@ class BackfillRunnerTest {
             // Register a handler that simulates immediate persistence (verification + persist flow)
             messaging.registerBlockNotificationHandler(
                     new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
-                        @Override
-                        public void handleBackfilled(
+                        private void handleBackfilled(
                                 org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
                             // Simulate immediate persistence
-                            messaging.sendBlockPersisted(new PersistedNotification(
+                            messaging.sendBlockNotification(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
+                        }
+
+                        @Override
+                        public void handleNotification(
+                                org.hiero.block.node.spi.blockmessaging.BlockNotification notification) {
+                            switch (notification) {
+                                case org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification b ->
+                                    handleBackfilled(b);
+                                default -> {}
+                            }
                         }
                     },
                     false,
@@ -509,11 +545,20 @@ class BackfillRunnerTest {
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
                     new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
-                        @Override
-                        public void handleBackfilled(
+                        private void handleBackfilled(
                                 org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
-                            messaging.sendBlockPersisted(new PersistedNotification(
+                            messaging.sendBlockNotification(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
+                        }
+
+                        @Override
+                        public void handleNotification(
+                                org.hiero.block.node.spi.blockmessaging.BlockNotification notification) {
+                            switch (notification) {
+                                case org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification b ->
+                                    handleBackfilled(b);
+                                default -> {}
+                            }
                         }
                     },
                     false,
@@ -600,11 +645,20 @@ class BackfillRunnerTest {
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
                     new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
-                        @Override
-                        public void handleBackfilled(
+                        private void handleBackfilled(
                                 org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
-                            messaging.sendBlockPersisted(new PersistedNotification(
+                            messaging.sendBlockNotification(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
+                        }
+
+                        @Override
+                        public void handleNotification(
+                                org.hiero.block.node.spi.blockmessaging.BlockNotification notification) {
+                            switch (notification) {
+                                case org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification b ->
+                                    handleBackfilled(b);
+                                default -> {}
+                            }
                         }
                     },
                     false,
@@ -665,11 +719,20 @@ class BackfillRunnerTest {
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
                     new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
-                        @Override
-                        public void handleBackfilled(
+                        private void handleBackfilled(
                                 org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
-                            messaging.sendBlockPersisted(new PersistedNotification(
+                            messaging.sendBlockNotification(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
+                        }
+
+                        @Override
+                        public void handleNotification(
+                                org.hiero.block.node.spi.blockmessaging.BlockNotification notification) {
+                            switch (notification) {
+                                case org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification b ->
+                                    handleBackfilled(b);
+                                default -> {}
+                            }
                         }
                     },
                     false,
@@ -722,11 +785,20 @@ class BackfillRunnerTest {
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
                     new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
-                        @Override
-                        public void handleBackfilled(
+                        private void handleBackfilled(
                                 org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
-                            messaging.sendBlockPersisted(new PersistedNotification(
+                            messaging.sendBlockNotification(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
+                        }
+
+                        @Override
+                        public void handleNotification(
+                                org.hiero.block.node.spi.blockmessaging.BlockNotification notification) {
+                            switch (notification) {
+                                case org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification b ->
+                                    handleBackfilled(b);
+                                default -> {}
+                            }
                         }
                     },
                     false,
@@ -759,11 +831,20 @@ class BackfillRunnerTest {
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
                     new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
-                        @Override
-                        public void handleBackfilled(
+                        private void handleBackfilled(
                                 org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
-                            messaging.sendBlockPersisted(new PersistedNotification(
+                            messaging.sendBlockNotification(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
+                        }
+
+                        @Override
+                        public void handleNotification(
+                                org.hiero.block.node.spi.blockmessaging.BlockNotification notification) {
+                            switch (notification) {
+                                case org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification b ->
+                                    handleBackfilled(b);
+                                default -> {}
+                            }
                         }
                     },
                     false,
@@ -799,11 +880,20 @@ class BackfillRunnerTest {
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
                     new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
-                        @Override
-                        public void handleBackfilled(
+                        private void handleBackfilled(
                                 org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
-                            messaging.sendBlockPersisted(new PersistedNotification(
+                            messaging.sendBlockNotification(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
+                        }
+
+                        @Override
+                        public void handleNotification(
+                                org.hiero.block.node.spi.blockmessaging.BlockNotification notification) {
+                            switch (notification) {
+                                case org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification b ->
+                                    handleBackfilled(b);
+                                default -> {}
+                            }
                         }
                     },
                     false,

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationServicePlugin.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationServicePlugin.java
@@ -186,8 +186,8 @@ public final class VerificationServicePlugin implements BlockNodePlugin, BlockIt
         }
     }
 
-    /// {@inheritDoc}
-    /// ---
+    /// Handles a backfilled block notification, dispatched from [#handleNotification].
+    ///
     /// This is where we receive blocks from backfill.
     /// We will always receive a complete block, one per notification.
     /// We can safely wrap the block as [BlockItems] which is both the start

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationServicePlugin.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationServicePlugin.java
@@ -19,6 +19,7 @@ import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
@@ -195,8 +196,7 @@ public final class VerificationServicePlugin implements BlockNodePlugin, BlockIt
     ///
     /// @param notification the [BackfilledBlockNotification] received as an
     ///     event.
-    @Override
-    public void handleBackfilled(final BackfilledBlockNotification notification) {
+    void handleBackfilled(final BackfilledBlockNotification notification) {
         try {
             if (notification != null
                     && notification.blockNumber() >= 0L
@@ -228,10 +228,19 @@ public final class VerificationServicePlugin implements BlockNodePlugin, BlockIt
     /// immediately after.
     ///
     /// @param notification a [PersistedNotification] received as an event.
-    @Override
-    public void handlePersisted(final PersistedNotification notification) {
+    private void handlePersisted(final PersistedNotification notification) {
         if (notification != null && !notification.succeeded()) {
             recentlyVerifiedBlocks.remove(notification.blockNumber());
+        }
+    }
+
+    /// {@inheritDoc}
+    @Override
+    public void handleNotification(final BlockNotification notification) {
+        switch (notification) {
+            case BackfilledBlockNotification b -> handleBackfilled(b);
+            case PersistedNotification p -> handlePersisted(p);
+            default -> {}
         }
     }
 

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/SessionResultHandler.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/SessionResultHandler.java
@@ -98,7 +98,7 @@ public final class SessionResultHandler implements BiConsumer<BlockVerificationR
     /// Send a notification to messaging.
     private void safeSendNotification(final VerificationNotification notification) {
         try {
-            context.blockMessaging().sendBlockVerification(notification);
+            context.blockMessaging().sendBlockNotification(notification);
         } catch (final RuntimeException e) {
             final String message =
                     "Failed to send verification notification for completed session with id %d for block %d with source %s"

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
@@ -38,6 +38,7 @@ import org.hiero.block.node.base.BlockFile;
 import org.hiero.block.node.base.ranges.ConcurrentLongRangeSet;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
@@ -332,7 +333,14 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
     // ==== BlockNotificationHandler Methods ===========================================================================
 
     @Override
-    public void handleVerification(VerificationNotification notification) {
+    public void handleNotification(final BlockNotification notification) {
+        switch (notification) {
+            case VerificationNotification v -> handleVerification(v);
+            default -> {}
+        }
+    }
+
+    private void handleVerification(VerificationNotification notification) {
         if (notification != null && notification.success()) {
             writeBlockToStagingPath(notification.block(), notification.blockNumber());
         }
@@ -624,7 +632,7 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
                     // @todo is this needed? Does anything actually care when a zip file is completed?
                     plugin.context
                             .blockMessaging()
-                            .sendBlockPersisted(
+                            .sendBlockNotification(
                                     new PersistedNotification(batchLastBlockNumber, true, 1_000, BlockSource.HISTORY));
                     plugin.cleanup();
                 }

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
@@ -317,7 +317,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
@@ -352,7 +352,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 20; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 20 blocks are zipped yet
@@ -387,7 +387,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 14; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 20 blocks are zipped yet
@@ -419,7 +419,7 @@ class BlockFileHistoricPluginTest {
                 }
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 20 blocks are zipped yet
@@ -460,7 +460,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
                 expectedBlocks.add(new BlockUnparsed(block.blockItems()));
             }
@@ -512,7 +512,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 5; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 5 blocks are zipped yet
@@ -532,7 +532,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 5; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
@@ -567,7 +567,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 3; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // generate next blocks with a gap and make sure we reach the
@@ -576,7 +576,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 5; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // we now have blocks 0-2 and 5-9, so we have a gap
@@ -611,7 +611,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 42; i < 64; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
 
@@ -636,7 +636,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 30; i < 42; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
 
@@ -660,7 +660,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 15; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
 
@@ -688,7 +688,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 15; i < 23; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
 
@@ -717,7 +717,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 23; i < 27; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
 
@@ -744,7 +744,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 3; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // generate next blocks with a gap and make sure we reach the
@@ -753,7 +753,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 5; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // we now have blocks 0-2 and 5-9, so we have a gap
@@ -786,7 +786,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
@@ -822,7 +822,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks have accessors yet
@@ -851,7 +851,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
                 expectedBlocks.add(new BlockUnparsed(block.blockItems()));
             }
@@ -883,7 +883,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
@@ -917,7 +917,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks appear in the available range
@@ -947,7 +947,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
@@ -978,7 +978,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
@@ -1012,7 +1012,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
@@ -1045,7 +1045,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
@@ -1078,7 +1078,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 10 blocks are zipped yet
@@ -1109,7 +1109,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 150; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 150 blocks are zipped yet and are
@@ -1135,7 +1135,7 @@ class BlockFileHistoricPluginTest {
 
             final BlockUnparsed block =
                     TestBlockBuilder.generateBlockWithNumber(150).blockUnparsed();
-            blockMessaging.sendBlockVerification(new VerificationNotification(
+            blockMessaging.sendBlockNotification(new VerificationNotification(
                     true, null, 150, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             // assert that the size of the available blocks is now 100 (post retention policy cleanup)
             assertThat(plugin.availableBlocks().size()).isEqualTo(100);
@@ -1170,7 +1170,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 150; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
             // assert that none of the first 150 blocks are zipped yet and are
@@ -1193,7 +1193,7 @@ class BlockFileHistoricPluginTest {
             // not need to actually persist the block
             final BlockUnparsed block =
                     TestBlockBuilder.generateBlockWithNumber(150).blockUnparsed();
-            blockMessaging.sendBlockVerification(new VerificationNotification(
+            blockMessaging.sendBlockNotification(new VerificationNotification(
                     true, null, 150, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             // assert that the size of the available blocks is still 150 (post retention policy cleanup)
             assertThat(plugin.availableBlocks().size()).isEqualTo(150);
@@ -1221,7 +1221,7 @@ class BlockFileHistoricPluginTest {
             // set that fills the retention threshold exactly
             for (int i = 100; i < 200; i++) {
                 final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             }
 
@@ -1240,7 +1240,7 @@ class BlockFileHistoricPluginTest {
             // retention threshold, triggering cleanup of the oldest blocks.
             for (int i = 200; i < 210; i++) {
                 final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             }
 
@@ -1322,7 +1322,7 @@ class BlockFileHistoricPluginTest {
             // This represents the initial arrival of blocks that need to be archived.
             for (int i = 0; i < 10; i++) {
                 final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             }
 
@@ -1347,7 +1347,7 @@ class BlockFileHistoricPluginTest {
             // instead of being skipped as it would be with the default configuration.
             for (int i = 0; i < 10; i++) {
                 final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             }
 
@@ -1374,7 +1374,7 @@ class BlockFileHistoricPluginTest {
         private void sendBlockVerificationNotifications(final int startInclusive, final int endExclusive) {
             for (int i = startInclusive; i < endExclusive; i++) {
                 final TestBlock block = TestBlockBuilder.generateBlockWithNumber(i);
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             }
         }
@@ -1515,7 +1515,7 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
 

--- a/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPlugin.java
+++ b/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPlugin.java
@@ -40,6 +40,7 @@ import org.hiero.block.node.base.ranges.ConcurrentLongRangeSet;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
@@ -309,12 +310,20 @@ public final class BlockFileRecentPlugin implements BlockProviderPlugin, BlockNo
 
     /**
      * {@inheritDoc}
-     * <p>
+     */
+    @Override
+    public void handleNotification(final BlockNotification notification) {
+        switch (notification) {
+            case VerificationNotification v -> handleVerification(v);
+            default -> {}
+        }
+    }
+
+    /**
      * This method is called when a block verification notification is received. It is called on the block notification
      * thread.
      */
-    @Override
-    public void handleVerification(VerificationNotification notification) {
+    private void handleVerification(VerificationNotification notification) {
         try {
             final long startTime = System.nanoTime();
             LOGGER.log(DEBUG, "Persistence Handle verification started for block {0}", notification.blockNumber());
@@ -389,7 +398,7 @@ public final class BlockFileRecentPlugin implements BlockProviderPlugin, BlockNo
     }
 
     private void sendBlockNotification(final long number, final boolean succeeded, final BlockSource source) {
-        blockMessaging.sendBlockPersisted(new PersistedNotification(number, succeeded, defaultPriority(), source));
+        blockMessaging.sendBlockNotification(new PersistedNotification(number, succeeded, defaultPriority(), source));
     }
 
     private BlockHeader getBlockHeader(final BlockUnparsed block) {

--- a/block-node/blocks-file-recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPluginTest.java
+++ b/block-node/blocks-file-recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPluginTest.java
@@ -198,7 +198,7 @@ class BlockFileRecentPluginTest {
             assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().max());
             assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().min());
             // send verified block notification
-            blockMessaging.sendBlockVerification(new VerificationNotification(
+            blockMessaging.sendBlockNotification(new VerificationNotification(
                     true, null, blockNumber, Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             // now try and read it back
             final BlockUnparsed blockFromPlugin = plugin.block(blockNumber).blockUnparsed();
@@ -230,7 +230,7 @@ class BlockFileRecentPluginTest {
             assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().max());
             assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().min());
             // send verified block notification with failure
-            blockMessaging.sendBlockVerification(new VerificationNotification(
+            blockMessaging.sendBlockNotification(new VerificationNotification(
                     false,
                     FailureInfo.standard(FailureType.BAD_BLOCK_PROOF),
                     blockNumber,
@@ -263,7 +263,7 @@ class BlockFileRecentPluginTest {
             assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().max());
             assertEquals(UNKNOWN_BLOCK_NUMBER, plugin.availableBlocks().min());
             // send verified block notification
-            blockMessaging.sendBlockVerification(new VerificationNotification(
+            blockMessaging.sendBlockNotification(new VerificationNotification(
                     true, null, blockNumber, Bytes.EMPTY, blockOrig, BlockSource.PUBLISHER));
             // now try and read it back
             final BlockUnparsed blockFromPlugin = plugin.block(blockNumber).blockUnparsed();
@@ -290,7 +290,7 @@ class BlockFileRecentPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 // send the block items to the plugin
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
                 // assert that the block is persisted
                 final Path persistedBlock = BlockFile.nestedDirectoriesBlockFilePath(
@@ -347,7 +347,7 @@ class BlockFileRecentPluginTest {
                 final BlockUnparsed block =
                         TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
                 // send the block items to the plugin
-                blockMessaging.sendBlockVerification(new VerificationNotification(
+                blockMessaging.sendBlockNotification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
                 // assert that the block is persisted
                 final Path persistedBlock = BlockFile.nestedDirectoriesBlockFilePath(

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTask.java
@@ -246,7 +246,7 @@ public class BlockUploadTask implements Callable<UploadResult> {
                 // fall back to blockNum so the notification is never dropped.
                 final Map.Entry<Long, BlockSource> last =
                         blocksInBuffer.isEmpty() ? Map.entry(blockNum, blockSource) : blocksInBuffer.lastEntry();
-                blockMessaging.sendBlockPersisted(
+                blockMessaging.sendBlockNotification(
                         new PersistedNotification(last.getKey(), true, 1_000, last.getValue()));
                 final long rangeStart = blocksInBuffer.isEmpty() ? blockNum : blocksInBuffer.firstKey();
                 applicationStateFacility.addStoredBlockRange(new LongRange(rangeStart, last.getKey()));
@@ -264,7 +264,8 @@ public class BlockUploadTask implements Callable<UploadResult> {
             final BlockSource firstBlockSource = blocksInBuffer.isEmpty()
                     ? blockSource
                     : blocksInBuffer.firstEntry().getValue();
-            blockMessaging.sendBlockPersisted(new PersistedNotification(firstBlockNum, false, 1_000, firstBlockSource));
+            blockMessaging.sendBlockNotification(
+                    new PersistedNotification(firstBlockNum, false, 1_000, firstBlockSource));
             LOGGER.log(INFO, "Failed to upload part containing blocks %d to %d".formatted(firstBlockNum, blockNum), e);
             return null;
         }
@@ -294,7 +295,7 @@ public class BlockUploadTask implements Callable<UploadResult> {
             doUploadPart(buffer, s3, uploadId, etags);
         } catch (S3ResponseException | IOException e) {
             final Map.Entry<Long, BlockSource> first = blocksInBuffer.firstEntry();
-            blockMessaging.sendBlockPersisted(
+            blockMessaging.sendBlockNotification(
                     new PersistedNotification(first.getKey(), false, 1_000, first.getValue()));
             LOGGER.log(INFO, "Failed to upload final part for key {0}", key, e);
             partResult = UploadResult.FAILED;
@@ -302,7 +303,8 @@ public class BlockUploadTask implements Callable<UploadResult> {
         }
         if (partResult == UploadResult.SUCCESS) {
             final Map.Entry<Long, BlockSource> last = blocksInBuffer.lastEntry();
-            blockMessaging.sendBlockPersisted(new PersistedNotification(last.getKey(), true, 1_000, last.getValue()));
+            blockMessaging.sendBlockNotification(
+                    new PersistedNotification(last.getKey(), true, 1_000, last.getValue()));
             applicationStateFacility.addStoredBlockRange(new LongRange(blocksInBuffer.firstKey(), last.getKey()));
             metricsHolder.blocksWritten().increment(blocksInBuffer.size());
             metricsHolder.storedBytes().increment(buffer.length);

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
@@ -24,6 +24,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.hiero.block.node.spi.historicalblocks.LongRange;
@@ -224,7 +225,14 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
 
     /// {@inheritDoc}
     @Override
-    public void handleVerification(VerificationNotification notification) {
+    public void handleNotification(final BlockNotification notification) {
+        switch (notification) {
+            case VerificationNotification v -> handleVerification(v);
+            default -> {}
+        }
+    }
+
+    void handleVerification(VerificationNotification notification) {
         try {
             if (notification != null && notification.success() && notification.block() != null) {
                 // If the task was cancelled (i.e. stop() was called), do not start a new task or process

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTask.java
@@ -111,7 +111,7 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
                         // S3 part, not per completed archive. If lastProcessedBlock's tar bytes
                         // straddle a part boundary, the trailing portion is still in the buffer
                         // and will be uploaded later — but the block is declared persisted here.
-                        blockMessaging.sendBlockPersisted(
+                        blockMessaging.sendBlockNotification(
                                 new PersistedNotification(lastProcessedBlock, true, 1_000, lastSource));
                         applicationStateFacility.addStoredBlockRange(
                                 new LongRange(lastNotifiedBlock + 1, lastProcessedBlock));
@@ -137,13 +137,13 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
             if (buffer.length > 0) {
                 try {
                     doUploadPart(buffer, s3, uploadId, etags);
-                    blockMessaging.sendBlockPersisted(new PersistedNotification(lastBlock, true, 1_000, lastSource));
+                    blockMessaging.sendBlockNotification(new PersistedNotification(lastBlock, true, 1_000, lastSource));
                     applicationStateFacility.addStoredBlockRange(new LongRange(lastNotifiedBlock + 1, lastBlock));
                     metricsHolder.blocksWritten().increment(lastBlock - lastNotifiedBlock);
                     metricsHolder.storedBytes().increment(buffer.length);
                 } catch (S3ResponseException | IOException e) {
                     S3UploadUtils.abortQuietly(s3, s3Key, uploadId);
-                    blockMessaging.sendBlockPersisted(
+                    blockMessaging.sendBlockNotification(
                             new PersistedNotification(lastNotifiedBlock + 1, false, 1_000, lastSource));
                     LOGGER.log(INFO, "Failed to upload final temp archive part for key {0}", s3Key, e);
                     throw e;

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchiveIntegrationTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchiveIntegrationTest.java
@@ -312,7 +312,7 @@ class CloudStorageArchiveIntegrationTest {
 
     private void sendVerification(final PluginContext pc, final TestBlock block) {
         pc.messaging()
-                .sendBlockVerification(new VerificationNotification(
+                .sendBlockNotification(new VerificationNotification(
                         true, null, block.number(), Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
     }
 

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
@@ -740,7 +740,7 @@ class CloudStorageArchivePluginTest {
 
         /// Sends a single [VerificationNotification] via the messaging facility.
         private void sendVerification(TestBlock block) {
-            blockMessaging.sendBlockVerification(new VerificationNotification(
+            blockMessaging.sendBlockNotification(new VerificationNotification(
                     true, null, block.number(), Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
         }
 
@@ -1082,7 +1082,7 @@ class CloudStorageArchivePluginTest {
                 final BlockUnparsed block = BlockUnparsed.newBuilder()
                         .blockItems(new BlockItemUnparsed[] {item})
                         .build();
-                blockMessaging.sendBlockVerification(
+                blockMessaging.sendBlockNotification(
                         new VerificationNotification(true, null, i, Bytes.EMPTY, block, BlockSource.PUBLISHER));
             }
 
@@ -1182,7 +1182,7 @@ class CloudStorageArchivePluginTest {
         }
 
         private void sendVerification(TestBlock block) {
-            blockMessaging.sendBlockVerification(new VerificationNotification(
+            blockMessaging.sendBlockNotification(new VerificationNotification(
                     true, null, block.number(), Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
         }
     }
@@ -1610,7 +1610,7 @@ class CloudStorageArchivePluginTest {
         }
 
         private void sendVerification(TestBlock block) {
-            blockMessaging.sendBlockVerification(new VerificationNotification(
+            blockMessaging.sendBlockNotification(new VerificationNotification(
                     true, null, block.number(), Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
         }
     }
@@ -1901,7 +1901,7 @@ class CloudStorageArchivePluginTest {
         }
 
         private void sendVerification(TestBlock block) {
-            blockMessaging.sendBlockVerification(new VerificationNotification(
+            blockMessaging.sendBlockNotification(new VerificationNotification(
                     true, null, block.number(), Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
         }
     }
@@ -2030,7 +2030,7 @@ class CloudStorageArchivePluginTest {
             // handleVerification() detects the done-but-failed recovery future, catches the
             // resulting ExecutionException, and increments failedTasks.
             final TestBlock block = TestBlockBuilder.generateBlocksInRange(0, 0).getFirst();
-            failingMessaging.sendBlockVerification(new VerificationNotification(
+            failingMessaging.sendBlockNotification(new VerificationNotification(
                     true, null, block.number(), Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
             assertThat(exporter.getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_FAILED_TASKS.name()))
                     .isEqualTo(1L);
@@ -2046,7 +2046,7 @@ class CloudStorageArchivePluginTest {
         }
 
         private void sendVerification(TestBlock block) {
-            blockMessaging.sendBlockVerification(new VerificationNotification(
+            blockMessaging.sendBlockNotification(new VerificationNotification(
                     true, null, block.number(), Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
         }
     }
@@ -2144,7 +2144,7 @@ class CloudStorageArchivePluginTest {
         }
 
         private void sendVerification(TestBlock block) {
-            blockMessaging.sendBlockVerification(new VerificationNotification(
+            blockMessaging.sendBlockNotification(new VerificationNotification(
                     true, null, block.number(), Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
         }
     }
@@ -2296,7 +2296,7 @@ class CloudStorageArchivePluginTest {
         }
 
         private void sendVerification(TestBlock block) {
-            blockMessaging.sendBlockVerification(new VerificationNotification(
+            blockMessaging.sendBlockNotification(new VerificationNotification(
                     true, null, block.number(), Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
         }
     }

--- a/block-node/cloud-storage-expanded/src/main/java/org/hiero/block/node/cloud/storage/expanded/ExpandedCloudStoragePlugin.java
+++ b/block-node/cloud-storage-expanded/src/main/java/org/hiero/block/node/cloud/storage/expanded/ExpandedCloudStoragePlugin.java
@@ -21,6 +21,7 @@ import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
@@ -231,12 +232,18 @@ public class ExpandedCloudStoragePlugin implements BlockNodePlugin, BlockNotific
     // ---- BlockNotificationHandler -------------------------------------------
 
     /// {@inheritDoc}
-    ///
+    @Override
+    public void handleNotification(final BlockNotification notification) {
+        switch (notification) {
+            case VerificationNotification v -> handleVerification(v);
+            default -> {}
+        }
+    }
+
     /// Drains any completed upload tasks (publishing {@link PersistedNotification} for
     /// each), then submits this block as a new {@link SingleBlockStoreTask} to the
     /// {@link CompletionService}.
-    @Override
-    public void handleVerification(@NonNull final VerificationNotification notification) {
+    void handleVerification(@NonNull final VerificationNotification notification) {
         if (s3Client == null) {
             LOGGER.log(
                     TRACE, "Skipping upload for block {0}: S3 client is not configured.", notification.blockNumber());
@@ -315,7 +322,7 @@ public class ExpandedCloudStoragePlugin implements BlockNodePlugin, BlockNotific
 
     /// Publishes a {@link PersistedNotification} for the given upload result and updates metrics.
     private void publishResult(final SingleBlockStoreTask.UploadResult result) {
-        blockMessaging.sendBlockPersisted(
+        blockMessaging.sendBlockNotification(
                 new PersistedNotification(result.blockNumber(), result.succeeded(), 0, result.blockSource()));
         if (!result.succeeded()) {
             metricsHolder.uploadFailuresTotal().increment();

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -23,17 +23,13 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
-import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.GatingHandler;
-import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.NoBackPressureBlockItemHandler;
-import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
-import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification;
-import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.hiero.metrics.LongCounter;
 import org.hiero.metrics.ObservableGauge;
 import org.hiero.metrics.core.MetricKey;
@@ -51,26 +47,12 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
     /** Metric key for incoming block items seen by the mediator */
     public static final MetricKey<LongCounter> METRIC_MESSAGING_BLOCK_ITEMS_RECEIVED =
             MetricKey.of("messaging_block_items_received", LongCounter.class).addCategory(METRICS_CATEGORY);
-    /** Metric key for notifications issued after verification */
-    public static final MetricKey<LongCounter> METRIC_MESSAGING_BLOCK_VERIFICATION_NOTIFICATIONS = MetricKey.of(
-                    "messaging_block_verification_notifications", LongCounter.class)
+    /** Metric key for notifications sent, broken down by notification type */
+    public static final MetricKey<LongCounter> METRIC_MESSAGING_BLOCK_NOTIFICATIONS_SENT = MetricKey.of(
+                    "messaging_block_notifications_sent", LongCounter.class)
             .addCategory(METRICS_CATEGORY);
-    /** Metric key for notifications issued after persistence */
-    public static final MetricKey<LongCounter> METRIC_MESSAGING_BLOCK_PERSISTED_NOTIFICATIONS = MetricKey.of(
-                    "messaging_block_persisted_notifications", LongCounter.class)
-            .addCategory(METRICS_CATEGORY);
-    /** Metric key for notifications issued after backfilling */
-    public static final MetricKey<LongCounter> METRIC_MESSAGING_BLOCK_BACKFILLED_NOTIFICATIONS = MetricKey.of(
-                    "messaging_block_backfilled_notifications", LongCounter.class)
-            .addCategory(METRICS_CATEGORY);
-    /** Metric key for notifications issued after the newest block known to network */
-    public static final MetricKey<LongCounter> METRIC_MESSAGING_NEWEST_BLOCK_KNOWN_TO_NETWORK_NOTIFICATIONS =
-            MetricKey.of("messaging_newest_block_known_to_network_notifications", LongCounter.class)
-                    .addCategory(METRICS_CATEGORY);
-    /** Metric key for publisher status update notifications sent */
-    public static final MetricKey<LongCounter> METRIC_MESSAGING_PUBLISHER_STATUS_UPDATE_NOTIFICATIONS = MetricKey.of(
-                    "messaging_publisher_status_update_notifications", LongCounter.class)
-            .addCategory(METRICS_CATEGORY);
+    /** Dynamic label name identifying the notification type, by simple class name */
+    private static final String LABEL_NOTIFICATION_TYPE = "notification_type";
     /** Metric key for the number of active item listeners */
     public static final MetricKey<ObservableGauge> METRIC_MESSAGING_NO_OF_ITEM_LISTENERS = MetricKey.of(
                     "messaging_no_of_item_listeners", ObservableGauge.class)
@@ -91,16 +73,8 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
     // Metrics
     /** Counter for incoming block items seen by the mediator */
     private LongCounter.Measurement blockItemsReceivedCounter;
-    /** Counter for notifications issued after verification */
-    private LongCounter.Measurement blockVerificationNotificationsCounter;
-    /** Counter for notifications issued after persistence */
-    private LongCounter.Measurement blockPersistedNotificationsCounter;
-    /** Counter for notifications issued after backfilling */
-    private LongCounter.Measurement blockBackfilledNotificationsCounter;
-    /** Counter for notifications issued after the newest block known to network */
-    private LongCounter.Measurement newestBlockKnownToNetworkNotificationsCounter;
-    /** Counter for publisher status update notifications sent */
-    private LongCounter.Measurement publisherStatusUpdateNotificationsCounter;
+    /** Counter for notifications sent, labeled by notification type */
+    private LongCounter notificationsSentCounter;
 
     /**
      * The thread factory used to create the virtual threads for the disruptor. Virtual threads are daemon threads by
@@ -271,30 +245,10 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                         .setDescription("Incoming block items seen by the mediator"))
                 .getOrCreateNotLabeled();
 
-        blockVerificationNotificationsCounter = metricRegistry
-                .register(LongCounter.builder(METRIC_MESSAGING_BLOCK_VERIFICATION_NOTIFICATIONS)
-                        .setDescription("Notifications issued after verification"))
-                .getOrCreateNotLabeled();
-
-        blockPersistedNotificationsCounter = metricRegistry
-                .register(LongCounter.builder(METRIC_MESSAGING_BLOCK_PERSISTED_NOTIFICATIONS)
-                        .setDescription("Notifications issued after persistence"))
-                .getOrCreateNotLabeled();
-
-        blockBackfilledNotificationsCounter = metricRegistry
-                .register(LongCounter.builder(METRIC_MESSAGING_BLOCK_BACKFILLED_NOTIFICATIONS)
-                        .setDescription("Notifications issued after backfilling"))
-                .getOrCreateNotLabeled();
-
-        newestBlockKnownToNetworkNotificationsCounter = metricRegistry
-                .register(LongCounter.builder(METRIC_MESSAGING_NEWEST_BLOCK_KNOWN_TO_NETWORK_NOTIFICATIONS)
-                        .setDescription("Notifications issued after the newest block known to network"))
-                .getOrCreateNotLabeled();
-
-        publisherStatusUpdateNotificationsCounter = metricRegistry
-                .register(LongCounter.builder(METRIC_MESSAGING_PUBLISHER_STATUS_UPDATE_NOTIFICATIONS)
-                        .setDescription("Notifications issued for publisher status updates"))
-                .getOrCreateNotLabeled();
+        notificationsSentCounter =
+                metricRegistry.register(LongCounter.builder(METRIC_MESSAGING_BLOCK_NOTIFICATIONS_SENT)
+                        .setDescription("Notifications sent, by notification type")
+                        .addDynamicLabelNames(LABEL_NOTIFICATION_TYPE));
 
         // Initialize gauges
         metricRegistry
@@ -446,65 +400,16 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
      * {@inheritDoc}
      */
     @Override
-    public void sendBlockVerification(VerificationNotification notification) {
+    public void sendBlockNotification(final BlockNotification notification) {
         messageForwarder.submit(() -> {
             blockNotificationDisruptor.getRingBuffer().publishEvent((event, sequence) -> event.set(notification));
             // metrics
-            blockVerificationNotificationsCounter.increment();
+            final String notificationType = notification.getClass().getSimpleName();
+            notificationsSentCounter
+                    .getOrCreateLabeled(LABEL_NOTIFICATION_TYPE, notificationType)
+                    .increment();
             // logs
-            LOGGER.log(
-                    DEBUG,
-                    "Sending block verification notification for block={0} blockSource={1} and success={2} ",
-                    notification.blockNumber(),
-                    notification.source(),
-                    notification.success());
-        });
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void sendBlockPersisted(PersistedNotification notification) {
-        messageForwarder.submit(() -> {
-            LOGGER.log(
-                    DEBUG,
-                    "Sending block persisted notification: block={0} succeeded={1} source={2}",
-                    notification.blockNumber(),
-                    notification.succeeded(),
-                    notification.blockSource());
-            blockNotificationDisruptor.getRingBuffer().publishEvent((event, sequence) -> event.set(notification));
-            blockPersistedNotificationsCounter.increment();
-        });
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void sendBackfilledBlockNotification(BackfilledBlockNotification notification) {
-        messageForwarder.submit(() -> {
-            LOGGER.log(TRACE, "Sending backfilled block notification: block={0}", notification.blockNumber());
-            blockNotificationDisruptor.getRingBuffer().publishEvent((event, sequence) -> event.set(notification));
-            blockBackfilledNotificationsCounter.increment();
-        });
-    }
-
-    @Override
-    public void sendNewestBlockKnownToNetwork(NewestBlockKnownToNetworkNotification notification) {
-        messageForwarder.submit(() -> {
-            LOGGER.log(DEBUG, "Sending NewestBlockKnownToNetwork notification: block={0}", notification.blockNumber());
-            blockNotificationDisruptor.getRingBuffer().publishEvent((event, sequence) -> event.set(notification));
-            newestBlockKnownToNetworkNotificationsCounter.increment();
-        });
-    }
-
-    @Override
-    public void sendPublisherStatusUpdate(final PublisherStatusUpdateNotification notification) {
-        messageForwarder.submit(() -> {
-            LOGGER.log(DEBUG, "Sending publisher status update notification: {0}", notification);
-            blockNotificationDisruptor.getRingBuffer().publishEvent((event, sequence) -> event.set(notification));
-            publisherStatusUpdateNotificationsCounter.increment();
+            LOGGER.log(DEBUG, "Sending block notification: type={0} notification={1}", notificationType, notification);
         });
     }
 
@@ -515,22 +420,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
     public synchronized void registerBlockNotificationHandler(
             final BlockNotificationHandler handler, final boolean cpuIntensiveHandler, final String handlerName) {
         final InformedEventHandler<BlockNotificationRingEvent> informedEventHandler =
-                (event, sequence, endOfBatch, percentageBehindRingHead) -> {
-                    // dispatch the generic notification to the typed handler method it matches
-                    switch (event.get()) {
-                        case VerificationNotification v -> handler.handleVerification(v);
-                        case PersistedNotification p -> handler.handlePersisted(p);
-                        case BackfilledBlockNotification b -> handler.handleBackfilled(b);
-                        case NewestBlockKnownToNetworkNotification n -> handler.handleNewestBlockKnownToNetwork(n);
-                        case PublisherStatusUpdateNotification s -> handler.handlePublisherStatusUpdate(s);
-                        case null -> LOGGER.log(Level.INFO, "Received an event with no notification set");
-                        default ->
-                            LOGGER.log(
-                                    Level.INFO,
-                                    "Received a notification of unknown type: {0}",
-                                    event.get().getClass());
-                    }
-                };
+                (event, sequence, endOfBatch, percentageBehindRingHead) -> handler.handleNotification(event.get());
         if (blockNotificationDisruptor.hasStarted()) {
             // if the disruptor is already running, we need to register the handler with the disruptor
             registerHandler(

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -516,19 +516,19 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
             final BlockNotificationHandler handler, final boolean cpuIntensiveHandler, final String handlerName) {
         final InformedEventHandler<BlockNotificationRingEvent> informedEventHandler =
                 (event, sequence, endOfBatch, percentageBehindRingHead) -> {
-                    // send on the event
-                    if (event.getVerificationNotification() != null) {
-                        handler.handleVerification(event.getVerificationNotification());
-                    } else if (event.getPersistedNotification() != null) {
-                        handler.handlePersisted(event.getPersistedNotification());
-                    } else if (event.getBackfilledBlockNotification() != null) {
-                        handler.handleBackfilled(event.getBackfilledBlockNotification());
-                    } else if (event.getNewestBlockKnownToNetworkNotification() != null) {
-                        handler.handleNewestBlockKnownToNetwork(event.getNewestBlockKnownToNetworkNotification());
-                    } else if (event.getPublisherStatusUpdateNotification() != null) {
-                        handler.handlePublisherStatusUpdate(event.getPublisherStatusUpdateNotification());
-                    } else {
-                        LOGGER.log(Level.INFO, "Received an event with no notification set");
+                    // dispatch the generic notification to the typed handler method it matches
+                    switch (event.get()) {
+                        case VerificationNotification v -> handler.handleVerification(v);
+                        case PersistedNotification p -> handler.handlePersisted(p);
+                        case BackfilledBlockNotification b -> handler.handleBackfilled(b);
+                        case NewestBlockKnownToNetworkNotification n -> handler.handleNewestBlockKnownToNetwork(n);
+                        case PublisherStatusUpdateNotification s -> handler.handlePublisherStatusUpdate(s);
+                        case null -> LOGGER.log(Level.INFO, "Received an event with no notification set");
+                        default ->
+                            LOGGER.log(
+                                    Level.INFO,
+                                    "Received a notification of unknown type: {0}",
+                                    event.get().getClass());
                     }
                 };
         if (blockNotificationDisruptor.hasStarted()) {

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockNotificationRingEvent.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockNotificationRingEvent.java
@@ -1,156 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.messaging;
 
-import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
-import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
-import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
-import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification;
-import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 
-/**
- * Simple mutable container for notifications. The notifications ring buffer is
- * made up of these events. Only one of the fields should be set at any time.
- * These notifications are published to downstream subscribers through the LMAX
- * Disruptor.
- */
+/// Simple mutable container for a [BlockNotification]. The notifications ring buffer is made up
+/// of these events. These notifications are published to downstream subscribers through the LMAX
+/// Disruptor.
 public final class BlockNotificationRingEvent {
-    /** The block verification notification to be published to downstream subscribers through the LMAX Disruptor. */
-    private VerificationNotification verificationNotification;
-    /** The block persistence notification to be published to downstream subscribers through the LMAX Disruptor. */
-    private PersistedNotification persistedNotification;
-    /** The Backfilled block notification to be published to downstream subscribers through the LMAX Disruptor. */
-    private BackfilledBlockNotification backfilledBlockNotification;
-    /** The newest block known to network notification to be published to downstream subscribers through the LMAX Disruptor. */
-    private NewestBlockKnownToNetworkNotification newestBlockKnownToNetworkNotification;
-    /** The publisher status update notification to be published to downstream subscribers through the LMAX Disruptor. */
-    private PublisherStatusUpdateNotification publisherStatusUpdateNotification;
+    /// The notification to be published to downstream subscribers through the LMAX Disruptor.
+    private BlockNotification notification;
 
-    /**
-     * Sets the given notification to be published to downstream subscribers
-     * through the LMAX Disruptor.
-     *
-     * @param notification to set
-     */
-    public void set(final VerificationNotification notification) {
-        this.verificationNotification = notification;
-        this.persistedNotification = null;
-        this.backfilledBlockNotification = null;
-        this.newestBlockKnownToNetworkNotification = null;
-        this.publisherStatusUpdateNotification = null;
+    /// Sets the given notification to be published to downstream subscribers through the LMAX
+    /// Disruptor.
+    ///
+    /// @param notification to set
+    public void set(final BlockNotification notification) {
+        this.notification = notification;
     }
 
-    /**
-     * Sets the given notification to be published to downstream subscribers
-     * through the LMAX Disruptor.
-     *
-     * @param notification to set
-     */
-    public void set(final PersistedNotification notification) {
-        this.persistedNotification = notification;
-        this.verificationNotification = null;
-        this.backfilledBlockNotification = null;
-        this.newestBlockKnownToNetworkNotification = null;
-        this.publisherStatusUpdateNotification = null;
-    }
-
-    /**
-     * Sets the given notification to be published to downstream subscribers
-     * through the LMAX Disruptor.
-     *
-     * @param notification to set
-     */
-    public void set(final BackfilledBlockNotification notification) {
-        this.backfilledBlockNotification = notification;
-        this.verificationNotification = null;
-        this.persistedNotification = null;
-        this.newestBlockKnownToNetworkNotification = null;
-        this.publisherStatusUpdateNotification = null;
-    }
-
-    /**
-     * Sets the given notification to be published to downstream subscribers
-     * through the LMAX Disruptor.
-     *
-     * @param notification to set
-     */
-    public void set(final NewestBlockKnownToNetworkNotification notification) {
-        this.newestBlockKnownToNetworkNotification = notification;
-        this.backfilledBlockNotification = null;
-        this.verificationNotification = null;
-        this.persistedNotification = null;
-        this.publisherStatusUpdateNotification = null;
-    }
-    /**
-     * Sets the given notification to be published to downstream subscribers
-     * through the LMAX Disruptor.
-     *
-     * @param notification to set
-     */
-    public void set(final PublisherStatusUpdateNotification notification) {
-        this.publisherStatusUpdateNotification = notification;
-        this.newestBlockKnownToNetworkNotification = null;
-        this.backfilledBlockNotification = null;
-        this.verificationNotification = null;
-        this.persistedNotification = null;
-    }
-
-    /**
-     * Gets the verification notification of the event from the LMAX Disruptor
-     * on the consumer side.
-     * If the event is not a {@link VerificationNotification}, this
-     * will return null.
-     *
-     * @return the value of the event
-     */
-    public VerificationNotification getVerificationNotification() {
-        return verificationNotification;
-    }
-
-    /**
-     * Gets the persisted notification of the event from the LMAX Disruptor on
-     * the consumer side.
-     * If the event is not a {@link PersistedNotification}, this
-     * will return null.
-     *
-     * @return the value of the event
-     */
-    public PersistedNotification getPersistedNotification() {
-        return persistedNotification;
-    }
-
-    /**
-     * Gets the backfilled block notification of the event from the LMAX
-     * Disruptor on the consumer side.
-     * If the event is not a {@link BackfilledBlockNotification}, this
-     * will return null.
-     *
-     * @return the value of the event
-     */
-    public BackfilledBlockNotification getBackfilledBlockNotification() {
-        return backfilledBlockNotification;
-    }
-
-    /**
-     * Gets the newest block known to network notification of the event from the
-     * LMAX Disruptor on the consumer side.
-     * If the event is not a {@link NewestBlockKnownToNetworkNotification}, this
-     * will return null.
-     *
-     * @return the value of the event
-     */
-    public NewestBlockKnownToNetworkNotification getNewestBlockKnownToNetworkNotification() {
-        return newestBlockKnownToNetworkNotification;
-    }
-
-    /**
-     * Gets the publisher status update notification of the event from the LMAX
-     * Disruptor on the consumer side.
-     * If the event is not a {@link PublisherStatusUpdateNotification}, this
-     * will return null.
-     *
-     * @return the value of the event
-     */
-    public PublisherStatusUpdateNotification getPublisherStatusUpdateNotification() {
-        return publisherStatusUpdateNotification;
+    /// Gets the notification of the event from the LMAX Disruptor on the consumer side.
+    ///
+    /// @return the notification of the event
+    public BlockNotification get() {
+        return notification;
     }
 }

--- a/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationRingEventTest.java
+++ b/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationRingEventTest.java
@@ -8,10 +8,7 @@ import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.messaging.BlockNotificationRingEvent;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
-import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
-import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification;
-import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification.UpdateType;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,162 +18,79 @@ import org.junit.jupiter.api.Test;
  */
 class BlockNotificationRingEventTest {
     /**
-     * Tests that a new BlockNotificationRingEvent has null values for both notification types.
+     * Tests that a new BlockNotificationRingEvent has a null notification.
      */
     @Test
-    @DisplayName("New BlockNotificationRingEvent should have null values")
-    void newEventShouldHaveNullValues() {
+    @DisplayName("New BlockNotificationRingEvent should have a null notification")
+    void newEventShouldHaveNullNotification() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
-        assertNull(event.getVerificationNotification());
-        assertNull(event.getPersistedNotification());
-        assertNull(event.getBackfilledBlockNotification());
-        assertNull(event.getNewestBlockKnownToNetworkNotification());
-        assertNull(event.getPublisherStatusUpdateNotification());
+        assertNull(event.get());
     }
 
     /**
      * Tests setting and getting a verification notification.
      */
     @Test
-    @DisplayName("Should set and get verification notification correctly")
+    @DisplayName("Should set and get a verification notification correctly")
     void shouldSetAndGetVerificationNotification() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
         final VerificationNotification notification =
                 new VerificationNotification(true, null, 1, null, null, BlockSource.PUBLISHER);
         event.set(notification);
-        assertEquals(notification, event.getVerificationNotification());
-        assertNull(event.getPersistedNotification(), "Persisted notification should be null");
-        assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
-        assertNull(event.getPublisherStatusUpdateNotification(), "Publisher status update notification should be null");
-        assertNull(
-                event.getNewestBlockKnownToNetworkNotification(),
-                "Newest block known to network notification should be null");
+        assertEquals(notification, event.get());
     }
 
     /**
      * Tests setting and getting a persisted notification.
      */
     @Test
-    @DisplayName("Should set and get persisted notification correctly")
+    @DisplayName("Should set and get a persisted notification correctly")
     void shouldSetAndGetPersistedNotification() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
         final PersistedNotification notification = new PersistedNotification(2, true, 10, BlockSource.PUBLISHER);
         event.set(notification);
-        assertEquals(notification, event.getPersistedNotification());
-        assertNull(event.getVerificationNotification(), "Verification notification should be null");
-        assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
-        assertNull(event.getPublisherStatusUpdateNotification(), "Publisher status update notification should be null");
-        assertNull(
-                event.getNewestBlockKnownToNetworkNotification(),
-                "Newest block known to network notification should be null");
+        assertEquals(notification, event.get());
     }
 
     /**
      * Tests setting and getting a backfilled notification.
      */
     @Test
-    @DisplayName("Should set and get backfilled notification correctly")
+    @DisplayName("Should set and get a backfilled notification correctly")
     void shouldSetAndGetBackfilledNotification() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
         final BackfilledBlockNotification notification =
                 new BackfilledBlockNotification(1, BlockUnparsed.newBuilder().build());
         event.set(notification);
-        assertEquals(notification, event.getBackfilledBlockNotification());
-        assertNull(event.getVerificationNotification(), "Verification notification should be null");
-        assertNull(event.getPersistedNotification(), "Persisted notification should be null");
-        assertNull(event.getPublisherStatusUpdateNotification(), "Publisher status update notification should be null");
-        assertNull(
-                event.getNewestBlockKnownToNetworkNotification(),
-                "Newest block known to network notification should be null");
+        assertEquals(notification, event.get());
     }
 
     /**
-     * Tests setting and getting a backfilled notification.
+     * Tests that setting a new notification replaces the previous one, allowing the event to be
+     * reused across different notification types as the ring buffer recycles it.
      */
     @Test
-    @DisplayName("Should set and get NewestBlockKnownToNetworkNotification notification correctly")
-    void shouldSetAndGetNewestBlockKnownToNetworkNotification() {
-        final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
-        final NewestBlockKnownToNetworkNotification notification = new NewestBlockKnownToNetworkNotification(10L);
-        event.set(notification);
-        assertEquals(notification, event.getNewestBlockKnownToNetworkNotification());
-        assertNull(event.getVerificationNotification(), "Verification notification should be null");
-        assertNull(event.getPersistedNotification(), "Persisted notification should be null");
-        assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
-        assertNull(event.getPublisherStatusUpdateNotification(), "Publisher status update notification should be null");
-    }
-
-    /**
-     * Tests setting and getting a publisher status update notification.
-     */
-    @Test
-    @DisplayName("Should set and get publisher status update notification correctly")
-    void shouldSetAndGetPublisherStatusUpdateNotification() {
-        final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
-        final PublisherStatusUpdateNotification notification =
-                new PublisherStatusUpdateNotification(UpdateType.PUBLISHER_CONNECTED, 1);
-        event.set(notification);
-        assertEquals(notification, event.getPublisherStatusUpdateNotification());
-        assertNull(event.getVerificationNotification(), "Verification notification should be null");
-        assertNull(event.getPersistedNotification(), "Persisted notification should be null");
-        assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
-        assertNull(
-                event.getNewestBlockKnownToNetworkNotification(),
-                "Newest block known to network notification should be null");
-    }
-
-    /**
-     * Tests that setting a verification notification clears any existing persisted notification.
-     */
-    @Test
-    @DisplayName("Setting verification notification should clear persisted notification")
-    void settingVerificationNotificationShouldClearPersistedNotification() {
+    @DisplayName("Setting a new notification should replace the previous one")
+    void settingNewNotificationShouldReplacePrevious() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
         final PersistedNotification persistedNotification =
                 new PersistedNotification(2, true, 10, BlockSource.PUBLISHER);
         final VerificationNotification verificationNotification =
                 new VerificationNotification(true, null, 1, null, null, BlockSource.PUBLISHER);
 
-        // First set persisted notification
         event.set(persistedNotification);
-        assertEquals(persistedNotification, event.getPersistedNotification());
+        assertEquals(persistedNotification, event.get());
 
-        // Then set verification notification
         event.set(verificationNotification);
-
-        assertEquals(verificationNotification, event.getVerificationNotification());
-        assertNull(event.getPersistedNotification(), "Persisted notification should be cleared");
+        assertEquals(verificationNotification, event.get());
     }
 
     /**
-     * Tests that setting a persisted notification clears any existing verification notification.
+     * Tests that the event can be reused by setting different notifications of the same type.
      */
     @Test
-    @DisplayName("Setting persisted notification should clear verification notification")
-    void settingPersistedNotificationShouldClearVerificationNotification() {
-        final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
-        final VerificationNotification verificationNotification =
-                new VerificationNotification(true, null, 1, null, null, BlockSource.PUBLISHER);
-        final PersistedNotification persistedNotification =
-                new PersistedNotification(2, true, 10, BlockSource.PUBLISHER);
-
-        // First set verification notification
-        event.set(verificationNotification);
-        assertEquals(verificationNotification, event.getVerificationNotification());
-
-        // Then set persisted notification
-        event.set(persistedNotification);
-
-        assertEquals(persistedNotification, event.getPersistedNotification());
-        assertNull(event.getVerificationNotification(), "Verification notification should be cleared");
-    }
-
-    /**
-     * Tests that the event can be reused by setting different verification notifications.
-     */
-    @Test
-    @DisplayName("Should allow reuse with different verification notifications")
-    void shouldAllowReuseWithDifferentVerificationNotifications() {
+    @DisplayName("Should allow reuse with different notifications of the same type")
+    void shouldAllowReuseWithDifferentNotificationsOfSameType() {
         final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
         final VerificationNotification notification1 =
                 new VerificationNotification(true, null, 1, null, null, BlockSource.PUBLISHER);
@@ -184,30 +98,9 @@ class BlockNotificationRingEventTest {
                 new VerificationNotification(true, null, 1, null, null, BlockSource.PUBLISHER);
 
         event.set(notification1);
-        assertEquals(notification1, event.getVerificationNotification());
+        assertEquals(notification1, event.get());
 
-        // Set another verification notification
         event.set(notification2);
-        assertEquals(notification2, event.getVerificationNotification());
-        assertNull(event.getPersistedNotification());
-    }
-
-    /**
-     * Tests that the event can be reused by setting different persisted notifications.
-     */
-    @Test
-    @DisplayName("Should allow reuse with different persisted notifications")
-    void shouldAllowReuseWithDifferentPersistedNotifications() {
-        final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
-        final PersistedNotification notification1 = new PersistedNotification(2, true, 10, BlockSource.PUBLISHER);
-        final PersistedNotification notification2 = new PersistedNotification(2, true, 10, BlockSource.PUBLISHER);
-
-        event.set(notification1);
-        assertEquals(notification1, event.getPersistedNotification());
-
-        // Set another persisted notification
-        event.set(notification2);
-        assertEquals(notification2, event.getPersistedNotification());
-        assertNull(event.getVerificationNotification());
+        assertEquals(notification2, event.get());
     }
 }

--- a/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationTest.java
+++ b/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationTest.java
@@ -28,6 +28,7 @@ import org.hiero.block.node.messaging.BlockMessagingFacilityImpl;
 import org.hiero.block.node.messaging.MessagingConfig;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
@@ -223,25 +224,29 @@ public class BlockNotificationTest {
         final AtomicInteger handler2Sum = new AtomicInteger(0);
         final BlockNotificationHandler handler1 = new BlockNotificationHandler() {
             @Override
-            public void handleVerification(VerificationNotification notification) {
-                // process notifications
-                int receivedValue = (int) notification.blockNumber();
-                // add up all the received values
-                handler1Sum.addAndGet(receivedValue);
-                // update count of calls
-                handler1Counter.incrementAndGet();
+            public void handleNotification(BlockNotification notification) {
+                if (notification instanceof VerificationNotification verification) {
+                    // process notifications
+                    int receivedValue = (int) verification.blockNumber();
+                    // add up all the received values
+                    handler1Sum.addAndGet(receivedValue);
+                    // update count of calls
+                    handler1Counter.incrementAndGet();
+                }
             }
         };
         final BlockNotificationHandler handler2 = new BlockNotificationHandler() {
             @Override
-            public void handleVerification(VerificationNotification notification) {
-                // process notifications
-                int receivedValue = (int) notification.blockNumber();
-                // add up all the received values
-                handler2Sum.addAndGet(receivedValue);
-                // check if we are done
-                if (handler2Counter.incrementAndGet() == TEST_DATA_COUNT - 1) {
-                    latch.countDown();
+            public void handleNotification(BlockNotification notification) {
+                if (notification instanceof VerificationNotification verification) {
+                    // process notifications
+                    int receivedValue = (int) verification.blockNumber();
+                    // add up all the received values
+                    handler2Sum.addAndGet(receivedValue);
+                    // check if we are done
+                    if (handler2Counter.incrementAndGet() == TEST_DATA_COUNT - 1) {
+                        latch.countDown();
+                    }
                 }
             }
         };
@@ -259,7 +264,7 @@ public class BlockNotificationTest {
                 // wait for a bit to let the handler unregister
                 LockSupport.parkNanos(500_000);
             }
-            messagingService.sendBlockVerification(
+            messagingService.sendBlockNotification(
                     new VerificationNotification(true, null, i, null, null, BlockSource.PUBLISHER));
             // have to slow down production to make test reliable
             LockSupport.parkNanos(500_000);
@@ -340,7 +345,7 @@ public class BlockNotificationTest {
         @Override
         public void run() {
             for (int i = 0; i < TEST_DATA_COUNT; i++) {
-                messagingService.sendBlockVerification(
+                messagingService.sendBlockNotification(
                         new VerificationNotification(true, null, i, null, null, BlockSource.PUBLISHER));
                 int totalSent = sentCounter.incrementAndGet();
                 if (pauseControl != null) {
@@ -379,7 +384,7 @@ public class BlockNotificationTest {
         }
 
         @Override
-        public void handleVerification(VerificationNotification notification) {
+        public void handleNotification(BlockNotification notification) {
             if (expectedCount <= counters.incrementAndGet(identifier)) {
                 // call the latch countdown when we reach the expected count
                 latch.countDown();

--- a/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/CustomNotificationTest.java
+++ b/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/CustomNotificationTest.java
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.server.messaging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.hiero.block.node.app.fixtures.async.BlockingExecutor;
+import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
+import org.hiero.block.node.app.fixtures.async.TestThreadPoolManager;
+import org.hiero.block.node.messaging.BlockMessagingFacilityImpl;
+import org.hiero.block.node.spi.BlockNodeContext;
+import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
+import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/// Proves that a notification type defined entirely outside `spi-plugins` and `facility-messaging`
+/// — standing in for one a third-party plugin would define — can be sent and received through
+/// [BlockMessagingFacility] using only the public [BlockNotification]/[BlockNotificationHandler]
+/// contract, with no change to either module.
+///
+/// See `docs/design/architecture/generic-block-notifications.md` for the design this validates.
+class CustomNotificationTest {
+
+    /// Stand-in for a notification type defined by a plugin outside this module. Neither
+    /// `spi-plugins` nor `facility-messaging` know about this type at compile time.
+    private record PingNotification(int sequence) implements BlockNotification {}
+
+    @Test
+    @DisplayName("A plugin-defined notification type is delivered in order, exactly once, on the handler's own thread")
+    void customNotificationTypeIsDeliveredCorrectly() throws InterruptedException {
+        final int notificationCount = 20;
+        final List<PingNotification> received = new CopyOnWriteArrayList<>();
+        final List<String> receivingThreadNames = new CopyOnWriteArrayList<>();
+        final CountDownLatch latch = new CountDownLatch(notificationCount);
+
+        final BlockNotificationHandler handler = new BlockNotificationHandler() {
+            @Override
+            public void handleNotification(final BlockNotification notification) {
+                if (notification instanceof PingNotification ping) {
+                    received.add(ping);
+                    receivingThreadNames.add(Thread.currentThread().getName());
+                    latch.countDown();
+                }
+            }
+        };
+
+        final TestThreadPoolManager<BlockingExecutor, ScheduledBlockingExecutor> threadPoolManager =
+                new TestThreadPoolManager<>(
+                        new BlockingExecutor(new LinkedBlockingQueue<>()),
+                        new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+        final BlockNodeContext context = TestConfig.generateContext(threadPoolManager);
+        final BlockMessagingFacility messagingService = new BlockMessagingFacilityImpl();
+        messagingService.init(context, null);
+        messagingService.registerBlockNotificationHandler(handler, false, "ping-handler");
+        messagingService.start();
+
+        for (int i = 0; i < notificationCount; i++) {
+            messagingService.sendBlockNotification(new PingNotification(i));
+        }
+        // BlockingExecutor (the test thread pool) only runs queued tasks once asked to; this drains
+        // the queued sendBlockNotification publish tasks onto a single thread, preserving order.
+        threadPoolManager
+                .executor()
+                .executeAsync(false, 10_000L, true, true, () -> Executors.newSingleThreadExecutor());
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "All notifications should have been delivered");
+        messagingService.stop();
+
+        assertEquals(notificationCount, received.size(), "Every notification should be delivered exactly once");
+        for (int i = 0; i < notificationCount; i++) {
+            assertEquals(i, received.get(i).sequence(), "Notifications should be delivered in order");
+        }
+        assertEquals(
+                1,
+                receivingThreadNames.stream().distinct().count(),
+                "All notifications for one handler should arrive on the same dedicated thread");
+    }
+}

--- a/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/FacilityExceptionTest.java
+++ b/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/FacilityExceptionTest.java
@@ -20,6 +20,7 @@ import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
@@ -126,19 +127,7 @@ public class FacilityExceptionTest {
         service.registerBlockNotificationHandler(
                 new BlockNotificationHandler() {
                     @Override
-                    public void handleVerification(VerificationNotification notification) {
-                        // Simulate an exception
-                        throw new RuntimeException("Simulated exception");
-                    }
-
-                    @Override
-                    public void handlePersisted(PersistedNotification notification) {
-                        // Simulate an exception
-                        throw new RuntimeException("Simulated exception");
-                    }
-
-                    @Override
-                    public void handleBackfilled(BackfilledBlockNotification notification) {
+                    public void handleNotification(BlockNotification notification) {
                         // Simulate an exception
                         throw new RuntimeException("Simulated exception");
                     }
@@ -152,9 +141,9 @@ public class FacilityExceptionTest {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-        service.sendBlockVerification(new VerificationNotification(true, null, 1, null, null, BlockSource.PUBLISHER));
-        service.sendBlockPersisted(new PersistedNotification(1, true, 1, BlockSource.PUBLISHER));
-        service.sendBackfilledBlockNotification(
+        service.sendBlockNotification(new VerificationNotification(true, null, 1, null, null, BlockSource.PUBLISHER));
+        service.sendBlockNotification(new PersistedNotification(1, true, 1, BlockSource.PUBLISHER));
+        service.sendBlockNotification(
                 new BackfilledBlockNotification(1, BlockUnparsed.newBuilder().build()));
         threadPoolManager.executor().executeAsync(true, 10_000L, true, true, () -> Executors.newSingleThreadExecutor());
         service.stop();

--- a/block-node/s3-archive/src/main/java/org/hiero/block/node/archive/s3/S3ArchivePlugin.java
+++ b/block-node/s3-archive/src/main/java/org/hiero/block/node/archive/s3/S3ArchivePlugin.java
@@ -41,6 +41,7 @@ import org.hiero.block.node.base.tar.TaredBlockIterator;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
@@ -177,7 +178,14 @@ public class S3ArchivePlugin implements BlockNodePlugin, BlockNotificationHandle
      * {@inheritDoc}
      */
     @Override
-    public void handlePersisted(final PersistedNotification notification) {
+    public void handleNotification(final BlockNotification notification) {
+        switch (notification) {
+            case PersistedNotification p -> handlePersisted(p);
+            default -> {}
+        }
+    }
+
+    void handlePersisted(final PersistedNotification notification) {
         // get the latest persisted block number from the notification
         final long latestPersisted = notification.blockNumber();
         // compute what should be the start of the next batch to archive

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BackfilledBlockNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BackfilledBlockNotification.java
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.spi.blockmessaging;
 
-public record BackfilledBlockNotification(long blockNumber, org.hiero.block.internal.BlockUnparsed block) {}
+public record BackfilledBlockNotification(long blockNumber, org.hiero.block.internal.BlockUnparsed block)
+        implements BlockNotification {}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
@@ -60,41 +60,13 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
     void unregisterBlockItemHandler(final BlockItemHandler handler);
 
     /**
-     * Use this method to send block verification notifications to all registered handlers.
+     * Use this method to send a block notification to all registered handlers. Any type
+     * implementing {@link BlockNotification} may be sent, including notification types defined
+     * by a plugin outside this module.
      *
-     * @param notification the block verification notification to send
+     * @param notification the block notification to send
      */
-    void sendBlockVerification(final VerificationNotification notification);
-
-    /**
-     * Use this method to send block persisted notifications to all registered handlers.
-     *
-     * @param notification the block persisted notification to send
-     */
-    void sendBlockPersisted(final PersistedNotification notification);
-
-    /**
-     * Use this method to send backfilled block notifications to all registered handlers.
-     *
-     * @param notification the backfilled block notification to send
-     */
-    void sendBackfilledBlockNotification(final BackfilledBlockNotification notification);
-
-    /**
-     * Use this method to notify the system about a new block known to the network.
-     * This is used to inform the system that a new block header is known to the network,
-     * and our node should attempt to get up to date with the latest block.
-     *
-     * @param notification the notification containing the block number.
-     */
-    void sendNewestBlockKnownToNetwork(final NewestBlockKnownToNetworkNotification notification);
-
-    /**
-     * Use this method to send a publisher status update to all registered handlers.
-     *
-     * @param notification the publisher status update notification to send
-     */
-    void sendPublisherStatusUpdate(final PublisherStatusUpdateNotification notification);
+    void sendBlockNotification(final BlockNotification notification);
 
     /**
      * Use this method to register a block notification handler. The handler will be called every time new block

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockNotification.java
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.blockmessaging;
+
+/// Marker interface implemented by every notification sent through
+/// [BlockMessagingFacility]'s block notification ring buffer.
+///
+/// Any plugin may define its own record implementing this interface to emit a
+/// custom notification, without any change to `spi-plugins` or
+/// `facility-messaging`. See `docs/design/architecture/generic-block-notifications.md`
+/// for the full design and a worked example.
+public interface BlockNotification {}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockNotificationHandler.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockNotificationHandler.java
@@ -1,53 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.spi.blockmessaging;
 
-/**
- * Interface for handling block notifications.
- */
+/// Interface for handling block notifications.
+///
+/// Implementations receive every [BlockNotification] published to the facility and dispatch on
+/// its concrete type, typically with a pattern-matching `switch`. See
+/// `docs/design/architecture/generic-block-notifications.md` for the full design and a worked
+/// example.
 public interface BlockNotificationHandler extends GatingHandler {
-    /**
-     * Handle a block verification notification.
-     * <p>
-     * This is always called on a messaging thread.
-     * Each registered notification handler will have its own virtual thread.
-     *
-     * @param notification the block verification notification to handle
-     */
-    default void handleVerification(final VerificationNotification notification) {}
-
-    /**
-     * Handle a block persisted notification.
-     * <p>
-     * This is always called on a messaging thread.
-     * Each registered notification handler will have its own virtual thread.
-     *
-     * @param notification the block persisted notification to handle
-     */
-    default void handlePersisted(final PersistedNotification notification) {}
-
-    /**
-     * Handle a backfilled block notification.
-     * <p>
-     * This is always called on a messaging thread.
-     * Each registered notification handler will have its own virtual thread.
-     *
-     * @param notification the backfilled block notification to handle
-     */
-    default void handleBackfilled(final BackfilledBlockNotification notification) {}
-
-    /**
-     * Handle a new block known to the network notification. Always called on handler thread. Each registered handler
-     * will have its own virtual thread.
-     *
-     * @param notification the new block known to the network notification to handle
-     */
-    default void handleNewestBlockKnownToNetwork(final NewestBlockKnownToNetworkNotification notification) {}
-
-    /**
-     * Handle a publisher status update notification. Always called on handler thread. Each registered handler
-     * will have its own virtual thread.
-     *
-     * @param notification the publisher status update notification to handle
-     */
-    default void handlePublisherStatusUpdate(final PublisherStatusUpdateNotification notification) {}
+    /// Handle a block notification.
+    ///
+    /// This is always called on a messaging thread. Each registered notification handler has its
+    /// own virtual thread.
+    ///
+    /// @param notification the block notification to handle
+    void handleNotification(BlockNotification notification);
 }

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/NewestBlockKnownToNetworkNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/NewestBlockKnownToNetworkNotification.java
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.spi.blockmessaging;
 
-public record NewestBlockKnownToNetworkNotification(long blockNumber) {}
+public record NewestBlockKnownToNetworkNotification(long blockNumber) implements BlockNotification {}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/PersistedNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/PersistedNotification.java
@@ -2,4 +2,5 @@
 package org.hiero.block.node.spi.blockmessaging;
 
 public record PersistedNotification(
-        long blockNumber, boolean succeeded, int blockProviderPriority, BlockSource blockSource) {}
+        long blockNumber, boolean succeeded, int blockProviderPriority, BlockSource blockSource)
+        implements BlockNotification {}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/PublisherStatusUpdateNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/PublisherStatusUpdateNotification.java
@@ -4,7 +4,7 @@ package org.hiero.block.node.spi.blockmessaging;
 /**
  * A notification indicating a change in publisher status.
  */
-public record PublisherStatusUpdateNotification(UpdateType type, int activePublishers) {
+public record PublisherStatusUpdateNotification(UpdateType type, int activePublishers) implements BlockNotification {
     /**
      * An enum representing the type of publisher status update.
      */

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/VerificationNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/VerificationNotification.java
@@ -18,7 +18,8 @@ public record VerificationNotification(
         long blockNumber,
         Bytes blockHash,
         org.hiero.block.internal.BlockUnparsed block,
-        BlockSource source) {
+        BlockSource source)
+        implements BlockNotification {
     public VerificationNotification {
         if (success && failureInfo != null) {
             throw new IllegalArgumentException("Verification is successful, but a failure reason is provided");

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -57,6 +57,7 @@ import org.hiero.block.node.app.config.node.NodeConfig;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
@@ -337,7 +338,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         final NewestBlockKnownToNetworkNotification notification =
                 new NewestBlockKnownToNetworkNotification(newestKnownBlockNumber);
         // send the notification
-        serverContext.blockMessaging().sendNewestBlockKnownToNetwork(notification);
+        serverContext.blockMessaging().sendBlockNotification(notification);
     }
 
     @Override
@@ -390,6 +391,15 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         return publisherConfig;
     }
 
+    @Override
+    public void handleNotification(final BlockNotification notification) {
+        switch (notification) {
+            case VerificationNotification v -> handleVerification(v);
+            case PersistedNotification p -> handlePersisted(p);
+            default -> {}
+        }
+    }
+
     /// {@inheritDoc}
     ///
     /// This method handles verification notifications from the block messaging
@@ -399,8 +409,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     /// we will attempt to handle that failure. That includes allowing
     /// individual handlers to handle that block, but also scheduling the failed
     /// block to be resent.
-    @Override
-    public void handleVerification(@NonNull final VerificationNotification notification) {
+    void handleVerification(@NonNull final VerificationNotification notification) {
         final long blockNumber = notification.blockNumber();
         // Critical note: Only handle _failed_ verifications.
         // If we ever handle successful verifications, we must add conditions
@@ -447,8 +456,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     /// further declare the set explicitly unordered to further limit
     /// unnecessary ties between handlers. The overall time blocked should not
     /// significantly exceed the time to send a single acknowledgement.
-    @Override
-    public void handlePersisted(@NonNull final PersistedNotification notification) {
+    void handlePersisted(@NonNull final PersistedNotification notification) {
         if (notification != null) {
             final long blockNumber = notification.blockNumber();
             if (notification.succeeded()) {
@@ -783,7 +791,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         final PublisherStatusUpdateNotification notification =
                 new PublisherStatusUpdateNotification(type, activeHandlers.size());
         // send a publisher update
-        serverContext.blockMessaging().sendPublisherStatusUpdate(notification);
+        serverContext.blockMessaging().sendBlockNotification(notification);
     }
 
     /// This method cancels the publisher unavailability timeout
@@ -1388,7 +1396,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 // note, activePublishers.size() can definitely change between the isEmpty check and the call below
                 final PublisherStatusUpdateNotification notification = new PublisherStatusUpdateNotification(
                         UpdateType.PUBLISHER_UNAVAILABILITY_TIMEOUT, activePublishers.size());
-                messaging.sendPublisherStatusUpdate(notification);
+                messaging.sendBlockNotification(notification);
                 return true;
             } else {
                 return false;

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -400,7 +400,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         }
     }
 
-    /// {@inheritDoc}
+    /// Handles a verification notification, dispatched from [#handleNotification].
     ///
     /// This method handles verification notifications from the block messaging
     /// facility. Only in cases of failed verification, given that the block
@@ -434,7 +434,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         }
     }
 
-    /// {@inheritDoc}
+    /// Handles a persisted notification, dispatched from [#handleNotification].
     ///
     /// Here, we check the new persisted block number against the last persisted
     /// block number, and only send acknowledgements if the new persisted block

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginRegressionTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginRegressionTest.java
@@ -121,7 +121,7 @@ class StreamPublisherPluginRegressionTest
         publisher2.fromPluginBytes().clear();
 
         // Simulate LIVE_TAIL greedy backfill persisting block 5 from a peer.
-        blockMessaging.sendBlockPersisted(new PersistedNotification(stalledBlock, true, 0, BlockSource.BACKFILL));
+        blockMessaging.sendBlockNotification(new PersistedNotification(stalledBlock, true, 0, BlockSource.BACKFILL));
 
         // Re-enable the historical facility now that block 5's stalled
         // queue has been cleared by the headMap fix.

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestStreamPublisherManager.java
@@ -25,6 +25,7 @@ import org.hiero.block.internal.BlockItemSetUnparsed;
 import org.hiero.block.node.app.fixtures.TestUtils;
 import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
 import org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
@@ -141,7 +142,7 @@ public class TestStreamPublisherManager implements StreamPublisherManager {
     public void notifyTooFarBehind(long newestKnownBlockNumber) {
         final NewestBlockKnownToNetworkNotification notification =
                 new NewestBlockKnownToNetworkNotification(newestKnownBlockNumber);
-        blockMessagingFacility.sendNewestBlockKnownToNetwork(notification);
+        blockMessagingFacility.sendBlockNotification(notification);
     }
 
     @Override
@@ -174,6 +175,14 @@ public class TestStreamPublisherManager implements StreamPublisherManager {
     }
 
     @Override
+    public void handleNotification(final BlockNotification notification) {
+        switch (notification) {
+            case VerificationNotification v -> handleVerification(v);
+            case PersistedNotification p -> handlePersisted(p);
+            default -> {}
+        }
+    }
+
     public void handleVerification(final VerificationNotification notification) {
         throw new UnsupportedOperationException("implement handleVerification in test fixture if needed");
     }
@@ -187,7 +196,6 @@ public class TestStreamPublisherManager implements StreamPublisherManager {
     /// mitigate false positives in tests that use this fixture. Also, this
     /// method will NOT update the state of the manager (latestBlockNumber)! Any
     /// updates must be explicit!
-    @Override
     public void handlePersisted(final PersistedNotification notification) {
         final long newLastPersistedBlock = notification.blockNumber();
         if (newLastPersistedBlock > latestBlockNumber) {

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
@@ -32,6 +32,7 @@ import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.blockmessaging.BlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
@@ -403,7 +404,7 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                         verificationBlocksVerified.increment();
                         // send the notification to the block messaging service
                         LOGGER.log(DEBUG, "Sending verification notification for block={0}", currentBlockNumber);
-                        context.blockMessaging().sendBlockVerification(notification);
+                        context.blockMessaging().sendBlockNotification(notification);
                         // Update previousBlockHash and previousVerifiedBlockNumber for next block verification
                         this.previousBlockHash = notification.blockHash();
                         this.previousVerifiedBlockNumber = currentBlockNumber;
@@ -423,7 +424,7 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                                 notification.block() != null
                                         ? notification.block().blockItems()
                                         : null);
-                        context.blockMessaging().sendBlockVerification(notification);
+                        context.blockMessaging().sendBlockNotification(notification);
                     }
 
                     // end working time
@@ -512,18 +513,26 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
             final long blockNumber, final BlockSource source, final FailureType failureType) {
         verificationBlocksError.increment();
         context.blockMessaging()
-                .sendBlockVerification(new VerificationNotification(
+                .sendBlockNotification(new VerificationNotification(
                         false, FailureInfo.standard(failureType), blockNumber, null, null, source));
     }
 
     /**
      * {@inheritDoc}
-     * <p>
+     */
+    @Override
+    public void handleNotification(final BlockNotification notification) {
+        switch (notification) {
+            case BackfilledBlockNotification b -> handleBackfilled(b);
+            default -> {}
+        }
+    }
+
+    /**
      * This method is called when a block backfilled notification is received. It is called on the block notification
      * thread.
      */
-    @Override
-    public void handleBackfilled(BackfilledBlockNotification notification) {
+    void handleBackfilled(BackfilledBlockNotification notification) {
         try {
             // log the backfilled block notification received
             LOGGER.log(DEBUG, "Received backfill notification for block={0}", notification.blockNumber());
@@ -577,7 +586,7 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
                                         : null);
                     }
                     // send the verification notification for the backfilled block
-                    context.blockMessaging().sendBlockVerification(backfillNotification);
+                    context.blockMessaging().sendBlockNotification(backfillNotification);
                 } else {
                     LOGGER.log(
                             WARNING,

--- a/charts/block-node-server/dashboards/Hiero-Block-Node-Plugins/messaging-facility.json
+++ b/charts/block-node-server/dashboards/Hiero-Block-Node-Plugins/messaging-facility.json
@@ -208,7 +208,7 @@
       "pluginVersion": "11.4.0",
       "targets": [
         {
-          "expr": "rate(blocknode_messaging_block_verification_notifications_total[$__rate_interval])",
+          "expr": "rate(blocknode_messaging_block_notifications_sent_total{notification_type=\"VerificationNotification\"}[$__rate_interval])",
           "legendFormat": "verifications/s",
           "refId": "A"
         }
@@ -299,7 +299,7 @@
       "pluginVersion": "11.4.0",
       "targets": [
         {
-          "expr": "rate(blocknode_messaging_block_persisted_notifications_total[$__rate_interval])",
+          "expr": "rate(blocknode_messaging_block_notifications_sent_total{notification_type=\"PersistedNotification\"}[$__rate_interval])",
           "legendFormat": "persisted/s",
           "refId": "A"
         }
@@ -391,7 +391,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(blocknode_messaging_block_backfilled_notifications_total[$__rate_interval])",
+          "expr": "rate(blocknode_messaging_block_notifications_sent_total{notification_type=\"BackfilledBlockNotification\"}[$__rate_interval])",
           "legendFormat": "persisted/s",
           "range": true,
           "refId": "A"
@@ -484,7 +484,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(blocknode_messaging_newest_block_known_to_network_notifications_total[$__rate_interval])",
+          "expr": "rate(blocknode_messaging_block_notifications_sent_total{notification_type=\"NewestBlockKnownToNetworkNotification\"}[$__rate_interval])",
           "legendFormat": "persisted/s",
           "range": true,
           "refId": "A"

--- a/charts/block-node-server/dashboards/block-node-server.json
+++ b/charts/block-node-server/dashboards/block-node-server.json
@@ -435,7 +435,7 @@
           "refId": "B"
         },
         {
-          "expr": "rate(blocknode_messaging_block_persisted_notifications_total[$__rate_interval])",
+          "expr": "rate(blocknode_messaging_block_notifications_sent_total{notification_type=\"PersistedNotification\"}[$__rate_interval])",
           "legendFormat": "Blocks Persisted/s",
           "refId": "C"
         }

--- a/docs/block-node/metrics.md
+++ b/docs/block-node/metrics.md
@@ -103,18 +103,14 @@ Observes the block access service that serves requests for blocks.
 **Plugin:** `messaging [facility-messaging]`
 Observes the messaging system that connects the publisher with subscribers and the rest of the system.
 
-|  Type   |                          Name                           |                      Description                       |
-|---------|---------------------------------------------------------|--------------------------------------------------------|
-| Counter | `messaging_block_items_received`                        | Incoming block items seen by the mediator              |
-| Counter | `messaging_block_verification_notifications`            | Notifications issued after verification                |
-| Counter | `messaging_block_persisted_notifications`               | Notifications issued after persistence                 |
-| Gauge   | `messaging_no_of_item_listeners`                        | Active item listeners                                  |
-| Gauge   | `messaging_no_of_notification_listeners`                | Active notification listeners                          |
-| Gauge   | `messaging_item_queue_percent_used`                     | Percent of item queue utilised                         |
-| Gauge   | `messaging_notification_queue_percent_used`             | Percent of notification queue utilised                 |
-| Counter | `messaging_block_backfilled_notifications`              | Notifications issued after backfilling blocks          |
-| Counter | `messaging_newest_block_known_to_network_notifications` | Notifications issued for newest block known to network |
-| Counter | `messaging_publisher_status_update_notifications`       | Notifications issued for publisher status updates      |
+|  Type   |                    Name                     |                                    Description                                    |
+|---------|---------------------------------------------|-----------------------------------------------------------------------------------|
+| Counter | `messaging_block_items_received`            | Incoming block items seen by the mediator                                         |
+| Counter | `messaging_block_notifications_sent`        | Block notifications sent, labeled by `notification_type` (the notification class) |
+| Gauge   | `messaging_no_of_item_listeners`            | Active item listeners                                                             |
+| Gauge   | `messaging_no_of_notification_listeners`    | Active notification listeners                                                     |
+| Gauge   | `messaging_item_queue_percent_used`         | Percent of item queue utilised                                                    |
+| Gauge   | `messaging_notification_queue_percent_used` | Percent of notification queue utilised                                            |
 
 ---
 

--- a/docs/design/architecture/current-plugin-architecture.md
+++ b/docs/design/architecture/current-plugin-architecture.md
@@ -105,7 +105,7 @@ The inter-plugin event bus. Itself a plugin (and a required facility — startup
 - `registerBlockItemHandler(BlockItemHandler, cpuIntensive, name)` — subscribe with back-pressure; a slow handler slows the producer.
 - `registerNoBackpressureBlockItemHandler(...)` — subscribe without back-pressure; if the handler falls 80% behind, `onTooFarBehindError()` is called instead of blocking the producer.
 
-**Block Notifications** — five typed notification events for block lifecycle milestones:
+**Block Notifications** — any type implementing the `BlockNotification` marker interface can be sent and received. Five known notifications, defined in `spi-plugins`, cover core block lifecycle milestones:
 
 |              Notification               |       Sender        |                          Meaning                           |
 |-----------------------------------------|---------------------|------------------------------------------------------------|
@@ -115,7 +115,10 @@ The inter-plugin event bus. Itself a plugin (and a required facility — startup
 | `NewestBlockKnownToNetworkNotification` | Publisher plugin    | Consensus Node has reported the latest known block header. |
 | `PublisherStatusUpdateNotification`     | Publisher plugin    | Publisher connection state changed.                        |
 
-Any plugin may subscribe to notifications via `registerBlockNotificationHandler(BlockNotificationHandler, ...)`.
+- `sendBlockNotification(BlockNotification)` — one send method for every notification type, known or custom.
+- `registerBlockNotificationHandler(BlockNotificationHandler, cpuIntensive, name)` — subscribe; the handler's single `handleNotification(BlockNotification)` method dispatches on the concrete type, typically with a pattern-matching `switch`.
+
+Any plugin may define its own notification — a record implementing `BlockNotification` — without any change to `spi-plugins` or `facility-messaging`. See [generic-block-notifications.md](generic-block-notifications.md) for the full design and a worked example.
 
 ### `HistoricalBlockFacility` (interface + plugin)
 
@@ -228,9 +231,9 @@ Publisher Plugin
       ▼           ▼
  Subscriber    Verification    ...  (N handlers, each with optional back-pressure)
 
-Block Lifecycle Events (verification, persistence, backfill, etc.)
+Block Lifecycle Events (verification, persistence, backfill, custom types, etc.)
       │
-      ▼  sendBlockVerification() / sendBlockPersisted() / ...
+      ▼  sendBlockNotification(BlockNotification)
 ┌────────────────────────────┐
 │  Block Notification Buffer  │  (Disruptor ring)
 └────────────────────────────┘
@@ -342,12 +345,13 @@ flowchart LR
     BI --> VER[Verification Plugin]
     BI --> N1[... Plugin N]
 
-    VER -->|sendBlockVerification| BN[Block Notification\nDisruptor]
-    STOR[Storage Plugin] -->|sendBlockPersisted| BN
+    VER -->|sendBlockNotification\nVerificationNotification| BN["Block Notification\nDisruptor\n(BlockNotification)"]
+    STOR[Storage Plugin] -->|sendBlockNotification\nPersistedNotification| BN
+    CUSTOM[Any Plugin] -->|sendBlockNotification\ncustom type| BN
     BN --> SUB2[Subscriber Plugin]
     BN --> PUB2[Publisher Plugin]
     BN --> STOR[Storage Plugin]
-    BN --> N2[... Plugin N]
+    BN --> N2["... any handler with\na matching switch case"]
 ```
 
 ### Module Dependency Structure

--- a/docs/design/architecture/generic-block-notifications.md
+++ b/docs/design/architecture/generic-block-notifications.md
@@ -1,0 +1,366 @@
+# Generic Block Notifications
+
+Status: Proposed
+Tracking issue: [#1431](https://github.com/hiero-ledger/hiero-block-node/issues/1431)
+Related: [plugin-architecture.md](current-plugin-architecture.md), [Nano-Service-Approach.md](Nano-Service-Approach.md)
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Goals](#goals)
+3. [Non-Goals](#non-goals)
+4. [Terms](#terms)
+5. [Current Design (Problem)](#current-design-problem)
+6. [Design](#design)
+7. [Worked Example](#worked-example)
+8. [Migration](#migration)
+9. [Testing Plugin](#testing-plugin)
+10. [Diagrams](#diagrams)
+11. [Open Questions](#open-questions)
+
+## Purpose
+
+`BlockNotificationHandler` and `BlockMessagingFacility` hardcode one method pair per notification
+type. Adding a notification today means editing five files across two modules. A plugin outside
+`facility-messaging`/`spi-plugins` cannot introduce its own notification type at all.
+
+This document defines a generic `BlockNotification` type so any plugin — core or third-party — can
+define, emit, and consume its own notifications without touching the messaging facility.
+
+## Goals
+
+- A plugin defines a new notification type in its own module. No change to `spi-plugins` or
+  `facility-messaging` is required.
+- One send method, one handler method, one ring-buffer field, regardless of how many notification
+  types exist.
+- Existing notification behavior (threading, back-pressure, per-handler virtual thread) is
+  unchanged.
+- The messaging facility stays blind to notification content, per
+  [Nano-Service-Approach.md](Nano-Service-Approach.md) principle 3 ("no service should depend on
+  classes or interfaces from another service") — the facility depends only on the marker
+  interface, never on a specific notification type.
+
+## Non-Goals
+
+- **Discovery/listing of registered notification types at runtime.** Not required to unblock
+  plugin authors. Can be layered on later as an optional registry without changing the interfaces
+  defined here.
+- **Cross-node or network delivery.** This is in-process, single-JVM messaging only.
+- **Changes to the block item stream** (`BlockItems`, `BlockItemHandler`,
+  `NoBackPressureBlockItemHandler`). Unaffected — this document is scoped to the notification ring
+  only.
+
+## Terms
+
+<dl>
+  <dt>BlockNotification</dt>
+  <dd>Marker interface. Any record implementing it can be sent through the notification ring.</dd>
+
+  <dt>Known notification</dt>
+  <dd>A <code>BlockNotification</code> defined in <code>spi-plugins</code>, visible to every
+  module. The five existing notifications become known notifications.</dd>
+
+  <dt>Custom notification</dt>
+  <dd>A <code>BlockNotification</code> defined inside a plugin module. Only plugins with a
+  compile-time dependency on that record can consume it.</dd>
+
+  <dt>Notification handler</dt>
+  <dd>A plugin's implementation of <code>BlockNotificationHandler</code>, registered with the
+  facility to receive every notification on its own virtual thread.</dd>
+</dl>
+
+## Current Design (Problem)
+
+Adding one notification type today touches:
+
+| # |                           File                            |                              Change required                              |
+|---|-----------------------------------------------------------|---------------------------------------------------------------------------|
+| 1 | `spi-plugins/.../VerificationNotification.java` (example) | new record                                                                |
+| 2 | `spi-plugins/.../BlockMessagingFacility.java`             | new `sendX(...)` method                                                   |
+| 3 | `spi-plugins/.../BlockNotificationHandler.java`           | new `default void handleX(...) {}` method                                 |
+| 4 | `facility-messaging/.../BlockNotificationRingEvent.java`  | new field + `set(X)` + `getX()`                                           |
+| 5 | `facility-messaging/.../BlockMessagingFacilityImpl.java`  | new `sendX` impl + counter metric + `else if` branch in the dispatch loop |
+
+None of this is plugin-specific logic — it is bookkeeping repeated per type. A third-party plugin
+cannot make these edits because it does not own `spi-plugins` or `facility-messaging`.
+
+## Design
+
+### 1. Marker interface
+
+```java
+// spi-plugins/.../blockmessaging/BlockNotification.java
+package org.hiero.block.node.spi.blockmessaging;
+
+public interface BlockNotification {}
+```
+
+Plain interface, not sealed. Sealing would let the compiler check `switch` exhaustiveness, but it
+also closes the type to any implementer outside this module — which defeats the purpose. Every
+`switch` on `BlockNotification` needs a `default` branch regardless.
+
+The five existing notifications add `implements BlockNotification`. No other change to their
+shape.
+
+### 2. Ring event collapses to one field
+
+```java
+// facility-messaging/.../BlockNotificationRingEvent.java
+public final class BlockNotificationRingEvent {
+    private BlockNotification notification;
+
+    public void set(final BlockNotification notification) {
+        this.notification = notification;
+    }
+
+    public BlockNotification get() {
+        return notification;
+    }
+}
+```
+
+Replaces five fields, five `set(X)` overloads, five `getX()` getters.
+
+### 3. Facility: one send method
+
+```java
+// BlockMessagingFacility.java
+void sendBlockNotification(final BlockNotification notification);
+```
+
+Replaces `sendBlockVerification`, `sendBlockPersisted`, `sendBackfilledBlockNotification`,
+`sendNewestBlockKnownToNetwork`, `sendPublisherStatusUpdate`. Per
+[CLAUDE.md](../../../CLAUDE.md)'s no-backwards-compatibility-shim guidance, these five methods are
+removed, not deprecated — this is an internal SPI with a small number of call sites, all inside
+this repository, all updated in the same change.
+
+### 4. Handler: one dispatch method
+
+```java
+// BlockNotificationHandler.java
+public interface BlockNotificationHandler extends GatingHandler {
+    void handleNotification(BlockNotification notification);
+}
+```
+
+Replaces `handleVerification`, `handlePersisted`, `handleBackfilled`,
+`handleNewestBlockKnownToNetwork`, `handlePublisherStatusUpdate`. No default no-op — a plugin that
+registers a handler wants to react to at least one notification type; a `switch` with a `default`
+branch below expresses "ignore everything else" explicitly instead of silently.
+
+Consumers use pattern-matching `switch` (Java 21+) to dispatch:
+
+```java
+@Override
+public void handleNotification(BlockNotification notification) {
+    switch (notification) {
+        case VerificationNotification v -> handleVerification(v);
+        case PersistedNotification p -> handlePersisted(p);
+        case MyCustomNotification c -> handleCustom(c);
+        default -> { /* not a type this handler cares about */ }
+    }
+}
+```
+
+### 5. `BlockMessagingFacilityImpl` dispatch loop collapses
+
+```java
+final InformedEventHandler<BlockNotificationRingEvent> informedEventHandler =
+        (event, sequence, endOfBatch, percentageBehindRingHead) -> handler.handleNotification(event.get());
+```
+
+One line replaces the five-branch `if/else if` chain. The facility never inspects notification
+content — it forwards the reference, unchanged from today's behavior for the underlying
+Disruptor mechanics (threading, back-pressure, gating).
+
+### 6. Metrics
+
+`ProofVerificationMetrics` already uses a labeled counter (`LongCounter.builder(key)
+.addDynamicLabelNames(...)`, resolved per call via `getOrCreateLabeled(name, value, ...)`) — see
+`block-verification/.../metrics/ProofVerificationMetrics.java:38-89`. The facility reuses that
+pattern instead of one counter per notification type:
+
+```java
+private static final String LABEL_NOTIFICATION_TYPE = "notification_type";
+
+private static final MetricKey<LongCounter> METRIC_MESSAGING_BLOCK_NOTIFICATIONS_SENT =
+        MetricKey.of("messaging_block_notifications_sent", LongCounter.class).addCategory(METRICS_CATEGORY);
+
+// init
+notificationsSentCounter = metricRegistry.register(
+        LongCounter.builder(METRIC_MESSAGING_BLOCK_NOTIFICATIONS_SENT)
+                .setDescription("Notifications sent, by type")
+                .addDynamicLabelNames(LABEL_NOTIFICATION_TYPE));
+
+// on sendBlockNotification(notification)
+notificationsSentCounter
+        .getOrCreateLabeled(LABEL_NOTIFICATION_TYPE, notification.getClass().getSimpleName())
+        .increment();
+```
+
+This replaces the five per-type counters (`METRIC_MESSAGING_BLOCK_VERIFICATION_NOTIFICATIONS`,
+etc.) with one metric, while keeping the same per-type breakdown in Prometheus — including for
+custom notification types the facility has never seen a class for at compile time. Cardinality is
+bounded by the number of distinct `BlockNotification` classes loaded in the JVM (a handful, fixed
+by deployment), not by user-controlled data, so unbounded-label risk does not apply here.
+
+The queue/listener gauges (`messaging_notification_queue_percent_used`,
+`messaging_no_of_notification_listeners`) are already type-agnostic — unchanged.
+
+### 7. Package convention for custom notifications
+
+A plugin's custom notification records live in a `<module>.messaging` sub-package, mirroring the
+SPI's `blockmessaging` package name:
+
+```
+org.hiero.block.node.backfill.messaging.BackfillProgressNotification
+```
+
+To let another module consume it, the defining module exports that package in `module-info.java`:
+
+```java
+// backfill/module-info.java
+exports org.hiero.block.node.backfill.messaging to
+        org.hiero.block.node.stream.publisher;
+```
+
+|               Option                |                                                Trade-off                                                |
+|-------------------------------------|---------------------------------------------------------------------------------------------------------|
+| `exports ... to <specific modules>` | Strong encapsulation; every new consumer requires a one-line edit to the producer's `module-info.java`. |
+| `exports ...` (open to all)         | No producer-side edit needed per new consumer; any module on the classpath can read the type.           |
+
+Recommendation: use targeted `exports ... to` for notifications intended for a small, known set of
+consumers (matches existing JPMS conventions in this repo, e.g. `backfill`'s config export). Use an
+open `exports` only for notifications meant to be broadly consumable (e.g. by third-party plugins
+not known at compile time).
+
+## Worked Example
+
+A plugin (`backfill`) defines and emits a custom notification; another plugin (`stream-publisher`)
+consumes it.
+
+```java
+// backfill/.../messaging/BackfillProgressNotification.java
+package org.hiero.block.node.backfill.messaging;
+
+public record BackfillProgressNotification(long fromBlock, long toBlock, int percentComplete)
+        implements BlockNotification {}
+```
+
+```java
+// backfill/.../BackfillPlugin.java
+context.blockMessaging()
+        .sendBlockNotification(new BackfillProgressNotification(fromBlock, toBlock, percentComplete));
+```
+
+```java
+// stream-publisher/module-info.java
+requires org.hiero.block.node.backfill; // for the notification record only
+```
+
+```java
+// stream-publisher/.../PublisherPlugin.java
+@Override
+public void handleNotification(BlockNotification notification) {
+    switch (notification) {
+        case BackfillProgressNotification b -> log.log(DEBUG, "Backfill at {0}%", b.percentComplete());
+        default -> {}
+    }
+}
+```
+
+`stream-publisher` depends only on the `BackfillProgressNotification` record — never on
+`BackfillPlugin` or any backfill service class. This preserves nano-service isolation: backfill
+can be removed from a deployment and `stream-publisher`'s `switch` simply never matches that case.
+
+## Migration
+
+|                    Old call                    |                             New call                             |
+|------------------------------------------------|------------------------------------------------------------------|
+| `sendBlockVerification(n)`                     | `sendBlockNotification(n)`                                       |
+| `sendBlockPersisted(n)`                        | `sendBlockNotification(n)`                                       |
+| `sendBackfilledBlockNotification(n)`           | `sendBlockNotification(n)`                                       |
+| `sendNewestBlockKnownToNetwork(n)`             | `sendBlockNotification(n)`                                       |
+| `sendPublisherStatusUpdate(n)`                 | `sendBlockNotification(n)`                                       |
+| `handleVerification(VerificationNotification)` | `case VerificationNotification v -> ...` in `handleNotification` |
+| (same pattern for the other four handlers)     | (same pattern)                                                   |
+
+All call sites are inside this repository (`grep` for `sendBlock(Verification\|Persisted...)` and
+`handle(Verification\|Persisted...)` across `block-node/`). This is a single mechanical pass, done
+in one change — no transition period, no deprecated wrappers.
+
+## Testing Plugin
+
+Per issue #1431's task list, a test-only plugin validates the generic path end-to-end without any
+change to `BlockNodeApp` or another plugin:
+
+- Lives in a test-fixtures module, loaded only for tests via `ServiceLoader`.
+- Defines its own custom notification (e.g. `TestPingNotification(String id)`).
+- Registers a `BlockNotificationHandler` that records every `TestPingNotification` it receives.
+- Sends several `TestPingNotification`s and asserts they arrive in order, exactly once, on the
+  handler's own thread.
+- Proves: a plugin can introduce a wholly new notification type using only the public
+  `BlockMessagingFacility`/`BlockNotification` contract.
+
+## Diagrams
+
+### Type structure
+
+```mermaid
+classDiagram
+    class BlockNotification {
+        <<interface>>
+    }
+    class VerificationNotification
+    class PersistedNotification
+    class BackfilledBlockNotification
+    class NewestBlockKnownToNetworkNotification
+    class PublisherStatusUpdateNotification
+    class BackfillProgressNotification {
+        <<custom, defined in backfill module>>
+    }
+    BlockNotification <|.. VerificationNotification
+    BlockNotification <|.. PersistedNotification
+    BlockNotification <|.. BackfilledBlockNotification
+    BlockNotification <|.. NewestBlockKnownToNetworkNotification
+    BlockNotification <|.. PublisherStatusUpdateNotification
+    BlockNotification <|.. BackfillProgressNotification
+```
+
+### Emit and dispatch (generic + custom, same path)
+
+```mermaid
+sequenceDiagram
+    participant Backfill as Backfill Plugin
+    participant Facility as BlockMessagingFacility
+    participant Ring as Notification Disruptor
+    participant Publisher as Stream Publisher Plugin
+
+    Backfill->>Facility: sendBlockNotification(BackfillProgressNotification)
+    Facility->>Ring: publishEvent(event.set(notification))
+    Ring->>Publisher: handleNotification(notification)
+    Publisher->>Publisher: switch (notification) { case BackfillProgressNotification -> ... }
+```
+
+### Messaging architecture (updated)
+
+```mermaid
+flowchart LR
+    PUB[Publisher Plugin] -->|sendBlockItems| BI["Block Items\nDisruptor"]
+    BI --> SUB[Subscriber Plugin]
+    BI --> VER[Verification Plugin]
+
+    VER -->|sendBlockNotification\nVerificationNotification| BN["Block Notification\nDisruptor\n(BlockNotification)"]
+    STOR[Storage Plugin] -->|sendBlockNotification\nPersistedNotification| BN
+    BACKFILL[Backfill Plugin] -->|sendBlockNotification\nBackfillProgressNotification\ncustom type| BN
+    BN --> SUB2[Subscriber Plugin]
+    BN --> PUB2[Publisher Plugin]
+    BN --> N2["... any handler with\na matching switch case"]
+```
+
+## Open Questions
+
+- **Backward compatibility window**: none planned — see [Migration](#migration). Flag here if a
+  downstream consumer outside this repo depends on the five typed methods directly.
+- **Discovery**: out of scope (see [Non-Goals](#non-goals)). Revisit only if a concrete consumer
+  (e.g. an admin/debug endpoint) needs to list live notification types.

--- a/docs/design/architecture/generic-block-notifications.md
+++ b/docs/design/architecture/generic-block-notifications.md
@@ -291,16 +291,27 @@ in one change — no transition period, no deprecated wrappers.
 
 ## Testing Plugin
 
-Per issue #1431's task list, a test-only plugin validates the generic path end-to-end without any
-change to `BlockNodeApp` or another plugin:
+Per issue #1431's task list, a test validates the generic path end-to-end without any change to
+`spi-plugins` or `facility-messaging`:
+`facility-messaging/src/test/java/org/hiero/block/server/messaging/CustomNotificationTest.java`.
 
-- Lives in a test-fixtures module, loaded only for tests via `ServiceLoader`.
-- Defines its own custom notification (e.g. `TestPingNotification(String id)`).
-- Registers a `BlockNotificationHandler` that records every `TestPingNotification` it receives.
-- Sends several `TestPingNotification`s and asserts they arrive in order, exactly once, on the
-  handler's own thread.
-- Proves: a plugin can introduce a wholly new notification type using only the public
+- Defines a `PingNotification(int sequence)` record implementing `BlockNotification` inline in the
+  test — a stand-in for a type a third-party plugin would define, unknown to `spi-plugins` or
+  `facility-messaging` at compile time.
+- Registers a `BlockNotificationHandler` against the real `BlockMessagingFacilityImpl` (not a test
+  double) and records every `PingNotification` it receives.
+- Sends several `PingNotification`s and asserts they arrive in order, exactly once, and all on the
+  same thread (the handler's own dedicated thread).
+- Proves: a notification type introduced outside this module flows through the real
+  Disruptor-backed pipeline with the same delivery guarantees (ordering, exactly-once, dedicated
+  handler thread) as the five built-in notification types, using only the public
   `BlockMessagingFacility`/`BlockNotification` contract.
+
+A full ServiceLoader-discovered plugin exercising this (as opposed to a direct unit test against
+the facility) was considered but not built — the facility is what's generic here, not any
+particular plugin's wiring, so a unit test against `BlockMessagingFacilityImpl` proves the same
+thing with far less infrastructure. Revisit only if end-to-end/solo testing specifically needs a
+real plugin example.
 
 ## Diagrams
 

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/metrics/MetricsCommonTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/metrics/MetricsCommonTests.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.Future;
 import org.hiero.block.simulator.BlockStreamSimulatorApp;
 import org.hiero.block.suites.BaseSuite;
@@ -104,9 +105,13 @@ public class MetricsCommonTests extends BaseSuite {
         long blockItemsReceived =
                 metricsAccessor.getMetricValue("messaging_block_items_received", MetricsAccessor.MetricType.COUNTER);
         long verificationNotifications = metricsAccessor.getMetricValue(
-                "messaging_block_verification_notifications", MetricsAccessor.MetricType.COUNTER);
+                "messaging_block_notifications_sent",
+                MetricsAccessor.MetricType.COUNTER,
+                Map.of("notification_type", "VerificationNotification"));
         long persistedNotifications = metricsAccessor.getMetricValue(
-                "messaging_block_persisted_notifications", MetricsAccessor.MetricType.COUNTER);
+                "messaging_block_notifications_sent",
+                MetricsAccessor.MetricType.COUNTER,
+                Map.of("notification_type", "PersistedNotification"));
 
         assertTrue(blockItemsReceived >= 0, "Block items received should be a non-negative number");
         assertTrue(verificationNotifications >= 0, "Verification notifications should be a non-negative number");


### PR DESCRIPTION


## Summary

Replaces the five type-specific notification methods on `BlockMessagingFacility` and `BlockNotificationHandler` with a single generic pair (`sendBlockNotification`/`handleNotification`), so any plugin can define, emit, and consume its own notification type without touching `spi-plugins` or `facility-messaging`.

## Changes

- Design doc: `docs/design/architecture/generic-block-notifications.md`
- New `BlockNotification` marker interface; the five existing notification records now implement it
- `BlockNotificationRingEvent` collapsed from five typed fields/getters/setters to one
- `BlockMessagingFacility.sendBlockNotification(BlockNotification)` replaces the five `sendX` methods
- `BlockNotificationHandler.handleNotification(BlockNotification)` replaces the five `handleX` methods; consumers dispatch with a pattern-matching `switch`
- `BlockMessagingFacilityImpl` forwards notifications directly (no more type-check dispatch chain); the five per-type metric counters collapsed into one labeled counter (`notification_type` dynamic label)
- Migrated every plugin implementing `BlockNotificationHandler`: backfill, block-verification, blocks-file-historic, blocks-file-recent, cloud-storage-archive, cloud-storage-expanded, s3-archive, stream-publisher, verification, plus app test fixtures
- Added `CustomNotificationTest`, which defines a notification type inline (standing in for a third-party plugin's own type) and proves it flows through the real `BlockMessagingFacilityImpl` with the same delivery guarantees (in-order, exactly-once, dedicated handler thread) as the built-in types

## Test plan

- [x] `./gradlew compileJava compileTestJava compileTestFixturesJava` — full repo compiles
- [x] `./gradlew test` — full repo test suite passes
- [x] `CustomNotificationTest` re-run multiple times to rule out flakiness

## Related issues

Addresses #1431. Related, not addressed here: #1744, #2089.
