### PR TITLE
fix: Expand backfill to add failed persistence with source of BlockSource.BACKFILL to on-demand backfill

### DIFF
--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -512,11 +512,12 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
      * Submits a gap to the appropriate scheduler based on its type.
      *
      * @param gap the gap to submit
+     * @return true if the gap was accepted, false if the queue was full (gap discarded)
      */
-    private void submitGap(GapDetector.Gap gap) {
+    private boolean submitGap(GapDetector.Gap gap) {
         BackfillTaskScheduler scheduler =
                 (gap.type() == GapDetector.Type.HISTORICAL) ? historicalScheduler : liveTailScheduler;
-        scheduler.submit(gap);
+        return scheduler.submit(gap);
     }
 
     // Package-private for test visibility
@@ -545,7 +546,14 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
                     final String backfillPersistFailedMsg =
                             "Backfill persistence failed for block=[{0}], re-queuing for on-demand backfill";
                     LOGGER.log(INFO, backfillPersistFailedMsg, blockNumber);
-                    submitGap(new GapDetector.Gap(new LongRange(blockNumber, blockNumber), GapDetector.Type.LIVE_TAIL));
+                    if (!submitGap(
+                            new GapDetector.Gap(new LongRange(blockNumber, blockNumber), GapDetector.Type.LIVE_TAIL))) {
+                        // if the schedule queue is full mark this as a failure for visibility
+                        // This block will now be picked up during the next periodic autonomous scan of
+                        // detectAndScheduleGaps, which will see the block missing from stored ranges on its next tick
+                        // and re-detect/resubmit it as a gap
+                        metricsHolder.backfillPersistenceFailures().increment();
+                    }
                 } else {
                     final String liveTailSchedulerNullMsg =
                             "LiveScheduler unavailable. Persistence failed for block=[{0}], unable to requeue for on-demand backfill";

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -532,11 +532,22 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
     @Override
     public void handlePersisted(PersistedNotification notification) {
         if (notification.blockSource() == BlockSource.BACKFILL) {
-            // Add more detailed logging for persistence notifications
-            final String backfillPersistedMsg = "Received backfill persisted notification for block=[{0}]";
-            LOGGER.log(TRACE, backfillPersistedMsg, notification.blockNumber());
-
-            metricsHolder.backfillBlocksBackfilled().increment();
+            final long blockNumber = notification.blockNumber();
+            if (notification.succeeded()) {
+                final String backfillPersistedMsg = "Received backfill persisted notification for block=[{0}]";
+                LOGGER.log(TRACE, backfillPersistedMsg, blockNumber);
+                metricsHolder.backfillBlocksBackfilled().increment();
+            } else {
+                final String backfillPersistFailedMsg =
+                        "Backfill persistence failed for block=[{0}], re-queuing for on-demand backfill";
+                LOGGER.log(INFO, backfillPersistFailedMsg, blockNumber);
+                metricsHolder.backfillFetchErrors().increment();
+                // Submit directly rather than via scheduleGap: the block is very likely already below
+                // the live-tail high-water mark, and scheduleGap's dedup would otherwise drop the retry.
+                if (liveTailScheduler != null) {
+                    submitGap(new GapDetector.Gap(new LongRange(blockNumber, blockNumber), GapDetector.Type.LIVE_TAIL));
+                }
+            }
             pendingBackfillBlocks.updateAndGet(v -> Math.max(0, v - 1));
         } else {
             final String nonBackfillPersistedMsg = "Received non-backfill persisted notification: [{0}]";

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -68,6 +68,8 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
             MetricKey.of("backfill_fetch_errors", LongCounter.class).addCategory(METRICS_CATEGORY);
     public static final MetricKey<LongCounter> METRIC_BACKFILL_RETRIES =
             MetricKey.of("backfill_retries", LongCounter.class).addCategory(METRICS_CATEGORY);
+    public static final MetricKey<LongCounter> METRIC_BACKFILL_PERSISTENCE_FAILURES =
+            MetricKey.of("backfill_persistence_failure", LongCounter.class).addCategory(METRICS_CATEGORY);
 
     /** The logger for this class. */
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
@@ -531,11 +533,9 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
      */
     @Override
     public void handlePersisted(PersistedNotification notification) {
-        if (notification.blockSource() == BlockSource.BACKFILL) {
+        if (notification != null && notification.blockSource() == BlockSource.BACKFILL) {
             final long blockNumber = notification.blockNumber();
             if (notification.succeeded()) {
-                final String backfillPersistedMsg = "Received backfill persisted notification for block=[{0}]";
-                LOGGER.log(TRACE, backfillPersistedMsg, blockNumber);
                 metricsHolder.backfillBlocksBackfilled().increment();
             } else {
                 final String backfillPersistFailedMsg =
@@ -549,9 +549,6 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
                 }
             }
             pendingBackfillBlocks.updateAndGet(v -> Math.max(0, v - 1));
-        } else {
-            final String nonBackfillPersistedMsg = "Received non-backfill persisted notification: [{0}]";
-            LOGGER.log(TRACE, nonBackfillPersistedMsg, notification);
         }
     }
 
@@ -641,7 +638,8 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
             LongCounter.Measurement backfillFetchedBlocks,
             LongCounter.Measurement backfillBlocksBackfilled,
             LongCounter.Measurement backfillFetchErrors,
-            LongCounter.Measurement backfillRetries) {
+            LongCounter.Measurement backfillRetries,
+            LongCounter.Measurement backfillPersistenceFailures) {
 
         /**
          * Factory method to create a MetricsHolder with all metrics registered.
@@ -686,6 +684,10 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
                             .getOrCreateNotLabeled(),
                     metricRegistry
                             .register(LongCounter.builder(METRIC_BACKFILL_RETRIES)
+                                    .setDescription("Number of retries during the backfill process."))
+                            .getOrCreateNotLabeled(),
+                    metricRegistry
+                            .register(LongCounter.builder(METRIC_BACKFILL_PERSISTENCE_FAILURES)
                                     .setDescription("Number of retries during the backfill process."))
                             .getOrCreateNotLabeled());
         }

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -542,19 +542,18 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
                 // Submit directly rather than via scheduleGap: the block is very likely already below
                 // the live-tail high-water mark, and scheduleGap's dedup would otherwise drop the retry.
                 final long blockNumber = notification.blockNumber();
-                if (liveTailScheduler != null) {
+                if (liveTailScheduler != null
+                        && submitGap(new GapDetector.Gap(
+                                new LongRange(blockNumber, blockNumber), GapDetector.Type.LIVE_TAIL))) {
                     final String backfillPersistFailedMsg =
                             "Backfill persistence failed for block=[{0}], re-queuing for on-demand backfill";
                     LOGGER.log(INFO, backfillPersistFailedMsg, blockNumber);
-                    if (!submitGap(
-                            new GapDetector.Gap(new LongRange(blockNumber, blockNumber), GapDetector.Type.LIVE_TAIL))) {
-                        // if the schedule queue is full mark this as a failure for visibility
-                        // This block will now be picked up during the next periodic autonomous scan of
-                        // detectAndScheduleGaps, which will see the block missing from stored ranges on its next tick
-                        // and re-detect/resubmit it as a gap
-                        metricsHolder.backfillPersistenceFailures().increment();
-                    }
                 } else {
+                    // if the scheduler is null or schedule queue is full mark this as a failure for visibility
+                    // This block will now be picked up during the next periodic autonomous scan of
+                    // detectAndScheduleGaps, which will see the block missing from stored ranges on its next tick
+                    // and re-detect/resubmit it as a gap
+                    metricsHolder.backfillPersistenceFailures().increment();
                     final String liveTailSchedulerNullMsg =
                             "LiveScheduler unavailable. Persistence failed for block=[{0}], unable to requeue for on-demand backfill";
                     LOGGER.log(INFO, liveTailSchedulerNullMsg, blockNumber);

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -69,7 +69,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
     public static final MetricKey<LongCounter> METRIC_BACKFILL_RETRIES =
             MetricKey.of("backfill_retries", LongCounter.class).addCategory(METRICS_CATEGORY);
     public static final MetricKey<LongCounter> METRIC_BACKFILL_PERSISTENCE_FAILURES =
-            MetricKey.of("backfill_persistence_failure", LongCounter.class).addCategory(METRICS_CATEGORY);
+            MetricKey.of("backfill_persistence_failures", LongCounter.class).addCategory(METRICS_CATEGORY);
 
     /** The logger for this class. */
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
@@ -533,21 +533,27 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
      */
     @Override
     public void handlePersisted(PersistedNotification notification) {
-        if (notification != null && notification.blockSource() == BlockSource.BACKFILL) {
-            final long blockNumber = notification.blockNumber();
+        if (notification.blockSource() == BlockSource.BACKFILL) {
             if (notification.succeeded()) {
                 metricsHolder.backfillBlocksBackfilled().increment();
             } else {
-                final String backfillPersistFailedMsg =
-                        "Backfill persistence failed for block=[{0}], re-queuing for on-demand backfill";
-                LOGGER.log(INFO, backfillPersistFailedMsg, blockNumber);
-                metricsHolder.backfillPersistenceFailures.increment();
+                metricsHolder.backfillPersistenceFailures().increment();
                 // Submit directly rather than via scheduleGap: the block is very likely already below
                 // the live-tail high-water mark, and scheduleGap's dedup would otherwise drop the retry.
+                final long blockNumber = notification.blockNumber();
                 if (liveTailScheduler != null) {
+                    final String backfillPersistFailedMsg =
+                            "Backfill persistence failed for block=[{0}], re-queuing for on-demand backfill";
+                    LOGGER.log(INFO, backfillPersistFailedMsg, blockNumber);
                     submitGap(new GapDetector.Gap(new LongRange(blockNumber, blockNumber), GapDetector.Type.LIVE_TAIL));
+                } else {
+                    final String liveTailSchedulerNullMsg =
+                            "LiveScheduler unavailable. Persistence failed for block=[{0}], unable to requeue for on-demand backfill";
+                    LOGGER.log(INFO, liveTailSchedulerNullMsg, blockNumber);
                 }
             }
+            // This will be re-incremented if the block is re-queued for persistence in
+            // sendBlocksForPersistence. Always decrement
             pendingBackfillBlocks.updateAndGet(v -> Math.max(0, v - 1));
         }
     }
@@ -688,7 +694,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
                             .getOrCreateNotLabeled(),
                     metricRegistry
                             .register(LongCounter.builder(METRIC_BACKFILL_PERSISTENCE_FAILURES)
-                                    .setDescription("Number of retries during the backfill process."))
+                                    .setDescription("Number of backfill persistence failures"))
                             .getOrCreateNotLabeled());
         }
 

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -549,14 +549,13 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
                             "Backfill persistence failed for block=[{0}], re-queuing for on-demand backfill";
                     LOGGER.log(INFO, backfillPersistFailedMsg, blockNumber);
                 } else {
-                    // if the scheduler is null or schedule queue is full mark this as a failure for visibility
+                    // The live-tail scheduler is unavailable (plugin not yet started) or its queue is full.
                     // This block will now be picked up during the next periodic autonomous scan of
                     // detectAndScheduleGaps, which will see the block missing from stored ranges on its next tick
                     // and re-detect/resubmit it as a gap
-                    metricsHolder.backfillPersistenceFailures().increment();
-                    final String liveTailSchedulerNullMsg =
-                            "LiveScheduler unavailable. Persistence failed for block=[{0}], unable to requeue for on-demand backfill";
-                    LOGGER.log(INFO, liveTailSchedulerNullMsg, blockNumber);
+                    final String requeueFailedMsg =
+                            "Unable to requeue block=[{0}] for on-demand backfill (scheduler unavailable or queue full)";
+                    LOGGER.log(INFO, requeueFailedMsg, blockNumber);
                 }
             }
             // This will be re-incremented if the block is re-queued for persistence in

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -541,7 +541,7 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
                 final String backfillPersistFailedMsg =
                         "Backfill persistence failed for block=[{0}], re-queuing for on-demand backfill";
                 LOGGER.log(INFO, backfillPersistFailedMsg, blockNumber);
-                metricsHolder.backfillFetchErrors().increment();
+                metricsHolder.backfillPersistenceFailures.increment();
                 // Submit directly rather than via scheduleGap: the block is very likely already below
                 // the live-tail high-water mark, and scheduleGap's dedup would otherwise drop the retry.
                 if (liveTailScheduler != null) {

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.hiero.block.internal.BlockNodeSource;
 import org.hiero.block.internal.BlockNodeSourceConfig;
 import org.hiero.block.node.app.fixtures.blocks.BlockUtils;
@@ -657,6 +658,76 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
                 20,
                 blockMessaging.getSentVerificationNotifications().size(),
                 "Should have sent 20 verification notifications");
+    }
+
+    @Test
+    @DisplayName("Failed backfill persistence is re-queued for on-demand backfill and eventually succeeds")
+    void testFailedBackfillPersistenceIsRetried() throws InterruptedException {
+        final HistoricalBlockFacility blockNodeServerBlockFacility = getHistoricalBlockFacility(0, 50);
+        final TestBlockNodeServer mockServer = new TestBlockNodeServer(0, blockNodeServerBlockFacility);
+        testBlockNodeServers.add(mockServer);
+        BlockNodeSourceConfig config = BlockNodeSourceConfig.newBuilder()
+                .address("localhost")
+                .port(mockServer.port())
+                .priority(1)
+                .build();
+        BlockNodeSource backfillSource =
+                BlockNodeSource.newBuilder().nodes(config).build();
+        String backfillSourcePath = testTempDir + "/backfill-source-persist-retry.json";
+        createTestBlockNodeSourcesFile(backfillSource, backfillSourcePath);
+
+        final Map<String, String> configOverride = BackfillConfigBuilder.NewBuilder()
+                .backfillSourcePath(backfillSourcePath)
+                .build();
+
+        // create a historical block facility for the plugin (should have a GAP)
+        final HistoricalBlockFacility historicalBlockFacility = getHistoricalBlockFacility(0, 30);
+
+        // start block-node with blocks from 0 to 30; on-demand backfill will cover 31 to 50
+        start(new BackfillPlugin(), historicalBlockFacility, configOverride);
+
+        final long targetBlock = 40L;
+        final AtomicBoolean failedOnce = new AtomicBoolean();
+        // 20 blocks (31..50) must eventually succeed, including the one that fails its first attempt
+        CountDownLatch countDownLatch = new CountDownLatch(20);
+        registerDefaultTestBackfillHandler();
+        this.blockMessaging.registerBlockNotificationHandler(
+                new BlockNotificationHandler() {
+                    @Override
+                    public void handleVerification(VerificationNotification notification) {
+                        boolean induceFailure =
+                                notification.blockNumber() == targetBlock && failedOnce.compareAndSet(false, true);
+                        blockNodeContext
+                                .blockMessaging()
+                                .sendBlockPersisted(new PersistedNotification(
+                                        notification.blockNumber(), !induceFailure, 10, notification.source()));
+                        if (!induceFailure) {
+                            countDownLatch.countDown();
+                        }
+                    }
+                },
+                false,
+                "test-persist-retry-handler");
+
+        NewestBlockKnownToNetworkNotification newestBlockNotification = new NewestBlockKnownToNetworkNotification(50L);
+        this.blockMessaging.sendNewestBlockKnownToNetwork(newestBlockNotification);
+
+        assertTrue(
+                countDownLatch.await(1, TimeUnit.MINUTES),
+                "All 20 on-demand blocks should eventually be persisted, including the retried one");
+
+        assertTrue(failedOnce.get(), "The target block should have failed persistence at least once");
+
+        List<PersistedNotification> persisted = blockMessaging.getSentPersistedNotifications();
+        assertEquals(
+                21,
+                persisted.size(),
+                "Should have sent 20 successful notifications plus 1 failed notification for the retried block");
+        long failedCount = persisted.stream().filter(n -> !n.succeeded()).count();
+        assertEquals(1, failedCount, "Exactly one persisted notification should report failure");
+        assertTrue(
+                persisted.stream().anyMatch(n -> n.blockNumber() == targetBlock && n.succeeded()),
+                "The retried block should eventually be persisted successfully");
     }
 
     @Test

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
@@ -735,6 +735,41 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
     }
 
     @Test
+    @DisplayName("Failed persistence before start() is recorded without requeuing (no live-tail scheduler yet)")
+    void testFailedPersistenceBeforeStartIsHandledGracefully() {
+        final HistoricalBlockFacility historicalBlockFacility = getHistoricalBlockFacility(0, 10);
+        final String backfillSourcePath = testTempDir + "/backfill-source-persist-no-scheduler.json";
+        createTestBlockNodeSourcesFile(
+                BlockNodeSource.newBuilder()
+                        .nodes(BlockNodeSourceConfig.newBuilder()
+                                .address("localhost")
+                                .port(1)
+                                .priority(1)
+                                .build())
+                        .build(),
+                backfillSourcePath);
+        final Map<String, String> configOverride = BackfillConfigBuilder.NewBuilder()
+                .backfillSourcePath(backfillSourcePath)
+                .build();
+
+        // init() only: the live-tail scheduler isn't created until start(), so a failed persistence
+        // notification arriving in this window can't be requeued on-demand and must fall back to the
+        // periodic autonomous scan instead.
+        doInit(new BackfillPlugin(), historicalBlockFacility, null, configOverride, Map.of());
+
+        blockMessaging.sendBlockPersisted(new PersistedNotification(42L, false, 10, BlockSource.BACKFILL));
+
+        assertEquals(
+                1L,
+                getMetricValue(BackfillPlugin.METRIC_BACKFILL_PERSISTENCE_FAILURES),
+                "Should record the persistence failure even when the live-tail scheduler isn't available yet");
+        assertEquals(
+                1,
+                blockMessaging.getSentPersistedNotifications().size(),
+                "Should not trigger any further activity beyond the injected failed notification itself");
+    }
+
+    @Test
     @DisplayName("On-Demand Backfill - TSS Wraps Transition Block (466)")
     void testBackfillOnDemandTssWrapsBlock() throws InterruptedException, IOException, ParseException {
         final BlockUtils.SampleBlockInfo tssBlockInfo =

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
@@ -728,6 +728,10 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         assertTrue(
                 persisted.stream().anyMatch(n -> n.blockNumber() == targetBlock && n.succeeded()),
                 "The retried block should eventually be persisted successfully");
+        assertEquals(
+                1L,
+                getMetricValue(BackfillPlugin.METRIC_BACKFILL_PERSISTENCE_FAILURES),
+                "single backfill persistence failure was captured");
     }
 
     @Test

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillRunnerTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillRunnerTest.java
@@ -68,8 +68,8 @@ class BackfillRunnerTest {
                 mockFetchedBlocksCounter, // backfillFetchedBlocks
                 mock(LongCounter.Measurement.class), // backfillBlocksBackfilled
                 mockFetchErrorsCounter, // backfillFetchErrors
-                mock(LongCounter.Measurement.class),
-                mock(LongCounter.Measurement.class)); // backfillInFlightGauge
+                mock(LongCounter.Measurement.class), // backfillInFlightGauge
+                mock(LongCounter.Measurement.class));
         pendingBackfillBlocks = new AtomicLong(0);
         persistenceAwaiter = new BackfillPersistenceAwaiter();
         logger = System.getLogger(BackfillRunnerTest.class.getName());

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillRunnerTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillRunnerTest.java
@@ -68,6 +68,7 @@ class BackfillRunnerTest {
                 mockFetchedBlocksCounter, // backfillFetchedBlocks
                 mock(LongCounter.Measurement.class), // backfillBlocksBackfilled
                 mockFetchErrorsCounter, // backfillFetchErrors
+                mock(LongCounter.Measurement.class),
                 mock(LongCounter.Measurement.class)); // backfillInFlightGauge
         pendingBackfillBlocks = new AtomicLong(0);
         persistenceAwaiter = new BackfillPersistenceAwaiter();


### PR DESCRIPTION
## Reviewer Notes

### Refactored handlePersisted in BackfillPlugin.java
- It now checks notification.succeeded() instead of treating every BACKFILL-sourced notification as a success.
- On success: unchanged behavior (increments backfillBlocksBackfilled).
- On failure: logs at INFO, increments backfillFetchErrors, and re-submits the failed block directly to the live-tail scheduler as a single-block on-demand gap (bypassing the high-water-mark dedup that would otherwise silently drop the retry).
- pendingBackfillBlocks is decremented in both cases, since the block is no longer in-flight either way.
- Added a null-check on liveTailScheduler for the narrow window between init() registering the handler and start() creating the schedulers, matching similar guards elsewhere in the file.

### BackfillPluginTest.java
- Added an end-to-end integration test in  that induces a single persistence failure mid-way through an on-demand backfill run and confirms the block is retried and eventually persisted successfully, with exactly one failed notification recorded

## Related Issue(s)
Closes: #3208