### PR TITLE
fix(docker): unpin curl version in simulator Dockerfile

### DIFF
--- a/tools-and-tests/simulator/docker/Dockerfile
+++ b/tools-and-tests/simulator/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG BN_WORKDIR="/opt/hiero/block-node"
 ENV BN_WORKDIR=${BN_WORKDIR}
 RUN groupadd --gid $GID $UNAME
 RUN useradd --no-user-group --create-home --uid $UID --gid $GID --shell /bin/bash hedera
-RUN apt-get update && apt-get install -y --no-install-recommends curl=8.18.0-1ubuntu2.1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 WORKDIR ${BN_WORKDIR}
 
 # Copy the distribution and resources


### PR DESCRIPTION
Fixes #3145 

## Summary

- Unpin `curl` version in the simulator Dockerfile — `curl=8.18.0-1ubuntu2.1` was removed from Ubuntu apt repos, breaking the Docker image build with exit code 100
- Letting apt resolve the current version prevents this class of breakage whenever Ubuntu cycles out a package patch

## Root cause

`tools-and-tests/simulator/docker/Dockerfile` pinned an exact apt package version:

```dockerfile
RUN apt-get update && apt-get install -y --no-install-recommends curl=8.18.0-1ubuntu2.1 && ...
```

Ubuntu updated curl to a newer patch, removing the old version from the index. The build then fails with:

```
E: Version '8.18.0-1ubuntu2.1' for 'curl' was not found
```

Observed in:
- https://github.com/hiero-ledger/hiero-block-node/actions/runs/28619859448/job/84876082223 (PR #3144)
- https://github.com/hiero-ledger/hiero-block-node/actions/runs/28571650203/job/84880895098 (PR #3131)

## Changes

- `tools-and-tests/simulator/docker/Dockerfile` — remove `=8.18.0-1ubuntu2.1` version pin from the curl install step

## Test plan

- [ ] `Build Docker images` CI step passes on this PR
