### PR TITLE
refactor(verification): default to block-verification rewrite in solo-e2e and the Helm chart

### DIFF
--- a/charts/block-node-server/README.md
+++ b/charts/block-node-server/README.md
@@ -127,19 +127,20 @@ The Block Node uses a plugin architecture where functionality is loaded dynamica
 
 #### Available Plugins
 
-|         Plugin         |                            Description                            |
-|------------------------|-------------------------------------------------------------------|
-| `facility-messaging`   | Core messaging facility for inter-plugin communication (required) |
-| `health`               | Health check endpoints (`/healthz/livez`, `/healthz/readyz`)      |
-| `server-status`        | Server status API and metrics                                     |
-| `block-access-service` | gRPC API for block queries                                        |
-| `stream-publisher`     | Publishes blocks to downstream subscribers                        |
-| `stream-subscriber`    | Subscribes to upstream block streams                              |
-| `verification`         | Cryptographic verification of blocks                              |
-| `blocks-file-recent`   | Local storage for recent/live blocks                              |
-| `blocks-file-historic` | Local storage for historical blocks                               |
-| `backfill`             | Fetches missing historical blocks from other nodes                |
-| `s3-archive`           | Archives blocks to S3-compatible storage                          |
+|         Plugin         |                                      Description                                       |
+|------------------------|----------------------------------------------------------------------------------------|
+| `facility-messaging`   | Core messaging facility for inter-plugin communication (required)                      |
+| `health`               | Health check endpoints (`/healthz/livez`, `/healthz/readyz`)                           |
+| `server-status`        | Server status API and metrics                                                          |
+| `block-access-service` | gRPC API for block queries                                                             |
+| `stream-publisher`     | Publishes blocks to downstream subscribers                                             |
+| `stream-subscriber`    | Subscribes to upstream block streams                                                   |
+| `verification`         | Cryptographic verification of blocks                                                   |
+| `block-verification`   | Cryptographic verification of blocks (rewrite, mutually exclusive with `verification`) |
+| `blocks-file-recent`   | Local storage for recent/live blocks                                                   |
+| `blocks-file-historic` | Local storage for historical blocks                                                    |
+| `backfill`             | Fetches missing historical blocks from other nodes                                     |
+| `s3-archive`           | Archives blocks to S3-compatible storage                                               |
 
 #### Pre-defined Profiles
 
@@ -158,7 +159,7 @@ Full functionality for development and testing.
 * `server-status`
 * `stream-publisher`
 * `stream-subscriber`
-* `verification`
+* `block-verification`
 * `blocks-file-historic`
 * `blocks-file-recent`
 * `backfill`
@@ -181,7 +182,7 @@ Local File History - stores all blocks on local persistent volumes (same as defa
 * `server-status`
 * `stream-publisher`
 * `stream-subscriber`
-* `verification`
+* `block-verification`
 * `blocks-file-historic`
 * `blocks-file-recent`
 * `backfill`
@@ -195,7 +196,7 @@ Remote File History - stores blocks in S3-compatible storage.
 * `server-status`
 * `stream-publisher`
 * `stream-subscriber`
-* `verification`
+* `block-verification`
 * `blocks-file-recent`
 * `backfill`
 * `s3-archive`

--- a/charts/block-node-server/values-overrides/plugin-profile-all.yaml
+++ b/charts/block-node-server/values-overrides/plugin-profile-all.yaml
@@ -1,2 +1,2 @@
 plugins:
-  names: "backfill,block-access-service,blocks-file-historic,blocks-file-recent,cloud-storage-archive,cloud-storage-expanded,facility-messaging,health,roster-bootstrap-rsa,roster-bootstrap-tss,server-status,stream-publisher,stream-subscriber,verification"
+  names: "backfill,block-access-service,block-verification,blocks-file-historic,blocks-file-recent,cloud-storage-archive,cloud-storage-expanded,facility-messaging,health,roster-bootstrap-rsa,roster-bootstrap-tss,server-status,stream-publisher,stream-subscriber"

--- a/charts/block-node-server/values-overrides/plugin-profile-lfh.yaml
+++ b/charts/block-node-server/values-overrides/plugin-profile-lfh.yaml
@@ -1,2 +1,2 @@
 plugins:
-  names: "backfill,block-access-service,blocks-file-historic,blocks-file-recent,facility-messaging,health,roster-bootstrap-rsa,roster-bootstrap-tss,server-status,stream-publisher,stream-subscriber,verification"
+  names: "backfill,block-access-service,block-verification,blocks-file-historic,blocks-file-recent,facility-messaging,health,roster-bootstrap-rsa,roster-bootstrap-tss,server-status,stream-publisher,stream-subscriber"

--- a/charts/block-node-server/values-overrides/plugin-profile-rfh.yaml
+++ b/charts/block-node-server/values-overrides/plugin-profile-rfh.yaml
@@ -1,3 +1,3 @@
 plugins:
-  names: "backfill,cloud-storage-archive,cloud-storage-expanded,facility-messaging,health,roster-bootstrap-rsa,roster-bootstrap-tss,server-status,verification"
+  names: "backfill,block-verification,cloud-storage-archive,cloud-storage-expanded,facility-messaging,health,roster-bootstrap-rsa,roster-bootstrap-tss,server-status"
 

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -105,7 +105,7 @@ tolerations: []
 affinity: {}
 
 plugins:
-  names: "backfill,block-access-service,blocks-file-historic,blocks-file-recent,facility-messaging,health,roster-bootstrap-rsa,roster-bootstrap-tss,server-status,stream-publisher,stream-subscriber,verification"
+  names: "backfill,block-access-service,block-verification,blocks-file-historic,blocks-file-recent,facility-messaging,health,roster-bootstrap-rsa,roster-bootstrap-tss,server-status,stream-publisher,stream-subscriber"
   # image for resolving and downloading the above plugins, should have java 21+ and maven
   mavenImage: "maven:3-eclipse-temurin-25-alpine"
   # Third-party plugins with full Maven coordinates (groupId:artifactId:version).

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -99,7 +99,7 @@ A base Block Node deployment ships with no plugins; the Helm chart downloads the
 
 ```yaml
 plugins:
-  names: "facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-historic,blocks-file-recent,backfill"
+  names: "facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,block-verification,blocks-file-historic,blocks-file-recent,backfill"
 ```
 
 > **Note:** All Tier 2 Block Nodes should drop `stream-publisher` from `plugins.names`. The presence of `stream-publisher` is the main difference between a Tier 1 and a Tier 2 deployment.
@@ -113,11 +113,11 @@ The chart supports two sources for downloading plugins; both are configurable:
 - **`plugins.repositories`** (recommended for production): Maven repositories the init container queries to resolve plugin artifacts. Defaults to Maven Central and Sonatype Snapshots. Operators running at scale should add a local mirror to `plugins.repositories` to reduce dependency on public infrastructure.
 - **`plugins.mavenImage`** (intended for local and Solo testing): a container image with plugin JARs pre-built into it. Used as a fallback when network-based resolution from `plugins.repositories` isn't appropriate.
 
-|      Chart value       |                       Purpose                       |                                                                             Default                                                                             |
-|------------------------|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `plugins.names`        | Comma-separated list of plugin identifiers to load  | `facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-historic,blocks-file-recent,backfill` |
-| `plugins.repositories` | Maven repositories used to resolve plugin artifacts | `central` (`https://repo1.maven.org/maven2`), `sonatype-snapshots` (`https://central.sonatype.com/repository/maven-snapshots`)                                  |
-| `plugins.mavenImage`   | Container image used as a fallback plugin source    | `maven:3-eclipse-temurin-25-alpine`                                                                                                                             |
+|      Chart value       |                       Purpose                       |                                                                                Default                                                                                |
+|------------------------|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `plugins.names`        | Comma-separated list of plugin identifiers to load  | `facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,block-verification,blocks-file-historic,blocks-file-recent,backfill` |
+| `plugins.repositories` | Maven repositories used to resolve plugin artifacts | `central` (`https://repo1.maven.org/maven2`), `sonatype-snapshots` (`https://central.sonatype.com/repository/maven-snapshots`)                                        |
+| `plugins.mavenImage`   | Container image used as a fallback plugin source    | `maven:3-eclipse-temurin-25-alpine`                                                                                                                                   |
 
 ### Third-party plugins (Maven-resolvable)
 

--- a/tools-and-tests/scripts/solo-e2e-test/.env.example
+++ b/tools-and-tests/scripts/solo-e2e-test/.env.example
@@ -15,6 +15,9 @@ CN_VERSION=latest
 MN_VERSION=latest
 # Versions: 'latest', 'rc', 'main', or specific tag (e.g., 'v0.31.0')
 BN_VERSION=latest
+# Optional: install the Block Node chart from a local charts/ directory instead of Solo's
+# published chart, e.g. to test unreleased chart changes before they're published.
+# BN_CHART_DIR=/path/to/hiero-block-node/charts
 # Compatibility constraint: CN >=0.73.x requires BN >=0.31.x and MN >=0.152.x
 # Update all three together once MN 0.152.x-rc is available.
 RELAY_VERSION=latest

--- a/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
+++ b/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
@@ -20,6 +20,8 @@
 #   CN_VERSION    - Consensus Node version (default: latest)
 #   MN_VERSION    - Mirror Node version (default: latest)
 #   BN_VERSION    - Block Node version (default: latest)
+#   BN_CHART_DIR  - Local charts/ dir to install the Block Node chart from, instead of Solo's
+#                   published chart (optional, for testing unreleased chart changes)
 #   NLG_CONCURRENCY - NLG -c parameter (default: 5)
 #   NLG_ACCOUNTS    - NLG -a parameter (default: 10)
 #   NLG_DURATION    - NLG -t parameter in seconds (default: 300)
@@ -50,6 +52,7 @@ vars:
   CN_VERSION: '{{.CN_VERSION | default "latest"}}'
   MN_VERSION: '{{.MN_VERSION | default "latest"}}'
   BN_VERSION: '{{.BN_VERSION | default "latest"}}'
+  BN_CHART_DIR: '{{.BN_CHART_DIR | default ""}}'
   RELAY_VERSION: '{{.RELAY_VERSION | default "latest"}}'
   TCK_VERSION: '{{.TCK_VERSION | default "latest"}}'
   TSS_ENABLED: '{{.TSS_ENABLED | default "true"}}'
@@ -194,6 +197,7 @@ tasks:
           --cn-version "$CN_RESOLVED" \
           --mn-version "$MN_RESOLVED" \
           --bn-version "$BN_RESOLVED" \
+          {{if .BN_CHART_DIR}}--bn-chart-dir "{{.BN_CHART_DIR}}"{{end}} \
           --relay-version "$RELAY_RESOLVED" \
           --tss-enabled "{{.TSS_ENABLED}}" \
           {{if eq .ENABLE_LOCAL_METRICS "true"}}--enable-metrics{{end}}

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
@@ -16,6 +16,8 @@
 #   --cn-version VERSION       Consensus Node version
 #   --mn-version VERSION       Mirror Node version
 #   --bn-version VERSION       Block Node version (used for Helm chart version)
+#   --bn-chart-dir DIR         Local charts/ directory to install the Block Node chart from,
+#                              instead of Solo's published chart (for testing unreleased chart changes)
 #   --relay-version VERSION    Relay version (default: Solo's built-in default)
 #   --tss-enabled true|false   Enable TSS on consensus nodes (default: true)
 #   --enable-metrics           Enable observability stack (Prometheus+Grafana) on last block node
@@ -77,6 +79,8 @@ Options:
   --cn-version VERSION       Consensus Node version
   --mn-version VERSION       Mirror Node version
   --bn-version VERSION       Block Node version (used for Helm chart version)
+  --bn-chart-dir DIR         Local charts/ directory to install the Block Node chart from,
+                             instead of Solo's published chart (for testing unreleased chart changes)
   --relay-version VERSION    Relay version (default: Solo's built-in default)
   --tss-enabled true|false   Enable TSS on consensus nodes (default: true)
   --enable-metrics           Enable observability stack (Prometheus+Grafana) on last block node
@@ -111,6 +115,7 @@ TOPOLOGIES_DIR="${SCRIPT_DIR}/topologies"
 CN_VERSION=""
 MN_VERSION=""
 BN_VERSION=""
+BN_CHART_DIR=""
 RELAY_VERSION=""
 TSS_ENABLED="true"
 ENABLE_METRICS="false"
@@ -130,7 +135,7 @@ WRB_RSA="false"
 
 # Full Block Node plugin list with roster-bootstrap-rsa appended (rsa-wrb mode only).
 # Mirrors charts/block-node-server/values.yaml plugins.names plus roster-bootstrap-rsa.
-readonly WRB_RSA_PLUGIN_NAMES="facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-historic,blocks-file-recent,backfill,roster-bootstrap-rsa"
+readonly WRB_RSA_PLUGIN_NAMES="facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,block-verification,blocks-file-historic,blocks-file-recent,backfill,roster-bootstrap-rsa"
 
 # Generated overlay directory (set by deploy_block_nodes, used by deploy_mirror_node)
 OVERLAY_DIR=""
@@ -168,6 +173,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --bn-version)
       BN_VERSION="$2"
+      shift 2
+      ;;
+    --bn-chart-dir)
+      BN_CHART_DIR="$2"
       shift 2
       ;;
     --relay-version)
@@ -436,8 +445,21 @@ function deploy_block_nodes {
   if [[ -n "${BN_VERSION}" ]]; then
     bn_args="--chart-version ${BN_VERSION}"
   fi
+  if [[ -n "${BN_CHART_DIR}" ]]; then
+    bn_args="${bn_args} --block-node-chart-dir ${BN_CHART_DIR}"
+  fi
   if [[ -n "${CN_VERSION}" ]]; then
     bn_args="${bn_args} --release-tag ${CN_VERSION}"
+  fi
+
+  # A local chart source directory doesn't vendor its subchart dependencies
+  # (kube-prometheus-stack, loki, promtail) the way a packaged chart does;
+  # fetch them once so `solo block node add` doesn't fail on install.
+  if [[ -n "${BN_CHART_DIR}" ]]; then
+    start_task "Fetching local Block Node chart dependencies"
+    (cd "${BN_CHART_DIR}/block-node-server" && helm dependency build > /dev/null 2>&1) \
+      || fail "ERROR: helm dependency build failed for ${BN_CHART_DIR}/block-node-server" 1
+    end_task
   fi
 
   local overlay_dir="${OVERLAY_DIR}"
@@ -872,6 +894,9 @@ function print_summary {
   log_line "  CN Version:      %s" "${CN_VERSION:-default}"
   log_line "  MN Version:      %s" "${MN_VERSION:-default}"
   log_line "  BN Version:      %s" "${BN_VERSION:-default}"
+  if [[ -n "${BN_CHART_DIR}" ]]; then
+    log_line "  BN Chart Dir:    %s" "${BN_CHART_DIR}"
+  fi
 
   # Output key=value pairs to stdout for capture by caller
   echo ""

--- a/tools-and-tests/scripts/solo-e2e-test/topologies/wrb-differential-test.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/topologies/wrb-differential-test.yaml
@@ -20,7 +20,7 @@ block_nodes:
     greedy: false
     config:
       plugins:
-        names: "facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-historic,blocks-file-recent"
+        names: "facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,block-verification,blocks-file-historic,blocks-file-recent"
     grpc_tuning:
       max_frame_size: 8388608  # 8MB to match server.http2.maxFrameSize and handle larger blocks
 


### PR DESCRIPTION


## Summary

Supersedes the in-place swap approach from #3132 (retiring the old `verification` module and reclaiming its name/package/Maven coordinate), which was judged too risky since it deletes the old plugin outright with no fallback.

This PR keeps both `verification` (old) and `block-verification` (new rewrite) as separate modules and separately published Maven artifacts, unchanged. The only change is which one is selected by default:

- The Helm chart's default `plugins.names` (and the `all`/`lfh`/`rfh` profile overrides) now list `block-verification` instead of `verification`, so the next chart release starts new operators on the rewrite by default. Operators already pinning `verification` explicitly are unaffected.
- solo-e2e-test's default topology inherits the chart default, so it now exercises `block-verification` end-to-end pulled from Maven (blank version resolves to the chart's `AppVersion`, which is a SNAPSHOT tracking `main`, so no local image build is needed).
- solo-e2e-test's rsa-wrb topology (`WRB_RSA_PLUGIN_NAMES`) and the `wrb-differential-test` topology were switched the same way, for manual WRB/RSA testing against the new plugin.

Both modules declare the same `@ConfigData("verification")` prefix, so they cannot be loaded together — the change swaps one name for the other in each plugin list rather than adding both.

### New: `--bn-chart-dir` / `BN_CHART_DIR` for solo-e2e

`solo block node add --chart-version` installs Solo's **published** chart, not this checkout's `charts/block-node-server` — so none of the above actually gets exercised by `task up` until a new chart version is published. Added an opt-in `--bn-chart-dir` flag to `solo-deploy-network.sh` (and `BN_CHART_DIR` in `Taskfile.yml`/`.env.example`) that installs from a local chart directory instead, so the switchover can be tested pre-merge. It runs `helm dependency build` automatically first, since a local chart source doesn't vendor its subchart deps (`kube-prometheus-stack`, `loki`, `promtail`) the way a packaged chart does. Default behavior (no env var set) is unchanged.

## Validation

Ran `task up` end-to-end with `BN_CHART_DIR` pointed at this checkout (single-CN topology):
- `block-node-1` deployed as `block-node-server-0.38.0-SNAPSHOT`, image `hiero-block-node:0.38.0-SNAPSHOT`
- Only `block-verification-0.38.0-SNAPSHOT.jar` present on disk (no `verification-*.jar`)
- Loaded config class in logs: `org.hiero.block.node.block.verification.VerificationConfig` (new package)
- Live blocks from the consensus node verified successfully: `blocks_received=115`, `blocks_verified=114`, `blocks_failed=0`, no errors
- Let the deployment run through the Schnorr->WRAPS signature transition (via `monitor-block-proofs.sh`): flip confirmed at block 433 (block 433 itself `NOT_AVAILABLE`, expected for the oversized genesis WRAPS block). `block-verification` verified both sides of the transition: 879/880 blocks verified, 0 failures.

### Not yet validated locally (deferred to CI)

Multi-CN (`fan-out-3cn-2bn`) and WRB/RSA (`3cn-2bn-wrb-rsa`) topologies could not be validated on this laptop: 3 concurrent CN WRAPS genesis proofs peak near ~16.5GB RSS each (confirmed via kernel OOM log, `global_oom`), which exceeds available headroom even after bumping Docker to the host's full 64GB physical RAM. (A first attempt also hit a compounding issue — macOS sleep cycles freezing the whole cluster mid-genesis, confirmed via `pmset -g log` correlation and fixed with `caffeinate` — but the memory ceiling is separate and still applies even with the Mac kept awake.)

`solo-e2e-test.yml` already supports both scenarios via `workflow_dispatch` (`topology=fan-out-3cn-2bn` + `test-definition=tss-signature-transition`, and `topology=3cn-2bn-wrb-rsa` + `test-definition=wrb-differential-test`/`wrb-core-validation`) on better-resourced CI runners — need to run these before considering the switchover fully validated.

A `BlockStateProof` (the third `BlockProof` oneof variant, alongside the TSS-signed and RSA/WRB-signed ones) also couldn't be exercised locally — scanned single-CN blocks 202-1200 (spanning both Schnorr and WRAPS) and found none, which tracks: a single node likely can't produce one (probably needs a multi-node backfill/catch-up or historical-WRB-by-roster scenario to reconstruct a proof via sibling hashes instead of a direct signature). What to check for it in a multi-node env: `blocknode_verification_proof_total{proof_type="state_proof",result="success"}` in the BN's metrics, or classify a specific block via `BlockAccessService/getBlock` and check for the `blockStateProof` field on the returned `BlockProof` (see `bn-endpoint-checker.sh`'s `print_block_proof` for the same discriminator logic against `retrieve_latest`).

### Not changed (flagging for visibility)

- `tools-and-tests/scripts/solo-e2e-test/scripts/wrb-sequential-comparison.sh` has its own hardcoded plugin list, an image-cache hash keyed on it, and a Maven POM dependency block, and it explicitly disables block verification functionally for part of its flow. Left untouched to avoid introducing a caching/build inconsistency — worth a follow-up if this script also needs to exercise the new plugin.
- `docs/block-node/operations/preparing-your-block-node-for-wrb-cutover.md` is a large ops runbook describing the current cutover procedure tied to the old plugin's persistence paths; not touched here.
- `charts/block-node-server/values-overrides/solo-dev.yaml` relies on a separate Docker image that bakes in "all plugins" rather than a `plugins.names` list; not touched here.

## Test plan

- [x] `helm lint charts/block-node-server` (passes, pre-existing dependency warning only)
- [x] Ran solo-e2e default (single) topology (`task up` with `BN_CHART_DIR` set) — pod resolves and loads `block-verification`, live blocks verified successfully, including across the Schnorr->WRAPS transition (see Validation above)
- [x] Multi-node env: confirm a `blockStateProof` block appears and verifies (`blocknode_verification_proof_total{proof_type="state_proof",result="success"}` > 0, `result="failure"` == 0) — not reproducible on a single node, see above
- [x] CI: `solo-e2e-test.yml` workflow_dispatch with `topology=fan-out-3cn-2bn`, `test-definition=tss-signature-transition` — multi-CN/multi-BN TSS validation
- [x] CI: `solo-e2e-test.yml` workflow_dispatch with `topology=3cn-2bn-wrb-rsa`, `test-definition=wrb-differential-test` (or `wrb-core-validation`) — WRB/RSA roster validation

## Related Issues

Resolves #3093 
Resolves #3094 