### PR TITLE
feat: Files Historic Plugin Sends Persisted Notifications on Staged Blocks and not on Zips

### DIFF
--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
@@ -372,6 +372,8 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
             if (createDirectoryOrFail(verifiedBlockPath)) {
                 if (writeBlockOrFail(block, blockNumber, verifiedBlockPath)) {
                     if (config.stagedBlockNotificationsEnabled()) {
+                        // block is durably staged, but not yet accessible via block(long) until its
+                        // batch is zipped; see FilesHistoricConfig.stagedBlockNotificationsEnabled
                         sendBlockNotification(blockNumber, true, source);
                     }
                 } else {

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPlugin.java
@@ -370,7 +370,11 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
             final Path verifiedBlockPath = BlockFile.nestedDirectoriesBlockFilePath(
                     stagingPath, blockNumber, config.compression(), config.maxFilesPerDir());
             if (createDirectoryOrFail(verifiedBlockPath)) {
-                if (!writeBlockOrFail(block, blockNumber, verifiedBlockPath)) {
+                if (writeBlockOrFail(block, blockNumber, verifiedBlockPath)) {
+                    if (config.stagedBlockNotificationsEnabled()) {
+                        sendBlockNotification(blockNumber, true, source);
+                    }
+                } else {
                     sendBlockNotification(blockNumber, false, source);
                 }
             } else {
@@ -633,9 +637,11 @@ public final class BlockFileHistoricPlugin implements BlockProviderPlugin, Block
                     plugin.totalZipFiles.incrementAndGet();
                     final String successMessage = "Successfully moved batch of blocks[{0} -> {1}] to zip file.";
                     plugin.LOGGER.log(DEBUG, successMessage, batchFirstBlockNumber, batchLastBlockNumber);
-                    // now all the blocks are in the zip file and accessible, send notification
-                    // @todo is this needed? Does anything actually care when a zip file is completed?
-                    plugin.sendBlockNotification(batchLastBlockNumber, true, BlockSource.HISTORY);
+                    // now all the blocks are in the zip file and accessible, send notification, unless
+                    // notifications were already sent per block as each one was staged
+                    if (!plugin.config.stagedBlockNotificationsEnabled()) {
+                        plugin.sendBlockNotification(batchLastBlockNumber, true, BlockSource.HISTORY);
+                    }
                     plugin.cleanup();
                 }
             } catch (final IOException e) {

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
@@ -24,6 +24,10 @@ import org.hiero.block.node.base.Loggable;
  * {@link #powersOfTenPerZipFileContents} is set to 3, then this means that 5 zips will be retained and these zips
  * contain 10^3 blocks, i.e. 5_000 blocks effectively retained. If set to 0 (zero), blocks will be retained
  * indefinitely.
+ * @param stagedBlockNotificationsEnabled whether a Persisted Notification is sent for every block as soon as it
+ * is staged, rather than once per zip batch (using the last block number of the batch). Defaults to disabled, so
+ * that by default only a single Persisted Notification is sent per successfully archived zip batch, matching the
+ * plugin's legacy behavior.
  */
 @ConfigData("files.historic")
 public record FilesHistoricConfig(
@@ -32,6 +36,7 @@ public record FilesHistoricConfig(
         @Loggable @ConfigProperty(defaultValue = "ZSTD") CompressionType compression,
         @Loggable @ConfigProperty(defaultValue = "4") @Min(1) @Max(6) int powersOfTenPerZipFileContents,
         @Loggable @ConfigProperty(defaultValue = "0") @Min(0) long blockRetentionThreshold,
-        @Loggable @ConfigProperty(defaultValue = "3") @Min(1) int maxFilesPerDir) {
+        @Loggable @ConfigProperty(defaultValue = "3") @Min(1) int maxFilesPerDir,
+        @Loggable @ConfigProperty(defaultValue = "false") boolean stagedBlockNotificationsEnabled) {
         // spotless:on
 }

--- a/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
+++ b/block-node/blocks-file-historic/src/main/java/org/hiero/block/node/blocks/files/historic/FilesHistoricConfig.java
@@ -27,7 +27,8 @@ import org.hiero.block.node.base.Loggable;
  * @param stagedBlockNotificationsEnabled whether a Persisted Notification is sent for every block as soon as it
  * is staged, rather than once per zip batch (using the last block number of the batch). Defaults to disabled, so
  * that by default only a single Persisted Notification is sent per successfully archived zip batch, matching the
- * plugin's legacy behavior.
+ * plugin's legacy behavior. Note: a staged block is not retrievable via {@code block(long)} until its batch is
+ * zipped.
  */
 @ConfigData("files.historic")
 public record FilesHistoricConfig(

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
@@ -941,9 +941,11 @@ class BlockFileHistoricPluginTest {
                 blockMessaging.sendBlockVerification(new VerificationNotification(
                         true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
             }
-            // assert that none of the first 10 blocks are zipped yet
+            // assert that none of the first 10 blocks are zipped yet, and thus not yet accessible, even
+            // though they will have already been notified as persisted (persisted != accessible)
             for (int i = 0; i < 10; i++) {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
+                assertThat(toTest.block(i)).isNull();
             }
             // a persistence notification is expected for each staged block, before the batch is even zipped
             final List<PersistedNotification> sentPersistedNotifications =
@@ -959,6 +961,10 @@ class BlockFileHistoricPluginTest {
             // completed zip batch, as each block was already notified individually when staged
             pluginExecutor.executeSerially();
             assertThat(blockMessaging.getSentPersistedNotifications()).hasSize(10);
+            // now that the batch has been zipped, the blocks become accessible
+            for (int i = 0; i < 10; i++) {
+                assertThat(toTest.block(i)).isNotNull();
+            }
         }
 
         /**

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockFileHistoricPluginTest.java
@@ -84,7 +84,7 @@ class BlockFileHistoricPluginTest {
         // use 10 blocks per zip, assuming that the first zip file will contain
         // for example blocks 0-9, the second zip file will contain blocks 10-19
         // also we will not use compression, and we will use the jUnit temp dir
-        testConfig = new FilesHistoricConfig(dataRoot, CompressionType.NONE, 1, 10L, 3);
+        testConfig = new FilesHistoricConfig(dataRoot, CompressionType.NONE, 1, 10L, 3, false);
         // build the plugin using the test environment
         toTest = new BlockFileHistoricPlugin();
         // initialize an in memory historical block facility to use for testing
@@ -104,7 +104,15 @@ class BlockFileHistoricPluginTest {
                 String.valueOf(testConfig.powersOfTenPerZipFileContents()));
         final Entry<String, String> blockRetentionThreshold = Map.entry(
                 "files.historic.blockRetentionThreshold", String.valueOf(testConfig.blockRetentionThreshold()));
-        return Map.ofEntries(rootPath, compression, powersOfTenPerZipFileContents, blockRetentionThreshold);
+        final Entry<String, String> stagedBlockNotificationsEnabled = Map.entry(
+                "files.historic.stagedBlockNotificationsEnabled",
+                String.valueOf(testConfig.stagedBlockNotificationsEnabled()));
+        return Map.ofEntries(
+                rootPath,
+                compression,
+                powersOfTenPerZipFileContents,
+                blockRetentionThreshold,
+                stagedBlockNotificationsEnabled);
     }
 
     /**
@@ -298,7 +306,15 @@ class BlockFileHistoricPluginTest {
                     String.valueOf(testConfig.powersOfTenPerZipFileContents()));
             final Entry<String, String> blockRetentionThreshold = Map.entry(
                     "files.historic.blockRetentionThreshold", String.valueOf(testConfig.blockRetentionThreshold()));
-            return Map.ofEntries(rootPath, compression, powersOfTenPerZipFileContents, blockRetentionThreshold);
+            final Entry<String, String> stagedBlockNotificationsEnabled = Map.entry(
+                    "files.historic.stagedBlockNotificationsEnabled",
+                    String.valueOf(testConfig.stagedBlockNotificationsEnabled()));
+            return Map.ofEntries(
+                    rootPath,
+                    compression,
+                    powersOfTenPerZipFileContents,
+                    blockRetentionThreshold,
+                    stagedBlockNotificationsEnabled);
         }
 
         /**
@@ -872,13 +888,51 @@ class BlockFileHistoricPluginTest {
         }
 
         /**
-         * This test aims to verify that the plugin will proceed to send a
-         * {@link PersistedNotification} with the correct range of blocks
-         * after a successful archival.
+         * This test aims to verify that, with the default configuration, the plugin falls back to its
+         * legacy behavior of sending a single {@link PersistedNotification} per zip batch, using the last
+         * block number of the batch, once the archival completes.
          */
         @Test
-        @DisplayName("Test happy path zip successful notification sent")
+        @DisplayName("Test happy path zip successful notification sent per completed batch")
         void testZipRangeHappyPathNotificationSent() throws IOException {
+            // generate first 10 blocks from numbers 0-9 and add them to the
+            // test historical block facility
+            for (int i = 0; i < 10; i++) {
+                final BlockUnparsed block =
+                        TestBlockBuilder.generateBlockWithNumber(i).blockUnparsed();
+                blockMessaging.sendBlockVerification(new VerificationNotification(
+                        true, null, i, Bytes.EMPTY, new BlockUnparsed(block.blockItems()), BlockSource.PUBLISHER));
+            }
+            // assert that none of the first 10 blocks are zipped yet, and no notification was sent yet
+            for (int i = 0; i < 10; i++) {
+                assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
+            }
+            assertThat(blockMessaging.getSentPersistedNotifications()).isEmpty();
+            // execute serially to ensure all tasks are completed
+            pluginExecutor.executeSerially();
+            // assert that a single persistence notification was sent for the whole batch, using the last
+            // block number of the batch
+            final List<PersistedNotification> sentPersistedNotifications =
+                    blockMessaging.getSentPersistedNotifications();
+            assertThat(sentPersistedNotifications)
+                    .isNotEmpty()
+                    .hasSize(1)
+                    .element(0)
+                    .returns(true, PersistedNotification::succeeded)
+                    .returns(9L, PersistedNotification::blockNumber)
+                    .returns(toTest.defaultPriority(), PersistedNotification::blockProviderPriority);
+        }
+
+        /**
+         * This test aims to verify that when {@code stagedBlockNotificationsEnabled} is enabled, the
+         * plugin sends a {@link PersistedNotification} for every block as soon as it is staged, rather than
+         * waiting for the whole batch to be zipped.
+         */
+        @Test
+        @DisplayName("Test happy path zip successful notification sent per staged block when enabled")
+        void testZipRangeHappyPathNotificationSentPerStagedBlock() throws IOException {
+            testConfig = new FilesHistoricConfig(dataRoot, CompressionType.NONE, 1, 10L, 3, true);
+            start(toTest, testHistoricalBlockFacility, getConfigOverrides());
             // generate first 10 blocks from numbers 0-9 and add them to the
             // test historical block facility
             for (int i = 0; i < 10; i++) {
@@ -891,19 +945,20 @@ class BlockFileHistoricPluginTest {
             for (int i = 0; i < 10; i++) {
                 assertThat(BlockPath.computeExistingBlockPath(testConfig, i)).isNull();
             }
-            // execute serially to ensure all tasks are completed
-            pluginExecutor.executeSerially();
-            // assert that a persistence notification was sent, we expect 2
-            // notifications total, one in the beginning of this test and one
-            // sent by the plugin itself
+            // a persistence notification is expected for each staged block, before the batch is even zipped
             final List<PersistedNotification> sentPersistedNotifications =
                     blockMessaging.getSentPersistedNotifications();
-            assertThat(sentPersistedNotifications)
-                    .isNotEmpty()
-                    .hasSize(1)
-                    .element(0)
-                    .returns(true, PersistedNotification::succeeded)
-                    .returns(toTest.defaultPriority(), PersistedNotification::blockProviderPriority);
+            assertThat(sentPersistedNotifications).hasSize(10);
+            for (int i = 0; i < 10; i++) {
+                assertThat(sentPersistedNotifications.get(i))
+                        .returns(true, PersistedNotification::succeeded)
+                        .returns((long) i, PersistedNotification::blockNumber)
+                        .returns(toTest.defaultPriority(), PersistedNotification::blockProviderPriority);
+            }
+            // execute serially to ensure all tasks are completed, no additional notification is sent for the
+            // completed zip batch, as each block was already notified individually when staged
+            pluginExecutor.executeSerially();
+            assertThat(blockMessaging.getSentPersistedNotifications()).hasSize(10);
         }
 
         /**
@@ -1136,8 +1191,11 @@ class BlockFileHistoricPluginTest {
         }
 
         /**
-         * This test aims to verify that the plugin will not send any
-         * {@link PersistedNotification} for a zip that failed exceptionally.
+         * This test aims to verify that, with the default configuration (staged block notifications
+         * disabled), the plugin will not send any {@link PersistedNotification} for a zip that failed
+         * exceptionally. Individual blocks are still staged successfully, so this assertion only holds when
+         * per-staged-block notifications are disabled; otherwise each block would receive its own success
+         * notification when it was staged, independent of the later zip failure.
          */
         @Test
         @DisplayName("Test exception during move no persistence notification sent")
@@ -1273,7 +1331,7 @@ class BlockFileHistoricPluginTest {
         @DisplayName("Test retention policy threshold disabled")
         void testRetentionPolicyThresholdDisabled() throws IOException {
             // change the retention policy to be disabled
-            testConfig = new FilesHistoricConfig(dataRoot, CompressionType.NONE, 1, 0L, 3);
+            testConfig = new FilesHistoricConfig(dataRoot, CompressionType.NONE, 1, 0L, 3, false);
             // override the config in the plugin
             start(toTest, testHistoricalBlockFacility, getConfigOverrides());
             // generate first 150 blocks from numbers 0-149 and add them to the
@@ -1426,7 +1484,7 @@ class BlockFileHistoricPluginTest {
             // Configure plugin with allowZippingMultipleTimes = true (last parameter).
             // This special configuration allows the same batch to be re-archived when
             // duplicate notifications arrive, unlike the default idempotent behavior.
-            testConfig = new FilesHistoricConfig(dataRoot, CompressionType.NONE, 1, 10L, 3);
+            testConfig = new FilesHistoricConfig(dataRoot, CompressionType.NONE, 1, 10L, 3, false);
             start(toTest, testHistoricalBlockFacility, getConfigOverrides());
 
             // Send the first set of block verification notifications (blocks 0-9).
@@ -1585,14 +1643,22 @@ class BlockFileHistoricPluginTest {
                     String.valueOf(config.powersOfTenPerZipFileContents()));
             final Entry<String, String> blockRetentionThreshold = Map.entry(
                     "files.historic.blockRetentionThreshold", String.valueOf(config.blockRetentionThreshold()));
-            return Map.ofEntries(rootPath, compression, powersOfTenPerZipFileContents, blockRetentionThreshold);
+            final Entry<String, String> stagedBlockNotificationsEnabled = Map.entry(
+                    "files.historic.stagedBlockNotificationsEnabled",
+                    String.valueOf(config.stagedBlockNotificationsEnabled()));
+            return Map.ofEntries(
+                    rootPath,
+                    compression,
+                    powersOfTenPerZipFileContents,
+                    blockRetentionThreshold,
+                    stagedBlockNotificationsEnabled);
         }
 
         @Test
         @DisplayName("init moves corrupted zip file without shutting down")
         void initMovesCorruptedZipWithoutShutdown() throws IOException {
             final Path corruptedRoot = dataRoot.resolve("corrupted-zip-root");
-            testConfig = new FilesHistoricConfig(corruptedRoot, CompressionType.NONE, 1, 10L, 3);
+            testConfig = new FilesHistoricConfig(corruptedRoot, CompressionType.NONE, 1, 10L, 3, false);
 
             final BlockPath corruptedZipLocation = BlockPath.computeBlockPath(testConfig, 0L);
             Files.createDirectories(corruptedZipLocation.dirPath());
@@ -1618,7 +1684,8 @@ class BlockFileHistoricPluginTest {
             final Path mismatchRoot = dataRoot.resolve("config-mismatch-root");
 
             // Phase 1: Start with powersOfTenPerZipFileContents = 1, which creates archives like "00.zip" (2 chars)
-            FilesHistoricConfig initialConfig = new FilesHistoricConfig(mismatchRoot, CompressionType.NONE, 1, 10L, 3);
+            FilesHistoricConfig initialConfig =
+                    new FilesHistoricConfig(mismatchRoot, CompressionType.NONE, 1, 10L, 3, false);
             final BlockFileHistoricPlugin firstPlugin = new BlockFileHistoricPlugin();
             start(firstPlugin, regressionHistoricalBlockFacility, buildConfigOverrides(initialConfig));
 
@@ -1641,7 +1708,7 @@ class BlockFileHistoricPluginTest {
             // Phase 2: Restart the plugin with the same powersOfTenPerZipFileContents to make sure the
             // happy path works
 
-            testConfig = new FilesHistoricConfig(mismatchRoot, CompressionType.NONE, 1, 10L, 3);
+            testConfig = new FilesHistoricConfig(mismatchRoot, CompressionType.NONE, 1, 10L, 3, false);
             final BlockFileHistoricPlugin secondPlugin = new BlockFileHistoricPlugin();
             start(secondPlugin, regressionHistoricalBlockFacility, buildConfigOverrides(testConfig));
 
@@ -1651,7 +1718,7 @@ class BlockFileHistoricPluginTest {
 
             // Phase 3: Create plugin with different powersOfTenPerZipFileContents = 3
             // This expects archives like "0000.zip" (4 chars) but will find "00.zip" (2 chars)
-            testConfig = new FilesHistoricConfig(mismatchRoot, CompressionType.NONE, 3, 10L, 3);
+            testConfig = new FilesHistoricConfig(mismatchRoot, CompressionType.NONE, 3, 10L, 3, false);
             final BlockFileHistoricPlugin thirdPlugin = new BlockFileHistoricPlugin();
             start(thirdPlugin, regressionHistoricalBlockFacility, buildConfigOverrides(testConfig));
 

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/BlockPathTest.java
@@ -234,7 +234,7 @@ class BlockPathTest {
             final Path expectedDirPath = expectedZipFilePath.getParent();
             // create the config to use for the test, resolve paths with jimfs
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3);
+                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3, false);
             final BlockPath actual = BlockPath.computeBlockPath(testConfig, blockNumber);
             assertThat(actual)
                     .isNotNull()
@@ -270,7 +270,7 @@ class BlockPathTest {
             // create the config to use for the test, resolve paths temp dir as jimfs does not support
             // the File abstraction
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3);
+                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3, false);
             // create the zip file and directory and add entry
             createZipAndAddEntry(expectedDirPath, expectedZipFilePath, expectedBlockFileName);
             // call
@@ -318,7 +318,7 @@ class BlockPathTest {
             // create the config to use for the test, resolve paths temp dir as jimfs does not support
             // the File abstraction
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, differentCompressionType, digitsPerZipFileContents, 0L, 3);
+                    new FilesHistoricConfig(dataRoot, differentCompressionType, digitsPerZipFileContents, 0L, 3, false);
             // create the zip file and directory and add entry
             createZipAndAddEntry(expectedDirPath, expectedZipFilePath, expectedBlockFileName);
             // call
@@ -349,7 +349,7 @@ class BlockPathTest {
             final CompressionType expectedCompressionType = argAccessor.get(4, CompressionType.class);
             final int digitsPerZipFileContents = argAccessor.getInteger(5);
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3);
+                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3, false);
             // call
             final BlockPath actual = BlockPath.computeExistingBlockPath(testConfig, blockNumber);
             assertThat(actual).isNull();
@@ -377,7 +377,7 @@ class BlockPathTest {
             final Path expectedDirPath = expectedZipFilePath.getParent();
             // create the config to use for the test
             final FilesHistoricConfig testConfig =
-                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3);
+                    new FilesHistoricConfig(dataRoot, expectedCompressionType, digitsPerZipFileContents, 0L, 3, false);
             // create the zip file and directory and add entry
             createZipAndAddEntry(expectedDirPath, expectedZipFilePath, "nonexistent.blk.zstd");
             // call
@@ -428,7 +428,7 @@ class BlockPathTest {
                 for (int configIdx = 0; configIdx < compressionTypes.length; configIdx++) {
                     // Use config with compression type j (matching the file extension)
                     final BlockPath blockPathSameConfigCompression = BlockPath.computeExistingBlockPath(
-                            new FilesHistoricConfig(dataRoot, compressionTypes[configIdx], 4, 0L, 3),
+                            new FilesHistoricConfig(dataRoot, compressionTypes[configIdx], 4, 0L, 3, false),
                             compressionIdx + configIdx);
                     // Verify that the actual compression type i is detected from magic bytes or lack thereof
                     assertThat(blockPathSameConfigCompression)

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockAccessorTest.java
@@ -492,7 +492,8 @@ class ZipBlockAccessorTest {
                 compressionType,
                 localDefaultConfig.powersOfTenPerZipFileContents(),
                 localDefaultConfig.blockRetentionThreshold(),
-                localDefaultConfig.maxFilesPerDir());
+                localDefaultConfig.maxFilesPerDir(),
+                localDefaultConfig.stagedBlockNotificationsEnabled());
     }
 
     private FilesHistoricConfig getDefaultConfiguration() {

--- a/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
+++ b/block-node/blocks-file-historic/src/test/java/org/hiero/block/node/blocks/files/historic/ZipBlockArchiveTest.java
@@ -714,7 +714,7 @@ class ZipBlockArchiveTest {
     private FilesHistoricConfig createTestConfiguration(
             final Path blocksRoot, final int powersOfTenPerZipFileContents) {
         // for simplicity let's use no compression
-        return new FilesHistoricConfig(blocksRoot, CompressionType.NONE, powersOfTenPerZipFileContents, 0L, 3);
+        return new FilesHistoricConfig(blocksRoot, CompressionType.NONE, powersOfTenPerZipFileContents, 0L, 3, false);
     }
 
     /**

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -194,13 +194,14 @@ for the JSON schema.
 
 ### Files Historic Plugin Configuration
 
-| ENV Variable                                       | Description                                                                 |                             Default |
-|:---------------------------------------------------|:----------------------------------------------------------------------------|------------------------------------:|
-| FILES_HISTORIC_ROOT_PATH                           | Root path for saving historic blocks.                                       | /opt/hiero/block-node/data/historic |
-| FILES_HISTORIC_COMPRESSION                         | Compression type (e.g., ZSTD).                                              |                                ZSTD |
-| FILES_HISTORIC_POWERS_OF_TEN_PER_ZIP_FILE_CONTENTS | Files per zip in powers of ten (1=10, 2=100, …, 6=1,000,000).               |                                   4 |
-| FILES_HISTORIC_BLOCK_RETENTION_THRESHOLD           | Number of zips to retain. 0 means keep indefinitely.                        |                                   0 |
-| FILES_HISTORIC_MAX_FILES_PER_DIR                   | Max files per directory, as a number of digits, to avoid filesystem issues. |                                   3 |
+| ENV Variable                                       | Description                                                                                                     |                             Default |
+|:---------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|------------------------------------:|
+| FILES_HISTORIC_ROOT_PATH                           | Root path for saving historic blocks.                                                                           | /opt/hiero/block-node/data/historic |
+| FILES_HISTORIC_COMPRESSION                         | Compression type (e.g., ZSTD).                                                                                  |                                ZSTD |
+| FILES_HISTORIC_POWERS_OF_TEN_PER_ZIP_FILE_CONTENTS | Files per zip in powers of ten (1=10, 2=100, …, 6=1,000,000).                                                   |                                   4 |
+| FILES_HISTORIC_BLOCK_RETENTION_THRESHOLD           | Number of zips to retain. 0 means keep indefinitely.                                                            |                                   0 |
+| FILES_HISTORIC_MAX_FILES_PER_DIR                   | Max files per directory, as a number of digits, to avoid filesystem issues.                                     |                                   3 |
+| FILES_HISTORIC_STAGED_BLOCK_NOTIFICATIONS_ENABLED  | Send a Persisted Notification for every block as soon as it is staged, instead of once per completed zip batch. |                               false |
 
 > **Retention arithmetic:** Effective blocks retained = `FILES_HISTORIC_BLOCK_RETENTION_THRESHOLD` × 10^`FILES_HISTORIC_POWERS_OF_TEN_PER_ZIP_FILE_CONTENTS`.
 > Example: `FILES_HISTORIC_BLOCK_RETENTION_THRESHOLD=5` with `FILES_HISTORIC_POWERS_OF_TEN_PER_ZIP_FILE_CONTENTS=4` retains 50,000 blocks.

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -206,6 +206,10 @@ for the JSON schema.
 > **Retention arithmetic:** Effective blocks retained = `FILES_HISTORIC_BLOCK_RETENTION_THRESHOLD` × 10^`FILES_HISTORIC_POWERS_OF_TEN_PER_ZIP_FILE_CONTENTS`.
 > Example: `FILES_HISTORIC_BLOCK_RETENTION_THRESHOLD=5` with `FILES_HISTORIC_POWERS_OF_TEN_PER_ZIP_FILE_CONTENTS=4` retains 50,000 blocks.
 > A value of `0` for `FILES_HISTORIC_BLOCK_RETENTION_THRESHOLD` keeps blocks indefinitely.
+>
+> **Staged notifications caveat:** with `FILES_HISTORIC_STAGED_BLOCK_NOTIFICATIONS_ENABLED=true`, a block is not
+> retrievable from this plugin until its batch is zipped, so the Persisted Notification can arrive before the
+> block is actually accessible.
 
 ### Files Recent Plugin Configuration
 


### PR DESCRIPTION
## Reviewer Notes

### New `stagedBlockNotificationsEnabled` config flag on `FilesHistoricConfig`

Adds a `stagedBlockNotificationsEnabled` boolean (default `false`) that controls whether `BlockFileHistoricPlugin` fires a `PersistedNotification` for every block as soon as it is staged to disk, instead of the legacy behavior of one notification per completed zip batch. Default is disabled so existing deployments see no behavior change.

### `BlockFileHistoricPlugin` wiring

In the staging path, a successful `writeBlockOrFail` now sends a per-block success notification when the flag is on (previously nothing was sent on the success path here, only on failure). In the zip-completion path, the batch-level notification is now skipped entirely when per-staged-block notifications are enabled, since each block in the batch was already notified individually as it was staged.

## Related Issue(s)

Closes #2276