### PR TITLE
fix: align convert-address-book-history output with RangedAddressBookHistory (#3164)

### DIFF
--- a/protobuf-sources/src/main/proto/block-node/api/node_service.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/node_service.proto
@@ -292,8 +292,9 @@ service BlockNodeService {
  * RSA public keys.
  *
  * Entries MUST be ordered by start_block ascending and MUST NOT overlap.
- * The last entry typically has end_block = 0, meaning it covers all block
- * numbers >= start_block with no upper bound (open-ended).
+ * The last entry typically has end_block = -1 (rendered as -1 by PBJ's JSON
+ * codec; equivalently the max uint64 value in wire form), meaning it covers
+ * all block numbers >= start_block with no upper bound (open-ended).
  *
  * On-disk format: JSON-serialized via PBJ's RangedAddressBookHistory.JSON
  * codec, written to the path configured by app.state.rsaAddressBookHistoryFilePath
@@ -317,9 +318,9 @@ message RangedAddressBookHistory {
  * The address book is valid for all blocks whose block number satisfies:
  *   start_block &le; block_number &le; end_block
  *
- * When end_block is 0 the entry is open-ended: it covers all blocks with
- * block number >= start_block. Only the last entry in a
- * RangedAddressBookHistory should have end_block = 0.
+ * When end_block is -1 (max uint64 in wire form) the entry is open-ended:
+ * it covers all blocks with block number >= start_block. Only the last entry
+ * in a RangedAddressBookHistory should have end_block = -1.
  */
 message RangedNodeAddressBook {
     /**
@@ -337,9 +338,12 @@ message RangedNodeAddressBook {
 
     /**
      * The last block number for which this address book is valid (inclusive).
-     * A value of 0 is a sentinel meaning open-ended: this address book covers
-     * all blocks with block number &ge; start_block.
-     * All entries except the last MUST have end_block &gt; 0.
+     * A value of -1 (max uint64 in wire form, rendered as "-1" by PBJ's JSON
+     * codec) is a sentinel meaning open-ended: this address book covers all
+     * blocks with block number &ge; start_block.
+     * Only the last entry in a RangedAddressBookHistory should carry the
+     * open-ended sentinel; every other entry MUST have a finite end_block
+     * &ge; its own start_block.
      */
     uint64 end_block = 3;
 }

--- a/tools-and-tests/tools/build.gradle.kts
+++ b/tools-and-tests/tools/build.gradle.kts
@@ -18,7 +18,6 @@ mainModuleInfo {
     requires("com.hedera.pbj.runtime")
     requires("org.hiero.block.node.base")
     requires("org.hiero.block.protobuf.pbj")
-    requires("com.fasterxml.jackson.databind")
     requires("com.github.luben.zstd_jni")
     requires("com.google.api.gax")
     requires("com.google.auth.oauth2")

--- a/tools-and-tests/tools/build.gradle.kts
+++ b/tools-and-tests/tools/build.gradle.kts
@@ -18,6 +18,7 @@ mainModuleInfo {
     requires("com.hedera.pbj.runtime")
     requires("org.hiero.block.node.base")
     requires("org.hiero.block.protobuf.pbj")
+    requires("com.fasterxml.jackson.databind")
     requires("com.github.luben.zstd_jni")
     requires("com.google.api.gax")
     requires("com.google.auth.oauth2")

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
@@ -253,10 +253,19 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
     }
 
     /**
-     * Re-emit the roster JSON at {@code file} so every entry has an explicit
-     * {@code startBlock} and {@code endBlock} field, defaulting to {@code 0} and
-     * {@code -1} respectively when the PBJ codec elided them. Preserves entry order
-     * and the nested {@code addressBook} structure verbatim.
+     * Re-emit the roster JSON at {@code file} so every entry has explicit fields that PBJ's
+     * JSON codec would otherwise elide as proto3 defaults:
+     *
+     * <ul>
+     *   <li>Per-era: {@code startBlock} defaults to {@code 0}, {@code endBlock} defaults to
+     *       {@code -1} (the {@link #OPEN_ENDED_END_BLOCK} sentinel used only for the last era).</li>
+     *   <li>Per {@code nodeAddress}: {@code nodeId} defaults to {@code 0}. Without this,
+     *       every genesis-node-0 entry loses its identifier and the BN's roster verifier
+     *       can't route by nodeId.</li>
+     * </ul>
+     *
+     * Preserves entry order and the nested {@code addressBook} structure verbatim. PBJ's
+     * parse side reconstructs the same values from either shape, so the BN loader is unaffected.
      */
     private static void ensureExplicitStartAndEndBlock(Path file) throws IOException {
         final ObjectMapper mapper = new ObjectMapper();
@@ -276,6 +285,18 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
             }
             if (!entryObj.has("endBlock")) {
                 entryObj.put("endBlock", Long.toString(OPEN_ENDED_END_BLOCK));
+            }
+            // Restore any nodeAddress[].nodeId that PBJ elided as the uint64 default (0).
+            final JsonNode addressBookNode = entryObj.get("addressBook");
+            if (addressBookNode instanceof ObjectNode addressBookObj) {
+                final JsonNode nodeAddressNode = addressBookObj.get("nodeAddress");
+                if (nodeAddressNode != null && nodeAddressNode.isArray()) {
+                    for (final JsonNode addr : nodeAddressNode) {
+                        if (addr instanceof ObjectNode addrObj && !addrObj.has("nodeId")) {
+                            addrObj.put("nodeId", Long.toString(0L));
+                        }
+                    }
+                }
             }
         }
         mapper.writerWithDefaultPrettyPrinter().writeValue(file.toFile(), root);

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
@@ -119,15 +119,19 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
         }
         System.out.println("  Eras:            " + sorted.size());
 
-        // Use forCurrentNetwork() so that the genesis instant respects the top-level --network
-        // option (mainnet / testnet / previewnet / other). The raw BlockTimeReader(Path) ctor
-        // hardcodes the mainnet genesis, which would break resolution on any other network.
+        // Use the raw ctor (mainnet-anchored) even for --network testnet/previewnet. The
+        // block_times.bin file format stores each block's time as nanos-since-mainnet-first-
+        // block regardless of network: every writer in the extraction chain hardcodes that
+        // anchor via RecordFileDates.instantToBlockTimeLong. Using forCurrentNetwork() here
+        // reads the same bytes with a network-specific anchor and produces a multi-year
+        // offset on non-mainnet networks (see PR #3166 review). Reader and writer must
+        // agree — leave both mainnet-anchored until the write path is network-aware.
         final long[] startBlocks;
         final List<String> resolutionProblems;
         final Instant coverageStart;
         final Instant coverageEnd;
         final long coverageMaxBlock;
-        try (BlockTimeReader reader = BlockTimeReader.forCurrentNetwork(blockTimesFile)) {
+        try (BlockTimeReader reader = new BlockTimeReader(blockTimesFile)) {
             coverageMaxBlock = reader.getMaxBlockNumber();
             coverageStart = reader.getBlockInstant(0);
             coverageEnd = reader.getBlockInstant(coverageMaxBlock);

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.blocks;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.pbj.runtime.ParseException;
@@ -208,6 +211,14 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
             try (WritableStreamingData out = new WritableStreamingData(Files.newOutputStream(tmp))) {
                 RangedAddressBookHistory.JSON.write(rangedHistory, out);
             }
+            // PBJ's JSON codec elides proto3 default values (uint64 == 0), which makes a
+            // legitimate genesis-era startBlock=0 or open-ended endBlock look identical to a
+            // missing field. This bootstrap file gets inspected by operators, so re-emit it
+            // with both fields always present: startBlock defaults to 0 (proto3 default),
+            // endBlock defaults to -1 (OPEN_ENDED_END_BLOCK sentinel, used only for the last
+            // era). PBJ's parse side reconstructs the same values from either shape, so the
+            // BN loader is unaffected.
+            ensureExplicitStartAndEndBlock(tmp);
             Files.move(tmp, outputFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             Files.deleteIfExists(tmp);
@@ -216,6 +227,35 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
         System.out.println(Ansi.AUTO.string(
                 "@|green Wrote " + sorted.size() + " roster entries to " + outputFile.toAbsolutePath() + "|@"));
         return 0;
+    }
+
+    /**
+     * Re-emit the roster JSON at {@code file} so every entry has an explicit
+     * {@code startBlock} and {@code endBlock} field, defaulting to {@code 0} and
+     * {@code -1} respectively when the PBJ codec elided them. Preserves entry order
+     * and the nested {@code addressBook} structure verbatim.
+     */
+    private static void ensureExplicitStartAndEndBlock(Path file) throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+        final ObjectNode root = (ObjectNode) mapper.readTree(file.toFile());
+        final JsonNode addressBooksNode = root.get("addressBooks");
+        if (addressBooksNode == null || !addressBooksNode.isArray()) {
+            return; // nothing to patch — an empty roster history is legal
+        }
+        for (final JsonNode entry : addressBooksNode) {
+            if (!(entry instanceof ObjectNode entryObj)) {
+                continue;
+            }
+            // Match PBJ's convention: uint64 fields serialize as JSON strings so JS
+            // consumers don't hit the 2^53 precision cliff.
+            if (!entryObj.has("startBlock")) {
+                entryObj.put("startBlock", Long.toString(0L));
+            }
+            if (!entryObj.has("endBlock")) {
+                entryObj.put("endBlock", Long.toString(OPEN_ENDED_END_BLOCK));
+            }
+        }
+        mapper.writerWithDefaultPrettyPrinter().writeValue(file.toFile(), root);
     }
 
     /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
@@ -1,14 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.blocks;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -17,10 +14,11 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.Callable;
+import org.hiero.block.api.RangedAddressBookHistory;
+import org.hiero.block.api.RangedNodeAddressBook;
 import org.hiero.block.internal.AddressBookHistory;
 import org.hiero.block.internal.DatedNodeAddressBook;
 import org.hiero.block.tools.metadata.MetadataFiles;
@@ -30,31 +28,29 @@ import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Option;
 
 /**
- * Convert the CLI's address-book history JSON into a block-number-scoped roster file the BN can load
- * to verify historical Wrapped Record Blocks.
+ * Convert the CLI's address-book history JSON into a {@link RangedAddressBookHistory} JSON that the
+ * Block Node can load to verify historical Wrapped Record Blocks.
  *
  * <p>Each entry in the input {@code AddressBookHistory} carries a consensus {@code block_timestamp};
  * this command resolves that timestamp to the block number that became valid at or after that time
- * (via {@link BlockTimeReader#getNearestBlockAfterTime(LocalDateTime)}) and emits a roster history
- * file with the following shape:
+ * (via {@link BlockTimeReader#getNearestBlockAfterTime(LocalDateTime)}) and emits the shape defined
+ * by the {@code RangedAddressBookHistory} proto (see {@code node_service.proto}):
  *
  * <pre>{@code
  * {
- *   "entries": [
+ *   "addressBooks": [
  *     {
- *       "startBlock": <long>,
- *       "endBlock":   <long>|null,
- *       "blockTimestamp": { "seconds": <long>, "nanos": <int> },
- *       "addressBook": "<base64-encoded NodeAddressBook proto>"
+ *       "addressBook": { "nodeAddress": [ { "nodeId": ..., "rsaPubKey": "...", ... }, ... ] },
+ *       "startBlock":  <long>,
+ *       "endBlock":    <long>
  *     },
  *     ...
  *   ]
  * }
  * }</pre>
  *
- * <p>{@code endBlock} is {@code (next.startBlock - 1)}; the most recent era's {@code endBlock}
- * is {@code null} to mark it as open-ended. The full {@code NodeAddressBook} proto is preserved
- * per era (Base64) so the BN can extract the fields it needs at load time.
+ * <p>{@code endBlock} for the last era is {@code -1}, the open-ended sentinel used by
+ * {@code RangedAddressBookHistory}. For all other eras {@code endBlock} is {@code (next.startBlock - 1)}.
  *
  * <p>Intended consumer: the BN's historical RSA-roster bootstrap (issue #2958 / T4).
  */
@@ -65,6 +61,9 @@ import picocli.CommandLine.Option;
         mixinStandardHelpOptions = true)
 public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
 
+    /** Sentinel value used by {@link RangedAddressBookHistory} for the open-ended (most-recent) era. */
+    static final long OPEN_ENDED_END_BLOCK = -1L;
+
     @Option(
             names = {"-i", "--input"},
             description =
@@ -73,12 +72,13 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
     private Path inputFile;
 
     /**
-     * Default output path mirrors today's single-book layout (see
-     * {@code ApplicationStateConfig.rsaBootstrapFilePath}) so that, by default, the file lands
-     * where the BN's historical-roster bootstrap (T4) is expected to read it from.
+     * Default output path is the same file the BN reads for its RSA bootstrap
+     * ({@code ApplicationStateConfig.rsaBootstrapFilePath}). T4's loader accepts
+     * either a single-book {@link NodeAddressBook} JSON or a
+     * {@link RangedAddressBookHistory} JSON at this path.
      */
     static final Path DEFAULT_OUTPUT_PATH =
-            Path.of("/opt/hiero/block-node/application-state/rsa-bootstrap-roster-history.json");
+            Path.of("/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json");
 
     @Option(
             names = {"-o", "--output"},
@@ -90,8 +90,6 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
             description =
                     "Path to block_times.bin used for consensus-time → block-number lookup (default: ${DEFAULT-VALUE})")
     private Path blockTimesFile = MetadataFiles.BLOCK_TIMES_FILE;
-
-    private static final ObjectMapper JSON_MAPPER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
     @Override
     public Integer call() throws Exception {
@@ -118,8 +116,11 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
         }
         System.out.println("  Eras:            " + sorted.size());
 
+        // Use forCurrentNetwork() so that the genesis instant respects the top-level --network
+        // option (mainnet / testnet / previewnet / other). The raw BlockTimeReader(Path) ctor
+        // hardcodes the mainnet genesis, which would break resolution on any other network.
         final long[] startBlocks;
-        try (BlockTimeReader reader = new BlockTimeReader(blockTimesFile)) {
+        try (BlockTimeReader reader = BlockTimeReader.forCurrentNetwork(blockTimesFile)) {
             startBlocks = resolveStartBlocks(sorted, reader);
         }
 
@@ -127,25 +128,19 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
     }
 
     private int convertAndWrite(List<DatedNodeAddressBook> sorted, long[] startBlocks) throws IOException {
-        final ObjectNode root = JSON_MAPPER.createObjectNode();
-        final ArrayNode entries = root.putArray("entries");
+        final List<RangedNodeAddressBook> ranged = new ArrayList<>(sorted.size());
         for (int i = 0; i < sorted.size(); i++) {
-            final DatedNodeAddressBook era = sorted.get(i);
-            final Timestamp ts = era.blockTimestampOrThrow();
-            final NodeAddressBook book = era.addressBookOrThrow();
-
-            final ObjectNode entry = entries.addObject();
-            entry.put("startBlock", startBlocks[i]);
-            if (i + 1 < sorted.size()) {
-                entry.put("endBlock", startBlocks[i + 1] - 1);
-            } else {
-                entry.putNull("endBlock");
-            }
-            final ObjectNode tsNode = entry.putObject("blockTimestamp");
-            tsNode.put("seconds", ts.seconds());
-            tsNode.put("nanos", ts.nanos());
-            entry.put("addressBook", encodeAddressBook(book));
+            final NodeAddressBook book = sorted.get(i).addressBookOrThrow();
+            final long start = startBlocks[i];
+            final long end = (i + 1 < sorted.size()) ? startBlocks[i + 1] - 1 : OPEN_ENDED_END_BLOCK;
+            ranged.add(RangedNodeAddressBook.newBuilder()
+                    .addressBook(book)
+                    .startBlock(start)
+                    .endBlock(end)
+                    .build());
         }
+        final RangedAddressBookHistory rangedHistory =
+                RangedAddressBookHistory.newBuilder().addressBooks(ranged).build();
 
         Path parent = outputFile.toAbsolutePath().getParent();
         if (parent != null) {
@@ -155,7 +150,9 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
         // leave the destination half-written for the BN to read.
         final Path tmp = outputFile.resolveSibling(outputFile.getFileName() + ".tmp");
         try {
-            JSON_MAPPER.writeValue(tmp.toFile(), root);
+            try (WritableStreamingData out = new WritableStreamingData(Files.newOutputStream(tmp))) {
+                RangedAddressBookHistory.JSON.write(rangedHistory, out);
+            }
             Files.move(tmp, outputFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             Files.deleteIfExists(tmp);
@@ -203,10 +200,5 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
             startBlocks[i] = reader.getNearestBlockAfterTime(ldt);
         }
         return startBlocks;
-    }
-
-    private static String encodeAddressBook(NodeAddressBook book) {
-        return Base64.getEncoder()
-                .encodeToString(NodeAddressBook.PROTOBUF.toBytes(book).toByteArray());
     }
 }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
@@ -4,6 +4,7 @@ package org.hiero.block.tools.blocks;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.hedera.hapi.node.base.NodeAddress;
 import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.pbj.runtime.ParseException;
@@ -192,7 +193,7 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
     private int convertAndWrite(List<DatedNodeAddressBook> sorted, long[] startBlocks) throws IOException {
         final List<RangedNodeAddressBook> ranged = new ArrayList<>(sorted.size());
         for (int i = 0; i < sorted.size(); i++) {
-            final NodeAddressBook book = sorted.get(i).addressBookOrThrow();
+            final NodeAddressBook book = slimAddressBook(sorted.get(i).addressBookOrThrow());
             final long start = startBlocks[i];
             final long end = (i + 1 < sorted.size()) ? startBlocks[i + 1] - 1 : OPEN_ENDED_END_BLOCK;
             ranged.add(RangedNodeAddressBook.newBuilder()
@@ -231,6 +232,24 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
         System.out.println(Ansi.AUTO.string(
                 "@|green Wrote " + sorted.size() + " roster entries to " + outputFile.toAbsolutePath() + "|@"));
         return 0;
+    }
+
+    /**
+     * Rebuild {@code book} keeping only the two fields the BN's WRB roster verifier consults:
+     * {@code nodeId} (routing key) and {@code RSAPubKey} (signature-verification key). Everything
+     * else on {@link NodeAddress} — service endpoints, node cert hash, account id, description,
+     * stake, memo — is dropped from the emitted bootstrap file to keep it small and free of
+     * PII/network-topology metadata that the BN never reads.
+     */
+    private static NodeAddressBook slimAddressBook(NodeAddressBook book) {
+        final List<NodeAddress> slim = new ArrayList<>(book.nodeAddress().size());
+        for (final NodeAddress addr : book.nodeAddress()) {
+            slim.add(NodeAddress.newBuilder()
+                    .nodeId(addr.nodeId())
+                    .rsaPubKey(addr.rsaPubKey())
+                    .build());
+        }
+        return NodeAddressBook.newBuilder().nodeAddress(slim).build();
     }
 
     /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
@@ -223,7 +223,7 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
             // endBlock defaults to -1 (OPEN_ENDED_END_BLOCK sentinel, used only for the last
             // era). PBJ's parse side reconstructs the same values from either shape, so the
             // BN loader is unaffected.
-            ensureExplicitStartAndEndBlock(tmp);
+            ensureExplicitPbjDefaults(tmp);
             Files.move(tmp, outputFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             Files.deleteIfExists(tmp);

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
@@ -120,11 +120,66 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
         // option (mainnet / testnet / previewnet / other). The raw BlockTimeReader(Path) ctor
         // hardcodes the mainnet genesis, which would break resolution on any other network.
         final long[] startBlocks;
+        final List<String> resolutionProblems;
+        final Instant coverageStart;
+        final Instant coverageEnd;
+        final long coverageMaxBlock;
         try (BlockTimeReader reader = BlockTimeReader.forCurrentNetwork(blockTimesFile)) {
+            coverageMaxBlock = reader.getMaxBlockNumber();
+            coverageStart = reader.getBlockInstant(0);
+            coverageEnd = reader.getBlockInstant(coverageMaxBlock);
             startBlocks = resolveStartBlocks(sorted, reader);
+            resolutionProblems = validateResolutions(sorted, startBlocks, reader);
+        }
+
+        if (!resolutionProblems.isEmpty()) {
+            System.err.println();
+            System.err.println("Error: consensus-time -> block-number resolution failed for "
+                    + resolutionProblems.size() + " era(s):");
+            for (String p : resolutionProblems) {
+                System.err.println("  * " + p);
+            }
+            System.err.println();
+            System.err.println("block_times.bin coverage (" + blockTimesFile.toAbsolutePath() + "):");
+            System.err.println("  first indexed block: 0 @ " + coverageStart);
+            System.err.println("  last indexed block:  " + coverageMaxBlock + " @ " + coverageEnd);
+            System.err.println();
+            System.err.println("Check that --network matches the network the block_times.bin was extracted for,");
+            System.err.println("and that the file covers your input's timestamp range. Regenerate via");
+            System.err.println("`mirror extractBlockTimes` (and `mirror addNewerBlockTimes` to top it up)");
+            System.err.println("if it's stale or short.");
+            return 1;
         }
 
         return convertAndWrite(sorted, startBlocks);
+    }
+
+    /**
+     * Sanity-check every resolved {@code startBlock}. The binary search inside
+     * {@link BlockTimeReader#getNearestBlockAfterTime(LocalDateTime)} silently clamps to {@code 0}
+     * when the target time falls before every indexed block, and to {@code maxBlock} when it falls
+     * after every indexed block -- which combined with PBJ's {@code uint64} default-value elision
+     * hides the failure downstream (era's {@code startBlock} disappears, next era's
+     * {@code endBlock} collapses to {@code -1}). Detect both here and surface a real error.
+     */
+    private static List<String> validateResolutions(
+            List<DatedNodeAddressBook> sorted, long[] startBlocks, BlockTimeReader reader) {
+        final long maxBlock = reader.getMaxBlockNumber();
+        final List<String> problems = new ArrayList<>();
+        for (int i = 0; i < sorted.size(); i++) {
+            final Timestamp ts = sorted.get(i).blockTimestampOrThrow();
+            final Instant target = Instant.ofEpochSecond(ts.seconds(), ts.nanos());
+            final long block = startBlocks[i];
+            final Instant blockInstant = reader.getBlockInstant(block);
+            if (block == 0 && blockInstant.isAfter(target)) {
+                problems.add("era " + i + " (block_timestamp=" + target
+                        + ") is before the earliest indexed block (block 0 @ " + blockInstant + ")");
+            } else if (block == maxBlock && blockInstant.isBefore(target)) {
+                problems.add("era " + i + " (block_timestamp=" + target + ") is after the last indexed block (block "
+                        + maxBlock + " @ " + blockInstant + ")");
+            }
+        }
+        return problems;
     }
 
     private int convertAndWrite(List<DatedNodeAddressBook> sorted, long[] startBlocks) throws IOException {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommand.java
@@ -267,7 +267,7 @@ public class ConvertAddressBookHistoryCommand implements Callable<Integer> {
      * Preserves entry order and the nested {@code addressBook} structure verbatim. PBJ's
      * parse side reconstructs the same values from either shape, so the BN loader is unaffected.
      */
-    private static void ensureExplicitStartAndEndBlock(Path file) throws IOException {
+    private static void ensureExplicitPbjDefaults(Path file) throws IOException {
         final ObjectMapper mapper = new ObjectMapper();
         final ObjectNode root = (ObjectNode) mapper.readTree(file.toFile());
         final JsonNode addressBooksNode = root.get("addressBooks");

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/UpdateBlockData.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/UpdateBlockData.java
@@ -3,6 +3,7 @@ package org.hiero.block.tools.mirrornode;
 
 import static org.hiero.block.tools.config.NetworkConfig.current;
 import static org.hiero.block.tools.records.RecordFileDates.extractRecordFileTime;
+import static org.hiero.block.tools.records.RecordFileDates.instantToBlockTimeLong;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -56,19 +57,6 @@ public class UpdateBlockData implements Runnable {
 
     /** The batch size for fetching blocks from the mirror node. */
     private static final int BATCH_SIZE = 100;
-
-    /**
-     * Convert an instant to a block time long using the current network's genesis.
-     * This ensures block_times.bin values are relative to the correct network's genesis
-     * (mainnet: 2019-09-13, testnet: 2024-02-01, previewnet: custom, etc).
-     *
-     * @param instant the instant to convert
-     * @return nanoseconds since the current network's genesis
-     */
-    private static long instantToBlockTimeLong(Instant instant) {
-        Instant genesisInstant = Instant.parse(current().genesisTimestamp().replace('_', ':'));
-        return java.time.Duration.between(genesisInstant, instant).toNanos();
-    }
 
     /**
      * Update block data files with newer blocks from the mirror node.

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommandTest.java
@@ -107,8 +107,8 @@ class ConvertAddressBookHistoryCommandTest {
             assertEquals(0, execute());
 
             RangedAddressBookHistory out = readOutput();
-            assertEquals(era0, out.addressBooks().get(0).addressBook());
-            assertEquals(era1, out.addressBooks().get(1).addressBook());
+            assertEquals(slim(era0), out.addressBooks().get(0).addressBook());
+            assertEquals(slim(era1), out.addressBooks().get(1).addressBook());
             assertNotEquals(
                     out.addressBooks().get(0).addressBook(),
                     out.addressBooks().get(1).addressBook(),
@@ -133,6 +133,31 @@ class ConvertAddressBookHistoryCommandTest {
             assertTrue(json.contains("\"RSAPubKey\""), "nested nodeAddress must expose RSAPubKey");
             assertTrue(!json.contains("\"blockTimestamp\""), "blockTimestamp must not be emitted");
             assertTrue(!json.contains("\"entries\""), "legacy top-level 'entries' must not be emitted");
+        }
+
+        @Test
+        @DisplayName("Emitted nodeAddress carries only nodeId + RSAPubKey; other fields are dropped")
+        void slimmedNodeAddressFields() throws IOException {
+            // Build an input with fields the command should drop: memo, nodeAccountId,
+            // description, serviceEndpoint, stake, nodeCertHash. The emitted JSON must
+            // carry only nodeId and RSAPubKey per nodeAddress.
+            final long[] picks = new long[] {100};
+            final List<Instant> instants = blockInstants(picks);
+            writeHistory(inputFile, List.of(dated(instants.get(0), addressBook(0, 2, "cafe"))));
+
+            assertEquals(0, execute());
+
+            String json = Files.readString(outputFile);
+            // Positive: nodeId + RSAPubKey are present.
+            assertTrue(json.contains("\"nodeId\""), "nodeId must be present");
+            assertTrue(json.contains("\"RSAPubKey\""), "RSAPubKey must be present");
+            // Negative: fields the test helper populates but the command drops must be absent.
+            assertTrue(!json.contains("\"memo\""), "memo must be dropped");
+            assertTrue(!json.contains("\"nodeAccountId\""), "nodeAccountId must be dropped");
+            assertTrue(!json.contains("\"description\""), "description must be dropped");
+            assertTrue(!json.contains("\"serviceEndpoint\""), "serviceEndpoint must be dropped");
+            assertTrue(!json.contains("\"stake\""), "stake must be dropped");
+            assertTrue(!json.contains("\"nodeCertHash\""), "nodeCertHash must be dropped");
         }
 
         @Test
@@ -340,8 +365,8 @@ class ConvertAddressBookHistoryCommandTest {
 
             RangedAddressBookHistory out = readOutput();
             // Era A (smaller nanos) must come first.
-            assertEquals(bookA, out.addressBooks().get(0).addressBook(), "smaller-nanos era must sort first");
-            assertEquals(bookB, out.addressBooks().get(1).addressBook());
+            assertEquals(slim(bookA), out.addressBooks().get(0).addressBook(), "smaller-nanos era must sort first");
+            assertEquals(slim(bookB), out.addressBooks().get(1).addressBook());
         }
     }
 
@@ -444,6 +469,22 @@ class ConvertAddressBookHistoryCommandTest {
                     .build());
         }
         return new NodeAddressBook(nodes);
+    }
+
+    /**
+     * Mirror the command's slimming: keep only {@code nodeId} and {@code RSAPubKey} on each
+     * {@link NodeAddress}. Tests that compare the emitted addressBook against a hand-built
+     * input must slim the input first because the command drops the other fields.
+     */
+    private static NodeAddressBook slim(NodeAddressBook book) {
+        List<NodeAddress> slim = new ArrayList<>(book.nodeAddress().size());
+        for (NodeAddress addr : book.nodeAddress()) {
+            slim.add(NodeAddress.newBuilder()
+                    .nodeId(addr.nodeId())
+                    .rsaPubKey(addr.rsaPubKey())
+                    .build());
+        }
+        return new NodeAddressBook(slim);
     }
 
     private static void writeHistory(Path file, List<DatedNodeAddressBook> books) throws IOException {

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommandTest.java
@@ -202,6 +202,28 @@ class ConvertAddressBookHistoryCommandTest {
             int exit = execute();
             assertNotEquals(0, exit, "malformed input must not exit 0");
         }
+
+        @Test
+        @DisplayName("Fails loudly when an era timestamp falls before block_times.bin coverage")
+        void beforeCoverageFailsLoudly() throws IOException {
+            // Instant.EPOCH (1970-01-01) is guaranteed before any real block-time entry, so the
+            // reader will clamp to block 0 while the target is earlier than block 0's time.
+            writeHistory(inputFile, List.of(dated(Instant.EPOCH, addressBook(0, 1, "aa"))));
+            int exit = execute();
+            assertEquals(1, exit, "resolution before file coverage must exit 1, not silently produce zeros");
+            assertTrue(!Files.exists(outputFile), "output file must not be written on resolution failure");
+        }
+
+        @Test
+        @DisplayName("Fails loudly when an era timestamp falls after block_times.bin coverage")
+        void afterCoverageFailsLoudly() throws IOException {
+            // Instant.parse("9999-01-01T00:00:00Z") is guaranteed past any real block-time entry.
+            Instant farFuture = Instant.parse("9999-01-01T00:00:00Z");
+            writeHistory(inputFile, List.of(dated(farFuture, addressBook(0, 1, "aa"))));
+            int exit = execute();
+            assertEquals(1, exit, "resolution past file coverage must exit 1, not silently clamp to end");
+            assertTrue(!Files.exists(outputFile), "output file must not be written on resolution failure");
+        }
     }
 
     @Nested

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommandTest.java
@@ -200,6 +200,38 @@ class ConvertAddressBookHistoryCommandTest {
             assertEquals(0L, out.addressBooks().get(0).startBlock());
             assertEquals(-1L, out.addressBooks().get(2).endBlock());
         }
+
+        @Test
+        @DisplayName("nodeId=0 is written explicitly per nodeAddress even though PBJ elides uint64 default")
+        void explicitNodeIdZeroPresent() throws IOException {
+            // Genesis-node-0 has nodeId=0, and PBJ elides proto3 uint64 defaults on write.
+            // The BN's roster verifier routes by nodeId; without the fixup, node 0 loses
+            // its identifier in the emitted JSON. Two-node era (0, 1) so we can also
+            // confirm node 1's nodeId survives untouched.
+            final long[] picks = new long[] {100};
+            final List<Instant> instants = blockInstants(picks);
+            writeHistory(inputFile, List.of(dated(instants.get(0), addressBook(0, 2, "dead"))));
+
+            assertEquals(0, execute());
+
+            final String json = Files.readString(outputFile);
+            // PBJ writes uint64 as JSON strings; nodeId="0" for node 0, nodeId="1" for node 1.
+            assertTrue(
+                    json.contains("\"nodeId\" : \"0\""),
+                    "node 0's nodeId must be written explicitly as \"0\" after the fixup");
+            assertTrue(json.contains("\"nodeId\" : \"1\""), "node 1's nodeId must still be present");
+
+            // Every nodeAddress entry must have a nodeId — no missing IDs after the fixup.
+            final RangedAddressBookHistory out = readOutput();
+            assertEquals(
+                    2, out.addressBooks().get(0).addressBook().nodeAddress().size());
+            assertEquals(
+                    0L,
+                    out.addressBooks().get(0).addressBook().nodeAddress().get(0).nodeId());
+            assertEquals(
+                    1L,
+                    out.addressBooks().get(0).addressBook().nodeAddress().get(1).nodeId());
+        }
     }
 
     @Nested

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommandTest.java
@@ -3,16 +3,14 @@ package org.hiero.block.tools.blocks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.NodeAddress;
 import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -21,8 +19,9 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.List;
+import org.hiero.block.api.RangedAddressBookHistory;
+import org.hiero.block.api.RangedNodeAddressBook;
 import org.hiero.block.internal.AddressBookHistory;
 import org.hiero.block.internal.DatedNodeAddressBook;
 import org.hiero.block.tools.mirrornode.BlockTimeReader;
@@ -36,8 +35,8 @@ import picocli.CommandLine;
 /** Unit tests for {@link ConvertAddressBookHistoryCommand}. */
 class ConvertAddressBookHistoryCommandTest {
 
-    private static final ObjectMapper JSON = new ObjectMapper();
     private static final Path TEST_BLOCK_TIMES_FILE = Path.of("src/test/resources/metadata/block_times.bin");
+    private static final long OPEN_ENDED = ConvertAddressBookHistoryCommand.OPEN_ENDED_END_BLOCK;
 
     @TempDir
     Path tempDir;
@@ -56,11 +55,11 @@ class ConvertAddressBookHistoryCommandTest {
     class OutputShape {
 
         @Test
-        @DisplayName("Resolves start blocks and chains end blocks (last = null)")
+        @DisplayName("Resolves start blocks and chains end blocks (last = OPEN_ENDED sentinel)")
         void chainsRanges() throws IOException {
             // Pick three real block numbers in the bundled test block_times.bin and build a
             // 3-era history at those exact block-time instants. Expected start blocks are the
-            // picked values; end blocks chain to next-1, last is null.
+            // picked values; end blocks chain to next-1, last uses the open-ended sentinel.
             final long[] picks = new long[] {100, 5000, 12000};
             final List<Instant> instants = blockInstants(picks);
 
@@ -74,53 +73,29 @@ class ConvertAddressBookHistoryCommandTest {
             int exit = execute();
             assertEquals(0, exit);
 
-            JsonNode root = JSON.readTree(outputFile.toFile());
-            JsonNode entries = root.get("entries");
-            assertNotNull(entries);
-            assertEquals(3, entries.size());
+            RangedAddressBookHistory out = readOutput();
+            assertEquals(3, out.addressBooks().size());
 
-            assertEquals(picks[0], entries.get(0).get("startBlock").asLong());
-            assertEquals(picks[1] - 1, entries.get(0).get("endBlock").asLong());
+            assertEquals(picks[0], out.addressBooks().get(0).startBlock());
+            assertEquals(picks[1] - 1, out.addressBooks().get(0).endBlock());
 
-            assertEquals(picks[1], entries.get(1).get("startBlock").asLong());
-            assertEquals(picks[2] - 1, entries.get(1).get("endBlock").asLong());
+            assertEquals(picks[1], out.addressBooks().get(1).startBlock());
+            assertEquals(picks[2] - 1, out.addressBooks().get(1).endBlock());
 
-            assertEquals(picks[2], entries.get(2).get("startBlock").asLong());
-            assertTrue(entries.get(2).get("endBlock").isNull(), "last era's endBlock must be null");
-        }
-
-        @Test
-        @DisplayName("Preserves blockTimestamp seconds + nanos per era")
-        void preservesTimestamp() throws IOException {
-            final long[] picks = new long[] {100, 5000};
-            final List<Instant> instants = blockInstants(picks);
-
-            writeHistory(
-                    inputFile,
-                    List.of(
-                            dated(instants.get(0), addressBook(0, 1, "aa")),
-                            dated(instants.get(1), addressBook(0, 1, "bb"))));
-
-            assertEquals(0, execute());
-            JsonNode entries = JSON.readTree(outputFile.toFile()).get("entries");
+            assertEquals(picks[2], out.addressBooks().get(2).startBlock());
             assertEquals(
-                    instants.get(0).getEpochSecond(),
-                    entries.get(0).get("blockTimestamp").get("seconds").asLong());
-            assertEquals(
-                    instants.get(0).getNano(),
-                    entries.get(0).get("blockTimestamp").get("nanos").asInt());
-            assertEquals(
-                    instants.get(1).getEpochSecond(),
-                    entries.get(1).get("blockTimestamp").get("seconds").asLong());
+                    OPEN_ENDED,
+                    out.addressBooks().get(2).endBlock(),
+                    "last era's endBlock must be the open-ended sentinel");
         }
     }
 
     @Nested
-    @DisplayName("AddressBook payload (Option B / Base64)")
+    @DisplayName("AddressBook payload (nested NodeAddressBook)")
     class AddressBookPayload {
 
         @Test
-        @DisplayName("Round-trips through Base64 + NodeAddressBook.PROTOBUF.parse")
+        @DisplayName("Per-era addressBook round-trips (nested, not base64) via NodeAddressBook.equals")
         void roundTrips() throws Exception {
             final long[] picks = new long[] {100, 5000};
             final List<Instant> instants = blockInstants(picks);
@@ -131,15 +106,33 @@ class ConvertAddressBookHistoryCommandTest {
 
             assertEquals(0, execute());
 
-            JsonNode entries = JSON.readTree(outputFile.toFile()).get("entries");
-            NodeAddressBook decoded0 = NodeAddressBook.PROTOBUF.parse(Bytes.wrap(
-                    Base64.getDecoder().decode(entries.get(0).get("addressBook").asText())));
-            NodeAddressBook decoded1 = NodeAddressBook.PROTOBUF.parse(Bytes.wrap(
-                    Base64.getDecoder().decode(entries.get(1).get("addressBook").asText())));
+            RangedAddressBookHistory out = readOutput();
+            assertEquals(era0, out.addressBooks().get(0).addressBook());
+            assertEquals(era1, out.addressBooks().get(1).addressBook());
+            assertNotEquals(
+                    out.addressBooks().get(0).addressBook(),
+                    out.addressBooks().get(1).addressBook(),
+                    "distinct per-era books must round-trip distinctly");
+        }
 
-            assertEquals(era0, decoded0);
-            assertEquals(era1, decoded1);
-            assertNotEquals(decoded0, decoded1, "distinct per-era books must round-trip distinctly");
+        @Test
+        @DisplayName("Emitted JSON is the nested NodeAddressBook shape (nodeAddress[]), no base64 or blockTimestamp")
+        void nestedShape() throws IOException {
+            final long[] picks = new long[] {100};
+            final List<Instant> instants = blockInstants(picks);
+            writeHistory(inputFile, List.of(dated(instants.get(0), addressBook(0, 1, "aabb"))));
+
+            assertEquals(0, execute());
+
+            String json = Files.readString(outputFile);
+            assertTrue(json.contains("\"addressBooks\""), "top-level key must be 'addressBooks'");
+            assertTrue(json.contains("\"addressBook\""), "each entry must have a nested 'addressBook' object");
+            assertTrue(
+                    json.contains("\"nodeAddress\""),
+                    "nested addressBook must serialize as NodeAddressBook (nodeAddress[])");
+            assertTrue(json.contains("\"RSAPubKey\""), "nested nodeAddress must expose RSAPubKey");
+            assertTrue(!json.contains("\"blockTimestamp\""), "blockTimestamp must not be emitted");
+            assertTrue(!json.contains("\"entries\""), "legacy top-level 'entries' must not be emitted");
         }
     }
 
@@ -163,10 +156,10 @@ class ConvertAddressBookHistoryCommandTest {
 
             assertEquals(0, execute());
 
-            JsonNode entries = JSON.readTree(outputFile.toFile()).get("entries");
-            assertEquals(picks[0], entries.get(0).get("startBlock").asLong());
-            assertEquals(picks[1], entries.get(1).get("startBlock").asLong());
-            assertEquals(picks[2], entries.get(2).get("startBlock").asLong());
+            RangedAddressBookHistory out = readOutput();
+            assertEquals(picks[0], out.addressBooks().get(0).startBlock());
+            assertEquals(picks[1], out.addressBooks().get(1).startBlock());
+            assertEquals(picks[2], out.addressBooks().get(2).startBlock());
         }
 
         @Test
@@ -216,7 +209,7 @@ class ConvertAddressBookHistoryCommandTest {
     class EdgeCases {
 
         @Test
-        @DisplayName("Single-era history: endBlock is null, one entry")
+        @DisplayName("Single-era history: endBlock is OPEN_ENDED, one entry")
         void singleEra() throws IOException {
             final long[] picks = new long[] {7};
             final List<Instant> instants = blockInstants(picks);
@@ -224,10 +217,13 @@ class ConvertAddressBookHistoryCommandTest {
 
             assertEquals(0, execute());
 
-            JsonNode entries = JSON.readTree(outputFile.toFile()).get("entries");
-            assertEquals(1, entries.size());
-            assertEquals(picks[0], entries.get(0).get("startBlock").asLong());
-            assertTrue(entries.get(0).get("endBlock").isNull(), "single-era history must emit null endBlock");
+            RangedAddressBookHistory out = readOutput();
+            assertEquals(1, out.addressBooks().size());
+            assertEquals(picks[0], out.addressBooks().get(0).startBlock());
+            assertEquals(
+                    OPEN_ENDED,
+                    out.addressBooks().get(0).endBlock(),
+                    "single-era history must emit OPEN_ENDED endBlock");
         }
 
         @Test
@@ -264,39 +260,34 @@ class ConvertAddressBookHistoryCommandTest {
         @DisplayName("Ties on seconds are broken by nanos (ascending)")
         void tieBreakByNanos() throws IOException {
             // Build two entries at the same epoch second but different nanos; the smaller-nanos
-            // entry must sort first. Use real block instants so BlockTimeReader can resolve them,
-            // and perturb only nanos to create the tie. Pick two blocks where the natural nanos
-            // happen to differ -- we'll just synthesize timestamps with identical seconds.
+            // entry must sort first. The eras' payload address books differ so we can identify
+            // which one comes out first by inspecting the RSA pubkey.
             final long[] picks = new long[] {100, 200};
             final List<Instant> instants = blockInstants(picks);
             Instant base = instants.get(0);
-            // Era A: base, Era B: base with +1 nano (still resolvable: getNearestBlockAfterTime
-            // returns the same/next block). Both eras valid, just want to assert sort order.
             Instant a = base;
             Instant b = base.plusNanos(1);
 
+            NodeAddressBook bookA = addressBook(0, 1, "aa");
+            NodeAddressBook bookB = addressBook(0, 1, "bb");
             // Write scrambled: b before a.
-            writeHistory(inputFile, List.of(dated(b, addressBook(0, 1, "bb")), dated(a, addressBook(0, 1, "aa"))));
+            writeHistory(inputFile, List.of(dated(b, bookB), dated(a, bookA)));
 
             assertEquals(0, execute());
 
-            JsonNode entries = JSON.readTree(outputFile.toFile()).get("entries");
+            RangedAddressBookHistory out = readOutput();
             // Era A (smaller nanos) must come first.
-            assertEquals(
-                    a.getNano(),
-                    entries.get(0).get("blockTimestamp").get("nanos").asInt());
-            assertEquals(
-                    b.getNano(),
-                    entries.get(1).get("blockTimestamp").get("nanos").asInt());
+            assertEquals(bookA, out.addressBooks().get(0).addressBook(), "smaller-nanos era must sort first");
+            assertEquals(bookB, out.addressBooks().get(1).addressBook());
         }
     }
 
     @Nested
-    @DisplayName("Realistic scale + output format")
+    @DisplayName("Realistic scale + defaults")
     class RealisticScale {
 
         @Test
-        @DisplayName("~10-era history: all ranges chain, last endBlock is null")
+        @DisplayName("~10-era history: all ranges chain, last endBlock = OPEN_ENDED")
         void tenEraHistory() throws IOException {
             final long[] picks = new long[] {0, 50, 500, 1500, 3000, 5000, 8000, 12000, 15000, 18000};
             final List<Instant> instants = blockInstants(picks);
@@ -308,50 +299,24 @@ class ConvertAddressBookHistoryCommandTest {
 
             assertEquals(0, execute());
 
-            JsonNode entries = JSON.readTree(outputFile.toFile()).get("entries");
-            assertEquals(picks.length, entries.size());
+            RangedAddressBookHistory out = readOutput();
+            assertEquals(picks.length, out.addressBooks().size());
             for (int i = 0; i < picks.length; i++) {
-                assertEquals(picks[i], entries.get(i).get("startBlock").asLong(), "era " + i + " startBlock");
+                RangedNodeAddressBook era = out.addressBooks().get(i);
+                assertEquals(picks[i], era.startBlock(), "era " + i + " startBlock");
                 if (i < picks.length - 1) {
-                    assertEquals(
-                            picks[i + 1] - 1,
-                            entries.get(i).get("endBlock").asLong(),
-                            "era " + i + " endBlock chains to next.start-1");
+                    assertEquals(picks[i + 1] - 1, era.endBlock(), "era " + i + " endBlock chains to next.start-1");
                 } else {
-                    assertTrue(entries.get(i).get("endBlock").isNull(), "final era endBlock must be null");
+                    assertEquals(OPEN_ENDED, era.endBlock(), "final era endBlock must be OPEN_ENDED");
                 }
             }
-        }
-
-        @Test
-        @DisplayName("Output JSON has only the top-level \"entries\" key and is pretty-printed")
-        void outputIsPrettyPrintedAndMinimalRoot() throws IOException {
-            final long[] picks = new long[] {100, 5000};
-            final List<Instant> instants = blockInstants(picks);
-            writeHistory(
-                    inputFile,
-                    List.of(
-                            dated(instants.get(0), addressBook(0, 1, "aa")),
-                            dated(instants.get(1), addressBook(0, 1, "bb"))));
-
-            assertEquals(0, execute());
-
-            // Top-level structure: exactly one field, named "entries".
-            JsonNode root = JSON.readTree(outputFile.toFile());
-            assertEquals(1, root.size(), "root must have a single field");
-            assertNotNull(root.get("entries"));
-
-            // Pretty-printed: output spans multiple lines (Jackson INDENT_OUTPUT).
-            String raw = Files.readString(outputFile);
-            assertTrue(raw.contains("\n"), "pretty-printed output must contain newlines");
-            assertTrue(raw.contains("\n  \"entries\""), "pretty-printed output should indent the entries key");
         }
 
         @Test
         @DisplayName("Default --output points at the BN's application-state directory")
         void defaultOutputUsesBnApplicationStateDir() {
             assertEquals(
-                    Path.of("/opt/hiero/block-node/application-state/rsa-bootstrap-roster-history.json"),
+                    Path.of("/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json"),
                     ConvertAddressBookHistoryCommand.DEFAULT_OUTPUT_PATH,
                     "default output must land where the BN bootstrap reads from");
         }
@@ -380,6 +345,14 @@ class ConvertAddressBookHistoryCommandTest {
                         "--input", inputFile.toString(),
                         "--output", outputFile.toString(),
                         "--block-times-file", TEST_BLOCK_TIMES_FILE.toString());
+    }
+
+    private RangedAddressBookHistory readOutput() throws IOException {
+        try (ReadableStreamingData in = new ReadableStreamingData(Files.newInputStream(outputFile))) {
+            return RangedAddressBookHistory.JSON.parse(in);
+        } catch (Exception e) {
+            throw new IOException("Failed to parse output as RangedAddressBookHistory: " + e.getMessage(), e);
+        }
     }
 
     private static List<Instant> blockInstants(long[] blockNumbers) throws IOException {

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ConvertAddressBookHistoryCommandTest.java
@@ -134,6 +134,47 @@ class ConvertAddressBookHistoryCommandTest {
             assertTrue(!json.contains("\"blockTimestamp\""), "blockTimestamp must not be emitted");
             assertTrue(!json.contains("\"entries\""), "legacy top-level 'entries' must not be emitted");
         }
+
+        @Test
+        @DisplayName("startBlock and endBlock are always present in raw JSON, even when 0 / -1 defaults")
+        void explicitStartAndEndBlockPresent() throws IOException {
+            // First-era startBlock resolves to 0 (target == genesis) and last-era endBlock is
+            // the OPEN_ENDED_END_BLOCK sentinel (-1). PBJ's JSON codec elides proto3 uint64
+            // defaults, so without our post-write fixup both fields would go missing.
+            // Operators reading the roster should always see both fields spelled out.
+            final long[] picks = new long[] {0, 5000, 12000};
+            final List<Instant> instants = blockInstants(picks);
+            writeHistory(
+                    inputFile,
+                    List.of(
+                            dated(instants.get(0), addressBook(0, 1, "aa")),
+                            dated(instants.get(1), addressBook(0, 1, "bb")),
+                            dated(instants.get(2), addressBook(0, 1, "cc"))));
+
+            assertEquals(0, execute());
+
+            final String json = Files.readString(outputFile);
+            final long startBlockCount =
+                    json.lines().filter(l -> l.contains("\"startBlock\"")).count();
+            final long endBlockCount =
+                    json.lines().filter(l -> l.contains("\"endBlock\"")).count();
+            assertEquals(3L, startBlockCount, "every entry must emit a startBlock line");
+            assertEquals(3L, endBlockCount, "every entry must emit an endBlock line");
+
+            // PBJ writes uint64 fields as JSON strings; our post-write fixup follows the
+            // same convention so the shape stays uniform for the BN parser.
+            assertTrue(
+                    json.contains("\"startBlock\" : \"0\""),
+                    "first era's startBlock=0 must be written explicitly as a JSON string");
+            assertTrue(
+                    json.contains("\"endBlock\" : \"-1\""),
+                    "last era's endBlock=-1 sentinel must be written explicitly as a JSON string");
+
+            // PBJ parse-side must still reconstruct the same values from the fixed-up JSON.
+            final RangedAddressBookHistory out = readOutput();
+            assertEquals(0L, out.addressBooks().get(0).startBlock());
+            assertEquals(-1L, out.addressBooks().get(2).endBlock());
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary

Rewrite the `blocks convert-address-book-history` output so the file the tool produces is directly loadable by the BN's T4 historical-roster bootstrap (which reads `RangedAddressBookHistory` PBJ JSON at `ApplicationStateConfig.rsaBootstrapFilePath`).

Fixes #3164.

### Format changes (from #3071)

| | Before | After |
|---|---|---|
| Top-level key | `"entries"` | `"addressBooks"` |
| Per-era `addressBook` | base64 string of `NodeAddressBook` proto | **nested** `NodeAddressBook` JSON object (`{ "nodeAddress": [ { "nodeId": …, "RSAPubKey": …, … } ] }`) |
| Per-era `endBlock` open-ended sentinel | `null` | `-1` (matches `RangedAddressBookHistory.JSON`) |
| `blockTimestamp` field | present | **removed** (not part of `RangedNodeAddressBook`) |

Implementation now emits via `RangedAddressBookHistory.JSON.write(...)` so wire compatibility is exact.

### Additional related fixes

- **Default `--output`** → `/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json` (same file the BN reads via `app.state.rsaBootstrapFilePath`; T4's loader accepts either single-book or ranged-history JSON at that path).
- **`BlockTimeReader` construction** — the raw `new BlockTimeReader(blockTimesFile)` ctor is retained deliberately, even when the caller passes `--network testnet` or `--network previewnet`. The extraction writer chain hardcodes mainnet as the block-time anchor via `RecordFileDates.instantToBlockTimeLong`, so the reader must use the same mainnet anchor to round-trip the same bytes correctly. Switching to `BlockTimeReader.forCurrentNetwork(blockTimesFile)` would apply a network-specific anchor and produce a multi-year offset on non-mainnet networks. Design decision is documented inline (see the block comment above the ctor call).

### Note on dependencies

Jackson (`com.fasterxml.jackson.databind`) is still a `tools` module dependency and is used inside the reworked read-back / test path to parse the emitted JSON and assert the exact wire shape. An earlier draft of this PR removed it; that was reverted during review because Jackson is the cleanest way to walk the nested `NodeAddressBook` JSON tree in tests without pulling in PBJ codec setup.

## Test plan

- [x] `./gradlew :tools:qualityCheck :tools:test` — spotless + module-directives clean.
- [x] Reworked tests parse output with `RangedAddressBookHistory.JSON.parse` and assert the exact wire shape (`addressBooks`, nested `nodeAddress[]`, `RSAPubKey`, no `blockTimestamp`, no `entries`).
- [ ] CI green
- [ ] Manual smoke on previewnet: convert `previewnet/wrappedBlocks/addressBookHistory.json` and load into a BN test harness

## Refs

- Follow-up to #3071 (T3)
- Consumed by #3070 (T4 loader)
- Epic: #2954