### PR TITLE
fix: Fixed Server Status handling of earliest managed block (#3212)

### DIFF
--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
@@ -64,8 +64,12 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
         // later block as the last available block so publishers know they can stream from earliestManagedBlock
         // instead of assuming the node only wants older blocks between the oldest stored block and earliest managed
         // block.
-        if (highestAvailableBlock != UNKNOWN_BLOCK_NUMBER && highestAvailableBlock < earliestManagedBlock) {
-            highestAvailableBlock = earliestManagedBlock;
+        if (highestAvailableBlock != UNKNOWN_BLOCK_NUMBER
+                && highestAvailableBlock < earliestManagedBlock
+                && earliestManagedBlock > 0) {
+            // Fix for bug #3203. CN will stream next block if we return UNKNOWN_BLOCK_NUMBER,
+            //   but if we return a future block here, CN will not send any data.
+            highestAvailableBlock = UNKNOWN_BLOCK_NUMBER;
         }
 
         // TODO(#579) Should get from state config or status, which would be provided by the context from responsible

--- a/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java
+++ b/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java
@@ -92,16 +92,14 @@ public class ServerStatusServicePluginTest
         assertFalse(response.onlyLatestState());
     }
 
-    /**
-     * Tests that when {@code earliestManagedBlock} is configured higher than the last block currently
-     * held by the node, the reported {@code lastAvailableBlock} is raised to that configured value, while
-     * {@code firstAvailableBlock} is left untouched, so publishers know they can stream later blocks even
-     * though the node only holds older ones.
-     *
-     * @throws ParseException if there is an error parsing the response
-     */
+    /// Tests that when `earliestManagedBlock` is configured higher than the last block currently
+    /// held by the node, the reported `lastAvailableBlock` is \`-1\` (unknown block), while
+    /// `firstAvailableBlock` is left untouched, so publishers know they can stream later blocks even
+    /// though the node only holds older ones.
+    ///
+    /// @throws ParseException if there is an error parsing the response
     @Test
-    @DisplayName("Should raise lastAvailableBlock to earliestManagedBlock when node holds only older blocks")
+    @DisplayName("Should return -1 for lastAvailableBlock when < earliestManagedBlock and node holds only older blocks")
     void shouldRaiseLastAvailableBlockToEarliestManagedBlock() throws ParseException {
         final ServerStatusServicePlugin localPlugin = new ServerStatusServicePlugin();
         start(
@@ -116,7 +114,7 @@ public class ServerStatusServicePluginTest
         final ServerStatusResponse response = standardParse(ServerStatusResponse.PROTOBUF, fromPluginBytes.getLast());
 
         assertEquals(0, response.firstAvailableBlock());
-        assertEquals(100, response.lastAvailableBlock());
+        assertEquals(-1, response.lastAvailableBlock());
     }
 
     /**

--- a/protobuf-sources/src/main/proto/block-node/api/node_service.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/node_service.proto
@@ -89,7 +89,11 @@ message ServerStatusResponse {
      * The greatest block number available from this Block-Node.
      * <p>
      * Any request for a block with a block number higher than this
-     * value MAY fail.
+     * value MAY fail.<br/>
+     * If this value is `uint64_max` then the Block Node MAY accept the next
+     * block offered from a Publisher, regardless of block number.<br/>
+     * If this value is `uint64_max` then Subscribers SHOULD query the
+     * `serverStatusDetail` API for accurate available block information.
      */
     uint64 last_available_block = 2;
 


### PR DESCRIPTION
Cherry-pick of #3212 