### PR TITLE
chore: Preserve the real exception when a Future fails in CloudStorageArchivePlugin instead of a causeless IllegalStateException

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/logging/TestLogHandler.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/logging/TestLogHandler.java
@@ -11,10 +11,14 @@ import java.util.logging.LogRecord;
  */
 public class TestLogHandler extends Handler {
     private final List<String> messages = new ArrayList<>();
+    private final List<Throwable> thrownExceptions = new ArrayList<>();
 
     @Override
     public void publish(LogRecord record) {
         messages.add(record.getMessage());
+        if (record.getThrown() != null) {
+            thrownExceptions.add(record.getThrown());
+        }
     }
 
     @Override
@@ -31,5 +35,13 @@ public class TestLogHandler extends Handler {
         return (int) messages.stream()
                 .filter(msg -> msg != null && msg.contains(substring))
                 .count();
+    }
+
+    /**
+     * Returns every {@link Throwable} attached to a captured log record (via
+     * {@link LogRecord#getThrown()}), in the order the records were published.
+     */
+    public List<Throwable> thrownExceptions() {
+        return List.copyOf(thrownExceptions);
     }
 }

--- a/block-node/cloud-storage-archive/build.gradle.kts
+++ b/block-node/cloud-storage-archive/build.gradle.kts
@@ -8,15 +8,16 @@ description = "Hiero Block Node - Blocks File Archive Cloud Storage"
 tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
 
 mainModuleInfo {
-    runtimeOnly("com.swirlds.config.impl")
     runtimeOnly("com.hedera.pbj.grpc.helidon.config")
+    runtimeOnly("com.swirlds.config.impl")
 }
 
 testModuleInfo {
+    requires("org.hiero.block.node.app.test.fixtures")
+    requires("io.minio")
+    requires("java.logging")
+    requires("org.assertj.core")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
-    requires("org.assertj.core")
-    requires("org.hiero.block.node.app.test.fixtures")
     requires("org.testcontainers")
-    requires("io.minio")
 }

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
@@ -247,30 +247,39 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
             } else {
                 logInvalidOrFailedNotification(notification);
             }
-        } catch (IllegalStateException e) {
-            LOGGER.log(WARNING, "Could not complete uploading blocks to cloud archive storage", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
             metricsHolder.failedTasks().increment();
+            // Capture before triggerMidRunRecovery() runs, since it nulls currentUploadFuture itself.
+            final boolean fromUploadTask = currentUploadFuture != null;
             triggerMidRunRecovery();
-            // routeVerifiedBlock() was never reached (the exception bypassed it), so stash the
-            // triggering block manually — it is safe to use blocksStash directly because
-            // triggerMidRunRecovery() already cleared currentUploadFuture.
-            if (notification != null && notification.block() != null) {
+            if (fromUploadTask) {
+                // routeVerifiedBlock() was never reached (the exception bypassed it), so stash the
+                // triggering block manually — it is safe to use blocksStash directly because
+                // triggerMidRunRecovery() already set currentGroupStart to -1.
+                LOGGER.log(WARNING, "Block upload task failed", e.getCause());
                 blocksStash.put(
                         notification.blockNumber(), new BlockWithSource(notification.block(), notification.source()));
+            } else {
+                // Exception from the recovery task itself; recoveryFuture is already null (cleared in
+                // completeRecoveryIfReady() before this was thrown), so the triggerMidRunRecovery() call
+                // above submits a retry.
+                LOGGER.log(WARNING, "Could not complete uploading blocks to cloud archive storage", e.getCause());
             }
         }
     }
 
     /// Checks whether the active [BlockUploadTask] has finished and cleans up its state.
     /// Returns `true` if the task was cancelled, signalling the caller to skip further processing.
-    private boolean checkCompletedUpload() {
+    private boolean checkCompletedUpload() throws ExecutionException, InterruptedException {
         boolean cancelled = false;
         if (currentUploadFuture != null && currentUploadFuture.isDone()) {
             if (currentUploadFuture.isCancelled()) {
                 LOGGER.log(TRACE, "Block upload task was cancelled");
                 cancelled = true;
             } else {
-                final UploadResult uploadResult = currentUploadFuture.resultNow();
+                final UploadResult uploadResult = currentUploadFuture.get();
                 if (uploadResult == UploadResult.FAILED) {
                     LOGGER.log(WARNING, "Block upload task failed");
                     metricsHolder.failedTasks().increment();
@@ -293,7 +302,7 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     /// [TempArchiveUploadTask] calls `ApplicationStateFacility.addStoredBlockRange()` once after
     /// both the multipart upload and the meta file write succeed, so no additional range
     /// registration is needed here.
-    private void checkAndDrainTempUploadResults() {
+    private void checkAndDrainTempUploadResults() throws InterruptedException {
         final Iterator<Map.Entry<Long, Future<TempArchiveEntry>>> it =
                 tempUploadFutures.entrySet().iterator();
         while (it.hasNext()) {
@@ -305,21 +314,22 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                 it.remove();
                 continue;
             }
-            it.remove();
             try {
-                final TempArchiveEntry result = entry.getValue().resultNow();
+                final TempArchiveEntry result = entry.getValue().get();
+                it.remove();
                 tempArchiveTracker.put(result.firstBlock(), result);
                 tempSegmentLastBlock.remove(result.firstBlock());
                 metricsHolder.successfulTasks().increment();
                 final long groupStart = (result.firstBlock() / groupSize) * groupSize;
                 checkGroupCoverage(groupStart);
                 LOGGER.log(TRACE, "Temp archive completed: blocks [{0}, {1}]", result.firstBlock(), result.lastBlock());
-            } catch (IllegalStateException e) {
+            } catch (ExecutionException e) {
+                it.remove();
                 LOGGER.log(
                         WARNING,
-                        "Temp archive upload failed for firstBlock {0}; triggering mid-run recovery",
-                        entry.getKey(),
-                        e);
+                        "Temp archive upload failed for firstBlock %d; triggering mid-run recovery"
+                                .formatted(entry.getKey()),
+                        e.getCause());
                 metricsHolder.failedTasks().increment();
                 triggerMidRunRecovery();
             }
@@ -327,7 +337,7 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     }
 
     /// Submits pending [ConsolidationTask]s and drains completed ones.
-    private void checkAndDrainConsolidations() {
+    private void checkAndDrainConsolidations() throws InterruptedException {
         // Process completed consolidations.
         final Iterator<Map.Entry<Long, Future<UploadResult>>> it =
                 consolidationFutures.entrySet().iterator();
@@ -341,15 +351,17 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                 it.remove();
                 continue;
             }
-            it.remove();
             try {
-                entry.getValue().resultNow();
+                entry.getValue().get();
+                it.remove();
                 tempArchiveTracker.subMap(groupStart, groupStart + groupSize).clear();
                 tempGroupNextExpected.remove(groupStart);
                 metricsHolder.successfulTasks().increment();
                 LOGGER.log(TRACE, "Consolidation completed for group {0}", groupStart);
-            } catch (IllegalStateException e) {
-                LOGGER.log(WARNING, "Consolidation task threw exception for group {0}", groupStart, e);
+            } catch (ExecutionException e) {
+                it.remove();
+                LOGGER.log(
+                        WARNING, "Consolidation task threw exception for group %d".formatted(groupStart), e.getCause());
                 metricsHolder.failedTasks().increment();
                 checkGroupCoverage(groupStart);
             }
@@ -441,10 +453,10 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     ///
     /// When the result is a fresh start, no upload task is created and the next call to
     /// [handleVerification] will fall through to [tryStartNewUploadTask] as normal.
-    private void completeRecoveryIfReady() {
+    private void completeRecoveryIfReady() throws ExecutionException, InterruptedException {
         if (recoveryFuture != null && recoveryFuture.isDone()) {
             try {
-                final RecoveryResult result = recoveryFuture.resultNow();
+                final RecoveryResult result = recoveryFuture.get();
 
                 // Rebuild the temporary-archive tracker from startup recovery.  These archives
                 // survived a restart so their block ranges must be re-registered with the state

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
@@ -455,6 +455,11 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     /// [handleVerification] will fall through to [tryStartNewUploadTask] as normal.
     private void completeRecoveryIfReady() throws ExecutionException, InterruptedException {
         if (recoveryFuture != null && recoveryFuture.isDone()) {
+            if (recoveryFuture.isCancelled()) {
+                LOGGER.log(TRACE, "Startup recovery task was cancelled");
+                recoveryFuture = null;
+                return;
+            }
             try {
                 final RecoveryResult result = recoveryFuture.get();
 

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTask.java
@@ -134,6 +134,7 @@ class TempArchiveUploadTask implements Callable<TempArchiveEntry> {
                 } catch (S3ResponseException | IOException e) {
                     LOGGER.log(INFO, "Failed to accumulate block {0} for temp archive {1}", currentBlock, s3Key, e);
                     S3UploadUtils.abortQuietly(s3, s3Key, uploadId);
+                    blockMessaging.sendBlockPersisted(new PersistedNotification(firstBlock, false, 1_000, lastSource));
                     throw e;
                 }
             }

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.bucky.S3Client;
+import com.hedera.bucky.S3ResponseException;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
@@ -36,6 +37,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
@@ -44,6 +46,7 @@ import org.hiero.block.node.app.fixtures.async.BlockingExecutor;
 import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
 import org.hiero.block.node.app.fixtures.blocks.TestBlock;
 import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
+import org.hiero.block.node.app.fixtures.logging.TestLogHandler;
 import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.RecordingServiceBuilder;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
@@ -59,6 +62,7 @@ import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
 import org.hiero.block.node.spi.historicalblocks.LongRange;
 import org.hiero.metrics.core.MetricRegistry;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -1764,10 +1768,26 @@ class CloudStorageArchivePluginTest {
     final class MidRunRecoveryTests
             extends PluginTestBase<CloudStorageArchivePlugin, BlockingExecutor, ScheduledBlockingExecutor> {
 
+        /// Captures log records emitted by [CloudStorageArchivePlugin] so failure tests can assert
+        /// the real exception was logged, not a causeless [IllegalStateException].
+        private final TestLogHandler logHandler = new TestLogHandler();
+        private Logger pluginLogger;
+
         MidRunRecoveryTests() {
             super(
                     new BlockingExecutor(new LinkedBlockingQueue<>()),
                     new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+        }
+
+        @BeforeEach
+        void attachLogHandler() {
+            pluginLogger = Logger.getLogger(CloudStorageArchivePlugin.class.getName());
+            pluginLogger.addHandler(logHandler);
+        }
+
+        @AfterEach
+        void detachLogHandler() {
+            pluginLogger.removeHandler(logHandler);
         }
 
         /// Verifies that a task returning [UploadResult.FAILED] triggers recovery:
@@ -1934,10 +1954,11 @@ class CloudStorageArchivePluginTest {
             // RuntimeException.
             assertThatThrownBy(executor::executeSerially).isInstanceOf(RuntimeException.class);
 
-            // Block 10 triggers handleVerification() -> checkCompletedUpload() -> resultNow() throws
-            // IllegalStateException -> caught by handleVerification() -> triggerMidRunRecovery()
-            // (moves currentGroupPending blocks 5-9 to stash) -> blocksStash.put(10) stashes the
-            // triggering block explicitly.
+            // Block 10 triggers handleVerification() -> checkCompletedUpload() calls
+            // currentUploadFuture.get(), which throws ExecutionException, propagating up to
+            // handleVerification()'s catch block. It logs the real cause via e.getCause(), then
+            // calls triggerMidRunRecovery() (moves currentGroupPending blocks 5-9 to stash) and
+            // manually stashes block 10 itself, since routeVerifiedBlock(10) is never reached.
             sendVerification(blocks.get(10));
 
             assertThat(plugin.currentUploadFuture).isNull();
@@ -1945,6 +1966,9 @@ class CloudStorageArchivePluginTest {
             assertThat(plugin.blocksStash).containsKeys(5L, 6L, 7L, 8L, 9L, 10L);
             assertThat(getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_FAILED_TASKS))
                     .isEqualTo(1L);
+            assertThat(logHandler.thrownExceptions())
+                    .anySatisfy(
+                            t -> assertThat(t).isInstanceOf(IOException.class).hasMessage("simulated S3 failure"));
 
             executor.executeSerially();
             assertThat(plugin.isRecoveryComplete()).isTrue();
@@ -1997,6 +2021,9 @@ class CloudStorageArchivePluginTest {
             assertThat(plugin.blocksStash).containsKey(20L);
             assertThat(getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_FAILED_TASKS))
                     .isEqualTo(1L);
+            assertThat(logHandler.thrownExceptions())
+                    .anySatisfy(t ->
+                            assertThat(t).isInstanceOf(IOException.class).hasMessage("simulated temp upload failure"));
 
             // Drive recovery and verify it completes.
             executor.executeSerially();
@@ -2136,6 +2163,11 @@ class CloudStorageArchivePluginTest {
         private static final int GROUPING_LEVEL = 1;
         private final BlockingExecutor pluginExecutor;
 
+        /// Captures log records emitted by [CloudStorageArchivePlugin] so the failed-recovery test
+        /// can assert the real exception was logged, not a causeless [IllegalStateException].
+        private final TestLogHandler logHandler = new TestLogHandler();
+        private Logger pluginLogger;
+
         TaskMetricsTests() {
             super(
                     new BlockingExecutor(new LinkedBlockingQueue<>()),
@@ -2145,6 +2177,17 @@ class CloudStorageArchivePluginTest {
                     new SimpleInMemoryHistoricalBlockFacility(),
                     pluginConfig(GROUPING_LEVEL, 10));
             pluginExecutor = testThreadPoolManager.executor();
+        }
+
+        @BeforeEach
+        void attachLogHandler() {
+            pluginLogger = Logger.getLogger(CloudStorageArchivePlugin.class.getName());
+            pluginLogger.addHandler(logHandler);
+        }
+
+        @AfterEach
+        void detachLogHandler() {
+            pluginLogger.removeHandler(logHandler);
         }
 
         /// Drains the main plugin's startup recovery task before each test.
@@ -2243,8 +2286,6 @@ class CloudStorageArchivePluginTest {
                 pluginExecutor.executeSerially();
             } catch (RuntimeException ignored) {
             }
-            // handleVerification() detects the done-but-failed recovery future, catches the
-            // resulting ExecutionException, and increments failedTasks.
             final TestBlock block = TestBlockBuilder.generateBlocksInRange(0, 0).getFirst();
             failingMessaging.sendBlockVerification(new VerificationNotification(
                     true, null, block.number(), Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
@@ -2252,6 +2293,10 @@ class CloudStorageArchivePluginTest {
                     .isEqualTo(1L);
             assertThat(exporter.getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_SUCCESSFUL_TASKS.name()))
                     .isZero();
+            assertThat(logHandler.thrownExceptions()).anySatisfy(t -> {
+                assertThat(t).isInstanceOf(S3ResponseException.class);
+                assertThat(((S3ResponseException) t).getResponseStatusCode()).isEqualTo(403);
+            });
             failingPlugin.stop();
         }
 
@@ -2280,6 +2325,11 @@ class CloudStorageArchivePluginTest {
         private static final int GROUPING_LEVEL = 1; // groupSize = 10^1 = 10
         private final BlockingExecutor pluginExecutor;
 
+        /// Captures log records emitted by [CloudStorageArchivePlugin] so the retry test can assert
+        /// the real exception was logged, not a causeless [IllegalStateException].
+        private final TestLogHandler logHandler = new TestLogHandler();
+        private Logger pluginLogger;
+
         ConsolidationRetryTests() {
             super(
                     new BlockingExecutor(new LinkedBlockingQueue<>()),
@@ -2289,6 +2339,17 @@ class CloudStorageArchivePluginTest {
                     new SimpleInMemoryHistoricalBlockFacility(),
                     pluginConfig(GROUPING_LEVEL, 10));
             pluginExecutor = testThreadPoolManager.executor();
+        }
+
+        @BeforeEach
+        void attachLogHandler() {
+            pluginLogger = Logger.getLogger(CloudStorageArchivePlugin.class.getName());
+            pluginLogger.addHandler(logHandler);
+        }
+
+        @AfterEach
+        void detachLogHandler() {
+            pluginLogger.removeHandler(logHandler);
         }
 
         @BeforeEach
@@ -2341,6 +2402,9 @@ class CloudStorageArchivePluginTest {
             sendVerification(TestBlockBuilder.generateBlocksInRange(groupSize * 4 - 1, groupSize * 4 - 1)
                     .getFirst());
             assertThat(plugin.consolidationFutures).containsKey((long) groupSize);
+            assertThat(logHandler.thrownExceptions()).anySatisfy(t -> assertThat(t)
+                    .isInstanceOf(IOException.class)
+                    .hasMessage("simulated consolidation failure"));
 
             // Run the remaining queued tasks: BlockUploadTask[20,29] (still queued from before)
             // and the retry ConsolidationTask[10,19].

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTaskTest.java
@@ -350,11 +350,12 @@ class TempArchiveUploadTaskTest {
     }
 
     /// Verifies that when [doUploadPart] throws during a mid-loop part flush, [call()] rethrows
-    /// the exception, aborts the multipart upload, and sends no [PersistedNotification] (no data
-    /// was durably confirmed before the failure).
+    /// the exception, aborts the multipart upload, and sends one failed [PersistedNotification]
+    /// for the first unseen block — consistent with the other two upload-failure paths in this
+    /// class, even though the aborted parts never became a retrievable object.
     @Test
-    @DisplayName("Part upload failure during loop: exception rethrown, no notifications sent, upload aborted")
-    void partUploadFailureDuringLoopThrowsAndAbortsUpload() throws Exception {
+    @DisplayName("Part upload failure during loop: failed notification sent, exception rethrown, upload aborted")
+    void partUploadFailureDuringLoopSendsFailedNotificationAndThrows() throws Exception {
         final String s3Key = TempArchiveKey.formatTar(0, "");
         final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
         final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
@@ -371,7 +372,11 @@ class TempArchiveUploadTaskTest {
                 new FailingUploadPartTask(config, messaging, asf, createMetricsHolder(), s3Key, 0, queue);
 
         assertThatThrownBy(task::call).isInstanceOf(IOException.class);
-        assertThat(messaging.getSentPersistedNotifications()).isEmpty();
+        final List<PersistedNotification> notifications = messaging.getSentPersistedNotifications();
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications.getFirst().succeeded()).isFalse();
+        assertThat(notifications.getFirst().blockNumber()).isZero();
+        assertThat(notifications.getFirst().blockSource()).isEqualTo(BlockSource.PUBLISHER);
         assertThat(asf.addedRanges).isEmpty();
         try (S3Client s3 = openS3Client()) {
             assertThat(s3.listMultipartUploads()).doesNotContainKey(s3Key);


### PR DESCRIPTION
## Reviewer Notes

### Four Future call sites switched from resultNow() to get()

`checkCompletedUpload()`, `checkAndDrainTempUploadResults()`, `checkAndDrainConsolidations()`, and `completeRecoveryIfReady()` all consumed an already-done `Future` via `resultNow()`, which throws a causeless `IllegalStateException` ("Task completed with exception") on failure and discards the real thrown exception. Each site now calls `get()` in a local try/catch: `catch (ExecutionException e)` logs `e.getCause()`, the actual `S3ResponseException` / `IOException` / `S3ClientInitializationException` the task threw, and `catch (InterruptedException e)` restores the interrupt flag and takes no further action, matching this plugin's behavior prior to an earlier refactor (26195e56) that had switched it to `resultNow()`.

### Test coverage added via a shared TestLogHandler

`TestLogHandler` (test fixtures) now also captures `LogRecord#getThrown()`, not just messages. The three affected test nest classes attach/detach it per test and assert the real exception type (and, where relevant, message or status code) was logged.

## Related Issue(s)

Closes #3239 
