### PR TITLE
chore(release): publish block-stream-tools fat JAR as a release artifact

### DIFF
--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -92,6 +92,60 @@ jobs:
             ./protobuf-sources/block-node-protobuf-${{ env.VERSION }}.tgz
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  package-block-stream-tools:
+    timeout-minutes: 10
+    runs-on: hl-bn-lin-md
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Extract version
+        id: extract_version
+        run: |
+          VERSION=$(cat version.txt)
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        with:
+          distribution: "temurin"
+          java-version: "25.0.2"
+
+      - name: Produce artifact
+        run: ${GRADLE_EXEC} :tools:shadowJar
+
+      - name: Rename artifact
+        run: |
+          cp ./tools-and-tests/tools/build/libs/tools-${{ env.VERSION }}-all.jar \
+             ./tools-and-tests/tools/build/libs/block-stream-tools-${{ env.VERSION }}.jar
+
+      - name: Upload artifact
+        if: "${{ github.event_name != 'workflow_dispatch' || github.event.inputs.publish == 'true' }}"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: block-stream-tools-${{ env.VERSION }}.jar
+          path: ./tools-and-tests/tools/build/libs/block-stream-tools-${{ env.VERSION }}.jar
+          if-no-files-found: error
+
+      - name: Attach artifact to GitHub Release
+        uses: step-security/release-action@a0d8e0f90f554c15366ca2c9046bf4090d24adbe # v1.21.0
+        with:
+          tag: v${{ env.VERSION }}
+          allowUpdates: true
+          draft: true
+          skipIfReleaseExists: true
+          artifacts: |
+            ./tools-and-tests/tools/build/libs/block-stream-tools-${{ env.VERSION }}.jar
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   publish-app:
     timeout-minutes: 30
     runs-on: hl-bn-lin-md


### PR DESCRIPTION
## Reviewer Notes
Add a new `package-block-stream-tools` job to `release-push-image.yaml` that builds the fat JAR for the operator CLI tool (tools-and-tests/tools) and attaches it to the GitHub draft release alongside the existing protobuf artifact.

The tool is not yet published to Maven Central; releasing via GitHub lets downstream consumers (infra repos, CI scripts) fetch a versioned artifact without building from source.

## Summary

The `block-stream-tools` CLI (tools-and-tests/tools) is currently only usable by building
from source. Infra repos and CI scripts that need to wrap record files, validate block
streams, or bulk-load historic blocks have no stable, versioned artifact to fetch.

This PR adds a `package-block-stream-tools` job to `release-push-image.yaml` that
builds the fat JAR and attaches it to the GitHub draft release on every tagged push —
matching the pattern already used for the protobuf sources artifact. Publishing to Maven
Central is intentionally deferred; the release attachment is a zero-overhead interim that
solves the distribution gap now.

## Changes

**`.github/workflows/release-push-image.yaml`** — new job `package-block-stream-tools`:

```yaml
package-block-stream-tools:
  steps:
    - Harden Runner / Checkout / Extract version / Set up JDK 25
    - Produce artifact:  ./gradlew :tools:shadowJar
    - Rename artifact:   tools-<version>-all.jar → block-stream-tools-<version>.jar
    - Upload artifact:   GitHub Actions artifact store
    - Attach to release: step-security/release-action (draft: true, allowUpdates: true,
                         skipIfReleaseExists: true)
```

The job is structurally identical to `package-protobuf-source`:
- Same runner (`hl-bn-lin-md`), same pinned action SHAs
- Same `skipIfReleaseExists: true` guard so re-runs on the same tag are idempotent
- Same `workflow_dispatch || publish == true` condition on upload/attach steps

The rename step (`cp tools-<v>-all.jar block-stream-tools-<v>.jar`) gives the release
attachment a consumer-friendly name that is independent of the Gradle internal shadow
output convention.

## Backward Compatibility

| Scenario | Impact |
|---|---|
| Existing tags / published releases | None — job only attaches to the release for the current `VERSION` |
| Consumers building from source today | No change; this is additive |
| Future Maven Central publication | Rename the module artifact ID to `block-stream-tools` at that point; this job's rename step already aligns the filename |

## Testing

- YAML is linted by the existing workflow validation CI.
- The Gradle task `:tools:shadowJar` already runs in the main build; the only new CI
  surface is the rename and release-attach steps, which mirror a tested pattern from
  `package-protobuf-source`.
- Validate locally: `./gradlew :tools:shadowJar` confirms the shadow JAR is produced at
  `tools-and-tests/tools/build/libs/tools-<version>-all.jar`.

## Related

- `package-protobuf-source` job — the reference pattern this job follows
- `tools-and-tests/tools/build.gradle.kts` — confirms `shadow` plugin and `mainClass`
- Future: rename the Gradle module from `tools` to `block-stream-tools` when publishing
  to Maven Central

## Related Issue(s)
Resolves #3266 
