### PR TITLE
chore: release automation hardening — versioned release notes and smart version inference

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -4,9 +4,24 @@ name: Release Automation
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version (semver)"
+      release_type:
+        description: |
+          Release type.
+          rc    → bumps current rc (0.38.0-rc1 → 0.38.0-rc2) or starts rc1 from SNAPSHOT.
+          alpha → same logic for alpha pre-releases.
+          GA    → strips the pre-release suffix (0.38.0-rc2 → 0.38.0).
+          custom → uses the custom_version field below verbatim; all other inputs are ignored.
         required: true
+        default: "rc"
+        type: choice
+        options:
+          - rc
+          - alpha
+          - GA
+          - custom
+      custom_version:
+        description: "Full version string — only honoured when release_type is 'custom' (e.g. 0.38.0-hotfix.1)"
+        required: false
 
 permissions:
   contents: write
@@ -39,12 +54,61 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Compute Release Version
+        run: |
+          RELEASE_TYPE="${{ github.event.inputs.release_type }}"
+          if [[ "$RELEASE_TYPE" == "custom" ]]; then
+            CUSTOM="${{ github.event.inputs.custom_version }}"
+            if [[ -z "$CUSTOM" ]]; then
+              echo "::error::custom_version input is required when release_type is 'custom'"
+              exit 1
+            fi
+            COMPUTED_VERSION="$CUSTOM"
+          else
+            # Read version.txt from main via the GitHub API — no checkout needed yet.
+            CURRENT=$(gh api "repos/${{ github.repository }}/contents/version.txt" \
+              --jq '.content' | base64 -d | tr -d '[:space:]')
+            echo "Current repo version: $CURRENT"
+
+            if [[ "$CURRENT" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-rc([0-9]+)$ ]]; then
+              BASE="${BASH_REMATCH[1]}" && RC_N="${BASH_REMATCH[2]}" && KIND="rc"
+            elif [[ "$CURRENT" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-alpha([0-9]+)$ ]]; then
+              BASE="${BASH_REMATCH[1]}" && ALPHA_N="${BASH_REMATCH[2]}" && KIND="alpha"
+            elif [[ "$CURRENT" =~ ^([0-9]+\.[0-9]+\.[0-9]+)(-SNAPSHOT)?$ ]]; then
+              BASE="${BASH_REMATCH[1]}" && KIND="snapshot"
+            else
+              echo "::error::Unrecognised version format '$CURRENT' in version.txt"
+              exit 1
+            fi
+
+            case "$RELEASE_TYPE" in
+              rc)
+                [[ "$KIND" == "rc" ]] \
+                  && COMPUTED_VERSION="${BASE}-rc$((RC_N + 1))" \
+                  || COMPUTED_VERSION="${BASE}-rc1"
+                ;;
+              alpha)
+                [[ "$KIND" == "alpha" ]] \
+                  && COMPUTED_VERSION="${BASE}-alpha$((ALPHA_N + 1))" \
+                  || COMPUTED_VERSION="${BASE}-alpha1"
+                ;;
+              GA)
+                COMPUTED_VERSION="$BASE"
+                ;;
+            esac
+          fi
+
+          echo "Computed release version: $COMPUTED_VERSION"
+          echo "COMPUTED_VERSION=$COMPUTED_VERSION" >> "$GITHUB_ENV"
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+
       - name: Parse Version
         id: version_parser
         uses: step-security/semver-utils@5bb182a08240146b23b61cc002cb74004377da4b # v5.0.0
         with:
           lenient: false
-          version: ${{ github.event.inputs.version }}
+          version: ${{ env.COMPUTED_VERSION }}
 
       - name: Set Release Environment Variables
         run: |

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -193,7 +193,6 @@ jobs:
           tagging_message: ${{ env.RELEASE_TAG }}
 
       - name: Install git-cliff
-        if: ${{ steps.version_parser.outputs.prerelease == '' }}
         run: |
           TARBALL="git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-musl.tar.gz"
           gh release download "v${GIT_CLIFF_VERSION}" \
@@ -210,7 +209,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Generate Release Notes
-        if: ${{ steps.version_parser.outputs.prerelease == '' }}
         run: |
           git cliff \
             --config cliff.toml \
@@ -226,7 +224,6 @@ jobs:
           draft: true
           generateReleaseNotes: false
           name: ${{ env.RELEASE_TAG }}
-          omitBody: ${{ steps.version_parser.outputs.prerelease != '' }}
           prerelease: ${{ steps.version_parser.outputs.prerelease != '' }}
           tag: ${{ env.RELEASE_TAG }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -149,7 +149,6 @@ jobs:
           git cliff \
             --config cliff.toml \
             --latest \
-            --strip header \
             --output "${RELEASE_NOTES_FILENAME}.md"
 
       - name: Create Github Release

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -65,8 +65,10 @@ jobs:
             fi
             COMPUTED_VERSION="$CUSTOM"
           else
-            # Read version.txt from main via the GitHub API — no checkout needed yet.
-            CURRENT=$(gh api "repos/${{ github.repository }}/contents/version.txt" \
+            # Read version.txt from the dispatching branch — no checkout needed yet.
+            # Using github.ref_name (not 'main') so rc2/GA runs off release/* read
+            # the correct pre-release version rather than the SNAPSHOT on main.
+            CURRENT=$(gh api "repos/${{ github.repository }}/contents/version.txt?ref=${{ github.ref_name }}" \
               --jq '.content' | base64 -d | tr -d '[:space:]')
             echo "Current repo version: $CURRENT"
 

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -55,15 +55,17 @@ jobs:
           egress-policy: audit
 
       - name: Compute Release Version
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          INPUT_RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+          INPUT_CUSTOM_VERSION: ${{ github.event.inputs.custom_version }}
         run: |
-          RELEASE_TYPE="${{ github.event.inputs.release_type }}"
-          if [[ "$RELEASE_TYPE" == "custom" ]]; then
-            CUSTOM="${{ github.event.inputs.custom_version }}"
-            if [[ -z "$CUSTOM" ]]; then
+          if [[ "$INPUT_RELEASE_TYPE" == "custom" ]]; then
+            if [[ -z "$INPUT_CUSTOM_VERSION" ]]; then
               echo "::error::custom_version input is required when release_type is 'custom'"
               exit 1
             fi
-            COMPUTED_VERSION="$CUSTOM"
+            COMPUTED_VERSION="$INPUT_CUSTOM_VERSION"
           else
             # Read version.txt from the dispatching branch — no checkout needed yet.
             # Using github.ref_name (not 'main') so rc2/GA runs off release/* read
@@ -83,7 +85,7 @@ jobs:
               exit 1
             fi
 
-            case "$RELEASE_TYPE" in
+            case "$INPUT_RELEASE_TYPE" in
               rc)
                 [[ "$KIND" == "rc" ]] \
                   && COMPUTED_VERSION="${BASE}-rc$((RC_N + 1))" \
@@ -102,8 +104,6 @@ jobs:
 
           echo "Computed release version: $COMPUTED_VERSION"
           echo "COMPUTED_VERSION=$COMPUTED_VERSION" >> "$GITHUB_ENV"
-        env:
-          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Parse Version
         id: version_parser

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -23,6 +23,10 @@ jobs:
     runs-on: hl-bn-lin-md
     env:
       RELEASE_NOTES_FILENAME: release_notes
+      # Bump this to pick up a new git-cliff release; verify the new SHA via:
+      #   gh release view v<VERSION> --repo orhun/git-cliff --json assets \
+      #     | jq '.assets[].name' | grep sha256
+      GIT_CLIFF_VERSION: "2.8.0"
     outputs:
       create_pr: ${{ env.CREATE_PR }}
       next_version_snapshot: ${{ env.NEXT_VERSION_SNAPSHOT }}
@@ -122,15 +126,40 @@ jobs:
           commit_user_email: ${{ steps.gpg_importer.outputs.email }}
           tagging_message: ${{ env.RELEASE_TAG }}
 
+      - name: Install git-cliff
+        run: |
+          TARBALL="git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          gh release download "v${GIT_CLIFF_VERSION}" \
+            --repo orhun/git-cliff \
+            --pattern "${TARBALL}" \
+            --pattern "${TARBALL}.sha256"
+          sha256sum --check "${TARBALL}.sha256"
+          tar xzf "${TARBALL}" \
+            --strip-components=1 \
+            "git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-musl/git-cliff"
+          sudo install -m755 git-cliff /usr/local/bin/git-cliff
+          rm "${TARBALL}" "${TARBALL}.sha256"
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Generate Release Notes
+        run: |
+          git cliff \
+            --config cliff.toml \
+            --latest \
+            --strip header \
+            --output "${RELEASE_NOTES_FILENAME}.md"
+
       - name: Create Github Release
         uses: step-security/release-action@a0d8e0f90f554c15366ca2c9046bf4090d24adbe # v1.21.0
         with:
           allowUpdates: true
+          bodyFile: "${{ env.RELEASE_NOTES_FILENAME }}.md"
           commit: ${{ env.RELEASE_BRANCH }}
           draft: true
           generateReleaseNotes: false
           name: ${{ env.RELEASE_TAG }}
-          omitBody: ${{ steps.milestone.outputs.milestone_id == '' }}
+          omitBody: false
           prerelease: ${{ steps.version_parser.outputs.prerelease != '' }}
           tag: ${{ env.RELEASE_TAG }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -127,6 +127,7 @@ jobs:
           tagging_message: ${{ env.RELEASE_TAG }}
 
       - name: Install git-cliff
+        if: ${{ steps.version_parser.outputs.prerelease == '' }}
         run: |
           TARBALL="git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-musl.tar.gz"
           gh release download "v${GIT_CLIFF_VERSION}" \
@@ -143,6 +144,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Generate Release Notes
+        if: ${{ steps.version_parser.outputs.prerelease == '' }}
         run: |
           git cliff \
             --config cliff.toml \
@@ -159,7 +161,7 @@ jobs:
           draft: true
           generateReleaseNotes: false
           name: ${{ env.RELEASE_TAG }}
-          omitBody: false
+          omitBody: ${{ steps.version_parser.outputs.prerelease != '' }}
           prerelease: ${{ steps.version_parser.outputs.prerelease != '' }}
           tag: ${{ env.RELEASE_TAG }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -4,12 +4,19 @@
 # See: https://git-cliff.org/docs/configuration
 
 [changelog]
-header = ""
+# Rendered once at the top of the output — appears in the GitHub draft release edit box
+# as a visible reminder to add a prose summary before publishing.
+# git-cliff cannot auto-write a narrative; the author fills this in (or uses the
+# GitHub Copilot ✨ button in the release editor to generate one).
+header = """
+> ✏️ _Add a 2–4 sentence summary of the key changes in this release, then delete this line._
+
+"""
 body = """
 {% for group, commits in commits | group_by(attribute="group") -%}
 ### {{ group }}
 
-{% for commit in commits | sort(attribute="description") -%}
+{% for commit in commits -%}
 - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.description | upper_first }}
 {% endfor %}
 {% endfor %}
@@ -38,3 +45,6 @@ commit_parsers = [
 filter_commits = true
 # Match all release tags (stable and rc alike).
 tag_pattern = "v[0-9].*"
+# Newest commits appear first within each section, avoiding the case-sensitivity
+# quirk of alphabetical sort (uppercase ASCII < lowercase ASCII).
+sort_commits = "newest"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,40 @@
+# cliff.toml — git-cliff changelog configuration
+# Reads squash-merge commit messages (which are PR titles following Conventional Commits)
+# and groups them into labelled sections for GitHub release notes.
+# See: https://git-cliff.org/docs/configuration
+
+[changelog]
+header = ""
+body = """
+{% for group, commits in commits | group_by(attribute="group") -%}
+### {{ group }}
+
+{% for commit in commits | sort(attribute="description") -%}
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.description | upper_first }}
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+# Commits that do not follow Conventional Commits are excluded from the changelog.
+# All PRs in this repo are required to use conventional commit titles, so nothing
+# legitimate should be filtered here.
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+  { message = "^feat",     group = "✨ Features" },
+  { message = "^fix",      group = "🐛 Bug Fixes" },
+  { message = "^docs",     group = "📚 Documentation" },
+  { message = "^perf",     group = "⚡ Performance" },
+  { message = "^refactor", group = "♻️ Refactoring" },
+  { message = "^test",     group = "🧪 Tests" },
+  { message = "^build",    group = "🔧 Build & Maintenance" },
+  { message = "^chore",    group = "🔧 Build & Maintenance" },
+  # ci: commits are infra-only noise; skip them entirely.
+  { message = "^ci",       skip = true },
+]
+filter_commits = true
+# Match all release tags (stable and rc alike).
+tag_pattern = "v[0-9].*"


### PR DESCRIPTION
## Reviewer Notes
Two improvements to the release workflow:

1. **Automated release notes** — wires [git-cliff](https://git-cliff.org) into
   `release-automation.yaml` so GA draft releases automatically include a conventional-commit
   changelog grouped by type. RC/alpha releases are unaffected.

2. **Smart version inference** — replaces the manual free-text version input with a
   `release_type` choice (`rc` | `alpha` | `GA` | `custom`). The workflow reads `version.txt`
   from `main` via the GitHub API and computes the correct next version automatically, e.g.
   `0.39.0-SNAPSHOT` + `rc` → `0.39.0-rc1`; `0.39.0-rc1` + `rc` → `0.39.0-rc2`;
   `0.39.0-rc2` + `GA` → `0.39.0`. Engineers no longer type version strings manually.

## Changes

### `cliff.toml` (new)

Root-level configuration for git-cliff. Reads conventional commit messages and maps them to
labelled sections:

| Prefix | Section |
|--------|---------|
| `feat` | ✨ Features |
| `fix` | 🐛 Bug Fixes |
| `docs` | 📚 Documentation |
| `perf` | ⚡ Performance |
| `refactor` | ♻️ Refactoring |
| `test` | 🧪 Tests |
| `build`, `chore` | 🔧 Build & Maintenance |
| `ci` | _(skipped — infra noise)_ |

`filter_unconventional = true` drops any commit that does not match the parser list.
Because all PR titles are required to use conventional commit prefixes, nothing legitimate
is filtered.

Within each section commits appear newest-first (chronological, `sort_commits = "newest"`).
Alphabetical sort was intentionally avoided because Tera's built-in sort is case-sensitive
(ASCII uppercase < lowercase), which caused version-bump entries like "Bump Azure/…" to float
above lowercase entries. Newest-first is also more useful for readers tracking incremental
change. Scopes are bolded:

```
### ✨ Features
- **state-management:** Three concurrent state versions + hash on promotion
- **health:** Modify health plugin to use a separate Helidon Webserver (#3216)

### 🐛 Bug Fixes
- Fix lastAvailableBlock inflation when EMB exceeds stored blocks (#3213)

### 🔧 Build & Maintenance
- Bump hederaCryptographyVersion from 3.11.0 to 3.11.2 (#3183)
```

GitHub auto-hyperlinks bare `#NNNN` references in release bodies, so no explicit link
templating is needed.

A blockquote placeholder appears at the very top of each generated draft, prompting the
author to add a prose summary before publishing. git-cliff cannot auto-generate narrative
text — the placeholder makes this obvious in the edit UI:

```
> ✏️ _Add a 2–4 sentence summary of the key changes in this release, then delete this line._
```

(The GitHub Copilot ✨ button in the release editor can also draft a summary once the
commit list is visible.)

**Future option — skip version-bump commits**: Release automation itself generates a
`chore(release): Bump versions for v0.38.0-SNAPSHOT` commit which appears in Build &
Maintenance. To exclude it, add the following rule to `commit_parsers` in `cliff.toml`
**before** the generic `^chore` entry:

```toml
{ message = "^chore\\(release\\)", skip = true },
```

### `.github/workflows/release-automation.yaml`

#### Version inference (new, runs first)

The `workflow_dispatch` inputs are replaced:

| Before | After |
|--------|-------|
| `version` (free text, required) | `release_type` (choice: `rc` / `alpha` / `GA` / `custom`, default `rc`) |
| — | `custom_version` (free text, optional — only used when `release_type` is `custom`) |

A new **Compute Release Version** step runs immediately after Harden Runner, before any other
steps touch the repo:

```yaml
- name: Compute Release Version
  run: |
    RELEASE_TYPE="${{ github.event.inputs.release_type }}"
    if [[ "$RELEASE_TYPE" == "custom" ]]; then
      COMPUTED_VERSION="${{ github.event.inputs.custom_version }}"
    else
      CURRENT=$(gh api "repos/${{ github.repository }}/contents/version.txt" \
        --jq '.content' | base64 -d | tr -d '[:space:]')
      # ... regex parse + bump logic ...
    fi
    echo "COMPUTED_VERSION=$COMPUTED_VERSION" >> "$GITHUB_ENV"
  env:
    GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
```

Inference rules (`version.txt` is read from the **dispatching branch** via `?ref=github.ref_name`,
not hardcoded to `main`):

| Dispatching branch | `version.txt` | `release_type` | Computed version |
|---|---|---|---|
| `main` | `0.38.0-SNAPSHOT` | `rc` | `0.38.0-rc1` |
| `release/0.38` | `0.38.0-rc1` | `rc` | `0.38.0-rc2` |
| `release/0.38` | `0.38.0-rc2` | `GA` | `0.38.0` |
| `main` | `0.39.0-SNAPSHOT` | `alpha` | `0.39.0-alpha1` |
| `release/0.39` | `0.39.0-alpha1` | `alpha` | `0.39.0-alpha2` |
| _(any)_ | _(any)_ | `custom` | value of `custom_version` input (validated non-empty) |

The `version.txt` read uses `gh api` with `${{ secrets.GH_ACCESS_TOKEN }}` — no checkout
is required. The computed version is fed directly into the **Parse Version** step (`semver-utils`)
as `${{ env.COMPUTED_VERSION }}`; everything downstream (`RELEASE_BRANCH`, `RELEASE_TAG`,
milestone, tagging) is completely unchanged.

If `release_type` is `custom` and `custom_version` is empty, the step emits
`::error::` and exits non-zero, failing the workflow before any release state is modified.

#### Release notes steps (new, runs near the end)

Two new steps inserted between **Commit and Tag** and **Create Github Release**, both
gated on `if: steps.version_parser.outputs.prerelease == ''` so they run only for GA
versions (`0.38.0`, `0.37.1`, …) and are skipped entirely for `0.38.0-rc1`, etc.

**Install git-cliff**

Downloads the statically-linked musl binary from the upstream GitHub release using the
already-trusted `gh` CLI, then verifies it against the `.sha256` file published alongside
the tarball. No new action trust is introduced — the checksum is provided by the same
release and verified before extraction.

```yaml
- name: Install git-cliff
  if: ${{ steps.version_parser.outputs.prerelease == '' }}
  run: |
    TARBALL="git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-musl.tar.gz"
    gh release download "v${GIT_CLIFF_VERSION}" \
      --repo orhun/git-cliff \
      --pattern "${TARBALL}" \
      --pattern "${TARBALL}.sha256"
    sha256sum --check "${TARBALL}.sha256"
    tar xzf "${TARBALL}" \
      --strip-components=1 \
      "git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-musl/git-cliff"
    sudo install -m755 git-cliff /usr/local/bin/git-cliff
    rm "${TARBALL}" "${TARBALL}.sha256"
  env:
    GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
```

`GIT_CLIFF_VERSION` is a job-level env var (`"2.8.0"`) with an inline comment showing how
to find the SHA of a new release when bumping the version.

**Generate Release Notes**

Runs `git cliff --latest` to produce the changelog for the range from the previous `v*`
tag to the tag just created by the preceding **Commit and Tag** step. Output is written to
`release_notes.md` (matching the pre-existing `RELEASE_NOTES_FILENAME` env var).

```yaml
- name: Generate Release Notes
  if: ${{ steps.version_parser.outputs.prerelease == '' }}
  run: |
    git cliff \
      --config cliff.toml \
      --latest \
      --output "${RELEASE_NOTES_FILENAME}.md"
```

**Create Github Release** (updated)

Two parameter changes:

```yaml
bodyFile: "${{ env.RELEASE_NOTES_FILENAME }}.md"   # new — wire in generated notes
omitBody: ${{ steps.version_parser.outputs.prerelease != '' }}  # restored — omit for rc/alpha
```

`step-security/release-action` skips reading `bodyFile` when `omitBody` is `true`, so
missing-file errors cannot occur on rc/alpha runs.

## Backward Compatibility

| Scenario | Impact |
|---|---|
| Triggering a GA release | Select `GA` — version inferred automatically. Draft includes grouped release notes. |
| Triggering an RC | Select `rc` (default) — version inferred and bumped automatically. Notes body omitted. |
| Hotfix / non-standard version | Select `custom` and provide the full version string. |
| Upgrading git-cliff version | Bump `GIT_CLIFF_VERSION` in the job env; no other changes required. |
| Repos without a previous tag | `--latest` on a single-tag repo includes all commits from the beginning — safe, if verbose. |

Example [v0.38.0 release notes](https://github.com/user-attachments/files/30072291/v0.38.0.md)

## Related Issue(s)
Resolves #1443 