### PR TITLE
feat(solo-e2e): custom Solo fork/branch builds, refreshed default versions, and WRAPS support on CN >= v0.76

### DIFF
--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -191,16 +191,12 @@ jobs:
           MATRIX_COUNT=$(echo "${MATRIX_JSON}" | jq '. | length')
           echo "matrix_count=${MATRIX_COUNT}" >> "$GITHUB_OUTPUT"
 
-          # MN pinned: v0.157.0+ (HIP-1137) broke Solo CLI's block node env var injection.
-          # Track https://github.com/hiero-ledger/solo/issues/4863 to unpin MN_PINNED.
-          MN_PINNED="v0.156.0"
-
           # Configure versions based on run type and trigger
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
             # TAG release: use the tag for BN, latest GA for CN/MN
             BN_VERSION="${{ github.ref_name }}"
             CN_VERSION="latest"
-            MN_VERSION="${MN_PINNED}"
+            MN_VERSION="latest"
           elif [[ "${RUN_TYPE}" == "rc" ]]; then
             # RC run: use SNAPSHOT BN against RC versions of CN/MN
             BN_VERSION="${{ inputs.block-node-version }}"
@@ -208,7 +204,7 @@ jobs:
             CN_VERSION="${{ inputs.consensus-node-version }}"
             CN_VERSION="${CN_VERSION:-rc}"
             MN_VERSION="${{ inputs.mirror-node-version }}"
-            MN_VERSION="${MN_VERSION:-${MN_PINNED}}"
+            MN_VERSION="${MN_VERSION:-latest}"
           elif [[ -n "${{ inputs.block-node-version }}" ]]; then
             # Manual override with explicit versions
             BN_VERSION="${{ inputs.block-node-version }}"
@@ -220,14 +216,14 @@ jobs:
             # Scheduled runs (daily/weekend): use SNAPSHOT BN against GA stable CN/MN
             BN_VERSION="main"
             CN_VERSION="latest"
-            MN_VERSION="${MN_PINNED}"
+            MN_VERSION="latest"
           fi
 
           # Solo CLI version: use input if provided, otherwise default to latest stable
           if [[ -n "${{ inputs.solo-version }}" ]]; then
             SOLO_VERSION="${{ inputs.solo-version }}"
           else
-            SOLO_VERSION="0.79.0"
+            SOLO_VERSION="0.83.0"
           fi
 
           # Relay version: use input if provided, otherwise default to latest

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -39,6 +39,18 @@ on:
         description: "Solo CLI Version"
         type: string
         default: "0.79.0"
+      solo-source:
+        description: "Solo install source: 'npm' or 'git' (build an approved fork/branch)"
+        type: string
+        default: "npm"
+      solo-git-repo:
+        description: "Solo fork (owner/repo) when solo-source=git; must be an approved repo"
+        type: string
+        default: ""
+      solo-git-ref:
+        description: "Solo branch/tag/SHA to build when solo-source=git"
+        type: string
+        default: ""
       tss-enabled:
         description: "Enable TSS/WRAPS on consensus nodes"
         type: boolean
@@ -136,6 +148,22 @@ on:
         description: "Solo CLI Version"
         required: false
         default: "0.79.0"
+      solo-source:
+        description: "Solo install source"
+        required: false
+        default: "npm"
+        type: choice
+        options:
+          - npm
+          - git
+      solo-git-repo:
+        description: "Solo fork (owner/repo) when solo-source=git; must be an approved repo (hiero-ledger/solo, hashgraph/solo, AlfredoG87/solo)"
+        required: false
+        default: ""
+      solo-git-ref:
+        description: "Solo branch/tag/SHA to build when solo-source=git"
+        required: false
+        default: ""
       tss-enabled:
         description: "Enable TSS (Threshold Signature Scheme) on consensus nodes"
         required: false
@@ -203,6 +231,9 @@ env:
   CLUSTER_REFERENCE: "kind-solo-cluster"
   # Solo CLI environment variables (these are read directly by Solo from the process env)
   MIRROR_NODE_PINGER_TPS: ${{ inputs.mirror-node-pinger-tps }}
+  # Read by solo-setup-cluster.sh / solo-deploy-network.sh to skip the minimum-version
+  # check when a custom fork/branch build is in use.
+  SOLO_SOURCE: ${{ inputs.solo-source }}
 
 jobs:
   solo-test-deploy:
@@ -281,11 +312,16 @@ jobs:
           RELAY_RESOLVED=$(echo "$OUTPUT" | grep "^relay_version=" | cut -d= -f2)
           echo "RELAY_VERSION=${RELAY_RESOLVED}" >> "${GITHUB_ENV}"
 
-      # Install Solo CLI
-      - name: Install Solo CLI via npm
+      # Install Solo CLI (npm by default, or build an approved fork/branch when solo-source=git)
+      - name: Install Solo CLI
         id: solo
+        env:
+          SOLO_SOURCE: ${{ inputs.solo-source }}
+          SOLO_VERSION: ${{ inputs.solo-version }}
+          SOLO_GIT_REPO: ${{ inputs.solo-git-repo }}
+          SOLO_GIT_REF: ${{ inputs.solo-git-ref }}
         run: |
-          npm i @hashgraph/solo@${{ inputs.solo-version }} -g
+          ./tools-and-tests/scripts/solo-e2e-test/scripts/solo-install.sh
           # Extract version number from solo output (handles various output formats)
           SOLO_INSTALLED=$(solo --version 2>/dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown")
           echo "Solo version: ${SOLO_INSTALLED}"
@@ -379,7 +415,7 @@ jobs:
             echo "| Mirror Node | \`${{ inputs.mirror-node-version || 'latest' }}\` | \`${{ steps.versions.outputs.mn_version }}\` |"
             echo "| Block Node | \`${{ inputs.block-node-version || 'latest' }}\` | \`${{ steps.versions.outputs.bn_version }}\` |"
             echo "| Relay | \`${{ inputs.relay-version || 'latest' }}\` | \`${{ steps.versions.outputs.relay_version }}\` |"
-            echo "| Solo CLI | \`${{ inputs.solo-version || 'latest' }}\` | \`${{ steps.solo.outputs.solo_version }}\` |"
+            echo "| Solo CLI | \`${{ inputs.solo-source == 'git' && format('git:{0}@{1}', inputs.solo-git-repo, inputs.solo-git-ref) || (inputs.solo-version || 'latest') }}\` | \`${{ steps.solo.outputs.solo_version }}\` |"
             echo "| JS-SDK | \`${{ inputs.js-sdk-version || 'v2.83.0' }}\` | |"
             echo "| TSS Enabled | | \`${{ inputs.tss-enabled }}\` |"
             echo ""

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -12,17 +12,15 @@ on:
       block-node-version:
         description: "Block Node version ('latest', 'rc', 'main', or tag like 'v0.21.2')"
         type: string
-        default: "latest"
+        default: "main"
       consensus-node-version:
         description: "Consensus Node version ('latest', 'rc', or tag like 'v0.68.6')"
         type: string
-        default: "latest"
+        default: "rc"
       mirror-node-version:
-        # Pinned: MN v0.157.0+ (HIP-1137) broke Solo CLI's block node env var injection.
-        # Track https://github.com/hiero-ledger/solo/issues/4863 to unpin.
         description: "Mirror Node version ('latest', 'rc', or tag like 'v0.146.0')"
         type: string
-        default: "v0.156.0"
+        default: "latest"
       relay-version:
         description: "Relay version ('latest' or tag like 'v0.75.0')"
         type: string
@@ -38,7 +36,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         type: string
-        default: "0.79.0"
+        default: "0.83.0"
       solo-source:
         description: "Solo install source: 'npm' or 'git' (build an approved fork/branch)"
         type: string
@@ -121,17 +119,15 @@ on:
       block-node-version:
         description: "Block Node version ('latest', 'rc', 'main', or tag like 'v0.29.0')"
         required: false
-        default: "latest"
+        default: "main"
       consensus-node-version:
         description: "Consensus Node version ('latest', 'rc' or tag like 'v0.73.0-rc3')"
         required: false
-        default: "latest"
+        default: "rc"
       mirror-node-version:
-        # Pinned: MN v0.157.0+ (HIP-1137) broke Solo CLI's block node env var injection.
-        # Track https://github.com/hiero-ledger/solo/issues/4863 to unpin.
         description: "Mirror Node version ('latest', 'rc' or tag like 'v0.150.0')"
         required: false
-        default: "v0.156.0"
+        default: "latest"
       relay-version:
         description: "Relay version ('latest' or tag like 'v0.75.0')"
         required: false
@@ -147,7 +143,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         required: false
-        default: "0.79.0"
+        default: "0.83.0"
       solo-source:
         description: "Solo install source"
         required: false

--- a/tools-and-tests/scripts/network-topology-tool/generate-chart-values-config-overlays.sh
+++ b/tools-and-tests/scripts/network-topology-tool/generate-chart-values-config-overlays.sh
@@ -311,8 +311,9 @@ function generate_mn_overlay {
     bn_dns=$(get_service_dns "${bn}" "${NAMESPACE}")
 
     nodes_config="${nodes_config}
-              - host: ${bn_dns}
-                port: ${bn_port}"
+              - endpoints:
+                  - host: ${bn_dns}
+                    port: ${bn_port}"
   done <<< "${block_node_names}"
 
   # Image overrides (workaround, ALL topologies): the default GraalVM-native Mirror Node

--- a/tools-and-tests/scripts/solo-e2e-test/.env.example
+++ b/tools-and-tests/scripts/solo-e2e-test/.env.example
@@ -21,6 +21,16 @@ RELAY_VERSION=latest
 SOLO_VERSION=latest
 TCK_VERSION=latest
 
+# Solo install source (used by 'task solo:install'):
+#   npm (default) - install published @hashgraph/solo@${SOLO_VERSION}
+#   git           - build an approved fork/branch from source
+# Approved git repos: hiero-ledger/solo, hashgraph/solo, AlfredoG87/solo
+SOLO_SOURCE=npm
+# git mode only - fork and ref (branch/tag/SHA) to build:
+# SOLO_SOURCE=git
+# SOLO_GIT_REPO=AlfredoG87/solo
+# SOLO_GIT_REF=fix/bn-health-port-5283
+
 # TSS/WRAPS on consensus nodes enabled (default: true)
 TSS_ENABLED=true
 

--- a/tools-and-tests/scripts/solo-e2e-test/.gitignore
+++ b/tools-and-tests/scripts/solo-e2e-test/.gitignore
@@ -1,5 +1,6 @@
 .tmp/
 out/
+.solo-build/
 overnight-test-results.log
 overnight-test-output.log
 

--- a/tools-and-tests/scripts/solo-e2e-test/README.md
+++ b/tools-and-tests/scripts/solo-e2e-test/README.md
@@ -264,11 +264,11 @@ By default Solo is installed from npm (`npm i @hashgraph/solo -g`). When a fix i
 
 Set `SOLO_SOURCE=git` and point at the fork:
 
-| Variable        | Purpose                                          |
-|-----------------|--------------------------------------------------|
+|    Variable     |                      Purpose                      |
+|-----------------|---------------------------------------------------|
 | `SOLO_SOURCE`   | `git` to build from source (`npm` is the default) |
-| `SOLO_GIT_REPO` | `owner/repo` — must be in the approved allowlist |
-| `SOLO_GIT_REF`  | Branch, tag, or commit SHA to build              |
+| `SOLO_GIT_REPO` | `owner/repo` — must be in the approved allowlist  |
+| `SOLO_GIT_REF`  | Branch, tag, or commit SHA to build               |
 
 **Approved repositories** (allowlist enforced by `scripts/solo-install.sh`): `hiero-ledger/solo`, `hashgraph/solo`, `AlfredoG87/solo`. Any other repo is rejected with a hard failure.
 

--- a/tools-and-tests/scripts/solo-e2e-test/README.md
+++ b/tools-and-tests/scripts/solo-e2e-test/README.md
@@ -219,7 +219,10 @@ cp .env.example .env
 | `CLUSTER_NAME`           | `solo-cluster`           | Kind cluster name                                                    |
 | `NAMESPACE`              | `solo-network`           | Kubernetes namespace                                                 |
 | `DEPLOYMENT`             | `deployment-solo`        | Solo deployment name                                                 |
-| `SOLO_VERSION`           | `latest`                 | Solo CLI version (CI pins to `0.63.0`)                               |
+| `SOLO_VERSION`           | `latest`                 | Solo CLI version (CI pins to `0.79.0`)                               |
+| `SOLO_SOURCE`            | `npm`                    | Solo install source: `npm` or `git` (see Custom Solo Build)          |
+| `SOLO_GIT_REPO`          | (empty)                  | Fork `owner/repo` when `SOLO_SOURCE=git` (must be approved)          |
+| `SOLO_GIT_REF`           | (empty)                  | Branch/tag/SHA when `SOLO_SOURCE=git`                                |
 | `CN_VERSION`             | `latest`                 | Consensus Node version                                               |
 | `MN_VERSION`             | `latest`                 | Mirror Node version                                                  |
 | `BN_VERSION`             | `latest`                 | Block Node version                                                   |
@@ -254,6 +257,36 @@ Variables can be overridden on the command line for one-off runs. Command-line v
 task up TOPOLOGY=paired-3 BN_VERSION=v0.24.0
 task load:up NLG_ARGS="-c 10 -a 20 -tt 600"
 ```
+
+## Custom Solo Build (fork/branch)
+
+By default Solo is installed from npm (`npm i @hashgraph/solo -g`). When a fix isn't released yet, you can build Solo from an **approved fork/branch** instead and install it globally.
+
+Set `SOLO_SOURCE=git` and point at the fork:
+
+| Variable        | Purpose                                          |
+|-----------------|--------------------------------------------------|
+| `SOLO_SOURCE`   | `git` to build from source (`npm` is the default) |
+| `SOLO_GIT_REPO` | `owner/repo` — must be in the approved allowlist |
+| `SOLO_GIT_REF`  | Branch, tag, or commit SHA to build              |
+
+**Approved repositories** (allowlist enforced by `scripts/solo-install.sh`): `hiero-ledger/solo`, `hashgraph/solo`, `AlfredoG87/solo`. Any other repo is rejected with a hard failure.
+
+The build mirrors Solo's own `build:compile` (`npm ci` → `npx tsc` → `node resources/post-build-script.js`) then `npm i -g .` from the clone. A bare `npm i github:owner/repo#ref -g` does **not** work — Solo's `prepare` script is not a build, so `dist/` would be missing.
+
+**Local:**
+
+```bash
+# Install a custom build, then deploy as usual
+task solo:install SOLO_SOURCE=git SOLO_GIT_REPO=AlfredoG87/solo SOLO_GIT_REF=fix/bn-health-port-5283
+task up TOPOLOGY=single
+```
+
+The clone lands in `.solo-build/` (gitignored). The minimum-version check in the setup/deploy scripts is skipped for git builds, since a fork may be based on older code.
+
+**CI:** dispatch the `Solo E2E Test` workflow with `solo-source=git`, `solo-git-repo=<approved fork>`, `solo-git-ref=<ref>`.
+
+> ⚠️ CI executes the cloned code (`npm ci` runs lifecycle scripts). The allowlist is the security boundary — keep it short and trusted.
 
 ## Load Generation
 

--- a/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
+++ b/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
@@ -54,6 +54,12 @@ vars:
   TCK_VERSION: '{{.TCK_VERSION | default "latest"}}'
   TSS_ENABLED: '{{.TSS_ENABLED | default "true"}}'
 
+  # Solo install source: 'npm' (default) or 'git' (build an approved fork/branch)
+  SOLO_SOURCE: '{{.SOLO_SOURCE | default "npm"}}'
+  SOLO_VERSION: '{{.SOLO_VERSION | default "latest"}}'
+  SOLO_GIT_REPO: '{{.SOLO_GIT_REPO | default ""}}'
+  SOLO_GIT_REF: '{{.SOLO_GIT_REF | default ""}}'
+
   # NLG load generation parameters
   NLG_TEST_TYPE: '{{.NLG_TEST_TYPE | default "CryptoTransferLoadTest"}}'
   NLG_ARGS: '{{.NLG_ARGS | default "-c 5 -a 10 -tt 300"}}'
@@ -79,7 +85,7 @@ tasks:
         command -v kubectl >/dev/null 2>&1 || { echo "ERROR: kubectl not found"; exit 1; }
         command -v helm >/dev/null 2>&1 || { echo "ERROR: helm not found"; exit 1; }
         command -v kind >/dev/null 2>&1 || { echo "ERROR: kind not found"; exit 1; }
-        command -v solo >/dev/null 2>&1 || { echo "ERROR: solo not found. Install with: npm i @hashgraph/solo -g"; exit 1; }
+        command -v solo >/dev/null 2>&1 || { echo "ERROR: solo not found. Install with: npm i @hashgraph/solo -g (or 'task solo:install' for a custom fork/branch build)"; exit 1; }
         command -v yq >/dev/null 2>&1 || { echo "ERROR: yq not found. Install from: https://github.com/mikefarah/yq"; exit 1; }
         echo "All prerequisites found!"
         echo ""
@@ -92,6 +98,16 @@ tasks:
         echo "  yq: $(yq --version)"
         command -v pnpm >/dev/null 2>&1 && echo "  pnpm: $(pnpm --version)" || echo "  pnpm: not installed (needed for TCK tests)"
     silent: true
+
+  solo:install:
+    desc: Install Solo CLI (npm by default, or an approved fork/branch via SOLO_SOURCE=git)
+    cmds:
+      - |
+        SOLO_SOURCE="{{.SOLO_SOURCE}}" \
+        SOLO_VERSION="{{.SOLO_VERSION}}" \
+        SOLO_GIT_REPO="{{.SOLO_GIT_REPO}}" \
+        SOLO_GIT_REF="{{.SOLO_GIT_REF}}" \
+          "{{.SCRIPTS_DIR}}/solo-install.sh"
 
   # ============================================================================
   # Cluster Lifecycle

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
@@ -584,31 +584,36 @@ EOF
   fi
 }
 
-# WRAPS v1.0.0 proving keys: downloaded + extracted once into a local cache and handed to Solo via
-# --wraps-key-path on every deploy (no ~2 GB re-download). Pre-staging is required because CN-side
-# runtime download is dropped before genesis on CN v0.75.x — see project-patterns.md (WRAPS on
-# solo-e2e). Solo stages these under its cache dir named `wraps-v0.2.0` (default directoryName,
-# not overridable here), so that directory holds v1.0.0 contents on this setup.
+# WRAPS v1.0.0 proving keys: the tarball + its extracted .bin files are cached once and handed to
+# Solo via --wraps-key-path on every deploy (no ~2 GB re-download). Solo stages both into each CN
+# pod: the extracted .bin files (TSS_LIB_WRAPS_ARTIFACTS_PATH, used by CN v0.75.x) and the tarball
+# at data/keys/wraps.tar.gz (tss.wrapsProvingKeyPath, used by CN >= v0.76 at genesis). Keeping the
+# tarball is what lets CN >= v0.76 load the proving key at genesis instead of racing a runtime
+# download — see project-patterns.md (WRAPS on solo-e2e).
 WRAPS_DOWNLOAD_URL="https://builds.hedera.com/tss/hiero/wraps/v1.0/wraps-v1.0.0.tar.gz"
 WRAPS_KEYS_DIR="${HOME}/.solo/cache/wraps-v1.0.0-keys"
 WRAPS_KEY_FILES="decider_pp.bin decider_vp.bin nova_pp.bin nova_vp.bin"
 
-## Download and extract the WRAPS v1.0.0 proving keys into `keys_dir` once; later deploys reuse them.
+## Cache the WRAPS v1.0.0 proving key tarball and its extracted .bin files into `keys_dir` once;
+## later deploys reuse them. The tarball is kept (not deleted) so Solo can stage it into the CN pod.
 function ensure_wraps_keys_cached {
   local keys_dir="${1}"
+  local tarball="${keys_dir}/wraps-v1.0.0.tar.gz"
   local f=""
-  local need_download="false"
+  local need_extract="false"
   for f in ${WRAPS_KEY_FILES}; do
-    [[ -f "${keys_dir}/${f}" ]] || need_download="true"
+    [[ -f "${keys_dir}/${f}" ]] || need_extract="true"
   done
 
-  if [[ "${need_download}" == "true" ]]; then
-    log_line "Caching WRAPS v1.0.0 proving keys (one-time download + extract, ~2 GB)"
+  if [[ ! -f "${tarball}" ]]; then
+    log_line "Caching WRAPS v1.0.0 proving key tarball (one-time download, ~2 GB)"
     mkdir -p "${keys_dir}"
-    local tarball="${keys_dir}/wraps-v1.0.0.tar.gz"
     curl -fSL "${WRAPS_DOWNLOAD_URL}" -o "${tarball}" || fail "ERROR: Failed to download WRAPS v1.0.0" 1
+    need_extract="true"
+  fi
+
+  if [[ "${need_extract}" == "true" ]]; then
     tar -xzf "${tarball}" -C "${keys_dir}" || fail "ERROR: Failed to extract WRAPS v1.0.0 archive" 1
-    rm -f "${tarball}"
   fi
 
   for f in ${WRAPS_KEY_FILES}; do

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
@@ -894,10 +894,14 @@ function check_prerequisites {
     fail "ERROR: solo CLI not found. Install with: npm i @hashgraph/solo -g" 1
   fi
 
-  # Enforce minimum Solo version (required for TSS support)
+  # Enforce minimum Solo version (required for TSS support).
+  # A custom build (SOLO_SOURCE=git) may be based on older code; we trust the
+  # operator who explicitly selected a git source and skip the hard-fail.
   local solo_version
   solo_version=$(solo --version 2>&1 | grep 'Version' | sed 's/.*: *//' | tr -d '[:space:]')
-  if [[ -n "${solo_version}" ]]; then
+  if [[ "${SOLO_SOURCE:-npm}" == "git" ]]; then
+    log_line "  NOTE: Custom Solo build detected (SOLO_SOURCE=git), version %s - skipping minimum-version check" "${solo_version:-unknown}"
+  elif [[ -n "${solo_version}" ]]; then
     # Simple semver comparison: split into major.minor.patch and compare numerically
     IFS='.' read -r cur_major cur_minor cur_patch <<< "${solo_version}"
     IFS='.' read -r min_major min_minor min_patch <<< "${SOLO_MIN_VERSION}"

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-install.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-install.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Installs the Solo CLI globally, either from npm (default) or by building an
+# approved fork/branch from source. Single entry point shared by the Taskfile
+# and the solo-e2e-test CI workflow.
+#
+# Usage:
+#   ./solo-install.sh
+#
+# Environment Variables:
+#   SOLO_SOURCE    - 'npm' (default) or 'git'
+#
+#   npm mode:
+#     SOLO_VERSION   - npm dist-tag or version (default: latest)
+#
+#   git mode:
+#     SOLO_GIT_REPO  - owner/repo on GitHub; must be in the approved allowlist
+#     SOLO_GIT_REF   - branch, tag, or commit SHA to build
+#     SOLO_SRC_DIR   - clone directory (default: <script-dir>/../.solo-build)
+#
+# Security boundary:
+#   git mode clones and executes third-party code (npm ci runs lifecycle
+#   scripts). Only repositories in APPROVED_REPOS are permitted. This gate is
+#   what makes it safe to expose SOLO_GIT_REPO as a CI input.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SOLO_SOURCE="${SOLO_SOURCE:-npm}"
+SOLO_VERSION="${SOLO_VERSION:-latest}"
+SOLO_GIT_REPO="${SOLO_GIT_REPO:-}"
+SOLO_GIT_REF="${SOLO_GIT_REF:-}"
+SOLO_SRC_DIR="${SOLO_SRC_DIR:-${SCRIPT_DIR}/../.solo-build}"
+
+# Repositories permitted as a git source. This is the security boundary:
+# git mode builds and runs code from these repos, so the list is intentionally
+# short and explicit.
+readonly APPROVED_REPOS=(
+  "hiero-ledger/solo"
+  "hashgraph/solo"
+  "AlfredoG87/solo"
+)
+
+function fail {
+  printf '%s\n' "${1}" >&2
+  exit "${2-1}"
+}
+
+function is_approved_repo {
+  local candidate="${1}"
+  local repo
+  for repo in "${APPROVED_REPOS[@]}"; do
+    if [[ "${repo}" == "${candidate}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+function print_resolved_version {
+  local source_label="${1}"
+  local resolved
+  resolved="$(solo --version 2>/dev/null | grep 'Version' | sed 's/.*: *//' | tr -d '[:space:]')"
+  echo ""
+  echo "Solo installed successfully"
+  echo "  Source:  ${source_label}"
+  echo "  Version: ${resolved:-unknown}"
+}
+
+function install_from_npm {
+  echo "Installing Solo from npm: @hashgraph/solo@${SOLO_VERSION}"
+  npm i "@hashgraph/solo@${SOLO_VERSION}" -g
+  print_resolved_version "npm @hashgraph/solo@${SOLO_VERSION}"
+}
+
+function install_from_git {
+  if [[ -z "${SOLO_GIT_REPO}" ]]; then
+    fail "ERROR: SOLO_SOURCE=git requires SOLO_GIT_REPO (owner/repo)." 1
+  fi
+  if [[ -z "${SOLO_GIT_REF}" ]]; then
+    fail "ERROR: SOLO_SOURCE=git requires SOLO_GIT_REF (branch, tag, or SHA)." 1
+  fi
+  if ! is_approved_repo "${SOLO_GIT_REPO}"; then
+    fail "ERROR: SOLO_GIT_REPO '${SOLO_GIT_REPO}' is not in the approved allowlist: ${APPROVED_REPOS[*]}" 1
+  fi
+
+  echo "Building Solo from source: ${SOLO_GIT_REPO}@${SOLO_GIT_REF}"
+  echo "  Clone dir: ${SOLO_SRC_DIR}"
+
+  rm -rf "${SOLO_SRC_DIR}"
+  git clone --depth 1 --branch "${SOLO_GIT_REF}" \
+    "https://github.com/${SOLO_GIT_REPO}.git" "${SOLO_SRC_DIR}"
+
+  # Build mirrors solo's own 'build:compile': install deps, transpile, then run
+  # the post-build script that stages the runtime resources into dist/. A bare
+  # 'npm i github:owner/repo#ref -g' does NOT work: solo's 'prepare' script is
+  # not a build, so dist/ would be missing.
+  (
+    cd "${SOLO_SRC_DIR}"
+    npm ci
+    npx tsc
+    node resources/post-build-script.js
+    npm i -g .
+  )
+
+  print_resolved_version "git ${SOLO_GIT_REPO}@${SOLO_GIT_REF}"
+}
+
+function main {
+  case "${SOLO_SOURCE}" in
+    npm)
+      install_from_npm
+      ;;
+    git)
+      install_from_git
+      ;;
+    *)
+      fail "ERROR: SOLO_SOURCE must be 'npm' or 'git' (got '${SOLO_SOURCE}')." 1
+      ;;
+  esac
+}
+
+main

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-setup-cluster.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-setup-cluster.sh
@@ -215,11 +215,15 @@ function check_prerequisites {
   fi
   end_task "FOUND ($(command -v solo))"
 
-  # Enforce minimum Solo version (required for TSS support)
+  # Enforce minimum Solo version (required for TSS support).
+  # A custom build (SOLO_SOURCE=git) may be based on older code; we trust the
+  # operator who explicitly selected a git source and skip the hard-fail.
   local solo_min_version="0.61.0"
   local solo_version
   solo_version=$(solo --version 2>&1 | grep 'Version' | sed 's/.*: *//' | tr -d '[:space:]')
-  if [[ -n "${solo_version}" ]]; then
+  if [[ "${SOLO_SOURCE:-npm}" == "git" ]]; then
+    log_line "  NOTE: Custom Solo build detected (SOLO_SOURCE=git), version ${solo_version:-unknown} - skipping minimum-version check"
+  elif [[ -n "${solo_version}" ]]; then
     IFS='.' read -r cur_major cur_minor cur_patch <<< "${solo_version}"
     IFS='.' read -r min_major min_minor min_patch <<< "${solo_min_version}"
     local is_outdated="false"


### PR DESCRIPTION
## What

Extends the solo-e2e-test harness so it can run against **unreleased Solo, latest-RC Consensus Node, and latest-GA Mirror Node**, and fixes the WRAPS (Schnorr -> WRAPS) transition on Consensus Node >= v0.76. Three related changes, kept on one branch because they were validated together end-to-end in CI (custom Solo build + BN v0.39.0-rc1 + CN rc + MN latest + WRAPS transition).

npm remains the default Solo source everywhere; the new behavior is opt-in.

## 1. Build Solo from an approved fork/branch

New shared installer `tools-and-tests/scripts/solo-e2e-test/scripts/solo-install.sh`, used by both the Taskfile and CI. Controlled by env vars:

| Variable | Meaning |
|----------|---------|
| `SOLO_SOURCE` | `npm` (default) or `git` |
| `SOLO_VERSION` | npm mode: dist-tag/version (default `latest`) |
| `SOLO_GIT_REPO` | git mode: `owner/repo`, must be in the allowlist |
| `SOLO_GIT_REF` | git mode: branch/tag/SHA |

git mode enforces an allowlist (`hiero-ledger/solo`, `hashgraph/solo`, `AlfredoG87/solo`), clones and builds the fork the way Solo builds itself (`npm ci` -> `npx tsc` -> `node resources/post-build-script.js`), and installs it globally. The allowlist is the security boundary: CI executes the cloned code, so only trusted repos are permitted.

- `solo-setup-cluster.sh`, `solo-deploy-network.sh`: skip the minimum Solo-version check when `SOLO_SOURCE=git` (a fork may be based on older code).
- `Taskfile.yml`: `solo:install` task, `SOLO_SOURCE`/`SOLO_VERSION`/`SOLO_GIT_REPO`/`SOLO_GIT_REF` vars, check-task hint.
- `.gitignore`: ignore the `.solo-build/` clone dir.
- `.env.example`: document the new vars.
- `solo-e2e-test.yml`: `solo-source`/`solo-git-repo`/`solo-git-ref` inputs on both triggers, install step routed through the script, `SOLO_SOURCE` exported for the setup/deploy scripts, git source shown in the step summary.
- `README.md`: "Custom Solo Build (fork/branch)" section.

## 2. Refresh default versions (latest-RC CN, latest-GA MN)

- `solo-e2e-test.yml` / `solo-e2e-scheduler.yml`: default CN `latest -> rc`, MN pinned `v0.156.0 -> latest` (removes the HIP-1137 pin), Solo `0.79.0 -> 0.83.0`, BN `latest -> main` (test workflow).
- `generate-chart-values-config-overlays.sh`: switch the Mirror Node -> Block Node overlay to the `endpoints:` structure, which is what unblocks MN >= v0.157.0 (HIP-1137) — the reason MN was pinned.

## 3. WRAPS proving key for CN >= v0.76

`solo-deploy-network.sh` (`ensure_wraps_keys_cached`): cache and keep the WRAPS v1.0.0 proving-key tarball (previously deleted after extraction) alongside its extracted `.bin` files. CN >= v0.76 loads the proving key from a tarball at `data/keys/wraps.tar.gz` at genesis, so Solo now stages the tarball into each CN pod. Its SHA-384 matches the CN's expected `tss.wrapsProvingKeyHash`, so the node finds the local copy, verifies it, and skips the ~2 GB runtime download — making the library ready before the genesis WRAPS proof and letting the network transition Schnorr -> WRAPS.

This half depends on a companion Solo change (stage the tarball at `data/keys/wraps.tar.gz`) carried in the fork used for validation.

## Usage

Local:

```bash
task solo:install SOLO_SOURCE=git SOLO_GIT_REPO=AlfredoG87/solo SOLO_GIT_REF=<ref>
task up TOPOLOGY=single
```

CI: dispatch **Solo E2E Test** with `solo-source=git`, `solo-git-repo=<approved fork>`, `solo-git-ref=<ref>`.

## Testing

Validated end-to-end in CI (`workflow_dispatch`, topology `2cn-2bn-backfill`) with `solo-source=git`, BN `v0.39.0-rc1`, CN `rc` (`v0.76.0-rc.3`), MN `latest`:

- Install Solo CLI (fork build), Cluster setup, Deploy network, Run Test Definitions all succeed.
- `tss-signature-transition` passes: `Schnorr -> WRAPS at block 390` (389 SCHNORR 2920 B, 390 oversized genesis block unservable, 391 WRAPS 3432 B).
- The npm-mode install path and existing scheduled runs are unaffected (git mode is opt-in; scheduler inherits the new default versions only).
