### PR TITLE
fix(ci): use gh pr list --state open to avoid false-positive on closed sync PR

### DIFF
--- a/.github/workflows/sync-docs-to-gitbook.yaml
+++ b/.github/workflows/sync-docs-to-gitbook.yaml
@@ -69,7 +69,8 @@ jobs:
           git checkout -b "$BRANCH"
           git commit -S --signoff -m "chore: sync block-node docs from hiero-block-node@${GITHUB_SHA::7}"
           git push --force --set-upstream origin "$BRANCH"
-          if gh pr view "$BRANCH" --repo hiero-ledger/hiero-docs >/dev/null 2>&1; then
+          OPEN_PRS=$(gh pr list --repo hiero-ledger/hiero-docs --head "$BRANCH" --state open --json number --jq 'length')
+          if [ "$OPEN_PRS" -gt 0 ]; then
             echo "Sync PR already open for $BRANCH; it now reflects the latest docs."
           else
             gh pr create --repo hiero-ledger/hiero-docs \


### PR DESCRIPTION

## Reviewer Notes
Follow-up PR for https://github.com/hiero-ledger/hiero-block-node/pull/3277 to avoid a false positive.
