### PR TITLE
fix(ci): use sha512 checksum and make git-cliff steps non-blocking

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -40,7 +40,7 @@ jobs:
       RELEASE_NOTES_FILENAME: release_notes
       # Bump this to pick up a new git-cliff release; verify the new SHA via:
       #   gh release view v<VERSION> --repo orhun/git-cliff --json assets \
-      #     | jq '.assets[].name' | grep sha256
+      #     | jq '.assets[].name' | grep sha512
       GIT_CLIFF_VERSION: "2.8.0"
     outputs:
       create_pr: ${{ env.CREATE_PR }}
@@ -198,13 +198,13 @@ jobs:
           gh release download "v${GIT_CLIFF_VERSION}" \
             --repo orhun/git-cliff \
             --pattern "${TARBALL}" \
-            --pattern "${TARBALL}.sha256"
-          sha256sum --check "${TARBALL}.sha256"
+            --pattern "${TARBALL}.sha512"
+          sha512sum --check "${TARBALL}.sha512"
           tar xzf "${TARBALL}" \
             --strip-components=1 \
             "git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-musl/git-cliff"
           sudo install -m755 git-cliff /usr/local/bin/git-cliff
-          rm "${TARBALL}" "${TARBALL}.sha256"
+          rm "${TARBALL}" "${TARBALL}.sha512"
         env:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -193,6 +193,8 @@ jobs:
           tagging_message: ${{ env.RELEASE_TAG }}
 
       - name: Install git-cliff
+        id: install_cliff
+        continue-on-error: true
         run: |
           TARBALL="git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-musl.tar.gz"
           gh release download "v${GIT_CLIFF_VERSION}" \
@@ -209,11 +211,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Generate Release Notes
+        if: steps.install_cliff.outcome == 'success'
+        continue-on-error: true
         run: |
           git cliff \
             --config cliff.toml \
             --latest \
             --output "${RELEASE_NOTES_FILENAME}.md"
+
+      - name: Ensure Release Notes File Exists
+        run: |
+          # Guarantees the file is present even when git-cliff install or generation failed,
+          # so the release step always has a valid (possibly empty) bodyFile to reference.
+          touch "${RELEASE_NOTES_FILENAME}.md"
 
       - name: Create Github Release
         uses: step-security/release-action@a0d8e0f90f554c15366ca2c9046bf4090d24adbe # v1.21.0


### PR DESCRIPTION
## Summary

- git-cliff releases publish `.sha512` per-asset checksum files, not `.sha256`. The `Install git-cliff` step tried to download `${TARBALL}.sha256` which doesn't exist in any git-cliff release, causing an immediate exit-1 after a successful tarball download.
- Both cliff steps are now `continue-on-error: true` so a future version mismatch or network hiccup cannot block a release. A guard step ensures the `bodyFile` reference always resolves to a valid (possibly empty) file.
- Fixes the failed run: https://github.com/hiero-ledger/hiero-block-node/actions/runs/30125095647/job/89586623980

## Changes

- `sha256` → `sha512` in the download pattern, checksum command, `rm` cleanup, and inline comment hint
- `continue-on-error: true` on `Install git-cliff` (with `id: install_cliff`) and `Generate Release Notes`
- `Generate Release Notes` skipped (`if: steps.install_cliff.outcome == 'success'`) when cliff isn't installed
- New `Ensure Release Notes File Exists` step (`touch`) always runs so `Create Github Release` always has a valid `bodyFile`

## Related Issue(s)

Fixes regression introduced in #3275. Companion fix for `release/0.39` in #3287.