### PR TITLE
chore: Update node operator Taskfile for 0.38 logic

### DIFF
--- a/tools-and-tests/scripts/node-operations/Taskfile.yml
+++ b/tools-and-tests/scripts/node-operations/Taskfile.yml
@@ -40,6 +40,43 @@ tasks:
             - kubectl -n ${NAMESPACE} exec ${POD} -- sh -c 'rm -rf /opt/hiero/block-node/application-state/* /opt/hiero/block-node/backfill/*'
             - kubectl -n ${NAMESPACE} delete pod $POD
 
+    shutdown-bn:
+        cmds:
+            - kubectl scale statefulset/$RELEASE-block-node-server --replicas=0 -n $NAMESPACE
+            - kubectl wait pod -l app.kubernetes.io/instance=$RELEASE -n $NAMESPACE --for=delete --timeout=120s
+
+    # Use when the BN is already offline (scaled to 0 via shutdown-bn).
+    # Mounts PVCs directly via a one-shot busybox pod so no BN process is running
+    # during the wipe — prevents the node from writing new data or initiating backfill
+    # while its storage is being cleared.
+    reset-file-store-offline:
+        cmds:
+            - |
+              kubectl run bn-reset -n $NAMESPACE --image=busybox --restart=Never --rm -i \
+                --overrides='{
+                  "spec": {
+                    "volumes": [
+                      {"name":"live","persistentVolumeClaim":{"claimName":"live-storage-pvc"}},
+                      {"name":"archive","persistentVolumeClaim":{"claimName":"archive-storage-pvc"}},
+                      {"name":"appstate","persistentVolumeClaim":{"claimName":"application-state-storage-pvc"}}
+                    ],
+                    "containers": [{
+                      "name":"bn-reset","image":"busybox",
+                      "command":["sh","-c","rm -rf /live/live-data/* /archive/archive-data/* /appstate/*"],
+                      "volumeMounts": [
+                        {"name":"live","mountPath":"/live"},
+                        {"name":"archive","mountPath":"/archive"},
+                        {"name":"appstate","mountPath":"/appstate"}
+                      ]
+                    }]
+                  }
+                }'
+
+    start-bn:
+        cmds:
+            - kubectl scale statefulset/$RELEASE-block-node-server --replicas=1 -n $NAMESPACE
+            - kubectl rollout status statefulset/$RELEASE-block-node-server -n $NAMESPACE --timeout=300s
+
     reset-upgrade:
         cmds:
             - task: reset-file-store

--- a/tools-and-tests/scripts/node-operations/Taskfile.yml
+++ b/tools-and-tests/scripts/node-operations/Taskfile.yml
@@ -3,6 +3,9 @@ version: '3'
 dotenv: ['.env']
 
 tasks:
+    # Uninstalls the Helm release and deletes all associated PVCs, PVs, and the namespace.
+    # DESTRUCTIVE — all block data, application state, and logs are permanently lost.
+    # Requires: RELEASE, NAMESPACE
     clear-release:
         cmds:
             - helm uninstall $RELEASE -n $NAMESPACE
@@ -10,6 +13,9 @@ tasks:
             - kubectl delete pv -n $NAMESPACE application-state-storage-pv archive-storage-pv live-storage-pv logging-storage-pv plugins-pv
             - kubectl delete namespace $NAMESPACE
 
+    # One-time bare-metal setup: copies the kubeadm kubeconfig into ~/.kube/config and
+    # verifies that helm and kubectl can reach the cluster.
+    # Run once per machine before any other task.
     load-kubectl-helm:
         cmds:
             - mkdir -p ${HOME}/.kube
@@ -20,6 +26,11 @@ tasks:
             - kubectl config get-clusters
             - mkdir values-override
 
+    # First-time install of the block node chart into a new namespace.
+    # Applies host-path PV manifests, installs the chart, annotates the service for MetalLB,
+    # then waits 90 s for the pod to start before printing cluster state.
+    # Replace <values> with your operator-specific values file (e.g. bare-metal-values.yaml).
+    # Requires: RELEASE, NAMESPACE, VERSION
     helm-release:
         cmds:
             - kubectl create namespace $NAMESPACE
@@ -29,17 +40,30 @@ tasks:
             - sleep 90
             - kubectl get all -n $NAMESPACE
 
+    # Upgrades (or installs if not present) the chart to $VERSION in an existing namespace.
+    # Safe to run against a live BN — Helm performs a rolling update.
+    # Replace <values> with your operator-specific values file.
+    # Requires: RELEASE, NAMESPACE, VERSION
     helm-upgrade:
         cmds:
             - helm upgrade $RELEASE oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server --version $VERSION -n $NAMESPACE --install --values values-override/<values>.yaml
             - kubectl get all -n $NAMESPACE
 
+    # Use when the BN is online (scaled to 1) and no inflow is expected via publishing or backfill.
+    # Wipes live, historic, application-state, and backfill directories then restarts the pod.
+    # For a safer fleet reset where multiple BNs must be cleared simultaneously, use
+    # shutdown-bn → reset-file-store-offline → start-bn instead.
+    # Requires: NAMESPACE, POD
     reset-file-store:
         cmds:
             - kubectl -n ${NAMESPACE} exec ${POD} -- sh -c 'rm -rf /opt/hiero/block-node/data/live/* /opt/hiero/block-node/data/historic/*'
             - kubectl -n ${NAMESPACE} exec ${POD} -- sh -c 'rm -rf /opt/hiero/block-node/application-state/* /opt/hiero/block-node/backfill/*'
             - kubectl -n ${NAMESPACE} delete pod $POD
 
+    # Gracefully stops the BN by scaling the StatefulSet to 0 and waiting for the pod to terminate.
+    # No new blocks will be accepted and no backfill connections will be initiated after this returns.
+    # Follow with reset-file-store-offline to wipe data, then start-bn to bring the node back up.
+    # Requires: RELEASE, NAMESPACE
     shutdown-bn:
         cmds:
             - kubectl scale statefulset/$RELEASE-block-node-server --replicas=0 -n $NAMESPACE
@@ -49,6 +73,8 @@ tasks:
     # Mounts PVCs directly via a one-shot busybox pod so no BN process is running
     # during the wipe — prevents the node from writing new data or initiating backfill
     # while its storage is being cleared.
+    # backfill/ is ephemeral (pod filesystem) and is implicitly cleared when the pod restarts.
+    # Requires: NAMESPACE
     reset-file-store-offline:
         cmds:
             - |
@@ -72,26 +98,40 @@ tasks:
                   }
                 }'
 
+    # Scales the StatefulSet back to 1 and waits for the pod to pass its readiness probe.
+    # Use after shutdown-bn (and optionally reset-file-store-offline) to bring the node back online.
+    # Requires: RELEASE, NAMESPACE
     start-bn:
         cmds:
             - kubectl scale statefulset/$RELEASE-block-node-server --replicas=1 -n $NAMESPACE
             - kubectl rollout status statefulset/$RELEASE-block-node-server -n $NAMESPACE --timeout=300s
 
+    # Convenience task: wipes block data and immediately upgrades to $VERSION.
+    # BN is briefly offline between reset-file-store (pod deleted) and helm-upgrade (pod recreated).
+    # Requires: RELEASE, NAMESPACE, VERSION, POD
     reset-upgrade:
         cmds:
             - task: reset-file-store
             - task: helm-upgrade
 
+    # Triggers a rolling restart of the BN pod without changing any configuration.
+    # Useful to pick up a new image tag or recover from a hung pod.
+    # Requires: RELEASE, NAMESPACE
     restart-bn:
         cmds:
             - kubectl rollout restart deployment $RELEASE-block-node-server -n $NAMESPACE
 
+    # Downloads the block-node protobuf bundle for $VERSION and extracts it to ~/block-node-protobuf-$VERSION.
+    # Required before using grpcurl to make gRPC calls against the block node.
+    # Requires: VERSION
     setup-bn-proto:
         cmds:
             - curl -L https://github.com/hiero-ledger/hiero-block-node/releases/download/v$VERSION/block-node-protobuf-$VERSION.tgz -o block-node-protobuf-$VERSION.tgz
             - tar -xzf block-node-protobuf-$VERSION.tgz -C ~/block-node-protobuf-$VERSION
             - rm block-node-protobuf-$VERSION.tgz
 
+    # Installs grpcurl v1.8.7 to /usr/local/bin.
+    # Run once per machine. Used alongside setup-bn-proto to make gRPC calls against the block node.
     setup-grpcurl:
         cmds:
             - curl -L https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_x86_64.tar.gz -o grpcurl.tar.gz

--- a/tools-and-tests/scripts/node-operations/Taskfile.yml
+++ b/tools-and-tests/scripts/node-operations/Taskfile.yml
@@ -6,8 +6,8 @@ tasks:
     clear-release:
         cmds:
             - helm uninstall $RELEASE -n $NAMESPACE
-            - kubectl delete pvc -n $NAMESPACE live-storage-pvc logging-storage-pvc archive-storage-pvc
-            - kubectl delete pv -n $NAMESPACE archive-storage-pv live-storage-pv logging-storage-pv
+            - kubectl delete pvc -n $NAMESPACE application-state-storage-pvc archive-storage-pvc live-storage-pvc logging-storage-pvc plugins-pvc
+            - kubectl delete pv -n $NAMESPACE application-state-storage-pv archive-storage-pv live-storage-pv logging-storage-pv plugins-pv
             - kubectl delete namespace $NAMESPACE
 
     load-kubectl-helm:
@@ -24,19 +24,20 @@ tasks:
         cmds:
             - kubectl create namespace $NAMESPACE
             - kubectl apply -f values-override/host-path.yaml
-            - helm install $RELEASE oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server --version $VERSION -n $NAMESPACE --values values-override/bare-metal-values.yaml
+            - helm install $RELEASE oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server --version $VERSION -n $NAMESPACE --values values-override/<values>.yaml
             - kubectl annotate -n $NAMESPACE service $RELEASE-block-node-server "metallb.io/address-pool=public-address-pool"
             - sleep 90
             - kubectl get all -n $NAMESPACE
 
     helm-upgrade:
         cmds:
-            - helm upgrade $RELEASE oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server --version $VERSION -n $NAMESPACE  --install --values values-override/bare-metal-values.yaml
+            - helm upgrade $RELEASE oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server --version $VERSION -n $NAMESPACE --install --values values-override/<values>.yaml
             - kubectl get all -n $NAMESPACE
 
     reset-file-store:
         cmds:
             - kubectl -n ${NAMESPACE} exec ${POD} -- sh -c 'rm -rf /opt/hiero/block-node/data/live/* /opt/hiero/block-node/data/historic/*'
+            - kubectl -n ${NAMESPACE} exec ${POD} -- sh -c 'rm -rf /opt/hiero/block-node/application-state/* /opt/hiero/block-node/backfill/*'
             - kubectl -n ${NAMESPACE} delete pod $POD
 
     reset-upgrade:


### PR DESCRIPTION
## Reviewer Notes
The Helm chart gained two new persistence volumes in v0.38 — `applicationState` and
`plugins` — but the operator runbook `Taskfile.yml` was not updated to account for them.
This left `clear-release` silently skipping those PVCs/PVs (leaking storage on teardown)
and `reset-file-store` leaving stale application-state and backfill data behind between
upgrades.  


Three gaps in `tools-and-tests/scripts/node-operations/Taskfile.yml` are addressed:

1. **Missing v0.38 volumes** — the Helm chart added `applicationState` and `plugins`
   persistence in v0.38, but `clear-release` and `reset-file-store` were never updated.
   `clear-release` silently leaked those PVCs/PVs on teardown; `reset-file-store` left
   stale application-state and backfill data behind between test runs.

2. **Fleet reset race** — in multi-BN environments, resetting nodes sequentially with the
   existing `reset-file-store` task leaves a window where a freshly-reset node can
   backfill from a node that hasn't been reset yet. Three new tasks enable a safe
   coordinated reset: shut down all nodes first, wipe storage offline, restart together.

3. **Hardcoded values filename** — `helm-release` and `helm-upgrade` referenced
   `bare-metal-values.yaml` by name, silently breaking on any machine that uses a
   different filename. Replaced with a `<values>` placeholder.

All existing tasks continue to work without change.

## Changes

### `clear-release` — add v0.38 PVCs and PVs

```diff
-  kubectl delete pvc -n $NAMESPACE live-storage-pvc logging-storage-pvc archive-storage-pvc
-  kubectl delete pv  -n $NAMESPACE archive-storage-pv live-storage-pv logging-storage-pv
+  kubectl delete pvc -n $NAMESPACE application-state-storage-pvc archive-storage-pvc live-storage-pvc logging-storage-pvc plugins-pvc
+  kubectl delete pv  -n $NAMESPACE application-state-storage-pv archive-storage-pv live-storage-pv logging-storage-pv plugins-pv
```

| Volume | Before | After |
|---|---|---|
| `archive-storage` | ✓ | ✓ |
| `live-storage` | ✓ | ✓ |
| `logging-storage` | ✓ | ✓ |
| `application-state-storage` | missing | **added** |
| `plugins-storage` | missing | **added** |

### `reset-file-store` — wipe application-state and backfill directories

```diff
  kubectl -n ${NAMESPACE} exec ${POD} -- sh -c 'rm -rf /opt/hiero/block-node/data/live/* /opt/hiero/block-node/data/historic/*'
+ kubectl -n ${NAMESPACE} exec ${POD} -- sh -c 'rm -rf /opt/hiero/block-node/application-state/* /opt/hiero/block-node/backfill/*'
  kubectl -n ${NAMESPACE} delete pod $POD
```

Without this, TSS application state and backfill cursor data survived across test runs,
causing a fresh node to skip or re-verify blocks incorrectly.

### `helm-release` and `helm-upgrade` — generic values placeholder

```diff
-  --values values-override/bare-metal-values.yaml
+  --values values-override/<values>.yaml
```

### New tasks: `shutdown-bn`, `reset-file-store-offline`, `start-bn`

Enables a safe coordinated fleet reset where no node can backfill from another
mid-reset. Intended sequence:

```
# 1. Stop all BNs (no inbound blocks, no backfill)
task shutdown-bn RELEASE=bn1 NAMESPACE=...
task shutdown-bn RELEASE=bn2 NAMESPACE=...

# 2. Wipe each node's persistent storage while offline
task reset-file-store-offline NAMESPACE=...   # on bn1
task reset-file-store-offline NAMESPACE=...   # on bn2

# 3. Restart all together
task start-bn RELEASE=bn1 NAMESPACE=...
task start-bn RELEASE=bn2 NAMESPACE=...
```

**`shutdown-bn`** — scales the StatefulSet to 0 replicas and waits for pod deletion.

**`reset-file-store-offline`** — runs a one-shot busybox pod that mounts the three
persistent data PVCs directly and wipes them with no BN process running:

| PVC | Mount | Wiped path |
|---|---|---|
| `live-storage-pvc` | `/live` | `/live/live-data/*` |
| `archive-storage-pvc` | `/archive` | `/archive/archive-data/*` |
| `application-state-storage-pvc` | `/appstate` | `/appstate/*` |

`backfill/` lives in the pod's ephemeral layer and is automatically cleared when the pod
is terminated by `shutdown-bn`.

**`start-bn`** — scales back to 1 replica and waits for the rollout readiness check.

### Operator comments on all tasks

Every task now carries a comment documenting its purpose, preconditions, destructive
impact (where applicable), and required `.env` variables.

## Backward Compatibility

| Scenario | Impact |
|---|---|
| Operators on v0.37 or earlier | `clear-release` attempts to delete PVCs/PVs that don't exist yet — benign errors unless `--ignore-not-found` is needed |
| Operators on v0.38+ | Correct — all six PVCs/PVs are now covered |
| `helm-release` / `helm-upgrade` callers | Must substitute `<values>` with their actual filename before running |
| Existing `reset-file-store` / `reset-upgrade` users | No change — tasks are unmodified |


## Related Issue(s)
Resolves #3201 
