### PR TITLE
fix: drop orphan sidecars at wrap time via signed manifest check (fixes #3224)

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/parsed/ParsedRecordBlock.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/parsed/ParsedRecordBlock.java
@@ -5,6 +5,7 @@ import static org.hiero.block.tools.utils.Sha384.sha384Digest;
 
 import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.hapi.streams.SidecarFile;
+import com.hedera.hapi.streams.SidecarMetadata;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
@@ -13,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
@@ -48,40 +50,120 @@ public record ParsedRecordBlock(
     /**
      * Parse an unparsed record block into a parsed record block.
      *
+     * <p>Sidecar candidates picked up from the source (any file matching the {@code _NN.rcd}
+     * sidecar naming pattern next to the record file) are filtered against the record file's
+     * signed {@code sidecars[]} manifest. Any candidate whose SHA-384 does not appear in the
+     * signed manifest is dropped with a warning: the record file's manifest is authoritative,
+     * and embedding a candidate the CN never signed produces a wrapped block with unsigned
+     * bytes that downstream integrity checks will reject. See issue #3224 for background.
+     *
      * @param recordFileBlock the unparsed record block
      * @return the parsed record block
      */
     public static ParsedRecordBlock parse(UnparsedRecordBlock recordFileBlock) {
-        return new ParsedRecordBlock(
-                ParsedRecordFile.parse(recordFileBlock.primaryRecordFile()),
-                recordFileBlock.signatureFiles().stream()
-                        .map(sigFile -> {
-                            try {
-                                return new ParsedSignatureFile(sigFile);
-                            } catch (RuntimeException e) {
-                                System.err.println("Warning: Skipping corrupted signature file: " + sigFile.path()
-                                        + " (" + sigFile.data().length + " bytes) - " + e.getMessage());
-                                return null;
-                            }
-                        })
-                        .filter(sig -> sig != null)
-                        .toList(),
-                recordFileBlock.primarySidecarFiles().stream()
-                        .map(ps -> {
-                            try {
-                                // Use 5-arg parse to specify both maxDepth and maxSize
-                                // The 3-arg parse incorrectly passes maxSize as maxDepth
-                                return SidecarFile.PROTOBUF.parse(
-                                        Bytes.wrap(ps.data()).toReadableSequentialData(),
-                                        false, // strictMode
-                                        true, // parseUnknownFields
-                                        MAX_DEPTH, // maxDepth
-                                        MAX_SIDECAR_SIZE); // maxSize
-                            } catch (ParseException e) {
-                                throw new RuntimeException(e);
-                            }
-                        })
-                        .toList());
+        final ParsedRecordFile recordFile = ParsedRecordFile.parse(recordFileBlock.primaryRecordFile());
+        final List<ParsedSignatureFile> signatureFiles = recordFileBlock.signatureFiles().stream()
+                .map(sigFile -> {
+                    try {
+                        return new ParsedSignatureFile(sigFile);
+                    } catch (RuntimeException e) {
+                        System.err.println("Warning: Skipping corrupted signature file: " + sigFile.path() + " ("
+                                + sigFile.data().length + " bytes) - " + e.getMessage());
+                        return null;
+                    }
+                })
+                .filter(sig -> sig != null)
+                .toList();
+        final List<SidecarFile> parsedSidecars = recordFileBlock.primarySidecarFiles().stream()
+                .map(ps -> {
+                    try {
+                        // Use 5-arg parse to specify both maxDepth and maxSize
+                        // The 3-arg parse incorrectly passes maxSize as maxDepth
+                        return SidecarFile.PROTOBUF.parse(
+                                Bytes.wrap(ps.data()).toReadableSequentialData(),
+                                false, // strictMode
+                                true, // parseUnknownFields
+                                MAX_DEPTH, // maxDepth
+                                MAX_SIDECAR_SIZE); // maxSize
+                    } catch (ParseException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .toList();
+        final List<SidecarFile> filteredSidecars = filterOrphanSidecars(
+                parsedSidecars, recordFile.recordStreamFile().sidecars());
+        return new ParsedRecordBlock(recordFile, signatureFiles, filteredSidecars);
+    }
+
+    /**
+     * Filter a list of parsed sidecar files, keeping only those whose SHA-384 appears in the
+     * record file's signed sidecar manifest. Any sidecar without a matching signed hash is
+     * dropped with a warning printed to {@code stderr}.
+     *
+     * <p>Motivation: at wrap time, sidecar candidates are gathered by filename pattern next to
+     * the record file. In rare cases a single dissenting CN node writes a sidecar file for a
+     * block that consensus later declared had no sidecar; that orphan lingers in the bucket
+     * and gets swept in by the filename matcher. Embedding it into the WRB produces bytes with
+     * no cryptographic backing. Since the RSA signature only covers the manifest, treating the
+     * manifest as authoritative and dropping unmatched candidates keeps the WRB honest.
+     *
+     * <p>The returned list preserves the relative order of the retained sidecars. This is
+     * package-private so tests can exercise the filter directly.
+     */
+    static List<SidecarFile> filterOrphanSidecars(
+            final List<SidecarFile> parsedSidecars, final List<SidecarMetadata> sidecarMetadatas) {
+        return filterOrphanSidecars(parsedSidecars, sidecarMetadatas, System.err::println);
+    }
+
+    /**
+     * Overload of {@link #filterOrphanSidecars(List, List)} with an injectable warning sink so
+     * tests can capture drop diagnostics without racing on {@code System.setErr}. The sink is
+     * invoked once per dropped sidecar with a human-readable message.
+     */
+    static List<SidecarFile> filterOrphanSidecars(
+            final List<SidecarFile> parsedSidecars,
+            final List<SidecarMetadata> sidecarMetadatas,
+            final java.util.function.Consumer<String> warningSink) {
+        if (parsedSidecars.isEmpty()) {
+            return parsedSidecars;
+        }
+        final List<byte[]> signedHashes = new ArrayList<>(sidecarMetadatas.size());
+        for (final SidecarMetadata meta : sidecarMetadatas) {
+            if (meta.hasHash()) {
+                signedHashes.add(meta.hashOrThrow().hash().toByteArray());
+            }
+        }
+        final MessageDigest digest = sha384Digest();
+        final List<SidecarFile> kept = new ArrayList<>(parsedSidecars.size());
+        for (int i = 0; i < parsedSidecars.size(); i++) {
+            final SidecarFile sf = parsedSidecars.get(i);
+            SidecarFile.PROTOBUF.toBytes(sf).writeTo(digest);
+            final byte[] hash = digest.digest();
+            if (containsHash(signedHashes, hash)) {
+                kept.add(sf);
+            } else {
+                warningSink.accept("Warning: Dropping orphan sidecar #" + i + " (SHA-384 " + hex(hash)
+                        + ") not referenced by record file's signed sidecars[] manifest");
+            }
+        }
+        return kept;
+    }
+
+    private static boolean containsHash(final List<byte[]> hashes, final byte[] target) {
+        for (final byte[] h : hashes) {
+            if (Arrays.equals(h, target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String hex(final byte[] bytes) {
+        final StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (final byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
     }
 
     /**

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/parsed/ParsedRecordBlock.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/records/model/parsed/ParsedRecordBlock.java
@@ -16,6 +16,7 @@ import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
 import org.hiero.block.tools.records.model.unparsed.UnparsedRecordBlock;
@@ -142,7 +143,8 @@ public record ParsedRecordBlock(
             if (containsHash(signedHashes, hash)) {
                 kept.add(sf);
             } else {
-                warningSink.accept("Warning: Dropping orphan sidecar #" + i + " (SHA-384 " + hex(hash)
+                warningSink.accept("Warning: Dropping orphan sidecar #" + i + " (SHA-384 "
+                        + HexFormat.of().formatHex(hash)
                         + ") not referenced by record file's signed sidecars[] manifest");
             }
         }
@@ -156,14 +158,6 @@ public record ParsedRecordBlock(
             }
         }
         return false;
-    }
-
-    private static String hex(final byte[] bytes) {
-        final StringBuilder sb = new StringBuilder(bytes.length * 2);
-        for (final byte b : bytes) {
-            sb.append(String.format("%02x", b));
-        }
-        return sb.toString();
     }
 
     /**

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/records/model/parsed/ParsedRecordBlockFilterTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/records/model/parsed/ParsedRecordBlockFilterTest.java
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.records.model.parsed;
+
+import static org.hiero.block.tools.utils.Sha384.sha384Digest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.streams.ContractAction;
+import com.hedera.hapi.streams.ContractActions;
+import com.hedera.hapi.streams.HashAlgorithm;
+import com.hedera.hapi.streams.HashObject;
+import com.hedera.hapi.streams.SidecarFile;
+import com.hedera.hapi.streams.SidecarMetadata;
+import com.hedera.hapi.streams.TransactionSidecarRecord;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct-invocation tests for {@link ParsedRecordBlock#filterOrphanSidecars(List, List)}.
+ *
+ * <p>Kept in a dedicated file so the state-sharing {@link ParsedRecordBlockTest} lifecycle
+ * isn't disturbed. The filter is invoked by name (package-private) rather than exercised
+ * through {@link ParsedRecordBlock#parse} so we can control inputs precisely without
+ * standing up full record files.
+ */
+class ParsedRecordBlockFilterTest {
+
+    @Nested
+    @DisplayName("filterOrphanSidecars")
+    class FilterTests {
+
+        @Test
+        @DisplayName("empty sidecar list returns the same empty list")
+        void emptyList_returnsSameList() {
+            final List<String> warnings = new ArrayList<>();
+            final List<SidecarFile> in = List.of();
+            final List<SidecarFile> out = ParsedRecordBlock.filterOrphanSidecars(in, List.of(), warnings::add);
+            assertSame(in, out, "empty input short-circuits without allocation");
+            assertEquals(0, warnings.size(), "no warnings should be emitted for empty input");
+        }
+
+        @Test
+        @DisplayName("all sidecars with matching signed hashes are retained")
+        void allMatch_allRetained() {
+            final SidecarFile s0 = sidecarWith("a");
+            final SidecarFile s1 = sidecarWith("b");
+            final List<SidecarFile> in = List.of(s0, s1);
+            final List<SidecarMetadata> metas = List.of(metadataFor(s0), metadataFor(s1));
+            final List<String> warnings = new ArrayList<>();
+
+            final List<SidecarFile> out = ParsedRecordBlock.filterOrphanSidecars(in, metas, warnings::add);
+
+            assertEquals(2, out.size());
+            assertSame(s0, out.get(0));
+            assertSame(s1, out.get(1));
+            assertEquals(0, warnings.size(), "no warnings when every candidate matches");
+        }
+
+        @Test
+        @DisplayName("orphan sidecar (no matching signed hash) is dropped and warning emitted")
+        void orphanDropped_warningLogged() {
+            final SidecarFile signed = sidecarWith("signed");
+            final SidecarFile orphan = sidecarWith("orphan");
+            final List<SidecarFile> in = List.of(signed, orphan);
+            final List<SidecarMetadata> metas = List.of(metadataFor(signed));
+            final List<String> warnings = new ArrayList<>();
+
+            final List<SidecarFile> out = ParsedRecordBlock.filterOrphanSidecars(in, metas, warnings::add);
+
+            assertEquals(1, out.size(), "orphan should be dropped");
+            assertSame(signed, out.get(0), "only the signed sidecar remains");
+            assertEquals(1, warnings.size(), "exactly one warning for the one dropped sidecar");
+            assertTrue(warnings.get(0).contains("Dropping orphan sidecar"), "warning shape");
+            assertTrue(warnings.get(0).contains("#1"), "warning identifies the dropped index");
+        }
+
+        @Test
+        @DisplayName("all sidecars orphaned - all dropped, empty list returned")
+        void allOrphans_allDropped() {
+            final SidecarFile s0 = sidecarWith("a");
+            final SidecarFile s1 = sidecarWith("b");
+            final List<SidecarFile> in = List.of(s0, s1);
+            final List<SidecarMetadata> metas = List.of(); // signed list empty
+            final List<String> warnings = new ArrayList<>();
+
+            final List<SidecarFile> out = ParsedRecordBlock.filterOrphanSidecars(in, metas, warnings::add);
+
+            assertEquals(0, out.size(), "with empty signed list, every candidate is an orphan");
+            assertEquals(2, warnings.size(), "one warning per dropped sidecar");
+            assertTrue(warnings.get(0).contains("#0"));
+            assertTrue(warnings.get(1).contains("#1"));
+        }
+
+        @Test
+        @DisplayName("metadata entry without a hash field does not vouch for any sidecar")
+        void metadataWithoutHash_treatedAsUnsigned() {
+            final SidecarFile s = sidecarWith("x");
+            final List<SidecarFile> in = List.of(s);
+            final List<SidecarMetadata> metas = List.of(SidecarMetadata.DEFAULT); // no hash set
+            final List<String> warnings = new ArrayList<>();
+
+            final List<SidecarFile> out = ParsedRecordBlock.filterOrphanSidecars(in, metas, warnings::add);
+
+            assertEquals(0, out.size(), "metadata with no hash cannot back any sidecar");
+            assertEquals(1, warnings.size());
+            assertTrue(warnings.get(0).contains("Dropping orphan sidecar"));
+        }
+
+        @Test
+        @DisplayName(
+                "signed hash present but no matching candidate - candidate kept only if its hash is in signed list")
+        void extraSignedHash_doesNotAffectRetentionDecision() {
+            // Two signed hashes, only one candidate that matches the first.
+            // The extra signed hash without a candidate is the MISSING case, which is a separate concern
+            // (handled elsewhere). The filter itself should still retain the one candidate that matches.
+            final SidecarFile matches = sidecarWith("here");
+            final SidecarFile ghost = sidecarWith("gone"); // never presented as candidate
+            final List<SidecarFile> in = List.of(matches);
+            final List<SidecarMetadata> metas = List.of(metadataFor(matches), metadataFor(ghost));
+            final List<String> warnings = new ArrayList<>();
+
+            final List<SidecarFile> out = ParsedRecordBlock.filterOrphanSidecars(in, metas, warnings::add);
+            assertEquals(1, out.size());
+            assertSame(matches, out.get(0));
+            assertEquals(0, warnings.size(), "no warnings when the candidate matches");
+        }
+
+        @Test
+        @DisplayName("relative order of retained sidecars is preserved")
+        void retainedOrderPreserved() {
+            final SidecarFile a = sidecarWith("a");
+            final SidecarFile b = sidecarWith("b");
+            final SidecarFile c = sidecarWith("c");
+            // in list: [a, b, c]; b is the orphan; expect [a, c] out.
+            final List<SidecarFile> in = List.of(a, b, c);
+            final List<SidecarMetadata> metas = List.of(metadataFor(a), metadataFor(c));
+            final List<String> warnings = new ArrayList<>();
+
+            final List<SidecarFile> out = ParsedRecordBlock.filterOrphanSidecars(in, metas, warnings::add);
+            assertEquals(2, out.size());
+            assertSame(a, out.get(0));
+            assertSame(c, out.get(1));
+            assertEquals(1, warnings.size(), "one warning for the one dropped sidecar");
+            assertTrue(warnings.get(0).contains("#1"));
+        }
+    }
+
+    // --- helpers ---
+
+    /**
+     * Build a small distinct {@link SidecarFile} whose serialized bytes hash to a stable
+     * per-tag SHA-384. A single {@link TransactionSidecarRecord} with the given tag encoded
+     * into the record's inner {@code ContractActions} payload is enough to differentiate
+     * one sidecar from another.
+     */
+    private static SidecarFile sidecarWith(final String tag) {
+        final Timestamp ts = new Timestamp(1, tag.hashCode() & 0x7fffffff);
+        final ContractAction action =
+                ContractAction.newBuilder().input(Bytes.wrap(tag.getBytes())).build();
+        final ContractActions actions =
+                ContractActions.newBuilder().contractActions(action).build();
+        final TransactionSidecarRecord record = TransactionSidecarRecord.newBuilder()
+                .consensusTimestamp(ts)
+                .actions(actions)
+                .build();
+        return SidecarFile.newBuilder().sidecarRecords(record).build();
+    }
+
+    /** Build a {@link SidecarMetadata} entry whose hash equals SHA-384 of the given sidecar's serialized bytes. */
+    private static SidecarMetadata metadataFor(final SidecarFile sf) {
+        final MessageDigest digest = sha384Digest();
+        SidecarFile.PROTOBUF.toBytes(sf).writeTo(digest);
+        final byte[] hash = digest.digest();
+        final HashObject ho = HashObject.newBuilder()
+                .algorithm(HashAlgorithm.SHA_384)
+                .length(hash.length)
+                .hash(Bytes.wrap(hash))
+                .build();
+        return SidecarMetadata.newBuilder().hash(ho).build();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3224. The wrap pipeline picks up any file matching the sidecar filename pattern (`<timestamp>_NN.rcd*`) next to the record file and embeds its bytes into the WRB, without checking whether the record file's signed `sidecars[]` manifest actually declares it. This change treats the manifest as authoritative: candidate sidecars whose SHA-384 does not appear in the signed list are dropped with a warning before the RecordFileItem is constructed.

## What changed

- `ParsedRecordBlock.parse` now runs a filter pass over the parsed sidecar list against `recordStreamFile.sidecars[]`, keeping only entries whose SHA-384 matches a signed metadata hash.
- New `filterOrphanSidecars(List<SidecarFile>, List<SidecarMetadata>)` helper. Wraps a second overload that accepts an injectable `Consumer<String>` warning sink so tests can capture drop diagnostics without racing on `System.setErr` under parallel test forks.
- 7 unit tests in `ParsedRecordBlockFilterTest` covering: empty input short-circuit, all-match retention, single-orphan drop, all-orphan drop, metadata without hash field, extra signed hash with no candidate, and preservation of retained-list ordering.

## Motivation

Empirical background from the sidecar integrity investigation on mainnet (~97.6M blocks): three historical WRBs turned out to contain orphan sidecar bytes from 1-2 dissenting CN nodes for blocks that had zero contract activity. The dissenters' sidecar files remained in the bucket unreferenced by any signed manifest; the wrap-time filename matcher swept them in anyway. Detail in issue #3224.

The wrap-side integrity check (added by PR #3219) catches this at wrap time by aborting the wrap. That's the right safety net, but the correct default is to not embed the orphan in the first place. This PR is that default.

## Scope note (historical remediation is out of scope)

The 3 known mainnet occurrences are locked into the canonical chain hash for their block ranges (the entire serialized `RecordFileItem`, including `sidecar_file_contents`, is hashed into the WRB block hash via `BlockStreamBlockHasher`; see `case BLOCK_HEADER, RECORD_FILE, ...` in `hashBlockInternal`). Re-wrapping any of them would cascade through every subsequent block's `previous_block_hash` and effectively fork mainnet from the network's perspective. Those WRBs are canonical mainnet; this PR is prevention-only, not remediation.


## Related

- Issue #3196 / PR #3219: sidecar integrity validation (detection side)
- Investigation notes summarize the three mainnet observations that motivated this fix
