### PR TITLE
fix: Edge case persistence exceptions do not push a persistence notification

### DIFF
--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
@@ -18,7 +18,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
@@ -324,7 +323,7 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
     @Override
     public void handleVerification(VerificationNotification notification) {
         if (notification != null && notification.success()) {
-            writeBlockToStagingPath(notification.block(), notification.blockNumber());
+            writeBlockToStagingPath(notification.block(), notification.blockNumber(), notification.source());
         }
         try {
             attemptZipping();
@@ -335,14 +334,23 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
     }
 
     // ==== Private Methods ============================================================================================
-    private void writeBlockToStagingPath(final BlockUnparsed block, final long blockNumber) {
+    private void sendBlockNotification(final long blockNumber, final boolean succeeded, final BlockSource source) {
+        context.blockMessaging()
+                .sendBlockPersisted(new PersistedNotification(
+                        blockNumber, succeeded, defaultPriority(), source == null ? BlockSource.UNKNOWN : source));
+    }
+
+    private void writeBlockToStagingPath(final BlockUnparsed block, final long blockNumber, final BlockSource source) {
         if (block == null || block.blockItems() == null || block.blockItems().isEmpty()) {
+            LOGGER.log(WARNING, "Block {0} is null or has no block items, cannot write to staging path", blockNumber);
+            sendBlockNotification(blockNumber, false, source);
             return;
         }
 
         BlockItemUnparsed firstItem = block.blockItems().getFirst();
         if (!firstItem.hasBlockHeader()) {
             LOGGER.log(WARNING, "Block {0} has no block header, cannot write to staging path", blockNumber);
+            sendBlockNotification(blockNumber, false, source);
             return;
         }
 
@@ -354,13 +362,21 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
                     "Block number mismatch between notification {0} and block header {1}, not writing block",
                     blockNumber,
                     headerNumber);
+            sendBlockNotification(blockNumber, false, source);
             return;
         }
 
-        final Path verifiedBlockPath = BlockFile.nestedDirectoriesBlockFilePath(
-                stagingPath, blockNumber, config.compression(), config.maxFilesPerDir());
-        createDirectoryOrFail(verifiedBlockPath);
-        writeBlockOrFail(block, blockNumber, verifiedBlockPath);
+        try {
+            final Path verifiedBlockPath = BlockFile.nestedDirectoriesBlockFilePath(
+                    stagingPath, blockNumber, config.compression(), config.maxFilesPerDir());
+            if (createDirectoryOrFail(verifiedBlockPath, blockNumber, source)) {
+                writeBlockOrFail(block, blockNumber, source, verifiedBlockPath);
+            }
+        } catch (final RuntimeException e) {
+            final String message = "Failed to persist block %d due to %s".formatted(blockNumber, e);
+            LOGGER.log(WARNING, message, e);
+            sendBlockNotification(blockNumber, false, source);
+        }
     }
 
     private BlockHeader getBlockHeader(final BlockUnparsed block) {
@@ -373,19 +389,23 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
         }
     }
 
-    private void createDirectoryOrFail(final Path verifiedBlockPath) {
+    private boolean createDirectoryOrFail(
+            final Path verifiedBlockPath, final long blockNumber, final BlockSource source) {
         try {
             // create parent directory if it does not exist
             Files.createDirectories(verifiedBlockPath.getParent());
+            return true;
         } catch (final IOException e) {
             final String message = "Failed to create directories for path %s due to %s"
                     .formatted(verifiedBlockPath.toAbsolutePath(), e);
-            LOGGER.log(INFO, message, e);
-            throw new UncheckedIOException(e.getMessage(), e);
+            LOGGER.log(WARNING, message, e);
+            sendBlockNotification(blockNumber, false, source);
+            return false;
         }
     }
 
-    private void writeBlockOrFail(final BlockUnparsed block, final long blockNumber, final Path verifiedBlockPath) {
+    private void writeBlockOrFail(
+            final BlockUnparsed block, final long blockNumber, final BlockSource source, final Path verifiedBlockPath) {
         try (final WritableStreamingData streamingData = new WritableStreamingData(new BufferedOutputStream(
                 config.compression().wrapStream(Files.newOutputStream(verifiedBlockPath)), 16384))) {
             BlockUnparsed.PROTOBUF.write(block, streamingData);
@@ -397,6 +417,7 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
         } catch (final IOException e) {
             final String message = "Failed to write file for block %d due to %s".formatted(blockNumber, e);
             LOGGER.log(WARNING, message, e);
+            sendBlockNotification(blockNumber, false, source);
         }
     }
 
@@ -612,14 +633,16 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
                     plugin.LOGGER.log(DEBUG, successMessage, batchFirstBlockNumber, batchLastBlockNumber);
                     // now all the blocks are in the zip file and accessible, send notification
                     // @todo is this needed? Does anything actually care when a zip file is completed?
-                    plugin.context
-                            .blockMessaging()
-                            .sendBlockPersisted(
-                                    new PersistedNotification(batchLastBlockNumber, true, 1_000, BlockSource.HISTORY));
+                    plugin.sendBlockNotification(batchLastBlockNumber, true, BlockSource.HISTORY);
                     plugin.cleanup();
                 }
             } catch (final IOException e) {
                 final String failMessage = "Failed to move batch of blocks [%d -> %d] to zip file"
+                        .formatted(batchFirstBlockNumber, batchLastBlockNumber);
+                plugin.LOGGER.log(WARNING, failMessage, e);
+                cleanupZipWorkFiles();
+            } catch (final RuntimeException e) {
+                final String failMessage = "Unexpected failure moving batch of blocks [%d -> %d] to zip file"
                         .formatted(batchFirstBlockNumber, batchLastBlockNumber);
                 plugin.LOGGER.log(WARNING, failMessage, e);
                 cleanupZipWorkFiles();

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
@@ -369,8 +369,12 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
         try {
             final Path verifiedBlockPath = BlockFile.nestedDirectoriesBlockFilePath(
                     stagingPath, blockNumber, config.compression(), config.maxFilesPerDir());
-            if (createDirectoryOrFail(verifiedBlockPath, blockNumber, source)) {
-                writeBlockOrFail(block, blockNumber, source, verifiedBlockPath);
+            if (createDirectoryOrFail(verifiedBlockPath)) {
+                if (!writeBlockOrFail(block, blockNumber, verifiedBlockPath)) {
+                    sendBlockNotification(blockNumber, false, source);
+                }
+            } else {
+                sendBlockNotification(blockNumber, false, source);
             }
         } catch (final RuntimeException e) {
             final String message = "Failed to persist block %d due to %s".formatted(blockNumber, e);
@@ -389,8 +393,7 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
         }
     }
 
-    private boolean createDirectoryOrFail(
-            final Path verifiedBlockPath, final long blockNumber, final BlockSource source) {
+    private boolean createDirectoryOrFail(final Path verifiedBlockPath) {
         try {
             // create parent directory if it does not exist
             Files.createDirectories(verifiedBlockPath.getParent());
@@ -399,13 +402,11 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
             final String message = "Failed to create directories for path %s due to %s"
                     .formatted(verifiedBlockPath.toAbsolutePath(), e);
             LOGGER.log(WARNING, message, e);
-            sendBlockNotification(blockNumber, false, source);
             return false;
         }
     }
 
-    private void writeBlockOrFail(
-            final BlockUnparsed block, final long blockNumber, final BlockSource source, final Path verifiedBlockPath) {
+    private boolean writeBlockOrFail(final BlockUnparsed block, final long blockNumber, final Path verifiedBlockPath) {
         try (final WritableStreamingData streamingData = new WritableStreamingData(new BufferedOutputStream(
                 config.compression().wrapStream(Files.newOutputStream(verifiedBlockPath)), 16384))) {
             BlockUnparsed.PROTOBUF.write(block, streamingData);
@@ -414,10 +415,11 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
             LOGGER.log(DEBUG, "Wrote verified block {0} to file {1}", blockNumber, verifiedBlockPath.toAbsolutePath());
             // update the oldest and newest verified block numbers
             availableStagedBlocks.add(blockNumber);
+            return true;
         } catch (final IOException e) {
             final String message = "Failed to write file for block %d due to %s".formatted(blockNumber, e);
             LOGGER.log(WARNING, message, e);
-            sendBlockNotification(blockNumber, false, source);
+            return false;
         }
     }
 

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
@@ -42,6 +42,7 @@ import org.hiero.block.node.app.fixtures.plugintest.RecordingServiceBuilder;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
 import org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility;
 import org.hiero.block.node.app.fixtures.plugintest.TestHealthFacility;
+import org.hiero.block.node.base.BlockFile;
 import org.hiero.block.node.base.CompressionType;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
@@ -906,6 +907,107 @@ class BlockFileHistoricPluginTest {
         }
 
         /**
+         * This test aims to verify that the plugin will send a failed
+         * {@link PersistedNotification} when the verified block passed in the
+         * notification is empty.
+         */
+        @Test
+        @DisplayName("Test failed notification sent for empty block")
+        void testFailedNotificationSentForEmptyBlock() {
+            final long blockNumber = 0L;
+            blockMessaging.sendBlockVerification(new VerificationNotification(
+                    true, null, blockNumber, Bytes.EMPTY, new BlockUnparsed(List.of()), BlockSource.PUBLISHER));
+            assertThat(toTest.availableBlocks().contains(blockNumber)).isFalse();
+            final List<PersistedNotification> sentPersistedNotifications =
+                    blockMessaging.getSentPersistedNotifications();
+            assertThat(sentPersistedNotifications)
+                    .isNotEmpty()
+                    .hasSize(1)
+                    .element(0)
+                    .returns(false, PersistedNotification::succeeded)
+                    .returns(blockNumber, PersistedNotification::blockNumber);
+        }
+
+        /**
+         * This test aims to verify that the plugin will send a failed
+         * {@link PersistedNotification} when the first item of the verified
+         * block is not a block header.
+         */
+        @Test
+        @DisplayName("Test failed notification sent for missing block header")
+        void testFailedNotificationSentForMissingBlockHeader() {
+            final long blockNumber = 0L;
+            final BlockUnparsed block = new BlockUnparsed(List.of(TestBlockBuilder.sampleRoundHeaderUnparsed(0L)));
+            blockMessaging.sendBlockVerification(
+                    new VerificationNotification(true, null, blockNumber, Bytes.EMPTY, block, BlockSource.PUBLISHER));
+            assertThat(toTest.availableBlocks().contains(blockNumber)).isFalse();
+            final List<PersistedNotification> sentPersistedNotifications =
+                    blockMessaging.getSentPersistedNotifications();
+            assertThat(sentPersistedNotifications)
+                    .isNotEmpty()
+                    .hasSize(1)
+                    .element(0)
+                    .returns(false, PersistedNotification::succeeded)
+                    .returns(blockNumber, PersistedNotification::blockNumber);
+        }
+
+        /**
+         * This test aims to verify that the plugin will send a failed
+         * {@link PersistedNotification} when the block header number does not
+         * match the notification's block number.
+         */
+        @Test
+        @DisplayName("Test failed notification sent for block number mismatch")
+        void testFailedNotificationSentForBlockNumberMismatch() {
+            final long notifiedBlockNumber = 5L;
+            final BlockUnparsed block =
+                    TestBlockBuilder.generateBlockWithNumber(0L).blockUnparsed();
+            blockMessaging.sendBlockVerification(new VerificationNotification(
+                    true, null, notifiedBlockNumber, Bytes.EMPTY, block, BlockSource.PUBLISHER));
+            assertThat(toTest.availableBlocks().contains(notifiedBlockNumber)).isFalse();
+            final List<PersistedNotification> sentPersistedNotifications =
+                    blockMessaging.getSentPersistedNotifications();
+            assertThat(sentPersistedNotifications)
+                    .isNotEmpty()
+                    .hasSize(1)
+                    .element(0)
+                    .returns(false, PersistedNotification::succeeded)
+                    .returns(notifiedBlockNumber, PersistedNotification::blockNumber);
+        }
+
+        /**
+         * This test aims to verify that the plugin will send a failed
+         * {@link PersistedNotification} when the staging directory for the
+         * verified block cannot be created.
+         */
+        @Test
+        @DisplayName("Test failed notification sent when staging directory creation fails")
+        void testFailedNotificationSentWhenStagingDirectoryCreationFails() throws IOException {
+            final long blockNumber = 0L;
+            // pre-create a regular file at the path where the plugin needs to create a staging
+            // directory, this forces Files.createDirectories to throw inside createDirectoryOrFail
+            final Path stagingPath = testConfig.rootPath().resolve("staging");
+            final Path blockFilePath = BlockFile.nestedDirectoriesBlockFilePath(
+                    stagingPath, blockNumber, testConfig.compression(), testConfig.maxFilesPerDir());
+            final Path blockParentDir = blockFilePath.getParent();
+            Files.createDirectories(blockParentDir.getParent());
+            Files.createFile(blockParentDir);
+            final BlockUnparsed block =
+                    TestBlockBuilder.generateBlockWithNumber(blockNumber).blockUnparsed();
+            blockMessaging.sendBlockVerification(
+                    new VerificationNotification(true, null, blockNumber, Bytes.EMPTY, block, BlockSource.PUBLISHER));
+            assertThat(toTest.availableBlocks().contains(blockNumber)).isFalse();
+            final List<PersistedNotification> sentPersistedNotifications =
+                    blockMessaging.getSentPersistedNotifications();
+            assertThat(sentPersistedNotifications)
+                    .isNotEmpty()
+                    .hasSize(1)
+                    .element(0)
+                    .returns(false, PersistedNotification::succeeded)
+                    .returns(blockNumber, PersistedNotification::blockNumber);
+        }
+
+        /**
          * This test aims to verify that the plugin will properly update it's
          * available blocks list after a successful archival.
          */
@@ -1060,10 +1162,19 @@ class BlockFileHistoricPluginTest {
             Files.setPosixFilePermissions(targetZipDir, Collections.emptySet());
             // execute serially to ensure all tasks are completed
             pluginExecutor.executeSerially();
-            // assert that no notification was sent to the block messaging
+            // assert that no notification was sent to the block messaging, the blocks
+            // are still safely staged and will be retried on the next verification
             final int totalSentNotifications =
                     blockMessaging.getSentPersistedNotifications().size();
             assertThat(totalSentNotifications).isEqualTo(0);
+            // assert that the staged block files are still present on disk, i.e. the
+            // blocks were not lost, only the zip archival step failed
+            final Path stagingPath = testConfig.rootPath().resolve("staging");
+            for (int i = 0; i < 10; i++) {
+                final Path stagedBlockPath = BlockFile.nestedDirectoriesBlockFilePath(
+                        stagingPath, i, testConfig.compression(), testConfig.maxFilesPerDir());
+                assertThat(stagedBlockPath).exists();
+            }
         }
 
         /**

--- a/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPlugin.java
+++ b/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPlugin.java
@@ -366,14 +366,22 @@ public final class BlockFileRecentPlugin implements BlockProviderPlugin, BlockNo
                 } else {
                     final Path verifiedBlockPath = RecentBlockPath.computeBlockPath(config, blockNumber)
                             .path();
-                    createDirectoryOrFail(verifiedBlockPath);
-                    writeBlockOrFail(block, blockNumber, effectiveSource, verifiedBlockPath);
+                    try {
+                        if (createDirectoryOrFail(verifiedBlockPath, blockNumber, effectiveSource)) {
+                            writeBlockOrFail(block, blockNumber, effectiveSource, verifiedBlockPath);
+                        }
+                    } catch (final RuntimeException e) {
+                        final String message = "Failed to persist block %d due to %s".formatted(blockNumber, e);
+                        LOGGER.log(WARNING, message, e);
+                        sendBlockNotification(blockNumber, false, effectiveSource);
+                    }
                 }
             } else {
                 LOGGER.log(INFO, "Block {0} has no block header, cannot write to live path", blockNumber);
                 sendBlockNotification(blockNumber, false, effectiveSource);
             }
         } else {
+            LOGGER.log(WARNING, "Block {0} is null or has no block items, cannot write to live path", blockNumber);
             sendBlockNotification(blockNumber, false, effectiveSource);
         }
     }
@@ -416,15 +424,18 @@ public final class BlockFileRecentPlugin implements BlockProviderPlugin, BlockNo
         }
     }
 
-    private void createDirectoryOrFail(final Path verifiedBlockPath) {
+    private boolean createDirectoryOrFail(
+            final Path verifiedBlockPath, final long blockNumber, final BlockSource source) {
         try {
             // create parent directory if it does not exist
             Files.createDirectories(verifiedBlockPath.getParent());
+            return true;
         } catch (final IOException e) {
             final String message = "Failed to create directories for path %s due to %s"
                     .formatted(verifiedBlockPath.toAbsolutePath(), e);
             LOGGER.log(WARNING, message, e);
-            throw new UncheckedIOException(e);
+            sendBlockNotification(blockNumber, false, source);
+            return false;
         }
     }
 

--- a/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPlugin.java
+++ b/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPlugin.java
@@ -367,8 +367,14 @@ public final class BlockFileRecentPlugin implements BlockProviderPlugin, BlockNo
                     final Path verifiedBlockPath = RecentBlockPath.computeBlockPath(config, blockNumber)
                             .path();
                     try {
-                        if (createDirectoryOrFail(verifiedBlockPath, blockNumber, effectiveSource)) {
-                            writeBlockOrFail(block, blockNumber, effectiveSource, verifiedBlockPath);
+                        if (createDirectoryOrFail(verifiedBlockPath)) {
+                            if (writeBlockOrFail(block, blockNumber, verifiedBlockPath)) {
+                                sendBlockNotification(blockNumber, true, effectiveSource);
+                            } else {
+                                sendBlockNotification(blockNumber, false, effectiveSource);
+                            }
+                        } else {
+                            sendBlockNotification(blockNumber, false, effectiveSource);
                         }
                     } catch (final RuntimeException e) {
                         final String message = "Failed to persist block %d due to %s".formatted(blockNumber, e);
@@ -400,8 +406,7 @@ public final class BlockFileRecentPlugin implements BlockProviderPlugin, BlockNo
         }
     }
 
-    private void writeBlockOrFail(
-            final BlockUnparsed block, final long blockNumber, final BlockSource source, final Path verifiedBlockPath) {
+    private boolean writeBlockOrFail(final BlockUnparsed block, final long blockNumber, final Path verifiedBlockPath) {
         try (final WritableStreamingData streamingData = new WritableStreamingData(new BufferedOutputStream(
                 config.compression().wrapStream(Files.newOutputStream(verifiedBlockPath)), 16384))) {
             BlockUnparsed.PROTOBUF.write(block, streamingData);
@@ -412,20 +417,17 @@ public final class BlockFileRecentPlugin implements BlockProviderPlugin, BlockNo
             LOGGER.log(DEBUG, "Wrote verified block {0} to file {1}", blockNumber, verifiedBlockPath.toAbsolutePath());
             // update the oldest and newest verified block numbers
             availableBlocks.add(blockNumber);
-            // Send block persisted notification
-            final BlockSource effectiveSource = source == null ? UNKNOWN : source;
-            sendBlockNotification(blockNumber, true, effectiveSource);
             // Increment blocks written counter
             blocksWrittenCounter.increment();
+            return true;
         } catch (final IOException e) {
             final String message = "Failed to write file for block %d due to %s".formatted(blockNumber, e);
             LOGGER.log(WARNING, message, e);
-            sendBlockNotification(blockNumber, false, source);
+            return false;
         }
     }
 
-    private boolean createDirectoryOrFail(
-            final Path verifiedBlockPath, final long blockNumber, final BlockSource source) {
+    private boolean createDirectoryOrFail(final Path verifiedBlockPath) {
         try {
             // create parent directory if it does not exist
             Files.createDirectories(verifiedBlockPath.getParent());
@@ -434,7 +436,6 @@ public final class BlockFileRecentPlugin implements BlockProviderPlugin, BlockNo
             final String message = "Failed to create directories for path %s due to %s"
                     .formatted(verifiedBlockPath.toAbsolutePath(), e);
             LOGGER.log(WARNING, message, e);
-            sendBlockNotification(blockNumber, false, source);
             return false;
         }
     }

--- a/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPlugin.java
+++ b/block-node/blocks-file-recent/src/main/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPlugin.java
@@ -367,15 +367,9 @@ public final class BlockFileRecentPlugin implements BlockProviderPlugin, BlockNo
                     final Path verifiedBlockPath = RecentBlockPath.computeBlockPath(config, blockNumber)
                             .path();
                     try {
-                        if (createDirectoryOrFail(verifiedBlockPath)) {
-                            if (writeBlockOrFail(block, blockNumber, verifiedBlockPath)) {
-                                sendBlockNotification(blockNumber, true, effectiveSource);
-                            } else {
-                                sendBlockNotification(blockNumber, false, effectiveSource);
-                            }
-                        } else {
-                            sendBlockNotification(blockNumber, false, effectiveSource);
-                        }
+                        final boolean success = createDirectoryOrFail(verifiedBlockPath)
+                                && writeBlockOrFail(block, blockNumber, verifiedBlockPath);
+                        sendBlockNotification(blockNumber, success, effectiveSource);
                     } catch (final RuntimeException e) {
                         final String message = "Failed to persist block %d due to %s".formatted(blockNumber, e);
                         LOGGER.log(WARNING, message, e);

--- a/block-node/blocks-file-recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPluginTest.java
+++ b/block-node/blocks-file-recent/src/test/java/org/hiero/block/node/blocks/files/recent/BlockFileRecentPluginTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
@@ -27,6 +28,7 @@ import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBloc
 import org.hiero.block.node.base.BlockFile;
 import org.hiero.block.node.base.CompressionType;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
+import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureInfo;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureType;
@@ -369,6 +371,42 @@ class BlockFileRecentPluginTest {
                         filesRecentConfigOverride.maxFilesPerDir());
                 assertThat(persistedBlock).exists();
             }
+        }
+
+        /**
+         * Test that a failed persistence notification is sent when the live block
+         * directory cannot be created (e.g. an unexpected {@link RuntimeException}
+         * escapes the write path).
+         */
+        @Test
+        @DisplayName("Test failed notification sent when directory creation fails")
+        void testFailedNotificationSentWhenDirectoryCreationFails() throws IOException {
+            final long blockNumber = 0L;
+            // pre-create a regular file at the path where the plugin needs to create a directory,
+            // this forces Files.createDirectories to throw inside createDirectoryOrFail
+            final Path blockFilePath = BlockFile.nestedDirectoriesBlockFilePath(
+                    blocksRootPath, blockNumber, filesRecentConfig.compression(), filesRecentConfig.maxFilesPerDir());
+            final Path blockParentDir = blockFilePath.getParent();
+            Files.createDirectories(blockParentDir.getParent());
+            Files.createFile(blockParentDir);
+            // send verified block notification
+            final BlockUnparsed block =
+                    TestBlockBuilder.generateBlockWithNumber(blockNumber).blockUnparsed();
+            blockMessaging.sendBlockVerification(
+                    new VerificationNotification(true, null, blockNumber, Bytes.EMPTY, block, BlockSource.PUBLISHER));
+            // assert the block was not persisted
+            assertThat(plugin.block(blockNumber)).isNull();
+            assertThat(plugin.availableBlocks().contains(blockNumber)).isFalse();
+            // assert that a failed persistence notification was sent
+            final List<PersistedNotification> sentPersistedNotifications =
+                    blockMessaging.getSentPersistedNotifications();
+            assertThat(sentPersistedNotifications)
+                    .isNotEmpty()
+                    .hasSize(1)
+                    .element(0)
+                    .returns(false, PersistedNotification::succeeded)
+                    .returns(blockNumber, PersistedNotification::blockNumber)
+                    .returns(BlockSource.PUBLISHER, PersistedNotification::blockSource);
         }
 
         /**


### PR DESCRIPTION
## Reviewer Notes

 ### `BlockFileHistoricPlugin`: every early-return path in `writeBlockToStagingPath` now sends a failed notification

Previously, a null/empty block, a missing block header, or a block-number mismatch caused the method to silently return without notifying anyone. Each of those checks now sends a new persisted notification returning

### `createDirectoryOrFail` and `writeBlockOrFail` no longer let exceptions escape uncaught

`createDirectoryOrFail` used to throw `UncheckedIOException` on a failed `Files.createDirectories`; it now returns a boolean, logs the failure, and sends a failed notification itself. The caller only proceeds to `writeBlockOrFail` if directory creation succeeded. `writeBlockOrFail`'s existing `IOException` catch now also sends a failed notification (it previously only logged). The whole call chain in `writeBlockToStagingPath` is additionally wrapped in a `catch (RuntimeException e)` so any unchecked exception we did not anticipate still results in a failed notification rather than being swallowed or crashing the handler thread. Same approach was applied to `BlockFileRecentPlugin`.

## Related Issue(s)

Closes #3252 