### PR TITLE
chore: Don't register config extensions manually

### DIFF
--- a/block-node/app-config/src/main/java/module-info.java
+++ b/block-node/app-config/src/main/java/module-info.java
@@ -19,6 +19,7 @@ module org.hiero.block.node.app.config {
     exports org.hiero.block.node.app.config.node;
 
     requires transitive com.swirlds.config.api;
+    requires transitive org.hiero.block.node.spi;
     requires com.swirlds.base;
     requires org.hiero.block.node.base;
     requires java.logging;

--- a/block-node/app-config/src/main/java/module-info.java
+++ b/block-node/app-config/src/main/java/module-info.java
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.app.config.AppConfigExtension;
+
 module org.hiero.block.node.app.config {
+    exports org.hiero.block.node.app.config.state;
+
     // export configuration classes to the config module
     exports org.hiero.block.node.app.config to
             com.swirlds.config.impl,
@@ -13,7 +17,6 @@ module org.hiero.block.node.app.config {
             org.hiero.block.node.health;
     // export the node-wide configuration to everything.
     exports org.hiero.block.node.app.config.node;
-    exports org.hiero.block.node.app.config.state;
 
     requires transitive com.swirlds.config.api;
     requires com.swirlds.base;
@@ -21,4 +24,7 @@ module org.hiero.block.node.app.config {
     requires java.logging;
     requires static transitive com.github.spotbugs.annotations;
     requires static java.compiler;
+
+    provides com.swirlds.config.api.ConfigurationExtension with
+            AppConfigExtension;
 }

--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/AppConfigExtension.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/AppConfigExtension.java
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.app.config;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+import org.hiero.block.node.app.config.node.NodeConfig;
+import org.hiero.block.node.app.config.state.ApplicationStateConfig;
+
+/** Registers the application-wide configuration data types for auto-discovery. */
+public class AppConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public AppConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(ServerConfig.class, WebServerHttp2Config.class, NodeConfig.class, ApplicationStateConfig.class);
+    }
+}

--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/AutomaticEnvironmentVariableConfigSource.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/AutomaticEnvironmentVariableConfigSource.java
@@ -4,6 +4,7 @@ package org.hiero.block.node.app.config;
 import com.swirlds.base.ArgumentUtils;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
+import com.swirlds.config.api.ConfigurationExtension;
 import com.swirlds.config.api.source.ConfigSource;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -16,6 +17,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.hiero.block.node.spi.ServiceLoaderFunction;
 
 /**
  * Config source that automatically maps environment variables to configuration properties based on micro profile
@@ -33,14 +35,22 @@ public final class AutomaticEnvironmentVariableConfigSource implements ConfigSou
     private final Function<String, String> envVarGetter;
 
     /**
-     * Creates a new AutomaticEnvironmentVariableConfigSource instance.
+     * Creates a new AutomaticEnvironmentVariableConfigSource instance, discovering the configuration types to collect
+     * property names from via every {@link ConfigurationExtension} on {@code serviceLoader}. This is the same source
+     * of truth that {@link com.swirlds.config.api.ConfigurationBuilder#autoDiscoverExtensions()} resolves against, so
+     * this source sees exactly the same set of config data types as get registered with the configuration.
      *
-     * @param configTypes the configuration types to collect property names from
+     * @param serviceLoader the service loader used to discover {@link ConfigurationExtension} implementations
      * @param envVarGetter the function to get the environment variable value, this is needed to all for testing
      */
     public AutomaticEnvironmentVariableConfigSource(
-            @NonNull final List<Class<? extends Record>> configTypes, Function<String, String> envVarGetter) {
+            @NonNull final ServiceLoaderFunction serviceLoader, Function<String, String> envVarGetter) {
         this.envVarGetter = envVarGetter;
+        final List<Class<? extends Record>> configTypes = serviceLoader
+                .loadServices(ConfigurationExtension.class)
+                .flatMap(extension -> extension.getConfigDataTypes().stream())
+                .distinct()
+                .toList();
         final Map<String, String> envToPropertyNameMap = collectEnvToPropertyNameMappings(configTypes);
         propertyNameToEnvMap = envToPropertyNameMap.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));

--- a/block-node/app-config/src/test/java/org/hiero/block/node/app/config/AutomaticEnvironmentVariableConfigSourceTest.java
+++ b/block-node/app-config/src/test/java/org/hiero/block/node/app/config/AutomaticEnvironmentVariableConfigSourceTest.java
@@ -6,15 +6,47 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
+import com.swirlds.config.api.ConfigurationExtension;
 import java.util.Collections;
-import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.hiero.block.node.spi.ServiceLoaderFunction;
 import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for logging.
  */
 public class AutomaticEnvironmentVariableConfigSourceTest {
+    /** The config types that {@link #testServiceLoader()} reports as available, standing in for what would normally
+     * be discovered from every module's {@link ConfigurationExtension}. */
+    private static final Set<Class<? extends Record>> TEST_CONFIG_TYPES =
+            Set.of(TestSecretConfig.class, ServerConfig.class);
+
+    /**
+     * A {@link ServiceLoaderFunction} that reports a single {@link ConfigurationExtension} exposing
+     * {@link #TEST_CONFIG_TYPES}, so tests do not depend on what is actually registered via {@code provides} on the
+     * real module path.
+     */
+    private static ServiceLoaderFunction testServiceLoader() {
+        return new ServiceLoaderFunction() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public <C> Stream<? extends C> loadServices(Class<C> serviceClass) {
+                if (serviceClass == ConfigurationExtension.class) {
+                    final ConfigurationExtension extension = new ConfigurationExtension() {
+                        @Override
+                        public Set<Class<? extends Record>> getConfigDataTypes() {
+                            return TEST_CONFIG_TYPES;
+                        }
+                    };
+                    return Stream.of(extension).map(e -> (C) e);
+                }
+                return Stream.empty();
+            }
+        };
+    }
+
     /**
      * Set up the test environment by initializing the logger and adding a custom log handler so that we can capture
      * log messages.
@@ -22,9 +54,7 @@ public class AutomaticEnvironmentVariableConfigSourceTest {
     @Test
     void testNotSettingEnv() {
         final Configuration config = ConfigurationBuilder.create()
-                .autoDiscoverExtensions()
-                .withSource(new AutomaticEnvironmentVariableConfigSource(
-                        List.of(TestSecretConfig.class, ServerConfig.class), System::getenv))
+                .withSource(new AutomaticEnvironmentVariableConfigSource(testServiceLoader(), System::getenv))
                 .withConfigDataType(ServerConfig.class)
                 .build();
         assertEquals(40840, config.getConfigData(ServerConfig.class).port());
@@ -38,7 +68,7 @@ public class AutomaticEnvironmentVariableConfigSourceTest {
         // create a AutomaticEnvironmentVariableConfigSource with a modified environment variable source
         final AutomaticEnvironmentVariableConfigSource automaticEnvironmentVariableConfigSource =
                 new AutomaticEnvironmentVariableConfigSource(
-                        List.of(TestSecretConfig.class, ServerConfig.class),
+                        testServiceLoader(),
                         varName -> "SERVER_PORT".equals(varName) ? "1234" : System.getenv(varName));
         // check that we can get the correct environment variable from the config source
         assertEquals("1234", automaticEnvironmentVariableConfigSource.getValue("server.port"));
@@ -60,8 +90,7 @@ public class AutomaticEnvironmentVariableConfigSourceTest {
     @Test
     void testOtherSourceMethods() {
         final AutomaticEnvironmentVariableConfigSource automaticEnvironmentVariableConfigSource =
-                new AutomaticEnvironmentVariableConfigSource(
-                        List.of(TestSecretConfig.class, ServerConfig.class), System::getenv);
+                new AutomaticEnvironmentVariableConfigSource(testServiceLoader(), System::getenv);
         assertEquals(300, automaticEnvironmentVariableConfigSource.getOrdinal());
         assertEquals(
                 AutomaticEnvironmentVariableConfigSource.class.getSimpleName(),

--- a/block-node/app/src/main/java/module-info.java
+++ b/block-node/app/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import com.swirlds.config.api.ConfigurationExtension;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
 import org.hiero.block.node.spi.historicalblocks.BlockProviderPlugin;
@@ -6,11 +7,6 @@ import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
 
 module org.hiero.block.node.app {
     exports org.hiero.block.node.app;
-    // it is expected the app module will never export any packages, only use others
-    uses HistoricalBlockFacility;
-    uses BlockMessagingFacility;
-    uses BlockNodePlugin;
-    uses BlockProviderPlugin;
 
     requires com.hedera.pbj.grpc.helidon.config;
     requires com.hedera.pbj.grpc.helidon;
@@ -30,4 +26,11 @@ module org.hiero.block.node.app {
     requires java.logging; // javax.annotation.processing.Generated
     requires static transitive com.github.spotbugs.annotations;
     requires static java.compiler;
+
+    uses BlockMessagingFacility;
+    uses BlockNodePlugin;
+    uses BlockProviderPlugin;
+    uses ConfigurationExtension;
+    // it is expected the app module will never export any packages, only use others
+    uses HistoricalBlockFacility;
 }

--- a/block-node/app/src/main/java/module-info.java
+++ b/block-node/app/src/main/java/module-info.java
@@ -31,6 +31,5 @@ module org.hiero.block.node.app {
     uses BlockNodePlugin;
     uses BlockProviderPlugin;
     uses ConfigurationExtension;
-    // it is expected the app module will never export any packages, only use others
     uses HistoricalBlockFacility;
 }

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -18,6 +18,7 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
+import com.swirlds.config.api.ConfigurationExtension;
 import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
 import com.swirlds.config.extensions.sources.SystemPropertiesConfigSource;
 import io.helidon.common.socket.SocketOptions;
@@ -55,7 +56,6 @@ import org.hiero.block.internal.BlockRangesState;
 import org.hiero.block.node.app.config.AutomaticEnvironmentVariableConfigSource;
 import org.hiero.block.node.app.config.ServerConfig;
 import org.hiero.block.node.app.config.WebServerHttp2Config;
-import org.hiero.block.node.app.config.node.NodeConfig;
 import org.hiero.block.node.app.config.state.ApplicationStateConfig;
 import org.hiero.block.node.app.logging.CleanColorfulFormatter;
 import org.hiero.block.node.app.logging.ConfigLogger;
@@ -206,24 +206,23 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         // Load all the plugins, just the classes are crated at this point, they are not initialized
         serviceLoader.loadServices(BlockNodePlugin.class).forEach(loadedPlugins::add);
         // ==== CONFIGURATION ==========================================================================================
-        // Collect all the config data types from the plugins and global server level
-        final List<Class<? extends Record>> allConfigDataTypes = new ArrayList<>();
-        allConfigDataTypes.add(ServerConfig.class);
-        allConfigDataTypes.add(WebServerHttp2Config.class);
-        allConfigDataTypes.add(NodeConfig.class);
-        allConfigDataTypes.add(ApplicationStateConfig.class);
-        loadedPlugins.forEach(plugin -> allConfigDataTypes.addAll(plugin.configDataTypes()));
+        // Collect all the config data types registered by every module's ConfigurationExtension; this is the same
+        // source of truth that autoDiscoverExtensions() below resolves against, so the env var source below sees
+        // exactly the same set of config data types as get registered with the configuration.
+        final List<Class<? extends Record>> allConfigDataTypes = serviceLoader
+                .loadServices(ConfigurationExtension.class)
+                .flatMap(extension -> extension.getConfigDataTypes().stream())
+                .distinct()
+                .toList();
         // Init BlockNode Configuration
         String appProperties = getClass().getClassLoader().getResource(APPLICATION_TEST_PROPERTIES) != null
                 ? APPLICATION_TEST_PROPERTIES
                 : APPLICATION_PROPERTIES;
-        //noinspection unchecked
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
                 .autoDiscoverExtensions()
                 .withSource(new AutomaticEnvironmentVariableConfigSource(allConfigDataTypes, System::getenv))
                 .withSource(SystemPropertiesConfigSource.getInstance())
-                .withSources(new ClasspathFileConfigSource(Path.of(appProperties)))
-                .withConfigDataTypes(allConfigDataTypes.toArray(new Class[0]));
+                .withSources(new ClasspathFileConfigSource(Path.of(appProperties)));
         // Build the configuration
         final Configuration configuration = configurationBuilder.build();
         // Log the configuration

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -18,7 +18,6 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
-import com.swirlds.config.api.ConfigurationExtension;
 import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
 import com.swirlds.config.extensions.sources.SystemPropertiesConfigSource;
 import io.helidon.common.socket.SocketOptions;
@@ -206,21 +205,17 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
         // Load all the plugins, just the classes are crated at this point, they are not initialized
         serviceLoader.loadServices(BlockNodePlugin.class).forEach(loadedPlugins::add);
         // ==== CONFIGURATION ==========================================================================================
-        // Collect all the config data types registered by every module's ConfigurationExtension; this is the same
-        // source of truth that autoDiscoverExtensions() below resolves against, so the env var source below sees
-        // exactly the same set of config data types as get registered with the configuration.
-        final List<Class<? extends Record>> allConfigDataTypes = serviceLoader
-                .loadServices(ConfigurationExtension.class)
-                .flatMap(extension -> extension.getConfigDataTypes().stream())
-                .distinct()
-                .toList();
         // Init BlockNode Configuration
         String appProperties = getClass().getClassLoader().getResource(APPLICATION_TEST_PROPERTIES) != null
                 ? APPLICATION_TEST_PROPERTIES
                 : APPLICATION_PROPERTIES;
-        final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
-                .autoDiscoverExtensions()
-                .withSource(new AutomaticEnvironmentVariableConfigSource(allConfigDataTypes, System::getenv))
+        final ConfigurationBuilder configurationBuilder =
+                ConfigurationBuilder.create().autoDiscoverExtensions();
+        // AutomaticEnvironmentVariableConfigSource does its own ConfigurationExtension lookup to learn every
+        // config data type; it must be constructed after autoDiscoverExtensions() above returns, not from within
+        // another extension's callback, or the nested ServiceLoader lookup deadlocks against the one in progress.
+        configurationBuilder
+                .withSource(new AutomaticEnvironmentVariableConfigSource(serviceLoader, System::getenv))
                 .withSource(SystemPropertiesConfigSource.getInstance())
                 .withSources(new ClasspathFileConfigSource(Path.of(appProperties)));
         // Build the configuration

--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
@@ -84,7 +84,6 @@ class BlockNodeAppTest {
     private static <T extends BlockNodePlugin> T createMockedPlugin(int num, Class<T> pluginClass) {
         T plugin = mock(pluginClass);
         when(plugin.name()).thenReturn(pluginClass.getSimpleName() + " " + num);
-        when(plugin.configDataTypes()).thenReturn(List.of());
         return plugin;
     }
 
@@ -865,11 +864,6 @@ class BlockNodeAppTest {
                         }
 
                         @Override
-                        public List<Class<? extends Record>> configDataTypes() {
-                            return List.of();
-                        }
-
-                        @Override
                         public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
                             serviceBuilder.registerHttpService("/pub", 40840, rules -> {});
                         }
@@ -878,11 +872,6 @@ class BlockNodeAppTest {
                         @Override
                         public String name() {
                             return "TestConsumer";
-                        }
-
-                        @Override
-                        public List<Class<? extends Record>> configDataTypes() {
-                            return List.of();
                         }
 
                         @Override
@@ -924,11 +913,6 @@ class BlockNodeAppTest {
                         }
 
                         @Override
-                        public List<Class<? extends Record>> configDataTypes() {
-                            return List.of();
-                        }
-
-                        @Override
                         public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
                             serviceBuilder.registerHttpService("/svc1", 40840, rules -> {});
                         }
@@ -937,11 +921,6 @@ class BlockNodeAppTest {
                         @Override
                         public String name() {
                             return "TestPlugin2";
-                        }
-
-                        @Override
-                        public List<Class<? extends Record>> configDataTypes() {
-                            return List.of();
                         }
 
                         @Override

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
@@ -186,13 +186,10 @@ public abstract class PluginTestBase<
         this.plugin = plugin;
         this.activeHistoricalBlockFacility = historicalBlockFacility;
         org.hiero.block.node.app.fixtures.logging.CleanColorfulFormatter.makeLoggingColorful();
-        // Build the configuration
-        //noinspection unchecked
-        ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
-                .withConfigDataType(org.hiero.block.node.app.config.node.NodeConfig.class)
-                .withConfigDataTypes(plugin.configDataTypes().toArray(new Class[0]))
-                .withConfigDataType(org.hiero.block.node.app.config.ServerConfig.class)
-                .withConfigDataType(org.hiero.block.node.app.config.WebServerHttp2Config.class);
+        // Build the configuration; autoDiscoverExtensions() picks up the ConfigurationExtension of the plugin under
+        // test (and any other module on the test classpath), the same source of truth BlockNodeApp uses in production.
+        ConfigurationBuilder configurationBuilder =
+                ConfigurationBuilder.create().autoDiscoverExtensions();
         if (configOverrides != null) {
             for (Entry<String, String> override : configOverrides.entrySet()) {
                 configurationBuilder = configurationBuilder.withValue(override.getKey(), override.getValue());

--- a/block-node/backfill/src/main/java/module-info.java
+++ b/block-node/backfill/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.backfill.BackfillConfigExtension;
 import org.hiero.block.node.backfill.BackfillPlugin;
 
 module org.hiero.block.node.backfill {
@@ -20,6 +21,8 @@ module org.hiero.block.node.backfill {
 
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    provides com.swirlds.config.api.ConfigurationExtension with
+            BackfillConfigExtension;
     provides org.hiero.block.node.spi.BlockNodePlugin with
             BackfillPlugin;
 }

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillConfigExtension.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.backfill;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class BackfillConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public BackfillConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(BackfillConfiguration.class);
+    }
+}

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -125,15 +125,6 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
     private MetricsHolder metricsHolder;
 
     /**
-     * {@inheritDoc}
-     */
-    @NonNull
-    @Override
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(BackfillConfiguration.class);
-    }
-
-    /**
      * Initializes the metrics for the backfill process.
      */
     private void initMetrics() {

--- a/block-node/block-access-service/src/main/java/module-info.java
+++ b/block-node/block-access-service/src/main/java/module-info.java
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.access.service.BlockAccessConfigExtension;
 import org.hiero.block.node.access.service.BlockAccessServicePlugin;
 
 module org.hiero.block.node.access.service {
-    uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
-
     // export configuration classes to the config module and app
     exports org.hiero.block.node.access.service to
             com.swirlds.config.impl,
@@ -17,6 +16,10 @@ module org.hiero.block.node.access.service {
     requires transitive org.hiero.metrics;
     requires org.hiero.block.node.base;
 
+    uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
+
+    provides com.swirlds.config.api.ConfigurationExtension with
+            BlockAccessConfigExtension;
     provides org.hiero.block.node.spi.BlockNodePlugin with
             BlockAccessServicePlugin;
 }

--- a/block-node/block-access-service/src/main/java/org/hiero/block/node/access/service/BlockAccessConfigExtension.java
+++ b/block-node/block-access-service/src/main/java/org/hiero/block/node/access/service/BlockAccessConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.access.service;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class BlockAccessConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public BlockAccessConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(BlockAccessConfig.class);
+    }
+}

--- a/block-node/block-access-service/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
+++ b/block-node/block-access-service/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
@@ -10,7 +10,6 @@ import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.Pipelines;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.List;
 import org.hiero.block.api.BlockAccessServiceInterface;
 import org.hiero.block.api.BlockRequest;
 import org.hiero.block.api.BlockResponse;
@@ -188,14 +187,5 @@ public class BlockAccessServicePlugin implements BlockNodePlugin, BlockAccessSer
         final Integer port =
                 context.configuration().getConfigData(BlockAccessConfig.class).port();
         serviceBuilder.registerGrpcService(port, this);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @NonNull
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(BlockAccessConfig.class);
     }
 }

--- a/block-node/block-verification/src/main/java/module-info.java
+++ b/block-node/block-verification/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.block.verification.VerificationConfigExtension;
 import org.hiero.block.node.block.verification.VerificationServicePlugin;
 
 module org.hiero.block.node.block.verification {
@@ -20,6 +21,8 @@ module org.hiero.block.node.block.verification {
 
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    provides com.swirlds.config.api.ConfigurationExtension with
+            VerificationConfigExtension;
     provides org.hiero.block.node.spi.BlockNodePlugin with
             VerificationServicePlugin;
 }

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationConfigExtension.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.block.verification;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class VerificationConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public VerificationConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(VerificationConfig.class);
+    }
+}

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationServicePlugin.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationServicePlugin.java
@@ -8,7 +8,6 @@ import static java.lang.System.Logger.Level.WARNING;
 import com.hedera.hapi.block.stream.output.BlockHeader;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
@@ -73,15 +72,6 @@ public final class VerificationServicePlugin implements BlockNodePlugin, BlockIt
     public VerificationServicePlugin() {
         this.lastVerifiedBlock = new AtomicLong(-1);
         this.recentlyVerifiedBlocks = new ConcurrentLinkedDeque<>();
-    }
-
-    /// {@inheritDoc}
-    /// ---
-    /// Exposes [VerificationConfig] as a configuration data type.
-    @NonNull
-    @Override
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(VerificationConfig.class);
     }
 
     /// {@inheritDoc}

--- a/block-node/blocks-file-historic/src/main/java/module-info.java
+++ b/block-node/blocks-file-historic/src/main/java/module-info.java
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import org.hiero.block.node.blocks.files.historic.BlockFileHistoricPlugin;
+import org.hiero.block.node.blocks.files.historic.FilesHistoricConfigExtension;
 
 module org.hiero.block.node.blocks.files.historic {
     // export configuration classes to the config module and app
@@ -19,6 +20,8 @@ module org.hiero.block.node.blocks.files.historic {
 
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    provides com.swirlds.config.api.ConfigurationExtension with
+            FilesHistoricConfigExtension;
     provides org.hiero.block.node.spi.historicalblocks.BlockProviderPlugin with
             BlockFileHistoricPlugin;
 }

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
@@ -26,7 +26,6 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Deque;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -117,15 +116,6 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
     private LongCounter.Measurement zipsDeletedFailedCounter;
 
     // ==== BlockProviderPlugin Methods ================================================================================
-
-    /**
-     * {@inheritDoc}
-     */
-    @NonNull
-    @Override
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(FilesHistoricConfig.class);
-    }
 
     /**
      * {@inheritDoc}

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfigExtension.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.blocks.files.historic;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class FilesHistoricConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public FilesHistoricConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(FilesHistoricConfig.class);
+    }
+}

--- a/block-node/blocks-file-recent/src/main/java/module-info.java
+++ b/block-node/blocks-file-recent/src/main/java/module-info.java
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import org.hiero.block.node.blocks.files.recent.BlockFileRecentPlugin;
+import org.hiero.block.node.blocks.files.recent.FilesRecentConfigExtension;
 
 module org.hiero.block.node.blocks.files.recent {
     // export configuration classes to the config module and app
@@ -18,6 +19,8 @@ module org.hiero.block.node.blocks.files.recent {
 
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    provides com.swirlds.config.api.ConfigurationExtension with
+            FilesRecentConfigExtension;
     provides org.hiero.block.node.spi.historicalblocks.BlockProviderPlugin with
             BlockFileRecentPlugin;
 }

--- a/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPlugin.java
+++ b/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPlugin.java
@@ -28,7 +28,6 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -148,15 +147,6 @@ public final class BlockFileRecentPlugin implements BlockProviderPlugin, BlockNo
     public BlockFileRecentPlugin() {}
 
     // ==== BlockProviderPlugin Methods ================================================================================
-
-    /**
-     * {@inheritDoc}
-     */
-    @NonNull
-    @Override
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(FilesRecentConfig.class);
-    }
 
     /**
      * {@inheritDoc}

--- a/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/FilesRecentConfigExtension.java
+++ b/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/FilesRecentConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.blocks.files.recent;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class FilesRecentConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public FilesRecentConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(FilesRecentConfig.class);
+    }
+}

--- a/block-node/cloud-storage-archive/src/main/java/module-info.java
+++ b/block-node/cloud-storage-archive/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.cloud.storage.archive.CloudStorageArchiveConfigExtension;
 import org.hiero.block.node.cloud.storage.archive.CloudStorageArchivePlugin;
 
 module org.hiero.block.node.cloud.storage.archive {
@@ -15,6 +16,8 @@ module org.hiero.block.node.cloud.storage.archive {
     requires org.hiero.block.node.base;
     requires org.hiero.block.protobuf.pbj;
 
+    provides com.swirlds.config.api.ConfigurationExtension with
+            CloudStorageArchiveConfigExtension;
     provides org.hiero.block.node.spi.BlockNodePlugin with
             CloudStorageArchivePlugin;
 }

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchiveConfigExtension.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchiveConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.cloud.storage.archive;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class CloudStorageArchiveConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public CloudStorageArchiveConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(CloudStorageArchiveConfig.class);
+    }
+}

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
@@ -187,13 +187,6 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
 
     /// {@inheritDoc}
     @Override
-    @NonNull
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(CloudStorageArchiveConfig.class);
-    }
-
-    /// {@inheritDoc}
-    @Override
     public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
         this.context = requireNonNull(context);
         this.config = context.configuration().getConfigData(CloudStorageArchiveConfig.class);

--- a/block-node/cloud-storage-expanded/src/main/java/module-info.java
+++ b/block-node/cloud-storage-expanded/src/main/java/module-info.java
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.cloud.storage.expanded.ExpandedCloudStorageConfigExtension;
 import org.hiero.block.node.cloud.storage.expanded.ExpandedCloudStoragePlugin;
 
 module org.hiero.block.node.cloud.storage.expanded {
-    uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
-
     // export configuration classes to the config module and app
     exports org.hiero.block.node.cloud.storage.expanded to
             com.swirlds.config.impl,
@@ -19,6 +18,10 @@ module org.hiero.block.node.cloud.storage.expanded {
     requires org.hiero.block.node.base;
     requires com.github.spotbugs.annotations;
 
+    uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
+
+    provides com.swirlds.config.api.ConfigurationExtension with
+            ExpandedCloudStorageConfigExtension;
     provides org.hiero.block.node.spi.BlockNodePlugin with
             ExpandedCloudStoragePlugin;
 }

--- a/block-node/cloud-storage-expanded/src/main/java/org/hiero/block/node/cloud/storage/expanded/ExpandedCloudStorageConfigExtension.java
+++ b/block-node/cloud-storage-expanded/src/main/java/org/hiero/block/node/cloud/storage/expanded/ExpandedCloudStorageConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.cloud.storage.expanded;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class ExpandedCloudStorageConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public ExpandedCloudStorageConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(ExpandedCloudStorageConfig.class);
+    }
+}

--- a/block-node/cloud-storage-expanded/src/main/java/org/hiero/block/node/cloud/storage/expanded/ExpandedCloudStoragePlugin.java
+++ b/block-node/cloud-storage-expanded/src/main/java/org/hiero/block/node/cloud/storage/expanded/ExpandedCloudStoragePlugin.java
@@ -6,7 +6,6 @@ import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletionService;
@@ -138,13 +137,6 @@ public class ExpandedCloudStoragePlugin implements BlockNodePlugin, BlockNotific
     }
 
     // ---- BlockNodePlugin ----------------------------------------------------
-
-    /// {@inheritDoc}
-    @NonNull
-    @Override
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(ExpandedCloudStorageConfig.class);
-    }
 
     /// {@inheritDoc}
     @Override

--- a/block-node/facility-messaging/src/main/java/module-info.java
+++ b/block-node/facility-messaging/src/main/java/module-info.java
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import org.hiero.block.node.messaging.BlockMessagingFacilityImpl;
+import org.hiero.block.node.messaging.MessagingConfigExtension;
 
 module org.hiero.block.node.messaging {
     // export configuration classes to the config module
@@ -18,6 +19,8 @@ module org.hiero.block.node.messaging {
 
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    provides com.swirlds.config.api.ConfigurationExtension with
+            MessagingConfigExtension;
     provides org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility with
             BlockMessagingFacilityImpl;
 }

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -12,7 +12,6 @@ import com.lmax.disruptor.SequenceBarrier;
 import com.lmax.disruptor.SleepingWaitStrategy;
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -214,15 +213,6 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
             new ArrayList<>();
 
     private ExecutorService messageForwarder;
-
-    /**
-     * {@inheritDoc}
-     */
-    @NonNull
-    @Override
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(MessagingConfig.class);
-    }
 
     /**
      * {@inheritDoc}

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/MessagingConfigExtension.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/MessagingConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.messaging;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class MessagingConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public MessagingConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(MessagingConfig.class);
+    }
+}

--- a/block-node/health/src/main/java/module-info.java
+++ b/block-node/health/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.health.HealthConfigExtension;
 import org.hiero.block.node.health.HealthServicePlugin;
 
 module org.hiero.block.node.health {
@@ -22,6 +23,8 @@ module org.hiero.block.node.health {
 
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    provides com.swirlds.config.api.ConfigurationExtension with
+            HealthConfigExtension;
     provides org.hiero.block.node.spi.BlockNodePlugin with
             HealthServicePlugin;
 }

--- a/block-node/health/src/main/java/org/hiero/block/node/health/HealthConfigExtension.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/HealthConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.health;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class HealthConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public HealthConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(HealthConfig.class);
+    }
+}

--- a/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/HealthServicePlugin.java
@@ -15,7 +15,6 @@ import io.helidon.webserver.http.ServerResponse;
 import io.helidon.webserver.http2.Http2Config;
 import java.lang.System.Logger;
 import java.time.Duration;
-import java.util.List;
 import java.util.TreeMap;
 import org.hiero.block.node.app.config.WebServerHttp2Config;
 import org.hiero.block.node.spi.ApplicationStateFacility;
@@ -103,13 +102,6 @@ public class HealthServicePlugin implements BlockNodePlugin {
         // register a new web server
         serviceBuilder.registerHttpNewServer(servicesToRegister, webserverHttpConfig, socketConfig, commonSocketValues);
         LOGGER.log(DEBUG, "Completed health facility initialization");
-    }
-
-    /// {@inheritDoc}
-    @Override
-    @NonNull
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(HealthConfig.class);
     }
 
     /// Handles the request for liveness endpoint, that must be defined

--- a/block-node/roster-bootstrap-rsa/src/main/java/module-info.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.roster.bootstrap.rsa.RsaRosterBootstrapConfigExtension;
 import org.hiero.block.node.roster.bootstrap.rsa.RsaRosterBootstrapPlugin;
 
 /// RSA Roster Bootstrap Plugin module.
@@ -28,6 +29,8 @@ module org.hiero.block.node.roster.bootstrap.rsa {
     requires org.hiero.block.node.base;
     requires java.net.http;
 
+    provides com.swirlds.config.api.ConfigurationExtension with
+            RsaRosterBootstrapConfigExtension;
     provides org.hiero.block.node.spi.BlockNodePlugin with
             RsaRosterBootstrapPlugin;
 }

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfigExtension.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.roster.bootstrap.rsa;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class RsaRosterBootstrapConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public RsaRosterBootstrapConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(RsaRosterBootstrapConfig.class);
+    }
+}

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
@@ -132,12 +132,6 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
 
     /// {@inheritDoc}
     @Override
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(RsaRosterBootstrapConfig.class);
-    }
-
-    /// {@inheritDoc}
-    @Override
     public void init(final BlockNodeContext context, final ServiceBuilder serviceBuilder) {
         this.context = context;
         this.config = context.configuration().getConfigData(RsaRosterBootstrapConfig.class);

--- a/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
+++ b/block-node/roster-bootstrap-rsa/src/test/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPluginTest.java
@@ -968,16 +968,6 @@ class RsaRosterBootstrapPluginTest
     }
 
     // -------------------------------------------------------------------------
-    // Config registration
-    // -------------------------------------------------------------------------
-
-    @Test
-    @DisplayName("configDataTypes() includes RsaRosterBootstrapConfig")
-    void configDataTypesIncludesRsaRosterBootstrapConfig() {
-        assertTrue(new RsaRosterBootstrapPlugin().configDataTypes().contains(RsaRosterBootstrapConfig.class));
-    }
-
-    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 

--- a/block-node/roster-bootstrap-tss/src/main/java/module-info.java
+++ b/block-node/roster-bootstrap-tss/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.roster.bootstrap.tss.RosterBootstrapTssConfigExtension;
 import org.hiero.block.node.roster.bootstrap.tss.RosterBootstrapTssPlugin;
 
 module org.hiero.block.node.roster.bootstrap.tss {
@@ -15,6 +16,8 @@ module org.hiero.block.node.roster.bootstrap.tss {
     requires transitive org.hiero.metrics;
     requires com.hedera.pbj.runtime;
 
+    provides com.swirlds.config.api.ConfigurationExtension with
+            RosterBootstrapTssConfigExtension;
     provides org.hiero.block.node.spi.BlockNodePlugin with
             RosterBootstrapTssPlugin;
 }

--- a/block-node/roster-bootstrap-tss/src/main/java/org/hiero/block/node/roster/bootstrap/tss/RosterBootstrapTssConfigExtension.java
+++ b/block-node/roster-bootstrap-tss/src/main/java/org/hiero/block/node/roster/bootstrap/tss/RosterBootstrapTssConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.roster.bootstrap.tss;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class RosterBootstrapTssConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public RosterBootstrapTssConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(RosterBootstrapTssConfig.class);
+    }
+}

--- a/block-node/roster-bootstrap-tss/src/main/java/org/hiero/block/node/roster/bootstrap/tss/RosterBootstrapTssPlugin.java
+++ b/block-node/roster-bootstrap-tss/src/main/java/org/hiero/block/node/roster/bootstrap/tss/RosterBootstrapTssPlugin.java
@@ -64,13 +64,6 @@ public class RosterBootstrapTssPlugin implements BlockNodePlugin {
     private final AtomicLong currentBlockNodePeers = new AtomicLong(0);
 
     /// {@inheritDoc}
-    @NonNull
-    @Override
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(RosterBootstrapTssConfig.class);
-    }
-
-    /// {@inheritDoc}
     @Override
     public void init(BlockNodeContext context, ServiceBuilder serviceBuilder) {
         this.applicationStateFacility = Objects.requireNonNull(context.applicationStateFacility());

--- a/block-node/s3-archive/src/main/java/module-info.java
+++ b/block-node/s3-archive/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.archive.s3.S3ArchiveConfigExtension;
 import org.hiero.block.node.archive.s3.S3ArchivePlugin;
 
 module org.hiero.block.node.archive.s3cloud {
@@ -21,6 +22,8 @@ module org.hiero.block.node.archive.s3cloud {
 
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    provides com.swirlds.config.api.ConfigurationExtension with
+            S3ArchiveConfigExtension;
     provides org.hiero.block.node.spi.BlockNodePlugin with
             S3ArchivePlugin;
 }

--- a/block-node/s3-archive/src/main/java/org/hiero/block/node/archive/s3/S3ArchiveConfigExtension.java
+++ b/block-node/s3-archive/src/main/java/org/hiero/block/node/archive/s3/S3ArchiveConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.archive.s3;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class S3ArchiveConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public S3ArchiveConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(S3ArchiveConfig.class);
+    }
+}

--- a/block-node/s3-archive/src/main/java/org/hiero/block/node/archive/s3/S3ArchivePlugin.java
+++ b/block-node/s3-archive/src/main/java/org/hiero/block/node/archive/s3/S3ArchivePlugin.java
@@ -11,7 +11,6 @@ import static org.hiero.block.node.base.ParseHelper.standardParse;
 import com.hedera.hapi.block.stream.output.BlockHeader;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.lang.System.Logger.Level;
 import java.time.Instant;
@@ -19,7 +18,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
@@ -85,15 +83,6 @@ public class S3ArchivePlugin implements BlockNodePlugin, BlockNotificationHandle
     private final AtomicLong lastArchivedBlockNumber = new AtomicLong(UNKNOWN_BLOCK_NUMBER);
 
     // ==== Plugin Methods =============================================================================================
-
-    /**
-     * {@inheritDoc}
-     */
-    @NonNull
-    @Override
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(S3ArchiveConfig.class);
-    }
 
     /**
      * {@inheritDoc}

--- a/block-node/server-status/src/main/java/module-info.java
+++ b/block-node/server-status/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.server.status.ServerStatusConfigExtension;
 import org.hiero.block.node.server.status.ServerStatusServicePlugin;
 
 module org.hiero.block.node.server.status {
@@ -19,6 +20,8 @@ module org.hiero.block.node.server.status {
 
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    provides com.swirlds.config.api.ConfigurationExtension with
+            ServerStatusConfigExtension;
     provides org.hiero.block.node.spi.BlockNodePlugin with
             ServerStatusServicePlugin;
 }

--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusConfigExtension.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.server.status;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class ServerStatusConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public ServerStatusConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(ServerStatusConfig.class);
+    }
+}

--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
@@ -175,15 +175,6 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
 
     /**
      * {@inheritDoc}
-     */
-    @Override
-    @NonNull
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(ServerStatusConfig.class);
-    }
-
-    /**
-     * {@inheritDoc}
      * This method is called on a separate thread. Make sure this.context is marked as `volatile`
      */
     @Override

--- a/block-node/spi-plugins/src/main/java/module-info.java
+++ b/block-node/spi-plugins/src/main/java/module-info.java
@@ -16,6 +16,7 @@ module org.hiero.block.node.spi {
     requires transitive io.helidon.webserver;
     requires static transitive com.github.spotbugs.annotations;
 
+    uses com.swirlds.config.api.ConfigurationExtension;
     uses org.hiero.block.node.spi.BlockNodePlugin;
     uses org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
     uses org.hiero.block.node.spi.historicalblocks.BlockProviderPlugin;

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/BlockNodePlugin.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/BlockNodePlugin.java
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.spi;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Collections;
-import java.util.List;
 import org.hiero.block.api.BlockNodeVersions.PluginVersion;
 import org.hiero.block.node.spi.module.ModuleInfoAccessor;
 
@@ -29,19 +26,6 @@ public interface BlockNodePlugin {
      */
     default String name() {
         return getClass().getSimpleName();
-    }
-
-    /**
-     * Get all configuration data types that should be added to the configuration api. The returned collection must not
-     * be null but can be empty set if no configuration is needed for this plugin. This is called before init and all
-     * configuration is loaded before init is called.
-     *
-     * @return list of Java record classes that use the {@link com.swirlds.config.api.ConfigData} and
-     * {@link com.swirlds.config.api.ConfigProperty} annotations
-     */
-    @NonNull
-    default List<Class<? extends Record>> configDataTypes() {
-        return Collections.emptyList();
     }
 
     /**

--- a/block-node/stream-publisher/src/main/java/module-info.java
+++ b/block-node/stream-publisher/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.stream.publisher.PublisherConfigExtension;
 import org.hiero.block.node.stream.publisher.StreamPublisherPlugin;
 
 module org.hiero.block.node.stream.publisher {
@@ -19,6 +20,8 @@ module org.hiero.block.node.stream.publisher {
 
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    provides com.swirlds.config.api.ConfigurationExtension with
+            PublisherConfigExtension;
     provides org.hiero.block.node.spi.BlockNodePlugin with
             StreamPublisherPlugin;
 }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfigExtension.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.stream.publisher;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class PublisherConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public PublisherConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(PublisherConfig.class);
+    }
+}

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
@@ -8,7 +8,6 @@ import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.Pipelines;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.List;
 import java.util.Objects;
 import org.hiero.block.api.BlockStreamPublishServiceInterface;
 import org.hiero.block.api.PublishStreamRequest;
@@ -181,12 +180,6 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
     public void stop() {
         context.blockMessaging().unregisterBlockNotificationHandler(publisherManager);
         publisherManager.shutdown();
-    }
-
-    @Override
-    @NonNull
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(PublisherConfig.class);
     }
 
     /// This method is called when a new publisher handler is created.

--- a/block-node/stream-subscriber/src/main/java/module-info.java
+++ b/block-node/stream-subscriber/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.stream.subscriber.SubscriberConfigExtension;
 import org.hiero.block.node.stream.subscriber.SubscriberServicePlugin;
 
 module org.hiero.block.node.stream.subscriber {
@@ -18,6 +19,8 @@ module org.hiero.block.node.stream.subscriber {
 
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    provides com.swirlds.config.api.ConfigurationExtension with
+            SubscriberConfigExtension;
     provides org.hiero.block.node.spi.BlockNodePlugin with
             SubscriberServicePlugin;
 }

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberConfigExtension.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.stream.subscriber;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class SubscriberConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public SubscriberConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(SubscriberConfig.class);
+    }
+}

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
@@ -12,7 +12,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionService;
@@ -83,15 +82,6 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
     @Override
     public void stop() {
         clientHandler.stop();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @NonNull
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(SubscriberConfig.class);
     }
 
     /*==================== BlockStreamSubscribeServiceInterface Methods ====================*/

--- a/block-node/verification/src/main/java/module-info.java
+++ b/block-node/verification/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.block.node.verification.VerificationConfigExtension;
 import org.hiero.block.node.verification.VerificationServicePlugin;
 
 module org.hiero.block.node.verification {
@@ -21,6 +22,8 @@ module org.hiero.block.node.verification {
 
     uses com.swirlds.config.api.spi.ConfigurationBuilderFactory;
 
+    provides com.swirlds.config.api.ConfigurationExtension with
+            VerificationConfigExtension;
     provides org.hiero.block.node.spi.BlockNodePlugin with
             VerificationServicePlugin;
 }

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationConfigExtension.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationConfigExtension.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.verification;
+
+import com.swirlds.config.api.ConfigurationExtension;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+
+/** Registers this module's configuration data types for auto-discovery. */
+public class VerificationConfigExtension implements ConfigurationExtension {
+
+    /** Explicitly defined constructor. */
+    public VerificationConfigExtension() {
+        super();
+    }
+
+    @NonNull
+    @Override
+    public Set<Class<? extends Record>> getConfigDataTypes() {
+        return Set.of(VerificationConfig.class);
+    }
+}

--- a/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
+++ b/block-node/verification/src/main/java/org/hiero/block/node/verification/VerificationServicePlugin.java
@@ -157,15 +157,6 @@ public class VerificationServicePlugin implements BlockNodePlugin, BlockItemHand
     private record CachedRsaKeys(NodeAddressBook book, Map<Long, PublicKey> keys) {}
 
     /**
-     * {@inheritDoc}
-     */
-    @NonNull
-    @Override
-    public List<Class<? extends Record>> configDataTypes() {
-        return List.of(VerificationConfig.class);
-    }
-
-    /**
      * Initialize metrics for the verification plugin.
      *
      * @param context The block node context


### PR DESCRIPTION
## Reviewer Notes

### `ConfigurationExtension` auto-discovery for all 16 config-bearing modules

Every module with a `@ConfigData` record now ships a `<Module>ConfigExtension implements ConfigurationExtension` plus a `provides com.swirlds.config.api.ConfigurationExtension with ...;` directive in its module-info, mirroring the existing SimulatorConfigExtension pattern. `app-config` gets a single `AppConfigExtension` covering the four app-level records (ServerConfig, WebServerHttp2Config, NodeConfig, ApplicationStateConfig) that were previously wired in by hand in BlockNodeApp. This is purely additive: `BlockNodePlugin.configDataTypes()` overrides are untouched since PluginTestBase still depends on them.

### `BlockNodeApp` retires manual config-type aggregation

`BlockNodeApp`'s constructor no longer builds `allConfigDataTypes` by walking `loadedPlugins` and calling `.configDataTypes()` on each, and no longer calls `.withConfigDataTypes(...)` on the `ConfigurationBuilder`; `.autoDiscoverExtensions()` now does that job via the extensions added above. `AutomaticEnvironmentVariableConfigSource`
  (which still needs an explicit type list to derive env var names) is now populated from `serviceLoader.loadServices(ConfigurationExtension.class)` instead, so both consumers read from the same source of truth.

## Related Issue(s)

Closes #2370
Relates to #2381