### PR TITLE
docs(block-node): add Production Node Operation Guide (#3187)

### DIFF
--- a/docs/block-node/operations/production-guide/configure-alloy-telemetry.md
+++ b/docs/block-node/operations/production-guide/configure-alloy-telemetry.md
@@ -48,13 +48,13 @@ is `HASHGRAPH`.
 
 > Destroy any local copy of the credentials file after creating the Secret. The tokens now
 > live only in the cluster.
-
-> **Security note:** Kubernetes Secrets backed by etcd are not encrypted at rest by default
+>
+> **Security note:** Kubernetes Secrets backed by `etcd` are not encrypted at rest by default
 > and may leak sensitive data into swap or temporary files. For production deployments, using
 > an External Secrets Operator integrated with a managed vault (HashiCorp Vault, AWS Secrets
 > Manager, GCP Secret Manager, or similar) is **strongly recommended**. If you use the default
-> etcd provider, configure
-> [encryption at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)
+> `etcd` provider, configure
+> [encryption at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#ensure-all-secrets-are-encrypted)
 > before storing credentials.
 
 You can also populate the Secret using the External Secrets Operator from a vault, Terraform,

--- a/docs/block-node/operations/production-guide/configure-alloy-telemetry.md
+++ b/docs/block-node/operations/production-guide/configure-alloy-telemetry.md
@@ -49,9 +49,17 @@ is `HASHGRAPH`.
 > Destroy any local copy of the credentials file after creating the Secret. The tokens now
 > live only in the cluster.
 
+> **Security note:** Kubernetes Secrets backed by etcd are not encrypted at rest by default
+> and may leak sensitive data into swap or temporary files. For production deployments, using
+> an External Secrets Operator integrated with a managed vault (HashiCorp Vault, AWS Secrets
+> Manager, GCP Secret Manager, or similar) is **strongly recommended**. If you use the default
+> etcd provider, configure
+> [encryption at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)
+> before storing credentials.
+
 You can also populate the Secret using the External Secrets Operator from a vault, Terraform,
 or any other mechanism your organization uses - the manual `kubectl` path above is the simplest
-for initial deployment.
+path for an initial deployment only.
 
 ---
 

--- a/docs/block-node/operations/production-guide/configure-alloy-telemetry.md
+++ b/docs/block-node/operations/production-guide/configure-alloy-telemetry.md
@@ -1,0 +1,96 @@
+# Configure Alloy Telemetry
+
+Grafana Alloy ships Prometheus metrics (remote-write) and Loki logs from the Block Node
+cluster to the operator's observability infrastructure.
+
+Telemetry is opt-out for council Tier 1 operators during the initial deployment period.
+If you are opting out, skip this page, record the decision with Hashgraph DevOps, and
+proceed directly to [Network Validation and Go-Live](./network-validation-go-live.md).
+
+> **Before starting:** Complete [Install the Block Node](./install-block-node.md). Alloy
+> requires the Kubernetes cluster to be running.
+
+---
+
+## What you need before starting
+
+Obtain the following from Hashgraph DevOps through the approved coordination channel:
+
+|               Value                |             Placeholder              |                  Notes                  |
+|------------------------------------|--------------------------------------|-----------------------------------------|
+| Prometheus remote-write URL        | `<PROMETHEUS_REMOTE_WRITE_URL>`      | Non-secret; used on the install command |
+| Prometheus remote-write username   | `<PROMETHEUS_REMOTE_WRITE_USERNAME>` | Non-secret                              |
+| Prometheus write-only access token | `<PROMETHEUS_REMOTE_WRITE_PASSWORD>` | Secret - deliver via secure channel     |
+| Loki remote-write URL              | `<LOKI_REMOTE_WRITE_URL>`            | Non-secret                              |
+| Loki remote-write username         | `<LOKI_REMOTE_WRITE_USERNAME>`       | Non-secret                              |
+| Loki write-only access token       | `<LOKI_REMOTE_WRITE_PASSWORD>`       | Secret - deliver via secure channel     |
+
+---
+
+## Step 1 - Create the credentials Secret **[OPERATOR]**
+
+Alloy reads credentials from a Kubernetes Secret named `grafana-alloy-secrets` in the
+`grafana-alloy` namespace. Create the namespace and Secret before installing Alloy:
+
+```bash
+kubectl create namespace grafana-alloy
+
+kubectl create secret generic grafana-alloy-secrets \
+  --namespace=grafana-alloy \
+  --from-literal=PROMETHEUS_PASSWORD_HASHGRAPH=<PROMETHEUS_REMOTE_WRITE_PASSWORD> \
+  --from-literal=LOKI_PASSWORD_HASHGRAPH=<LOKI_REMOTE_WRITE_PASSWORD>
+```
+
+The Secret key names follow the pattern `PROMETHEUS_PASSWORD_<REMOTE_NAME>` and
+`LOKI_PASSWORD_<REMOTE_NAME>`, where `<REMOTE_NAME>` is the uppercase name used in
+`--add-prometheus-remote` and `--add-loki-remote` below. For the Hashgraph remote, the name
+is `HASHGRAPH`.
+
+> Destroy any local copy of the credentials file after creating the Secret. The tokens now
+> live only in the cluster.
+
+You can also populate the Secret using the External Secrets Operator from a vault, Terraform,
+or any other mechanism your organization uses - the manual `kubectl` path above is the simplest
+for initial deployment.
+
+---
+
+## Step 2 - Install Alloy **[OPERATOR]**
+
+```bash
+sudo solo-provisioner alloy cluster install \
+  --cluster-name=<BLOCK_NODE_CLUSTER_NAME> \
+  --monitor-block-node \
+  --add-prometheus-remote="name=hashgraph,url=<PROMETHEUS_REMOTE_WRITE_URL>,username=<PROMETHEUS_REMOTE_WRITE_USERNAME>,labelProfile=ops" \
+  --add-loki-remote="name=hashgraph,url=<LOKI_REMOTE_WRITE_URL>,username=<LOKI_REMOTE_WRITE_USERNAME>,labelProfile=ops"
+```
+
+The `labelProfile=ops` option automatically injects standard labels into every metric and
+log stream so Hashgraph can attribute and isolate this operator's telemetry:
+
+|      Label       |            Value            |
+|------------------|-----------------------------|
+| `cluster`        | `<BLOCK_NODE_CLUSTER_NAME>` |
+| `environment`    | Set by label profile        |
+| `instance_type`  | `lfh`                       |
+| `inventory_name` | Operator node label         |
+| `ip`             | Block Node public IP        |
+
+---
+
+## Step 3 - Verify Alloy **[COORDINATED]**
+
+Check that the Alloy pod is running:
+
+```bash
+kubectl -n grafana-alloy get pods
+```
+
+Hashgraph DevOps confirms that metrics and logs are landing in the configured remotes. Do not
+proceed to network validation until Hashgraph confirms Alloy is shipping.
+
+---
+
+## Next step
+
+Proceed to [Network Validation and Go-Live](./network-validation-go-live.md).

--- a/docs/block-node/operations/production-guide/disaster-recovery.md
+++ b/docs/block-node/operations/production-guide/disaster-recovery.md
@@ -1,0 +1,111 @@
+# Disaster Recovery
+
+When something goes wrong, open a support ticket first (see
+[Incident reporting](./steady-state-operations.md#incident-reporting)), then use the matching
+scenario below.
+
+> **Reset blast radius.** `sudo solo-provisioner block node reset --profile=mainnet` destroys
+> all block data on this node. The Block Node re-syncs from upstream (multi-week backfill). Only
+> reset when the scenario calls for it or when explicitly instructed by Hashgraph DevOps.
+
+---
+
+## Scenario A - Block Node pod unhealthy, host fine
+
+**Symptoms:** crash-looping, pod not reaching Ready state, or producing errors on an otherwise
+healthy host.
+
+1. Capture pod logs, events, and status before taking action:
+
+   ```bash
+   kubectl -n block-node describe <pod>
+   kubectl -n block-node logs <pod> --previous
+   kubectl get events -n block-node --sort-by=.lastTimestamp | tail -20
+   ```
+2. Attempt a rolling restart:
+
+   ```bash
+   kubectl -n block-node rollout restart sts/<RELEASE_NAME>
+   kubectl -n block-node rollout status sts/<RELEASE_NAME>
+   ```
+3. If still failing, escalate to Hashgraph DevOps with the captured diagnostics.
+4. Last resort - reset the Block Node (destroys all block data; full re-backfill required):
+
+   ```bash
+   sudo solo-provisioner block node reset --profile=mainnet
+   ```
+
+---
+
+## Scenario B - Data corruption or inconsistent state
+
+**Symptoms:** verification errors, mismatched block hashes, stuck queues.
+
+1. **Pause before resetting.** Corruption is rare and the diagnostics are valuable - capture
+   logs and metrics before taking any action.
+2. Engage Hashgraph DevOps via the shared coordination channel.
+3. Once Hashgraph DevOps approves a reset:
+
+   ```bash
+   sudo solo-provisioner block node reset --profile=mainnet
+   ```
+4. Confirm the RSA bootstrap roster is in place at the expected path before the Block Node
+   restarts.
+5. Re-backfill begins automatically. Monitor progress per
+   [Backfill expectations](./network-validation-go-live.md#backfill-expectations).
+
+---
+
+## Scenario C - Host loss (hardware failure or full reimage)
+
+1. New hardware must meet the Tier 1 LFH specification —
+   see [Prerequisites](./prerequisites.md#compute-and-memory).
+2. Re-run the full deployment workflow:
+   - [Install the Block Node](./install-block-node.md)
+   - [Configure Alloy Telemetry](./configure-alloy-telemetry.md) (if telemetry is enabled)
+3. Re-run network validation with Hashgraph DevOps per
+   [Network Validation and Go-Live](./network-validation-go-live.md).
+4. Reset and re-backfill.
+5. No re-registration is required as long as the `admin_key` is preserved. Coordinate any
+   public IP or FQDN changes with Hashgraph DevOps before go-live.
+
+---
+
+## Scenario D - Region or facility outage
+
+A single-node Tier 1 operator has no in-region failover by design. Other Tier 1 Block Nodes
+continue ingesting during one operator's outage - this is the redundancy model per HIP-1081.
+
+1. Notify Hashgraph DevOps via the shared coordination channel as soon as the outage is known.
+2. Provide an estimated return-to-service time.
+3. On recovery, resume from Scenario A or C as appropriate.
+
+> Active/passive failover and per-operator multi-region deployment are not part of the Tier 1
+> reference profile. Raise as a separate design discussion if your organization requires that
+> posture.
+
+---
+
+## Upgrade with reset
+
+When a major schema migration requires clearing storage, Hashgraph DevOps will explicitly
+instruct you to use `--with-reset`:
+
+```bash
+sudo solo-provisioner block node upgrade \
+  --profile=mainnet \
+  --values=<UPDATED_VALUES_FILE> \
+  --no-reuse-values \
+  --chart-version=<X.Y.Z> \
+  --with-reset
+```
+
+Do not use `--with-reset` unless explicitly instructed. This is rare.
+
+---
+
+## Related documentation
+
+- [Troubleshooting](../../troubleshooting.md)
+- [Resetting and Upgrading the Block Node](../resetting-and-upgrading-the-block-node.md)
+- [Operator FAQ](../../operator-faq.md)

--- a/docs/block-node/operations/production-guide/getting-help.md
+++ b/docs/block-node/operations/production-guide/getting-help.md
@@ -17,7 +17,7 @@ Escalate in tier order:
 | 3 - P0 escalation    | On-call contact (provided at handoff)                                                     | Production outages requiring immediate response       |
 
 Response timeframes for Tier 2 and 3 are governed by the Operating Agreement,
-Exhibit B § 7c.
+Exhibit B §7c.
 
 ---
 
@@ -59,7 +59,12 @@ Exhibit B § 7c.
 
 - [HIP-1081 - Block Node](https://hips.hedera.com/hip/hip-1081)
 - [HIP-1056 - Block Streams](https://hips.hedera.com/hip/hip-1056)
+- [HIP-1137 - Block Node Discovery](https://hips.hedera.com/hip/hip-1137)
+- [HIP-1357 - Block Node Tier 1 Rewards](https://hips.hedera.com/hip/hip-1357)
+- [HIP-1193 - Block Stream Cutover](https://hips.hedera.com/hip/hip-1193)
 - [HIP-1200 - hinTS](https://hips.hedera.com/hip/hip-1200)
+- [HIP-1424 - Block Merkle Hashing](https://hips.hedera.com/hip/hip-1424)
+- [HIP-1427 - Record File Wrapping](https://hips.hedera.com/hip/hip-1427)
 
 ---
 

--- a/docs/block-node/operations/production-guide/getting-help.md
+++ b/docs/block-node/operations/production-guide/getting-help.md
@@ -1,0 +1,76 @@
+# Getting Help
+
+Use the channels below to get support, report issues, and stay current with Block Node
+releases and community discussions.
+
+---
+
+## Support channels
+
+Escalate in tier order:
+
+|         Tier         |                                          Channel                                          |                        Use for                        |
+|----------------------|-------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| 1 - Community        | [Hiero Discord](https://discord.gg/hiero)                                                 | General questions, community discussion               |
+| 1 - Issues           | [hiero-block-node GitHub Issues](https://github.com/hiero-ledger/hiero-block-node/issues) | Bug reports, doc improvements                         |
+| 2 - Hashgraph DevOps | Shared coordination channel (provided at handoff)                                         | Installation support, upgrade coordination, incidents |
+| 3 - P0 escalation    | On-call contact (provided at handoff)                                                     | Production outages requiring immediate response       |
+
+Response timeframes for Tier 2 and 3 are governed by the Operating Agreement,
+Exhibit B § 7c.
+
+---
+
+## Community
+
+- **Hiero Block Streams Community Group** - `<BLOCK_STREAMS_COMMUNITY_URL>` (obtain from
+  Hashgraph DevOps at handoff)
+- **Hiero Discord** - [discord.gg/hiero](https://discord.gg/hiero)
+- **GitHub Discussions** - [hiero-ledger/hiero-block-node](https://github.com/hiero-ledger/hiero-block-node/discussions)
+
+---
+
+## Reference documentation
+
+### Block Node operator docs
+
+- [Block Node Overview](../../block-node-overview.md)
+- [Block Node Hardware Specifications](../block-node-hardware-specifications.md)
+- [Network Ports and Protocols](../network-ports-and-protocols.md)
+- [Block Node On-Chain Registration (HIP-1137)](../../block-node-on-chain-registration.md)
+- [Configuration Reference](../../configuration.md)
+- [Metrics Reference](../../metrics.md)
+- [Operator FAQ](../../operator-faq.md)
+- [Troubleshooting](../../troubleshooting.md)
+- [Resetting and Upgrading the Block Node](../resetting-and-upgrading-the-block-node.md)
+
+### Deployment guides
+
+- [Deploy with Solo Provisioner](../solo-weaver-single-node-k8s-deployment.md)
+- [Deploy on Bare Metal (Kubernetes)](../single-node-k8s-deployment.md)
+- [Solo Provisioner Quickstart](https://github.com/hashgraph/solo-weaver/blob/main/docs/quickstart.md)
+
+### Integration guides
+
+- [Connecting a Mirror Node to a Block Node](../connecting-a-mirror-node-to-a-block-node.md)
+- [Configure Consensus Node Streaming](../consensus-node-to-block-node-configuration.md)
+
+### Specifications
+
+- [HIP-1081 - Block Node](https://hips.hedera.com/hip/hip-1081)
+- [HIP-1056 - Block Streams](https://hips.hedera.com/hip/hip-1056)
+- [HIP-1200 - hinTS](https://hips.hedera.com/hip/hip-1200)
+
+---
+
+## Useful diagnostic commands
+
+When opening a support ticket or community thread, include:
+
+```bash
+solo-provisioner version --output=json
+helm -n block-node list
+kubectl -n block-node get pods,sts,svc,events
+kubectl -n block-node logs <pod> --tail=500
+uname -a && uptime && free -h && df -h
+```

--- a/docs/block-node/operations/production-guide/install-block-node.md
+++ b/docs/block-node/operations/production-guide/install-block-node.md
@@ -1,0 +1,193 @@
+# Install the Block Node
+
+> **Before starting:** Complete all items in [Prerequisites](./prerequisites.md)
+> and confirm deployment decisions with Hashgraph DevOps.
+
+---
+
+## Step 1 - Confirm deployment decisions **[COORDINATED]**
+
+Before running any install commands, confirm the following with Hashgraph DevOps:
+
+|            Decision             |           Mainnet default           |                          Notes                           |
+|---------------------------------|-------------------------------------|----------------------------------------------------------|
+| Profile                         | `mainnet` (LFH)                     | Tier 1 is always LFH. Contact Hashgraph if you need RFH  |
+| OS                              | Ubuntu 24.04 LTS or Debian 13.4 LTS | Per hardware specification                               |
+| Storage sizes                   | Provided by Hashgraph               | Passed as `--*-size` flags at install time               |
+| Alloy remote URLs and usernames | Received during Day Minus           | Non-secret; used in the Alloy install command            |
+| Cluster name                    | `<BLOCK_NODE_CLUSTER_NAME>`         | Assigned by Hashgraph; format: `lfhNN-mainnet-blocknode` |
+| TLS posture                     | Operator decision                   | Must be coordinated before installation                  |
+| Deployment values overlay       | `<HASHGRAPH_PROVIDED_VALUES_FILE>`  | Hashgraph ships this file during Day Minus               |
+
+Hashgraph will provide a deployment values file (`<HASHGRAPH_PROVIDED_VALUES_FILE>`) - a thin
+overlay on top of the upstream canonical `lfh-values.yaml`. Keep your copy; do not modify it
+after handoff without coordination on the shared channel.
+
+---
+
+## Step 2 - Install Solo Provisioner **[OPERATOR]**
+
+```bash
+curl -sSL https://raw.githubusercontent.com/hashgraph/solo-weaver/main/install.sh | bash
+solo-provisioner --help
+```
+
+The `weaver:2500` service account and the `hedera:2000` user (used for storage ownership) are
+created automatically during installation. No system users need to be pre-created.
+
+---
+
+## Step 3 - Run preflight checks **[OPERATOR]**
+
+```bash
+sudo solo-provisioner block node check --profile=mainnet
+```
+
+This validates CPU, memory, disk, dependencies, network connectivity, and storage against the
+mainnet profile requirements.
+
+> **If preflight fails, stop.** Resolve all reported issues before proceeding. Do not run the
+> install command against a host that fails preflight.
+
+---
+
+## Step 4 - Prepare the RSA bootstrap roster **[COORDINATED]**
+
+The Block Node requires an RSA bootstrap roster at first startup for Wrapped Record Block
+(WRB) verification. This is a JSON `NodeAddressBook` mapping Consensus Node IDs to their RSA
+public keys.
+
+Default path:
+`/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json`
+(configurable via `app.state.rsaBootstrapFilePath`)
+
+Hashgraph will confirm the delivery method before installation:
+
+|   Delivery method    |                                                 How it works                                                  |
+|----------------------|---------------------------------------------------------------------------------------------------------------|
+| Pre-generated file   | Hashgraph ships the file in the chart values; provisioner places it at startup                                |
+| Mirror Node fallback | `roster.bootstrap.rsa.mirrorNodeBaseUrl` is configured; the BN fetches and caches the roster on first startup |
+
+> If neither a file nor a Mirror Node URL is configured, the Block Node warns and continues,
+> but WRB verification will not work. If the Mirror Node URL is configured but unreachable
+> and no local file exists, the Block Node retries indefinitely rather than aborting - it
+> surfaces a degraded state and keeps running. If a local cached file exists, the Block Node
+> uses it and retries the Mirror Node in the background.
+
+---
+
+## Step 5 - Install the Block Node **[OPERATOR]**
+
+A single command installs the full Kubernetes stack and the Block Node chart:
+
+```bash
+sudo solo-provisioner block node install \
+  --profile=mainnet \
+  --config=/etc/solo-provisioner/config.yaml \
+  --values=<HASHGRAPH_PROVIDED_VALUES_FILE> \
+  --plugin-preset=tier1-lfh \
+  --base-path=/opt/hiero/block-node/data \
+  --live-size=2500Gi \
+  --archive-size=<ARCHIVE_SIZE> \
+  --verification-size=30Gi \
+  --log-size=8Gi
+```
+
+**Flag notes:**
+
+- `--config` - Solo Provisioner configuration file (YAML) that sets release-level defaults
+  such as namespace, chart version, and storage paths. Hashgraph provides this file
+  (`/etc/solo-provisioner/config.yaml`) during Day Minus coordination. Do not modify it after
+  handoff without coordination.
+- `--values` - Helm values overlay for the Block Node chart, also provided by Hashgraph.
+  This is a separate file from `--config`; it configures chart-level settings such as plugins
+  and resource limits.
+- `--plugin-preset=tier1-lfh` - deploys the Local Full History plugin set required for
+  Tier 1 mainnet.
+
+**Storage layout created by this command:**
+
+|       Volume        |   Drive   |            Size             |         Flag          |                       Purpose                       |
+|---------------------|-----------|-----------------------------|-----------------------|-----------------------------------------------------|
+| `live`              | Fast NVMe | 2.5 TB                      | `--live-size`         | Recent blocks and live state (performance-critical) |
+| `archive`           | Bulk HDD  | 80% of provisioned bulk HDD | `--archive-size`      | Compressed historic block archive                   |
+| `application-state` | Bulk HDD  | 30 GB                       | `--verification-size` | Verification and application state                  |
+| `log`               | OS disk   | 8 GB                        | `--log-size`          | Logs (kept off the NVMe working set)                |
+
+> **Storage sizes are passed as flags, not in the values file.** Solo Provisioner creates the
+> PVCs from these flags; the chart references the resulting claims.
+
+**Calculating `<ARCHIVE_SIZE>`:**
+
+Set this to approximately 80% of your provisioned bulk HDD capacity. For example:
+- 100 TiB of HDD → `--archive-size=80Ti`
+- 500 TiB of HDD → `--archive-size=400Ti`
+
+The 20% headroom allows storage growth to be caught before the volume fills completely. See
+[How do I size the archive PVC?](../../operator-faq.md#how-do-i-size-the-archive-pvc-relative-to-my-bulk-storage-disk)
+for the full reasoning.
+
+**`<HASHGRAPH_PROVIDED_VALUES_FILE>`** is the cohort-pinned values overlay Hashgraph delivers
+during Day Minus. It sets chart defaults appropriate for the current mainnet release.
+
+---
+
+## Step 6 - Verify the install **[OPERATOR]**
+
+Check that the Block Node pod is running:
+
+```bash
+kubectl get pods -A
+kubectl -n block-node get pods,sts,svc
+```
+
+Check the Block Node server status. The grpcurl command requires the Block Node protobuf
+bundle, which is published as a release artifact. Download it once and reuse it for all
+checks:
+
+```bash
+# Download the protobuf bundle for the installed Block Node version
+BUNDLE_URL=$(curl -s https://api.github.com/repos/hiero-ledger/hiero-block-node/releases/latest \
+  | grep "browser_download_url.*block-node-protobuf.*tgz" \
+  | head -1 | cut -d '"' -f 4)
+curl -sL -O "$BUNDLE_URL"
+tar -xzf block-node-protobuf-*.tgz
+
+# Find the extracted directory name (use it as <VERSION> below)
+ls -d block-node-protobuf-*
+```
+
+On a fresh install with no blocks ingested yet:
+
+```bash
+grpcurl -plaintext -emit-defaults \
+  -import-path block-node-protobuf-<VERSION> \
+  -proto block-node/api/node_service.proto \
+  -d '{}' <BLOCK_NODE_PUBLIC_IP>:40840 \
+  org.hiero.block.api.BlockNodeService/serverStatus
+```
+
+Replace `<VERSION>` with the directory name from the `ls` output above.
+
+Expected response before the first block arrives:
+
+```json
+{
+  "firstAvailableBlock": "18446744073709551615",
+  "lastAvailableBlock": "18446744073709551615",
+  "onlyLatestState": false,
+  "versionInformation": null
+}
+```
+
+The value `18446744073709551615` is `uint64` max - the sentinel for "no blocks received yet."
+This persists until the first block stream arrives from the Consensus Node.
+
+---
+
+## Next step
+
+Proceed to [Configure Alloy Telemetry](./configure-alloy-telemetry.md).
+
+If opting out of telemetry, record the decision with Hashgraph DevOps and proceed directly to
+[Network Validation and Go-Live](./network-validation-go-live.md).

--- a/docs/block-node/operations/production-guide/install-block-node.md
+++ b/docs/block-node/operations/production-guide/install-block-node.md
@@ -54,8 +54,10 @@ mainnet profile requirements.
 ## Step 4 - Prepare the RSA bootstrap roster **[COORDINATED]**
 
 The Block Node requires an RSA bootstrap roster at first startup for Wrapped Record Block
-(WRB) verification. This is a JSON `NodeAddressBook` mapping Consensus Node IDs to their RSA
-public keys.
+(WRB) verification. This is a JSON `AddressBookHistory` which contains repeated
+`DatedNodeAddressBook` entries for each historical address book for the network. Each entry
+maps Consensus Node IDs to their RSA public keys and other details for a specified range of
+blocks.
 
 Default path:
 `/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json`
@@ -74,6 +76,11 @@ Hashgraph will confirm the delivery method before installation:
 > surfaces a degraded state and keeps running. If a local cached file exists, the Block Node
 > uses it and retries the Mirror Node in the background.
 
+The Block Node also re-queries the mirror node on a regular basis to retrieve any updated
+address books. This process will continue until the Cutover release (per HIP-1193), after
+which a new BN release will incorporate the final address book history file in the codebase
+and the RSA Bootstrap plugin will be removed.
+
 ---
 
 ## Step 5 - Install the Block Node **[OPERATOR]**
@@ -89,8 +96,8 @@ sudo solo-provisioner block node install \
   --base-path=/opt/hiero/block-node/data \
   --live-size=2500Gi \
   --archive-size=<ARCHIVE_SIZE> \
-  --verification-size=30Gi \
-  --log-size=8Gi
+  --application-state-size=30Gi \
+  --log-size=10Gi
 ```
 
 **Flag notes:**
@@ -107,12 +114,12 @@ sudo solo-provisioner block node install \
 
 **Storage layout created by this command:**
 
-|       Volume        |   Drive   |            Size             |         Flag          |                       Purpose                       |
-|---------------------|-----------|-----------------------------|-----------------------|-----------------------------------------------------|
-| `live`              | Fast NVMe | 2.5 TB                      | `--live-size`         | Recent blocks and live state (performance-critical) |
-| `archive`           | Bulk HDD  | 80% of provisioned bulk HDD | `--archive-size`      | Compressed historic block archive                   |
-| `application-state` | Bulk HDD  | 30 GB                       | `--verification-size` | Verification and application state                  |
-| `log`               | OS disk   | 8 GB                        | `--log-size`          | Logs (kept off the NVMe working set)                |
+|       Volume        |   Drive   |            Size             |            Flag            |                       Purpose                       |
+|---------------------|-----------|-----------------------------|----------------------------|-----------------------------------------------------|
+| `live`              | Fast NVMe | 2.5 TB                      | `--live-size`              | Recent blocks and live state (performance-critical) |
+| `archive`           | Bulk HDD  | 80% of provisioned bulk HDD | `--archive-size`           | Compressed historic block archive                   |
+| `application-state` | Bulk HDD  | 30 GB                       | `--application-state-size` | Internal application state                          |
+| `log`               | OS disk   | 10 GB                       | `--log-size`               | Logs (kept off the NVMe working set)                |
 
 > **Storage sizes are passed as flags, not in the values file.** Solo Provisioner creates the
 > PVCs from these flags; the chart references the resulting claims.
@@ -163,7 +170,7 @@ On a fresh install with no blocks ingested yet:
 grpcurl -plaintext -emit-defaults \
   -import-path block-node-protobuf-<VERSION> \
   -proto block-node/api/node_service.proto \
-  -d '{}' <BLOCK_NODE_PUBLIC_IP>:40840 \
+  -d '{}' <BLOCK_NODE_PUBLIC_IP>:40982 \
   org.hiero.block.api.BlockNodeService/serverStatus
 ```
 
@@ -181,7 +188,7 @@ Expected response before the first block arrives:
 ```
 
 The value `18446744073709551615` is `uint64` max - the sentinel for "no blocks received yet."
-This persists until the first block stream arrives from the Consensus Node.
+This value is returned until at least one block from the Consensus Node or backfill is received and stored.
 
 ---
 

--- a/docs/block-node/operations/production-guide/network-validation-go-live.md
+++ b/docs/block-node/operations/production-guide/network-validation-go-live.md
@@ -65,8 +65,8 @@ For details on the on-chain registration process, see
 Hashgraph DevOps confirms:
 - The Block Node is ingesting blocks from the configured Consensus Node
 - The Block Node is reachable on its public endpoints
-- Hashgraph adds the Block Node `/status` endpoint to the central health monitor and standard
-dashboards
+- Hashgraph adds the Block Node `/healthz` health endpoint to the central health monitor and
+standard dashboards
 
 The operator is formally added to the upgrade pool after this step.
 

--- a/docs/block-node/operations/production-guide/network-validation-go-live.md
+++ b/docs/block-node/operations/production-guide/network-validation-go-live.md
@@ -1,0 +1,101 @@
+# Network Validation and Go-Live
+
+> **Before starting:** The Block Node must be running and Alloy must be confirmed shipping
+> (or telemetry opt-out recorded) before starting this page.
+
+---
+
+## Network validation **[HASHGRAPH]**
+
+Hashgraph runs an end-to-end validation against a Hashgraph-operated reference endpoint
+during the Day Zero session. No operator-side preparation is required beyond the prerequisites.
+
+This step confirms:
+- The Block Node is reachable on its public endpoints
+- Block ingest is working correctly from a test Consensus Node
+- Metrics and logs are landing in the configured remotes (if telemetry is enabled)
+
+After validation, the Block Node is reset to a clean state before it enters production.
+
+---
+
+## Reset before go-live **[OPERATOR]**
+
+After network validation, reset the Block Node. This clears all state accumulated during
+testing so the production Block Node starts clean:
+
+```bash
+sudo solo-provisioner block node reset --profile=mainnet
+```
+
+This command:
+1. Scales the StatefulSet to 0
+2. Clears all data directories (`live`, `archive`, `application-state`, `log`)
+3. Scales the StatefulSet back to 1
+
+> **This reset is mandatory.** Without it, test data accumulated during validation pollutes
+> the production Block Node. Do not skip this step.
+
+Confirm the RSA bootstrap roster is in place at the expected path before the Block Node
+restarts. See [Install the Block Node - Step 4](./install-block-node.md#step-4--prepare-the-rsa-bootstrap-roster-coordinated).
+
+---
+
+## Network inclusion **[COORDINATED]**
+
+Network inclusion requires signing the Block Node registration transaction with the `admin_key`
+using the Hedera Transaction Tool. Hashgraph DevOps coordinates this step and provides the
+signing procedure at handoff.
+
+On the Consensus Node side, inclusion is config-driven via `block-nodes.json`. Hashgraph
+manages this configuration and the node-management tooling that distributes it to the
+Consensus Nodes.
+
+> **`admin_key` custody.** If the `admin_key` is lost, the Block Node registration cannot be
+> updated. Treat it as a production signing key from day one and document the recovery path
+> before go-live.
+
+For details on the on-chain registration process, see
+[Block Node On-Chain Registration](../../block-node-on-chain-registration.md).
+
+---
+
+## Handoff and close **[COORDINATED]**
+
+Hashgraph DevOps confirms:
+- The Block Node is ingesting blocks from the configured Consensus Node
+- The Block Node is reachable on its public endpoints
+- Hashgraph adds the Block Node `/status` endpoint to the central health monitor and standard
+dashboards
+
+The operator is formally added to the upgrade pool after this step.
+
+---
+
+## Backfill expectations
+
+After reset, the Block Node backfills block history from upstream Block Nodes. This is not
+instantaneous.
+
+Full backfill of current history - approximately 20 TB and growing - may take **days to
+several weeks**, depending on:
+- Network throughput to upstream Block Nodes
+- Bulk disk write performance on this host
+- Total history size at the time of deployment
+
+Hashgraph will confirm the backfill approach before handoff:
+
+|        Approach         |                                                      How it works                                                      |
+|-------------------------|------------------------------------------------------------------------------------------------------------------------|
+| **Live backfill**       | The Block Node comes up after reset and fills history over a multi-week window                                         |
+| **Pre-loaded snapshot** | The operator restores an archive snapshot to the bulk volume after reset, then the Block Node catches up only the tail |
+
+Track backfill progress:
+- `serverStatus` - the `firstAvailableBlock` / `lastAvailableBlock` range widens as backfill proceeds
+- Metrics: `backfill_pending_blocks`, `backfill_blocks_backfilled`, `backfill_fetch_errors`
+
+---
+
+## Next step
+
+Proceed to [Steady State Operations](./steady-state-operations.md).

--- a/docs/block-node/operations/production-guide/overview.md
+++ b/docs/block-node/operations/production-guide/overview.md
@@ -27,11 +27,11 @@ operator-owned bare-metal hardware. The supported interface for installation and
 management is **Solo Provisioner** (`solo-provisioner`), distributed from the
 [`solo-weaver`](https://github.com/hashgraph/solo-weaver) repository.
 
-|                 Component                 |                                                                     Role                                                                      |
-|-------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| **Block Node** (`hiero-block-node`)       | Ingests block streams from Consensus Nodes, maintains live state, serves block data to subscribers                                            |
-| **Solo Provisioner** (`solo-provisioner`) | Installs and manages the full host stack: Kubernetes (kubeadm/kubelet, CRI-O, Cilium, MetalLB), Helm, the Block Node chart, and Grafana Alloy |
-| **Grafana Alloy**                         | Telemetry agent shipping Prometheus metrics and Loki logs to the operator's observability infrastructure                                      |
+|                 Component                 |                                                                                     Role                                                                                     |
+|-------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Block Node** (`hiero-block-node`)       | Ingests block streams from Consensus Nodes, maintains live state, serves block data to subscribers                                                                           |
+| **Solo Provisioner** (`solo-provisioner`) | Installs and manages the full host stack: Kubernetes (kubeadm/kubelet, CRI-O, Cilium, MetalLB), the Block Node Helm chart via a Kubernetes Operator (CRD), and Grafana Alloy |
+| **Grafana Alloy**                         | Telemetry agent shipping Prometheus metrics and Loki logs to the operator's observability infrastructure                                                                     |
 
 This guide covers:
 

--- a/docs/block-node/operations/production-guide/overview.md
+++ b/docs/block-node/operations/production-guide/overview.md
@@ -1,0 +1,88 @@
+# Production Node Operation Guide - Overview
+
+> **Scope:** Tier 1 Block Node operators deploying to a production network (mainnet, testnet,
+> or future Hiero networks) using the Local Full History (LFH) profile. Examples use
+> `--profile=mainnet`; substitute the appropriate profile for your target network. Tier 2
+> deployment is not covered here.
+
+---
+
+## Who this guide is for
+
+This guide is written for:
+
+- **Council operators** deploying a Tier 1 mainnet Block Node
+- **Sysadmins and DevOps engineers** who own the host, Kubernetes cluster, and lifecycle
+- **Technical stakeholders** who need to understand the end-to-end deployment process
+
+Readers are assumed to be comfortable with Linux system administration, Kubernetes basics,
+and Helm. This is a production deployment guide, not a beginner walkthrough.
+
+---
+
+## What this guide covers
+
+A Tier 1 Block Node runs as a Helm chart inside a single-node Kubernetes cluster on
+operator-owned bare-metal hardware. The supported interface for installation and lifecycle
+management is **Solo Provisioner** (`solo-provisioner`), distributed from the
+[`solo-weaver`](https://github.com/hashgraph/solo-weaver) repository.
+
+|                 Component                 |                                                                     Role                                                                      |
+|-------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| **Block Node** (`hiero-block-node`)       | Ingests block streams from Consensus Nodes, maintains live state, serves block data to subscribers                                            |
+| **Solo Provisioner** (`solo-provisioner`) | Installs and manages the full host stack: Kubernetes (kubeadm/kubelet, CRI-O, Cilium, MetalLB), Helm, the Block Node chart, and Grafana Alloy |
+| **Grafana Alloy**                         | Telemetry agent shipping Prometheus metrics and Loki logs to the operator's observability infrastructure                                      |
+
+This guide covers:
+
+|                               Page                                |                         Content                         |
+|-------------------------------------------------------------------|---------------------------------------------------------|
+| [Prerequisites](./prerequisites.md)                               | Hardware, network, TLS, and pre-deployment coordination |
+| [Install the Block Node](./install-block-node.md)                 | Solo Provisioner install with production storage flags  |
+| [Configure Alloy Telemetry](./configure-alloy-telemetry.md)       | Grafana Alloy setup and remote-write configuration      |
+| [Network Validation and Go-Live](./network-validation-go-live.md) | Validation, reset, network inclusion, and backfill      |
+| [Steady State Operations](./steady-state-operations.md)           | Health checks, upgrades, and incident reporting         |
+| [Disaster Recovery](./disaster-recovery.md)                       | Four failure scenarios and resolution steps             |
+| [Getting Help](./getting-help.md)                                 | Support channels, community, and reference links        |
+
+---
+
+## Responsibility model
+
+Steps across this guide are labeled with who performs them:
+
+- **[OPERATOR]** - the council operator runs this independently
+- **[HASHGRAPH]** - performed or confirmed by Hashgraph DevOps before proceeding
+- **[COORDINATED]** - both parties need to be present or in communication
+
+---
+
+## Sensitive values
+
+Some values in this guide are intentionally not published. Placeholders indicate
+operator-specific or Hashgraph-provided inputs. Obtain Hashgraph-provided values through
+your approved coordination channel. Never commit secrets or credentials to version control.
+
+Common placeholders used in this guide:
+
+|                   Placeholder                   |            Who provides it            |
+|-------------------------------------------------|---------------------------------------|
+| `<BLOCK_NODE_PUBLIC_IP>`                        | Operator                              |
+| `<BLOCK_NODE_FQDN>`                             | Operator                              |
+| `<BLOCK_NODE_CLUSTER_NAME>`                     | Hashgraph DevOps                      |
+| `<ALLOWED_CN_SOURCE_IPS>`                       | Hashgraph DevOps                      |
+| `<HASHGRAPH_PROVIDED_VALUES_FILE>`              | Hashgraph DevOps (via secure channel) |
+| `<PROMETHEUS_REMOTE_WRITE_URL>` and `_USERNAME` | Hashgraph DevOps                      |
+| `<LOKI_REMOTE_WRITE_URL>` and `_USERNAME`       | Hashgraph DevOps                      |
+| `<PROMETHEUS_REMOTE_WRITE_PASSWORD>`            | Hashgraph DevOps (via secure channel) |
+| `<LOKI_REMOTE_WRITE_PASSWORD>`                  | Hashgraph DevOps (via secure channel) |
+
+---
+
+## Related documentation
+
+- [Block Node Hardware Specifications](../block-node-hardware-specifications.md)
+- [Network Ports and Protocols](../network-ports-and-protocols.md)
+- [Block Node On-Chain Registration](../../block-node-on-chain-registration.md)
+- [Operator FAQ](../../operator-faq.md)
+- [Solo Provisioner Quickstart](https://github.com/hashgraph/solo-weaver/blob/main/docs/quickstart.md)

--- a/docs/block-node/operations/production-guide/prerequisites.md
+++ b/docs/block-node/operations/production-guide/prerequisites.md
@@ -41,6 +41,7 @@ Before scheduling any installation work:
 
 > **Enterprise NVMe sizing.** Drives marketed as "8 TB" often ship at 7.84 TB, 7.68 TB, or
 > 6.4 TB usable after overprovisioning. Acceptable as long as usable space is ≥ 7.5 TB.
+> Usable space may be the aggregate capacity across multiple drives.
 
 Storage performance targets (aggregate across all drives, not per-drive):
 
@@ -68,24 +69,56 @@ For full capacity derivations and planning models, see
 
 ## Firewall and connectivity
 
-The Block Node's only required inbound exposure is the gRPC port. Lock inbound access to
-the Consensus Node source IPs provided by Hashgraph DevOps. Deny all other inbound by
+The Block Node exposes per-service ports. Lock inbound access to the **publisher port**
+(`40984`) to Consensus Node source IPs provided by Hashgraph DevOps. The remaining
+per-service ports are accessible to their respective clients. Deny all other inbound by
 default.
+
+| Port  |    Service    |                  Restrict to                   |
+|-------|---------------|------------------------------------------------|
+| 40984 | Publisher     | Consensus Node source IPs (Hashgraph-provided) |
+| 40980 | Subscriber    | Mirror Nodes and peer Block Nodes              |
+| 40981 | Block Access  | Authorized clients                             |
+| 40982 | Server Status | Monitoring and operators                       |
+| 40983 | Health        | Monitoring and operators                       |
+| 40840 | LoadBalancer  | External clients (MetalLB front-end)           |
 
 ```bash
 # nftables
-sudo nft add rule inet filter input ip saddr { <ALLOWED_CN_SOURCE_IPS> } tcp dport 40840 accept
+# Publisher port — Consensus Nodes only
+sudo nft add rule inet filter input ip saddr { <ALLOWED_CN_SOURCE_IPS> } tcp dport 40984 accept
+sudo nft add rule inet filter input tcp dport 40984 drop
+# Other per-service ports
+sudo nft add rule inet filter input tcp dport { 40840, 40980, 40981, 40982, 40983 } accept
 
-# iptables (one ACCEPT per source, then a default DROP for the port)
-sudo iptables -A INPUT -p tcp -s <ALLOWED_CN_SOURCE_IPS> --dport 40840 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 40840 -j DROP
+# iptables
+# Publisher port — Consensus Nodes only
+sudo iptables -A INPUT -p tcp -s <ALLOWED_CN_SOURCE_IPS> --dport 40984 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 40984 -j DROP
+# Other per-service ports
+for port in 40840 40980 40981 40982 40983; do
+  sudo iptables -A INPUT -p tcp --dport "$port" -j ACCEPT
+done
 
 # ufw
-sudo ufw allow from <ALLOWED_CN_SOURCE_IPS> to any port 40840 proto tcp
+# Publisher port — Consensus Nodes only
+sudo ufw allow from <ALLOWED_CN_SOURCE_IPS> to any port 40984 proto tcp
+sudo ufw deny 40984/tcp
+# Other per-service ports
+for port in 40840 40980 40981 40982 40983; do
+  sudo ufw allow "$port"/tcp
+done
 ```
 
 Replace `<ALLOWED_CN_SOURCE_IPS>` with the CN public IP(s) provided by Hashgraph DevOps.
 Persist rules across reboots per your distribution's conventions.
+
+> **Tip:** If the `/opt/hiero/block-node/application-state/known-publishers.json` configuration
+> file is populated with the Consensus Node source IPs, Solo Provisioner handles these firewall
+> rules automatically. Two related partner configuration files are also available:
+> - `inbound-partners.json` — Block Nodes permitted to backfill from this node.
+> - `outbound-partners.json` — Mirror Nodes and partner systems with priority access to the
+> `subscribeStream` API.
 
 Outbound requirements:
 
@@ -127,9 +160,11 @@ coordinated with Hashgraph DevOps before installation.
 
 **If enabling TLS on the subscriber port:**
 
-- Generate a TLS certificate and private key for `<BLOCK_NODE_FQDN>:40840` - either a
+- Configure TLS termination at the firewall, ingress controller, or load balancer — the
+  Block Node application does not terminate TLS connections.
+- Generate a TLS certificate and private key for `<BLOCK_NODE_FQDN>:40980` - either a
   publicly-trusted certificate or an org-issued certificate from internal PKI
-- Deliver the certificate, private key, and full chain to Hashgraph DevOps through the agreed
+- Deliver the certificate, and full authority chain to Hashgraph DevOps through the agreed
   secure channel
 - Record the expiry date and renewal owner - TLS material is operator-owned for the life of
   the Block Node
@@ -201,15 +236,16 @@ curl -sSI --max-time 5 https://<LOKI_REMOTE_WRITE_URL> | head -1
 # Confirm host's public IP
 curl -sS https://ifconfig.me; echo
 
-# Confirm port 40840 reachable from outside the network (run from a remote host)
-# nc -vz <BLOCK_NODE_PUBLIC_IP> 40840
+# Confirm publisher port 40984 reachable from CN source IPs (run from a remote host)
+# nc -vz <BLOCK_NODE_PUBLIC_IP> 40984
 ```
 
 Also confirm:
 
-- Static IPv4 is actually static (not ephemeral/cloud-assigned), externally reachable, and
-  shared with Hashgraph for expected-source ACLs
-- Inbound ALLOW on TCP 40840 from the Hashgraph-provided CN public IP(s) is confirmed
+- Static IPv4 (or IPv6, if preferred and supported by the hosting environment) is actually
+  static (not ephemeral/cloud-assigned), externally reachable, and shared with Hashgraph for
+  expected-source ACLs
+- Inbound ALLOW on TCP 40984 (publisher) from the Hashgraph-provided CN public IP(s) is confirmed
 - Any non-standard port configuration communicated to Hashgraph DevOps
 
 ---

--- a/docs/block-node/operations/production-guide/prerequisites.md
+++ b/docs/block-node/operations/production-guide/prerequisites.md
@@ -1,0 +1,220 @@
+# Prerequisites
+
+Complete every item in this page before scheduling the Day Zero installation session. If a
+requirement cannot be met, contact Hashgraph DevOps before proceeding.
+
+---
+
+## Coordination prerequisites **[COORDINATED]**
+
+Before scheduling any installation work:
+
+- Operator technical PoCs (primary and backup) are named and reachable
+- On-call rotation is defined and includes a 24/7 escalation path pageable by Hashgraph
+- A secure secret-exchange channel has been agreed for delivering credentials, TLS material,
+  and Alloy tokens
+- Operator PoCs are joined to the shared coordination channel with Hashgraph DevOps before
+  installation begins - coordination, troubleshooting, and Day Zero incidents all flow through
+  this channel
+
+---
+
+## Compute and memory
+
+|      Component      |                                  Requirement                                  |
+|---------------------|-------------------------------------------------------------------------------|
+| CPU                 | 24 cores / 48 threads, single-socket, ≥ 2.0 GHz base clock                    |
+| CPU benchmark floor | Geekbench 6 single-core ≥ 1500; Passmark single-threaded ≥ 2800               |
+| RAM                 | 256 GB                                                                        |
+| PCIe                | 4.0 or higher (PCIe 3.0 may be bandwidth-limited)                             |
+| Sockets             | Single-socket only - dual-socket configurations are not validated (NUMA risk) |
+
+---
+
+## Storage
+
+|             Volume              |      Drive type       |                        Capacity                         |                 Purpose                 |
+|---------------------------------|-----------------------|---------------------------------------------------------|-----------------------------------------|
+| OS disk (separate, recommended) | SSD, RAID 1 preferred | 240+ GB                                                 | OS only - keep off the NVMe working set |
+| Fast NVMe                       | NVMe SSD              | 7.5 TB usable                                           | Recent and live blocks, live state      |
+| Bulk HDD                        | HDD                   | 100 TB minimum; 500 TB recommended (≈ 4 yr at 10 k TPS) | Compressed historic block archive       |
+
+> **Enterprise NVMe sizing.** Drives marketed as "8 TB" often ship at 7.84 TB, 7.68 TB, or
+> 6.4 TB usable after overprovisioning. Acceptable as long as usable space is ≥ 7.5 TB.
+
+Storage performance targets (aggregate across all drives, not per-drive):
+
+|   Tier    | Sustained write | Sustained read | Write IOPS | Read IOPS | Random read AIO | P99 write | P99 read |
+|-----------|-----------------|----------------|------------|-----------|-----------------|-----------|----------|
+| Fast NVMe | 4 GBps          | 6 GBps         | 350 000    | 900 000   | 1 000 000       | < 300 µs  | < 200 µs |
+| Bulk HDD  | 300 MBps        | 1 GBps         | 1 200      | 4 000     | -               | -         | -        |
+
+For full capacity derivations and planning models, see
+[Block Node Hardware Specifications](../block-node-hardware-specifications.md).
+
+---
+
+## Network requirements
+
+|               Requirement                |                           Target                           |
+|------------------------------------------|------------------------------------------------------------|
+| NIC                                      | 2 × 10 Gbps minimum; 25 Gbps or bonded 10 Gbps recommended |
+| CN-to-BN latency                         | < 10 ms P95                                                |
+| CN-to-BN-to-Client latency               | < 25 ms P95                                                |
+| Burst egress at 20 k TPS, 33 subscribers | ≈ 6 Gbps                                                   |
+| Public IPv4                              | Static, dedicated to this Block Node host                  |
+
+---
+
+## Firewall and connectivity
+
+The Block Node's only required inbound exposure is the gRPC port. Lock inbound access to
+the Consensus Node source IPs provided by Hashgraph DevOps. Deny all other inbound by
+default.
+
+```bash
+# nftables
+sudo nft add rule inet filter input ip saddr { <ALLOWED_CN_SOURCE_IPS> } tcp dport 40840 accept
+
+# iptables (one ACCEPT per source, then a default DROP for the port)
+sudo iptables -A INPUT -p tcp -s <ALLOWED_CN_SOURCE_IPS> --dport 40840 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 40840 -j DROP
+
+# ufw
+sudo ufw allow from <ALLOWED_CN_SOURCE_IPS> to any port 40840 proto tcp
+```
+
+Replace `<ALLOWED_CN_SOURCE_IPS>` with the CN public IP(s) provided by Hashgraph DevOps.
+Persist rules across reboots per your distribution's conventions.
+
+Outbound requirements:
+
+- Container registry and chart repositories: `ghcr.io`, `raw.githubusercontent.com`,
+  `github.com`
+- Grafana Alloy remote-write endpoints (TLS outbound) - URLs provided by Hashgraph DevOps
+- NTP synchronized
+- DNS resolving for `ghcr.io`, the chart repo, and Alloy remotes
+
+Communicate any non-standard port configuration to Hashgraph DevOps before installation.
+
+See [Network Ports and Protocols](../network-ports-and-protocols.md) for the full port reference.
+
+---
+
+## OS and software baseline
+
+- **Operating system:** Ubuntu 24.04 LTS or Debian 13.4 LTS
+- `curl` installed; root or `sudo` access required for Solo Provisioner commands
+- No pre-existing Kubernetes installation, container runtime, or conflicting `kubelet`
+
+> **Do not pre-install Kubernetes components.** Solo Provisioner installs and manages the full
+> stack (kubeadm/kubelet, CRI-O, Cilium, MetalLB, Helm, kubectl, k9s, metrics-server). If any
+> of these are already present, plan a clean reimage before proceeding.
+
+---
+
+## TLS decision **[OPERATOR + HASHGRAPH]**
+
+Whether to enable TLS on the Block Node's gRPC endpoint is an operator decision that must be
+coordinated with Hashgraph DevOps before installation.
+
+> **Current TLS limitations by port.** As of CN 0.76, TLS on the **publish port (CN → BN)**
+> is not supported - the CN PBJ client disables TLS globally, and enabling TLS upstream on this
+> port breaks CN streaming. TLS on the **subscriber port** (MN → BN) is permitted. TLS support
+> on the publish port is targeted for a future CN release (~0.78/0.79). See
+> [Operator FAQ - TLS](../../operator-faq.md#does-the-block-node-support-tls-or-authentication-on-its-endpoints)
+> for the full per-port status.
+
+**If enabling TLS on the subscriber port:**
+
+- Generate a TLS certificate and private key for `<BLOCK_NODE_FQDN>:40840` - either a
+  publicly-trusted certificate or an org-issued certificate from internal PKI
+- Deliver the certificate, private key, and full chain to Hashgraph DevOps through the agreed
+  secure channel
+- Record the expiry date and renewal owner - TLS material is operator-owned for the life of
+  the Block Node
+
+**If not enabling TLS:**
+
+- Record the decision with Hashgraph DevOps
+
+---
+
+## Hosting and host access
+
+- Tier 1 datacenter posture (physical and logical security, audit-ready) per HIP-1081
+- Geographic and provider diversity from other council Block Node operators (Hashgraph tracks)
+- Low latency to the operator's Consensus Node where applicable
+- Host access (SSH, jump hosts, bastions, MFA, key rotation) is entirely the operator's
+  responsibility - Hashgraph does not install or operate access tooling on mainnet operator
+  hardware
+- On-call engineers must be able to reach the host within the timeframes set out in the
+  Operating Agreement
+
+---
+
+## Observability prerequisites **[COORDINATED]**
+
+Receive the following from Hashgraph DevOps through the approved coordination channel before
+installation:
+
+- Prometheus remote-write URL (`<PROMETHEUS_REMOTE_WRITE_URL>`)
+- Prometheus remote-write username (`<PROMETHEUS_REMOTE_WRITE_USERNAME>`)
+- Loki remote-write URL (`<LOKI_REMOTE_WRITE_URL>`)
+- Loki remote-write username (`<LOKI_REMOTE_WRITE_USERNAME>`)
+- Write-only access tokens for each remote (delivered via secure channel, handled separately
+  from the install command)
+
+Telemetry is opt-out for council Tier 1 operators during the initial deployment period.
+Contact Hashgraph DevOps if you need to opt out.
+
+---
+
+## Business onboarding prerequisites **[HASHGRAPH]**
+
+The following are confirmed by Hashgraph governance before handoff:
+
+- Technical sponsor and business sponsor assigned
+- Node specification approved (CPU/RAM/disk/NIC)
+- Hosting facility and geographic location approved (HIP-1081 diversity check)
+- Operator `admin_key` structure recorded - BN registration requires signing the registration
+  transaction with this key using the Hedera Transaction Tool; Hashgraph provides the signing
+  steps at handoff
+
+---
+
+## Network preflight checklist **[OPERATOR]**
+
+Run the following on the host before scheduling the Day Zero session. If any check fails,
+resolve it before proceeding - if these fail, the install will too.
+
+```bash
+# Resolve container registry and chart repository hosts
+for h in ghcr.io raw.githubusercontent.com github.com; do
+  getent hosts "$h" >/dev/null && echo "  ok $h" || echo "  FAIL $h"
+done
+
+# Confirm outbound TLS reach to Grafana Alloy remotes
+curl -sSI --max-time 5 https://<PROMETHEUS_REMOTE_WRITE_URL> | head -1
+curl -sSI --max-time 5 https://<LOKI_REMOTE_WRITE_URL> | head -1
+
+# Confirm host's public IP
+curl -sS https://ifconfig.me; echo
+
+# Confirm port 40840 reachable from outside the network (run from a remote host)
+# nc -vz <BLOCK_NODE_PUBLIC_IP> 40840
+```
+
+Also confirm:
+
+- Static IPv4 is actually static (not ephemeral/cloud-assigned), externally reachable, and
+  shared with Hashgraph for expected-source ACLs
+- Inbound ALLOW on TCP 40840 from the Hashgraph-provided CN public IP(s) is confirmed
+- Any non-standard port configuration communicated to Hashgraph DevOps
+
+---
+
+## Next step
+
+Once all prerequisites above are confirmed, proceed to
+[Install the Block Node](./install-block-node.md).

--- a/docs/block-node/operations/production-guide/steady-state-operations.md
+++ b/docs/block-node/operations/production-guide/steady-state-operations.md
@@ -1,0 +1,140 @@
+# Steady State Operations
+
+Day-to-day operations reference for Tier 1 Block Node operators on mainnet.
+
+---
+
+## Set the pod variable
+
+Set `$BN` once per session to avoid typing the full pod name in every command:
+
+```bash
+export BN=$(kubectl -n block-node get pod \
+  -l app.kubernetes.io/name=block-node-server -o name | head -1)
+```
+
+---
+
+## Health checks
+
+|              Task               |                                   Command                                    |
+|---------------------------------|------------------------------------------------------------------------------|
+| Quick health (all namespaces)   | `kubectl get pods -A \| grep -v Running`                                     |
+| Block Node pod(s)               | `kubectl -n block-node get pods -l app.kubernetes.io/name=block-node-server` |
+| Block Node service and endpoint | `kubectl -n block-node get svc,endpoints`                                    |
+| Alloy pod(s)                    | `kubectl -n grafana-alloy get pods`                                          |
+| Recent cluster events           | `kubectl get events -A --sort-by=.lastTimestamp \| tail -40`                 |
+| k9s TUI                         | `k9s`                                                                        |
+
+---
+
+## Key metrics
+
+Dashboard links are provided by Hashgraph DevOps at handoff. The most important metrics to
+watch:
+
+|         Category         |                                                          Metrics                                                          |               What to watch for                |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------|------------------------------------------------|
+| Node state               | `app_state_status`, `app_historical_oldest_block`, `app_historical_newest_block`                                          | Non-RUNNING status or stalled block height     |
+| Ingestion (publisher)    | `publisher_block_items_received`, `publisher_open_connections`, `publisher_stream_errors`, `publisher_receive_latency_ns` | Drop in receive rate, rising latency or errors |
+| Verification             | `verification_blocks_failed`, `verification_blocks_error`, `verification_block_time`                                      | Spikes in failures or verification time        |
+| Storage                  | `files_recent_total_bytes_stored`, `files_historic_total_bytes_stored`, `files_recent_persistence_time_latency_ns`        | Growth rate or latency spikes                  |
+| Messaging / backpressure | `messaging_item_queue_percent_used`, `messaging_notification_queue_percent_used`                                          | Queue saturation                               |
+| Subscribers              | `subscriber_open_connections`, `subscriber_errors`                                                                        | Dropped clients or streaming errors            |
+| Backfill                 | `backfill_blocks_backfilled`, `backfill_fetch_errors`, `backfill_pending_blocks`                                          | Rising errors or stuck backfill                |
+| Cloud archive            | `cloud_storage_archive_failed_tasks`, `cloud_storage_archive_blocks_written`                                              | Archival failures or stalled writes            |
+| Host                     | CPU, RAM, disk IO, NIC throughput                                                                                         | Resource saturation                            |
+
+---
+
+## Logs
+
+```bash
+kubectl -n block-node logs -f $BN              # tail live
+kubectl -n block-node logs $BN --since=5m      # recent logs
+kubectl -n block-node logs $BN --previous      # post-crash container logs
+kubectl -n block-node exec -it $BN -- bash     # shell into pod
+```
+
+Key log tags to grep for:
+
+|             Tag             |               Indicates                |
+|-----------------------------|----------------------------------------|
+| `StreamPublisherPlugin`     | Incoming blocks from Consensus Nodes   |
+| `VerificationServicePlugin` | Signature or proof validation failures |
+
+---
+
+## Pod operations
+
+|                      Task                       |                          Command                           |
+|-------------------------------------------------|------------------------------------------------------------|
+| Describe pod                                    | `kubectl -n block-node describe $BN`                       |
+| Rolling restart                                 | `kubectl -n block-node rollout restart sts/<RELEASE_NAME>` |
+| Watch rollout                                   | `kubectl -n block-node rollout status sts/<RELEASE_NAME>`  |
+| Solo Provisioner version                        | `solo-provisioner version`                                 |
+| Installed Helm releases (find `<RELEASE_NAME>`) | `helm -n block-node list`                                  |
+
+Replace `<RELEASE_NAME>` with the name shown in the `NAME` column of `helm -n block-node list`.
+
+---
+
+## Upgrades **[OPERATOR]**
+
+Upgrade obligations and timing are governed by the Operating Agreement. Hashgraph publishes
+chart versions and release notes; operators schedule upgrades against their own
+change-management process. Coordinate cohort-wide staggering on the shared channel to avoid
+simultaneous restarts. Security-critical upgrades are flagged by Hashgraph DevOps.
+
+```bash
+sudo solo-provisioner block node upgrade \
+  --profile=mainnet \
+  --values=<UPDATED_VALUES_FILE> \
+  --no-reuse-values \
+  --chart-version=<X.Y.Z>
+```
+
+Notes:
+- `<UPDATED_VALUES_FILE>` is the values overlay Hashgraph provides for the new release
+- `--no-reuse-values` discards any previously applied values and uses only the specified
+file - always pass this flag to avoid inheriting stale chart defaults from a previous install
+- Use `--with-reset` only when explicitly instructed by Hashgraph DevOps - this clears all
+block data and triggers a full re-backfill
+
+---
+
+## Incident reporting
+
+When opening a support ticket, attach:
+
+```bash
+solo-provisioner version --output=json
+helm -n block-node list
+kubectl -n block-node get pods,sts,svc,events
+kubectl -n block-node logs $BN --tail=2000
+uname -a && uptime && free -h && df -h
+```
+
+Escalate through the agreed shared channel with Hashgraph DevOps. For P0 incidents, use the
+on-call contact provided at handoff.
+
+---
+
+## Backups and pre-incident hygiene
+
+- Hashgraph does **not** back up `live`, `archive`, or `application-state` volumes - block
+  data is reproducible from upstream by design
+- Hashgraph retains telemetry shipped via Alloy, subject to platform retention windows
+- Keep operator-side copies of `<HASHGRAPH_PROVIDED_VALUES_FILE>`, the RSA bootstrap roster
+  file (if using the pre-generated delivery path), and the TLS bundle
+- Document the `admin_key` recovery path - losing the key means the registration cannot be
+  updated
+
+---
+
+## Related documentation
+
+- [Resetting and Upgrading the Block Node](../resetting-and-upgrading-the-block-node.md)
+- [Troubleshooting](../../troubleshooting.md)
+- [Operator FAQ](../../operator-faq.md)
+- [Metrics Reference](../../metrics.md)


### PR DESCRIPTION
## Reviewer Notes
Creates a new 'Production Node Operation Guide' section for Tier 1 Block Node operators deploying to production networks (mainnet, testnet, or future Hiero networks) using the Local Full History (LFH) profile.

Content is derived from Keifer's Tier 1 Block Node Operator Package PDF (2026-06-03), rewritten for public docs, generalized beyond mainnet, and cross-verified against the hiero-block-node and solo-weaver codebases. All sensitive values (IPs, FQDNs, credentials, cluster names) are replaced with labelled placeholders directing operators to Hashgraph DevOps.

Pages added (8):
- overview.md — audience, architecture, responsibility model
- prerequisites.md — hardware, network, TLS, preflight checklist
- install-block-node.md — Solo Provisioner install (profile=mainnet, plugin-preset=tier1-lfh, storage flags, RSA bootstrap roster)
- configure-alloy-telemetry.md — Grafana Alloy setup and remote-write
- network-validation-go-live.md — validation, reset, inclusion, backfill
- steady-state-operations.md — health checks, metrics, upgrades, incident
- disaster-recovery.md — four failure scenarios (A-D)
- getting-help.md — support channels, community, reference docs

## Related Issue(s)
 Closes #3187 