### PR TITLE
chore: Resume hanging temp archive uploads across restarts instead of always discarding them

### DIFF
--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTask.java
@@ -248,8 +248,11 @@ public class BlockUploadTask implements Callable<UploadResult> {
                 // fall back to blockNum so the notification is never dropped.
                 final Map.Entry<Long, BlockSource> last =
                         blocksInBuffer.isEmpty() ? Map.entry(blockNum, blockSource) : blocksInBuffer.lastEntry();
-                blockMessaging.sendBlockPersisted(
-                        new PersistedNotification(last.getKey(), true, 1_000, last.getValue()));
+                blockMessaging.sendBlockPersisted(new PersistedNotification(
+                        last.getKey(),
+                        true,
+                        CloudStorageArchivePlugin.CLOUD_ARCHIVE_PERSISTENCE_NOTIFICATION_PRIORITY,
+                        last.getValue()));
                 final long rangeStart = blocksInBuffer.isEmpty() ? blockNum : blocksInBuffer.firstKey();
                 applicationStateFacility.addStoredBlockRange(new LongRange(rangeStart, last.getKey()));
                 metricsHolder.blocksWritten().increment(blocksInBuffer.size());
@@ -266,7 +269,11 @@ public class BlockUploadTask implements Callable<UploadResult> {
             final BlockSource firstBlockSource = blocksInBuffer.isEmpty()
                     ? blockSource
                     : blocksInBuffer.firstEntry().getValue();
-            blockMessaging.sendBlockPersisted(new PersistedNotification(firstBlockNum, false, 1_000, firstBlockSource));
+            blockMessaging.sendBlockPersisted(new PersistedNotification(
+                    firstBlockNum,
+                    false,
+                    CloudStorageArchivePlugin.CLOUD_ARCHIVE_PERSISTENCE_NOTIFICATION_PRIORITY,
+                    firstBlockSource));
             LOGGER.log(INFO, "Failed to upload part containing blocks %d to %d".formatted(firstBlockNum, blockNum), e);
             return null;
         }
@@ -296,15 +303,22 @@ public class BlockUploadTask implements Callable<UploadResult> {
             doUploadPart(buffer, s3, uploadId, etags);
         } catch (S3ResponseException | IOException e) {
             final Map.Entry<Long, BlockSource> first = blocksInBuffer.firstEntry();
-            blockMessaging.sendBlockPersisted(
-                    new PersistedNotification(first.getKey(), false, 1_000, first.getValue()));
+            blockMessaging.sendBlockPersisted(new PersistedNotification(
+                    first.getKey(),
+                    false,
+                    CloudStorageArchivePlugin.CLOUD_ARCHIVE_PERSISTENCE_NOTIFICATION_PRIORITY,
+                    first.getValue()));
             LOGGER.log(INFO, "Failed to upload final part for key {0}", key, e);
             partResult = UploadResult.FAILED;
             // Consistent with flushPartIfNeeded(): false notification signals failure; no retry here.
         }
         if (partResult == UploadResult.SUCCESS) {
             final Map.Entry<Long, BlockSource> last = blocksInBuffer.lastEntry();
-            blockMessaging.sendBlockPersisted(new PersistedNotification(last.getKey(), true, 1_000, last.getValue()));
+            blockMessaging.sendBlockPersisted(new PersistedNotification(
+                    last.getKey(),
+                    true,
+                    CloudStorageArchivePlugin.CLOUD_ARCHIVE_PERSISTENCE_NOTIFICATION_PRIORITY,
+                    last.getValue()));
             applicationStateFacility.addStoredBlockRange(new LongRange(blocksInBuffer.firstKey(), last.getKey()));
             metricsHolder.blocksWritten().increment(blocksInBuffer.size());
             metricsHolder.storedBytes().increment(buffer.length);

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
@@ -8,7 +8,9 @@ import static java.lang.System.Logger.Level.WARNING;
 import static java.util.Objects.requireNonNull;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -181,6 +183,11 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     /// Accessed only from the notification handler thread.
     final ConcurrentSkipListMap<Long, BlockWithSource> tempOverflowStash = new ConcurrentSkipListMap<>();
 
+    /// Resumed temp archives deferred at startup because [CloudStorageArchiveConfig#maxConcurrentTempArchives()]
+    /// was already reached. Drained in order whenever a temp upload slot frees up.
+    /// Accessed only from the notification handler thread.
+    final Deque<TempArchiveResumeState> pendingResumedArchives = new ArrayDeque<>();
+
     /// Groups whose temp archives fully cover `[groupStart, groupStart+groupSize)`, queued for
     /// consolidation.  Keyed by groupStart.
     /// Accessed only from the notification handler thread.
@@ -232,6 +239,7 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                 // the current block since the plugin is shutting down.
                 if (!checkCompletedUpload()) {
                     checkAndDrainTempUploadResults();
+                    drainPendingResumedArchives();
                     drainOverflowStash();
                     checkAndDrainConsolidations();
                     // While recovery is running, stash every block.  routeVerifiedBlock() sends
@@ -383,8 +391,8 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     }
 
     /// Re-routes blocks from [tempOverflowStash] in block-number order while upload slots are free.
-    /// Called after [checkAndDrainTempUploadResults] so that any just-freed slots are visible.
-    /// Skipped during recovery to avoid racing with the recovery result.
+    /// Called after [checkAndDrainTempUploadResults] and [#drainPendingResumedArchives] so that any
+    /// just-freed slots are visible. Skipped during recovery to avoid racing with the recovery result.
     ///
     /// A block is always eligible to drain if its group already has an active streaming queue
     /// (adding to an existing segment costs no new slot).  A block whose group has no active queue
@@ -527,7 +535,11 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
 
     /// Resumes each hanging temp archive upload found by [StartupRecoveryTask].  When two entries
     /// share a groupStart, only the one with the highest [TempArchiveResumeState#nextBlockNumber()]
-    /// becomes the active queue for that group; the others finalise immediately via `SEGMENT_END`.
+    /// becomes the active queue for that group; the others finalise immediately via `SEGMENT_END`,
+    /// uncapped since finalising is one-shot, not an ongoing slot. Active winners beyond
+    /// [CloudStorageArchiveConfig#maxConcurrentTempArchives()] (counted via [tempGroupActiveQueues],
+    /// which only winners occupy) are deferred to [pendingResumedArchives] and started later by
+    /// [#drainPendingResumedArchives].
     private void resumeHangingTempArchives(List<TempArchiveResumeState> resumableTempArchives) {
         final Map<Long, TempArchiveResumeState> activeResumedByGroup = new HashMap<>();
         for (final TempArchiveResumeState resumed : resumableTempArchives) {
@@ -539,30 +551,59 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
         }
         for (final TempArchiveResumeState resumed : resumableTempArchives) {
             final long groupStart = (resumed.firstBlock() / groupSize) * groupSize;
-            final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
             tempSegmentLastBlock.put(resumed.firstBlock(), resumed.nextBlockNumber() - 1);
-            if (activeResumedByGroup.get(groupStart) == resumed) {
-                tempGroupActiveQueues.put(groupStart, queue);
-                tempGroupActiveSegmentFirstBlock.put(groupStart, resumed.firstBlock());
-                tempGroupNextExpected.put(groupStart, resumed.nextBlockNumber());
-            } else {
+            if (activeResumedByGroup.get(groupStart) != resumed) {
+                final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
                 queue.offer(TempArchiveUploadTask.SEGMENT_END);
                 LOGGER.log(
                         TRACE,
                         "Resumable temp archive firstBlock={0} for group {1} superseded; finalising as-is",
                         resumed.firstBlock(),
                         groupStart);
+                tempUploadFutures.put(
+                        resumed.firstBlock(),
+                        virtualThreadExecutor.submit(newResumedTempArchiveUploadTask(
+                                resumed.s3Key(), resumed.firstBlock(), queue, resumed)));
+            } else if (tempGroupActiveQueues.size() >= config.maxConcurrentTempArchives()) {
+                pendingResumedArchives.add(resumed);
+                LOGGER.log(
+                        TRACE,
+                        "Concurrent temp archive limit ({0}) reached; deferring resume of firstBlock={1} for group {2}",
+                        config.maxConcurrentTempArchives(),
+                        resumed.firstBlock(),
+                        groupStart);
+            } else {
+                startResumedTempSegment(groupStart, resumed);
             }
-            tempUploadFutures.put(
-                    resumed.firstBlock(),
-                    virtualThreadExecutor.submit(
-                            newResumedTempArchiveUploadTask(resumed.s3Key(), resumed.firstBlock(), queue, resumed)));
-            LOGGER.log(
-                    TRACE,
-                    "Resumed hanging temp archive for group {0}, firstBlock={1}, nextBlockNumber={2}",
-                    groupStart,
-                    resumed.firstBlock(),
-                    resumed.nextBlockNumber());
+        }
+    }
+
+    /// Starts (or resumes, via [#drainPendingResumedArchives]) the active streaming segment for
+    /// `resumed`, registering it as the group's active queue and submitting its upload task.
+    private void startResumedTempSegment(long groupStart, TempArchiveResumeState resumed) {
+        final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
+        tempGroupActiveQueues.put(groupStart, queue);
+        tempGroupActiveSegmentFirstBlock.put(groupStart, resumed.firstBlock());
+        tempGroupNextExpected.put(groupStart, resumed.nextBlockNumber());
+        tempUploadFutures.put(
+                resumed.firstBlock(),
+                virtualThreadExecutor.submit(
+                        newResumedTempArchiveUploadTask(resumed.s3Key(), resumed.firstBlock(), queue, resumed)));
+        LOGGER.log(
+                TRACE,
+                "Resumed hanging temp archive for group {0}, firstBlock={1}, nextBlockNumber={2}",
+                groupStart,
+                resumed.firstBlock(),
+                resumed.nextBlockNumber());
+    }
+
+    /// Starts deferred resumed temp archives (see [#resumeHangingTempArchives]) in the order
+    /// [StartupRecoveryTask] returned them, one per freed slot, while
+    /// [CloudStorageArchiveConfig#maxConcurrentTempArchives()] allows it.
+    private void drainPendingResumedArchives() {
+        while (!pendingResumedArchives.isEmpty() && tempUploadFutures.size() < config.maxConcurrentTempArchives()) {
+            final TempArchiveResumeState resumed = pendingResumedArchives.poll();
+            startResumedTempSegment((resumed.firstBlock() / groupSize) * groupSize, resumed);
         }
     }
 
@@ -590,13 +631,16 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
         }
     }
 
-    /// Returns `true` when the group starting at `groupStart` has any in-flight or completed
-    /// temporary archive data (active streaming segments, in-flight futures, or tracker entries).
+    /// Returns `true` when the group starting at `groupStart` has any in-flight, completed, or
+    /// deferred-but-pending temporary archive data (active streaming segments, in-flight futures,
+    /// tracker entries, or a resumed archive waiting in [pendingResumedArchives] for a free slot).
     private boolean hasAnyTempDataForGroup(long groupStart) {
         final long groupEnd = groupStart + groupSize;
         return tempGroupActiveQueues.containsKey(groupStart)
                 || !tempUploadFutures.subMap(groupStart, groupEnd).isEmpty()
-                || !tempArchiveTracker.subMap(groupStart, groupEnd).isEmpty();
+                || !tempArchiveTracker.subMap(groupStart, groupEnd).isEmpty()
+                || pendingResumedArchives.stream()
+                        .anyMatch(r -> (r.firstBlock() / groupSize) * groupSize == groupStart);
     }
 
     /// Initialises a new [BlockUploadTask] for the group that contains `blockNumber`, submits it
@@ -912,6 +956,16 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                 }
             }
         }
+        if (!covered) {
+            // Deferred resumed archives (see resumeHangingTempArchives) aren't in tempUploadFutures
+            // yet, but their pre-crash range was already durably uploaded.
+            for (TempArchiveResumeState pending : pendingResumedArchives) {
+                if (blockNumber >= pending.firstBlock() && blockNumber < pending.nextBlockNumber()) {
+                    covered = true;
+                    break;
+                }
+            }
+        }
         return covered;
     }
 
@@ -1027,6 +1081,7 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
         tempSegmentLastBlock.clear();
         tempUploadFutures.clear();
         tempOverflowStash.clear();
+        pendingResumedArchives.clear();
         pendingConsolidations.clear();
         consolidationFutures.clear();
         LOGGER.log(TRACE, "Cloud storage archive plugin stopped");

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
@@ -535,10 +535,10 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
 
     /// Resumes each hanging temp archive upload found by [StartupRecoveryTask].  When two entries
     /// share a groupStart, only the one with the highest [TempArchiveResumeState#nextBlockNumber()]
-    /// becomes the active queue for that group; the others finalise immediately via `SEGMENT_END`,
-    /// uncapped since finalising is one-shot, not an ongoing slot. Active winners beyond
-    /// [CloudStorageArchiveConfig#maxConcurrentTempArchives()] (counted via [tempGroupActiveQueues],
-    /// which only winners occupy) are deferred to [pendingResumedArchives] and started later by
+    /// becomes the active queue for that group; the others finalise immediately via `SEGMENT_END`.
+    /// Active winners beyond [CloudStorageArchiveConfig#maxConcurrentTempArchives()] (counted via
+    /// [tempUploadFutures], the same gate used by [#drainPendingResumedArchives] and
+    /// [#drainOverflowStash]) are deferred to [pendingResumedArchives] and started later by
     /// [#drainPendingResumedArchives].
     private void resumeHangingTempArchives(List<TempArchiveResumeState> resumableTempArchives) {
         final Map<Long, TempArchiveResumeState> activeResumedByGroup = new HashMap<>();
@@ -564,7 +564,7 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                         resumed.firstBlock(),
                         virtualThreadExecutor.submit(newResumedTempArchiveUploadTask(
                                 resumed.s3Key(), resumed.firstBlock(), queue, resumed)));
-            } else if (tempGroupActiveQueues.size() >= config.maxConcurrentTempArchives()) {
+            } else if (tempUploadFutures.size() >= config.maxConcurrentTempArchives()) {
                 pendingResumedArchives.add(resumed);
                 LOGGER.log(
                         TRACE,

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
@@ -9,6 +9,7 @@ import static java.util.Objects.requireNonNull;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,10 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
 
     /// The logger for this class.
     private static final System.Logger LOGGER = System.getLogger(CloudStorageArchivePlugin.class.getName());
+
+    /// Block-provider priority used in [org.hiero.block.node.spi.blockmessaging.PersistedNotification]s
+    /// sent by this plugin.
+    public static final int CLOUD_ARCHIVE_PERSISTENCE_NOTIFICATION_PRIORITY = 1_000;
 
     public static final MetricKey<LongCounter> METRIC_CLOUD_ARCHIVE_BLOCKS_WRITTEN = MetricKey.of(
                     "cloud_storage_archive_blocks_written", LongCounter.class)
@@ -442,7 +447,8 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     /// Consumes the result of the [StartupRecoveryTask] and, when the prior S3 state is
     /// discovered, sets [currentGroupStart], creates a fresh [BlockingQueue], and submits a
     /// [BlockUploadTask] for the recovered group before replaying any blocks that arrived during
-    /// recovery.  Also rebuilds [tempArchiveTracker] from any durable temporary archives found.
+    /// recovery.  Also rebuilds [tempArchiveTracker] from any durable temporary archives found, and
+    /// resumes any hanging temp archive uploads found resumable.
     ///
     /// When the result is a fresh start, no upload task is created and the next call to
     /// [handleVerification] will fall through to [tryStartNewUploadTask] as normal.
@@ -459,7 +465,7 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                 // Rebuild the temporary-archive tracker from startup recovery.  These archives
                 // survived a restart so their block ranges must be re-registered with the state
                 // facility (the upload task's per-run registration did not survive the restart).
-                if (result.tempArchives() != null) {
+                if (!result.tempArchives().isEmpty()) {
                     for (final TempArchiveEntry entry : result.tempArchives()) {
                         tempArchiveTracker.put(entry.firstBlock(), entry);
                         context.applicationStateFacility()
@@ -476,33 +482,87 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                             .forEach(this::checkGroupCoverage);
                 }
 
+                resumeHangingTempArchives(result.resumableTempArchives());
+
                 lastHandedOffBlock = result.lastHandedOffBlock();
 
                 if (result.currentGroupStart() != -1) {
-                    currentGroupStart = result.currentGroupStart();
-                    nextBlockToQueue = result.uploadId() != null ? result.nextBlockNumber() : currentGroupStart;
                     if (result.completedRanges() != null) {
                         result.completedRanges().streamRanges().forEach(range -> context.applicationStateFacility()
                                 .addStoredBlockRange(range));
-                    } else if (nextBlockToQueue > 0) {
-                        // Case 2 (resume): completed archives unknown; fall back to broad range
-                        context.applicationStateFacility().addStoredBlockRange(new LongRange(0, nextBlockToQueue - 1));
                     }
-                    currentBlockQueue = new LinkedBlockingQueue<>();
-                    currentUploadFuture = virtualThreadExecutor.submit(new BlockUploadTask(
-                            config,
-                            context.blockMessaging(),
-                            currentGroupStart,
-                            groupSize,
-                            currentBlockQueue,
-                            result.uploadId() != null ? result : null,
-                            metricsHolder,
-                            context.applicationStateFacility()));
+                    // Don't start a Case 1 (uploadId == null) regular task for a group that
+                    // resumeHangingTempArchives() just claimed -- same guard as tryStartNewUploadTask.
+                    if (result.uploadId() != null || !hasAnyTempDataForGroup(result.currentGroupStart())) {
+                        currentGroupStart = result.currentGroupStart();
+                        nextBlockToQueue = result.uploadId() != null ? result.nextBlockNumber() : currentGroupStart;
+                        if (result.completedRanges() == null && nextBlockToQueue > 0) {
+                            // Case 2 (resume): completed archives unknown; fall back to broad range
+                            context.applicationStateFacility()
+                                    .addStoredBlockRange(new LongRange(0, nextBlockToQueue - 1));
+                        }
+                        currentBlockQueue = new LinkedBlockingQueue<>();
+                        currentUploadFuture = virtualThreadExecutor.submit(new BlockUploadTask(
+                                config,
+                                context.blockMessaging(),
+                                currentGroupStart,
+                                groupSize,
+                                currentBlockQueue,
+                                result.uploadId() != null ? result : null,
+                                metricsHolder,
+                                context.applicationStateFacility()));
+                    } else {
+                        LOGGER.log(
+                                TRACE,
+                                "Group {0} has resumed temp archive data; skipping regular upload start",
+                                result.currentGroupStart());
+                    }
                 }
                 tryReplayStash();
             } finally {
                 recoveryFuture = null;
             }
+        }
+    }
+
+    /// Resumes each hanging temp archive upload found by [StartupRecoveryTask].  When two entries
+    /// share a groupStart, only the one with the highest [TempArchiveResumeState#nextBlockNumber()]
+    /// becomes the active queue for that group; the others finalise immediately via `SEGMENT_END`.
+    private void resumeHangingTempArchives(List<TempArchiveResumeState> resumableTempArchives) {
+        final Map<Long, TempArchiveResumeState> activeResumedByGroup = new HashMap<>();
+        for (final TempArchiveResumeState resumed : resumableTempArchives) {
+            final long groupStart = (resumed.firstBlock() / groupSize) * groupSize;
+            final TempArchiveResumeState current = activeResumedByGroup.get(groupStart);
+            if (current == null || resumed.nextBlockNumber() > current.nextBlockNumber()) {
+                activeResumedByGroup.put(groupStart, resumed);
+            }
+        }
+        for (final TempArchiveResumeState resumed : resumableTempArchives) {
+            final long groupStart = (resumed.firstBlock() / groupSize) * groupSize;
+            final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
+            tempSegmentLastBlock.put(resumed.firstBlock(), resumed.nextBlockNumber() - 1);
+            if (activeResumedByGroup.get(groupStart) == resumed) {
+                tempGroupActiveQueues.put(groupStart, queue);
+                tempGroupActiveSegmentFirstBlock.put(groupStart, resumed.firstBlock());
+                tempGroupNextExpected.put(groupStart, resumed.nextBlockNumber());
+            } else {
+                queue.offer(TempArchiveUploadTask.SEGMENT_END);
+                LOGGER.log(
+                        TRACE,
+                        "Resumable temp archive firstBlock={0} for group {1} superseded; finalising as-is",
+                        resumed.firstBlock(),
+                        groupStart);
+            }
+            tempUploadFutures.put(
+                    resumed.firstBlock(),
+                    virtualThreadExecutor.submit(
+                            newResumedTempArchiveUploadTask(resumed.s3Key(), resumed.firstBlock(), queue, resumed)));
+            LOGGER.log(
+                    TRACE,
+                    "Resumed hanging temp archive for group {0}, firstBlock={1}, nextBlockNumber={2}",
+                    groupStart,
+                    resumed.firstBlock(),
+                    resumed.nextBlockNumber());
         }
     }
 
@@ -586,6 +646,21 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                 s3Key,
                 firstBlock,
                 queue);
+    }
+
+    /// Creates the [Callable] for a [TempArchiveUploadTask] resuming a hanging upload found by
+    /// [StartupRecoveryTask].  Extracted for test overriding.
+    Callable<TempArchiveEntry> newResumedTempArchiveUploadTask(
+            String s3Key, long firstBlock, BlockingQueue<BlockWithSource> queue, TempArchiveResumeState resumeState) {
+        return new TempArchiveUploadTask(
+                config,
+                context.blockMessaging(),
+                context.applicationStateFacility(),
+                metricsHolder,
+                s3Key,
+                firstBlock,
+                queue,
+                resumeState);
     }
 
     /// Starts a new upload task if none is active, then routes `blockNumber` to the regular pending

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
@@ -211,8 +211,6 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                     "Cloud storage archive plugin is not active because of empty values for the following configurations: {0}",
                     String.join(", ", violations));
         } else {
-            // register to listen to block notifications if config is valid
-            context.blockMessaging().registerBlockNotificationHandler(this, false, "Cloud Storage Archive");
             configValid = true;
         }
         groupSize = Math.powExact(10, config.groupingLevel());
@@ -222,10 +220,10 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     @Override
     public void start() {
         virtualThreadExecutor = context.threadPoolManager().getVirtualThreadExecutor();
-        // Skip recovery when config is invalid: the handler is not registered, so the result
-        // would never be consumed and the task would fail immediately with a bad-config S3 error.
         if (configValid) {
             recoveryFuture = virtualThreadExecutor.submit(new StartupRecoveryTask(config));
+            // register to listen to block notifications if config is valid
+            context.blockMessaging().registerBlockNotificationHandler(this, false, "Cloud Storage Archive");
         }
         LOGGER.log(TRACE, "Cloud storage archive plugin started");
     }

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/RecoveryResult.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/RecoveryResult.java
@@ -29,8 +29,9 @@ import org.hiero.block.node.base.ranges.ConcurrentLongRangeSet;
 ///                          by [BlockUploadTask] to seed its accumulation buffer so that the
 ///                          previously-started S3 part is completed correctly on resume;
 ///                          non-null when [uploadId] is non-null
-/// @param tempArchives      temporary archives found in S3 during startup; `null` on mid-run
-///                          recovery paths that skip the temporary-archive scan
+/// @param tempArchives      temporary archives found in S3 during startup; empty when none exist
+/// @param resumableTempArchives hanging temp archive uploads found resumable during startup;
+///                          several can coexist, unlike the regular path's single resume slot
 /// @param lastHandedOffBlock the last block number handed off to any upload task before the
 ///                           restart, or `-1` when nothing was archived yet (fresh start)
 /// @param completedRanges   the ranges of completed tar archives found during startup, so that
@@ -45,5 +46,6 @@ record RecoveryResult(
         long nextBlockNumber,
         byte[] trailingBytes,
         List<TempArchiveEntry> tempArchives,
+        List<TempArchiveResumeState> resumableTempArchives,
         long lastHandedOffBlock,
         ConcurrentLongRangeSet completedRanges) {}

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTask.java
@@ -141,7 +141,8 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
         final List<String> allTarKeys = findAllTarKeys(s3);
         if (allTarKeys.isEmpty()) {
             LOGGER.log(TRACE, "No prior state found in S3 bucket, starting fresh");
-            recoveryResult = new RecoveryResult(-1, null, null, 0, null, null, null, -1, new ConcurrentLongRangeSet());
+            recoveryResult =
+                    new RecoveryResult(-1, null, null, 0, null, List.of(), List.of(), -1, new ConcurrentLongRangeSet());
         } else {
             final long groupSize = Math.powExact(10, config.groupingLevel());
             final ConcurrentLongRangeSet completedRanges = new ConcurrentLongRangeSet();
@@ -162,7 +163,7 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
                 // Every listed key was a foreign object; there is no prior archive state.
                 LOGGER.log(TRACE, "No valid archive objects found in S3 bucket, starting fresh");
                 recoveryResult = new RecoveryResult(
-                        -1, null, null, 0, null, null, null, -1, new ConcurrentLongRangeSet());
+                        -1, null, null, 0, null, List.of(), List.of(), -1, new ConcurrentLongRangeSet());
             } else {
                 LOGGER.log(
                         TRACE,
@@ -170,7 +171,7 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
                         maxGroupStart,
                         maxGroupStart + groupSize);
                 recoveryResult = new RecoveryResult(
-                        maxGroupStart + groupSize, null, null, 0, null, null, null, -1, completedRanges);
+                        maxGroupStart + groupSize, null, null, 0, null, List.of(), List.of(), -1, completedRanges);
             }
         }
         return recoveryResult;
@@ -269,8 +270,8 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
                             newEtags,
                             scanResult.blockNumber(),
                             scanResult.trailingBytes(),
-                            null,
-                            null,
+                            List.of(),
+                            List.of(),
                             -1,
                             null);
                 } else {
@@ -395,9 +396,10 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
         final List<TempArchiveResumeState> resumableEntries = new ArrayList<>();
         for (final Map.Entry<String, List<String>> entry : allUploads.entrySet()) {
             if (entry.getKey().startsWith(tmpPfx)) {
+                final List<TempArchiveResumeState> keyCandidates = new ArrayList<>();
                 for (final String uploadId : entry.getValue()) {
                     try {
-                        resolveHangingTempUpload(s3, entry.getKey(), uploadId, objectKeyPrefix, resumableEntries);
+                        resolveHangingTempUpload(s3, entry.getKey(), uploadId, objectKeyPrefix, keyCandidates);
                     } catch (S3ResponseException | IOException e) {
                         LOGGER.log(
                                 DEBUG,
@@ -407,6 +409,7 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
                                 e);
                     }
                 }
+                keepBestResumeCandidate(s3, keyCandidates, resumableEntries);
             }
         }
 
@@ -514,6 +517,46 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
             s3.abortMultipartUpload(key, newUploadId);
             s3.deleteObject(key);
         }
+    }
+
+    /// `candidates` normally holds at most one entry per `.tmp` key; more than one means two hanging
+    /// uploads existed for the same key. Keeps the highest [TempArchiveResumeState#nextBlockNumber()]
+    /// and aborts the rest so they don't leak into the next restart's recovery scan.
+    private void keepBestResumeCandidate(
+            S3Client s3, List<TempArchiveResumeState> candidates, List<TempArchiveResumeState> resumable) {
+        if (candidates.isEmpty()) {
+            return;
+        }
+        TempArchiveResumeState best = candidates.get(0);
+        for (final TempArchiveResumeState candidate : candidates) {
+            if (candidate.nextBlockNumber() > best.nextBlockNumber()) {
+                best = candidate;
+            }
+        }
+        for (final TempArchiveResumeState candidate : candidates) {
+            if (candidate != best) {
+                LOGGER.log(
+                        DEBUG,
+                        "Multiple hanging uploads resolved for temp archive key {0}; discarding upload {1}"
+                                + " (nextBlockNumber={2}) in favor of {3} (nextBlockNumber={4})",
+                        candidate.s3Key(),
+                        candidate.uploadId(),
+                        candidate.nextBlockNumber(),
+                        best.uploadId(),
+                        best.nextBlockNumber());
+                try {
+                    s3.abortMultipartUpload(candidate.s3Key(), candidate.uploadId());
+                } catch (S3ResponseException | IOException e) {
+                    LOGGER.log(
+                            DEBUG,
+                            "Failed to abort superseded upload {0} for key {1}",
+                            candidate.uploadId(),
+                            candidate.s3Key(),
+                            e);
+                }
+            }
+        }
+        resumable.add(best);
     }
 
     /// Carries the two outcomes of [#recoverTempArchives]: durably completed temp archives (from

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTask.java
@@ -36,12 +36,13 @@ import org.hiero.block.node.base.ranges.ConcurrentLongRangeSet;
 /// 3. **Multiple hanging multipart uploads** — should never happen in normal operation.  All uploads
 ///    are aborted and the task falls back to Case 1.
 ///
-/// In addition, the task scans the `tmp/` virtual directory to rebuild the
-/// [TempArchiveEntry] list from `.meta` companion objects, and aborts any hanging multipart uploads
-/// for `.tmp` keys (those blocks will be re-delivered by backfill).
+/// In addition, the task scans the `tmp/` virtual directory to rebuild the [TempArchiveEntry] list
+/// from `.meta` companion objects, and resolves any hanging multipart uploads for `.tmp` keys:
+/// each is independently resumed (if durable parts are found) or aborted (if empty or gibberish),
+/// mirroring cases 2 and 3 above per key.
 ///
 /// Returns a [RecoveryResult] describing whether to start fresh, resume at a group boundary, or
-/// resume an in-progress upload, together with the list of completed temporary archives.
+/// resume an in-progress upload, together with the completed and resumable temporary archives.
 class StartupRecoveryTask implements Callable<RecoveryResult> {
 
     private static final System.Logger LOGGER = System.getLogger(StartupRecoveryTask.class.getName());
@@ -76,14 +77,18 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
                         default -> recoverFromMultipleHangingUploads(s3, regularUploads);
                     };
 
-            final List<TempArchiveEntry> tempArchives = recoverTempArchives(s3, allUploads);
-            return withTempArchives(baseResult, tempArchives);
+            final TempArchiveRecovery tempRecovery = recoverTempArchives(s3, allUploads);
+            return withTempArchives(baseResult, tempRecovery.completed(), tempRecovery.resumable());
         }
     }
 
-    // Returns a new RecoveryResult identical to [result] but with [tempArchives] set and
-    // [lastHandedOffBlock] computed from the recovery state and any recovered temp archives.
-    private RecoveryResult withTempArchives(RecoveryResult result, List<TempArchiveEntry> tempArchives) {
+    // Returns a new RecoveryResult identical to [result] but with [tempArchives] and
+    // [resumableTempArchives] set and [lastHandedOffBlock] computed from the recovery state and
+    // any recovered or resumable temp archives.
+    private RecoveryResult withTempArchives(
+            RecoveryResult result,
+            List<TempArchiveEntry> tempArchives,
+            List<TempArchiveResumeState> resumableTempArchives) {
         long lastHandedOffBlock;
         if (result.currentGroupStart() == -1) {
             lastHandedOffBlock = -1;
@@ -98,6 +103,9 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
                 lastHandedOffBlock = entry.lastBlock();
             }
         }
+        for (final TempArchiveResumeState resumed : resumableTempArchives) {
+            lastHandedOffBlock = Math.max(lastHandedOffBlock, resumed.nextBlockNumber() - 1);
+        }
         return new RecoveryResult(
                 result.currentGroupStart(),
                 result.uploadId(),
@@ -105,6 +113,7 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
                 result.nextBlockNumber(),
                 result.trailingBytes(),
                 tempArchives,
+                resumableTempArchives,
                 lastHandedOffBlock,
                 result.completedRanges());
     }
@@ -132,7 +141,7 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
         final List<String> allTarKeys = findAllTarKeys(s3);
         if (allTarKeys.isEmpty()) {
             LOGGER.log(TRACE, "No prior state found in S3 bucket, starting fresh");
-            recoveryResult = new RecoveryResult(-1, null, null, 0, null, null, -1, new ConcurrentLongRangeSet());
+            recoveryResult = new RecoveryResult(-1, null, null, 0, null, null, null, -1, new ConcurrentLongRangeSet());
         } else {
             final long groupSize = Math.powExact(10, config.groupingLevel());
             final ConcurrentLongRangeSet completedRanges = new ConcurrentLongRangeSet();
@@ -152,15 +161,16 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
             if (maxGroupStart == -1) {
                 // Every listed key was a foreign object; there is no prior archive state.
                 LOGGER.log(TRACE, "No valid archive objects found in S3 bucket, starting fresh");
-                recoveryResult = new RecoveryResult(-1, null, null, 0, null, null, -1, new ConcurrentLongRangeSet());
+                recoveryResult = new RecoveryResult(
+                        -1, null, null, 0, null, null, null, -1, new ConcurrentLongRangeSet());
             } else {
                 LOGGER.log(
                         TRACE,
                         "Last completed tar group starts at {0}, resuming from {1}",
                         maxGroupStart,
                         maxGroupStart + groupSize);
-                recoveryResult =
-                        new RecoveryResult(maxGroupStart + groupSize, null, null, 0, null, null, -1, completedRanges);
+                recoveryResult = new RecoveryResult(
+                        maxGroupStart + groupSize, null, null, 0, null, null, null, -1, completedRanges);
             }
         }
         return recoveryResult;
@@ -245,8 +255,8 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
                         s3.createMultipartUpload(key, config.storageClass().name(), S3UploadUtils.CONTENT_TYPE);
                 final List<String> newEtags = new ArrayList<>();
 
-                final PartScanResult scanResult = rebuildUpload(s3, key, groupStart, newUploadId, newEtags, parts);
-                if (scanResult.trailingBytes().length > 0) {
+                final PartScanResult scanResult = rebuildUpload(s3, key, newUploadId, newEtags, parts, groupStart);
+                if (scanResult.found()) {
                     LOGGER.log(
                             TRACE,
                             "Recovery prepared upload {0} for key {1}; resuming from block {2}",
@@ -259,6 +269,7 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
                             newEtags,
                             scanResult.blockNumber(),
                             scanResult.trailingBytes(),
+                            null,
                             null,
                             -1,
                             null);
@@ -283,18 +294,24 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
     ///
     /// Parts with no valid UStar header are discarded.  When a boundary is found, the bytes of the
     /// boundary part before the last block-start marker are returned as trailing carry-over bytes
-    /// that [BlockUploadTask] prepends to its accumulation buffer on resume.  If no part contains a
-    /// block start, an empty [PartScanResult#trailingBytes] signals the caller to fall back to
-    /// completed-objects recovery.
+    /// that [BlockUploadTask] prepends to its accumulation buffer on resume. [PartScanResult#found]
+    /// signals whether a boundary was located; trailingBytes can legitimately be empty even when
+    /// found is `true` (marker at offset 0), so it cannot be used as that signal itself.
     ///
-    /// @return a [PartScanResult] with the recovered block number and the bytes of the boundary
-    ///         part preceding the last block-start marker, or empty [PartScanResult#trailingBytes]
-    ///         if no valid header is found
+    /// @param initialBlockNumber fallback block number if no part contains a valid tar header
+    /// @return a [PartScanResult] with the recovered block number, the bytes of the boundary part
+    ///         preceding the last block-start marker, and whether a boundary was found
     private PartScanResult rebuildUpload(
-            S3Client s3, String key, long groupStart, String newUploadId, List<String> newEtags, List<PartInfo> parts)
+            S3Client s3,
+            String key,
+            String newUploadId,
+            List<String> newEtags,
+            List<PartInfo> parts,
+            long initialBlockNumber)
             throws S3ResponseException, IOException {
-        long blockNumber = groupStart;
+        long blockNumber = initialBlockNumber;
         byte[] trailingBytes = new byte[0];
+        boolean found = false;
 
         // Absolute byte offsets within the S3 object, required for range-download and server-side-copy calls.
         final long[] startOffsets = new long[parts.size()];
@@ -326,6 +343,7 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
                     blockNumber = partBlockNumber;
                     // Bytes before the block-start marker; BlockUploadTask prepends these to its buffer on resume.
                     trailingBytes = Arrays.copyOfRange(partBytes, 0, markerOffset);
+                    found = true;
                     break;
                 } catch (NumberFormatException e) {
                     // Should not happen, but if it does, log it and continue scanning
@@ -335,13 +353,13 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
         }
 
         // No block start found in any part.
-        return new PartScanResult(blockNumber, trailingBytes);
+        return new PartScanResult(blockNumber, trailingBytes, found);
     }
 
-    /// Carries the result of a backwards parts scan: the recovered block number and the bytes of the
-    /// boundary part that precede the last block-start marker (carry-over bytes that [BlockUploadTask]
-    /// must prepend to its accumulation buffer on resume).
-    private record PartScanResult(long blockNumber, byte[] trailingBytes) {}
+    /// Carries the result of a backwards parts scan: the recovered block number, the trailing
+    /// carry-over bytes [BlockUploadTask] must prepend to its buffer on resume, and whether a
+    /// boundary was found at all (trailingBytes can be legitimately empty either way).
+    private record PartScanResult(long blockNumber, byte[] trailingBytes, boolean found) {}
 
     /// Case 3: multiple hanging uploads — abort all and fall back to completed-objects recovery.
     private RecoveryResult recoverFromMultipleHangingUploads(S3Client s3, Map<String, List<String>> uploads)
@@ -360,28 +378,33 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
         return recoverFromCompletedObjects(s3);
     }
 
-    /// Scans the `tmp/` virtual directory to rebuild the temporary-archive tracker and aborts any
-    /// hanging multipart uploads for `.tmp` keys (those block ranges will be re-delivered by
-    /// backfill).
+    /// Scans the `tmp/` virtual directory to rebuild the temporary-archive tracker and resolves any
+    /// hanging multipart uploads for `.tmp` keys, deciding independently per key whether to resume
+    /// or abort (unlike the regular path, several temp uploads can hang at once since
+    /// [CloudStorageArchiveConfig#maxConcurrentTempArchives()] allows concurrent segments).
     ///
     /// Only archives with a companion `.meta` file (written atomically after the multipart upload
-    /// completes) are considered fully durable and included in the returned list.  `.tmp` objects
-    /// without a `.meta` companion are treated as incomplete and their orphaned `.tmp` objects are
-    /// deleted.
-    private List<TempArchiveEntry> recoverTempArchives(S3Client s3, Map<String, List<String>> allUploads)
+    /// completes) are considered fully durable and included in the returned completed list.
+    /// `.tmp` objects without a `.meta` companion are treated as incomplete; those not claimed by a
+    /// resumed upload (see [#resolveHangingTempUpload]) are orphaned and deleted.
+    private TempArchiveRecovery recoverTempArchives(S3Client s3, Map<String, List<String>> allUploads)
             throws S3ResponseException, IOException {
         final String objectKeyPrefix = config.objectKeyPrefix();
         final String tmpPfx = TempArchiveKey.tmpPrefix(objectKeyPrefix);
 
-        // Abort hanging temp uploads — those blocks will be re-delivered by backfill.
+        final List<TempArchiveResumeState> resumableEntries = new ArrayList<>();
         for (final Map.Entry<String, List<String>> entry : allUploads.entrySet()) {
             if (entry.getKey().startsWith(tmpPfx)) {
                 for (final String uploadId : entry.getValue()) {
                     try {
-                        s3.abortMultipartUpload(entry.getKey(), uploadId);
-                        LOGGER.log(TRACE, "Aborted hanging temp archive upload for key {0}", entry.getKey());
+                        resolveHangingTempUpload(s3, entry.getKey(), uploadId, objectKeyPrefix, resumableEntries);
                     } catch (S3ResponseException | IOException e) {
-                        LOGGER.log(DEBUG, "Failed to abort temp archive upload {0}", entry.getKey(), e);
+                        LOGGER.log(
+                                DEBUG,
+                                "Failed to resolve hanging temp archive upload {0} for key {1}",
+                                uploadId,
+                                entry.getKey(),
+                                e);
                     }
                 }
             }
@@ -409,7 +432,7 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
             }
         }
 
-        // Delete orphaned .tmp objects (those without a valid .meta companion).
+        // Delete orphaned .tmp objects (no valid .meta companion, and not claimed by a resumed upload).
         for (final String key : tmpDirObjects) {
             if (!TempArchiveKey.isTempTarKey(key, objectKeyPrefix)) {
                 continue;
@@ -427,7 +450,8 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
             }
             final String metaKey = TempArchiveKey.formatMeta(firstBlock, objectKeyPrefix);
             final boolean hasValidMeta = completedEntries.stream().anyMatch(e -> e.firstBlock() == firstBlock);
-            if (!hasValidMeta) {
+            final boolean isResumed = resumableEntries.stream().anyMatch(e -> e.firstBlock() == firstBlock);
+            if (!hasValidMeta && !isResumed) {
                 LOGGER.log(TRACE, "Deleting orphaned temp archive {0} (no valid .meta companion)", key);
                 try {
                     s3.deleteObject(key);
@@ -443,8 +467,58 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
             }
         }
 
-        return completedEntries;
+        return new TempArchiveRecovery(completedEntries, resumableEntries);
     }
+
+    /// Resolves one hanging temp-archive multipart upload: aborts it if no parts were ever
+    /// uploaded, otherwise completes it into a materialized readable object, starts a fresh upload
+    /// for the same key, and scans backwards via [#rebuildUpload] to find the last clean
+    /// block-start boundary. Adds a [TempArchiveResumeState] to `resumable` when a boundary is
+    /// found; otherwise aborts the new upload and deletes the intermediate object, mirroring
+    /// [#recoverFromSingleHangingUpload]'s gibberish-parts branch.
+    private void resolveHangingTempUpload(
+            S3Client s3, String key, String uploadId, String objectKeyPrefix, List<TempArchiveResumeState> resumable)
+            throws S3ResponseException, IOException {
+        final List<PartInfo> parts = s3.listParts(key, uploadId);
+        if (parts.isEmpty()) {
+            s3.abortMultipartUpload(key, uploadId);
+            LOGGER.log(TRACE, "Hanging temp archive upload for key {0} had no parts, aborted", key);
+            return;
+        }
+
+        s3.completeMultipartUpload(
+                key, uploadId, parts.stream().map(PartInfo::etag).toList());
+        LOGGER.log(TRACE, "Completed hanging temp archive upload to create temporary S3 object at key {0}", key);
+        final String newUploadId =
+                s3.createMultipartUpload(key, config.storageClass().name(), S3UploadUtils.CONTENT_TYPE);
+        final List<String> newEtags = new ArrayList<>();
+        final long originalFirstBlock = TempArchiveKey.parseFirstBlockFromTar(key, objectKeyPrefix);
+
+        final PartScanResult scanResult = rebuildUpload(s3, key, newUploadId, newEtags, parts, originalFirstBlock);
+        if (scanResult.found()) {
+            LOGGER.log(
+                    TRACE,
+                    "Recovery prepared upload {0} for temp archive key {1}; resuming from block {2}",
+                    newUploadId,
+                    key,
+                    scanResult.blockNumber());
+            resumable.add(new TempArchiveResumeState(
+                    key,
+                    originalFirstBlock,
+                    scanResult.blockNumber(),
+                    newUploadId,
+                    newEtags,
+                    scanResult.trailingBytes()));
+        } else {
+            LOGGER.log(DEBUG, "No block start found in any part for temp archive key {0}; aborting", key);
+            s3.abortMultipartUpload(key, newUploadId);
+            s3.deleteObject(key);
+        }
+    }
+
+    /// Carries the two outcomes of [#recoverTempArchives]: durably completed temp archives (from
+    /// `.meta` files) and hanging temp uploads found resumable.
+    private record TempArchiveRecovery(List<TempArchiveEntry> completed, List<TempArchiveResumeState> resumable) {}
 
     /// Lists all object keys under [prefix] by paging through [S3Client#listObjectsPage] calls.
     private List<String> listAllObjectsUnderPrefix(S3Client s3, String prefix) throws S3ResponseException, IOException {

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/TempArchiveResumeState.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/TempArchiveResumeState.java
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.cloud.storage.archive;
+
+import java.util.List;
+
+/// Describes a hanging [TempArchiveUploadTask] multipart upload that [StartupRecoveryTask] has
+/// determined is resumable, rather than aborted.
+///
+/// Unlike [TempArchiveEntry] (which represents only durably completed archives, tracked in
+/// [CloudStorageArchivePlugin#tempArchiveTracker]), this record describes a segment whose
+/// multipart upload is still open on S3.  Keeping the two types separate means every existing
+/// [TempArchiveEntry] consumer: `StartupRecoveryTask#withTempArchives`,
+/// `CloudStorageArchivePlugin#hasAnyTempDataForGroup`,
+/// `CloudStorageArchivePlugin#isBlockCoveredByAnyTempSegment`, can keep treating every tracker
+/// entry as done, without special-casing a still-open upload.
+///
+/// @param s3Key           the S3 key of the `.tmp` tar object
+/// @param firstBlock      the segment's original first block number (its identity / S3 key), used
+///                        to key the resumed [TempArchiveUploadTask] the same way a fresh segment
+///                        would be
+/// @param nextBlockNumber the first block number not yet durably part of the upload; the resumed
+///                        [TempArchiveUploadTask] begins consuming its queue from this block
+/// @param uploadId        the multipart upload ID of the newly created upload to resume
+/// @param etags           ETags of the parts already committed before the boundary part, in
+///                        part-number order
+/// @param trailingBytes   bytes from the start of the boundary part up to (but not including) the
+///                        last block-start marker; prepended to the resumed task's accumulation
+///                        buffer so the previously-started S3 part is completed correctly
+record TempArchiveResumeState(
+        String s3Key,
+        long firstBlock,
+        long nextBlockNumber,
+        String uploadId,
+        List<String> etags,
+        byte[] trailingBytes) {}

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTask.java
@@ -35,12 +35,19 @@ import org.hiero.block.node.spi.historicalblocks.LongRange;
 /// 3. Offer verified blocks to the queue in ascending block-number order.
 /// 4. Signal the end of the segment by offering [SEGMENT_END].
 ///
+/// **Resume after restart**: given a [TempArchiveResumeState] via the resume constructor, the task
+/// reuses the existing upload ID and ETags, seeds its buffer from `trailingBytes`, and begins the
+/// block loop from `nextBlockNumber` rather than [firstBlock].
+///
 /// If the task's thread is interrupted (e.g. during plugin shutdown), [call] still rethrows
-/// [InterruptedException] in every case. But if at least one block has already been accumulated,
-/// the interrupt is first treated like [SEGMENT_END]: the multipart upload is completed and the
-/// `.meta` companion is written before the exception is rethrown, since a temp archive has no
-/// required end block and whatever was accumulated is already a valid, self-contained archive.
-/// Only an interrupt with zero blocks accumulated aborts the multipart upload instead.
+/// [InterruptedException] in every case. But if at least one new block has already been
+/// accumulated during this run, the interrupt is first treated like [SEGMENT_END]: the multipart
+/// upload is completed before the exception is rethrown, since a temp archive has no required end
+/// block.
+///
+/// Like [BlockUploadTask], this task never calls `abortMultipartUpload` on any failure path --
+/// every failure leaves the multipart upload hanging on S3, with whatever parts are already
+/// durable, for [StartupRecoveryTask] to adjudicate on the next startup.
 ///
 /// On completion the task:
 /// 1. Completes the S3 multipart upload for the tar content at the `.tmp` key.
@@ -66,7 +73,10 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
     private final long firstBlock;
     private final int partSizeBytes;
     private final BlockingQueue<BlockWithSource> blockQueue;
+    /// When non-null, the task resumes an existing multipart upload rather than creating a new one.
+    private final TempArchiveResumeState resumeState;
 
+    /// Creates a new task that will start a fresh upload for a segment beginning at `firstBlock`.
     TempArchiveUploadTask(
             @NonNull CloudStorageArchiveConfig config,
             @NonNull BlockMessagingFacility blockMessaging,
@@ -75,6 +85,22 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
             @NonNull String s3Key,
             long firstBlock,
             @NonNull BlockingQueue<BlockWithSource> blockQueue) {
+        this(config, blockMessaging, applicationStateFacility, metricsHolder, s3Key, firstBlock, blockQueue, null);
+    }
+
+    /// Creates a task that resumes an existing upload prepared by [StartupRecoveryTask].
+    ///
+    /// @param resumeState non-null when resuming; carries the upload ID, existing ETags, trailing
+    ///                     bytes, and the first block number not yet uploaded
+    TempArchiveUploadTask(
+            @NonNull CloudStorageArchiveConfig config,
+            @NonNull BlockMessagingFacility blockMessaging,
+            @NonNull ApplicationStateFacility applicationStateFacility,
+            @NonNull CloudStorageArchivePlugin.MetricsHolder metricsHolder,
+            @NonNull String s3Key,
+            long firstBlock,
+            @NonNull BlockingQueue<BlockWithSource> blockQueue,
+            TempArchiveResumeState resumeState) {
         this.config = requireNonNull(config);
         this.blockMessaging = requireNonNull(blockMessaging);
         this.applicationStateFacility = requireNonNull(applicationStateFacility);
@@ -83,19 +109,25 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
         this.firstBlock = firstBlock;
         this.partSizeBytes = config.partSizeMb() * 1024 * 1024;
         this.blockQueue = requireNonNull(blockQueue);
+        this.resumeState = resumeState;
     }
 
     @Override
     public TempArchiveEntry call()
             throws S3ClientInitializationException, S3ResponseException, IOException, InterruptedException {
         try (S3Client s3 = S3UploadUtils.createClient(config)) {
-            final String uploadId =
-                    s3.createMultipartUpload(s3Key, config.storageClass().name(), S3UploadUtils.CONTENT_TYPE);
-            final List<String> etags = new ArrayList<>();
-            byte[] buffer = new byte[0];
+            final String uploadId = resumeState != null
+                    ? resumeState.uploadId()
+                    : s3.createMultipartUpload(s3Key, config.storageClass().name(), S3UploadUtils.CONTENT_TYPE);
+            final List<String> etags = resumeState != null ? new ArrayList<>(resumeState.etags()) : new ArrayList<>();
+            byte[] buffer = resumeState != null && resumeState.trailingBytes() != null
+                    ? resumeState.trailingBytes()
+                    : new byte[0];
             long totalBytes = 0;
-            long currentBlock = firstBlock;
-            long lastProcessedBlock = firstBlock - 1;
+            // When resuming, start from the first block not yet in the upload.
+            final long loopStart = resumeState != null ? resumeState.nextBlockNumber() : firstBlock;
+            long currentBlock = loopStart;
+            long lastProcessedBlock = loopStart - 1;
             BlockSource lastSource = BlockSource.UNKNOWN;
 
             while (true) {
@@ -117,23 +149,21 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
                         totalBytes += partSizeBytes;
                     }
                 } catch (InterruptedException e) {
-                    if (lastProcessedBlock >= firstBlock) {
+                    if (lastProcessedBlock >= loopStart) {
                         LOGGER.log(
                                 INFO,
                                 "Temp archive upload task for key {0} interrupted with blocks [{1}, {2}]"
                                         + " accumulated; completing early instead of aborting",
                                 s3Key,
-                                firstBlock,
+                                loopStart,
                                 lastProcessedBlock);
                         completeSegment(s3, uploadId, etags, buffer, totalBytes, lastProcessedBlock, lastSource);
                     } else {
                         LOGGER.log(TRACE, "Temp archive upload task interrupted for key {0}", s3Key, e);
-                        S3UploadUtils.abortQuietly(s3, s3Key, uploadId);
                     }
                     throw e;
                 } catch (S3ResponseException | IOException e) {
                     LOGGER.log(INFO, "Failed to accumulate block {0} for temp archive {1}", currentBlock, s3Key, e);
-                    S3UploadUtils.abortQuietly(s3, s3Key, uploadId);
                     blockMessaging.sendBlockPersisted(new PersistedNotification(firstBlock, false, 1_000, lastSource));
                     throw e;
                 }
@@ -162,8 +192,11 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
                 doUploadPart(buffer, s3, uploadId, etags);
                 totalBytes += buffer.length;
             } catch (S3ResponseException | IOException e) {
-                S3UploadUtils.abortQuietly(s3, s3Key, uploadId);
-                blockMessaging.sendBlockPersisted(new PersistedNotification(firstBlock, false, 1_000, lastSource));
+                blockMessaging.sendBlockPersisted(new PersistedNotification(
+                        firstBlock,
+                        false,
+                        CloudStorageArchivePlugin.CLOUD_ARCHIVE_PERSISTENCE_NOTIFICATION_PRIORITY,
+                        lastSource));
                 LOGGER.log(INFO, "Failed to upload final temp archive part for key {0}", s3Key, e);
                 throw e;
             }
@@ -172,8 +205,11 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
         try {
             doCompleteMultipartUpload(s3, s3Key, uploadId, etags);
         } catch (S3ResponseException | IOException e) {
-            S3UploadUtils.abortQuietly(s3, s3Key, uploadId);
-            blockMessaging.sendBlockPersisted(new PersistedNotification(firstBlock, false, 1_000, lastSource));
+            blockMessaging.sendBlockPersisted(new PersistedNotification(
+                    firstBlock,
+                    false,
+                    CloudStorageArchivePlugin.CLOUD_ARCHIVE_PERSISTENCE_NOTIFICATION_PRIORITY,
+                    lastSource));
             LOGGER.log(INFO, "Failed to complete temp archive multipart upload for key {0}", s3Key, e);
             throw e;
         }
@@ -184,7 +220,11 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
             doUploadTextFile(s3, metaKey, config.storageClass().name(), String.valueOf(lastBlock));
         } catch (S3ResponseException | IOException e) {
             LOGGER.log(INFO, "Failed to write temp archive meta {0}, tar is already committed", metaKey, e);
-            blockMessaging.sendBlockPersisted(new PersistedNotification(lastBlock, true, 1_000, lastSource));
+            blockMessaging.sendBlockPersisted(new PersistedNotification(
+                    lastBlock,
+                    true,
+                    CloudStorageArchivePlugin.CLOUD_ARCHIVE_PERSISTENCE_NOTIFICATION_PRIORITY,
+                    lastSource));
             applicationStateFacility.addStoredBlockRange(new LongRange(firstBlock, lastBlock));
             metricsHolder.blocksWritten().increment(lastBlock - firstBlock + 1);
             metricsHolder.storedBytes().increment(totalBytes);
@@ -192,7 +232,11 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
         }
         LOGGER.log(TRACE, "Wrote temp archive meta {0}", metaKey);
 
-        blockMessaging.sendBlockPersisted(new PersistedNotification(lastBlock, true, 1_000, lastSource));
+        blockMessaging.sendBlockPersisted(new PersistedNotification(
+                lastBlock,
+                true,
+                CloudStorageArchivePlugin.CLOUD_ARCHIVE_PERSISTENCE_NOTIFICATION_PRIORITY,
+                lastSource));
         applicationStateFacility.addStoredBlockRange(new LongRange(firstBlock, lastBlock));
         metricsHolder.blocksWritten().increment(lastBlock - firstBlock + 1);
         metricsHolder.storedBytes().increment(totalBytes);

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
@@ -225,6 +225,26 @@ class CloudStorageArchivePluginTest {
         }
     }
 
+    /// A [CloudStorageArchivePlugin] subclass that replaces a resumed [TempArchiveUploadTask] with
+    /// a configurable [Callable], mirroring [FailingTempArchivePlugin] for the resume path. Used to
+    /// drive the resumed-temp-upload-failure code path without a live S3 upload actually running.
+    private static class FailingResumedTempArchivePlugin extends CloudStorageArchivePlugin {
+        private final Callable<TempArchiveEntry> tempBehavior;
+
+        FailingResumedTempArchivePlugin(Callable<TempArchiveEntry> tempBehavior) {
+            this.tempBehavior = tempBehavior;
+        }
+
+        @Override
+        Callable<TempArchiveEntry> newResumedTempArchiveUploadTask(
+                String s3Key,
+                long firstBlock,
+                BlockingQueue<BlockWithSource> queue,
+                TempArchiveResumeState resumeState) {
+            return tempBehavior;
+        }
+    }
+
     /// Constructor and init tests that do not require a running plugin.
     @Nested
     @DisplayName("Constructor & Init Tests")
@@ -1721,6 +1741,236 @@ class CloudStorageArchivePluginTest {
             assertThat(capturedRanges).contains(new LongRange(5, 9), new LongRange(20, 29));
         }
 
+        /// Verifies the full resume-from-hanging-temp-archive path end-to-end: a hanging temp
+        /// archive multipart upload for a mid-group segment (blocks 5–9, the tail of group 0) with
+        /// one durable part is planted before recovery runs; recovery must resume it (not abort it)
+        /// into the same live-queue maps a fresh segment would use -- no redundant second segment
+        /// for the group -- and the resumed task must complete the segment correctly once the
+        /// remaining verified block arrives.
+        @Test
+        @DisplayName("Plugin resumes a hanging temp archive upload with durable parts and completes the segment")
+        void resumeFromHangingTempArchiveCompletesSegment() throws Exception {
+            final CloudStorageArchiveConfig config = makeConfig();
+            final long segmentFirstBlock = 5L;
+            final String tarKey = TempArchiveKey.formatTar(segmentFirstBlock, config.objectKeyPrefix());
+            final List<TestBlock> segmentBlocks = TestBlockBuilder.generateBlocksInRange(5, 9);
+
+            // Plant a hanging temp archive multipart upload with a durable part covering blocks
+            // 5-9, simulating a prior run that crashed after flushing this part but before
+            // SEGMENT_END arrived.
+            try (S3Client s3 = openS3Client(config)) {
+                final String uploadId =
+                        s3.createMultipartUpload(tarKey, config.storageClass().name(), CONTENT_TYPE);
+                s3.multipartUploadPart(tarKey, uploadId, 1, buildTarBytes(segmentBlocks, (int) segmentFirstBlock));
+                // deliberately NOT completing — simulate a crash mid-upload
+            }
+
+            // Run startup recovery: finds the hanging temp upload, completes it to materialize a
+            // readable object, and prepares a resumable state (nextBlockNumber=9, trailingBytes =
+            // entries for blocks 5-8).
+            pluginExecutor.executeSerially();
+
+            // Block 9 is both the resume point and the last block of group 0 (groupSize=10); this
+            // notification triggers completeRecoveryIfReady() (registering the resumed segment)
+            // and then routeVerifiedBlock, which enqueues block 9 onto the resumed task's own
+            // queue and immediately closes the segment.
+            sendVerification(TestBlockBuilder.generateBlocksInRange(9, 9).getFirst());
+
+            // The resumed segment is registered under its original firstBlock -- no redundant
+            // second segment for the group.
+            assertThat(plugin.tempUploadFutures).containsOnlyKeys(segmentFirstBlock);
+
+            // Run the resumed TempArchiveUploadTask; its queue already has block 9 + SEGMENT_END.
+            pluginExecutor.executeSerially();
+
+            // Re-send block 9: recognized as a duplicate against the now-completed tracker entry,
+            // which also drains the completed future into tempArchiveTracker as a side effect.
+            sendVerification(TestBlockBuilder.generateBlocksInRange(9, 9).getFirst());
+
+            assertThat(plugin.tempArchiveTracker).containsKey(segmentFirstBlock);
+            final TempArchiveEntry entry = plugin.tempArchiveTracker.get(segmentFirstBlock);
+            assertThat(entry.firstBlock()).isEqualTo(segmentFirstBlock);
+            assertThat(entry.lastBlock()).isEqualTo(9L);
+            assertThat(entry.uploadId()).isNull();
+
+            try (S3Client s3 = openS3Client(config)) {
+                assertThat(s3.listMultipartUploads()).doesNotContainKey(tarKey);
+            }
+            assertThat(getAllObjects())
+                    .contains(tarKey, TempArchiveKey.formatMeta(segmentFirstBlock, config.objectKeyPrefix()));
+        }
+
+        /// Reproduces the race where a resumed temp-archive segment and a freshly-started regular
+        /// [BlockUploadTask] both claim the same group. Group 0's tar completed cleanly before the
+        /// crash, but the temp segment for group 1 (started while group 0 was still active, then
+        /// left hanging by the crash) covers the very group that [StartupRecoveryTask] computes as
+        /// `currentGroupStart` for Case 1 (`groupSize`). Pre-fix, `completeRecoveryIfReady()` started
+        /// a second, conflicting [BlockUploadTask] for that group regardless of the resumed temp
+        /// segment, so the resumed segment's queue never received another block or `SEGMENT_END` and
+        /// its virtual thread blocked forever on `blockQueue.take()`.
+        @Test
+        @DisplayName("Resumed temp archive for the next group prevents a conflicting regular task from starting")
+        void resumedTempArchiveForNextGroupPreventsConflictingRegularTask() throws Exception {
+            final long groupSize = Math.powExact(10, GROUPING_LEVEL);
+            final CloudStorageArchiveConfig config = makeConfig();
+
+            // Group 0 completed cleanly before the crash.
+            final String firstKey = ArchiveKey.format(0, GROUPING_LEVEL, "");
+            final List<TestBlock> firstGroupBlocks = TestBlockBuilder.generateBlocksInRange(0, (int) groupSize - 1);
+            try (S3Client s3 = openS3Client(config)) {
+                final String uploadId =
+                        s3.createMultipartUpload(firstKey, config.storageClass().name(), CONTENT_TYPE);
+                final String etag = s3.multipartUploadPart(firstKey, uploadId, 1, buildTarBytes(firstGroupBlocks, 0));
+                s3.completeMultipartUpload(firstKey, uploadId, List.of(etag));
+            }
+
+            // Group 1 (blocks 10-19) has a hanging temp archive segment for blocks 15-17, left
+            // over from a gap-buffer flush while group 0 was still the active regular group.
+            final long segmentFirstBlock = groupSize + 5;
+            final String tarKey = TempArchiveKey.formatTar(segmentFirstBlock, config.objectKeyPrefix());
+            final List<TestBlock> segmentBlocks =
+                    TestBlockBuilder.generateBlocksInRange((int) segmentFirstBlock, (int) segmentFirstBlock + 2);
+            try (S3Client s3 = openS3Client(config)) {
+                final String uploadId =
+                        s3.createMultipartUpload(tarKey, config.storageClass().name(), CONTENT_TYPE);
+                s3.multipartUploadPart(tarKey, uploadId, 1, buildTarBytes(segmentBlocks, (int) segmentFirstBlock));
+                // deliberately NOT completing -- simulate a crash mid-upload
+            }
+
+            pluginExecutor.executeSerially();
+
+            // Trigger completeRecoveryIfReady() with the next expected block for the resumed segment.
+            sendVerification(
+                    TestBlockBuilder.generateBlocksInRange((int) segmentFirstBlock + 3, (int) segmentFirstBlock + 3)
+                            .getFirst());
+
+            // The resumed segment still owns group 1's active queue.
+            assertThat(plugin.tempUploadFutures).containsKey(segmentFirstBlock);
+            assertThat(plugin.tempGroupActiveQueues).containsKey(groupSize);
+
+            // No conflicting regular BlockUploadTask was started for the same group -- the resumed
+            // segment is the sole owner, so the plugin must fall through to the temp-archive path
+            // for any further blocks in this group instead of starting a competing regular task.
+            assertThat(plugin.currentUploadFuture).isNull();
+        }
+
+        /// Dedicated test protecting the "never abort" design: once a hanging temp segment is
+        /// resumed, blocks that were already durable in the pre-crash upload (below the resume
+        /// point) must be recognized as duplicates via
+        /// [CloudStorageArchivePlugin#isBlockCoveredByAnyTempSegment] and discarded -- not
+        /// re-queued to the resumed task (which only expects blocks from the resume point onward
+        /// and would otherwise stall forever waiting for a block nobody will send) or
+        /// double-counted -- even while the resumed task is still in flight, not yet completed.
+        @Test
+        @DisplayName(
+                "Redelivered blocks below the resume point are discarded as duplicates while the segment is in flight")
+        void redeliveredBlocksBelowResumePointAreDiscardedWhileSegmentInFlight() throws Exception {
+            final CloudStorageArchiveConfig config = makeConfig();
+            final long segmentFirstBlock = 5L;
+            final String tarKey = TempArchiveKey.formatTar(segmentFirstBlock, config.objectKeyPrefix());
+            final List<TestBlock> segmentBlocks = TestBlockBuilder.generateBlocksInRange(5, 9);
+
+            try (S3Client s3 = openS3Client(config)) {
+                final String uploadId =
+                        s3.createMultipartUpload(tarKey, config.storageClass().name(), CONTENT_TYPE);
+                s3.multipartUploadPart(tarKey, uploadId, 1, buildTarBytes(segmentBlocks, (int) segmentFirstBlock));
+                // deliberately NOT completing — simulate a crash mid-upload
+            }
+
+            pluginExecutor.executeSerially();
+
+            // Trigger completeRecoveryIfReady() with an unrelated, far-ahead block so the resumed
+            // segment is registered without closing it (unlike the full round-trip test above).
+            sendVerification(TestBlockBuilder.generateBlocksInRange(50, 50).getFirst());
+
+            // The resumed segment is registered and its task is in flight (not yet run/completed).
+            assertThat(plugin.tempUploadFutures).containsKey(segmentFirstBlock);
+            assertThat(plugin.tempUploadFutures.get(segmentFirstBlock).isDone()).isFalse();
+
+            final long duplicatesBefore =
+                    getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_DUPLICATE_BLOCKS_DISCARDED);
+
+            // Redeliver block 6 — already durable in the old (pre-crash) part, below nextBlockNumber=9.
+            sendVerification(TestBlockBuilder.generateBlocksInRange(6, 6).getFirst());
+
+            // Discarded as a duplicate — not queued to the resumed task, not double-counted.
+            assertThat(getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_DUPLICATE_BLOCKS_DISCARDED))
+                    .isEqualTo(duplicatesBefore + 1);
+            assertThat(plugin.tempUploadFutures.get(segmentFirstBlock).isDone()).isFalse();
+        }
+
+        /// Verifies that two hanging temp archive uploads for the SAME group are both resumed and
+        /// both complete, instead of the second [Map#put] in [CloudStorageArchivePlugin
+        /// #completeRecoveryIfReady] silently overwriting the first segment's queue reference in
+        /// `tempGroupActiveQueues` and orphaning its virtual thread on `queue.take()` forever.
+        ///
+        /// Plants two hanging `.tmp` multipart uploads in the same group [0,9]: firstBlock=2
+        /// (blocks 2-3, recoverable nextBlockNumber=3) and firstBlock=6 (blocks 6-7-8, recoverable
+        /// nextBlockNumber=8). Segment 6 has the higher nextBlockNumber, so it becomes the "active"
+        /// continuation that receives blocks 8-9; segment 2 must be seeded with SEGMENT_END so it
+        /// still finalises on its own.
+        @Test
+        @DisplayName("Two hanging temp archives for the same group are both resumed and both complete")
+        void twoResumableTempArchivesForSameGroupBothComplete() throws Exception {
+            final CloudStorageArchiveConfig config = makeConfig();
+            final long supersededFirstBlock = 2L;
+            final long activeFirstBlock = 6L;
+            final String supersededTarKey = TempArchiveKey.formatTar(supersededFirstBlock, config.objectKeyPrefix());
+            final String activeTarKey = TempArchiveKey.formatTar(activeFirstBlock, config.objectKeyPrefix());
+
+            try (S3Client s3 = openS3Client(config)) {
+                final String supersededUploadId = s3.createMultipartUpload(
+                        supersededTarKey, config.storageClass().name(), CONTENT_TYPE);
+                s3.multipartUploadPart(
+                        supersededTarKey,
+                        supersededUploadId,
+                        1,
+                        buildTarBytes(TestBlockBuilder.generateBlocksInRange(2, 3), (int) supersededFirstBlock));
+                // deliberately NOT completing — simulate a crash mid-upload
+
+                final String activeUploadId = s3.createMultipartUpload(
+                        activeTarKey, config.storageClass().name(), CONTENT_TYPE);
+                s3.multipartUploadPart(
+                        activeTarKey,
+                        activeUploadId,
+                        1,
+                        buildTarBytes(TestBlockBuilder.generateBlocksInRange(6, 8), (int) activeFirstBlock));
+                // deliberately NOT completing — simulate a crash mid-upload
+            }
+
+            // Recovery resolves both hanging uploads independently into two resumable entries.
+            pluginExecutor.executeSerially();
+
+            // Block 8 is the resume point for the active segment; this notification triggers
+            // completeRecoveryIfReady() (registering both resumed segments) and then routes block 8
+            // into the active segment's queue.
+            sendVerification(TestBlockBuilder.generateBlocksInRange(8, 8).getFirst());
+            assertThat(plugin.tempUploadFutures).containsOnlyKeys(supersededFirstBlock, activeFirstBlock);
+
+            // Block 9 is the last block of the group; it also routes to the active segment and
+            // closes it with SEGMENT_END.
+            sendVerification(TestBlockBuilder.generateBlocksInRange(9, 9).getFirst());
+
+            // Run both resumed tasks. Without the fix, the superseded segment's task would block
+            // forever on queue.take() (bounded only by BlockingExecutor's 60s per-task timeout).
+            pluginExecutor.executeSerially();
+
+            // An unrelated notification drains the now-completed futures into tempArchiveTracker.
+            sendVerification(TestBlockBuilder.generateBlocksInRange(50, 50).getFirst());
+
+            assertThat(plugin.tempUploadFutures).doesNotContainKeys(supersededFirstBlock, activeFirstBlock);
+            assertThat(plugin.tempArchiveTracker).containsKeys(supersededFirstBlock, activeFirstBlock);
+            assertThat(plugin.tempArchiveTracker.get(supersededFirstBlock).lastBlock())
+                    .isEqualTo(2L);
+            assertThat(plugin.tempArchiveTracker.get(activeFirstBlock).lastBlock())
+                    .isEqualTo(9L);
+
+            try (S3Client s3 = openS3Client(config)) {
+                assertThat(s3.listMultipartUploads()).doesNotContainKeys(supersededTarKey, activeTarKey);
+            }
+            assertThat(getAllObjects()).contains(supersededTarKey, activeTarKey);
+        }
+
         private CloudStorageArchiveConfig makeConfig() {
             final ConfigurationBuilder builder =
                     ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);
@@ -2028,6 +2278,59 @@ class CloudStorageArchivePluginTest {
             // Drive recovery and verify it completes.
             executor.executeSerially();
             assertThat(plugin.isRecoveryComplete()).isTrue();
+        }
+
+        /// Verifies that a failing RESUMED [TempArchiveUploadTask] triggers mid-run recovery via
+        /// the same glue code as a fresh one, proving `newResumedTempArchiveUploadTask` is wired
+        /// into [CloudStorageArchivePlugin#checkAndDrainTempUploadResults] identically to
+        /// [CloudStorageArchivePlugin#newTempArchiveUploadTask].
+        ///
+        /// A hanging temp archive multipart upload for a mid-group segment (blocks 5-9) with one
+        /// durable part is planted in S3 before the plugin starts, so recovery resumes it into
+        /// [FailingResumedTempArchivePlugin]'s mocked failing behavior instead of a real upload.
+        @Test
+        @DisplayName("Resumed temp archive upload failure triggers mid-run recovery")
+        void failedResumedTempUploadTriggersMidRunRecovery() throws Exception {
+            final ConfigurationBuilder builder =
+                    ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);
+            pluginConfig(1, 10).forEach(builder::withValue);
+            final CloudStorageArchiveConfig cfg = builder.build().getConfigData(CloudStorageArchiveConfig.class);
+
+            final long segmentFirstBlock = 5L;
+            final String tarKey = TempArchiveKey.formatTar(segmentFirstBlock, cfg.objectKeyPrefix());
+            final List<TestBlock> segmentBlocks = TestBlockBuilder.generateBlocksInRange(5, 9);
+            try (S3Client s3 = new S3Client(
+                    cfg.regionName(), cfg.endpointUrl(), cfg.bucketName(), cfg.accessKey(), cfg.secretKey())) {
+                final String uploadId =
+                        s3.createMultipartUpload(tarKey, cfg.storageClass().name(), "application/x-tar");
+                final byte[] tarBytes = RecoveryIntegrationTests.buildTarBytes(segmentBlocks, (int) segmentFirstBlock);
+                s3.multipartUploadPart(tarKey, uploadId, 1, tarBytes);
+                // deliberately NOT completing — simulate a crash mid-upload
+            }
+
+            start(
+                    new FailingResumedTempArchivePlugin(() -> {
+                        throw new IOException("simulated resumed temp upload failure");
+                    }),
+                    new SimpleInMemoryHistoricalBlockFacility(),
+                    pluginConfig(1, 10));
+            final BlockingExecutor executor = testThreadPoolManager.executor();
+            executor.executeSerially(); // drain startup recovery -- prepares the resumable segment
+
+            // Trigger completeRecoveryIfReady(), which registers the resumed segment via
+            // newResumedTempArchiveUploadTask (the mocked failing behavior).
+            sendVerification(TestBlockBuilder.generateBlocksInRange(50, 50).getFirst());
+            assertThat(plugin.tempUploadFutures).containsKey(segmentFirstBlock);
+
+            // Running the mocked task throws — the exception propagates as RuntimeException.
+            assertThatThrownBy(executor::executeSerially).isInstanceOf(RuntimeException.class);
+
+            // The next notification drains the failed future and triggers mid-run recovery.
+            sendVerification(TestBlockBuilder.generateBlocksInRange(51, 51).getFirst());
+
+            assertThat(plugin.tempUploadFutures).doesNotContainKey(segmentFirstBlock);
+            assertThat(getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_FAILED_TASKS))
+                    .isEqualTo(1L);
         }
 
         /// Verifies that [triggerMidRunRecovery] clears [gapBuffer] and moves its entries to

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
@@ -1971,6 +1971,89 @@ class CloudStorageArchivePluginTest {
             assertThat(getAllObjects()).contains(supersededTarKey, activeTarKey);
         }
 
+        /// Five hanging temp archives for five distinct groups are found resumable at startup, but
+        /// the default `maxConcurrentTempArchives=4`. Only the first four (in S3-key / ascending
+        /// firstBlock order) should be started immediately; the fifth must be deferred to
+        /// [CloudStorageArchivePlugin#pendingResumedArchives] rather than pushing `tempUploadFutures`
+        /// past the configured limit.
+        @Test
+        @DisplayName("Resumable archives beyond the concurrency limit are deferred, not started immediately")
+        void excessResumableArchivesAreDeferred() throws Exception {
+            final CloudStorageArchiveConfig config = makeConfig();
+            for (final long firstBlock : List.of(20L, 40L, 60L, 80L, 100L)) {
+                plantHangingTempArchive(config, firstBlock);
+            }
+
+            // Recovery resolves all five hanging uploads into resumable entries.
+            pluginExecutor.executeSerially();
+
+            // Trigger completeRecoveryIfReady() with an unrelated, far-ahead block.
+            sendVerification(TestBlockBuilder.generateBlocksInRange(200, 200).getFirst());
+
+            // Only four of the five winning resumed archives fit under the default cap of 4.
+            assertThat(plugin.tempUploadFutures).containsOnlyKeys(20L, 40L, 60L, 80L);
+            assertThat(plugin.tempGroupActiveQueues).containsOnlyKeys(20L, 40L, 60L, 80L);
+            assertThat(plugin.pendingResumedArchives).hasSize(1);
+            assertThat(plugin.pendingResumedArchives.peek().firstBlock()).isEqualTo(100L);
+        }
+
+        /// Once a slot frees, the deferred resumable archive for group 100 must be started by
+        /// `CloudStorageArchivePlugin.drainPendingResumedArchives`. [BlockingExecutor#executeSerially]
+        /// runs every queued task, not just one, so all four active segments (20, 40, 60, 80) are
+        /// closed here before running it -- otherwise the still-open ones would block on
+        /// `queue.take()` for up to their 60s per-task timeout.
+        @Test
+        @DisplayName("Deferred resumable archive is started once a temp-upload slot frees")
+        void deferredResumableArchiveStartsWhenSlotFrees() throws Exception {
+            final int groupSize = Math.powExact(10, GROUPING_LEVEL);
+            final CloudStorageArchiveConfig config = makeConfig();
+            for (final long firstBlock : List.of(20L, 40L, 60L, 80L, 100L)) {
+                plantHangingTempArchive(config, firstBlock);
+            }
+
+            pluginExecutor.executeSerially();
+            sendVerification(TestBlockBuilder.generateBlocksInRange(200, 200).getFirst());
+            assertThat(plugin.pendingResumedArchives).hasSize(1);
+
+            // Complete every active segment's group. Each segment was planted with 2 blocks
+            // (firstBlock, firstBlock+1); recovery conservatively treats the last written tar entry
+            // as unconfirmed and resumes from it, so the resume point is firstBlock+1, not +2 (see
+            // resumeFromHangingUploadCompletesGroup, which resends the last uploaded block the same way).
+            for (final long groupStart : List.of(20L, 40L, 60L, 80L)) {
+                sendVerifications(
+                        TestBlockBuilder.generateBlocksInRange((int) groupStart + 1, (int) groupStart + groupSize - 1));
+            }
+            assertThat(plugin.tempGroupActiveQueues).isEmpty();
+
+            // Run all four now-closed TempArchiveUploadTasks to completion.
+            pluginExecutor.executeSerially();
+
+            // Drives checkAndDrainTempUploadResults (frees all four slots), then
+            // drainPendingResumedArchives (starts the deferred firstBlock=100 archive), then
+            // drainOverflowStash (block 200, stashed earlier while slots were full, starts its own
+            // new segment with a slot to spare).
+            sendVerification(TestBlockBuilder.generateBlocksInRange(201, 201).getFirst());
+
+            assertThat(plugin.pendingResumedArchives).isEmpty();
+            assertThat(plugin.tempUploadFutures).containsOnlyKeys(100L, 200L);
+            assertThat(plugin.tempGroupActiveQueues).containsKeys(100L, 200L);
+            assertThat(plugin.tempArchiveTracker).containsKeys(20L, 40L, 60L, 80L);
+        }
+
+        /// Plants a hanging (never-completed) multipart upload for a 2-block temp archive segment
+        /// starting at `firstBlock`, simulating a crash mid-upload.
+        private void plantHangingTempArchive(CloudStorageArchiveConfig config, long firstBlock) throws Exception {
+            final String tarKey = TempArchiveKey.formatTar(firstBlock, config.objectKeyPrefix());
+            final List<TestBlock> blocks =
+                    TestBlockBuilder.generateBlocksInRange((int) firstBlock, (int) firstBlock + 1);
+            try (S3Client s3 = openS3Client(config)) {
+                final String uploadId =
+                        s3.createMultipartUpload(tarKey, config.storageClass().name(), CONTENT_TYPE);
+                s3.multipartUploadPart(tarKey, uploadId, 1, buildTarBytes(blocks, (int) firstBlock));
+                // deliberately NOT completing — simulate a crash mid-upload
+            }
+        }
+
         private CloudStorageArchiveConfig makeConfig() {
             final ConfigurationBuilder builder =
                     ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
@@ -44,6 +44,7 @@ import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.app.fixtures.TestMetricsExporter;
 import org.hiero.block.node.app.fixtures.async.BlockingExecutor;
 import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
+import org.hiero.block.node.app.fixtures.async.TestThreadPoolManager;
 import org.hiero.block.node.app.fixtures.blocks.TestBlock;
 import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
 import org.hiero.block.node.app.fixtures.logging.TestLogHandler;
@@ -292,17 +293,16 @@ class CloudStorageArchivePluginTest {
             assertThatNoException().isThrownBy(() -> plugin.init(testContext, null));
         }
 
-        /// Verifies that the plugin does NOT register as a block notification handler when a
-        /// required configuration field is blank or empty.  Each case omits exactly one field, or
-        /// sets it to whitespace only, so that [CloudStorageArchiveConfig#validate] returns a
-        /// non-empty violation list.
-        @ParameterizedTest(name = "plugin not registered when {0} is blank or empty")
-        @MethodSource("blankOrEmptyFieldConfigs")
-        @DisplayName("Plugin not registered when a required config field is blank or empty")
-        void testPluginNotRegisteredForMissingField(String fieldName, Map<String, String> configValues) {
+        /// Verifies that [CloudStorageArchivePlugin#stop] does not throw and does not attempt to
+        /// unregister a notification handler that was never registered (because `configValid` is
+        /// `false` when a required configuration field is absent).
+        @Test
+        @DisplayName("stop() with invalid config does not throw and does not unregister handler")
+        void testStopWithInvalidConfigDoesNotUnregister() {
             final ConfigurationBuilder builder =
                     ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);
-            configValues.forEach(builder::withValue);
+            // endpointUrl present but other required fields absent — configValid stays false.
+            builder.withValue("cloud.storage.archive.endpointUrl", "http://localhost:9000");
             final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
             final BlockNodeContext testContext = new BlockNodeContext(
                     builder.build(),
@@ -318,8 +318,82 @@ class CloudStorageArchivePluginTest {
                     null,
                     new ArrayList<>(),
                     new ArrayList<>());
-            new CloudStorageArchivePlugin().init(testContext, null);
+            final CloudStorageArchivePlugin plugin = new CloudStorageArchivePlugin();
+            plugin.init(testContext, null);
             assertThat(messaging.getBlockNotificationHandlerCount()).isZero();
+            assertThatNoException().isThrownBy(plugin::stop);
+            assertThat(messaging.getBlockNotificationHandlerCount()).isZero();
+        }
+    }
+
+    /// Integration tests that drive the plugin via [PluginTestBase].
+    @Nested
+    @DisplayName("Plugin Tests")
+    final class PluginTests
+            extends PluginTestBase<CloudStorageArchivePlugin, BlockingExecutor, ScheduledBlockingExecutor> {
+
+        private static final int GROUPING_LEVEL = 1; // groupSize = 10^1 = 10 blocks per tar
+        private final BlockingExecutor pluginExecutor;
+
+        PluginTests() {
+            super(
+                    new BlockingExecutor(new LinkedBlockingQueue<>()),
+                    new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+            start(new CloudStorageArchivePlugin(), new SimpleInMemoryHistoricalBlockFacility(), pluginConfig());
+            pluginExecutor = testThreadPoolManager.executor();
+        }
+
+        /// Drains the startup recovery task after [clearBucket] has cleaned S3.
+        ///
+        /// The constructor runs before `@BeforeEach`, so recovery must be deferred here to avoid
+        /// seeing stale S3 objects left by a previous test.
+        @BeforeEach
+        void drainRecovery() {
+            pluginExecutor.executeSerially();
+        }
+
+        /// Verifies that the plugin registers as a block notification handler once started with a
+        /// valid configuration (registration happens in [CloudStorageArchivePlugin#start], after the
+        /// startup recovery task has been submitted).
+        @Test
+        @DisplayName("Plugin registers as notification handler once started with a valid configuration")
+        void testPluginRegisteredOnStart() {
+            assertThat(blockMessaging.getBlockNotificationHandlerCount()).isOne();
+        }
+
+        /// Verifies that [CloudStorageArchivePlugin#start] does not register or submit a startup
+        /// recovery task when a required config field is blank or empty. Uses its own plugin and
+        /// context, since the class-level ones already belong to a plugin started with valid config.
+        @ParameterizedTest(name = "plugin not registered when {0} is blank or empty")
+        @MethodSource("blankOrEmptyFieldConfigs")
+        @DisplayName("start() does not register as notification handler when a required config field is blank or empty")
+        void testStartDoesNotRegisterForMissingField(String fieldName, Map<String, String> configValues) {
+            final ConfigurationBuilder builder =
+                    ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);
+            configValues.forEach(builder::withValue);
+            final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
+            final BlockingExecutor executor = new BlockingExecutor(new LinkedBlockingQueue<>());
+            final TestThreadPoolManager<BlockingExecutor, ScheduledBlockingExecutor> invalidConfigThreadPoolManager =
+                    new TestThreadPoolManager<>(executor, new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+            final BlockNodeContext testContext = new BlockNodeContext(
+                    builder.build(),
+                    MetricRegistry.builder().build(),
+                    new TestHealthFacility(),
+                    messaging,
+                    new SimpleInMemoryHistoricalBlockFacility(),
+                    null,
+                    null,
+                    invalidConfigThreadPoolManager,
+                    null,
+                    null,
+                    null,
+                    new ArrayList<>(),
+                    new ArrayList<>());
+            final CloudStorageArchivePlugin invalidConfigPlugin = new CloudStorageArchivePlugin();
+            invalidConfigPlugin.init(testContext, null);
+            invalidConfigPlugin.start();
+            assertThat(messaging.getBlockNotificationHandlerCount()).isZero();
+            assertThat(executor.wasAnyTaskSubmitted()).isFalse();
         }
 
         static Stream<Arguments> blankOrEmptyFieldConfigs() {
@@ -352,97 +426,6 @@ class CloudStorageArchivePluginTest {
             final Map<String, String> copy = new HashMap<>(source);
             copy.put(key, value);
             return copy;
-        }
-
-        /// Verifies that [CloudStorageArchivePlugin#stop] does not throw and does not attempt to
-        /// unregister a notification handler that was never registered (because `configValid` is
-        /// `false` when a required configuration field is absent).
-        @Test
-        @DisplayName("stop() with invalid config does not throw and does not unregister handler")
-        void testStopWithInvalidConfigDoesNotUnregister() {
-            final ConfigurationBuilder builder =
-                    ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);
-            // endpointUrl present but other required fields absent — configValid stays false.
-            builder.withValue("cloud.storage.archive.endpointUrl", "http://localhost:9000");
-            final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
-            final BlockNodeContext testContext = new BlockNodeContext(
-                    builder.build(),
-                    MetricRegistry.builder().build(),
-                    new TestHealthFacility(),
-                    messaging,
-                    new SimpleInMemoryHistoricalBlockFacility(),
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    new ArrayList<>(),
-                    new ArrayList<>());
-            final CloudStorageArchivePlugin plugin = new CloudStorageArchivePlugin();
-            plugin.init(testContext, null);
-            assertThat(messaging.getBlockNotificationHandlerCount()).isZero();
-            assertThatNoException().isThrownBy(plugin::stop);
-            assertThat(messaging.getBlockNotificationHandlerCount()).isZero();
-        }
-
-        /// Verifies that the plugin DOES register as a block notification handler when all
-        /// required configuration fields are present.
-        @Test
-        @DisplayName("Plugin registers as notification handler when all required config fields are present")
-        void testPluginRegisteredWhenAllConfigFieldsPresent() {
-            final Configuration configuration = ConfigurationBuilder.create()
-                    .withConfigDataType(CloudStorageArchiveConfig.class)
-                    .withValue("cloud.storage.archive.endpointUrl", "http://localhost:9000")
-                    .withValue("cloud.storage.archive.regionName", "us-east-1")
-                    .withValue("cloud.storage.archive.accessKey", "minioadmin")
-                    .withValue("cloud.storage.archive.secretKey", "minioadmin")
-                    .withValue("cloud.storage.archive.bucketName", "test-bucket")
-                    .build();
-            final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
-            final BlockNodeContext testContext = new BlockNodeContext(
-                    configuration,
-                    MetricRegistry.builder().build(),
-                    new TestHealthFacility(),
-                    messaging,
-                    new SimpleInMemoryHistoricalBlockFacility(),
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    new ArrayList<>(),
-                    new ArrayList<>());
-            new CloudStorageArchivePlugin().init(testContext, null);
-            assertThat(messaging.getBlockNotificationHandlerCount()).isOne();
-        }
-    }
-
-    /// Integration tests that drive the plugin via [PluginTestBase].
-    @Nested
-    @DisplayName("Plugin Tests")
-    final class PluginTests
-            extends PluginTestBase<CloudStorageArchivePlugin, BlockingExecutor, ScheduledBlockingExecutor> {
-
-        private static final int GROUPING_LEVEL = 1; // groupSize = 10^1 = 10 blocks per tar
-        private final BlockingExecutor pluginExecutor;
-
-        PluginTests() {
-            super(
-                    new BlockingExecutor(new LinkedBlockingQueue<>()),
-                    new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
-            start(new CloudStorageArchivePlugin(), new SimpleInMemoryHistoricalBlockFacility(), pluginConfig());
-            pluginExecutor = testThreadPoolManager.executor();
-        }
-
-        /// Drains the startup recovery task after [clearBucket] has cleaned S3.
-        ///
-        /// The constructor runs before `@BeforeEach`, so recovery must be deferred here to avoid
-        /// seeing stale S3 objects left by a previous test.
-        @BeforeEach
-        void drainRecovery() {
-            pluginExecutor.executeSerially();
         }
 
         @Test

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTaskTest.java
@@ -856,6 +856,40 @@ class StartupRecoveryTaskTest {
         }
     }
 
+    /// Verifies that when a `.tmp` key has two hanging multipart uploads at once (e.g. two
+    /// block-node instances briefly overlapped against the same bucket), recovery keeps only the
+    /// candidate with the higher `nextBlockNumber` and aborts the other's newly created upload,
+    /// rather than returning two [TempArchiveResumeState]s for the same `firstBlock`.
+    @Test
+    @DisplayName("Two hanging uploads for the same key: higher nextBlockNumber wins, loser's new upload aborted")
+    void twoHangingUploadsForSameKeyKeepsHigherNextBlockNumber() throws Exception {
+        final String tarKey = TempArchiveKey.formatTar(0, config.objectKeyPrefix());
+        final byte[] shorterPartBytes = buildTarBytes(TestBlockBuilder.generateBlocksInRange(0, 4));
+        final byte[] longerPartBytes = buildTarBytes(TestBlockBuilder.generateBlocksInRange(0, 9));
+        try (S3Client s3 = openS3Client()) {
+            final String shorterUploadId =
+                    s3.createMultipartUpload(tarKey, config.storageClass().name(), CONTENT_TYPE);
+            s3.multipartUploadPart(tarKey, shorterUploadId, 1, shorterPartBytes);
+            final String longerUploadId =
+                    s3.createMultipartUpload(tarKey, config.storageClass().name(), CONTENT_TYPE);
+            s3.multipartUploadPart(tarKey, longerUploadId, 1, longerPartBytes);
+            // Both uploads hanging simultaneously for the identical key.
+            assertThat(s3.listMultipartUploads().get(tarKey)).hasSize(2);
+        }
+
+        final RecoveryResult result = new StartupRecoveryTask(config).call();
+
+        assertThat(result.resumableTempArchives()).hasSize(1);
+        final TempArchiveResumeState resumeState =
+                result.resumableTempArchives().getFirst();
+        assertThat(resumeState.s3Key()).isEqualTo(tarKey);
+        assertThat(resumeState.nextBlockNumber()).isEqualTo(9L);
+        try (S3Client s3 = openS3Client()) {
+            // Only the winner's freshly created upload should remain hanging.
+            assertThat(s3.listMultipartUploads().get(tarKey)).hasSize(1);
+        }
+    }
+
     /// Direct test of the [#withTempArchives] fix: [RecoveryResult#lastHandedOffBlock()] must
     /// reflect `resumed.nextBlockNumber() - 1` so that gap detection in [CloudStorageArchivePlugin]
     /// does not treat the resumed range as not-yet-handed-off.

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTaskTest.java
@@ -695,10 +695,11 @@ class StartupRecoveryTaskTest {
         assertThat(result.lastHandedOffBlock()).isEqualTo(19L);
     }
 
-    /// Verifies that a hanging multipart upload targeting a `.tmp` key is aborted during recovery
-    /// and is not included in the returned [RecoveryResult#tempArchives()] list.
+    /// Verifies that a hanging multipart upload targeting a `.tmp` key with no parts is aborted
+    /// during recovery and is absent from both [RecoveryResult#tempArchives()] and
+    /// [RecoveryResult#resumableTempArchives()].
     @Test
-    @DisplayName("Hanging temp upload: aborted during recovery and absent from tempArchives")
+    @DisplayName("Hanging temp upload with no parts: aborted during recovery, absent from both lists")
     void hangingTempUploadIsAbortedAndNotInResult() throws Exception {
         final String tarKey = TempArchiveKey.formatTar(0, config.objectKeyPrefix());
         try (S3Client s3 = openS3Client()) {
@@ -709,9 +710,172 @@ class StartupRecoveryTaskTest {
         final RecoveryResult result = new StartupRecoveryTask(config).call();
 
         assertThat(result.tempArchives()).isEmpty();
+        assertThat(result.resumableTempArchives()).isEmpty();
         try (S3Client s3 = openS3Client()) {
             assertThat(s3.listMultipartUploads()).isEmpty();
         }
+    }
+
+    /// Verifies that a hanging temp archive multipart upload with durable parts is resumed rather
+    /// than aborted: recovery completes the old upload, starts a fresh one, and returns a
+    /// [TempArchiveResumeState] with the correct `s3Key`/`firstBlock`/`uploadId`/`etags`/
+    /// `nextBlockNumber`/`trailingBytes`. The segment must be absent from [RecoveryResult#tempArchives()]
+    /// (not yet durable) and the old multipart upload must no longer be hanging.
+    @Test
+    @DisplayName("Hanging temp upload with durable parts: resumed, correct resume state, absent from tempArchives")
+    void hangingTempUploadWithDurablePartsIsResumed() throws Exception {
+        final String tarKey = TempArchiveKey.formatTar(0, config.objectKeyPrefix());
+        final List<TestBlock> blocks = TestBlockBuilder.generateBlocksInRange(0, 4);
+        final byte[] partBytes = buildTarBytes(blocks);
+        final String oldUploadId;
+        try (S3Client s3 = openS3Client()) {
+            oldUploadId = s3.createMultipartUpload(tarKey, config.storageClass().name(), CONTENT_TYPE);
+            s3.multipartUploadPart(tarKey, oldUploadId, 1, partBytes);
+            // deliberately NOT completing — simulate a crash mid-upload
+        }
+
+        final RecoveryResult result = new StartupRecoveryTask(config).call();
+
+        assertThat(result.tempArchives()).isEmpty();
+        assertThat(result.resumableTempArchives()).hasSize(1);
+        final TempArchiveResumeState resumeState =
+                result.resumableTempArchives().getFirst();
+        assertThat(resumeState.s3Key()).isEqualTo(tarKey);
+        assertThat(resumeState.firstBlock()).isZero();
+        assertThat(resumeState.uploadId()).isNotNull().isNotEqualTo(oldUploadId);
+        assertThat(resumeState.etags()).isEmpty();
+        assertThat(resumeState.nextBlockNumber()).isEqualTo(4L);
+        final int block4HeaderOffset = TarEntries.findLastBlockStart(partBytes);
+        assertThat(resumeState.trailingBytes()).isEqualTo(Arrays.copyOfRange(partBytes, 0, block4HeaderOffset));
+        try (S3Client s3 = openS3Client()) {
+            // The old upload was completed (to materialize a readable object) and a fresh one
+            // opened for the same key -- left open for the resumed TempArchiveUploadTask.
+            final Map<String, List<String>> hangingUploads = s3.listMultipartUploads();
+            assertThat(hangingUploads).containsKey(tarKey);
+            assertThat(hangingUploads.get(tarKey)).doesNotContain(oldUploadId);
+        }
+    }
+
+    /// Verifies the marker-at-offset-0 edge case: the boundary part's block-start header sits at
+    /// byte offset 0 (the preceding part ends exactly on a 512-byte tar boundary), so
+    /// `trailingBytes` is legitimately empty even though a boundary WAS found. Regression test for
+    /// a bug where `trailingBytes().length > 0` was used as the "boundary found" signal, causing
+    /// this case to be misread as "no block start found in any part" and the upload aborted
+    /// instead of resumed.
+    @Test
+    @DisplayName("Hanging temp upload with marker at part offset 0: resumed despite empty trailingBytes")
+    void hangingTempUploadWithMarkerAtPartOffsetZeroIsResumed() throws Exception {
+        final String tarKey = TempArchiveKey.formatTar(0, config.objectKeyPrefix());
+        // Part 1: blocks 0-3, padded to PART_SIZE (a multiple of 512) so part 2 starts exactly on
+        // a tar-block boundary. Part 2: block 4's entry alone, so its header sits at offset 0.
+        final byte[] part1 = Arrays.copyOf(buildTarBytes(TestBlockBuilder.generateBlocksInRange(0, 3)), PART_SIZE);
+        final TestBlock block4 = TestBlockBuilder.generateBlockWithNumber(4);
+        final byte[] part2 = TarEntries.toTarEntry(block4.blockUnparsed(), block4.number());
+        final String oldUploadId;
+        try (S3Client s3 = openS3Client()) {
+            oldUploadId = s3.createMultipartUpload(tarKey, config.storageClass().name(), CONTENT_TYPE);
+            s3.multipartUploadPart(tarKey, oldUploadId, 1, part1);
+            s3.multipartUploadPart(tarKey, oldUploadId, 2, part2);
+            // deliberately NOT completing — simulate a crash mid-upload
+        }
+
+        final RecoveryResult result = new StartupRecoveryTask(config).call();
+
+        assertThat(result.tempArchives()).isEmpty();
+        assertThat(result.resumableTempArchives()).hasSize(1);
+        final TempArchiveResumeState resumeState =
+                result.resumableTempArchives().getFirst();
+        assertThat(resumeState.s3Key()).isEqualTo(tarKey);
+        assertThat(resumeState.firstBlock()).isZero();
+        assertThat(resumeState.uploadId()).isNotNull().isNotEqualTo(oldUploadId);
+        assertThat(resumeState.etags()).hasSize(1); // part 1 server-side copied into the new upload
+        assertThat(resumeState.nextBlockNumber()).isEqualTo(4L);
+        assertThat(resumeState.trailingBytes()).isEmpty();
+        try (S3Client s3 = openS3Client()) {
+            final Map<String, List<String>> hangingUploads = s3.listMultipartUploads();
+            assertThat(hangingUploads).containsKey(tarKey);
+            assertThat(hangingUploads.get(tarKey)).doesNotContain(oldUploadId);
+        }
+    }
+
+    /// Verifies that a hanging temp archive multipart upload whose parts contain no valid tar
+    /// header is aborted (not resumed): absent from both [RecoveryResult#tempArchives()] and
+    /// [RecoveryResult#resumableTempArchives()], with no leftover multipart upload or intermediate
+    /// S3 object.
+    @Test
+    @DisplayName("Hanging temp upload with gibberish parts: aborted, absent from both lists")
+    void hangingTempUploadWithGibberishPartsIsAborted() throws Exception {
+        final String tarKey = TempArchiveKey.formatTar(0, config.objectKeyPrefix());
+        try (S3Client s3 = openS3Client()) {
+            final String uploadId =
+                    s3.createMultipartUpload(tarKey, config.storageClass().name(), CONTENT_TYPE);
+            final byte[] gibberish = new byte[1024];
+            Arrays.fill(gibberish, (byte) 0x42);
+            s3.multipartUploadPart(tarKey, uploadId, 1, gibberish);
+            // deliberately NOT completing — simulate a crash mid-upload
+        }
+
+        final RecoveryResult result = new StartupRecoveryTask(config).call();
+
+        assertThat(result.tempArchives()).isEmpty();
+        assertThat(result.resumableTempArchives()).isEmpty();
+        try (S3Client s3 = openS3Client()) {
+            assertThat(s3.listMultipartUploads()).doesNotContainKey(tarKey);
+            assertThat(s3.listObjects(tarKey, 1)).doesNotContain(tarKey);
+        }
+    }
+
+    /// Verifies that two simultaneously hanging temp archive uploads are resolved independently --
+    /// one resumable (durable parts) and one empty (aborted) -- unlike the regular path's
+    /// all-or-nothing [#recoverFromMultipleHangingUploads].
+    @Test
+    @DisplayName("Two simultaneous hanging temp uploads: resolved independently, one resumed one aborted")
+    void twoSimultaneousHangingTempUploadsAreResolvedIndependently() throws Exception {
+        final String resumableKey = TempArchiveKey.formatTar(0, config.objectKeyPrefix());
+        final String emptyKey = TempArchiveKey.formatTar(100, config.objectKeyPrefix());
+        final byte[] partBytes = buildTarBytes(TestBlockBuilder.generateBlocksInRange(0, 4));
+        try (S3Client s3 = openS3Client()) {
+            final String resumableUploadId =
+                    s3.createMultipartUpload(resumableKey, config.storageClass().name(), CONTENT_TYPE);
+            s3.multipartUploadPart(resumableKey, resumableUploadId, 1, partBytes);
+            // No parts uploaded for the empty one.
+            s3.createMultipartUpload(emptyKey, config.storageClass().name(), CONTENT_TYPE);
+        }
+
+        final RecoveryResult result = new StartupRecoveryTask(config).call();
+
+        assertThat(result.resumableTempArchives()).hasSize(1);
+        final TempArchiveResumeState resumeState =
+                result.resumableTempArchives().getFirst();
+        assertThat(resumeState.s3Key()).isEqualTo(resumableKey);
+        assertThat(resumeState.nextBlockNumber()).isEqualTo(4L);
+        try (S3Client s3 = openS3Client()) {
+            final Map<String, List<String>> hangingUploads = s3.listMultipartUploads();
+            assertThat(hangingUploads).containsKey(resumableKey);
+            assertThat(hangingUploads).doesNotContainKey(emptyKey);
+        }
+    }
+
+    /// Direct test of the [#withTempArchives] fix: [RecoveryResult#lastHandedOffBlock()] must
+    /// reflect `resumed.nextBlockNumber() - 1` so that gap detection in [CloudStorageArchivePlugin]
+    /// does not treat the resumed range as not-yet-handed-off.
+    @Test
+    @DisplayName("Resumable temp upload: lastHandedOffBlock reflects nextBlockNumber - 1")
+    void resumableTempUploadUpdatesLastHandedOffBlock() throws Exception {
+        final String tarKey = TempArchiveKey.formatTar(0, config.objectKeyPrefix());
+        final byte[] partBytes = buildTarBytes(TestBlockBuilder.generateBlocksInRange(0, 4));
+        try (S3Client s3 = openS3Client()) {
+            final String uploadId =
+                    s3.createMultipartUpload(tarKey, config.storageClass().name(), CONTENT_TYPE);
+            s3.multipartUploadPart(tarKey, uploadId, 1, partBytes);
+        }
+
+        final RecoveryResult result = new StartupRecoveryTask(config).call();
+
+        assertThat(result.resumableTempArchives()).hasSize(1);
+        final TempArchiveResumeState resumeState =
+                result.resumableTempArchives().getFirst();
+        assertThat(result.lastHandedOffBlock()).isEqualTo(resumeState.nextBlockNumber() - 1);
     }
 
     /// Verifies that a `.tmp` object without a companion `.meta` file (orphaned) is deleted from

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTaskTest.java
@@ -21,6 +21,7 @@ import io.minio.messages.Item;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -204,11 +205,13 @@ class TempArchiveUploadTaskTest {
     }
 
     /// Verifies that when [doCompleteMultipartUpload] throws, [call()] rethrows the exception,
-    /// neither the `.tmp` key (not yet committed) nor the `.meta` key is present in S3, and a
-    /// failed [PersistedNotification] is sent so downstream subscribers are not left dangling.
+    /// neither the `.tmp` key (not yet committed) nor the `.meta` key is present in S3, a failed
+    /// [PersistedNotification] is sent so downstream subscribers are not left dangling, and --
+    /// unlike before the abort-removal -- the multipart upload is left hanging on S3 (with its
+    /// already-flushed part intact) for [StartupRecoveryTask] to resume, instead of being aborted.
     @Test
-    @DisplayName("completeMultipartUpload failure: exception rethrown; no keys committed; failed notification sent")
-    void completeFailureThrowsAndLeavesNoKeys() throws Exception {
+    @DisplayName("completeMultipartUpload failure: exception rethrown; upload left hanging, not aborted")
+    void completeFailureThrowsAndLeavesUploadHanging() throws Exception {
         final String s3Key = TempArchiveKey.formatTar(0, "");
         final String metaKey = TempArchiveKey.formatMeta(0, "");
         final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
@@ -226,6 +229,11 @@ class TempArchiveUploadTaskTest {
             // The multipart upload was never completed, so the .tmp object is not visible.
             assertThat(s3.listObjects(s3Key, 1)).doesNotContain(s3Key);
             assertThat(s3.listObjects(metaKey, 1)).doesNotContain(metaKey);
+            // The upload itself must still be hanging -- not aborted -- with its part intact.
+            final Map<String, List<String>> hangingUploads = s3.listMultipartUploads();
+            assertThat(hangingUploads).containsKey(s3Key);
+            assertThat(s3.listParts(s3Key, hangingUploads.get(s3Key).getFirst()))
+                    .isNotEmpty();
         }
         assertThat(asf.addedRanges).isEmpty();
         final List<PersistedNotification> notifications = messaging.getSentPersistedNotifications();
@@ -269,11 +277,11 @@ class TempArchiveUploadTaskTest {
     }
 
     /// Verifies that interrupting the virtual thread while it is blocked on [BlockingQueue#take]
-    /// with no blocks accumulated causes [call()] to rethrow [InterruptedException] and abort the
-    /// in-progress multipart upload.
+    /// with no blocks accumulated causes [call()] to rethrow [InterruptedException] and leave the
+    /// in-progress multipart upload hanging on S3 (not aborted) for [StartupRecoveryTask].
     @Test
-    @DisplayName("Thread interruption with no blocks accumulated aborts upload and rethrows InterruptedException")
-    void interruptionWithNoBlocksAbortsUploadAndRethrows() throws Exception {
+    @DisplayName("Thread interruption with no blocks accumulated leaves upload hanging, rethrows InterruptedException")
+    void interruptionWithNoBlocksLeavesUploadHangingAndRethrows() throws Exception {
         final String s3Key = TempArchiveKey.formatTar(0, "");
         final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
         final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
@@ -297,7 +305,7 @@ class TempArchiveUploadTaskTest {
 
         assertThat(caught[0]).isNotNull();
         try (S3Client s3 = openS3Client()) {
-            assertThat(s3.listMultipartUploads()).doesNotContainKey(s3Key);
+            assertThat(s3.listMultipartUploads()).containsKey(s3Key);
         }
     }
 
@@ -352,11 +360,11 @@ class TempArchiveUploadTaskTest {
     }
 
     /// Verifies that when [doUploadPart] throws during a mid-loop part flush, [call()] rethrows
-    /// the exception, aborts the multipart upload, and sends one failed [PersistedNotification]
-    /// for the first unseen block — consistent with the other two upload-failure paths in this
-    /// class, even though the aborted parts never became a retrievable object.
+    /// the exception, sends one failed [PersistedNotification] for the first unseen block --
+    /// consistent with the other two upload-failure paths in this class -- and leaves the
+    /// multipart upload hanging on S3 rather than aborting it.
     @Test
-    @DisplayName("Part upload failure during loop: failed notification sent, exception rethrown, upload aborted")
+    @DisplayName("Part upload failure during loop: failed notification sent, exception rethrown, upload left hanging")
     void partUploadFailureDuringLoopSendsFailedNotificationAndThrows() throws Exception {
         final String s3Key = TempArchiveKey.formatTar(0, "");
         final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
@@ -381,16 +389,16 @@ class TempArchiveUploadTaskTest {
         assertThat(notifications.getFirst().blockSource()).isEqualTo(BlockSource.PUBLISHER);
         assertThat(asf.addedRanges).isEmpty();
         try (S3Client s3 = openS3Client()) {
-            assertThat(s3.listMultipartUploads()).doesNotContainKey(s3Key);
+            assertThat(s3.listMultipartUploads()).containsKey(s3Key);
         }
     }
 
     /// Verifies that when [doUploadPart] throws while uploading the final partial buffer (after
-    /// SEGMENT_END), [call()] sends one failed [PersistedNotification] for the first unseen block
-    /// and rethrows the exception.
+    /// SEGMENT_END), [call()] sends one failed [PersistedNotification] for the first unseen block,
+    /// rethrows the exception, and leaves the multipart upload hanging on S3 rather than aborting it.
     @Test
-    @DisplayName("Part upload failure for final part: failed notification sent, exception rethrown")
-    void partUploadFailureForFinalPartSendsFailedNotificationAndThrows() throws Exception {
+    @DisplayName("Part upload failure for final part: failed notification sent, upload left hanging")
+    void partUploadFailureForFinalPartSendsFailedNotificationAndLeavesUploadHanging() throws Exception {
         final String s3Key = TempArchiveKey.formatTar(0, "");
         final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
         final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
@@ -414,7 +422,7 @@ class TempArchiveUploadTaskTest {
         assertThat(notifications.getFirst().blockSource()).isEqualTo(BlockSource.PUBLISHER);
         assertThat(asf.addedRanges).isEmpty();
         try (S3Client s3 = openS3Client()) {
-            assertThat(s3.listMultipartUploads()).doesNotContainKey(s3Key);
+            assertThat(s3.listMultipartUploads()).containsKey(s3Key);
         }
     }
 
@@ -448,6 +456,144 @@ class TempArchiveUploadTaskTest {
         assertThat(notifications).hasSize(1);
         assertThat(notifications.getFirst().blockNumber()).isEqualTo(numBlocks - 1L);
         assertThat(notifications.getFirst().succeeded()).isTrue();
+    }
+
+    /// Verifies the resume constructor's key behaviors together: it reuses the given upload ID and
+    /// ETags instead of starting a new multipart upload, prepends
+    /// [TempArchiveResumeState#trailingBytes()] to the accumulation buffer, begins consuming the
+    /// queue at [TempArchiveResumeState#nextBlockNumber()] rather than [firstBlock], and the
+    /// returned [TempArchiveEntry#firstBlock()] still reflects the original segment identity
+    /// passed to the constructor, not the resume point.
+    @Test
+    @DisplayName("Resume constructor: reuses uploadId/etags, prepends trailingBytes, resumes from nextBlockNumber")
+    void resumeConstructorResumesFromRecoveredStateAndPreservesSegmentIdentity() throws Exception {
+        final String s3Key = TempArchiveKey.formatTar(0, "");
+        final long firstBlock = 0;
+
+        // Manually build and upload a first part large enough to satisfy S3's non-final-part
+        // minimum size, simulating parts already server-side-copied by StartupRecoveryTask.
+        final List<BlockWithSource> preBlocks = new ArrayList<>();
+        for (int i = 0; i < 9; i++) {
+            preBlocks.add(makeBlock(BLOCK_DATA_BYTES));
+        }
+        byte[] part1Bytes = new byte[0];
+        for (int i = 0; i < preBlocks.size(); i++) {
+            part1Bytes = S3UploadUtils.concat(
+                    part1Bytes, TarEntries.toTarEntry(preBlocks.get(i).block(), firstBlock + i));
+        }
+        assertThat(part1Bytes.length).isGreaterThanOrEqualTo(PART_SIZE_MB * 1024 * 1024);
+
+        final String uploadId;
+        final String etag1;
+        try (S3Client s3 = openS3Client()) {
+            uploadId = s3.createMultipartUpload(s3Key, config.storageClass().name(), S3UploadUtils.CONTENT_TYPE);
+            etag1 = s3.multipartUploadPart(s3Key, uploadId, 1, part1Bytes);
+        }
+
+        final long nextBlockNumber = preBlocks.size();
+        // Arbitrary carry-over bytes representing a boundary part's not-yet-full tail.
+        final byte[] trailingBytes = TarEntries.toTarEntry(makeBlock(50).block(), 999);
+        final TempArchiveResumeState resumeState =
+                new TempArchiveResumeState(s3Key, firstBlock, nextBlockNumber, uploadId, List.of(etag1), trailingBytes);
+
+        final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
+        final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
+        final TrackingApplicationStateFacility asf = new TrackingApplicationStateFacility();
+        final BlockWithSource newBlock = makeBlock(100);
+        queue.put(newBlock);
+        queue.put(TempArchiveUploadTask.SEGMENT_END);
+
+        final TempArchiveUploadTask task = new TempArchiveUploadTask(
+                config, messaging, asf, createMetricsHolder(), s3Key, firstBlock, queue, resumeState);
+
+        final TempArchiveEntry entry = task.call();
+
+        // Original firstBlock identity preserved even though consumption started at nextBlockNumber.
+        assertThat(entry.firstBlock()).isZero();
+        // Consumption started at nextBlockNumber (9); the single new block became block 9.
+        assertThat(entry.lastBlock()).isEqualTo(nextBlockNumber);
+
+        try (S3Client s3 = openS3Client()) {
+            // Reused the existing upload -- it completed and is no longer hanging.
+            assertThat(s3.listMultipartUploads()).doesNotContainKey(s3Key);
+            final byte[] newEntryBytes = TarEntries.toTarEntry(newBlock.block(), nextBlockNumber);
+            final int expectedLength = part1Bytes.length + trailingBytes.length + newEntryBytes.length;
+            final byte[] finalTar = s3.downloadObjectRange(s3Key, 0, expectedLength - 1);
+            // The final tar begins with the manually-uploaded first part (proving the existing
+            // uploadId/etags were reused rather than a new upload started), followed by the
+            // prepended trailingBytes, followed by the new block's tar entry.
+            assertThat(Arrays.copyOfRange(finalTar, 0, part1Bytes.length)).isEqualTo(part1Bytes);
+            assertThat(Arrays.copyOfRange(finalTar, part1Bytes.length, part1Bytes.length + trailingBytes.length))
+                    .isEqualTo(trailingBytes);
+            assertThat(Arrays.copyOfRange(finalTar, part1Bytes.length + trailingBytes.length, expectedLength))
+                    .isEqualTo(newEntryBytes);
+        }
+    }
+
+    /// Verifies the loopStart fix for a resumed task: when a [TempArchiveUploadTask] resumes via
+    /// [TempArchiveResumeState] and is interrupted before consuming any NEW block, it must not
+    /// mistake the already-durable resumed part for data accumulated in this run and spuriously
+    /// complete the segment -- it must rethrow [InterruptedException] and leave the upload
+    /// hanging, exactly like a fresh task interrupted with zero blocks (mirrors
+    /// [StartupRecoveryTaskTest]'s round trip for the regular path, adapted to the resume path
+    /// since any real accumulated block always completes a temp archive on interrupt).
+    @Test
+    @DisplayName("Resumed task interrupted before any new block: upload stays hanging, not spuriously completed")
+    void resumedTaskInterruptedBeforeNewBlockLeavesUploadHanging() throws Exception {
+        final String s3Key = TempArchiveKey.formatTar(0, "");
+        final long firstBlock = 0;
+
+        // Manually build and upload a real first part, simulating parts a previous run already
+        // flushed and StartupRecoveryTask server-side-copied into a fresh upload before resuming.
+        final List<BlockWithSource> preBlocks = new ArrayList<>();
+        for (int i = 0; i < 9; i++) {
+            preBlocks.add(makeBlock(BLOCK_DATA_BYTES));
+        }
+        byte[] part1Bytes = new byte[0];
+        for (int i = 0; i < preBlocks.size(); i++) {
+            part1Bytes = S3UploadUtils.concat(
+                    part1Bytes, TarEntries.toTarEntry(preBlocks.get(i).block(), firstBlock + i));
+        }
+        final String uploadId;
+        final String etag1;
+        try (S3Client s3 = openS3Client()) {
+            uploadId = s3.createMultipartUpload(s3Key, config.storageClass().name(), S3UploadUtils.CONTENT_TYPE);
+            etag1 = s3.multipartUploadPart(s3Key, uploadId, 1, part1Bytes);
+        }
+        final long nextBlockNumber = preBlocks.size();
+        final TempArchiveResumeState resumeState =
+                new TempArchiveResumeState(s3Key, firstBlock, nextBlockNumber, uploadId, List.of(etag1), new byte[0]);
+
+        final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
+        final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
+        final TrackingApplicationStateFacility asf = new TrackingApplicationStateFacility();
+        final TempArchiveUploadTask task = new TempArchiveUploadTask(
+                config, messaging, asf, createMetricsHolder(), s3Key, firstBlock, queue, resumeState);
+
+        final InterruptedException[] caught = {null};
+        final Thread thread = new Thread(() -> {
+            try {
+                task.call();
+            } catch (InterruptedException e) {
+                caught[0] = e;
+            } catch (Exception ignored) {
+            }
+        });
+        thread.start();
+        // Give the resumed task time to seed its state and block on the next take() -- no new
+        // block is ever offered.
+        Thread.sleep(200);
+        thread.interrupt();
+        thread.join(5_000);
+
+        assertThat(caught[0]).isNotNull();
+        assertThat(messaging.getSentPersistedNotifications()).isEmpty();
+        try (S3Client s3 = openS3Client()) {
+            final Map<String, List<String>> hangingUploads = s3.listMultipartUploads();
+            assertThat(hangingUploads).containsKey(s3Key);
+            assertThat(s3.listParts(s3Key, hangingUploads.get(s3Key).getFirst()))
+                    .hasSize(1);
+        }
     }
 
     /// [TempArchiveUploadTask] subclass that always throws from [doUploadPart].


### PR DESCRIPTION
## Reviewer Notes

### `TempArchiveUploadTask` no longer aborts on any failure, not just interrupt

Every failure now leaves the multipart upload hanging on S3 with whatever parts already flushed, instead of calling `abortMultipartUpload`. A new resume constructor takes a `TempArchiveResumeState` (uploadId, etags, trailingBytes, nextBlockNumber) so the task can pick up where a previous run left off instead of starting a fresh upload. `loopStart` tracks the resume point so `lastProcessedBlock >= loopStart` correctly distinguishes newly accumulated blocks from already-durable ones; interrupting a resumed task before any new block arrives must not spuriously complete the segment.

### `StartupRecoveryTask` resolves each hanging temp upload independently

`recoverTempArchives` no longer unconditionally aborts every hanging `.tmp` multipart upload. `resolveHangingTempUpload` decides per key: no parts uploaded means abort (unchanged behavior); durable parts means complete the old upload to materialize a readable object, open a fresh multipart upload for the same key, and reuse `rebuildUpload`'s backward scan (already used by the regular per-group path) to find the last clean block-start boundary and produce a `TempArchiveResumeState`.

### `CloudStorageArchivePlugin` wiring

`resumeHangingTempArchives()` registers each `RecoveryResult#resumableTempArchives()` entry into the same `tempUploadFutures` / `tempGroupActiveQueues` / `tempSegmentLastBlock` maps a fresh temp segment would use, via a new `newResumedTempArchiveUploadTask` factory method (mirrors the existing `newTempArchiveUploadTask`, extracted for test overriding). When two resumed segments land in the same group, only the one with the highest `nextBlockNumber` becomes the active queue for further blocks; the other is seeded with`SEGMENT_END` so it finalizes on its own.

## Related Issue(s)

Closes #3138 
