### PR TITLE
fix(ci): run git config inside hiero-docs working directory

### DIFF
--- a/.github/workflows/sync-docs-to-gitbook.yaml
+++ b/.github/workflows/sync-docs-to-gitbook.yaml
@@ -48,24 +48,32 @@ jobs:
         id: gpg_importer
         uses: step-security/ghaction-import-gpg@c0b4a334b9b72bfaaebec86ef022a78a5b17f828 # v7.0.0
         with:
-          git_commit_gpgsign: true
-          git_tag_gpgsign: true
-          git_user_signingkey: true
           gpg_private_key: ${{ secrets.GPG_KEY_CONTENTS }}
           passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
 
-      - name: Open PR with GPG-signed commit
-        uses: step-security/create-pull-request@50c103da2b9ca12cd5bc013fc6931051a5aa872b # v8.1.1
-        with:
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
-          path: hiero-docs
-          branch: sync/block-node-docs
-          base: master
-          commit-message: "chore: sync block-node docs from hiero-block-node@${{ github.sha }}"
-          committer: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
-          author: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
-          signoff: true
-          title: "chore: sync block-node docs from hiero-block-node"
-          body: |
-            Automated sync of `block-node/` docs from hiero-block-node@${{ github.sha }}
-            by the sync-docs-to-gitbook workflow.
+      - name: Commit and open PR
+        working-directory: hiero-docs
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: |
+          git config user.name "${{ steps.gpg_importer.outputs.name }}"
+          git config user.email "${{ steps.gpg_importer.outputs.email }}"
+          git config user.signingkey "${{ steps.gpg_importer.outputs.fingerprint }}"
+          git config commit.gpgsign true
+          git add block-node/
+          if git diff --staged --quiet; then
+            echo "No block-node doc changes to sync."
+            exit 0
+          fi
+          BRANCH="sync/block-node-docs"
+          git checkout -b "$BRANCH"
+          git commit -S --signoff -m "chore: sync block-node docs from hiero-block-node@${GITHUB_SHA::7}"
+          git push --force --set-upstream origin "$BRANCH"
+          if gh pr view "$BRANCH" --repo hiero-ledger/hiero-docs >/dev/null 2>&1; then
+            echo "Sync PR already open for $BRANCH; it now reflects the latest docs."
+          else
+            gh pr create --repo hiero-ledger/hiero-docs \
+              --base master --head "$BRANCH" \
+              --title "chore: sync block-node docs from hiero-block-node" \
+              --body "Automated sync of \`block-node/\` docs from hiero-block-node@${GITHUB_SHA::7} by the sync-docs-to-gitbook workflow."
+          fi


### PR DESCRIPTION
## Reviewer Notes

The Import GPG Key action's git_commit_gpgsign, git_tag_gpgsign, and git_user_signingkey inputs internally run `git config` commands. With two repos checked out as subdirectories (block-node/ and hiero-docs/), the runner workspace root is not a git repo, causing `fatal: not in a git directory` on every sync run since #3156 merged.

Fix: remove the git_* inputs from the action (key import only) and configure git manually in a `run:` step scoped to `working-directory: hiero-docs`. GPG signing is preserved via `git commit -S`.
