### PR TITLE
feat: Make ServerStatus aware of the earliest managed block setting

### DIFF
--- a/block-node/server-status/src/main/java/module-info.java
+++ b/block-node/server-status/src/main/java/module-info.java
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-/* SPDX-License-Identifier: Apache-2.0 */
-
 import org.hiero.block.node.server.status.ServerStatusServicePlugin;
 
 module org.hiero.block.node.server.status {
@@ -18,8 +16,6 @@ module org.hiero.block.node.server.status {
     requires org.hiero.block.node.base;
     requires com.github.spotbugs.annotations;
 
-    uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
-    /* export configuration classes to the config module and app */
     provides org.hiero.block.node.spi.BlockNodePlugin with
             ServerStatusServicePlugin;
 }

--- a/block-node/server-status/src/main/java/module-info.java
+++ b/block-node/server-status/src/main/java/module-info.java
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
+/* SPDX-License-Identifier: Apache-2.0 */
+
 import org.hiero.block.node.server.status.ServerStatusServicePlugin;
 
 module org.hiero.block.node.server.status {
-    uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
-
-    // export configuration classes to the config module and app
     exports org.hiero.block.node.server.status to
             com.swirlds.config.impl,
             com.swirlds.config.extensions,
@@ -15,9 +14,12 @@ module org.hiero.block.node.server.status {
     requires transitive org.hiero.block.protobuf.pbj;
     requires transitive org.hiero.metrics;
     requires com.hedera.pbj.runtime;
+    requires org.hiero.block.node.app.config;
     requires org.hiero.block.node.base;
     requires com.github.spotbugs.annotations;
 
+    uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
+    /* export configuration classes to the config module and app */
     provides org.hiero.block.node.spi.BlockNodePlugin with
             ServerStatusServicePlugin;
 }

--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
@@ -59,12 +59,13 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
 
         final ServerStatusResponse.Builder serverStatusResponseBuilder = ServerStatusResponse.newBuilder();
         final long firstAvailableBlock = blockProvider.availableBlocks().min();
-        long lastAvailableBlock = blockProvider.availableBlocks().max();
+        long highestAvailableBlock = blockProvider.availableBlocks().max();
         // If this node is configured to manage blocks starting later than what it currently holds, report that
         // later block as the last available block so publishers know they can stream from earliestManagedBlock
-        // instead of assuming the node only wants its currently stored (older) blocks.
-        if (lastAvailableBlock != UNKNOWN_BLOCK_NUMBER && lastAvailableBlock < earliestManagedBlock) {
-            lastAvailableBlock = earliestManagedBlock;
+        // instead of assuming the node only wants older blocks between the oldest stored block and earliest managed
+        // block.
+        if (highestAvailableBlock != UNKNOWN_BLOCK_NUMBER && highestAvailableBlock < earliestManagedBlock) {
+            highestAvailableBlock = earliestManagedBlock;
         }
 
         // TODO(#579) Should get from state config or status, which would be provided by the context from responsible
@@ -78,7 +79,7 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
         // Build the response
         ServerStatusResponse response = serverStatusResponseBuilder
                 .firstAvailableBlock(firstAvailableBlock)
-                .lastAvailableBlock(lastAvailableBlock)
+                .lastAvailableBlock(highestAvailableBlock)
                 .onlyLatestState(onlyLatestState)
                 .build();
 
@@ -174,7 +175,7 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
     @Override
     @NonNull
     public List<Class<? extends Record>> configDataTypes() {
-        return List.of(ServerStatusConfig.class, NodeConfig.class);
+        return List.of(ServerStatusConfig.class);
     }
 
     /**

--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
@@ -12,6 +12,7 @@ import org.hiero.block.api.BlockRange;
 import org.hiero.block.api.ServerStatusDetailResponse;
 import org.hiero.block.api.ServerStatusRequest;
 import org.hiero.block.api.ServerStatusResponse;
+import org.hiero.block.node.app.config.node.NodeConfig;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
@@ -38,6 +39,8 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
     private HistoricalBlockFacility blockProvider;
     /** The block node context, used to provide access to facilities */
     private volatile BlockNodeContext blockNodeContext;
+    /** The earliest block number this node is configured to manage */
+    private long earliestManagedBlock;
     /** Counter for the number of status requests */
     private LongCounter.Measurement requestStatusCounter;
     /** Counter for the number of detail requests */
@@ -56,7 +59,13 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
 
         final ServerStatusResponse.Builder serverStatusResponseBuilder = ServerStatusResponse.newBuilder();
         final long firstAvailableBlock = blockProvider.availableBlocks().min();
-        final long lastAvailableBlock = blockProvider.availableBlocks().max();
+        long lastAvailableBlock = blockProvider.availableBlocks().max();
+        // If this node is configured to manage blocks starting later than what it currently holds, report that
+        // later block as the last available block so publishers know they can stream from earliestManagedBlock
+        // instead of assuming the node only wants its currently stored (older) blocks.
+        if (lastAvailableBlock != UNKNOWN_BLOCK_NUMBER && lastAvailableBlock < earliestManagedBlock) {
+            lastAvailableBlock = earliestManagedBlock;
+        }
 
         // TODO(#579) Should get from state config or status, which would be provided by the context from responsible
         // facility
@@ -136,6 +145,8 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
         requireNonNull(serviceBuilder);
         this.blockNodeContext = requireNonNull(context);
         this.blockProvider = requireNonNull(context.historicalBlockProvider());
+        this.earliestManagedBlock =
+                context.configuration().getConfigData(NodeConfig.class).earliestManagedBlock();
 
         final MetricRegistry metricRegistry = context.metricRegistry();
 
@@ -163,7 +174,7 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
     @Override
     @NonNull
     public List<Class<? extends Record>> configDataTypes() {
-        return List.of(ServerStatusConfig.class);
+        return List.of(ServerStatusConfig.class, NodeConfig.class);
     }
 
     /**

--- a/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java
+++ b/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.hedera.pbj.runtime.ParseException;
+import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import org.hiero.block.api.ServerStatusRequest;
@@ -89,6 +90,83 @@ public class ServerStatusServicePluginTest
         assertEquals(0, response.firstAvailableBlock());
         assertEquals(blocks - 1, response.lastAvailableBlock());
         assertFalse(response.onlyLatestState());
+    }
+
+    /**
+     * Tests that when {@code earliestManagedBlock} is configured higher than the last block currently
+     * held by the node, the reported {@code lastAvailableBlock} is raised to that configured value, while
+     * {@code firstAvailableBlock} is left untouched, so publishers know they can stream later blocks even
+     * though the node only holds older ones.
+     *
+     * @throws ParseException if there is an error parsing the response
+     */
+    @Test
+    @DisplayName("Should raise lastAvailableBlock to earliestManagedBlock when node holds only older blocks")
+    void shouldRaiseLastAvailableBlockToEarliestManagedBlock() throws ParseException {
+        final ServerStatusServicePlugin localPlugin = new ServerStatusServicePlugin();
+        start(
+                localPlugin,
+                localPlugin.methods().getFirst(),
+                new SimpleInMemoryHistoricalBlockFacility(),
+                Map.of("block.node.earliestManagedBlock", "100"));
+        sendBlocks(5);
+
+        final ServerStatusRequest request = ServerStatusRequest.newBuilder().build();
+        toPluginPipe.onNext(ServerStatusRequest.PROTOBUF.toBytes(request));
+        final ServerStatusResponse response = standardParse(ServerStatusResponse.PROTOBUF, fromPluginBytes.getLast());
+
+        assertEquals(0, response.firstAvailableBlock());
+        assertEquals(100, response.lastAvailableBlock());
+    }
+
+    /**
+     * Tests that {@code earliestManagedBlock} has no effect when the node already holds blocks at or
+     * beyond that configured value.
+     *
+     * @throws ParseException if there is an error parsing the response
+     */
+    @Test
+    @DisplayName("Should not lower or otherwise change lastAvailableBlock when it already meets earliestManagedBlock")
+    void shouldNotChangeLastAvailableBlockWhenAlreadyAtOrAboveEarliestManagedBlock() throws ParseException {
+        final ServerStatusServicePlugin localPlugin = new ServerStatusServicePlugin();
+        start(
+                localPlugin,
+                localPlugin.methods().getFirst(),
+                new SimpleInMemoryHistoricalBlockFacility(),
+                Map.of("block.node.earliestManagedBlock", "2"));
+        sendBlocks(5);
+
+        final ServerStatusRequest request = ServerStatusRequest.newBuilder().build();
+        toPluginPipe.onNext(ServerStatusRequest.PROTOBUF.toBytes(request));
+        final ServerStatusResponse response = standardParse(ServerStatusResponse.PROTOBUF, fromPluginBytes.getLast());
+
+        assertEquals(0, response.firstAvailableBlock());
+        assertEquals(4, response.lastAvailableBlock());
+    }
+
+    /**
+     * Tests that {@code earliestManagedBlock} has no effect when the node holds no blocks at all, since
+     * there is no meaningful "last available block" to report yet.
+     *
+     * @throws ParseException if there is an error parsing the response
+     */
+    @Test
+    @DisplayName(
+            "Should leave lastAvailableBlock as unknown when no blocks are available, even with earliestManagedBlock set")
+    void shouldLeaveLastAvailableBlockUnknownWhenNoBlocksAvailable() throws ParseException {
+        final ServerStatusServicePlugin localPlugin = new ServerStatusServicePlugin();
+        start(
+                localPlugin,
+                localPlugin.methods().getFirst(),
+                new SimpleInMemoryHistoricalBlockFacility(),
+                Map.of("block.node.earliestManagedBlock", "100"));
+
+        final ServerStatusRequest request = ServerStatusRequest.newBuilder().build();
+        toPluginPipe.onNext(ServerStatusRequest.PROTOBUF.toBytes(request));
+        final ServerStatusResponse response = standardParse(ServerStatusResponse.PROTOBUF, fromPluginBytes.getLast());
+
+        assertEquals(UNKNOWN_BLOCK_NUMBER, response.firstAvailableBlock());
+        assertEquals(UNKNOWN_BLOCK_NUMBER, response.lastAvailableBlock());
     }
 
     /**


### PR DESCRIPTION
## Reviewer Notes
This implements the fix for [#2971](https://github.com/hiero-ledger/hiero-block-node/issues/2971): the Status API's `serverStatus` RPC now floors the reported `lastAvailableBlock` at the configured `earliestManagedBlock` when the node actually holds blocks (leaving `firstAvailableBlock` untouched, per the issue's clarified invariant `first <= earliestManagedBlock <= last`), and leaves both as `UNKNOWN_BLOCK_NUMBER` when the node holds no blocks at all.

Changes:
- [ServerStatusServicePlugin.java](block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java) — reads `NodeConfig.earliestManagedBlock()` in `init()`, applies the floor to `lastAvailableBlock` in `serverStatus()`.
- [module-info.java](block-node/server-status/src/main/java/module-info.java) — added `requires org.hiero.block.node.app.config`.
- [ServerStatusServicePluginTest.java](block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java) — added 3 tests covering the raise case, the no-op case (already at/above EMB), and the empty-node case.

## Related Issue(s)
Closes: #2971
