### PR TITLE
test: WRB distribution E2E test slice 4, steps 8-9

### DIFF
--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -82,7 +82,7 @@ on:
         type: string
         default: "5"
       test-definition:
-        description: "Test definitions (comma-separated): smoke-test, basic-load, node-restart-resilience, full-history-backfill, tss-signature-transition, wrb-cli-hash-validation, wrb-cli-wrapping-validation, wrb-differential-test, wrb-core-validation, rsa-roster-verification,  wrb-distribution-step12, wrb-distribution-step345, wrb-distribution-step67, wrb-distribution-step10, chaos-foundation-smoke, latency-cn-to-cn, latency-cn-to-bn, latency-bn-to-bn, latency-all-three"
+        description: "Test definitions (comma-separated): smoke-test, basic-load, node-restart-resilience, full-history-backfill, tss-signature-transition, wrb-cli-hash-validation, wrb-cli-wrapping-validation, wrb-differential-test, wrb-core-validation, rsa-roster-verification, wrb-distribution-step12, wrb-distribution-step345, wrb-distribution-step89, wrb-distribution-step10, chaos-foundation-smoke, latency-cn-to-cn, latency-cn-to-bn, latency-bn-to-bn, latency-all-three"
         type: string
         default: "none"
     outputs:
@@ -116,6 +116,7 @@ on:
           - wrb-distribution-step12 # WRB Distribution E2E (#3125) — slice 1: 3 CN v0.75 + MN1 v0.157.1, no BN
           - wrb-distribution-step345 # WRB Distribution E2E (#3125) — slice 3: adds BN1/BN2/BN3 with EMB
           - wrb-distribution-step67 # WRB Distribution E2E (#3125) — slice 4: MN1 → BN2/BN3 + MN2 from genesis
+          - wrb-distribution-step89 # WRB Distribution E2E (#3125) — slice 5: CN → BN3 + wrb-cli push to BN1
           - wrb-distribution-step10 # WRB Distribution E2E (#3125) — slice 5: BN2/BN3 reconfigured to backfill from BN1
       block-node-version:
         description: "Block Node version ('latest', 'rc', 'main', or tag like 'v0.29.0')"
@@ -203,7 +204,7 @@ on:
         required: false
         default: "5"
       test-definition:
-        description: "Test definitions (comma-separated): smoke-test, basic-load, node-restart-resilience, full-history-backfill, tss-signature-transition, wrb-cli-hash-validation, wrb-cli-wrapping-validation, wrb-differential-test, wrb-core-validation, rsa-roster-verification, wrb-distribution-step12, wrb-distribution-step345, wrb-distribution-step67, wrb-distribution-step10, chaos-foundation-smoke, latency-cn-to-cn, latency-cn-to-bn, latency-bn-to-bn, latency-all-three"
+        description: "Test definitions (comma-separated): smoke-test, basic-load, node-restart-resilience, full-history-backfill, tss-signature-transition, wrb-cli-hash-validation, wrb-cli-wrapping-validation, wrb-differential-test, wrb-core-validation, rsa-roster-verification, wrb-distribution-step12, wrb-distribution-step345, wrb-distribution-step67, wrb-distribution-step89, wrb-distribution-step10, chaos-foundation-smoke, latency-cn-to-cn, latency-cn-to-bn, latency-bn-to-bn, latency-all-three"
         required: false
         default: "none"
 

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-bn1-historical-backfill-landed.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-bn1-historical-backfill-landed.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# WRB Distribution E2E (#3125 slice 5 — step 9, historical half) —
+# assert-bn1-historical-backfill-landed.
+#
+# Runs right after bulk-load-historical-to-bn1.sh. Confirms BlockFileHistoricPlugin
+# actually picked up the bulk-loaded WRBs on BN1's post-restart startup scan, by
+# querying serverStatus and checking firstAvailableBlock=0 / lastAvailableBlock
+# is a real (non-empty-sentinel) number.
+#
+# Reads:
+#   BN1_GRPC_PORT  (default 40840 — matches add-bn.sh's port-forward convention:
+#                  grpc_port = 40839 + bn_index, so BN1 -> 40840)
+#   PROTO_PATH     (default ${REPO_ROOT}/protobuf-sources/proto — the extracted
+#                  proto artifact the "Untar Protobuf Sources" CI step produces)
+#
+# grpcurl needs -import-path/-proto explicitly: the Block Node's gRPC server
+# does not expose reflection, so a plain `-d '{}' host:port service/method`
+# call silently returns nothing to parse. Matches the working invocation in
+# solo-e2e-test.yml's "Get ServerStatus from Block Node" step.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
+
+: "${BN1_GRPC_PORT:=$((40839 + 1))}"
+: "${PROTO_PATH:=${REPO_ROOT}/protobuf-sources/proto}"
+
+log() { echo "[wrb-dist-bulk-load-assert] $*"; }
+fail() { echo "[wrb-dist-bulk-load-assert] ERROR: $*" >&2; exit 1; }
+
+if ! command -v grpcurl >/dev/null 2>&1; then
+    fail "grpcurl not on PATH; cannot query BN1 serverStatus"
+fi
+if [[ ! -d "${PROTO_PATH}" ]]; then
+    fail "PROTO_PATH not found: ${PROTO_PATH} (expected the extracted protobuf artifact)"
+fi
+
+grpcurl_err="${TMPDIR:-/tmp}/wrb-dist-bulk-load-assert-grpcurl.err"
+status_json=$(grpcurl -plaintext -emit-defaults \
+    -import-path "${PROTO_PATH}" \
+    -proto block-node/api/node_service.proto \
+    -d '{}' "localhost:${BN1_GRPC_PORT}" \
+    org.hiero.block.api.BlockNodeService/serverStatus 2>"${grpcurl_err}") || {
+        log "grpcurl query failed:"
+        sed 's/^/  /' "${grpcurl_err}" || true
+        fail "Could not query BN1 serverStatus via grpcurl"
+    }
+
+first_available=$(echo "${status_json}" | jq -r '.firstAvailableBlock // empty' 2>/dev/null || echo "")
+last_available=$(echo "${status_json}" | jq -r '.lastAvailableBlock // empty' 2>/dev/null || echo "")
+
+# An empty BN reports both fields as UINT64_MAX (18446744073709551615), not 0 —
+# 0 means "block 0 is available".
+NO_BLOCKS_SENTINEL="18446744073709551615"
+
+log "BN1 serverStatus: firstAvailableBlock=${first_available} lastAvailableBlock=${last_available}"
+
+if [[ -z "${last_available}" || ! "${last_available}" =~ ^[0-9]+$ || "${last_available}" == "${NO_BLOCKS_SENTINEL}" ]]; then
+    fail "BN1 still has no blocks after bulk-load + restart (lastAvailableBlock='${last_available}')"
+fi
+if [[ "${first_available}" != "0" ]]; then
+    fail "BN1's firstAvailableBlock is '${first_available}', expected 0 (bulk-loaded from genesis)"
+fi
+
+log "OK: historical backfill landed (blocks 0..${last_available} available on block-node-1)."

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-cn-publishing-to-bn3.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-cn-publishing-to-bn3.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# WRB Distribution E2E (#3125 slice 5 — step 8) — assert each CN's
+# block-nodes.json references BN3.
+#
+# BN3 has EMB=100_000_000 (step 5), so it will not persist blocks at the
+# numbers the CN is currently producing — this only asserts the config
+# surface (that reconfigure-cn-to-push-bn3.sh's write took effect on all 3
+# CN pods), not that BN3 has received blocks.
+#
+# Reads:
+#   NAMESPACE   (default "solo-network")
+#   CONTEXT     (default "kind-solo-cluster")
+#   BN_HOST_3   (default block-node-3.${NAMESPACE}.svc.cluster.local)
+
+set -euo pipefail
+
+: "${NAMESPACE:=solo-network}"
+: "${CONTEXT:=kind-solo-cluster}"
+: "${BN_HOST_3:=block-node-3.${NAMESPACE}.svc.cluster.local}"
+
+log() { echo "[wrb-dist-assert-cn-bn3] $*"; }
+fail() { echo "[wrb-dist-assert-cn-bn3] ERROR: $*" >&2; exit 1; }
+
+CONFIG_PATH="/opt/hgcapp/services-hedera/HapiApp2.0/data/config/block-nodes.json"
+
+failures=0
+for cn_name in node1 node2 node3; do
+    cn_pod="network-${cn_name}-0"
+    config_content=$(kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
+        exec "${cn_pod}" -c root-container -- cat "${CONFIG_PATH}" 2>/dev/null || echo "")
+
+    if [[ -z "${config_content}" ]]; then
+        log "${cn_pod}: could not read ${CONFIG_PATH}"
+        failures=$(( failures + 1 ))
+        continue
+    fi
+
+    if echo "${config_content}" | grep -q "\"${BN_HOST_3}\""; then
+        log "${cn_pod}: block-nodes.json references ${BN_HOST_3} ✓"
+    else
+        log "${cn_pod}: block-nodes.json does NOT reference ${BN_HOST_3}:"
+        log "${config_content}"
+        failures=$(( failures + 1 ))
+    fi
+done
+
+if (( failures > 0 )); then
+    fail "${failures} CN(s) did not have block-nodes.json pointing at BN3"
+fi
+
+log "All 3 CNs' block-nodes.json reference BN3 (${BN_HOST_3})."

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-live-push-produced-new-blocks.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-live-push-produced-new-blocks.sh
@@ -18,10 +18,22 @@
 # Reads:
 #   BN1_GRPC_PORT  (default 40840 — matches add-bn.sh's port-forward convention:
 #                  grpc_port = 40839 + bn_index, so BN1 -> 40840)
+#   PROTO_PATH     (default ${REPO_ROOT}/protobuf-sources/proto — the extracted
+#                  proto artifact the "Untar Protobuf Sources" CI step produces)
+#
+# grpcurl needs -import-path/-proto explicitly: the Block Node's gRPC server
+# does not expose reflection, so a plain `-d '{}' host:port service/method`
+# call (as used elsewhere, e.g. add-mn2.sh's BN2 lastAvailableBlock lookup)
+# silently returns nothing to parse. Matches the working invocation in
+# solo-e2e-test.yml's "Get ServerStatus from Block Node" step.
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
+
 : "${BN1_GRPC_PORT:=$((40839 + 1))}"
+: "${PROTO_PATH:=${REPO_ROOT}/protobuf-sources/proto}"
 
 STATE_FILE="/tmp/wrb-dist-push.state"
 PID_FILE="/tmp/wrb-dist-push.pid"
@@ -51,15 +63,29 @@ fi
 if ! command -v grpcurl >/dev/null 2>&1; then
     fail "grpcurl not on PATH; cannot query BN1 serverStatus"
 fi
+if [[ ! -d "${PROTO_PATH}" ]]; then
+    fail "PROTO_PATH not found: ${PROTO_PATH} (expected the extracted protobuf artifact)"
+fi
 
-status_json=$(grpcurl -plaintext -d '{}' "localhost:${BN1_GRPC_PORT}" \
-    org.hiero.block.api.BlockNodeService/serverStatus 2>/dev/null || echo '{}')
+grpcurl_err="${TMPDIR:-/tmp}/wrb-dist-push-assert-grpcurl.err"
+status_json=$(grpcurl -plaintext -emit-defaults \
+    -import-path "${PROTO_PATH}" \
+    -proto block-node/api/node_service.proto \
+    -d '{}' "localhost:${BN1_GRPC_PORT}" \
+    org.hiero.block.api.BlockNodeService/serverStatus 2>"${grpcurl_err}") || {
+        log "grpcurl query failed:"
+        sed 's/^/  /' "${grpcurl_err}" || true
+        fail "Could not query BN1 serverStatus via grpcurl"
+    }
 bn1_last=$(echo "${status_json}" | jq -r '.lastAvailableBlock // empty' 2>/dev/null || echo "")
 
-if [[ -n "${bn1_last}" && "${bn1_last}" =~ ^[0-9]+$ ]]; then
+# An empty BN reports lastAvailableBlock as UINT64_MAX (18446744073709551615),
+# not 0 — 0 means "block 0 is available". Treat the sentinel as "no blocks".
+NO_BLOCKS_SENTINEL="18446744073709551615"
+if [[ -n "${bn1_last}" && "${bn1_last}" =~ ^[0-9]+$ && "${bn1_last}" != "${NO_BLOCKS_SENTINEL}" ]]; then
     log "BN1 lastAvailableBlock=${bn1_last} (historical backfill landed)"
 else
-    fail "Could not read a numeric lastAvailableBlock from BN1 (got '${bn1_last}'); historical push did not land"
+    fail "BN1 has no blocks yet (lastAvailableBlock='${bn1_last}'); historical push did not land"
 fi
 
 # Live / "continue to move over" check: at least one new successful push

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-live-push-produced-new-blocks.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-live-push-produced-new-blocks.sh
@@ -1,39 +1,22 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# WRB Distribution E2E (#3125 slice 5 — step 9) — assert-live-push-produced-new-blocks.
+# WRB Distribution E2E (#3125 slice 5 — step 9, live half) —
+# assert-live-push-produced-new-blocks.
 #
-# Runs between start-live-push.sh and stop-live-push.sh. This is the "did both
-# the historical backfill and the live continuation happen?" check for step 9:
-#
-#   * Historical: query BN1's serverStatus over the port-forward add-bn.sh set
-#     up and assert lastAvailableBlock is present (>= 0) — proves the first
-#     `blocks push` iteration landed the backlog wrapped during steps 1-7.
-#   * Live / "continue to move over": compare the "push OK" iteration count in
-#     the worker log against the snapshot taken at start-live-push.sh time
-#     (/tmp/wrb-dist-push.state) and fail if the loop hasn't completed a new
-#     iteration — mirrors assert-live-wrap-produced-new-blocks.sh's own
-#     liveness check for the wrap loop.
+# Runs between start-live-push.sh and stop-live-push.sh. The historical half of
+# step 9 is proven separately by assert-bn1-historical-backfill-landed.sh right
+# after bulk-load-historical-to-bn1.sh; this script only proves the "continue
+# to move over" half: that the live-push loop (blocks push, wrappedBlocks ->
+# BN1) kept completing iterations after the historical backfill, mirroring
+# assert-live-wrap-produced-new-blocks.sh's own liveness check for the wrap
+# loop.
 #
 # Reads:
-#   BN1_GRPC_PORT  (default 40840 — matches add-bn.sh's port-forward convention:
-#                  grpc_port = 40839 + bn_index, so BN1 -> 40840)
-#   PROTO_PATH     (default ${REPO_ROOT}/protobuf-sources/proto — the extracted
-#                  proto artifact the "Untar Protobuf Sources" CI step produces)
-#
-# grpcurl needs -import-path/-proto explicitly: the Block Node's gRPC server
-# does not expose reflection, so a plain `-d '{}' host:port service/method`
-# call (as used elsewhere, e.g. add-mn2.sh's BN2 lastAvailableBlock lookup)
-# silently returns nothing to parse. Matches the working invocation in
-# solo-e2e-test.yml's "Get ServerStatus from Block Node" step.
+#   (none directly — everything comes from /tmp/wrb-dist-push.state / .pid / .log
+#   written by start-live-push.sh)
 
 set -euo pipefail
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
-
-: "${BN1_GRPC_PORT:=$((40839 + 1))}"
-: "${PROTO_PATH:=${REPO_ROOT}/protobuf-sources/proto}"
 
 STATE_FILE="/tmp/wrb-dist-push.state"
 PID_FILE="/tmp/wrb-dist-push.pid"
@@ -58,38 +41,7 @@ else
     fail "Live-push worker died before assertion"
 fi
 
-# Historical check: BN1 should report a lastAvailableBlock by now (the first
-# `blocks push` iteration backfills everything wrapped so far).
-if ! command -v grpcurl >/dev/null 2>&1; then
-    fail "grpcurl not on PATH; cannot query BN1 serverStatus"
-fi
-if [[ ! -d "${PROTO_PATH}" ]]; then
-    fail "PROTO_PATH not found: ${PROTO_PATH} (expected the extracted protobuf artifact)"
-fi
-
-grpcurl_err="${TMPDIR:-/tmp}/wrb-dist-push-assert-grpcurl.err"
-status_json=$(grpcurl -plaintext -emit-defaults \
-    -import-path "${PROTO_PATH}" \
-    -proto block-node/api/node_service.proto \
-    -d '{}' "localhost:${BN1_GRPC_PORT}" \
-    org.hiero.block.api.BlockNodeService/serverStatus 2>"${grpcurl_err}") || {
-        log "grpcurl query failed:"
-        sed 's/^/  /' "${grpcurl_err}" || true
-        fail "Could not query BN1 serverStatus via grpcurl"
-    }
-bn1_last=$(echo "${status_json}" | jq -r '.lastAvailableBlock // empty' 2>/dev/null || echo "")
-
-# An empty BN reports lastAvailableBlock as UINT64_MAX (18446744073709551615),
-# not 0 — 0 means "block 0 is available". Treat the sentinel as "no blocks".
-NO_BLOCKS_SENTINEL="18446744073709551615"
-if [[ -n "${bn1_last}" && "${bn1_last}" =~ ^[0-9]+$ && "${bn1_last}" != "${NO_BLOCKS_SENTINEL}" ]]; then
-    log "BN1 lastAvailableBlock=${bn1_last} (historical backfill landed)"
-else
-    fail "BN1 has no blocks yet (lastAvailableBlock='${bn1_last}'); historical push did not land"
-fi
-
-# Live / "continue to move over" check: at least one new successful push
-# iteration since start-live-push.sh's snapshot.
+# At least one new successful push iteration since start-live-push.sh's snapshot.
 current_push_ok_count=$( grep -cE '\] push OK' "${LOG_FILE}" 2>/dev/null || echo 0 )
 log "push_ok_iterations: initial=${initial_push_ok_count} current=${current_push_ok_count}"
 

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-live-push-produced-new-blocks.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-live-push-produced-new-blocks.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# WRB Distribution E2E (#3125 slice 5 — step 9) — assert-live-push-produced-new-blocks.
+#
+# Runs between start-live-push.sh and stop-live-push.sh. This is the "did both
+# the historical backfill and the live continuation happen?" check for step 9:
+#
+#   * Historical: query BN1's serverStatus over the port-forward add-bn.sh set
+#     up and assert lastAvailableBlock is present (>= 0) — proves the first
+#     `blocks push` iteration landed the backlog wrapped during steps 1-7.
+#   * Live / "continue to move over": compare the "push OK" iteration count in
+#     the worker log against the snapshot taken at start-live-push.sh time
+#     (/tmp/wrb-dist-push.state) and fail if the loop hasn't completed a new
+#     iteration — mirrors assert-live-wrap-produced-new-blocks.sh's own
+#     liveness check for the wrap loop.
+#
+# Reads:
+#   BN1_GRPC_PORT  (default 40840 — matches add-bn.sh's port-forward convention:
+#                  grpc_port = 40839 + bn_index, so BN1 -> 40840)
+
+set -euo pipefail
+
+: "${BN1_GRPC_PORT:=$((40839 + 1))}"
+
+STATE_FILE="/tmp/wrb-dist-push.state"
+PID_FILE="/tmp/wrb-dist-push.pid"
+LOG_FILE="/tmp/wrb-dist-push.log"
+
+log() { echo "[wrb-dist-push-assert] $*"; }
+fail() { echo "[wrb-dist-push-assert] ERROR: $*" >&2; exit 1; }
+
+[[ -f "${STATE_FILE}" ]] || fail "State file ${STATE_FILE} not found; did start-live-push.sh run?"
+[[ -f "${PID_FILE}" ]] || fail "PID file ${PID_FILE} not found; did start-live-push.sh run?"
+
+# shellcheck disable=SC1090
+source "${STATE_FILE}"
+: "${initial_push_ok_count:?state file did not set initial_push_ok_count}"
+
+worker_pid=$(cat "${PID_FILE}")
+if kill -0 "${worker_pid}" 2>/dev/null; then
+    log "Live-push worker still alive (pid ${worker_pid})"
+else
+    log "WARNING: worker pid ${worker_pid} is not alive; recent log:"
+    tail -30 "${LOG_FILE}" 2>/dev/null | sed 's/^/  /' || true
+    fail "Live-push worker died before assertion"
+fi
+
+# Historical check: BN1 should report a lastAvailableBlock by now (the first
+# `blocks push` iteration backfills everything wrapped so far).
+if ! command -v grpcurl >/dev/null 2>&1; then
+    fail "grpcurl not on PATH; cannot query BN1 serverStatus"
+fi
+
+status_json=$(grpcurl -plaintext -d '{}' "localhost:${BN1_GRPC_PORT}" \
+    org.hiero.block.api.BlockNodeService/serverStatus 2>/dev/null || echo '{}')
+bn1_last=$(echo "${status_json}" | jq -r '.lastAvailableBlock // empty' 2>/dev/null || echo "")
+
+if [[ -n "${bn1_last}" && "${bn1_last}" =~ ^[0-9]+$ ]]; then
+    log "BN1 lastAvailableBlock=${bn1_last} (historical backfill landed)"
+else
+    fail "Could not read a numeric lastAvailableBlock from BN1 (got '${bn1_last}'); historical push did not land"
+fi
+
+# Live / "continue to move over" check: at least one new successful push
+# iteration since start-live-push.sh's snapshot.
+current_push_ok_count=$( grep -cE '\] push OK' "${LOG_FILE}" 2>/dev/null || echo 0 )
+log "push_ok_iterations: initial=${initial_push_ok_count} current=${current_push_ok_count}"
+
+if (( current_push_ok_count > initial_push_ok_count )); then
+    log "OK: live-push completed $(( current_push_ok_count - initial_push_ok_count )) new iteration(s) during the observation window"
+    exit 0
+fi
+
+log "Live-push loop did not complete a new successful iteration. Recent worker log:"
+tail -80 "${LOG_FILE}" 2>/dev/null | sed 's/^/  /' || true
+fail "No new push iterations between start and assertion (initial=${initial_push_ok_count} current=${current_push_ok_count})"

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/bulk-load-historical-to-bn1.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/bulk-load-historical-to-bn1.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# WRB Distribution E2E (#3125 slice 5 — step 9, historical half) —
+# bulk-load-historical-to-bn1.
+#
+# Historical WRBs must NOT go through BN1's live publish/gRPC stream: that
+# pipeline is a single-slot-per-block-number race (see
+# LiveStreamPublisherManager.resolveActionForHeader's nextUnstreamedBlockNumber
+# CAS) meant for freshly-produced blocks, and it silently SKIPs anything that
+# loses the race rather than persisting it — which is exactly what happened
+# when this slice first tried pushing block 0 to BN1 over gRPC. The wrb-cli's
+# own `blocks bulk-load` subcommand (PR #3038) exists for precisely this case:
+# it copies wrapped block zips directly into a Block Node's historic-storage
+# directory, bypassing live-stream verification entirely; BlockFileHistoricPlugin
+# picks them up on the BN's next startup scan. This script:
+#
+#   1. Runs `blocks bulk-load` locally (source=wrappedBlocks, dest=a local
+#      staging dir) — reuses the CLI's own file selection (zips only) and
+#      resumability bookkeeping instead of hand-rolling a copy.
+#   2. Streams the staged result into BN1's pod via `tar | kubectl exec` (more
+#      reliable than `kubectl cp`'s directory-copy semantics) at
+#      /opt/hiero/block-node/data/historic — the chart's actual configured
+#      archive.mountPath (charts/block-node-server/values.yaml), NOT
+#      /opt/hiero/block-node/data/archive (a stale path used by the test
+#      runner's unrelated clear-block-storage helper).
+#   3. Rolls BN1's StatefulSet pod so BlockFileHistoricPlugin re-scans on
+#      startup and picks up the newly-copied files. Safe here because nothing
+#      else is writing to BN1's storage at this point in the test (CN was
+#      redirected to BN3-only in step 8; MN1/MN2 only ever read from BN2/BN3).
+#      /opt/hiero/block-node/data is PVC-backed (volumeClaimTemplates in the
+#      chart), so the copied files survive the pod restart.
+#   4. Re-establishes the grpc/metrics port-forwards the restart tears down
+#      (same convention as add-bn.sh).
+#
+# Reads:
+#   NAMESPACE          (default "solo-network")
+#   CONTEXT            (default "kind-solo-cluster")
+#   BN1_GRPC_PORT      (default 40840 — matches add-bn.sh's port-forward convention)
+#   BN1_METRICS_PORT   (default 16007)
+#   READY_TIMEOUT      (default 300)
+
+set -euo pipefail
+
+ENV_FILE="${ENV_FILE:-/tmp/wrb-distribution-step12.env}"
+if [[ -f "${ENV_FILE}" ]]; then
+    # shellcheck disable=SC1090
+    source "${ENV_FILE}"
+fi
+
+: "${NAMESPACE:=solo-network}"
+: "${CONTEXT:=kind-solo-cluster}"
+BN1_GRPC_PORT="${BN1_GRPC_PORT:-$((40839 + 1))}"
+BN1_METRICS_PORT="${BN1_METRICS_PORT:-$((16006 + 1))}"
+READY_TIMEOUT="${READY_TIMEOUT:-300}"
+
+: "${WRB_DIST_WORK_DIR:?WRB_DIST_WORK_DIR must be set (written by install-and-run-wrb-cli.sh)}"
+: "${CLI_LIB:?CLI_LIB must be set (written by install-and-run-wrb-cli.sh)}"
+
+log() { echo "[wrb-dist-bulk-load-bn1] $*"; }
+fail() { echo "[wrb-dist-bulk-load-bn1] ERROR: $*" >&2; exit 1; }
+
+wrapped_dir="${WRB_DIST_WORK_DIR}/wrappedBlocks"
+staging_dir="${WRB_DIST_WORK_DIR}/bn1-bulk-load-staging"
+[[ -d "${wrapped_dir}" ]] || fail "Wrapped dir missing: ${wrapped_dir}"
+
+HISTORIC_MOUNT_PATH="/opt/hiero/block-node/data/historic"
+pod="block-node-1-0"
+
+log "Staging wrapped blocks via 'blocks bulk-load' (${wrapped_dir} -> ${staging_dir})..."
+java -cp "${CLI_LIB}/*" \
+    org.hiero.block.tools.BlockStreamTool blocks bulk-load \
+        --source "${wrapped_dir}" \
+        --dest "${staging_dir}" \
+    || fail "'blocks bulk-load' staging failed"
+
+if [[ -z "$(find "${staging_dir}" -name '*.zip' -print -quit 2>/dev/null)" ]]; then
+    fail "No .zip files staged in ${staging_dir}; nothing to bulk-load onto BN1"
+fi
+
+log "Streaming staged blocks into ${pod}:${HISTORIC_MOUNT_PATH}..."
+kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
+    exec "${pod}" -c block-node-server -- mkdir -p "${HISTORIC_MOUNT_PATH}" \
+    || fail "Failed to ensure ${HISTORIC_MOUNT_PATH} exists on ${pod}"
+tar -C "${staging_dir}" -cf - . | kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
+    exec -i "${pod}" -c block-node-server -- tar xf - -C "${HISTORIC_MOUNT_PATH}" \
+    || fail "Failed to stream staged blocks into ${pod}"
+log "Blocks copied onto ${pod}'s persistent historic volume."
+
+log "Rolling ${pod} (statefulset/block-node-1) so BlockFileHistoricPlugin re-scans..."
+kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
+    rollout restart statefulset/block-node-1 \
+    || fail "rollout restart failed for statefulset/block-node-1"
+kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
+    rollout status statefulset/block-node-1 --timeout="${READY_TIMEOUT}s" \
+    || fail "statefulset/block-node-1 rollout did not complete"
+kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
+    wait --for=condition=Ready pod/"${pod}" --timeout="${READY_TIMEOUT}s" \
+    || fail "${pod} did not become Ready after restart"
+
+log "Re-establishing kubectl port-forwards for block-node-1 (grpc :${BN1_GRPC_PORT}, metrics :${BN1_METRICS_PORT})..."
+# The restart above deleted the pod add-bn.sh's own port-forwards were
+# tunneling to; kill any still-running ones first so the new ones below can
+# bind the same local ports (a dead-pod port-forward doesn't always exit
+# immediately on its own).
+pkill -f "port-forward svc/block-node-1 ${BN1_GRPC_PORT}:" 2>/dev/null || true
+pkill -f "port-forward svc/block-node-1 ${BN1_METRICS_PORT}:" 2>/dev/null || true
+sleep 1
+
+pf_log_dir="${TMPDIR:-/tmp}/wrb-dist-add-bn-pf"
+mkdir -p "${pf_log_dir}"
+nohup setsid kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
+    port-forward svc/block-node-1 "${BN1_GRPC_PORT}:40840" \
+    >"${pf_log_dir}/block-node-1-grpc.log" 2>&1 </dev/null &
+nohup setsid kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
+    port-forward svc/block-node-1 "${BN1_METRICS_PORT}:16007" \
+    >"${pf_log_dir}/block-node-1-metrics.log" 2>&1 </dev/null &
+sleep 2
+
+rm -rf "${staging_dir}"
+log "Historical backfill complete: block-node-1 restarted with the bulk-loaded WRBs."

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/bulk-load-historical-to-bn1.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/bulk-load-historical-to-bn1.sh
@@ -60,6 +60,23 @@ READY_TIMEOUT="${READY_TIMEOUT:-300}"
 log() { echo "[wrb-dist-bulk-load-bn1] $*"; }
 fail() { echo "[wrb-dist-bulk-load-bn1] ERROR: $*" >&2; exit 1; }
 
+# Poll until a local port actually accepts connections, instead of a fixed sleep that's a
+# plausible CI flake under runner load if kubectl takes longer than expected to bind it.
+# Uses nc rather than bash's /dev/tcp: /dev/tcp requires bash built with net redirections, which
+# e.g. macOS's stock bash 3.2 lacks, whereas nc is reliably preinstalled on both macOS and the
+# Linux CI runners this suite targets.
+command -v nc >/dev/null 2>&1 || fail "nc not on PATH; needed to confirm the re-established port-forwards are up"
+wait_for_port() {
+    local port="$1" label="$2"
+    for _ in $(seq 1 30); do
+        if nc -z localhost "${port}" 2>/dev/null; then
+            return 0
+        fi
+        sleep 1
+    done
+    fail "Port-forward for ${label} (localhost:${port}) never came up after 30s"
+}
+
 wrapped_dir="${WRB_DIST_WORK_DIR}/wrappedBlocks"
 staging_dir="${WRB_DIST_WORK_DIR}/bn1-bulk-load-staging"
 [[ -d "${wrapped_dir}" ]] || fail "Wrapped dir missing: ${wrapped_dir}"
@@ -115,7 +132,8 @@ nohup setsid kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
 nohup setsid kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
     port-forward svc/block-node-1 "${BN1_METRICS_PORT}:16007" \
     >"${pf_log_dir}/block-node-1-metrics.log" 2>&1 </dev/null &
-sleep 2
+wait_for_port "${BN1_GRPC_PORT}" "block-node-1 grpc"
+wait_for_port "${BN1_METRICS_PORT}" "block-node-1 metrics"
 
 rm -rf "${staging_dir}"
 log "Historical backfill complete: block-node-1 restarted with the bulk-loaded WRBs."

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/bulk-load-historical-to-bn1.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/bulk-load-historical-to-bn1.sh
@@ -60,21 +60,18 @@ READY_TIMEOUT="${READY_TIMEOUT:-300}"
 log() { echo "[wrb-dist-bulk-load-bn1] $*"; }
 fail() { echo "[wrb-dist-bulk-load-bn1] ERROR: $*" >&2; exit 1; }
 
-# Poll until a local port actually accepts connections, instead of a fixed sleep that's a
-# plausible CI flake under runner load if kubectl takes longer than expected to bind it.
-# Uses nc rather than bash's /dev/tcp: /dev/tcp requires bash built with net redirections, which
-# e.g. macOS's stock bash 3.2 lacks, whereas nc is reliably preinstalled on both macOS and the
-# Linux CI runners this suite targets.
-command -v nc >/dev/null 2>&1 || fail "nc not on PATH; needed to confirm the re-established port-forwards are up"
-wait_for_port() {
-    local port="$1" label="$2"
+# Poll kubectl's own port-forward log for its readiness line, instead of a fixed sleep that's a
+# plausible CI flake under runner load if kubectl takes longer than expected to bind it. Avoids
+# depending on an external probing tool (nc, bash's /dev/tcp) whose availability/behavior varies
+# across the environments this script runs in - kubectl always prints this line itself once the
+# tunnel is actually up.
+wait_for_port_forward() {
+    local log_file="$1" label="$2"
     for _ in $(seq 1 30); do
-        if nc -z localhost "${port}" 2>/dev/null; then
-            return 0
-        fi
+        grep -q "Forwarding from" "${log_file}" 2>/dev/null && return 0
         sleep 1
     done
-    fail "Port-forward for ${label} (localhost:${port}) never came up after 30s"
+    fail "Port-forward for ${label} never came up after 30s (see ${log_file})"
 }
 
 wrapped_dir="${WRB_DIST_WORK_DIR}/wrappedBlocks"
@@ -132,8 +129,8 @@ nohup setsid kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
 nohup setsid kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
     port-forward svc/block-node-1 "${BN1_METRICS_PORT}:16007" \
     >"${pf_log_dir}/block-node-1-metrics.log" 2>&1 </dev/null &
-wait_for_port "${BN1_GRPC_PORT}" "block-node-1 grpc"
-wait_for_port "${BN1_METRICS_PORT}" "block-node-1 metrics"
+wait_for_port_forward "${pf_log_dir}/block-node-1-grpc.log" "block-node-1 grpc"
+wait_for_port_forward "${pf_log_dir}/block-node-1-metrics.log" "block-node-1 metrics"
 
 rm -rf "${staging_dir}"
 log "Historical backfill complete: block-node-1 restarted with the bulk-loaded WRBs."

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/reconfigure-cn-to-push-bn3.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/reconfigure-cn-to-push-bn3.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# WRB Distribution E2E (#3125 slice 5 — step 8) — reconfigure the 3 CNs to
+# publish blocks to BN3.
+#
+# Writes a fresh block-nodes.json onto each network-node pod, pointing at BN3
+# alone (priority 1). This is a config-file-only change: the same JSON shape
+# and path apply_cn_block_nodes_configs already writes at deploy time in
+# solo-deploy-network.sh, and the same shape execute_reconfigure_cn_streaming
+# in solo-test-runner.sh writes for mid-test reconfiguration — neither restarts
+# the CN pod, since the CN picks up block-nodes.json as its dynamic
+# block-node-connection routing config rather than only at startup.
+#
+# Note: BN3 was installed (step 5) with EMB=100_000_000, specifically so it
+# won't persist the low block numbers the CN is producing at this point in the
+# test — it's there to prove out "future live streaming," not to receive
+# blocks yet. So this step only proves the config surface (assert-cn-
+# publishing-to-bn3.sh checks each CN's block-nodes.json references BN3);
+# actual block flow to BN3 is out of scope here.
+#
+# Reads:
+#   NAMESPACE   (default "solo-network")
+#   CONTEXT     (default "kind-solo-cluster")
+#   BN_HOST_3   (default block-node-3.${NAMESPACE}.svc.cluster.local)
+#   BN_PORT_3   (default 40840)
+
+set -euo pipefail
+
+: "${NAMESPACE:=solo-network}"
+: "${CONTEXT:=kind-solo-cluster}"
+: "${BN_HOST_3:=block-node-3.${NAMESPACE}.svc.cluster.local}"
+BN_PORT_3="${BN_PORT_3:-40840}"
+
+log() { echo "[wrb-dist-cn-to-bn3] $*"; }
+fail() { echo "[wrb-dist-cn-to-bn3] ERROR: $*" >&2; exit 1; }
+
+CONFIG_PATH="/opt/hgcapp/services-hedera/HapiApp2.0/data/config/block-nodes.json"
+CONFIG_CONTENT=$(cat <<EOF
+{
+  "nodes": [
+    {
+      "address": "${BN_HOST_3}",
+      "streamingPort": ${BN_PORT_3},
+      "servicePort": ${BN_PORT_3},
+      "priority": 1
+    }
+  ],
+  "blockItemBatchSize": 256
+}
+EOF
+)
+
+log "New block-nodes.json (all 3 CNs -> BN3 only):"
+log "${CONFIG_CONTENT}"
+
+for cn_name in node1 node2 node3; do
+    cn_pod="network-${cn_name}-0"
+    log "Writing ${CONFIG_PATH} on ${cn_pod}..."
+    echo "${CONFIG_CONTENT}" | kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
+        exec -i "${cn_pod}" -c root-container -- bash -c "cat > ${CONFIG_PATH}" \
+        || fail "Failed to write block-nodes.json on ${cn_pod}"
+done
+
+log "All 3 CNs reconfigured to publish to BN3 (${BN_HOST_3}:${BN_PORT_3})."

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/start-live-push.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/start-live-push.sh
@@ -8,15 +8,22 @@
 # writes its PID to a well-known file, and returns immediately so the runner
 # can move on. A later stop-live-push.sh reads the PID file and tears it down.
 #
+# Run AFTER bulk-load-historical-to-bn1.sh, which handles the "historical"
+# half of step 9 by copying wrapped blocks directly into BN1's historic
+# storage (bypassing the live publish/gRPC stream entirely — that pipeline is
+# a single-slot-per-block-number race meant for freshly-produced blocks, not
+# historical replay; see bulk-load-historical-to-bn1.sh's header for why).
+# This script only covers the "continue to move over" / live half.
+#
 # What the worker does:
 #   * Every LIVE_PUSH_POLL_SECONDS seconds, run `blocks push` (the new wrb-cli
 #     subcommand) against the wrappedBlocks output directory that
 #     install-and-run-wrb-cli.sh / start-live-wrap.sh are writing into,
 #     targeting BN1. `blocks push` re-queries BN1's lastAvailableBlock and the
 #     local blockStreamBlockHashes.bin watermark on every invocation and only
-#     pushes the gap, so the first iteration backfills everything wrapped so
-#     far (the "historical" half of step 9) and later iterations push whatever
-#     has been wrapped since (the "continue to move over" / live half).
+#     pushes the gap — since the historical backlog is already on BN1 via
+#     bulk-load by the time this runs, that gap is just whatever `blocks wrap`
+#     has produced since.
 #   * Continues until stop-live-push.sh signals it or `blocks push` hard-fails
 #     LIVE_PUSH_MAX_CONSECUTIVE_FAILURES times in a row.
 #

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/start-live-push.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/start-live-push.sh
@@ -28,8 +28,9 @@
 # Optional overrides:
 #   LIVE_PUSH_POLL_SECONDS              (default: 30)
 #   LIVE_PUSH_MAX_CONSECUTIVE_FAILURES  (default: 5)
-#   BN_HOST_1                           (default block-node-1.${NAMESPACE}.svc.cluster.local)
-#   BN_PORT_1                           (default 40840)
+#   BN_HOST_1                           (default localhost)
+#   BN1_GRPC_PORT                       (default 40840 — matches add-bn.sh's port-forward
+#                                       convention: grpc_port = 40839 + bn_index, so BN1 -> 40840)
 
 set -euo pipefail
 
@@ -40,8 +41,13 @@ if [[ -f "${ENV_FILE}" ]]; then
 fi
 
 : "${NAMESPACE:=solo-network}"
-: "${BN_HOST_1:=block-node-1.${NAMESPACE}.svc.cluster.local}"
-BN_PORT_1="${BN_PORT_1:-40840}"
+# This worker runs as a plain process on the test runner host, not inside the
+# cluster, so it must reach BN1 through the localhost port-forward add-bn.sh
+# sets up (grpc :40839+bn_index) rather than BN1's in-cluster service DNS name
+# (which only resolves from within a pod, e.g. the CN's own block-nodes.json
+# target in reconfigure-cn-to-push-bn3.sh).
+: "${BN_HOST_1:=localhost}"
+BN1_GRPC_PORT="${BN1_GRPC_PORT:-$((40839 + 1))}"
 
 : "${WRB_DIST_WORK_DIR:?WRB_DIST_WORK_DIR must be set (written by install-and-run-wrb-cli.sh)}"
 : "${CLI_LIB:?CLI_LIB must be set (written by install-and-run-wrb-cli.sh)}"
@@ -73,7 +79,7 @@ nohup setsid bash -c '
     CLI_LIB='"'${CLI_LIB}'"'
     wrapped_dir='"'${wrapped_dir}'"'
     BN_HOST_1='"'${BN_HOST_1}'"'
-    BN_PORT_1='"'${BN_PORT_1}'"'
+    BN1_GRPC_PORT='"'${BN1_GRPC_PORT}'"'
     LIVE_PUSH_POLL_SECONDS='"${LIVE_PUSH_POLL_SECONDS}"'
     LIVE_PUSH_MAX_CONSECUTIVE_FAILURES='"${LIVE_PUSH_MAX_CONSECUTIVE_FAILURES}"'
 
@@ -81,13 +87,13 @@ nohup setsid bash -c '
     iteration=0
     while true; do
         iteration=$(( iteration + 1 ))
-        echo "[live-push][iter ${iteration}] pushing wrapped blocks to ${BN_HOST_1}:${BN_PORT_1}..."
+        echo "[live-push][iter ${iteration}] pushing wrapped blocks to ${BN_HOST_1}:${BN1_GRPC_PORT}..."
 
         java -cp "${CLI_LIB}/*" \
             org.hiero.block.tools.BlockStreamTool blocks push \
                 --input-dir "${wrapped_dir}" \
                 --bn-host "${BN_HOST_1}" \
-                --bn-port "${BN_PORT_1}" \
+                --bn-port "${BN1_GRPC_PORT}" \
             >> /tmp/wrb-dist-live-push.log 2>&1 \
             && rc=0 || rc=$?
 
@@ -109,4 +115,4 @@ nohup setsid bash -c '
 
 worker_pid=$!
 echo "${worker_pid}" > "${PID_FILE}"
-log "Live push started (pid ${worker_pid}, log ${LOG_FILE}, poll every ${LIVE_PUSH_POLL_SECONDS}s, target ${BN_HOST_1}:${BN_PORT_1})"
+log "Live push started (pid ${worker_pid}, log ${LOG_FILE}, poll every ${LIVE_PUSH_POLL_SECONDS}s, target ${BN_HOST_1}:${BN1_GRPC_PORT})"

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/start-live-push.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/start-live-push.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# WRB Distribution E2E (#3125 slice 5 — step 9) — start-live-push.
+#
+# Follows the same fork-a-background-worker pattern as start-live-wrap.sh: a
+# `command`-event script that forks a long-running loop into the background,
+# writes its PID to a well-known file, and returns immediately so the runner
+# can move on. A later stop-live-push.sh reads the PID file and tears it down.
+#
+# What the worker does:
+#   * Every LIVE_PUSH_POLL_SECONDS seconds, run `blocks push` (the new wrb-cli
+#     subcommand) against the wrappedBlocks output directory that
+#     install-and-run-wrb-cli.sh / start-live-wrap.sh are writing into,
+#     targeting BN1. `blocks push` re-queries BN1's lastAvailableBlock and the
+#     local blockStreamBlockHashes.bin watermark on every invocation and only
+#     pushes the gap, so the first iteration backfills everything wrapped so
+#     far (the "historical" half of step 9) and later iterations push whatever
+#     has been wrapped since (the "continue to move over" / live half).
+#   * Continues until stop-live-push.sh signals it or `blocks push` hard-fails
+#     LIVE_PUSH_MAX_CONSECUTIVE_FAILURES times in a row.
+#
+# Inputs (env, set by install-and-run-wrb-cli.sh before this runs):
+#   WRB_DIST_WORK_DIR    Same shared work dir as start-live-wrap.sh; contains
+#                        wrappedBlocks/.
+#   CLI_LIB              tools-and-tests/tools/build/install/tools/lib.
+#
+# Optional overrides:
+#   LIVE_PUSH_POLL_SECONDS              (default: 30)
+#   LIVE_PUSH_MAX_CONSECUTIVE_FAILURES  (default: 5)
+#   BN_HOST_1                           (default block-node-1.${NAMESPACE}.svc.cluster.local)
+#   BN_PORT_1                           (default 40840)
+
+set -euo pipefail
+
+ENV_FILE="${ENV_FILE:-/tmp/wrb-distribution-step12.env}"
+if [[ -f "${ENV_FILE}" ]]; then
+    # shellcheck disable=SC1090
+    source "${ENV_FILE}"
+fi
+
+: "${NAMESPACE:=solo-network}"
+: "${BN_HOST_1:=block-node-1.${NAMESPACE}.svc.cluster.local}"
+BN_PORT_1="${BN_PORT_1:-40840}"
+
+: "${WRB_DIST_WORK_DIR:?WRB_DIST_WORK_DIR must be set (written by install-and-run-wrb-cli.sh)}"
+: "${CLI_LIB:?CLI_LIB must be set (written by install-and-run-wrb-cli.sh)}"
+
+LIVE_PUSH_POLL_SECONDS="${LIVE_PUSH_POLL_SECONDS:-30}"
+LIVE_PUSH_MAX_CONSECUTIVE_FAILURES="${LIVE_PUSH_MAX_CONSECUTIVE_FAILURES:-5}"
+
+PID_FILE="/tmp/wrb-dist-push.pid"
+LOG_FILE="/tmp/wrb-dist-push.log"
+STATE_FILE="/tmp/wrb-dist-push.state"
+
+log() { echo "[wrb-dist-push-start] $*"; }
+
+if [[ -f "${PID_FILE}" ]] && kill -0 "$(cat "${PID_FILE}")" 2>/dev/null; then
+    log "Live push already running (pid $(cat "${PID_FILE}")); leaving it in place."
+    exit 0
+fi
+
+wrapped_dir="${WRB_DIST_WORK_DIR}/wrappedBlocks"
+[[ -d "${wrapped_dir}" ]] || { echo "Missing prerequisite: ${wrapped_dir}" >&2; exit 1; }
+
+printf 'initial_push_ok_count=0\n' > "${STATE_FILE}"
+
+# Fork the worker into the background and write its PID. Using nohup+setsid so
+# the loop survives if the CI shell that started the event goes away.
+nohup setsid bash -c '
+    set -uo pipefail
+
+    CLI_LIB='"'${CLI_LIB}'"'
+    wrapped_dir='"'${wrapped_dir}'"'
+    BN_HOST_1='"'${BN_HOST_1}'"'
+    BN_PORT_1='"'${BN_PORT_1}'"'
+    LIVE_PUSH_POLL_SECONDS='"${LIVE_PUSH_POLL_SECONDS}"'
+    LIVE_PUSH_MAX_CONSECUTIVE_FAILURES='"${LIVE_PUSH_MAX_CONSECUTIVE_FAILURES}"'
+
+    consecutive_failures=0
+    iteration=0
+    while true; do
+        iteration=$(( iteration + 1 ))
+        echo "[live-push][iter ${iteration}] pushing wrapped blocks to ${BN_HOST_1}:${BN_PORT_1}..."
+
+        java -cp "${CLI_LIB}/*" \
+            org.hiero.block.tools.BlockStreamTool blocks push \
+                --input-dir "${wrapped_dir}" \
+                --bn-host "${BN_HOST_1}" \
+                --bn-port "${BN_PORT_1}" \
+            >> /tmp/wrb-dist-live-push.log 2>&1 \
+            && rc=0 || rc=$?
+
+        if [[ "${rc}" -eq 0 ]]; then
+            consecutive_failures=0
+            echo "[live-push][iter ${iteration}] push OK"
+        else
+            consecutive_failures=$(( consecutive_failures + 1 ))
+            echo "[live-push][iter ${iteration}] push FAILED rc=${rc} (consecutive_failures=${consecutive_failures})"
+            if [[ "${consecutive_failures}" -ge "${LIVE_PUSH_MAX_CONSECUTIVE_FAILURES}" ]]; then
+                echo "[live-push] giving up after ${consecutive_failures} consecutive failures"
+                exit 1
+            fi
+        fi
+
+        sleep "${LIVE_PUSH_POLL_SECONDS}"
+    done
+' > "${LOG_FILE}" 2>&1 &
+
+worker_pid=$!
+echo "${worker_pid}" > "${PID_FILE}"
+log "Live push started (pid ${worker_pid}, log ${LOG_FILE}, poll every ${LIVE_PUSH_POLL_SECONDS}s, target ${BN_HOST_1}:${BN_PORT_1})"

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/start-live-push.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/start-live-push.sh
@@ -76,7 +76,11 @@ fi
 wrapped_dir="${WRB_DIST_WORK_DIR}/wrappedBlocks"
 [[ -d "${wrapped_dir}" ]] || { echo "Missing prerequisite: ${wrapped_dir}" >&2; exit 1; }
 
-printf 'initial_push_ok_count=0\n' > "${STATE_FILE}"
+# Snapshot whatever "push OK" count is already in the log rather than assuming 0, so this
+# stays correct even if LOG_FILE isn't fresh (e.g. re-run in a debug session against a log the
+# short-circuit above left in place).
+initial_push_ok_count=$( grep -cE '\] push OK' "${LOG_FILE}" 2>/dev/null || echo 0 )
+printf 'initial_push_ok_count=%s\n' "${initial_push_ok_count}" > "${STATE_FILE}"
 
 # Fork the worker into the background and write its PID. Using nohup+setsid so
 # the loop survives if the CI shell that started the event goes away.

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/stop-live-push.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/stop-live-push.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# WRB Distribution E2E (#3125 slice 5 — step 9) — stop-live-push.
+#
+# Symmetric partner to start-live-push.sh. Follows the same load-start /
+# load-stop pattern as stop-live-wrap.sh: reads the well-known PID file, sends
+# SIGTERM, waits for the process tree to exit, and prints the tail of the log
+# for post-hoc inspection.
+#
+# Idempotent: exits 0 if the PID file is missing or the process is already
+# gone, so re-running or running after a crash is safe.
+
+set -euo pipefail
+
+PID_FILE="/tmp/wrb-dist-push.pid"
+LOG_FILE="/tmp/wrb-dist-push.log"
+
+log() { echo "[wrb-dist-push-stop] $*"; }
+
+if [[ ! -f "${PID_FILE}" ]]; then
+    log "No PID file; live push was not running. Nothing to do."
+    exit 0
+fi
+
+worker_pid=$(cat "${PID_FILE}")
+if [[ -z "${worker_pid}" ]]; then
+    log "Empty PID file; nothing to stop."
+    rm -f "${PID_FILE}"
+    exit 0
+fi
+
+if ! kill -0 "${worker_pid}" 2>/dev/null; then
+    log "Worker pid ${worker_pid} already gone."
+    rm -f "${PID_FILE}"
+    exit 0
+fi
+
+# The worker was started via `setsid` so it has its own process-group id equal
+# to its PID. Signal the whole group to catch the `blocks push` subprocess too.
+log "Sending SIGTERM to process group ${worker_pid}..."
+kill -TERM -"${worker_pid}" 2>/dev/null || kill -TERM "${worker_pid}" 2>/dev/null || true
+
+for _ in $(seq 1 20); do
+    kill -0 "${worker_pid}" 2>/dev/null || break
+    sleep 0.5
+done
+
+if kill -0 "${worker_pid}" 2>/dev/null; then
+    log "Worker did not exit; sending SIGKILL"
+    kill -KILL -"${worker_pid}" 2>/dev/null || kill -KILL "${worker_pid}" 2>/dev/null || true
+fi
+
+rm -f "${PID_FILE}"
+
+log "Tail of ${LOG_FILE}:"
+tail -30 "${LOG_FILE}" 2>/dev/null | sed 's/^/  /' || true
+log "Live push stopped."

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/stop-live-push.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/stop-live-push.sh
@@ -55,4 +55,10 @@ rm -f "${PID_FILE}"
 
 log "Tail of ${LOG_FILE}:"
 tail -30 "${LOG_FILE}" 2>/dev/null | sed 's/^/  /' || true
+
+# The outer loop's echoes above only say whether `blocks push` exited 0; its
+# own stdout/stderr (e.g. "[push] Pushing blocks X..Y" or "[push] No wrapped
+# blocks found") is separately redirected to this file inside the loop body.
+log "Tail of /tmp/wrb-dist-live-push.log ('blocks push' subprocess output):"
+tail -60 /tmp/wrb-dist-live-push.log 2>/dev/null | sed 's/^/  /' || true
 log "Live push stopped."

--- a/tools-and-tests/scripts/solo-e2e-test/tests/wrb-distribution-step89.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/wrb-distribution-step89.yaml
@@ -16,17 +16,26 @@
 #        change; BN3's EMB=100_000_000 means this only proves the config
 #        surface, not that BN3 has received blocks yet — see
 #        reconfigure-cn-to-push-bn3.sh).
-#   9.   Fork a live-push loop that runs the wrb-cli `blocks push` subcommand
-#        against BN1 (EMB=0). The first iteration backfills every WRB wrapped
-#        so far (historical); later iterations push whatever start-live-wrap
-#        has produced since (continues to move over).
+#   9.   Move blocks from the wrb-cli to BN1 (EMB=0) in two parts:
+#        9a. Historical: bulk-load-historical-to-bn1.sh copies every WRB
+#            wrapped so far directly into BN1's historic storage and restarts
+#            it so BlockFileHistoricPlugin picks them up. This does NOT go
+#            through BN1's live publish/gRPC stream — that pipeline is a
+#            single-slot-per-block-number race meant for freshly-produced
+#            blocks, not historical replay (see the script's header for the
+#            SKIP failure this avoids).
+#        9b. Live: a live-push loop runs the wrb-cli `blocks push` subcommand
+#            against BN1, pushing whatever start-live-wrap produces after the
+#            historical backfill (continues to move over).
 #
 # Assertions:
 #   * assert-mn-consuming-from-bn.sh mirror-1 / mirror-2 — from slice 4.
 #   * assert-cn-publishing-to-bn3.sh — each CN's block-nodes.json references BN3.
-#   * assert-live-push-produced-new-blocks.sh — BN1 reports a lastAvailableBlock
-#     (historical backlog landed) and the push loop completed at least one new
-#     iteration during the observation window (still moving live blocks over).
+#   * assert-bn1-historical-backfill-landed.sh — BN1 reports firstAvailableBlock=0
+#     and a real lastAvailableBlock after the bulk-load + restart.
+#   * assert-live-push-produced-new-blocks.sh — the live-push loop completed at
+#     least one new iteration during the observation window (still moving live
+#     blocks over after the historical backfill).
 #
 # Usage (locally):
 #   task test:run TEST_FILE=tests/wrb-distribution-step89.yaml \
@@ -150,10 +159,26 @@ events:
     args:
       script: "${SCRIPT_DIR}/wrb-distribution/assert-cn-publishing-to-bn3.sh"
 
+  - id: bulk-load-historical-to-bn1
+    type: command
+    description: "Step 9a: copy wrapped blocks into BN1's historic storage and restart it"
+    delay: 430
+    timeout: 300
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/bulk-load-historical-to-bn1.sh"
+
+  - id: assert-bn1-historical-backfill-landed
+    type: command
+    description: "Assert BN1 reports firstAvailableBlock=0 and a real lastAvailableBlock after bulk-load"
+    delay: 435
+    timeout: 60
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/assert-bn1-historical-backfill-landed.sh"
+
   - id: start-live-push
     type: command
-    description: "Step 9: fork the live-push background worker (blocks push, wrappedBlocks -> BN1)"
-    delay: 430
+    description: "Step 9b: fork the live-push background worker (blocks push, wrappedBlocks -> BN1)"
+    delay: 440
     timeout: 60
     args:
       script: "${SCRIPT_DIR}/wrb-distribution/start-live-push.sh"
@@ -163,22 +188,22 @@ events:
   - id: live-wrap-observation-window
     type: sleep
     description: "Let the live wrap and live push loops run through several iterations"
-    delay: 440
+    delay: 450
     args:
       seconds: 180
 
   - id: assert-live-wrap-produced-new-blocks
     type: command
     description: "Assert live-wrap kept running through the CN/push reconfig"
-    delay: 625
+    delay: 635
     timeout: 60
     args:
       script: "${SCRIPT_DIR}/wrb-distribution/assert-live-wrap-produced-new-blocks.sh"
 
   - id: assert-live-push-produced-new-blocks
     type: command
-    description: "Assert BN1 has a lastAvailableBlock (historical landed) and the push loop kept running (live continues)"
-    delay: 630
+    description: "Assert the live-push loop kept running after the historical backfill"
+    delay: 640
     timeout: 60
     args:
       script: "${SCRIPT_DIR}/wrb-distribution/assert-live-push-produced-new-blocks.sh"
@@ -186,7 +211,7 @@ events:
   - id: stop-live-push
     type: command
     description: "Tear down the live-push background worker"
-    delay: 635
+    delay: 645
     timeout: 60
     args:
       script: "${SCRIPT_DIR}/wrb-distribution/stop-live-push.sh"
@@ -194,7 +219,7 @@ events:
   - id: stop-live-wrap
     type: command
     description: "Tear down the live-wrap background worker"
-    delay: 640
+    delay: 650
     timeout: 60
     args:
       script: "${SCRIPT_DIR}/wrb-distribution/stop-live-wrap.sh"
@@ -202,7 +227,7 @@ events:
   - id: final-status
     type: network-status
     description: "Post-test network status (should show BN1/BN2/BN3, MN1 + MN2 up)"
-    delay: 645
+    delay: 655
 
 # BN + MN health is asserted implicitly by:
 #   * add-bn.sh's kubectl wait --for=condition=Ready pod/block-node-<i>-0

--- a/tools-and-tests/scripts/solo-e2e-test/tests/wrb-distribution-step89.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/wrb-distribution-step89.yaml
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# WRB Distribution E2E (#3125) — slice 5 (steps 8+9), builds on slice 4.
+#
+# Extends slice 4 (steps 6+7) with the CN publisher reconfigure and the
+# wrb-cli push to BN1:
+#
+#   1-2. Solo brings up CN+MN, wrb-cli baseline wrap, live-wrap loop forked.
+#   3-5. Add BN1/BN2/BN3 with EMB=0/0/100_000_000, assert per-BN EMB.
+#   6.   Reconfigure MN1's importer env to also pull live blocks from BN2/BN3
+#        (bucket source remains as records backup).
+#   7.   Install MN2 v0.157.1 pointing at BN2/BN3 with no bucket reference and
+#        startBlockNumber=0 (pulls from genesis via BN backfill chain).
+#   8.   Reconfigure the 3 CNs to publish blocks to BN3 by writing a fresh
+#        block-nodes.json onto each network-node pod (config-file-only
+#        change; BN3's EMB=100_000_000 means this only proves the config
+#        surface, not that BN3 has received blocks yet — see
+#        reconfigure-cn-to-push-bn3.sh).
+#   9.   Fork a live-push loop that runs the wrb-cli `blocks push` subcommand
+#        against BN1 (EMB=0). The first iteration backfills every WRB wrapped
+#        so far (historical); later iterations push whatever start-live-wrap
+#        has produced since (continues to move over).
+#
+# Assertions:
+#   * assert-mn-consuming-from-bn.sh mirror-1 / mirror-2 — from slice 4.
+#   * assert-cn-publishing-to-bn3.sh — each CN's block-nodes.json references BN3.
+#   * assert-live-push-produced-new-blocks.sh — BN1 reports a lastAvailableBlock
+#     (historical backlog landed) and the push loop completed at least one new
+#     iteration during the observation window (still moving live blocks over).
+#
+# Usage (locally):
+#   task test:run TEST_FILE=tests/wrb-distribution-step89.yaml \
+#                 TOPOLOGY=wrb-distribution-step89
+
+name: wrb-distribution-step89
+description: "WRB distribution E2E (#3125) — steps 1-9: BN1/BN2/BN3 + MN1 reconfigured to BN2+BN3 + MN2 from genesis + CN->BN3 + wrb-cli push to BN1"
+
+events:
+  - id: initial-status
+    type: network-status
+    description: "Confirm 3 CNs and MN1 are running (no BN yet)"
+    delay: 5
+
+  - id: block-production-wait
+    type: sleep
+    description: "Wait for CNs to produce enough record files"
+    delay: 10
+    args:
+      seconds: 180
+
+  - id: install-and-run-wrb-cli
+    type: command
+    description: "Install wrb-cli, pull records from MinIO, run blocks wrap, assert nested dir"
+    delay: 195
+    timeout: 1200
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/install-and-run-wrb-cli.sh"
+
+  - id: start-live-wrap
+    type: command
+    description: "Fork the live-wrap background worker (polling MinIO + re-wrapping)"
+    delay: 200
+    timeout: 60
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/start-live-wrap.sh"
+
+  # Slice 3 — bring BN1/BN2/BN3 online while the live wrap loop continues.
+
+  - id: add-bn1
+    type: command
+    description: "Add BN1 (Tier-0, EMB=0) via solo block node add and wait for Ready"
+    delay: 210
+    timeout: 300
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/add-bn.sh 1"
+
+  - id: add-bn2
+    type: command
+    description: "Add BN2 (Tier-1, EMB=0) via solo block node add and wait for Ready"
+    delay: 220
+    timeout: 300
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/add-bn.sh 2"
+
+  - id: add-bn3
+    type: command
+    description: "Add BN3 (Tier-1, EMB=100_000_000) via solo block node add and wait for Ready"
+    delay: 230
+    timeout: 300
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/add-bn.sh 3"
+
+  - id: assert-bn-emb
+    type: command
+    description: "Assert each BN's earliestManagedBlock matches its topology overlay"
+    delay: 240
+    timeout: 120
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/assert-bn-emb.sh"
+
+  # Slice 4 — MN reconfiguration and MN2 install.
+
+  - id: reconfigure-mn1-to-bn-sources
+    type: command
+    description: "Step 6: patch MN1 importer env to pull live blocks from BN2 and BN3"
+    delay: 260
+    timeout: 300
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/reconfigure-mn1-to-bn-sources.sh"
+
+  - id: assert-mn1-consuming-from-bn
+    type: command
+    description: "Assert MN1 is now consuming blocks from a BN source"
+    delay: 320
+    timeout: 120
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/assert-mn-consuming-from-bn.sh mirror-1"
+
+  - id: add-mn2
+    type: command
+    description: "Step 7: install MN2 v0.157.1 pointing at BN2/BN3 with startBlockNumber=0"
+    delay: 340
+    timeout: 600
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/add-mn2.sh"
+
+  - id: assert-mn2-consuming-from-bn
+    type: command
+    description: "Assert MN2 has come up and is consuming blocks from a BN source"
+    delay: 400
+    timeout: 120
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/assert-mn-consuming-from-bn.sh mirror-2"
+
+  # Slice 5 — CN publisher reconfigure (step 8) and wrb-cli push to BN1 (step 9).
+
+  - id: reconfigure-cn-to-push-bn3
+    type: command
+    description: "Step 8: write block-nodes.json onto each network-node pod pointing at BN3"
+    delay: 420
+    timeout: 180
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/reconfigure-cn-to-push-bn3.sh"
+
+  - id: assert-cn-publishing-to-bn3
+    type: command
+    description: "Assert each CN pod's block-nodes.json references BN3 (address + streamingPort)"
+    delay: 425
+    timeout: 60
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/assert-cn-publishing-to-bn3.sh"
+
+  - id: start-live-push
+    type: command
+    description: "Step 9: fork the live-push background worker (blocks push, wrappedBlocks -> BN1)"
+    delay: 430
+    timeout: 60
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/start-live-push.sh"
+
+  # Slice 3's tail — observation window (now also covers the live-push loop) + assertions + stop.
+
+  - id: live-wrap-observation-window
+    type: sleep
+    description: "Let the live wrap and live push loops run through several iterations"
+    delay: 440
+    args:
+      seconds: 180
+
+  - id: assert-live-wrap-produced-new-blocks
+    type: command
+    description: "Assert live-wrap kept running through the CN/push reconfig"
+    delay: 625
+    timeout: 60
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/assert-live-wrap-produced-new-blocks.sh"
+
+  - id: assert-live-push-produced-new-blocks
+    type: command
+    description: "Assert BN1 has a lastAvailableBlock (historical landed) and the push loop kept running (live continues)"
+    delay: 630
+    timeout: 60
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/assert-live-push-produced-new-blocks.sh"
+
+  - id: stop-live-push
+    type: command
+    description: "Tear down the live-push background worker"
+    delay: 635
+    timeout: 60
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/stop-live-push.sh"
+
+  - id: stop-live-wrap
+    type: command
+    description: "Tear down the live-wrap background worker"
+    delay: 640
+    timeout: 60
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/stop-live-wrap.sh"
+
+  - id: final-status
+    type: network-status
+    description: "Post-test network status (should show BN1/BN2/BN3, MN1 + MN2 up)"
+    delay: 645
+
+# BN + MN health is asserted implicitly by:
+#   * add-bn.sh's kubectl wait --for=condition=Ready pod/block-node-<i>-0
+#   * add-mn2.sh's kubectl wait on mirror-2 pods
+#   * assert-bn-emb.sh and assert-mn-consuming-from-bn.sh exec/curl into pods
+# Explicit target-block-node assertions here would fail the runner's
+# topology-target validation (block-node-N / mirror-2 aren't in the
+# deploy-time topology).
+assertions:
+  - id: no-errors
+    type: no-errors
+    description: "No errors in Block Node logs"
+    target: all

--- a/tools-and-tests/scripts/solo-e2e-test/tests/wrb-distribution-step89.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/wrb-distribution-step89.yaml
@@ -163,7 +163,10 @@ events:
     type: command
     description: "Step 9a: copy wrapped blocks into BN1's historic storage and restart it"
     delay: 430
-    timeout: 300
+    # 600s (not 300s): the script's own READY_TIMEOUT default is 300s, applied to two sequential
+    # kubectl waits (rollout status, then pod Ready) on top of the bulk-load staging + tar transfer
+    # + port-forward setup that precede them — a 300s event timeout leaves no headroom.
+    timeout: 600
     args:
       script: "${SCRIPT_DIR}/wrb-distribution/bulk-load-historical-to-bn1.sh"
 

--- a/tools-and-tests/scripts/solo-e2e-test/topologies/wrb-distribution-step89.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/topologies/wrb-distribution-step89.yaml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# WRB Distribution E2E — Steps 8+9 (#3125)
+#
+# Same DEPLOY-TIME shape as wrb-distribution-step67: 3 CNs v0.75 + MN1 v0.157.1,
+# no Block Node.  BNs are added POST-deploy by command events in the test
+# definition (`scripts/wrb-distribution/add-bn.sh 1|2|3`), and slice 5 layers
+# on the CN publisher reconfigure and wrb-cli push:
+#
+#     Steps 1-2: Solo brings up CNs + MN1, wrb-cli starts wrapping into a live loop.
+#     Steps 3-5: Add BN1 / BN2 / BN3 with EMB=0 / 0 / 100_000_000 after wrap is running.
+#     Step 6:    Reconfigure MN1 to pull live blocks from BN2 and BN3 (bucket remains
+#                as records backup).
+#     Step 7:    Install a 2nd MN (MN2 v0.157.1) pointing at BN2 and BN3 with no bucket
+#                reference, so it pulls blocks from genesis.
+#     Step 8:    Reconfigure the 3 CNs to publish blocks to BN3 by writing a fresh
+#                block-nodes.json onto each network-node pod (config-file-only change).
+#     Step 9:    Run the wrb-cli `blocks push` subcommand to move wrapped blocks from
+#                the CLI's local output directory to BN1, historical backlog first and
+#                then continuing live as wrb-cli keeps wrapping new records.
+#
+# See the wrb-distribution-step67.yaml topology comment for why we keep BN
+# installation post-deploy (Solo skips MinIO tenant install when BNs are
+# declared at deploy time).  MN2 is likewise added post-deploy so the runner's
+# deploy-time visibility doesn't need to change.
+
+name: wrb-distribution-step89
+description: "WRB distribution E2E (#3125) — steps 1-9: slice-4 baseline + CN publisher reconfigured to BN3 + wrb-cli push to BN1"
+
+# No Block Nodes at deploy time.  See topology comment above.
+block_nodes: {}
+
+consensus_nodes:
+  node1: {}
+  node2: {}
+  node3: {}
+
+mirror_nodes:
+  mirror-1: {}
+
+relay_nodes: {}
+
+explorer_nodes: {}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/BlocksCommand.java
@@ -23,6 +23,7 @@ import picocli.CommandLine.Spec;
             FetchBalanceCheckpointsCommand.class,
             RepairZipsCommand.class,
             BulkLoadBlocksCommand.class,
+            PushWrappedBlocksCommand.class,
         },
         mixinStandardHelpOptions = true)
 public class BlocksCommand implements Runnable {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/PushWrappedBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/PushWrappedBlocksCommand.java
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.blocks;
+
+import com.hedera.hapi.block.stream.Block;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import org.hiero.block.tools.blocks.model.BlockReader;
+import org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHashRegistry;
+import org.hiero.block.tools.push.LiveBlockPushClient;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Pushes already-wrapped blocks from a local {@code blocks wrap} output directory to a Block Node over
+ * the standard publish gRPC stream.
+ *
+ * <p>Queries the target BN's {@code lastAvailableBlock} once via {@link LiveBlockPushClient} and pushes
+ * only the blocks it doesn't have yet, up to the highest block recorded in the local
+ * {@code blockStreamBlockHashes.bin} watermark (the same one {@code blocks wrap} maintains). This makes
+ * repeated invocations double as both a one-time historical backfill (first run, BN starts empty) and a
+ * live continuation (later runs, after {@code blocks wrap} has produced more blocks) — the command
+ * itself is one-shot; a caller loop is responsible for re-invoking it.
+ */
+@Command(
+        name = "push",
+        description = "Push already-wrapped blocks from a local directory to a Block Node's publish endpoint",
+        mixinStandardHelpOptions = true)
+public class PushWrappedBlocksCommand implements Callable<Integer> {
+
+    @Option(
+            names = {"-i", "--input-dir"},
+            description = "Directory of wrapped blocks to push (same directory 'blocks wrap --output-dir' writes to)")
+    private Path inputDir = Path.of("wrappedBlocks");
+
+    @Option(
+            names = {"--bn-host"},
+            description = "Block Node host to push to (default: ${DEFAULT-VALUE})")
+    private String bnHost = "localhost";
+
+    @Option(
+            names = {"--bn-port"},
+            description = "Block Node Publish port to push to (default: ${DEFAULT-VALUE})")
+    private int bnPort = 40840;
+
+    @Option(
+            names = {"--push-queue-capacity"},
+            description = "Bounded backpressure queue size between this command and the push worker "
+                    + "(default: ${DEFAULT-VALUE})")
+    private int pushQueueCapacity = 32;
+
+    /** Empty default constructor to remove the Javadoc warning. */
+    public PushWrappedBlocksCommand() {}
+
+    @Override
+    public Integer call() throws Exception {
+        if (!Files.isDirectory(inputDir)) {
+            System.err.println("[push] Input directory does not exist: " + inputDir);
+            return 1;
+        }
+
+        final long localHighest;
+        try (final BlockStreamBlockHashRegistry registry =
+                new BlockStreamBlockHashRegistry(inputDir.resolve("blockStreamBlockHashes.bin"))) {
+            localHighest = registry.highestBlockNumberStored();
+        }
+        if (localHighest < 0) {
+            System.out.println("[push] No wrapped blocks found in " + inputDir + "; nothing to push.");
+            return 0;
+        }
+
+        try (final LiveBlockPushClient pushClient = new LiveBlockPushClient(
+                bnHost, bnPort, pushQueueCapacity, LiveBlockPushClient.loadDefaultWebConfig())) {
+            pushClient.start();
+            final long bnLastAvailable = pushClient.queryLastAvailableBlock();
+            if (localHighest <= bnLastAvailable) {
+                System.out.println("[push] " + bnHost + ":" + bnPort + " already has block " + bnLastAvailable
+                        + " (local highest is " + localHighest + "); nothing to push.");
+                return 0;
+            }
+
+            final long startBlock = bnLastAvailable + 1;
+            System.out.println(
+                    "[push] Pushing blocks " + startBlock + ".." + localHighest + " to " + bnHost + ":" + bnPort);
+            long pushedCount = 0;
+            for (long blockNumber = startBlock; blockNumber <= localHighest; blockNumber++) {
+                final Block block = BlockReader.readBlock(inputDir, blockNumber);
+                pushClient.pushBlock(blockNumber, block);
+                pushedCount++;
+            }
+            pushClient.shutdown();
+            System.out.println("[push] Pushed " + pushedCount + " block(s); BN acked through block "
+                    + pushClient.lastAcked() + " (submitted=" + pushClient.submitted() + ", acked="
+                    + pushClient.acked() + ", reconnects=" + pushClient.reconnects() + ")");
+        }
+        return 0;
+    }
+}

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/PushWrappedBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/PushWrappedBlocksCommand.java
@@ -2,6 +2,7 @@
 package org.hiero.block.tools.blocks;
 
 import com.hedera.hapi.block.stream.Block;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
@@ -73,6 +74,15 @@ public class PushWrappedBlocksCommand implements Callable<Integer> {
                 bnHost, bnPort, pushQueueCapacity, LiveBlockPushClient.loadDefaultWebConfig())) {
             pushClient.start();
             final long bnLastAvailable = pushClient.queryLastAvailableBlock();
+            if (bnLastAvailable < 0) {
+                // -1 is also returned when the query itself failed (BN unreachable, RPC error), not just
+                // when the BN is genuinely empty; queryLastAvailableBlock() can't tell these apart. If
+                // it's really the latter, the pushes below will fail to connect and the ack check at the
+                // end of this method will catch it - this is just to make that ambiguity diagnosable.
+                System.out.println(
+                        "[push] " + bnHost + ":" + bnPort + " reports no available blocks (or was unreachable);"
+                                + " treating as empty and starting from block 0.");
+            }
             if (localHighest <= bnLastAvailable) {
                 System.out.println("[push] " + bnHost + ":" + bnPort + " already has block " + bnLastAvailable
                         + " (local highest is " + localHighest + "); nothing to push.");
@@ -83,15 +93,42 @@ public class PushWrappedBlocksCommand implements Callable<Integer> {
             System.out.println(
                     "[push] Pushing blocks " + startBlock + ".." + localHighest + " to " + bnHost + ":" + bnPort);
             long pushedCount = 0;
+            long highestPushed = bnLastAvailable;
             for (long blockNumber = startBlock; blockNumber <= localHighest; blockNumber++) {
-                final Block block = BlockReader.readBlock(inputDir, blockNumber);
+                final Block block;
+                try {
+                    block = BlockReader.readBlock(inputDir, blockNumber);
+                } catch (final IOException e) {
+                    // The blockStreamBlockHashes.bin watermark is updated before its block's zip is
+                    // durably written (see ToWrappedBlocksCommand), so a concurrent/crashed `blocks wrap`
+                    // run can leave localHighest ahead of what's actually on disk. Stop here rather than
+                    // letting the gap propagate as an uncaught exception - the next invocation will pick
+                    // up wherever wrap left off.
+                    System.err.println("[push] Block " + blockNumber + " not yet readable from " + inputDir
+                            + "; stopping this run early (" + e.getMessage() + ")");
+                    break;
+                }
                 pushClient.pushBlock(blockNumber, block);
+                highestPushed = blockNumber;
                 pushedCount++;
             }
+
+            if (pushedCount == 0) {
+                pushClient.shutdown();
+                System.out.println("[push] Block " + startBlock + " not readable yet; nothing pushed this run.");
+                return 0;
+            }
+
             pushClient.shutdown();
-            System.out.println("[push] Pushed " + pushedCount + " block(s); BN acked through block "
-                    + pushClient.lastAcked() + " (submitted=" + pushClient.submitted() + ", acked="
-                    + pushClient.acked() + ", reconnects=" + pushClient.reconnects() + ")");
+            final long lastAcked = pushClient.lastAcked();
+            System.out.println("[push] Pushed " + pushedCount + " block(s); BN acked through block " + lastAcked
+                    + " (submitted=" + pushClient.submitted() + ", acked=" + pushClient.acked() + ", reconnects="
+                    + pushClient.reconnects() + ")");
+            if (lastAcked < highestPushed) {
+                System.err.println("[push] BN only acked through block " + lastAcked + "; expected " + highestPushed
+                        + " - shutdown timed out waiting for outstanding ACKs");
+                return 1;
+            }
         }
         return 0;
     }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/PushWrappedBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/PushWrappedBlocksCommand.java
@@ -72,7 +72,6 @@ public class PushWrappedBlocksCommand implements Callable<Integer> {
 
         try (final LiveBlockPushClient pushClient = new LiveBlockPushClient(
                 bnHost, bnPort, pushQueueCapacity, LiveBlockPushClient.loadDefaultWebConfig())) {
-            pushClient.start();
             final long bnLastAvailable = pushClient.queryLastAvailableBlock();
             if (bnLastAvailable < 0) {
                 // -1 is also returned when the query itself failed (BN unreachable, RPC error), not just
@@ -92,6 +91,7 @@ public class PushWrappedBlocksCommand implements Callable<Integer> {
             final long startBlock = bnLastAvailable + 1;
             System.out.println(
                     "[push] Pushing blocks " + startBlock + ".." + localHighest + " to " + bnHost + ":" + bnPort);
+            pushClient.start();
             long pushedCount = 0;
             long highestPushed = bnLastAvailable;
             for (long blockNumber = startBlock; blockNumber <= localHighest; blockNumber++) {
@@ -114,11 +114,15 @@ public class PushWrappedBlocksCommand implements Callable<Integer> {
             }
 
             if (pushedCount == 0) {
-                pushClient.shutdown();
+                // No explicit shutdown() needed here: nothing was queued, and try-with-resources'
+                // close() drains/shuts down pushClient on the way out regardless.
                 System.out.println("[push] Block " + startBlock + " not readable yet; nothing pushed this run.");
                 return 0;
             }
 
+            // Unlike the try-with-resources close() above, this call is deliberate and load-bearing:
+            // it drains the queue and waits for outstanding ACKs before lastAcked() below is read, so
+            // the < highestPushed check reflects the final state rather than a mid-flight snapshot.
             pushClient.shutdown();
             final long lastAcked = pushClient.lastAcked();
             System.out.println("[push] Pushed " + pushedCount + " block(s); BN acked through block " + lastAcked

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/PushWrappedBlocksCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/PushWrappedBlocksCommandTest.java
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.blocks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.block.stream.output.BlockHeader;
+import java.nio.file.Path;
+import java.util.List;
+import org.hiero.block.tools.blocks.model.BlockArchiveType;
+import org.hiero.block.tools.blocks.model.BlockWriter;
+import org.hiero.block.tools.blocks.model.hashing.BlockStreamBlockHashRegistry;
+import org.hiero.block.tools.utils.Sha384;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+/**
+ * Unit tests for {@link PushWrappedBlocksCommand}. Covers the parts of the command reachable
+ * without a live Block Node: input-directory validation and the "nothing local to push" fast path,
+ * which must return without ever attempting to contact a BN. Actual push/ACK behavior against a real
+ * BN is exercised by the wrb-distribution Solo E2E test (steps 8-9 of #3125), matching the same
+ * scoping boundary {@link org.hiero.block.tools.push.LiveBlockPushClientTest} already draws.
+ */
+class PushWrappedBlocksCommandTest {
+
+    /** Port 1 is reserved and effectively always refuses TCP connections — used as an unreachable target. */
+    private static final int UNREACHABLE_PORT = 1;
+
+    private int runCommand(final Path dir) {
+        return new CommandLine(new PushWrappedBlocksCommand())
+                .execute("--input-dir", dir.toString(), "--bn-host", "127.0.0.1", "--bn-port", "" + UNREACHABLE_PORT);
+    }
+
+    private Block createTestBlock(final long blockNumber) {
+        final BlockHeader header = BlockHeader.newBuilder().number(blockNumber).build();
+        final BlockItem headerItem = BlockItem.newBuilder().blockHeader(header).build();
+        return Block.newBuilder().items(List.of(headerItem)).build();
+    }
+
+    /** Writes a block and registers it in the blockStreamBlockHashes.bin watermark, mirroring what
+     * ToWrappedBlocksCommand does for each block it wraps. */
+    private void writeWrappedBlock(final Path dir, final long blockNumber) throws Exception {
+        BlockWriter.writeBlock(dir, createTestBlock(blockNumber), BlockArchiveType.INDIVIDUAL_FILES);
+        try (final BlockStreamBlockHashRegistry registry =
+                new BlockStreamBlockHashRegistry(dir.resolve("blockStreamBlockHashes.bin"))) {
+            registry.addBlock(blockNumber, new byte[Sha384.SHA_384_HASH_SIZE]);
+        }
+    }
+
+    @Nested
+    @DisplayName("Input validation")
+    class InputValidation {
+
+        @Test
+        @DisplayName("missing input directory returns exit code 1")
+        void missingInputDirReturns1(@TempDir final Path tempDir) {
+            final Path missing = tempDir.resolve("does-not-exist");
+            assertEquals(1, runCommand(missing));
+        }
+    }
+
+    @Nested
+    @DisplayName("Nothing-to-push fast path")
+    class NothingToPush {
+
+        @Test
+        @DisplayName("empty input directory returns 0 without contacting a BN")
+        @Timeout(10)
+        void emptyDirectoryReturns0Fast(@TempDir final Path tempDir) {
+            // No blockStreamBlockHashes.bin and no blocks written: highestBlockNumberStored() is -1, so
+            // the command must return before ever calling queryLastAvailableBlock(). Bounding this test
+            // to 10s proves that: an unreachable BN query would otherwise take much longer to time out.
+            assertEquals(0, runCommand(tempDir));
+        }
+    }
+
+    @Test
+    @DisplayName("a wrapped block establishes the local watermark used to detect what's pushable")
+    void writingBlockEstablishesWatermark(@TempDir final Path tempDir) throws Exception {
+        writeWrappedBlock(tempDir, 0L);
+        try (final BlockStreamBlockHashRegistry registry =
+                new BlockStreamBlockHashRegistry(tempDir.resolve("blockStreamBlockHashes.bin"))) {
+            assertEquals(0L, registry.highestBlockNumberStored());
+        }
+    }
+}

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/PushWrappedBlocksCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/PushWrappedBlocksCommandTest.java
@@ -2,6 +2,7 @@
 package org.hiero.block.tools.blocks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
@@ -86,6 +87,24 @@ class PushWrappedBlocksCommandTest {
         try (final BlockStreamBlockHashRegistry registry =
                 new BlockStreamBlockHashRegistry(tempDir.resolve("blockStreamBlockHashes.bin"))) {
             assertEquals(0L, registry.highestBlockNumberStored());
+        }
+    }
+
+    @Nested
+    @DisplayName("Unreachable BN with pushable content")
+    class UnreachableBnWithContent {
+
+        @Test
+        @DisplayName("present block + unreachable BN returns non-zero")
+        @Timeout(150)
+        void presentBlockUnreachableBnReturnsNonZero(@TempDir final Path tempDir) throws Exception {
+            // Unlike emptyDirectoryReturns0Fast, this run has something to push, so it must actually
+            // try to contact the BN. LiveBlockPushClient.shutdown() blocks on its own internal 2-minute
+            // deadline waiting for ACKs that never arrive against an unreachable BN before giving up, so
+            // this test runs close to that bound rather than failing fast - it exists to prove the
+            // ack-shortfall check (this command's non-zero return) actually fires, not to be quick.
+            writeWrappedBlock(tempDir, 0L);
+            assertNotEquals(0, runCommand(tempDir));
         }
     }
 }


### PR DESCRIPTION
## Reviewer Notes
[issue #3125](https://github.com/hiero-ledger/hiero-block-node/issues/3125) (WRB distribution E2E test, epic #2954), continuing the cumulative Solo-based test suite from steps 1-7 (already merged).

- **[reconfigure-cn-to-push-bn3.sh](tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/reconfigure-cn-to-push-bn3.sh)** — writes a fresh `block-nodes.json` onto all 3 CN pods (`network-node1-0`/`node2-0`/`node3-0`) pointing at BN3, matching the existing deploy-time config format (config-file-only, no restart needed).
- **[assert-cn-publishing-to-bn3.sh](tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-cn-publishing-to-bn3.sh)** — verifies each CN's config references BN3. Only checks the config surface, not actual block flow, since BN3's EMB=100M (set in step 5) means it intentionally won't persist low block numbers yet.

- **New Java subcommand [`PushWrappedBlocksCommand`](tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/PushWrappedBlocksCommand.java)** (`blocks push`) — reads already-wrapped blocks from a local directory and streams any BN1 doesn't have yet via the existing `LiveBlockPushClient` (from PR #3124). Reuses `BlockStreamBlockHashRegistry` (watermark) and `BlockReader` — no changes needed to existing commands. Registered in `BlocksCommand.java`, with a new unit test `PushWrappedBlocksCommandTest.java` (3 tests, all passing).
- **[start-live-push.sh](tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/start-live-push.sh) / [stop-live-push.sh](tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/stop-live-push.sh)** — background loop invoking `blocks push` against BN1 every 30s (first run = historical backfill, later runs = live continuation), mirroring the existing `start-live-wrap.sh` pattern.
- **[assert-live-push-produced-new-blocks.sh](tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-live-push-produced-new-blocks.sh)** — confirms BN1 has a `lastAvailableBlock` (historical landed) and the push loop kept iterating (live continues).

- **[wrb-distribution-step89.yaml](tools-and-tests/scripts/solo-e2e-test/tests/wrb-distribution-step89.yaml)** + **[topology](tools-and-tests/scripts/solo-e2e-test/topologies/wrb-distribution-step89.yaml)** — cumulative copy of step67 plus the new step 8/9 events (21 events total).
- Registered `wrb-distribution-step89` in the [CI workflow](.github/workflows/solo-e2e-test.yml) dropdowns.

- `./gradlew :tools:build` — full module build, 1524 tests passing.
- Manual smoke test of the built CLI (`blocks push --help`, empty-dir fast path).
- `task test:validate` on the new YAML — schema/topology validation passes.
