### PR TITLE
feat: Cherry-pick Add a next expected block field to Server Status API (#3269) into release/0.39

### DIFF
--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -114,36 +114,29 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     volatile BlockNodeContext blockNodeContext;
     /// list of all loaded plugins. Package so accessible for testing.
     final List<BlockNodePlugin> loadedPlugins = new ArrayList<>();
-
     /// Create a ConcurrentLinkedQueue to hold TssData updates
     private final ConcurrentLinkedQueue<TssData> tssDataUpdates = new ConcurrentLinkedQueue<>();
-
     /// Pending address book history loaded at startup; consumed by the first checkForApplicationStateUpdates run.
     private final AtomicReference<RangedAddressBookHistory> pendingAddressBookHistory = new AtomicReference<>();
-
-    /** Cached O(log n) index built from the current address book history; rebuilt whenever history changes. */
+    /// Cached O(log n) index built from the current address book history; rebuilt whenever history changes.
     private volatile NavigableMap<Long, RangedNodeAddressBook> addressBookIndex = new TreeMap<>();
-
     /// Blocks reported as stored by plugins that do not serve them for retrieval
     final ConcurrentLongRangeSet storedBlocks = new ConcurrentLongRangeSet();
-
     /// Known inbound publishers loaded from configuration on startup; exposed for /statusz/inbound.
     private final AtomicReference<NetworkData> knownPublishers = new AtomicReference<>(NetworkData.DEFAULT);
-
     /// Designated inbound partners loaded from configuration on startup; exposed for /statusz/inbound.
     private final AtomicReference<NetworkData> inboundPartners = new AtomicReference<>(NetworkData.DEFAULT);
-
     /// Designated outbound partners loaded from configuration on startup; exposed for /statusz/outbound.
     private final AtomicReference<NetworkData> outboundPartners = new AtomicReference<>(NetworkData.DEFAULT);
-
     /// Backfill source connections reported by the backfill plugin; exposed for both /statusz endpoints.
     private final AtomicReference<NetworkData> backfillSources = new AtomicReference<>(NetworkData.DEFAULT);
-
     /// Block count at the time of the last scheduled persist; only read/written by the scanner thread
     private long lastPersistedBlockCount = 0;
-
     /// The ScheduledExecutorService used by the ApplicationStateFacility to check for TssData updates
     private ScheduledExecutorService applicationStateExecutor;
+    /// The next expected block for publishers, used by Server Status plugins
+    /// and set by Publisher plugins
+    private volatile long nextExpectedBlock = -1L;
 
     /// Constructor for the BlockNodeApp class.
     /// This constructor initializes the server configuration, loads the
@@ -425,8 +418,18 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
     }
 
     @Override
+    public long nextExpectedBlock() {
+        return nextExpectedBlock;
+    }
+
+    @Override
     public void updateBackfillSources(NetworkData sources) {
         backfillSources.set(sources != null ? sources : NetworkData.DEFAULT);
+    }
+
+    @Override
+    public void updateExpectedBlock(final long updatedExpectedBlock) {
+        nextExpectedBlock = updatedExpectedBlock;
     }
 
     /// Stages the supplied {@link RangedAddressBookHistory} for the next

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
@@ -82,6 +82,7 @@ public abstract class PluginTestBase<
 
     protected List<BlockRange> storedBlocks = List.of();
     protected List<BlockRange> availableBlocks = List.of();
+    protected volatile long nextExpectedBlock = -1L;
 
     protected PluginTestBase(@NonNull final E executorService, @NonNull final S scheduledExecutorService) {
         testThreadPoolManager = new TestThreadPoolManager<>(executorService, scheduledExecutorService);
@@ -358,6 +359,16 @@ public abstract class PluginTestBase<
     @Override
     public void addStoredBlockRange(final LongRange blockRange) {
         appStoredBlocks.add(blockRange);
+    }
+
+    @Override
+    public long nextExpectedBlock() {
+        return nextExpectedBlock;
+    }
+
+    @Override
+    public void updateExpectedBlock(final long updatedExpectedBlock) {
+        nextExpectedBlock = updatedExpectedBlock;
     }
 
     public void replaceAvailableBlocks(final List<BlockRange> availableBlocks) {

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestApplicationStateFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestApplicationStateFacility.java
@@ -25,6 +25,7 @@ public class TestApplicationStateFacility implements ApplicationStateFacility {
     private final Deque<TssData> tssDataUpdates;
     private final Deque<NodeAddressBook> nodeAddressBookUpdates;
     private RangedAddressBookHistory addressBookHistory = null;
+    private volatile long nextExpectedBlock = -1L;
 
     /** Non-empty sample network data used as the default for every connection set. */
     public static final NetworkData DEFAULT_NETWORK_DATA = NetworkData.newBuilder()
@@ -96,6 +97,11 @@ public class TestApplicationStateFacility implements ApplicationStateFacility {
     }
 
     @Override
+    public boolean updateAddressBookHistory(final RangedAddressBookHistory history) {
+        return false;
+    }
+
+    @Override
     public void addStoredBlockRange(final LongRange blockRange) {}
 
     @Override
@@ -119,7 +125,17 @@ public class TestApplicationStateFacility implements ApplicationStateFacility {
     }
 
     @Override
+    public long nextExpectedBlock() {
+        return nextExpectedBlock;
+    }
+
+    @Override
     public void updateBackfillSources(NetworkData sources) {
         this.backfillSources = sources;
+    }
+
+    @Override
+    public void updateExpectedBlock(final long updatedExpectedBlock) {
+        nextExpectedBlock = updatedExpectedBlock;
     }
 }

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/server/TestBlockNodeServer.java
@@ -2,6 +2,7 @@
 package org.hiero.block.node.app.fixtures.server;
 
 import static org.hiero.block.node.base.ParseHelper.standardParse;
+import static org.hiero.block.node.spi.BlockNodePlugin.UNKNOWN_BLOCK_NUMBER;
 
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
@@ -202,13 +203,17 @@ public class TestBlockNodeServer {
         @Override
         @NonNull
         public ServerStatusResponse serverStatus(@NonNull final ServerStatusRequest request) {
-            // Returns the available block range from the historical facility
+            // Fabricate the response from the available block range. The next expected block is the
+            // block after the highest available one, or -1 ("accept any block") when none are held.
+            final long lastAvailableBlock =
+                    historicalBlockFacility.availableBlocks().max();
+            final long nextExpectedBlock =
+                    lastAvailableBlock == UNKNOWN_BLOCK_NUMBER ? UNKNOWN_BLOCK_NUMBER : lastAvailableBlock + 1;
             return ServerStatusResponse.newBuilder()
                     .firstAvailableBlock(
                             historicalBlockFacility.availableBlocks().min())
-                    .lastAvailableBlock(
-                            historicalBlockFacility.availableBlocks().max())
-                    .onlyLatestState(false)
+                    .lastAvailableBlock(lastAvailableBlock)
+                    .nextExpectedBlock(nextExpectedBlock)
                     .build();
         }
 

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTaskTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.hiero.block.api.NetworkData;
+import org.hiero.block.api.RangedAddressBookHistory;
 import org.hiero.block.api.TssData;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
@@ -707,9 +708,25 @@ class BlockUploadTaskTest {
     /// [ApplicationStateFacility] implementation that records every stored range.
     private static final class TrackingApplicationStateFacility implements ApplicationStateFacility {
         final List<LongRange> storedRanges = new ArrayList<>();
+        volatile long nextExpectedBlock = -1L;
+
+        @Override
+        public long nextExpectedBlock() {
+            return nextExpectedBlock;
+        }
+
+        @Override
+        public void updateExpectedBlock(final long updatedExpectedBlock) {
+            nextExpectedBlock = updatedExpectedBlock;
+        }
 
         @Override
         public void updateTssData(TssData tssData) {}
+
+        @Override
+        public boolean updateAddressBookHistory(final RangedAddressBookHistory history) {
+            return false;
+        }
 
         public boolean updateAddressBook(NodeAddressBook nodeAddressBook) {
             return true;
@@ -718,6 +735,11 @@ class BlockUploadTaskTest {
         @Override
         public void addStoredBlockRange(LongRange blockRange) {
             storedRanges.add(blockRange);
+        }
+
+        @Override
+        public NodeAddressBook getAddressBookForBlock(final long blockNum) {
+            return null;
         }
 
         @Override

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/TempArchiveUploadTaskTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.bucky.S3Client;
+import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.ConfigurationBuilder;
@@ -26,6 +27,7 @@ import java.util.Random;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.hiero.block.api.NetworkData;
+import org.hiero.block.api.RangedAddressBookHistory;
 import org.hiero.block.api.TssData;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.BlockUnparsed;
@@ -512,12 +514,34 @@ class TempArchiveUploadTaskTest {
     private static final class TrackingApplicationStateFacility implements ApplicationStateFacility {
         final List<LongRange> addedRanges = new ArrayList<>();
 
+        private volatile long nextExpectedBlock = -1L;
+
+        @Override
+        public long nextExpectedBlock() {
+            return nextExpectedBlock;
+        }
+
+        @Override
+        public void updateExpectedBlock(final long updatedExpectedBlock) {
+            nextExpectedBlock = updatedExpectedBlock;
+        }
+
         @Override
         public void updateTssData(TssData tssData) {}
 
         @Override
+        public boolean updateAddressBookHistory(final RangedAddressBookHistory history) {
+            return false;
+        }
+
+        @Override
         public void addStoredBlockRange(LongRange blockRange) {
             addedRanges.add(blockRange);
+        }
+
+        @Override
+        public NodeAddressBook getAddressBookForBlock(final long blockNum) {
+            return null;
         }
 
         @Override

--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
@@ -13,6 +13,7 @@ import org.hiero.block.api.ServerStatusDetailResponse;
 import org.hiero.block.api.ServerStatusRequest;
 import org.hiero.block.api.ServerStatusResponse;
 import org.hiero.block.node.app.config.node.NodeConfig;
+import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
@@ -57,33 +58,27 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
     public ServerStatusResponse serverStatus(@NonNull final ServerStatusRequest request) {
         requestStatusCounter.increment();
 
+        final ApplicationStateFacility stateFacility = blockNodeContext.applicationStateFacility();
         final ServerStatusResponse.Builder serverStatusResponseBuilder = ServerStatusResponse.newBuilder();
         final long firstAvailableBlock = blockProvider.availableBlocks().min();
         long highestAvailableBlock = blockProvider.availableBlocks().max();
-        // If this node is configured to manage blocks starting later than what it currently holds, report that
-        // later block as the last available block so publishers know they can stream from earliestManagedBlock
-        // instead of assuming the node only wants older blocks between the oldest stored block and earliest managed
-        // block.
-        if (highestAvailableBlock != UNKNOWN_BLOCK_NUMBER
-                && highestAvailableBlock < earliestManagedBlock
-                && earliestManagedBlock > 0) {
-            // Fix for bug #3203. CN will stream next block if we return UNKNOWN_BLOCK_NUMBER,
-            //   but if we return a future block here, CN will not send any data.
-            highestAvailableBlock = UNKNOWN_BLOCK_NUMBER;
+        long nextExpectedBlock = stateFacility.nextExpectedBlock();
+        if (nextExpectedBlock < earliestManagedBlock) {
+            nextExpectedBlock = UNKNOWN_BLOCK_NUMBER;
         }
 
-        // TODO(#579) Should get from state config or status, which would be provided by the context from responsible
-        // facility
-        boolean onlyLatestState = false;
+        // TODO(#579) Should get from state config or status, which would be provided by
+        //     calls to the responsible plugin.
+        boolean onlyLatestState = true;
 
-        // TODO(#1139) Should get construct a block node version object from application config, which would be provided
-        // by
-        // the context from responsible facility
+        // TODO(#1139) Should construct a block node version object from application config,
+        //     which would be provided from the application state
 
         // Build the response
         ServerStatusResponse response = serverStatusResponseBuilder
                 .firstAvailableBlock(firstAvailableBlock)
                 .lastAvailableBlock(highestAvailableBlock)
+                .nextExpectedBlock(nextExpectedBlock)
                 .onlyLatestState(onlyLatestState)
                 .build();
 

--- a/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java
+++ b/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java
@@ -5,8 +5,8 @@ import static org.hiero.block.node.app.fixtures.TestUtils.enableDebugLogging;
 import static org.hiero.block.node.base.ParseHelper.standardParse;
 import static org.hiero.block.node.spi.BlockNodePlugin.UNKNOWN_BLOCK_NUMBER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.pbj.runtime.ParseException;
 import java.util.Map;
@@ -66,7 +66,9 @@ public class ServerStatusServicePluginTest
         assertNotNull(response);
         assertEquals(UNKNOWN_BLOCK_NUMBER, response.firstAvailableBlock());
         assertEquals(UNKNOWN_BLOCK_NUMBER, response.lastAvailableBlock());
-        assertFalse(response.onlyLatestState());
+        // No publisher has reported a next expected block, so the default (-1) is reported.
+        assertEquals(UNKNOWN_BLOCK_NUMBER, response.nextExpectedBlock());
+        assertTrue(response.onlyLatestState());
     }
 
     /**
@@ -89,18 +91,94 @@ public class ServerStatusServicePluginTest
         assertNotNull(response);
         assertEquals(0, response.firstAvailableBlock());
         assertEquals(blocks - 1, response.lastAvailableBlock());
-        assertFalse(response.onlyLatestState());
+        // Blocks were delivered via messaging, but no publisher manager updated the application
+        // state, so next expected block remains the default (-1).
+        assertEquals(UNKNOWN_BLOCK_NUMBER, response.nextExpectedBlock());
+        assertTrue(response.onlyLatestState());
     }
 
-    /// Tests that when `earliestManagedBlock` is configured higher than the last block currently
-    /// held by the node, the reported `lastAvailableBlock` is \`-1\` (unknown block), while
-    /// `firstAvailableBlock` is left untouched, so publishers know they can stream later blocks even
-    /// though the node only holds older ones.
+    /// Tests that when a publisher has reported a next expected block at or above
+    /// `earliestManagedBlock`, the value is reported verbatim in `nextExpectedBlock`.
     ///
     /// @throws ParseException if there is an error parsing the response
     @Test
-    @DisplayName("Should return -1 for lastAvailableBlock when < earliestManagedBlock and node holds only older blocks")
-    void shouldRaiseLastAvailableBlockToEarliestManagedBlock() throws ParseException {
+    @DisplayName("Should report the next expected block reported by the application state")
+    void shouldReportNextExpectedBlockWhenSet() throws ParseException {
+        final int blocks = 5;
+        sendBlocks(blocks);
+        // Simulate the publisher manager advancing the next expected block via the application state.
+        updateExpectedBlock(blocks);
+
+        final ServerStatusRequest request = ServerStatusRequest.newBuilder().build();
+        toPluginPipe.onNext(ServerStatusRequest.PROTOBUF.toBytes(request));
+        final ServerStatusResponse response = standardParse(ServerStatusResponse.PROTOBUF, fromPluginBytes.getLast());
+
+        assertEquals(0, response.firstAvailableBlock());
+        assertEquals(blocks - 1, response.lastAvailableBlock());
+        assertEquals(blocks, response.nextExpectedBlock());
+    }
+
+    /// Tests that a next expected block below the configured `earliestManagedBlock` is reported as
+    /// `-1` (unknown) so publishers know they may stream any block, while `lastAvailableBlock`
+    /// still reports the true highest block held.
+    ///
+    /// @throws ParseException if there is an error parsing the response
+    @Test
+    @DisplayName("Should report nextExpectedBlock = -1 when the reported value is below earliestManagedBlock")
+    void shouldReportUnknownNextExpectedBlockWhenBelowEarliestManagedBlock() throws ParseException {
+        final ServerStatusServicePlugin localPlugin = new ServerStatusServicePlugin();
+        start(
+                localPlugin,
+                localPlugin.methods().getFirst(),
+                new SimpleInMemoryHistoricalBlockFacility(),
+                Map.of("block.node.earliestManagedBlock", "100"));
+        sendBlocks(5);
+        // 50 is below the configured earliestManagedBlock (100) and must be reported as unknown.
+        updateExpectedBlock(50L);
+
+        final ServerStatusRequest request = ServerStatusRequest.newBuilder().build();
+        toPluginPipe.onNext(ServerStatusRequest.PROTOBUF.toBytes(request));
+        final ServerStatusResponse response = standardParse(ServerStatusResponse.PROTOBUF, fromPluginBytes.getLast());
+
+        // lastAvailableBlock reports the true max (bug #3203 fix now lives in nextExpectedBlock).
+        assertEquals(0, response.firstAvailableBlock());
+        assertEquals(4, response.lastAvailableBlock());
+        assertEquals(UNKNOWN_BLOCK_NUMBER, response.nextExpectedBlock());
+    }
+
+    /// Tests the boundary condition where the reported next expected block is exactly
+    /// `earliestManagedBlock`; it must be reported verbatim (not clamped to `-1`).
+    ///
+    /// @throws ParseException if there is an error parsing the response
+    @Test
+    @DisplayName("Should report nextExpectedBlock verbatim when it equals earliestManagedBlock")
+    void shouldReportNextExpectedBlockWhenEqualToEarliestManagedBlock() throws ParseException {
+        final ServerStatusServicePlugin localPlugin = new ServerStatusServicePlugin();
+        start(
+                localPlugin,
+                localPlugin.methods().getFirst(),
+                new SimpleInMemoryHistoricalBlockFacility(),
+                Map.of("block.node.earliestManagedBlock", "100"));
+        updateExpectedBlock(100L);
+
+        final ServerStatusRequest request = ServerStatusRequest.newBuilder().build();
+        toPluginPipe.onNext(ServerStatusRequest.PROTOBUF.toBytes(request));
+        final ServerStatusResponse response = standardParse(ServerStatusResponse.PROTOBUF, fromPluginBytes.getLast());
+
+        assertEquals(100L, response.nextExpectedBlock());
+    }
+
+    /// Tests that when `earliestManagedBlock` is configured higher than the last block currently
+    /// held by the node, `lastAvailableBlock` now reports the true highest block held (the
+    /// clamping removed by the next-expected-block change), while `nextExpectedBlock` carries the
+    /// `-1` "stream anything" signal because no publisher has reported a value at or above
+    /// `earliestManagedBlock`.
+    ///
+    /// @throws ParseException if there is an error parsing the response
+    @Test
+    @DisplayName(
+            "Should report raw lastAvailableBlock and nextExpectedBlock = -1 when node holds only blocks below earliestManagedBlock")
+    void shouldReportRawLastAvailableAndUnknownNextExpectedBelowEarliestManagedBlock() throws ParseException {
         final ServerStatusServicePlugin localPlugin = new ServerStatusServicePlugin();
         start(
                 localPlugin,
@@ -114,12 +192,13 @@ public class ServerStatusServicePluginTest
         final ServerStatusResponse response = standardParse(ServerStatusResponse.PROTOBUF, fromPluginBytes.getLast());
 
         assertEquals(0, response.firstAvailableBlock());
-        assertEquals(-1, response.lastAvailableBlock());
+        assertEquals(4, response.lastAvailableBlock());
+        assertEquals(UNKNOWN_BLOCK_NUMBER, response.nextExpectedBlock());
     }
 
     /**
-     * Tests that {@code earliestManagedBlock} has no effect when the node already holds blocks at or
-     * beyond that configured value.
+     * Tests that {@code earliestManagedBlock} has no effect on {@code lastAvailableBlock} when the
+     * node already holds blocks at or beyond that configured value.
      *
      * @throws ParseException if there is an error parsing the response
      */
@@ -140,6 +219,8 @@ public class ServerStatusServicePluginTest
 
         assertEquals(0, response.firstAvailableBlock());
         assertEquals(4, response.lastAvailableBlock());
+        // No value reported by a publisher, so the default (-1) is still returned.
+        assertEquals(UNKNOWN_BLOCK_NUMBER, response.nextExpectedBlock());
     }
 
     /**
@@ -165,6 +246,7 @@ public class ServerStatusServicePluginTest
 
         assertEquals(UNKNOWN_BLOCK_NUMBER, response.firstAvailableBlock());
         assertEquals(UNKNOWN_BLOCK_NUMBER, response.lastAvailableBlock());
+        assertEquals(UNKNOWN_BLOCK_NUMBER, response.nextExpectedBlock());
     }
 
     /**

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/ApplicationStateFacility.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/ApplicationStateFacility.java
@@ -35,9 +35,7 @@ public interface ApplicationStateFacility {
      * @return {@code true} if the history is queued for update, {@code false} if it was not
      *     (e.g. equal to the currently stored value or implementation does not support history)
      */
-    default boolean updateAddressBookHistory(RangedAddressBookHistory history) {
-        return false;
-    }
+    boolean updateAddressBookHistory(RangedAddressBookHistory history);
 
     /**
      * Records a contiguous range of blocks as stored (persisted but not necessarily retrievable by
@@ -53,9 +51,7 @@ public interface ApplicationStateFacility {
      * @param blockNum the block number whose address book you need
      * @return the {@link NodeAddressBook} or null if not found
      */
-    default NodeAddressBook getAddressBookForBlock(long blockNum) {
-        return null;
-    }
+    NodeAddressBook getAddressBookForBlock(long blockNum);
 
     /**
      * The set of known inbound publishers, loaded from configuration on startup. Reported by the
@@ -91,6 +87,16 @@ public interface ApplicationStateFacility {
     NetworkData backfillSources();
 
     /**
+     * The next block expected from publishers. This is approximate, but should
+     * be greater than the latest available block, in most situations, but may
+     * differ significantly if `EarliestManagedBlock` is configured or under
+     * some other conditions.
+     *
+     * @return the current value of the next expected block
+     */
+    long nextExpectedBlock();
+
+    /**
      * Registers (or replaces) the set of backfill source connections. Called by the backfill plugin
      * when it loads its sources, so that all connection information is owned by the Application State
      * facility rather than read directly from backfill configuration.
@@ -98,4 +104,13 @@ public interface ApplicationStateFacility {
      * @param sources the backfill source connections to publish
      */
     void updateBackfillSources(NetworkData sources);
+
+    /**
+     * Update the current value of the next expected block.
+     * This value is ephemeral, and is not written to, or read from, persistent
+     * storage.
+     *
+     * @param updatedExpectedBlock The new value for the next expected block.
+     */
+    void updateExpectedBlock(final long updatedExpectedBlock);
 }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -54,6 +54,7 @@ import org.hiero.block.api.PublishStreamResponse.EndOfStream.Code;
 import org.hiero.block.internal.BlockItemSetUnparsed;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.node.app.config.node.NodeConfig;
+import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
@@ -109,6 +110,9 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     private long lastPenaltyResetNanos;
     /// Scheduled handle for the flow-control refresh task.
     private ScheduledFuture<?> flowControlRefreshFuture;
+    /// Reference to application state facility, used to update the next
+    /// expected block value.
+    private final ApplicationStateFacility applicationState;
 
     /// Future tracking the queue forwarder task.
     ///
@@ -144,6 +148,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             @NonNull final BlockNodeContext context, @NonNull final MetricsHolder metricsHolder) {
         resetIsActive = new AtomicBoolean(true);
         serverContext = Objects.requireNonNull(context);
+        applicationState = serverContext.applicationStateFacility();
         metrics = Objects.requireNonNull(metricsHolder);
         threadManager = serverContext.threadPoolManager();
         handlers = new ConcurrentSkipListMap<>();
@@ -494,6 +499,11 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 }
             }
         }
+    }
+
+    /// Made protected for testing purposes.
+    protected long getNextUnstreamed() {
+        return nextUnstreamedBlockNumber.get();
     }
 
     /// Method to reset internal tracking and close all active connections.
@@ -907,12 +917,29 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         if (lastPersisted >= nextUnstreamed) {
             // potentially increment the next unstreamed
             final long newValue = lastPersisted + 1L;
-            if (nextUnstreamedBlockNumber.compareAndSet(nextUnstreamed, newValue)) {
+            if (updateNextUnstreamedAndExpected(nextUnstreamed, newValue)) {
                 // if cas was successful, we can update the local value as well
                 nextUnstreamed = newValue;
             }
         }
         return nextUnstreamed;
+    }
+
+    /// Execute a compare-and-set for next unstreamed block number, and if
+    /// that is successful, also update the application state next expected
+    /// block vlaue.
+    ///
+    /// @param currentValue The expected current value.
+    /// @param newValue The new value to set if the CAS check succeeds.
+    /// @return true if, and only if, the CAS check succeeded.
+    private boolean updateNextUnstreamedAndExpected(final long currentValue, final long newValue) {
+        final boolean valueWasSet = nextUnstreamedBlockNumber.compareAndSet(currentValue, newValue);
+        if (valueWasSet) {
+            // if cas was successful, we can update the value in application
+            // state as well.
+            applicationState.updateExpectedBlock(newValue >= earliestManagedBlock ? newValue : -1);
+        }
+        return valueWasSet;
     }
 
     /// todo(1420) add documentation
@@ -954,7 +981,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 // Handle an edge case where we need to accept a block before the earliest
                 // managed block right after the node (re)started.
                 && lastForwardedBlockNumber.get() == UNKNOWN_BLOCK_NUMBER
-                && nextUnstreamedBlockNumber.compareAndSet(earliestManagedBlock, blockNumber)) {
+                && updateNextUnstreamedAndExpected(earliestManagedBlock, blockNumber)) {
             metrics.lowestBlockNumber.set(blockNumber);
             return resolveActionForHeader(blockNumber);
         } else {
@@ -964,7 +991,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
 
     /// todo(1420) add documentation
     private BlockAction resolveActionForHeader(final long blockNumber) {
-        if (nextUnstreamedBlockNumber.compareAndSet(blockNumber, blockNumber + 1L)) {
+        if (updateNextUnstreamedAndExpected(blockNumber, blockNumber + 1L)) {
             updateHighestBlockMetric(blockNumber + 1);
             return BlockAction.ACCEPT;
         } else {

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerFlowControlTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerFlowControlTest.java
@@ -15,6 +15,7 @@ import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
 import org.hiero.block.node.app.fixtures.async.TestThreadPoolManager;
 import org.hiero.block.node.app.fixtures.pipeline.TestResponsePipeline;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
+import org.hiero.block.node.app.fixtures.plugintest.TestApplicationStateFacility;
 import org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.stream.publisher.LiveStreamPublisherManager.MetricsHolder;
@@ -311,7 +312,9 @@ class LiveStreamPublisherManagerFlowControlTest {
                 null,
                 messagingFacility,
                 historicalBlockFacility,
-                null,
+                // Non-null facility required: the manager publishes the next expected block on
+                // every successful next-unstreamed CAS and would otherwise NPE.
+                new TestApplicationStateFacility(),
                 null,
                 threadPoolManager,
                 null,

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -38,8 +38,8 @@ import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
 import org.hiero.block.node.app.fixtures.pipeline.TestResponsePipeline;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleBlockRangeSet;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
+import org.hiero.block.node.app.fixtures.plugintest.TestApplicationStateFacility;
 import org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility;
-import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceLoaderFunction;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
@@ -74,6 +74,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 class LiveStreamPublisherManagerTest {
 
     private TestMetricsExporter metricsExporter;
+
+    /// The application state facility backing the most recently generated context. Retained so
+    /// tests can assert next-expected-block values published by successful next-unstreamed CAS
+    /// updates. Reassigned on every [#generateContext] call.
+    private TestApplicationStateFacility testApplicationState;
 
     /// Constructor tests for the [LiveStreamPublisherManager].
     @Nested
@@ -381,6 +386,72 @@ class LiveStreamPublisherManagerTest {
                 final BlockAction actual = toTest.getActionForBlock(0L, action, publisherHandlerId);
                 // Assert
                 assertThat(actual).isEqualTo(BlockAction.END_ERROR);
+            }
+        }
+
+        /// Tests that a successful next-unstreamed CAS publishes the next expected block to the
+        /// [org.hiero.block.node.spi.ApplicationStateFacility], and that non-advancing offers do
+        /// not. Exercises all three CAS sites and both branches of the
+        /// `newValue >= earliestManagedBlock ? newValue : -1` rule.
+        @Nested
+        @DisplayName("nextExpectedBlock propagation Tests")
+        class NextExpectedBlockPropagationTests {
+            /// Accepting a block header advances next-unstreamed and publishes `header + 1`, which
+            /// is at or above the (default `0`) earliestManagedBlock.
+            @Test
+            @DisplayName("Accepting a header publishes next expected block = header + 1")
+            void headerAcceptPublishesNextExpectedBlock() {
+                final BlockAction action = toTest.getActionForBlock(0L, null, publisherHandlerId);
+                assertThat(action).isEqualTo(BlockAction.ACCEPT);
+                assertThat(testApplicationState.nextExpectedBlock()).isEqualTo(1L);
+            }
+
+            /// A successful persisted notification advances next-unstreamed past the persisted
+            /// block and publishes `persisted + 1`.
+            @Test
+            @DisplayName("Persisted notification publishes next expected block = persisted + 1")
+            void persistedNotificationPublishesNextExpectedBlock() {
+                toTest.handlePersisted(new PersistedNotification(10L, true, 0, BlockSource.PUBLISHER));
+                assertThat(testApplicationState.nextExpectedBlock()).isEqualTo(11L);
+            }
+
+            /// An offer that does not advance next-unstreamed (no CAS is attempted) must leave the
+            /// previously published next expected block unchanged.
+            @Test
+            @DisplayName("A non-advancing offer does not change the published next expected block")
+            void nonAdvancingOfferLeavesNextExpectedBlockUnchanged() {
+                assertThat(toTest.getActionForBlock(0L, null, publisherHandlerId))
+                        .isEqualTo(BlockAction.ACCEPT);
+                assertThat(testApplicationState.nextExpectedBlock()).isEqualTo(1L);
+                // A future block yields SEND_BEHIND with no CAS, so the published value must not change.
+                assertThat(toTest.getActionForBlock(5L, null, publisherHandlerId))
+                        .isEqualTo(BlockAction.SEND_BEHIND);
+                assertThat(testApplicationState.nextExpectedBlock()).isEqualTo(1L);
+            }
+
+            /// Accepting a block below `earliestManagedBlock` (the post-restart pre-EMB accept path
+            /// in `streamBeforeEmbOrElse`) publishes `-1` ("accept any block") rather than the block.
+            @Test
+            @DisplayName("Accepting a block below earliestManagedBlock publishes next expected block = -1")
+            void preEarliestManagedBlockAcceptPublishesUnknown() {
+                final Configuration embConfig = TestStreamPublisherManager.createTestConfiguration(
+                        Map.of("block.node.earliestManagedBlock", "100"));
+                final SimpleInMemoryHistoricalBlockFacility embHistorical = new SimpleInMemoryHistoricalBlockFacility();
+                final BlockNodeContext embContext =
+                        generateContext(embHistorical, threadPoolManager, messagingFacility, embConfig);
+                embHistorical.init(embContext, null);
+                final LiveStreamPublisherManager embManager =
+                        new LiveStreamPublisherManager(embContext, generateManagerMetrics());
+                final TestResponsePipeline<PublishStreamResponse> embPipeline = new TestResponsePipeline<>();
+                embManager.addHandler(embPipeline, sharedHandlerMetrics, null);
+                final long embHandlerId = 0L; // first handler registered on the fresh manager
+
+                // Block 50 is below earliestManagedBlock (100); right after (re)start it is accepted
+                // via the pre-EMB path, and the published next expected block must be -1.
+                assertThat(embManager.getActionForBlock(50L, null, embHandlerId))
+                        .isEqualTo(BlockAction.ACCEPT);
+                assertThat(embManager.getNextUnstreamed()).isEqualTo(51L);
+                assertThat(testApplicationState.nextExpectedBlock()).isEqualTo(-1L);
             }
         }
 
@@ -2820,14 +2891,16 @@ class LiveStreamPublisherManagerTest {
         final MetricRegistry metricRegistry = TestUtils.createMetrics();
         final HealthFacility serverHealth = null;
         final ServiceLoaderFunction serviceLoader = null;
-        final ApplicationStateFacility applicationStateFacility = null;
+        // A real (non-null) facility is required: the manager caches it and publishes the next
+        // expected block on every successful next-unstreamed CAS. Retain it so tests can assert.
+        testApplicationState = new TestApplicationStateFacility();
         return new BlockNodeContext(
                 configuration,
                 metricRegistry,
                 serverHealth,
                 blockMessagingFacility,
                 historicalBlockFacility,
-                applicationStateFacility,
+                testApplicationState,
                 serviceLoader,
                 threadPoolManager,
                 null,

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherManagerRegressionTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherManagerRegressionTest.java
@@ -22,6 +22,7 @@ import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
 import org.hiero.block.node.app.fixtures.pipeline.TestResponsePipeline;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleBlockRangeSet;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
+import org.hiero.block.node.app.fixtures.plugintest.TestApplicationStateFacility;
 import org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility;
 import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
@@ -393,7 +394,9 @@ class PublisherManagerRegressionTest {
                 .build();
         final MetricRegistry metrics = TestUtils.createMetrics();
         final HealthFacility serverHealth = null;
-        final ApplicationStateFacility applicationStateFacility = null;
+        // Non-null facility required: the manager publishes the next expected block on every
+        // successful next-unstreamed CAS and would otherwise NPE.
+        final ApplicationStateFacility applicationStateFacility = new TestApplicationStateFacility();
         final ServiceLoaderFunction serviceLoader = null;
         return new BlockNodeContext(
                 configuration,

--- a/protobuf-sources/src/main/proto/block-node/api/node_service.proto
+++ b/protobuf-sources/src/main/proto/block-node/api/node_service.proto
@@ -104,6 +104,16 @@ message ServerStatusResponse {
      * in any `StateSnapshotRequest` sent to this Block-Node.
      */
     bool only_latest_state = 3;
+
+    /**
+     * The next block that this Block-Node expects to receive from a Publisher.
+     *
+     * This value MAY contain `uint64_max` to indicate this Block-Node will accept
+     * any block as the next block. This is most common when a block node is
+     * newly installed or reset and backfilling history while accepting new
+     * blocks.
+     */
+    uint64 next_expected_block = 4;
 }
 
 /**


### PR DESCRIPTION

## Reviewer Notes
- Added the new field to the API definition in protocol buffer files
- Added support for the new field in the Application State interface
- Added support for the new field in the App implementation
- Updated test fixtures with new methods
- Added a method to combine update of the next expected block with the "next unstreamed" CAS check in the Publisher plugin.
   - Replaced all existing CAS updates with the new method.
- Added unit tests for new feature
- Updated unit tests and test fixtures as needed

