### PR TITLE
feat: Implemented step 10 of [#3125](https://github.com/hiero-ledger/hiero-block-node/issues/3125)

### DIFF
--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -223,7 +223,7 @@ jobs:
           if [[ -n "${{ inputs.solo-version }}" ]]; then
             SOLO_VERSION="${{ inputs.solo-version }}"
           else
-            SOLO_VERSION="0.83.0"
+            SOLO_VERSION="0.84.0"
           fi
 
           # Relay version: use input if provided, otherwise default to latest

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -308,6 +308,14 @@ jobs:
           # Export RELAY_VERSION so Solo CLI reads the resolved semver (not 'latest')
           RELAY_RESOLVED=$(echo "$OUTPUT" | grep "^relay_version=" | cut -d= -f2)
           echo "RELAY_VERSION=${RELAY_RESOLVED}" >> "${GITHUB_ENV}"
+          # Export MN_VERSION so the wrb-distribution scripts' JVM importer swap
+          # (reconfigure-mn1-to-bn-sources.sh / add-mn2.sh) always matches
+          # whatever version MN1 was actually installed with — Flyway rejects
+          # rolling the importer back to an older migration set than what's
+          # already applied to MN1's Postgres, so this must never drift from
+          # the resolved mn_version below.
+          MN_RESOLVED=$(echo "$OUTPUT" | grep "^mn_version=" | cut -d= -f2)
+          echo "MN_VERSION=${MN_RESOLVED}" >> "${GITHUB_ENV}"
 
       # Install Solo CLI (npm by default, or build an approved fork/branch when solo-source=git)
       - name: Install Solo CLI

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -82,7 +82,7 @@ on:
         type: string
         default: "5"
       test-definition:
-        description: "Test definitions (comma-separated): smoke-test, basic-load, node-restart-resilience, full-history-backfill, tss-signature-transition, wrb-cli-hash-validation, wrb-cli-wrapping-validation, wrb-differential-test, wrb-core-validation, wrb-distribution-step12, wrb-distribution-step345, chaos-foundation-smoke, latency-cn-to-cn, latency-cn-to-bn, latency-bn-to-bn, latency-all-three"
+        description: "Test definitions (comma-separated): smoke-test, basic-load, node-restart-resilience, full-history-backfill, tss-signature-transition, wrb-cli-hash-validation, wrb-cli-wrapping-validation, wrb-differential-test, wrb-core-validation, rsa-roster-verification,  wrb-distribution-step12, wrb-distribution-step345, wrb-distribution-step67, wrb-distribution-step10, chaos-foundation-smoke, latency-cn-to-cn, latency-cn-to-bn, latency-bn-to-bn, latency-all-three"
         type: string
         default: "none"
     outputs:

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -36,7 +36,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         type: string
-        default: "0.83.0"
+        default: "0.84.0"
       solo-source:
         description: "Solo install source: 'npm' or 'git' (build an approved fork/branch)"
         type: string
@@ -144,7 +144,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         required: false
-        default: "0.83.0"
+        default: "0.84.0"
       solo-source:
         description: "Solo install source"
         required: false

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -116,6 +116,7 @@ on:
           - wrb-distribution-step12 # WRB Distribution E2E (#3125) — slice 1: 3 CN v0.75 + MN1 v0.157.1, no BN
           - wrb-distribution-step345 # WRB Distribution E2E (#3125) — slice 3: adds BN1/BN2/BN3 with EMB
           - wrb-distribution-step67 # WRB Distribution E2E (#3125) — slice 4: MN1 → BN2/BN3 + MN2 from genesis
+          - wrb-distribution-step10 # WRB Distribution E2E (#3125) — slice 5: BN2/BN3 reconfigured to backfill from BN1
       block-node-version:
         description: "Block Node version ('latest', 'rc', 'main', or tag like 'v0.29.0')"
         required: false
@@ -202,7 +203,7 @@ on:
         required: false
         default: "5"
       test-definition:
-        description: "Test definitions (comma-separated): smoke-test, basic-load, node-restart-resilience, full-history-backfill, tss-signature-transition, wrb-cli-hash-validation, wrb-cli-wrapping-validation, wrb-differential-test, wrb-core-validation, rsa-roster-verification, wrb-distribution-step12, wrb-distribution-step345, wrb-distribution-step67, chaos-foundation-smoke, latency-cn-to-cn, latency-cn-to-bn, latency-bn-to-bn, latency-all-three"
+        description: "Test definitions (comma-separated): smoke-test, basic-load, node-restart-resilience, full-history-backfill, tss-signature-transition, wrb-cli-hash-validation, wrb-cli-wrapping-validation, wrb-differential-test, wrb-core-validation, rsa-roster-verification, wrb-distribution-step12, wrb-distribution-step345, wrb-distribution-step67, wrb-distribution-step10, chaos-foundation-smoke, latency-cn-to-cn, latency-cn-to-bn, latency-bn-to-bn, latency-all-three"
         required: false
         default: "none"
 

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/add-mn2.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/add-mn2.sh
@@ -22,8 +22,7 @@
 # Reads:
 #   NAMESPACE         (default "solo-network")
 #   CLUSTER_REFERENCE (default "kind-solo-cluster")
-#   MN_VERSION        (used for the importer image tag; falls back to mirror-1's
-#                     live image if unset)
+#   MN_VERSION        (used for the importer image tag; default "latest")
 #   BN_HOST_2         (default block-node-2.${NAMESPACE}.svc.cluster.local)
 #   BN_HOST_3         (default block-node-3.${NAMESPACE}.svc.cluster.local)
 #   BN2_GRPC_PORT     (default 40841 — matches add-bn.sh's convention:
@@ -51,7 +50,7 @@ fail() { echo "[wrb-dist-add-mn2] ERROR: $*" >&2; exit 1; }
 #    ghcr.io/hiero-ledger/hiero-mirror-node/importer image is GraalVM-native
 #    and can't reflect into List<BlockNodeProperties> for BN-source binding —
 #    see the same override in network-topology-tool/generate-chart-values-config-overlays.sh.
-mn_tag="${MN_VERSION:-v0.157.1}"
+mn_tag="${MN_VERSION:-latest}"
 mn_tag="${mn_tag#v}"
 importer_image="gcr.io/mirrornode/hedera-mirror-importer:${mn_tag}"
 log "  Using JVM importer image: ${importer_image}"

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-bn-backfill-source.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-bn-backfill-source.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# WRB Distribution E2E (#3125 slice 5) — assert that a Block Node has been
+# reconfigured (by reconfigure-bn-backfill.sh) to use another BN as its
+# backfill source.
+#
+# What this asserts, per target BN:
+#   1. BACKFILL_BLOCK_NODE_SOURCES_PATH is set on the running container to
+#      the expected mount path (proves the "-config" ConfigMap merge landed
+#      and the pod picked it up).
+#   2. The file at that path (mounted from the "-block-node-sources"
+#      ConfigMap) contains the expected source BN's address (proves the
+#      volume + volumeMount patch landed, not just the env var).
+#
+# Usage:
+#     assert-bn-backfill-source.sh <target-bn-index> [<target-bn-index> ...]
+#     assert-bn-backfill-source.sh 2 3
+#
+# Reads:
+#   NAMESPACE          (default "solo-network")
+#   CLUSTER_REFERENCE  (default "kind-solo-cluster")
+#   SOURCE_BN_INDEX    (default 1 — must match reconfigure-bn-backfill.sh)
+
+set -euo pipefail
+
+: "${NAMESPACE:=solo-network}"
+: "${CLUSTER_REFERENCE:=kind-solo-cluster}"
+: "${SOURCE_BN_INDEX:=1}"
+
+[[ $# -ge 1 ]] || { echo "assert-bn-backfill-source.sh: at least one target BN index required (e.g. 2 3)" >&2; exit 1; }
+
+log() { echo "[wrb-dist-bn-backfill-assert] $*"; }
+fail() { echo "[wrb-dist-bn-backfill-assert] ERROR: $*" >&2; exit 1; }
+
+source_bn="block-node-${SOURCE_BN_INDEX}"
+source_dns="${source_bn}.${NAMESPACE}.svc.cluster.local"
+expected_path="/opt/hiero/block-node/backfill/block-node-sources.json"
+
+failures=0
+for target_index in "$@"; do
+    target_bn="block-node-${target_index}"
+    pod="${target_bn}-0"
+
+    actual_path=$(kubectl --context "${CLUSTER_REFERENCE}" --namespace "${NAMESPACE}" \
+        exec "${pod}" -c block-node-server -- \
+        printenv BACKFILL_BLOCK_NODE_SOURCES_PATH 2>/dev/null | tr -d '[:space:]' || echo "")
+
+    if [[ "${actual_path}" != "${expected_path}" ]]; then
+        log "${target_bn}: BACKFILL_BLOCK_NODE_SOURCES_PATH='${actual_path:-<unset>}', expected '${expected_path}'"
+        failures=$(( failures + 1 ))
+        continue
+    fi
+
+    sources_content=$(kubectl --context "${CLUSTER_REFERENCE}" --namespace "${NAMESPACE}" \
+        exec "${pod}" -c block-node-server -- \
+        cat "${expected_path}" 2>/dev/null || echo "")
+
+    if [[ "${sources_content}" != *"${source_dns}"* ]]; then
+        log "${target_bn}: sources file does not reference ${source_dns}:"
+        log "  ${sources_content}"
+        failures=$(( failures + 1 ))
+        continue
+    fi
+
+    log "${target_bn}: backfill source = ${source_dns} ✓"
+done
+
+if (( failures > 0 )); then
+    fail "${failures} BN(s) not correctly configured for backfill from ${source_bn}"
+fi
+
+log "All target BNs are configured to backfill from ${source_bn}."

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-bn-backfill-source.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-bn-backfill-source.sh
@@ -21,6 +21,11 @@
 #   NAMESPACE          (default "solo-network")
 #   CLUSTER_REFERENCE  (default "kind-solo-cluster")
 #   SOURCE_BN_INDEX    (default 1 — must match reconfigure-bn-backfill.sh)
+#
+# The source BN's gRPC port is read from its own "-config" ConfigMap
+# (SERVER_PORT), falling back to 40840 only if that key is absent — same
+# derivation as reconfigure-bn-backfill.sh, so this checks against the port
+# that was actually written to the sources file.
 
 set -euo pipefail
 
@@ -35,6 +40,12 @@ fail() { echo "[wrb-dist-bn-backfill-assert] ERROR: $*" >&2; exit 1; }
 
 source_bn="block-node-${SOURCE_BN_INDEX}"
 source_dns="${source_bn}.${NAMESPACE}.svc.cluster.local"
+# Read the source BN's actual port the same way reconfigure-bn-backfill.sh
+# does, so this assertion matches what was actually written to the sources
+# file instead of assuming the chart default.
+source_port=$(kubectl --context "${CLUSTER_REFERENCE}" --namespace "${NAMESPACE}" \
+    get configmap "${source_bn}-config" -o jsonpath='{.data.SERVER_PORT}' 2>/dev/null || echo "")
+: "${source_port:=40840}"
 expected_path="/opt/hiero/block-node/backfill/block-node-sources.json"
 
 failures=0
@@ -56,14 +67,18 @@ for target_index in "$@"; do
         exec "${pod}" -c block-node-server -- \
         cat "${expected_path}" 2>/dev/null || echo "")
 
-    if [[ "${sources_content}" != *"${source_dns}"* ]]; then
-        log "${target_bn}: sources file does not reference ${source_dns}:"
+    # Exact address+port match via jq, not a substring check — a substring match
+    # on source_dns would prefix-match e.g. block-node-1 against block-node-10
+    # once the suite scales past 9 BNs.
+    if ! echo "${sources_content}" | jq -e --arg addr "${source_dns}" --argjson port "${source_port}" \
+        '.nodes[]? | select(.address == $addr and .port == $port)' >/dev/null 2>&1; then
+        log "${target_bn}: sources file does not reference ${source_dns}:${source_port}:"
         log "  ${sources_content}"
         failures=$(( failures + 1 ))
         continue
     fi
 
-    log "${target_bn}: backfill source = ${source_dns} ✓"
+    log "${target_bn}: backfill source = ${source_dns}:${source_port} ✓"
 done
 
 if (( failures > 0 )); then

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/reconfigure-bn-backfill.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/reconfigure-bn-backfill.sh
@@ -41,6 +41,9 @@
 #   SOURCE_BN_INDEX    (default 1 — BN1 is the backfill source per the issue)
 #   BACKFILL_GREEDY    (default "false")
 #   READY_TIMEOUT      (default 300)
+#
+# The source BN's gRPC port is read from its own "-config" ConfigMap
+# (SERVER_PORT), falling back to 40840 only if that key is absent.
 
 set -euo pipefail
 
@@ -58,11 +61,19 @@ fail() { echo "[wrb-dist-bn-backfill] ERROR: $*" >&2; exit 1; }
 target_bn="block-node-${target_index}"
 source_bn="block-node-${SOURCE_BN_INDEX}"
 source_dns="${source_bn}.${NAMESPACE}.svc.cluster.local"
-source_port=40840
 backfill_path="/opt/hiero/block-node/backfill"
 backfill_filename="block-node-sources.json"
 sources_configmap="${target_bn}-block-node-sources"
 config_configmap="${target_bn}-config"
+
+# Read the source BN's actual listening port from its own "-config" ConfigMap
+# (SERVER_PORT, rendered from blockNode.config.SERVER_PORT — see
+# charts/block-node-server/values.yaml) rather than assuming the chart
+# default, so this doesn't silently produce a wrong sources file for
+# custom-port topologies.
+source_port=$(kubectl --context "${CLUSTER_REFERENCE}" --namespace "${NAMESPACE}" \
+    get configmap "${source_bn}-config" -o jsonpath='{.data.SERVER_PORT}' 2>/dev/null || echo "")
+: "${source_port:=40840}"
 
 log "Reconfiguring ${target_bn} to backfill from ${source_bn} (${source_dns}:${source_port})..."
 
@@ -101,7 +112,18 @@ log "  ${config_configmap} patched (BACKFILL_BLOCK_NODE_SOURCES_PATH, BACKFILL_G
 # 3) Patch the StatefulSet's pod template to add the volume + volumeMount.
 #    volumes[] and containers[].volumeMounts[] are both merged on their
 #    `name` key by a strategic merge patch, so this appends rather than
-#    clobbering the chart's existing volumes/mounts.
+#    clobbering the chart's existing volumes/mounts. This depends on the
+#    container actually being named "block-node-server" (per
+#    charts/block-node-server/templates/statefulset.yaml) — if that ever
+#    changes, the volumeMount patch would silently no-op while the volume
+#    itself still gets added, so check it explicitly rather than fail later
+#    with a mount-less volume and no error.
+actual_container=$(kubectl --context "${CLUSTER_REFERENCE}" --namespace "${NAMESPACE}" \
+    get statefulset "${target_bn}" \
+    -o jsonpath='{.spec.template.spec.containers[0].name}')
+[[ "${actual_container}" == "block-node-server" ]] \
+    || fail "expected container named 'block-node-server' in ${target_bn}, got '${actual_container}'"
+
 statefulset_patch="${TMPDIR:-/tmp}/wrb-dist-${target_bn}-sts-patch.yaml"
 cat > "${statefulset_patch}" <<EOF
 spec:

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/reconfigure-bn-backfill.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/reconfigure-bn-backfill.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# WRB Distribution E2E (#3125 slice 5 — step 10) — reconfigure an
+# already-deployed Block Node to use another BN as a backfill source.
+#
+# BN2 and BN3 were installed post-hoc by add-bn.sh (slice 3), which does not
+# configure `blockNode.backfill.*` — there was no peer to backfill from at
+# that point. Solo has no `solo block node update`/`config` subcommand (only
+# `add`), so there's no way to re-render the chart for an existing release
+# through Solo. Reconfiguring in place means doing by hand what the Helm
+# templates would otherwise render, following the same kubectl-patch
+# philosophy as reconfigure-mn1-to-bn-sources.sh:
+#
+#   1. Create/update the "<bn>-block-node-sources" ConfigMap — this is what
+#      charts/block-node-server/templates/configmap-block-node-sources.yaml
+#      renders when `blockNode.backfill.sources` is set at install time.
+#   2. Merge BACKFILL_BLOCK_NODE_SOURCES_PATH / BACKFILL_GREEDY into the
+#      existing "<bn>-config" ConfigMap (already wired into the container via
+#      `envFrom: configMapRef`, so no env-var patch needed on the container).
+#   3. Patch the StatefulSet's pod template to add the "block-node-sources"
+#      volume + volumeMount that
+#      charts/block-node-server/templates/statefulset.yaml only renders when
+#      `blockNode.backfill.sources` is set — this is the piece a ConfigMap
+#      change alone can't add, since the mount doesn't exist yet.
+#
+# Step 3 changes the pod template itself, so the StatefulSet controller rolls
+# a new revision on its own — no explicit `kubectl rollout restart` needed,
+# same as any other spec.template change. Doing the ConfigMap merge (step 2)
+# before the template patch (step 3) ensures the new pod starts with the
+# updated env already in place.
+#
+# Usage:
+#     reconfigure-bn-backfill.sh <target-bn-index>
+#     reconfigure-bn-backfill.sh 2
+#     reconfigure-bn-backfill.sh 3
+#
+# Reads:
+#   NAMESPACE          (default "solo-network")
+#   CLUSTER_REFERENCE  (default "kind-solo-cluster")
+#   SOURCE_BN_INDEX    (default 1 — BN1 is the backfill source per the issue)
+#   BACKFILL_GREEDY    (default "false")
+#   READY_TIMEOUT      (default 300)
+
+set -euo pipefail
+
+: "${NAMESPACE:=solo-network}"
+: "${CLUSTER_REFERENCE:=kind-solo-cluster}"
+: "${SOURCE_BN_INDEX:=1}"
+: "${BACKFILL_GREEDY:=false}"
+READY_TIMEOUT="${READY_TIMEOUT:-300}"
+
+target_index="${1:?reconfigure-bn-backfill.sh: target BN index required (2|3)}"
+
+log() { echo "[wrb-dist-bn-backfill] $*"; }
+fail() { echo "[wrb-dist-bn-backfill] ERROR: $*" >&2; exit 1; }
+
+target_bn="block-node-${target_index}"
+source_bn="block-node-${SOURCE_BN_INDEX}"
+source_dns="${source_bn}.${NAMESPACE}.svc.cluster.local"
+source_port=40840
+backfill_path="/opt/hiero/block-node/backfill"
+backfill_filename="block-node-sources.json"
+sources_configmap="${target_bn}-block-node-sources"
+config_configmap="${target_bn}-config"
+
+log "Reconfiguring ${target_bn} to backfill from ${source_bn} (${source_dns}:${source_port})..."
+
+# 1) Create/update the sources ConfigMap (mirrors
+#    configmap-block-node-sources.yaml's rendered shape).
+sources_file="${TMPDIR:-/tmp}/wrb-dist-${target_bn}-sources.json"
+cat > "${sources_file}" <<EOF
+{
+  "nodes": [
+    { "address": "${source_dns}", "port": ${source_port}, "priority": 1 }
+  ]
+}
+EOF
+
+kubectl --context "${CLUSTER_REFERENCE}" --namespace "${NAMESPACE}" \
+    create configmap "${sources_configmap}" \
+    --from-file="${backfill_filename}=${sources_file}" \
+    --dry-run=client -o yaml \
+    | kubectl --context "${CLUSTER_REFERENCE}" --namespace "${NAMESPACE}" apply -f - \
+    || fail "failed to create/update ${sources_configmap}"
+log "  ${sources_configmap} applied."
+
+# 2) Merge the backfill env vars into the existing "-config" ConfigMap.
+kubectl --context "${CLUSTER_REFERENCE}" --namespace "${NAMESPACE}" \
+    patch configmap "${config_configmap}" --type merge -p "$(cat <<EOF
+{
+  "data": {
+    "BACKFILL_BLOCK_NODE_SOURCES_PATH": "${backfill_path}/${backfill_filename}",
+    "BACKFILL_GREEDY": "${BACKFILL_GREEDY}"
+  }
+}
+EOF
+)" || fail "failed to patch ${config_configmap}"
+log "  ${config_configmap} patched (BACKFILL_BLOCK_NODE_SOURCES_PATH, BACKFILL_GREEDY=${BACKFILL_GREEDY})."
+
+# 3) Patch the StatefulSet's pod template to add the volume + volumeMount.
+#    volumes[] and containers[].volumeMounts[] are both merged on their
+#    `name` key by a strategic merge patch, so this appends rather than
+#    clobbering the chart's existing volumes/mounts.
+statefulset_patch="${TMPDIR:-/tmp}/wrb-dist-${target_bn}-sts-patch.yaml"
+cat > "${statefulset_patch}" <<EOF
+spec:
+  template:
+    spec:
+      volumes:
+        - name: block-node-sources
+          configMap:
+            name: ${sources_configmap}
+      containers:
+      - name: block-node-server
+        volumeMounts:
+        - name: block-node-sources
+          mountPath: ${backfill_path}
+          readOnly: true
+EOF
+
+kubectl --context "${CLUSTER_REFERENCE}" --namespace "${NAMESPACE}" \
+    patch statefulset "${target_bn}" \
+    --patch-file "${statefulset_patch}" \
+    || fail "kubectl patch failed for statefulset/${target_bn}"
+
+log "Waiting for ${target_bn} rollout (timeout ${READY_TIMEOUT}s)..."
+kubectl --context "${CLUSTER_REFERENCE}" --namespace "${NAMESPACE}" \
+    rollout status statefulset/"${target_bn}" --timeout="${READY_TIMEOUT}s" \
+    || {
+        kubectl --context "${CLUSTER_REFERENCE}" --namespace "${NAMESPACE}" \
+            describe pod/"${target_bn}-0" | tail -30 || true
+        fail "${target_bn} rollout did not complete"
+    }
+
+log "${target_bn} is now backfilling from ${source_bn}."

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/reconfigure-mn1-to-bn-sources.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/reconfigure-mn1-to-bn-sources.sh
@@ -27,7 +27,10 @@
 #   BN_HOST_2         (default block-node-2.${NAMESPACE}.svc.cluster.local)
 #   BN_HOST_3         (default block-node-3.${NAMESPACE}.svc.cluster.local)
 #   MN_INSTANCE       (default "mirror-1")
-#   MN_VERSION        (default v0.157.1)
+#   MN_VERSION        (default "latest" — must be >= whatever version Solo
+#                     actually installed MN1 with, since Flyway rejects
+#                     rolling the importer back to an older migration set
+#                     than what's already applied to MN1's Postgres)
 #   READY_TIMEOUT     (default 300)
 
 set -euo pipefail
@@ -37,7 +40,7 @@ set -euo pipefail
 : "${BN_HOST_2:=block-node-2.${NAMESPACE}.svc.cluster.local}"
 : "${BN_HOST_3:=block-node-3.${NAMESPACE}.svc.cluster.local}"
 : "${MN_INSTANCE:=mirror-1}"
-: "${MN_VERSION:=v0.157.1}"
+: "${MN_VERSION:=latest}"
 READY_TIMEOUT="${READY_TIMEOUT:-300}"
 
 log() { echo "[wrb-dist-mn1-reconfig] $*"; }
@@ -68,10 +71,10 @@ spec:
       - name: importer
         image: ${jvm_image}
         # Match wrb-sequential-comparison.sh's memory shape. The Solo-installed
-        # default is too tight for MN v0.157.1's Flyway-migration + BN-source
-        # bootstrap over MN1's already-populated Postgres, which OOM-kills the
-        # importer container between "Successfully connected to database" and
-        # first block subscription.
+        # default is too tight for the Flyway-migration + BN-source bootstrap
+        # over MN1's already-populated Postgres, which OOM-kills the importer
+        # container between "Successfully connected to database" and first
+        # block subscription.
         resources:
           requests:
             cpu: 500m

--- a/tools-and-tests/scripts/solo-e2e-test/tests/wrb-distribution-step10.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/wrb-distribution-step10.yaml
@@ -7,7 +7,8 @@
 #   1-2. Solo brings up CN+MN, wrb-cli baseline wrap, live-wrap loop forked.
 #   3-5. Add BN1/BN2/BN3, EMB=0/0/100_000_000, assert per-BN EMB.
 #   6.   Reconfigure MN1's importer env to also pull live blocks from BN2/BN3.
-#   7.   Install MN2 v0.157.1 pointing at BN2/BN3 from genesis.
+#   7.   Install MN2 (JVM importer, latest by default) pointing at BN2/BN3
+#        from genesis.
 #   10.  Reconfigure BN2 and BN3 (via reconfigure-bn-backfill.sh) to set BN1
 #        as a backfill source.
 #
@@ -106,7 +107,7 @@ events:
 
   - id: add-mn2
     type: command
-    description: "Step 7: install MN2 v0.157.1 pointing at BN2/BN3 with startBlockNumber=0"
+    description: "Step 7: install MN2 (JVM importer, latest by default) pointing at BN2/BN3 with startBlockNumber=0"
     delay: 340
     timeout: 600
     args:

--- a/tools-and-tests/scripts/solo-e2e-test/tests/wrb-distribution-step10.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/wrb-distribution-step10.yaml
@@ -121,6 +121,15 @@ events:
       script: "${SCRIPT_DIR}/wrb-distribution/assert-mn-consuming-from-bn.sh mirror-2"
 
   # Slice 5 — BN-to-BN backfill reconfiguration (step 10).
+  #
+  # The 10s deltas between reconfigure-bn2-backfill/reconfigure-bn3-backfill/
+  # assert-bn-backfill-source look too tight for a StatefulSet rolling
+  # restart, but `delay` is only a floor ("don't start before T elapsed"),
+  # not a fixed offset — solo-test-runner.sh executes events sequentially and
+  # blocks on each script's exit. reconfigure-bn-backfill.sh itself blocks on
+  # `kubectl rollout status --timeout=300s` before returning, so the next
+  # event can't start until that BN's rollout has actually finished (or the
+  # step has already failed loudly).
 
   - id: reconfigure-bn2-backfill
     type: command

--- a/tools-and-tests/scripts/solo-e2e-test/tests/wrb-distribution-step10.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/wrb-distribution-step10.yaml
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# WRB Distribution E2E (#3125) — slice 5 (step 10), builds on slice 4 (step67).
+#
+# Extends slice 4 (steps 1-7) with the BN-to-BN backfill reconfiguration:
+#
+#   1-2. Solo brings up CN+MN, wrb-cli baseline wrap, live-wrap loop forked.
+#   3-5. Add BN1/BN2/BN3, EMB=0/0/100_000_000, assert per-BN EMB.
+#   6.   Reconfigure MN1's importer env to also pull live blocks from BN2/BN3.
+#   7.   Install MN2 v0.157.1 pointing at BN2/BN3 from genesis.
+#   10.  Reconfigure BN2 and BN3 (via reconfigure-bn-backfill.sh) to set BN1
+#        as a backfill source.
+#
+# Assertion on the step-10 change:
+#   * assert-bn-backfill-source.sh 2 3 — BN2 and BN3 both have
+#     BACKFILL_BLOCK_NODE_SOURCES_PATH set and their mounted sources file
+#     references BN1.
+#
+# Usage (locally):
+#   task test:run TEST_FILE=tests/wrb-distribution-step10.yaml \
+#                 TOPOLOGY=wrb-distribution-step10
+
+name: wrb-distribution-step10
+description: "WRB distribution E2E (#3125) — steps 1-7 baseline + step 10: BN2/BN3 reconfigured to backfill from BN1"
+
+events:
+  - id: initial-status
+    type: network-status
+    description: "Confirm 3 CNs and MN1 are running (no BN yet)"
+    delay: 5
+
+  - id: block-production-wait
+    type: sleep
+    description: "Wait for CNs to produce enough record files"
+    delay: 10
+    args:
+      seconds: 180
+
+  - id: install-and-run-wrb-cli
+    type: command
+    description: "Install wrb-cli, pull records from MinIO, run blocks wrap, assert nested dir"
+    delay: 195
+    timeout: 1200
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/install-and-run-wrb-cli.sh"
+
+  - id: start-live-wrap
+    type: command
+    description: "Fork the live-wrap background worker (polling MinIO + re-wrapping)"
+    delay: 200
+    timeout: 60
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/start-live-wrap.sh"
+
+  # Slice 3 — bring BN1/BN2/BN3 online while the live wrap loop continues.
+
+  - id: add-bn1
+    type: command
+    description: "Add BN1 (Tier-0, EMB=0) via solo block node add and wait for Ready"
+    delay: 210
+    timeout: 300
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/add-bn.sh 1"
+
+  - id: add-bn2
+    type: command
+    description: "Add BN2 (Tier-1, EMB=0) via solo block node add and wait for Ready"
+    delay: 220
+    timeout: 300
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/add-bn.sh 2"
+
+  - id: add-bn3
+    type: command
+    description: "Add BN3 (Tier-1, EMB=100_000_000) via solo block node add and wait for Ready"
+    delay: 230
+    timeout: 300
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/add-bn.sh 3"
+
+  - id: assert-bn-emb
+    type: command
+    description: "Assert each BN's earliestManagedBlock matches its topology overlay"
+    delay: 240
+    timeout: 120
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/assert-bn-emb.sh"
+
+  # Slice 4 — MN reconfiguration and MN2 install.
+
+  - id: reconfigure-mn1-to-bn-sources
+    type: command
+    description: "Step 6: patch MN1 importer env to pull live blocks from BN2 and BN3"
+    delay: 260
+    timeout: 300
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/reconfigure-mn1-to-bn-sources.sh"
+
+  - id: assert-mn1-consuming-from-bn
+    type: command
+    description: "Assert MN1 is now consuming blocks from a BN source"
+    delay: 320
+    timeout: 120
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/assert-mn-consuming-from-bn.sh mirror-1"
+
+  - id: add-mn2
+    type: command
+    description: "Step 7: install MN2 v0.157.1 pointing at BN2/BN3 with startBlockNumber=0"
+    delay: 340
+    timeout: 600
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/add-mn2.sh"
+
+  - id: assert-mn2-consuming-from-bn
+    type: command
+    description: "Assert MN2 has come up and is consuming blocks from a BN source"
+    delay: 400
+    timeout: 120
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/assert-mn-consuming-from-bn.sh mirror-2"
+
+  # Slice 5 — BN-to-BN backfill reconfiguration (step 10).
+
+  - id: reconfigure-bn2-backfill
+    type: command
+    description: "Step 10: reconfigure BN2 to set BN1 as a backfill source"
+    delay: 420
+    timeout: 300
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/reconfigure-bn-backfill.sh 2"
+
+  - id: reconfigure-bn3-backfill
+    type: command
+    description: "Step 10: reconfigure BN3 to set BN1 as a backfill source"
+    delay: 430
+    timeout: 300
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/reconfigure-bn-backfill.sh 3"
+
+  - id: assert-bn-backfill-source
+    type: command
+    description: "Assert BN2 and BN3 are both configured to backfill from BN1"
+    delay: 440
+    timeout: 120
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/assert-bn-backfill-source.sh 2 3"
+
+  # Slice 3's tail — observation window + live-wrap assertion + stop.
+
+  - id: live-wrap-observation-window
+    type: sleep
+    description: "Let the live wrap loop pick up records produced while BN backfill reconfig ran"
+    delay: 460
+    args:
+      seconds: 180
+
+  - id: assert-live-wrap-produced-new-blocks
+    type: command
+    description: "Assert live-wrap kept running through the BN backfill reconfig"
+    delay: 645
+    timeout: 60
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/assert-live-wrap-produced-new-blocks.sh"
+
+  - id: stop-live-wrap
+    type: command
+    description: "Tear down the live-wrap background worker"
+    delay: 650
+    timeout: 60
+    args:
+      script: "${SCRIPT_DIR}/wrb-distribution/stop-live-wrap.sh"
+
+  - id: final-status
+    type: network-status
+    description: "Post-test network status (should show BN1/BN2/BN3, MN1 + MN2 up)"
+    delay: 655
+
+# BN + MN health is asserted implicitly by:
+#   * add-bn.sh's kubectl wait --for=condition=Ready pod/block-node-<i>-0
+#   * add-mn2.sh's kubectl wait on mirror-2 pods
+#   * assert-bn-emb.sh / assert-mn-consuming-from-bn.sh / assert-bn-backfill-source.sh
+#     exec/curl into pods
+# Explicit target-block-node assertions here would fail the runner's
+# topology-target validation (block-node-N / mirror-2 aren't in the
+# deploy-time topology).
+assertions:
+  - id: no-errors
+    type: no-errors
+    description: "No errors in Block Node logs"
+    target: all

--- a/tools-and-tests/scripts/solo-e2e-test/topologies/wrb-distribution-step10.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/topologies/wrb-distribution-step10.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# WRB Distribution E2E (#3125) — slice 5 (step 10), builds on slice 4 (step67).
+#
+# Same DEPLOY-TIME shape as wrb-distribution-step67: 3 CNs v0.75 + MN1
+# v0.157.1, no Block Node. BN1/BN2/BN3 are added post-deploy (steps 3-5), MN1
+# is reconfigured and MN2 installed post-deploy (steps 6-7), and slice 5 adds
+# the BN-to-BN backfill reconfiguration (step 10) on top, all via command
+# events in the test definition:
+#
+#   1-2.  Solo brings up CN+MN, wrb-cli baseline wrap, live-wrap loop forked.
+#   3-5.  Add BN1/BN2/BN3, EMB=0/0/100_000_000, assert per-BN EMB.
+#   6-7.  Reconfigure MN1 to pull live blocks from BN2/BN3; install MN2
+#         pointing at BN2/BN3 from genesis.
+#   10.   Reconfigure BN2 and BN3 to set BN1 as a backfill source.
+#
+# See the wrb-distribution-step345.yaml topology comment for why BN
+# installation stays post-deploy (Solo skips MinIO tenant install when BNs
+# are declared at deploy time).
+
+name: wrb-distribution-step10
+description: "WRB distribution E2E (#3125) — steps 1-7 baseline + step 10: BN2/BN3 reconfigured to backfill from BN1"
+
+# No Block Nodes at deploy time. See topology comment above.
+block_nodes: {}
+
+consensus_nodes:
+  node1: {}
+  node2: {}
+  node3: {}
+
+mirror_nodes:
+  mirror-1: {}
+
+relay_nodes: {}
+
+explorer_nodes: {}


### PR DESCRIPTION
*"Use the solo-provisioner to reconfigure BN2 and BN3 to set BN1 as a backfill source"* — following the exact slicing pattern established by the prior steps (step12/step345/step67), as slice 5:

- [reconfigure-bn-backfill.sh](tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/reconfigure-bn-backfill.sh) — reconfigures an already-deployed BN (added post-hoc via `add-bn.sh`) to backfill from another BN. Since Solo has no `block node update` command, it does by hand what the Helm chart would render: creates the `<bn>-block-node-sources` ConfigMap, merges `BACKFILL_BLOCK_NODE_SOURCES_PATH`/`BACKFILL_GREEDY` into the existing `<bn>-config` ConfigMap, then patches the StatefulSet's pod template to add the volume + volumeMount the chart only renders when `blockNode.backfill.sources` is set at install time.
- [assert-bn-backfill-source.sh](tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-bn-backfill-source.sh) — verifies both the env var and the mounted sources file content on each target BN.
- [topologies/wrb-distribution-step10.yaml](tools-and-tests/scripts/solo-e2e-test/topologies/wrb-distribution-step10.yaml) and [tests/wrb-distribution-step10.yaml](tools-and-tests/scripts/solo-e2e-test/tests/wrb-distribution-step10.yaml) — same deploy-time shape as step67, extended with steps 1-7 plus the new step 10 reconfigure/assert events.
- Wired `wrb-distribution-step10` into the [solo-e2e-test.yml](.github/workflows/solo-e2e-test.yml) topology dropdown and test-definition description.

The test definition validated successfully via `solo-test-runner.sh --validate`. I couldn't run it end-to-end against a live cluster (would require standing up a Solo/Kind network), so the actual `kubectl patch` behavior against a real StatefulSet is unverified — worth a dry run before merging.

____________________________________________________________________

## Reviewer Notes

## Related Issue(s)
 Use keywords `Fix, Fixes, Fixed, Close, Closes, Closed, Resolve, Resolves, Resolved`
to connect an issue to be closed by this pull request.
