### PR TITLE
fix: Expand backfill to add failed persistence with source of BlockSo…

### DIFF
--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -68,6 +68,8 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
             MetricKey.of("backfill_fetch_errors", LongCounter.class).addCategory(METRICS_CATEGORY);
     public static final MetricKey<LongCounter> METRIC_BACKFILL_RETRIES =
             MetricKey.of("backfill_retries", LongCounter.class).addCategory(METRICS_CATEGORY);
+    public static final MetricKey<LongCounter> METRIC_BACKFILL_PERSISTENCE_FAILURES =
+            MetricKey.of("backfill_persistence_failures", LongCounter.class).addCategory(METRICS_CATEGORY);
 
     /** The logger for this class. */
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
@@ -510,11 +512,12 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
      * Submits a gap to the appropriate scheduler based on its type.
      *
      * @param gap the gap to submit
+     * @return true if the gap was accepted, false if the queue was full (gap discarded)
      */
-    private void submitGap(GapDetector.Gap gap) {
+    private boolean submitGap(GapDetector.Gap gap) {
         BackfillTaskScheduler scheduler =
                 (gap.type() == GapDetector.Type.HISTORICAL) ? historicalScheduler : liveTailScheduler;
-        scheduler.submit(gap);
+        return scheduler.submit(gap);
     }
 
     // Package-private for test visibility
@@ -532,15 +535,32 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
     @Override
     public void handlePersisted(PersistedNotification notification) {
         if (notification.blockSource() == BlockSource.BACKFILL) {
-            // Add more detailed logging for persistence notifications
-            final String backfillPersistedMsg = "Received backfill persisted notification for block=[{0}]";
-            LOGGER.log(TRACE, backfillPersistedMsg, notification.blockNumber());
-
-            metricsHolder.backfillBlocksBackfilled().increment();
+            if (notification.succeeded()) {
+                metricsHolder.backfillBlocksBackfilled().increment();
+            } else {
+                metricsHolder.backfillPersistenceFailures().increment();
+                // Submit directly rather than via scheduleGap: the block is very likely already below
+                // the live-tail high-water mark, and scheduleGap's dedup would otherwise drop the retry.
+                final long blockNumber = notification.blockNumber();
+                if (liveTailScheduler != null
+                        && submitGap(new GapDetector.Gap(
+                                new LongRange(blockNumber, blockNumber), GapDetector.Type.LIVE_TAIL))) {
+                    final String backfillPersistFailedMsg =
+                            "Backfill persistence failed for block=[{0}], re-queuing for on-demand backfill";
+                    LOGGER.log(INFO, backfillPersistFailedMsg, blockNumber);
+                } else {
+                    // The live-tail scheduler is unavailable (plugin not yet started) or its queue is full.
+                    // This block will now be picked up during the next periodic autonomous scan of
+                    // detectAndScheduleGaps, which will see the block missing from stored ranges on its next tick
+                    // and re-detect/resubmit it as a gap
+                    final String requeueFailedMsg =
+                            "Unable to requeue block=[{0}] for on-demand backfill (scheduler unavailable or queue full)";
+                    LOGGER.log(INFO, requeueFailedMsg, blockNumber);
+                }
+            }
+            // This will be re-incremented if the block is re-queued for persistence in
+            // sendBlocksForPersistence. Always decrement
             pendingBackfillBlocks.updateAndGet(v -> Math.max(0, v - 1));
-        } else {
-            final String nonBackfillPersistedMsg = "Received non-backfill persisted notification: [{0}]";
-            LOGGER.log(TRACE, nonBackfillPersistedMsg, notification);
         }
     }
 
@@ -630,7 +650,8 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
             LongCounter.Measurement backfillFetchedBlocks,
             LongCounter.Measurement backfillBlocksBackfilled,
             LongCounter.Measurement backfillFetchErrors,
-            LongCounter.Measurement backfillRetries) {
+            LongCounter.Measurement backfillRetries,
+            LongCounter.Measurement backfillPersistenceFailures) {
 
         /**
          * Factory method to create a MetricsHolder with all metrics registered.
@@ -676,6 +697,10 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
                     metricRegistry
                             .register(LongCounter.builder(METRIC_BACKFILL_RETRIES)
                                     .setDescription("Number of retries during the backfill process."))
+                            .getOrCreateNotLabeled(),
+                    metricRegistry
+                            .register(LongCounter.builder(METRIC_BACKFILL_PERSISTENCE_FAILURES)
+                                    .setDescription("Number of backfill persistence failures"))
                             .getOrCreateNotLabeled());
         }
 

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.hiero.block.internal.BlockNodeSource;
 import org.hiero.block.internal.BlockNodeSourceConfig;
 import org.hiero.block.node.app.fixtures.blocks.BlockUtils;
@@ -657,6 +658,115 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
                 20,
                 blockMessaging.getSentVerificationNotifications().size(),
                 "Should have sent 20 verification notifications");
+    }
+
+    @Test
+    @DisplayName("Failed backfill persistence is re-queued for on-demand backfill and eventually succeeds")
+    void testFailedBackfillPersistenceIsRetried() throws InterruptedException {
+        final HistoricalBlockFacility blockNodeServerBlockFacility = getHistoricalBlockFacility(0, 50);
+        final TestBlockNodeServer mockServer = new TestBlockNodeServer(0, blockNodeServerBlockFacility);
+        testBlockNodeServers.add(mockServer);
+        BlockNodeSourceConfig config = BlockNodeSourceConfig.newBuilder()
+                .address("localhost")
+                .port(mockServer.port())
+                .priority(1)
+                .build();
+        BlockNodeSource backfillSource =
+                BlockNodeSource.newBuilder().nodes(config).build();
+        String backfillSourcePath = testTempDir + "/backfill-source-persist-retry.json";
+        createTestBlockNodeSourcesFile(backfillSource, backfillSourcePath);
+
+        final Map<String, String> configOverride = BackfillConfigBuilder.NewBuilder()
+                .backfillSourcePath(backfillSourcePath)
+                .build();
+
+        // create a historical block facility for the plugin (should have a GAP)
+        final HistoricalBlockFacility historicalBlockFacility = getHistoricalBlockFacility(0, 30);
+
+        // start block-node with blocks from 0 to 30; on-demand backfill will cover 31 to 50
+        start(new BackfillPlugin(), historicalBlockFacility, configOverride);
+
+        final long targetBlock = 40L;
+        final AtomicBoolean failedOnce = new AtomicBoolean();
+        // 20 blocks (31..50) must eventually succeed, including the one that fails its first attempt
+        CountDownLatch countDownLatch = new CountDownLatch(20);
+        registerDefaultTestBackfillHandler();
+        this.blockMessaging.registerBlockNotificationHandler(
+                new BlockNotificationHandler() {
+                    @Override
+                    public void handleVerification(VerificationNotification notification) {
+                        boolean induceFailure =
+                                notification.blockNumber() == targetBlock && failedOnce.compareAndSet(false, true);
+                        blockNodeContext
+                                .blockMessaging()
+                                .sendBlockPersisted(new PersistedNotification(
+                                        notification.blockNumber(), !induceFailure, 10, notification.source()));
+                        if (!induceFailure) {
+                            countDownLatch.countDown();
+                        }
+                    }
+                },
+                false,
+                "test-persist-retry-handler");
+
+        NewestBlockKnownToNetworkNotification newestBlockNotification = new NewestBlockKnownToNetworkNotification(50L);
+        this.blockMessaging.sendNewestBlockKnownToNetwork(newestBlockNotification);
+
+        assertTrue(
+                countDownLatch.await(1, TimeUnit.MINUTES),
+                "All 20 on-demand blocks should eventually be persisted, including the retried one");
+
+        assertTrue(failedOnce.get(), "The target block should have failed persistence at least once");
+
+        List<PersistedNotification> persisted = blockMessaging.getSentPersistedNotifications();
+        assertEquals(
+                21,
+                persisted.size(),
+                "Should have sent 20 successful notifications plus 1 failed notification for the retried block");
+        long failedCount = persisted.stream().filter(n -> !n.succeeded()).count();
+        assertEquals(1, failedCount, "Exactly one persisted notification should report failure");
+        assertTrue(
+                persisted.stream().anyMatch(n -> n.blockNumber() == targetBlock && n.succeeded()),
+                "The retried block should eventually be persisted successfully");
+        assertEquals(
+                1L,
+                getMetricValue(BackfillPlugin.METRIC_BACKFILL_PERSISTENCE_FAILURES),
+                "single backfill persistence failure was captured");
+    }
+
+    @Test
+    @DisplayName("Failed persistence before start() is recorded without requeuing (no live-tail scheduler yet)")
+    void testFailedPersistenceBeforeStartIsHandledGracefully() {
+        final HistoricalBlockFacility historicalBlockFacility = getHistoricalBlockFacility(0, 10);
+        final String backfillSourcePath = testTempDir + "/backfill-source-persist-no-scheduler.json";
+        createTestBlockNodeSourcesFile(
+                BlockNodeSource.newBuilder()
+                        .nodes(BlockNodeSourceConfig.newBuilder()
+                                .address("localhost")
+                                .port(1)
+                                .priority(1)
+                                .build())
+                        .build(),
+                backfillSourcePath);
+        final Map<String, String> configOverride = BackfillConfigBuilder.NewBuilder()
+                .backfillSourcePath(backfillSourcePath)
+                .build();
+
+        // init() only: the live-tail scheduler isn't created until start(), so a failed persistence
+        // notification arriving in this window can't be requeued on-demand and must fall back to the
+        // periodic autonomous scan instead.
+        doInit(new BackfillPlugin(), historicalBlockFacility, null, configOverride, Map.of());
+
+        blockMessaging.sendBlockPersisted(new PersistedNotification(42L, false, 10, BlockSource.BACKFILL));
+
+        assertEquals(
+                1L,
+                getMetricValue(BackfillPlugin.METRIC_BACKFILL_PERSISTENCE_FAILURES),
+                "Should record the persistence failure even when the live-tail scheduler isn't available yet");
+        assertEquals(
+                1,
+                blockMessaging.getSentPersistedNotifications().size(),
+                "Should not trigger any further activity beyond the injected failed notification itself");
     }
 
     @Test

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillRunnerTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillRunnerTest.java
@@ -68,7 +68,8 @@ class BackfillRunnerTest {
                 mockFetchedBlocksCounter, // backfillFetchedBlocks
                 mock(LongCounter.Measurement.class), // backfillBlocksBackfilled
                 mockFetchErrorsCounter, // backfillFetchErrors
-                mock(LongCounter.Measurement.class)); // backfillInFlightGauge
+                mock(LongCounter.Measurement.class), // backfillInFlightGauge
+                mock(LongCounter.Measurement.class));
         pendingBackfillBlocks = new AtomicLong(0);
         persistenceAwaiter = new BackfillPersistenceAwaiter();
         logger = System.getLogger(BackfillRunnerTest.class.getName());


### PR DESCRIPTION
Cherry-pick of #3209  into `release/0.38`