### PR TITLE
fix: Remove Duplicate Entries of `recentlyVerifiedBlocks` on Failed Persistence

### DIFF
--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationServicePlugin.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationServicePlugin.java
@@ -163,6 +163,7 @@ public final class VerificationServicePlugin implements BlockNodePlugin, BlockIt
                 lastVerifiedBlock.compareAndSet(localLastVerified, highestStoredBlock);
                 localLastVerified = lastVerifiedBlock.get();
             }
+            LOGGER.log(INFO, "onContext update received, updated last verified block to {0}", lastVerifiedBlock.get());
         }
     }
 
@@ -247,9 +248,11 @@ public final class VerificationServicePlugin implements BlockNodePlugin, BlockIt
     /// We want to handle persisted notification so that we can update our
     /// recently verified blocks. If a block, that was recently verified has
     /// failed to persist, we have to expect its reception again. We want, in
-    /// those cases, to remove it from our set of recently verified blocks,
+    /// those cases, to remove it from our queue of recently verified blocks,
     /// because we want subsequent possible failures of verification to not
-    /// be informational.
+    /// be informational. The queue can hold duplicates of the same block
+    /// number (a block verified more than once is recorded once per
+    /// verification), so all occurrences must be removed, not just the first.
     /// Note that even if a subsequent failure happens before this update and
     /// an informational failure is propagated, this is still not disruptive
     /// because a failed persistence notification will inevitably follow
@@ -258,8 +261,13 @@ public final class VerificationServicePlugin implements BlockNodePlugin, BlockIt
     /// @param notification a [PersistedNotification] received as an event.
     @Override
     public void handlePersisted(final PersistedNotification notification) {
-        if (notification != null && !notification.succeeded()) {
-            recentlyVerifiedBlocks.remove(notification.blockNumber());
+        try {
+            if (notification != null && !notification.succeeded()) {
+                final long blockNumber = notification.blockNumber();
+                recentlyVerifiedBlocks.removeIf(block -> block == blockNumber);
+            }
+        } catch (final RuntimeException e) {
+            LOGGER.log(INFO, "Failed to handle persisted notification in verification ", e);
         }
     }
 

--- a/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/VerificationServicePluginTest.java
+++ b/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/VerificationServicePluginTest.java
@@ -36,6 +36,7 @@ import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBloc
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
+import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureInfo;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureType;
@@ -1372,6 +1373,57 @@ class VerificationServicePluginTest {
                     .returns(false, VerificationNotification::success)
                     .returns(FailureInfo.standard(FailureType.CANCELLED), VerificationNotification::failureInfo)
                     .returns(block0.number(), VerificationNotification::blockNumber)
+                    .returns(BlockSource.PUBLISHER, VerificationNotification::source)
+                    .returns(null, VerificationNotification::block)
+                    .returns(null, VerificationNotification::blockHash);
+        }
+    }
+
+    /// Tests for the recently verified blocks queue.
+    @Nested
+    @DisplayName("Recently Verified Blocks Tests")
+    class RecentlyVerifiedBlocksTests
+            extends PluginTestBase<VerificationServicePlugin, ExecutorService, ScheduledExecutorService> {
+        RecentlyVerifiedBlocksTests() {
+            super(
+                    Executors.newVirtualThreadPerTaskExecutor(),
+                    new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+            start(new VerificationServicePlugin(), new SimpleInMemoryHistoricalBlockFacility());
+        }
+
+        /// This test aims to assert that a failed persistence notification removes
+        /// all occurrences of a block from the recently verified blocks queue. The
+        /// queue can hold duplicates when the same block passes verification more
+        /// than once. If only the first occurrence were removed, a subsequent
+        /// verification failure for that block would still (incorrectly) be
+        /// reported as informational. We verify the same block twice, report a
+        /// failed persistence once, and then expect a subsequent verification
+        /// failure to be standard, not informational.
+        @Test
+        @DisplayName("Failed Persistence Removes All Duplicates from Recently Verified Blocks")
+        void testFailedPersistenceRemovesAllDuplicates() throws IOException, ParseException {
+            final ResourceTestBlock block0Valid = ResourceTestBlockBuilder.load(WRAPS.BLOCK_0);
+            // Verify block 0 successfully twice, the queue now holds its number twice
+            plugin.handleBlockItemsReceived(block0Valid.asBlockItems());
+            final List<VerificationNotification> firstPass = blockMessaging.getSentVerificationNotifications(1);
+            assertThat(firstPass).hasSize(1).first().returns(true, VerificationNotification::success);
+            firstPass.clear();
+            plugin.handleBlockItemsReceived(block0Valid.asBlockItems());
+            final List<VerificationNotification> secondPass = blockMessaging.getSentVerificationNotifications(1);
+            assertThat(secondPass).hasSize(1).first().returns(true, VerificationNotification::success);
+            secondPass.clear();
+            // Report failed persistence for block 0, all duplicates must be removed
+            plugin.handlePersisted(new PersistedNotification(block0Valid.number(), false, 0, BlockSource.PUBLISHER));
+            // Now fail verification of block 0, the failure must be standard, not informational
+            final ResourceTestBlock block0Invalid = appendProof(block0Valid, badTssSignedProof());
+            plugin.handleBlockItemsReceived(block0Invalid.asBlockItems());
+            final List<VerificationNotification> notifications = blockMessaging.getSentVerificationNotifications(1);
+            assertThat(notifications)
+                    .hasSize(1)
+                    .first()
+                    .returns(false, VerificationNotification::success)
+                    .returns(FailureInfo.standard(FailureType.BAD_BLOCK_PROOF), VerificationNotification::failureInfo)
+                    .returns(block0Invalid.number(), VerificationNotification::blockNumber)
                     .returns(BlockSource.PUBLISHER, VerificationNotification::source)
                     .returns(null, VerificationNotification::block)
                     .returns(null, VerificationNotification::blockHash);


### PR DESCRIPTION
* Removing all duplicates from the recentlyVerifiedBlock queue
* Added test

Fixes #3258