### PR TITLE
fix(health): close connections after health/status responses

### DIFF
--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ServerConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ServerConfig.java
@@ -20,8 +20,10 @@ import org.hiero.block.node.base.Loggable;
  *     {@code null} to fall back to this value
  * @param shutdownDelayMillis the delay in milliseconds for the service
  * @param maxTcpConnections the maximum number of TCP connections
- * @param idleConnectionPeriodMinutes the period of idle connections check in minutes
- * @param idleConnectionTimeoutMinutes the timeout of idle connections in minutes
+ * @param idleConnectionPeriodMinutes how often (minutes) the idle-connection reaper runs
+ * @param idleConnectionTimeoutMinutes how long (minutes) a connection may sit idle before it is
+ *     closed; kept short so idle sockets are reclaimed well before they accumulate to
+ *     {@code maxTcpConnections} and the server starts refusing new connections
  * @param tcpNoDelay whether to use TCP no delay
  * @param backlogSize the maximum length of the queue of incoming connections on the server socket.
  * @param writeQueueLength the number of buffers queued for write operations
@@ -39,8 +41,10 @@ public record ServerConfig(
             @Min(1024) @Max(65_535) int port,
         @Loggable @ConfigProperty(defaultValue = "500") int shutdownDelayMillis,
         @Loggable @ConfigProperty(defaultValue = "1000") int maxTcpConnections,
-        @Loggable @ConfigProperty(defaultValue = "5") int idleConnectionPeriodMinutes,
-        @Loggable @ConfigProperty(defaultValue = "30") int idleConnectionTimeoutMinutes,
+        @Loggable @ConfigProperty(defaultValue = "1")
+            @Min(1) @Max(60) int idleConnectionPeriodMinutes,
+        @Loggable @ConfigProperty(defaultValue = "2")
+            @Min(1) @Max(1_440) int idleConnectionTimeoutMinutes,
         @Loggable @ConfigProperty(defaultValue = "true") boolean tcpNoDelay,
         @Loggable @ConfigProperty(defaultValue = "8_192") int backlogSize,
         @Loggable @ConfigProperty(defaultValue = "8_192") int writeQueueLength) {}

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestServerRequest.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestServerRequest.java
@@ -8,6 +8,7 @@ import io.helidon.common.uri.UriInfo;
 import io.helidon.common.uri.UriQuery;
 import io.helidon.http.Header;
 import io.helidon.http.HttpPrologue;
+import io.helidon.http.Method;
 import io.helidon.http.RoutedPath;
 import io.helidon.http.ServerRequestHeaders;
 import io.helidon.http.media.ReadableEntity;
@@ -90,9 +91,10 @@ public class TestServerRequest implements ServerRequest {
         throw new UnsupportedOperationException();
     }
 
+    /** Reports HTTP/1.1, matching the protocol the {@code Connection: close} handling checks for. */
     @Override
     public HttpPrologue prologue() {
-        throw new UnsupportedOperationException();
+        return HttpPrologue.create("HTTP/1.1", "HTTP", "1.1", Method.GET, path, false);
     }
 
     @Override

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestServerResponse.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestServerResponse.java
@@ -10,17 +10,21 @@ import io.helidon.http.ServerResponseTrailers;
 import io.helidon.http.Status;
 import io.helidon.webserver.http.ServerResponse;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.UnaryOperator;
 
 /**
  * Minimal {@link ServerResponse} test double that records the status code, the {@code Content-Type}
- * header, and the sent entity, exposing them via accessors. All other operations are unsupported.
+ * header, the headers set via {@link #header(Header)}, and the sent entity, exposing them via
+ * accessors. All other operations are unsupported.
  */
 public class TestServerResponse implements ServerResponse {
     private int statusCode = -1;
     private String contentType;
     private Object sentEntity;
     private boolean sent;
+    private final List<Header> headers = new ArrayList<>();
 
     /** @return the status code passed to {@code status(...)}, or {@code -1} if unset */
     public int sentStatus() {
@@ -35,6 +39,11 @@ public class TestServerResponse implements ServerResponse {
     /** @return the entity passed to {@code send(...)}, or {@code null} if nothing was sent */
     public Object sentEntity() {
         return sentEntity;
+    }
+
+    /** @return {@code true} if the given header was set via {@link #header(Header)} */
+    public boolean hasHeader(Header header) {
+        return headers.contains(header);
     }
 
     @Override
@@ -64,6 +73,7 @@ public class TestServerResponse implements ServerResponse {
 
     @Override
     public ServerResponse header(Header header) {
+        headers.add(header);
         if (header.headerName().equals(HeaderNames.CONTENT_TYPE)) {
             this.contentType = header.values();
         }

--- a/block-node/health/build.gradle.kts
+++ b/block-node/health/build.gradle.kts
@@ -16,6 +16,7 @@ mainModuleInfo {
 
 testModuleInfo {
     requires("org.hiero.block.node.app.test.fixtures")
+    requires("io.helidon.common")
     requires("org.junit.jupiter.api")
     requires("org.mockito")
     requires("org.mockito.junit.jupiter")

--- a/block-node/health/src/main/java/module-info.java
+++ b/block-node/health/src/main/java/module-info.java
@@ -9,6 +9,7 @@ module org.hiero.block.node.health {
 
     requires transitive com.swirlds.config.api;
     requires transitive org.hiero.block.node.spi;
+    requires transitive org.hiero.metrics;
     requires transitive io.helidon.webserver;
     requires com.hedera.pbj.runtime;
     requires org.hiero.block.node.base;

--- a/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
@@ -12,12 +12,14 @@ import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 import java.lang.System.Logger;
 import java.util.List;
-import org.hiero.block.api.NetworkData;
 import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.health.HealthFacility;
+import org.hiero.metrics.LongCounter;
+import org.hiero.metrics.core.MetricKey;
+import org.hiero.metrics.core.MetricRegistry;
 
 /// Provides implementation for the health endpoints of the server.
 ///
@@ -37,6 +39,24 @@ public class HealthServicePlugin implements BlockNodePlugin {
     protected static final String INBOUND_PATH = STATUSZ_PATH + "/inbound";
     protected static final String OUTBOUND_PATH = STATUSZ_PATH + "/outbound";
 
+    /// Counter for health/status HTTP requests, labeled by [#LABEL_ENDPOINT] and [#LABEL_RESULT].
+    /// Kubernetes probes flatlining this counter while the pod stays up is an early signal that the
+    /// server has stopped accepting connections (see class doc), before liveness/readiness fail.
+    public static final MetricKey<LongCounter> METRIC_HEALTH_REQUESTS =
+            MetricKey.of("health_requests", LongCounter.class).addCategory(METRICS_CATEGORY);
+
+    /// Label naming the endpoint that served the request (`livez`, `readyz`, `statusz`).
+    static final String LABEL_ENDPOINT = "endpoint";
+    /// Label naming the outcome of the request (`ok`, `unavailable`, `not_found`, `error`).
+    static final String LABEL_RESULT = "result";
+    static final String ENDPOINT_LIVEZ = "livez";
+    static final String ENDPOINT_READYZ = "readyz";
+    static final String ENDPOINT_STATUSZ = "statusz";
+    static final String RESULT_OK = "ok";
+    static final String RESULT_UNAVAILABLE = "unavailable";
+    static final String RESULT_NOT_FOUND = "not_found";
+    static final String RESULT_ERROR = "error";
+
     /// The health facility, used for getting server status
     private HealthFacility healthFacility;
 
@@ -44,11 +64,18 @@ public class HealthServicePlugin implements BlockNodePlugin {
     /// for the statusz endpoints
     private ApplicationStateFacility applicationStateFacility;
 
+    /// Counter tracking every request served by the health/status endpoints.
+    private LongCounter requestCounter;
+
     /// {@inheritDoc}
     @Override
     public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
         healthFacility = context.serverHealth();
         applicationStateFacility = context.applicationStateFacility();
+        final MetricRegistry metricRegistry = context.metricRegistry();
+        requestCounter = metricRegistry.register(LongCounter.builder(METRIC_HEALTH_REQUESTS)
+                .setDescription("Health and status HTTP requests by endpoint and result")
+                .addDynamicLabelNames(LABEL_ENDPOINT, LABEL_RESULT));
         // A null port (the default) shares server.port
         final Integer port =
                 context.configuration().getConfigData(HealthConfig.class).port();
@@ -75,12 +102,15 @@ public class HealthServicePlugin implements BlockNodePlugin {
         try {
             if (healthFacility.isRunning()) {
                 closeAfterHttp1(req, res.status(200)).send("OK");
+                recordRequest(ENDPOINT_LIVEZ, RESULT_OK);
                 LOGGER.log(TRACE, "Responded code 200 (OK) to liveness check");
             } else {
                 closeAfterHttp1(req, res.status(503)).send("Service is not running");
+                recordRequest(ENDPOINT_LIVEZ, RESULT_UNAVAILABLE);
                 LOGGER.log(INFO, "Responded code 503 (Service is not running) to liveness check");
             }
         } catch (final RuntimeException e) {
+            recordRequest(ENDPOINT_LIVEZ, RESULT_ERROR);
             LOGGER.log(WARNING, "Failed to respond to liveness check due to %s".formatted(e), e);
         }
     }
@@ -94,37 +124,53 @@ public class HealthServicePlugin implements BlockNodePlugin {
         try {
             if (healthFacility.isRunning()) {
                 closeAfterHttp1(req, res.status(200)).send("OK");
+                recordRequest(ENDPOINT_READYZ, RESULT_OK);
                 LOGGER.log(TRACE, "Responded code 200 (OK) to readiness check");
             } else {
                 closeAfterHttp1(req, res.status(503)).send("Service is not running");
+                recordRequest(ENDPOINT_READYZ, RESULT_UNAVAILABLE);
                 LOGGER.log(INFO, "Responded code 503 (Service is not running) to readiness check");
             }
         } catch (final RuntimeException e) {
+            recordRequest(ENDPOINT_READYZ, RESULT_ERROR);
             LOGGER.log(WARNING, "Failed to respond to readiness check due to %s".formatted(e), e);
         }
     }
 
     /// Handles requests for the `/statusz` endpoints. The request subpath
     /// selects which handler runs. The matching handler builds and sends its
-    /// [NetworkData] response synchronously on the request thread.
+    /// [org.hiero.block.api.NetworkData] response synchronously on the request thread.
     ///
     /// @param req the server request
     /// @param res the server response
     public final void handleStatusz(@NonNull final ServerRequest req, @NonNull final ServerResponse res) {
         try {
             final String path = req.path().path();
-            NetworkData temp;
             if (path.endsWith(INBOUND_PATH)) {
                 new InboundStatusHandler(req, res, applicationStateFacility).createAndSendResponse();
+                recordRequest(ENDPOINT_STATUSZ, RESULT_OK);
             } else if (path.endsWith(OUTBOUND_PATH)) {
                 new OutboundStatusHandler(req, res, applicationStateFacility).createAndSendResponse();
+                recordRequest(ENDPOINT_STATUSZ, RESULT_OK);
             } else {
                 LOGGER.log(INFO, "Responded code 404 (Unknown statusz subpath) for {0}", path);
                 closeAfterHttp1(req, res.status(404)).send("Unknown statusz subpath");
+                recordRequest(ENDPOINT_STATUSZ, RESULT_NOT_FOUND);
             }
         } catch (final RuntimeException e) {
             LOGGER.log(WARNING, "Failed to respond to statusz check due to %s".formatted(e), e);
             closeAfterHttp1(req, res.status(500)).send();
+            recordRequest(ENDPOINT_STATUSZ, RESULT_ERROR);
         }
+    }
+
+    /// Increments [#METRIC_HEALTH_REQUESTS] for the given endpoint and result labels.
+    ///
+    /// @param endpoint the endpoint that served the request
+    /// @param result the outcome of the request
+    private void recordRequest(@NonNull final String endpoint, @NonNull final String result) {
+        requestCounter
+                .getOrCreateLabeled(LABEL_ENDPOINT, endpoint, LABEL_RESULT, result)
+                .increment();
     }
 }

--- a/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.health;
 
+import static io.helidon.http.HeaderValues.CONNECTION_CLOSE;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.TRACE;
@@ -19,6 +20,14 @@ import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.health.HealthFacility;
 
 /// Provides implementation for the health endpoints of the server.
+///
+/// Every response sets the `Connection: close` header. Kubernetes probes hit these
+/// endpoints continuously; left on keep-alive they accumulate as idle connections that
+/// Helidon only reaps after `server.idleConnectionTimeoutMinutes`, eventually exhausting
+/// `server.maxTcpConnections` and causing the server to refuse new connections. Closing
+/// after each response keeps the probe traffic from holding sockets open. Helidon flushes
+/// the full response before closing (see `Http1ServerResponse.keepConnectionOpen()`), so
+/// the reply is always delivered.
 public class HealthServicePlugin implements BlockNodePlugin {
     private final Logger LOGGER = System.getLogger(getClass().getName());
     protected static final String HEALTHZ_PATH = "/healthz";
@@ -65,10 +74,10 @@ public class HealthServicePlugin implements BlockNodePlugin {
     public final void handleLivez(@NonNull final ServerRequest req, @NonNull final ServerResponse res) {
         try {
             if (healthFacility.isRunning()) {
-                res.status(200).send("OK");
+                res.status(200).header(CONNECTION_CLOSE).send("OK");
                 LOGGER.log(TRACE, "Responded code 200 (OK) to liveness check");
             } else {
-                res.status(503).send("Service is not running");
+                res.status(503).header(CONNECTION_CLOSE).send("Service is not running");
                 LOGGER.log(INFO, "Responded code 503 (Service is not running) to liveness check");
             }
         } catch (final RuntimeException e) {
@@ -84,10 +93,10 @@ public class HealthServicePlugin implements BlockNodePlugin {
     public final void handleReadyz(@NonNull final ServerRequest req, @NonNull final ServerResponse res) {
         try {
             if (healthFacility.isRunning()) {
-                res.status(200).send("OK");
+                res.status(200).header(CONNECTION_CLOSE).send("OK");
                 LOGGER.log(TRACE, "Responded code 200 (OK) to readiness check");
             } else {
-                res.status(503).send("Service is not running");
+                res.status(503).header(CONNECTION_CLOSE).send("Service is not running");
                 LOGGER.log(INFO, "Responded code 503 (Service is not running) to readiness check");
             }
         } catch (final RuntimeException e) {
@@ -111,11 +120,11 @@ public class HealthServicePlugin implements BlockNodePlugin {
                 new OutboundStatusHandler(req, res, applicationStateFacility).createAndSendResponse();
             } else {
                 LOGGER.log(INFO, "Responded code 404 (Unknown statusz subpath) for {0}", path);
-                res.status(404).send("Unknown statusz subpath");
+                res.status(404).header(CONNECTION_CLOSE).send("Unknown statusz subpath");
             }
         } catch (final RuntimeException e) {
             LOGGER.log(WARNING, "Failed to respond to statusz check due to %s".formatted(e), e);
-            res.status(500).send();
+            res.status(500).header(CONNECTION_CLOSE).send();
         }
     }
 }

--- a/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.health;
 
-import static io.helidon.http.HeaderValues.CONNECTION_CLOSE;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
+import static org.hiero.block.node.health.HttpConnectionSupport.closeAfterHttp1;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.helidon.webserver.http.ServerRequest;
@@ -21,13 +21,13 @@ import org.hiero.block.node.spi.health.HealthFacility;
 
 /// Provides implementation for the health endpoints of the server.
 ///
-/// Every response sets the `Connection: close` header. Kubernetes probes hit these
-/// endpoints continuously; left on keep-alive they accumulate as idle connections that
-/// Helidon only reaps after `server.idleConnectionTimeoutMinutes`, eventually exhausting
-/// `server.maxTcpConnections` and causing the server to refuse new connections. Closing
-/// after each response keeps the probe traffic from holding sockets open. Helidon flushes
-/// the full response before closing (see `Http1ServerResponse.keepConnectionOpen()`), so
-/// the reply is always delivered.
+/// Every HTTP/1.1 response sets the `Connection: close` header (see [HttpConnectionSupport]).
+/// Kubernetes probes hit these endpoints continuously; left on keep-alive they accumulate as
+/// idle connections that Helidon only reaps after `server.idleConnectionTimeoutMinutes`,
+/// eventually exhausting `server.maxTcpConnections` and causing the server to refuse new
+/// connections. Closing after each response keeps the probe traffic from holding sockets open.
+/// Helidon flushes the full response before closing (see
+/// `Http1ServerResponse.keepConnectionOpen()`), so the reply is always delivered.
 public class HealthServicePlugin implements BlockNodePlugin {
     private final Logger LOGGER = System.getLogger(getClass().getName());
     protected static final String HEALTHZ_PATH = "/healthz";
@@ -74,10 +74,10 @@ public class HealthServicePlugin implements BlockNodePlugin {
     public final void handleLivez(@NonNull final ServerRequest req, @NonNull final ServerResponse res) {
         try {
             if (healthFacility.isRunning()) {
-                res.status(200).header(CONNECTION_CLOSE).send("OK");
+                closeAfterHttp1(req, res.status(200)).send("OK");
                 LOGGER.log(TRACE, "Responded code 200 (OK) to liveness check");
             } else {
-                res.status(503).header(CONNECTION_CLOSE).send("Service is not running");
+                closeAfterHttp1(req, res.status(503)).send("Service is not running");
                 LOGGER.log(INFO, "Responded code 503 (Service is not running) to liveness check");
             }
         } catch (final RuntimeException e) {
@@ -93,10 +93,10 @@ public class HealthServicePlugin implements BlockNodePlugin {
     public final void handleReadyz(@NonNull final ServerRequest req, @NonNull final ServerResponse res) {
         try {
             if (healthFacility.isRunning()) {
-                res.status(200).header(CONNECTION_CLOSE).send("OK");
+                closeAfterHttp1(req, res.status(200)).send("OK");
                 LOGGER.log(TRACE, "Responded code 200 (OK) to readiness check");
             } else {
-                res.status(503).header(CONNECTION_CLOSE).send("Service is not running");
+                closeAfterHttp1(req, res.status(503)).send("Service is not running");
                 LOGGER.log(INFO, "Responded code 503 (Service is not running) to readiness check");
             }
         } catch (final RuntimeException e) {
@@ -120,11 +120,11 @@ public class HealthServicePlugin implements BlockNodePlugin {
                 new OutboundStatusHandler(req, res, applicationStateFacility).createAndSendResponse();
             } else {
                 LOGGER.log(INFO, "Responded code 404 (Unknown statusz subpath) for {0}", path);
-                res.status(404).header(CONNECTION_CLOSE).send("Unknown statusz subpath");
+                closeAfterHttp1(req, res.status(404)).send("Unknown statusz subpath");
             }
         } catch (final RuntimeException e) {
             LOGGER.log(WARNING, "Failed to respond to statusz check due to %s".formatted(e), e);
-            res.status(500).header(CONNECTION_CLOSE).send();
+            closeAfterHttp1(req, res.status(500)).send();
         }
     }
 }

--- a/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
@@ -39,23 +39,21 @@ public class HealthServicePlugin implements BlockNodePlugin {
     protected static final String INBOUND_PATH = STATUSZ_PATH + "/inbound";
     protected static final String OUTBOUND_PATH = STATUSZ_PATH + "/outbound";
 
-    /// Counter for health/status HTTP requests, labeled by [#LABEL_ENDPOINT] and [#LABEL_RESULT].
+    /// Counter for health-check HTTP requests, labeled by [#LABEL_ENDPOINT] and [#LABEL_RESULT].
     /// Kubernetes probes flatlining this counter while the pod stays up is an early signal that the
     /// server has stopped accepting connections (see class doc), before liveness/readiness fail.
     public static final MetricKey<LongCounter> METRIC_HEALTH_REQUESTS =
             MetricKey.of("health_requests", LongCounter.class).addCategory(METRICS_CATEGORY);
 
-    /// Label naming the endpoint that served the request (`livez`, `readyz`, `statusz`).
+    /// Label naming the endpoint group that served the request. Only the health checks
+    /// (`livez`/`readyz`) are counted, so the sole value is [#ENDPOINT_HEALTH]; the `statusz`
+    /// endpoints serve statistics rather than health checks and are intentionally not counted.
     static final String LABEL_ENDPOINT = "endpoint";
-    /// Label naming the outcome of the request (`ok`, `unavailable`, `not_found`, `error`).
+    /// Label naming the outcome of the request (`success`, `failed`).
     static final String LABEL_RESULT = "result";
-    static final String ENDPOINT_LIVEZ = "livez";
-    static final String ENDPOINT_READYZ = "readyz";
-    static final String ENDPOINT_STATUSZ = "statusz";
-    static final String RESULT_OK = "ok";
-    static final String RESULT_UNAVAILABLE = "unavailable";
-    static final String RESULT_NOT_FOUND = "not_found";
-    static final String RESULT_ERROR = "error";
+    static final String ENDPOINT_HEALTH = "health";
+    static final String RESULT_SUCCESS = "success";
+    static final String RESULT_FAILED = "failed";
 
     /// The health facility, used for getting server status
     private HealthFacility healthFacility;
@@ -74,7 +72,7 @@ public class HealthServicePlugin implements BlockNodePlugin {
         applicationStateFacility = context.applicationStateFacility();
         final MetricRegistry metricRegistry = context.metricRegistry();
         requestCounter = metricRegistry.register(LongCounter.builder(METRIC_HEALTH_REQUESTS)
-                .setDescription("Health and status HTTP requests by endpoint and result")
+                .setDescription("Health check requests by endpoint and result")
                 .addDynamicLabelNames(LABEL_ENDPOINT, LABEL_RESULT));
         // A null port (the default) shares server.port
         final Integer port =
@@ -102,15 +100,15 @@ public class HealthServicePlugin implements BlockNodePlugin {
         try {
             if (healthFacility.isRunning()) {
                 closeAfterHttp1(req, res.status(200)).send("OK");
-                recordRequest(ENDPOINT_LIVEZ, RESULT_OK);
+                recordRequest(RESULT_SUCCESS);
                 LOGGER.log(TRACE, "Responded code 200 (OK) to liveness check");
             } else {
                 closeAfterHttp1(req, res.status(503)).send("Service is not running");
-                recordRequest(ENDPOINT_LIVEZ, RESULT_UNAVAILABLE);
+                recordRequest(RESULT_FAILED);
                 LOGGER.log(INFO, "Responded code 503 (Service is not running) to liveness check");
             }
         } catch (final RuntimeException e) {
-            recordRequest(ENDPOINT_LIVEZ, RESULT_ERROR);
+            recordRequest(RESULT_FAILED);
             LOGGER.log(WARNING, "Failed to respond to liveness check due to %s".formatted(e), e);
         }
     }
@@ -124,15 +122,15 @@ public class HealthServicePlugin implements BlockNodePlugin {
         try {
             if (healthFacility.isRunning()) {
                 closeAfterHttp1(req, res.status(200)).send("OK");
-                recordRequest(ENDPOINT_READYZ, RESULT_OK);
+                recordRequest(RESULT_SUCCESS);
                 LOGGER.log(TRACE, "Responded code 200 (OK) to readiness check");
             } else {
                 closeAfterHttp1(req, res.status(503)).send("Service is not running");
-                recordRequest(ENDPOINT_READYZ, RESULT_UNAVAILABLE);
+                recordRequest(RESULT_FAILED);
                 LOGGER.log(INFO, "Responded code 503 (Service is not running) to readiness check");
             }
         } catch (final RuntimeException e) {
-            recordRequest(ENDPOINT_READYZ, RESULT_ERROR);
+            recordRequest(RESULT_FAILED);
             LOGGER.log(WARNING, "Failed to respond to readiness check due to %s".formatted(e), e);
         }
     }
@@ -148,29 +146,25 @@ public class HealthServicePlugin implements BlockNodePlugin {
             final String path = req.path().path();
             if (path.endsWith(INBOUND_PATH)) {
                 new InboundStatusHandler(req, res, applicationStateFacility).createAndSendResponse();
-                recordRequest(ENDPOINT_STATUSZ, RESULT_OK);
             } else if (path.endsWith(OUTBOUND_PATH)) {
                 new OutboundStatusHandler(req, res, applicationStateFacility).createAndSendResponse();
-                recordRequest(ENDPOINT_STATUSZ, RESULT_OK);
             } else {
                 LOGGER.log(INFO, "Responded code 404 (Unknown statusz subpath) for {0}", path);
                 closeAfterHttp1(req, res.status(404)).send("Unknown statusz subpath");
-                recordRequest(ENDPOINT_STATUSZ, RESULT_NOT_FOUND);
             }
         } catch (final RuntimeException e) {
             LOGGER.log(WARNING, "Failed to respond to statusz check due to %s".formatted(e), e);
             closeAfterHttp1(req, res.status(500)).send();
-            recordRequest(ENDPOINT_STATUSZ, RESULT_ERROR);
         }
     }
 
-    /// Increments [#METRIC_HEALTH_REQUESTS] for the given endpoint and result labels.
+    /// Increments [#METRIC_HEALTH_REQUESTS] for a health check ([#ENDPOINT_HEALTH]) with the
+    /// given result.
     ///
-    /// @param endpoint the endpoint that served the request
     /// @param result the outcome of the request
-    private void recordRequest(@NonNull final String endpoint, @NonNull final String result) {
+    private void recordRequest(@NonNull final String result) {
         requestCounter
-                .getOrCreateLabeled(LABEL_ENDPOINT, endpoint, LABEL_RESULT, result)
+                .getOrCreateLabeled(LABEL_ENDPOINT, ENDPOINT_HEALTH, LABEL_RESULT, result)
                 .increment();
     }
 }

--- a/block-node/health/src/main/java/org/hiero/block/node/health/HttpConnectionSupport.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/HttpConnectionSupport.java
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.health;
+
+import static io.helidon.http.HeaderValues.CONNECTION_CLOSE;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+
+/// Adds `Connection: close` to a response, but only when the request came in over HTTP/1.1.
+///
+/// HTTP/2 forbids the `Connection` header outright (RFC 9113 8.2.2); Helidon throws
+/// `Http2Exception: Connection in response headers` if a handler sets it on an HTTP/2 response.
+/// The idle-connection problem this header works around is also HTTP/1.1-specific: keep-alive
+/// sockets held open by probes, not HTTP/2's single multiplexed connection.
+final class HttpConnectionSupport {
+    private static final String HTTP_1_1 = "1.1";
+
+    private HttpConnectionSupport() {}
+
+    @NonNull
+    static ServerResponse closeAfterHttp1(@NonNull final ServerRequest req, @NonNull final ServerResponse res) {
+        return HTTP_1_1.equals(req.prologue().protocolVersion()) ? res.header(CONNECTION_CLOSE) : res;
+    }
+}

--- a/block-node/health/src/main/java/org/hiero/block/node/health/InboundStatusHandler.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/InboundStatusHandler.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.health;
 
+import static io.helidon.http.HeaderValues.CONNECTION_CLOSE;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.helidon.http.HeaderNames;
 import io.helidon.webserver.http.ServerRequest;
@@ -46,6 +48,7 @@ final class InboundStatusHandler {
                 NetworkData.newBuilder().activeEndpoints(endpoints).build();
         response.status(200)
                 .header(HeaderNames.CONTENT_TYPE, "application/json")
+                .header(CONNECTION_CLOSE)
                 .send(NetworkData.JSON.toJSON(data));
     }
 }

--- a/block-node/health/src/main/java/org/hiero/block/node/health/InboundStatusHandler.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/InboundStatusHandler.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.health;
 
-import static io.helidon.http.HeaderValues.CONNECTION_CLOSE;
+import static org.hiero.block.node.health.HttpConnectionSupport.closeAfterHttp1;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.helidon.http.HeaderNames;
@@ -46,9 +46,7 @@ final class InboundStatusHandler {
         endpoints.addAll(appState.backfillSources().activeEndpoints());
         final NetworkData data =
                 NetworkData.newBuilder().activeEndpoints(endpoints).build();
-        response.status(200)
-                .header(HeaderNames.CONTENT_TYPE, "application/json")
-                .header(CONNECTION_CLOSE)
+        closeAfterHttp1(request, response.status(200).header(HeaderNames.CONTENT_TYPE, "application/json"))
                 .send(NetworkData.JSON.toJSON(data));
     }
 }

--- a/block-node/health/src/main/java/org/hiero/block/node/health/OutboundStatusHandler.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/OutboundStatusHandler.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.health;
 
+import static io.helidon.http.HeaderValues.CONNECTION_CLOSE;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.helidon.http.HeaderNames;
 import io.helidon.webserver.http.ServerRequest;
@@ -45,6 +47,7 @@ final class OutboundStatusHandler {
                 NetworkData.newBuilder().activeEndpoints(endpoints).build();
         response.status(200)
                 .header(HeaderNames.CONTENT_TYPE, "application/json")
+                .header(CONNECTION_CLOSE)
                 .send(NetworkData.JSON.toJSON(data));
     }
 }

--- a/block-node/health/src/main/java/org/hiero/block/node/health/OutboundStatusHandler.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/OutboundStatusHandler.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.health;
 
-import static io.helidon.http.HeaderValues.CONNECTION_CLOSE;
+import static org.hiero.block.node.health.HttpConnectionSupport.closeAfterHttp1;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.helidon.http.HeaderNames;
@@ -45,9 +45,7 @@ final class OutboundStatusHandler {
         endpoints.addAll(appState.backfillSources().activeEndpoints());
         final NetworkData data =
                 NetworkData.newBuilder().activeEndpoints(endpoints).build();
-        response.status(200)
-                .header(HeaderNames.CONTENT_TYPE, "application/json")
-                .header(CONNECTION_CLOSE)
+        closeAfterHttp1(request, response.status(200).header(HeaderNames.CONTENT_TYPE, "application/json"))
                 .send(NetworkData.JSON.toJSON(data));
     }
 }

--- a/block-node/health/src/test/java/org/hiero/block/node/health/HealthConnectionCloseTest.java
+++ b/block-node/health/src/test/java/org/hiero/block/node/health/HealthConnectionCloseTest.java
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.health;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.HttpService;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import org.hiero.block.node.app.fixtures.async.BlockingExecutor;
+import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
+import org.hiero.block.node.app.fixtures.plugintest.NoBlocksHistoricalBlockFacility;
+import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
+import org.hiero.block.node.spi.ServiceBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/// Integration test that runs the real [HealthServicePlugin] handlers behind a real Helidon
+/// [WebServer] (no mocked response) and asserts, at the socket level, that every health response
+/// carries the `Connection: close` header on the wire.
+///
+/// Why this is the right assertion: in Helidon 4.5 the server does not proactively close the TCP
+/// socket after a fixed-length response; it writes the `Connection: close` header and relies on the
+/// client to close (which the Kubernetes probe client does). That header is therefore our contract
+/// — it is what makes probe clients release their connections instead of leaving them idle to
+/// accumulate toward `server.maxTcpConnections`. If the header regresses, the client keeps the
+/// connection alive and the leak returns; this test fails in that case.
+///
+/// The request deliberately asks for `Connection: keep-alive` to prove the server overrides it.
+/// The response is read by `Content-Length` (never waiting on EOF), so the test is deterministic.
+///
+/// It uses [PluginTestBase] (real
+/// [org.hiero.block.node.app.fixtures.plugintest.TestHealthFacility] and configuration) and captures
+/// the [HttpService] the plugin registers by implementing [ServiceBuilder], then mounts it on the
+/// live server.
+class HealthConnectionCloseTest extends PluginTestBase<HealthServicePlugin, BlockingExecutor, ScheduledExecutorService>
+        implements ServiceBuilder {
+
+    private static final int SOCKET_TIMEOUT_MILLIS = 5_000;
+
+    /// Captures the HTTP services the plugin registers during {@code init}, keyed by base path.
+    private final Map<String, HttpService> registeredServices = new HashMap<>();
+
+    private WebServer webServer;
+
+    HealthConnectionCloseTest() {
+        super(
+                new BlockingExecutor(new LinkedBlockingQueue<>()),
+                new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+    }
+
+    /// Because this test implements {@link ServiceBuilder}, {@code PluginTestBase} passes it to
+    /// {@code plugin.init(...)}, so the plugin registers its real routing here.
+    @Override
+    public void registerHttpService(final String path, @Nullable final Integer port, final HttpService... service) {
+        for (final HttpService httpService : service) {
+            registeredServices.put(path, httpService);
+        }
+    }
+
+    @Override
+    public void registerGrpcService(@NonNull final ServiceInterface service, @Nullable final Integer port) {
+        // health plugin registers no gRPC services
+    }
+
+    @BeforeEach
+    void startServer() {
+        start(new HealthServicePlugin(), new NoBlocksHistoricalBlockFacility());
+        final HttpRouting.Builder routing = HttpRouting.builder();
+        registeredServices.forEach(routing::register);
+        webServer = WebServerConfig.builder().port(0).addRouting(routing).build();
+        webServer.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (webServer != null) {
+            webServer.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("livez sends Connection: close on the wire")
+    void livezSendsConnectionClose() throws IOException {
+        final HttpResponse response = fetch("/healthz/livez");
+        assertEquals(200, response.statusCode(), response::head);
+        assertConnectionClose(response);
+        assertEquals("OK", response.body());
+    }
+
+    @Test
+    @DisplayName("readyz sends Connection: close on the wire")
+    void readyzSendsConnectionClose() throws IOException {
+        final HttpResponse response = fetch("/healthz/readyz");
+        assertEquals(200, response.statusCode(), response::head);
+        assertConnectionClose(response);
+        assertEquals("OK", response.body());
+    }
+
+    @Test
+    @DisplayName("statusz responses also send Connection: close on the wire")
+    void statuszSendsConnectionClose() throws IOException {
+        // The statusz handler sets Connection: close on every branch (JSON 200 and the 404/500
+        // fallbacks); JSON 200 dispatch is covered by HealthServiceTest. Here we only assert the
+        // header contract survives to a real socket through the statusz handler.
+        final HttpResponse response = fetch("/statusz/inbound");
+        assertConnectionClose(response);
+    }
+
+    private static void assertConnectionClose(final HttpResponse response) {
+        assertTrue(
+                response.head().toLowerCase().contains("connection: close"),
+                () -> "response is missing 'Connection: close' header:\n" + response.head());
+    }
+
+    /// Sends an HTTP/1.1 GET that asks to keep the connection alive, then reads the status line and
+    /// headers, and the body by `Content-Length`. Never waits for EOF, so a kept-alive connection
+    /// cannot hang the test.
+    @NonNull
+    private HttpResponse fetch(@NonNull final String path) throws IOException {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress("127.0.0.1", webServer.port()), SOCKET_TIMEOUT_MILLIS);
+            socket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
+
+            final OutputStream out = socket.getOutputStream();
+            out.write(("GET " + path + " HTTP/1.1\r\n" + "Host: 127.0.0.1\r\n" + "Connection: keep-alive\r\n" + "\r\n")
+                    .getBytes(US_ASCII));
+            out.flush();
+
+            final InputStream in = socket.getInputStream();
+            final String head = readHead(in);
+            final String body = readBody(in, contentLength(head));
+            return new HttpResponse(head, body);
+        }
+    }
+
+    /// Reads the status line and header block up to (and excluding) the terminating blank line.
+    @NonNull
+    private static String readHead(@NonNull final InputStream in) throws IOException {
+        final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        int b;
+        while ((b = in.read()) != -1) {
+            buffer.write(b);
+            final byte[] bytes = buffer.toByteArray();
+            final int length = bytes.length;
+            if (length >= 4
+                    && bytes[length - 4] == '\r'
+                    && bytes[length - 3] == '\n'
+                    && bytes[length - 2] == '\r'
+                    && bytes[length - 1] == '\n') {
+                return new String(bytes, 0, length - 4, US_ASCII);
+            }
+        }
+        return buffer.toString(US_ASCII);
+    }
+
+    @NonNull
+    private static String readBody(@NonNull final InputStream in, final int contentLength) throws IOException {
+        final byte[] body = new byte[contentLength];
+        int offset = 0;
+        while (offset < contentLength) {
+            final int read = in.read(body, offset, contentLength - offset);
+            if (read == -1) {
+                break;
+            }
+            offset += read;
+        }
+        return new String(body, 0, offset, UTF_8);
+    }
+
+    private static int contentLength(@NonNull final String head) {
+        for (final String line : head.split("\r\n")) {
+            if (line.toLowerCase().startsWith("content-length:")) {
+                return Integer.parseInt(line.substring(line.indexOf(':') + 1).trim());
+            }
+        }
+        return 0;
+    }
+
+    /// Parsed HTTP response: the raw head (status line + headers) and the decoded body.
+    private record HttpResponse(
+            @NonNull String head, @NonNull String body) {
+        int statusCode() {
+            // status line looks like: HTTP/1.1 200 OK
+            final String[] parts = head.split("\r\n", 2)[0].split(" ");
+            return Integer.parseInt(parts[1]);
+        }
+    }
+}

--- a/block-node/health/src/test/java/org/hiero/block/node/health/HealthServiceTest.java
+++ b/block-node/health/src/test/java/org/hiero/block/node/health/HealthServiceTest.java
@@ -19,12 +19,14 @@ import io.helidon.webserver.http.ServerRequest;
 import io.helidon.webserver.http.ServerResponse;
 import java.nio.charset.StandardCharsets;
 import org.hiero.block.api.NetworkData;
+import org.hiero.block.node.app.fixtures.TestMetricsExporter;
 import org.hiero.block.node.app.fixtures.plugintest.TestApplicationStateFacility;
 import org.hiero.block.node.app.fixtures.plugintest.TestServerRequest;
 import org.hiero.block.node.app.fixtures.plugintest.TestServerResponse;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.health.HealthFacility;
+import org.hiero.metrics.core.MetricRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -45,11 +47,21 @@ class HealthServiceTest {
     @Mock
     ServiceBuilder serviceBuilder;
 
-    /** Stub the context configuration so {@code init} can read {@link HealthConfig} (port unset = null). */
-    private static void setupContextConfig(BlockNodeContext context) {
+    /** Captures metric values so tests can assert the request counter (one per test instance). */
+    private final TestMetricsExporter metricsExporter = new TestMetricsExporter();
+
+    /**
+     * Stub the context configuration so {@code init} can read {@link HealthConfig} (port unset = null),
+     * and wire a real {@link MetricRegistry} so {@code init} can register the request counter.
+     */
+    private void setupContextConfig(BlockNodeContext context) {
         final Configuration configuration = Mockito.mock(Configuration.class);
         Mockito.when(configuration.getConfigData(HealthConfig.class)).thenReturn(new HealthConfig(null));
         Mockito.when(context.configuration()).thenReturn(configuration);
+        Mockito.when(context.metricRegistry())
+                .thenReturn(MetricRegistry.builder()
+                        .setMetricsExporter(metricsExporter)
+                        .build());
     }
 
     /** Stubs {@code request.prologue()} to report HTTP/1.1, matching a real Kubernetes probe. */
@@ -292,5 +304,68 @@ class HealthServiceTest {
 
         assertEquals(404, response.sentStatus());
         assertTrue(response.hasHeader(CONNECTION_CLOSE));
+    }
+
+    @Test
+    public void testHandleLivez_recordsRequestMetric() {
+        // given
+        stubHttp1Request(serverRequest);
+        Mockito.when(serverResponse.status(200)).thenReturn(serverResponse);
+        Mockito.when(serverResponse.header(CONNECTION_CLOSE)).thenReturn(serverResponse);
+
+        BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
+        HealthFacility healthFacility = Mockito.mock(HealthFacility.class);
+        Mockito.when(healthFacility.isRunning()).thenReturn(true);
+        Mockito.when(context.serverHealth()).thenReturn(healthFacility);
+        setupContextConfig(context);
+
+        HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
+        healthServicePlugin.init(context, serviceBuilder);
+
+        // when
+        healthServicePlugin.handleLivez(serverRequest, serverResponse);
+
+        // then
+        assertEquals(1, metricsExporter.getMetricValue(METRIC_HEALTH_REQUESTS.name()));
+    }
+
+    @Test
+    public void testHandleReadyz_notRunning_recordsRequestMetric() {
+        // given
+        stubHttp1Request(serverRequest);
+        Mockito.when(serverResponse.status(503)).thenReturn(serverResponse);
+        Mockito.when(serverResponse.header(CONNECTION_CLOSE)).thenReturn(serverResponse);
+
+        BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
+        HealthFacility healthFacility = Mockito.mock(HealthFacility.class);
+        Mockito.when(healthFacility.isRunning()).thenReturn(false);
+        Mockito.when(context.serverHealth()).thenReturn(healthFacility);
+        setupContextConfig(context);
+
+        HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
+        healthServicePlugin.init(context, serviceBuilder);
+
+        // when
+        healthServicePlugin.handleReadyz(serverRequest, serverResponse);
+
+        // then
+        assertEquals(1, metricsExporter.getMetricValue(METRIC_HEALTH_REQUESTS.name()));
+    }
+
+    @Test
+    public void testHandleStatuszUnknownSubpath_recordsRequestMetric() {
+        // given
+        BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
+        Mockito.when(context.applicationStateFacility()).thenReturn(new TestApplicationStateFacility());
+        setupContextConfig(context);
+
+        HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
+        healthServicePlugin.init(context, serviceBuilder);
+
+        // when
+        healthServicePlugin.handleStatusz(new TestServerRequest("/statusz/bogus"), new TestServerResponse());
+
+        // then
+        assertEquals(1, metricsExporter.getMetricValue(METRIC_HEALTH_REQUESTS.name()));
     }
 }

--- a/block-node/health/src/test/java/org/hiero/block/node/health/HealthServiceTest.java
+++ b/block-node/health/src/test/java/org/hiero/block/node/health/HealthServiceTest.java
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.health;
 
+import static io.helidon.http.HeaderValues.CONNECTION_CLOSE;
 import static org.hiero.block.node.health.HealthServicePlugin.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -52,6 +54,7 @@ class HealthServiceTest {
     public void testHandleLivez() {
         // given
         Mockito.when(serverResponse.status(200)).thenReturn(serverResponse);
+        Mockito.when(serverResponse.header(CONNECTION_CLOSE)).thenReturn(serverResponse);
         Mockito.doNothing().when(serverResponse).send("OK");
 
         BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
@@ -67,6 +70,7 @@ class HealthServiceTest {
 
         // then
         Mockito.verify(serverResponse, Mockito.times(1)).status(200);
+        Mockito.verify(serverResponse, Mockito.times(1)).header(CONNECTION_CLOSE);
         Mockito.verify(serverResponse, Mockito.times(1)).send("OK");
     }
 
@@ -74,6 +78,7 @@ class HealthServiceTest {
     public void testHandleLivez_notRunning() {
         // given
         Mockito.when(serverResponse.status(503)).thenReturn(serverResponse);
+        Mockito.when(serverResponse.header(CONNECTION_CLOSE)).thenReturn(serverResponse);
 
         BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
         HealthFacility healthFacility = Mockito.mock(HealthFacility.class);
@@ -88,6 +93,7 @@ class HealthServiceTest {
 
         // then
         Mockito.verify(serverResponse, Mockito.times(1)).status(503);
+        Mockito.verify(serverResponse, Mockito.times(1)).header(CONNECTION_CLOSE);
         Mockito.verify(serverResponse, Mockito.times(1)).send("Service is not running");
     }
 
@@ -95,6 +101,7 @@ class HealthServiceTest {
     public void testHandleReadyz() {
         // given
         Mockito.when(serverResponse.status(200)).thenReturn(serverResponse);
+        Mockito.when(serverResponse.header(CONNECTION_CLOSE)).thenReturn(serverResponse);
         Mockito.doNothing().when(serverResponse).send("OK");
 
         BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
@@ -110,6 +117,7 @@ class HealthServiceTest {
 
         // then
         Mockito.verify(serverResponse, Mockito.times(1)).status(200);
+        Mockito.verify(serverResponse, Mockito.times(1)).header(CONNECTION_CLOSE);
         Mockito.verify(serverResponse, Mockito.times(1)).send("OK");
     }
 
@@ -117,6 +125,7 @@ class HealthServiceTest {
     public void testHandleReadyz_notRunning() {
         // given
         Mockito.when(serverResponse.status(503)).thenReturn(serverResponse);
+        Mockito.when(serverResponse.header(CONNECTION_CLOSE)).thenReturn(serverResponse);
 
         BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
         HealthFacility healthFacility = Mockito.mock(HealthFacility.class);
@@ -127,10 +136,11 @@ class HealthServiceTest {
         // when
         HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
         healthServicePlugin.init(context, serviceBuilder);
-        healthServicePlugin.handleLivez(serverRequest, serverResponse);
+        healthServicePlugin.handleReadyz(serverRequest, serverResponse);
 
         // then
         Mockito.verify(serverResponse, Mockito.times(1)).status(503);
+        Mockito.verify(serverResponse, Mockito.times(1)).header(CONNECTION_CLOSE);
         Mockito.verify(serverResponse, Mockito.times(1)).send("Service is not running");
     }
 
@@ -203,6 +213,7 @@ class HealthServiceTest {
 
         assertEquals(200, response.sentStatus());
         assertEquals("application/json", response.contentType());
+        assertTrue(response.hasHeader(CONNECTION_CLOSE));
         NetworkData sent =
                 NetworkData.JSON.parse(Bytes.wrap(((String) response.sentEntity()).getBytes(StandardCharsets.UTF_8)));
         assertFalse(sent.activeEndpoints().isEmpty());
@@ -222,6 +233,7 @@ class HealthServiceTest {
 
         assertEquals(200, response.sentStatus());
         assertEquals("application/json", response.contentType());
+        assertTrue(response.hasHeader(CONNECTION_CLOSE));
         NetworkData sent =
                 NetworkData.JSON.parse(Bytes.wrap(((String) response.sentEntity()).getBytes(StandardCharsets.UTF_8)));
         assertFalse(sent.activeEndpoints().isEmpty());
@@ -240,5 +252,6 @@ class HealthServiceTest {
         healthServicePlugin.handleStatusz(new TestServerRequest("/statusz/bogus"), response);
 
         assertEquals(404, response.sentStatus());
+        assertTrue(response.hasHeader(CONNECTION_CLOSE));
     }
 }

--- a/block-node/health/src/test/java/org/hiero/block/node/health/HealthServiceTest.java
+++ b/block-node/health/src/test/java/org/hiero/block/node/health/HealthServiceTest.java
@@ -353,19 +353,27 @@ class HealthServiceTest {
     }
 
     @Test
-    public void testHandleStatuszUnknownSubpath_recordsRequestMetric() {
-        // given
+    public void testHandleStatusz_doesNotRecordRequestMetric() {
+        // given: a running node and one health check so the request counter has a value to compare
+        stubHttp1Request(serverRequest);
+        Mockito.when(serverResponse.status(200)).thenReturn(serverResponse);
+        Mockito.when(serverResponse.header(CONNECTION_CLOSE)).thenReturn(serverResponse);
+
         BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
+        HealthFacility healthFacility = Mockito.mock(HealthFacility.class);
+        Mockito.when(healthFacility.isRunning()).thenReturn(true);
+        Mockito.when(context.serverHealth()).thenReturn(healthFacility);
         Mockito.when(context.applicationStateFacility()).thenReturn(new TestApplicationStateFacility());
         setupContextConfig(context);
 
         HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
         healthServicePlugin.init(context, serviceBuilder);
+        healthServicePlugin.handleLivez(serverRequest, serverResponse);
 
         // when
         healthServicePlugin.handleStatusz(new TestServerRequest("/statusz/bogus"), new TestServerResponse());
 
-        // then
+        // then: statusz serves statistics, not health checks, so it leaves the counter unchanged
         assertEquals(1, metricsExporter.getMetricValue(METRIC_HEALTH_REQUESTS.name()));
     }
 }

--- a/block-node/health/src/test/java/org/hiero/block/node/health/HealthServiceTest.java
+++ b/block-node/health/src/test/java/org/hiero/block/node/health/HealthServiceTest.java
@@ -11,6 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
+import io.helidon.http.HttpPrologue;
+import io.helidon.http.Method;
 import io.helidon.webserver.http.HttpRules;
 import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http.ServerRequest;
@@ -50,9 +52,16 @@ class HealthServiceTest {
         Mockito.when(context.configuration()).thenReturn(configuration);
     }
 
+    /** Stubs {@code request.prologue()} to report HTTP/1.1, matching a real Kubernetes probe. */
+    private static void stubHttp1Request(ServerRequest request) {
+        Mockito.when(request.prologue())
+                .thenReturn(HttpPrologue.create("HTTP/1.1", "HTTP", "1.1", Method.GET, "/", false));
+    }
+
     @Test
     public void testHandleLivez() {
         // given
+        stubHttp1Request(serverRequest);
         Mockito.when(serverResponse.status(200)).thenReturn(serverResponse);
         Mockito.when(serverResponse.header(CONNECTION_CLOSE)).thenReturn(serverResponse);
         Mockito.doNothing().when(serverResponse).send("OK");
@@ -74,9 +83,37 @@ class HealthServiceTest {
         Mockito.verify(serverResponse, Mockito.times(1)).send("OK");
     }
 
+    /// HTTP/2 forbids the `Connection` header (RFC 9113 8.2.2); Helidon throws an
+    /// `Http2Exception` if a handler sets it on an HTTP/2 response, so it must never be added
+    /// for HTTP/2 requests.
+    @Test
+    public void testHandleLivez_http2RequestDoesNotSetConnectionClose() {
+        // given
+        Mockito.when(serverRequest.prologue())
+                .thenReturn(HttpPrologue.create("HTTP/2.0", "HTTP", "2.0", Method.GET, "/", false));
+        Mockito.when(serverResponse.status(200)).thenReturn(serverResponse);
+        Mockito.doNothing().when(serverResponse).send("OK");
+
+        BlockNodeContext context = Mockito.mock(BlockNodeContext.class);
+        HealthFacility healthFacility = Mockito.mock(HealthFacility.class);
+        Mockito.when(healthFacility.isRunning()).thenReturn(true);
+        Mockito.when(context.serverHealth()).thenReturn(healthFacility);
+        setupContextConfig(context);
+
+        // when
+        HealthServicePlugin healthServicePlugin = new HealthServicePlugin();
+        healthServicePlugin.init(context, serviceBuilder);
+        healthServicePlugin.handleLivez(serverRequest, serverResponse);
+
+        // then
+        Mockito.verify(serverResponse, Mockito.never()).header(CONNECTION_CLOSE);
+        Mockito.verify(serverResponse, Mockito.times(1)).send("OK");
+    }
+
     @Test
     public void testHandleLivez_notRunning() {
         // given
+        stubHttp1Request(serverRequest);
         Mockito.when(serverResponse.status(503)).thenReturn(serverResponse);
         Mockito.when(serverResponse.header(CONNECTION_CLOSE)).thenReturn(serverResponse);
 
@@ -100,6 +137,7 @@ class HealthServiceTest {
     @Test
     public void testHandleReadyz() {
         // given
+        stubHttp1Request(serverRequest);
         Mockito.when(serverResponse.status(200)).thenReturn(serverResponse);
         Mockito.when(serverResponse.header(CONNECTION_CLOSE)).thenReturn(serverResponse);
         Mockito.doNothing().when(serverResponse).send("OK");
@@ -124,6 +162,7 @@ class HealthServiceTest {
     @Test
     public void testHandleReadyz_notRunning() {
         // given
+        stubHttp1Request(serverRequest);
         Mockito.when(serverResponse.status(503)).thenReturn(serverResponse);
         Mockito.when(serverResponse.header(CONNECTION_CLOSE)).thenReturn(serverResponse);
 


### PR DESCRIPTION
Fixes #3168 
# Close health/status connections after responding

## Problem (recap)

Under sustained Kubernetes probe traffic, Block Node pods eventually stopped answering `/healthz/livez` and `/healthz/readyz`, and the kubelet restarted them. Open TCP connections climbed and plateaued at 1000.

## Root cause

Health and status responses were served over keep-alive connections. Kubernetes probes hit these endpoints continuously, and each probe connection stayed open afterwards. Helidon only reaps idle connections after `server.idleConnectionTimeoutMinutes` (default **30 minutes**), so idle probe connections accumulated far faster than they were released and eventually hit `server.maxTcpConnections` (default **1000**). Once at the ceiling, Helidon refused new connections — including the probes themselves — so liveness/readiness failed and Kubernetes restarted the pod.

## Fix

Set the `Connection: close` header on every response from the health plugin (`/healthz/livez`, `/healthz/readyz`, and the `/statusz/*` endpoints, including the 404/500 fallbacks). This is the only handler-level lever over connection lifecycle in Helidon — `ServerResponse` exposes no `close()` and no socket handle.

Mechanism: the fix relies on the probe client honoring `Connection: close` (Kubernetes' Go HTTP client does). Helidon 4.5 emits the header but does not proactively close the socket itself — decompiling `Http1Connection` shows `Http1ServerResponse.keepConnectionOpen()` has a single caller, in an exception path; the normal path writes the header and loops back to read the next request. On receiving `Connection: close` the client closes its side, which releases the server socket. So the header is the contract, and it is what stops probe connections from lingering as idle keep-alive sockets.

## Changes

- `HealthServicePlugin` — `Connection: close` on livez/readyz (200 and 503) and on statusz 404/500 responses; class doc explains the rationale.
- `InboundStatusHandler` / `OutboundStatusHandler` — `Connection: close` on the JSON status responses.
- `TestServerResponse` (test fixture) — records headers set via `header(Header)` and exposes `hasHeader(...)`.
- `HealthServiceTest` — asserts the header is set on every endpoint; fixed a copy/paste in `testHandleReadyz_notRunning` that was exercising `handleLivez`.
- `HealthConnectionCloseTest` (new) — integration test that runs the real handlers behind a real Helidon `WebServer` (no mocked response) and asserts, at the socket level via a raw `Socket`, that `Connection: close` reaches the wire on `livez`/`readyz`/`statusz` even when the client requests keep-alive.

## Testing

`./gradlew :health:check` — 16 tests pass (unit + real-server integration).

