### PR TITLE
feat: Proto Ordinal Streaming Hasher Mapping in BlockHasher

### DIFF
--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/hasher/BlockHasher.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/hasher/BlockHasher.java
@@ -46,6 +46,14 @@ import org.hiero.block.node.spi.blockmessaging.BlockSource;
 public final class BlockHasher implements Supplier<HashingResult> {
     /// The time to park between polls of the block items deque when no data is available.
     private static final long DATA_BUSY_WAIT_TIME_NANOS = TimeUnit.MICROSECONDS.toNanos(200);
+    /// The first `BlockItem` field number governed by the block stream forward compatibility
+    /// numbering rule. Field numbers below this value belong to the first release; an unknown
+    /// field below it is reserved for item types that require specific handling.
+    private static final int FIRST_FORWARD_COMPATIBLE_FIELD_NUMBER = 20;
+    /// The modulus of the forward compatibility numbering rule: for a field numbered
+    /// [#FIRST_FORWARD_COMPATIBLE_FIELD_NUMBER] or above, the hashing category is the field
+    /// number modulo this value.
+    private static final int CATEGORY_MODULUS = 20;
     /// The number of the block being hashed.
     private final long blockNumber;
     /// The source of the block, carried through to the result and failures.
@@ -70,6 +78,26 @@ public final class BlockHasher implements Supplier<HashingResult> {
     private final NaiveStreamingTreeHasher stateChangesHasher;
     /// The tree hasher for trace data item hashes.
     private final NaiveStreamingTreeHasher traceDataHasher;
+    /// Extension 0 subtree hasher, leaf position 9 of the fixed 16 leaf block root tree
+    /// ("Merkle Mountain Top" in HIP-1424). The eight extension leaf positions (9 to 16) are
+    /// permanently defined in the tree; each hasher below is bound to its position. A hasher is
+    /// created when the block contains an item of the corresponding extension category, and a
+    /// null hasher means the leaf carries no data in this block, so it is excluded from the tree.
+    private NaiveStreamingTreeHasher extensionHasherZero;
+    /// Extension 1 subtree hasher, leaf position 10. See [#extensionHasherZero].
+    private NaiveStreamingTreeHasher extensionHasherOne;
+    /// Extension 2 subtree hasher, leaf position 11. See [#extensionHasherZero].
+    private NaiveStreamingTreeHasher extensionHasherTwo;
+    /// Extension 3 subtree hasher, leaf position 12. See [#extensionHasherZero].
+    private NaiveStreamingTreeHasher extensionHasherThree;
+    /// Extension 4 subtree hasher, leaf position 13. See [#extensionHasherZero].
+    private NaiveStreamingTreeHasher extensionHasherFour;
+    /// Extension 5 subtree hasher, leaf position 14. See [#extensionHasherZero].
+    private NaiveStreamingTreeHasher extensionHasherFive;
+    /// Extension 6 subtree hasher, leaf position 15. See [#extensionHasherZero].
+    private NaiveStreamingTreeHasher extensionHasherSix;
+    /// Extension 7 subtree hasher, leaf position 16. See [#extensionHasherZero].
+    private NaiveStreamingTreeHasher extensionHasherSeven;
     /// Provider of the verification data, used to publish TSS data found in block 0.
     private final VerificationDataProvider verificationDataProvider;
     /// The parsed block header, set when the header item is seen.
@@ -138,86 +166,9 @@ public final class BlockHasher implements Supplier<HashingResult> {
                     } else {
                         this.accumulatedBlockItems.addAll(currentBlockItems);
                         for (final BlockItemUnparsed item : currentBlockItems) {
-                            final BlockItemUnparsed.ItemOneOfType kind =
-                                    item.item().kind();
-                            switch (kind) {
-                                case BLOCK_HEADER -> {
-                                    if (this.blockHeader == null) {
-                                        this.blockHeader = standardParse(BlockHeader.PROTOBUF, item.blockHeader());
-                                        this.hapiProtoVersion = this.blockHeader.hapiProtoVersion();
-                                        if (this.hapiProtoVersion == null) {
-                                            throw new VerificationSessionFailedException(
-                                                    blockNumber,
-                                                    SessionFailureType.MISSING_MANDATORY_FIELD,
-                                                    blockSource);
-                                        } else {
-                                            outputTreeHasher.addLeaf(getBlockItemHash(item));
-                                        }
-                                    } else {
-                                        throw new VerificationSessionFailedException(
-                                                blockNumber, SessionFailureType.UNABLE_TO_PARSE, blockSource);
-                                    }
-                                }
-                                case ROUND_HEADER, EVENT_HEADER ->
-                                    consensusHeaderHasher.addLeaf(getBlockItemHash(item));
-                                case SIGNED_TRANSACTION -> {
-                                    inputTreeHasher.addLeaf(getBlockItemHash(item));
-                                    if (blockItemsRecord.blockNumber() == 0 && !verificationDataProvider.hasTssData()) {
-                                        final LedgerIdPublicationTransactionBody publication =
-                                                findLedgerIdPublication(item.signedTransaction());
-                                        if (publication != null) {
-                                            // publish TSS Data
-                                            final TssData tssData =
-                                                    VerificationHelper.extractTssData(publication, blockNumber);
-                                            verificationDataProvider.safeUpdateTssData(tssData, true);
-                                        }
-                                    }
-                                }
-                                case TRANSACTION_RESULT, TRANSACTION_OUTPUT ->
-                                    outputTreeHasher.addLeaf(getBlockItemHash(item));
-                                case STATE_CHANGES -> stateChangesHasher.addLeaf(getBlockItemHash(item));
-                                case TRACE_DATA -> traceDataHasher.addLeaf(getBlockItemHash(item));
-                                case RECORD_FILE -> {
-                                    if (this.rawRecordFileItemProtoBytes == null) {
-                                        this.rawRecordFileItemProtoBytes = item.recordFileOrThrow();
-                                        outputTreeHasher.addLeaf(getBlockItemHash(item));
-                                    } else {
-                                        throw new VerificationSessionFailedException(
-                                                blockNumber, SessionFailureType.UNABLE_TO_PARSE, blockSource);
-                                    }
-                                }
-                                case BLOCK_FOOTER -> {
-                                    if (this.blockFooter == null) {
-                                        this.blockFooter = standardParse(BlockFooter.PROTOBUF, item.blockFooter());
-                                    } else {
-                                        throw new VerificationSessionFailedException(
-                                                blockNumber, SessionFailureType.UNABLE_TO_PARSE, blockSource);
-                                    }
-                                }
-                                case BLOCK_PROOF -> {
-                                    final BlockProof blockProof = standardParse(BlockProof.PROTOBUF, item.blockProof());
-                                    blockProofs.add(blockProof);
-                                }
-                                case REDACTED_ITEM, FILTERED_SINGLE_ITEM -> {
-                                    // not permitted currently, fail the hashing.
-                                    throw new VerificationSessionFailedException(
-                                            blockNumber, SessionFailureType.UNABLE_TO_PARSE, blockSource);
-                                }
-                                case UNSET -> {
-                                    throw new VerificationSessionFailedException(
-                                            blockNumber, SessionFailureType.UNKNOWN_ERROR, blockSource);
-                                }
-                                default -> {
-                                    // @todo(3195) add field-number based sorting here.
-                                    throw new VerificationSessionFailedException(
-                                            blockNumber, SessionFailureType.UNKNOWN_ERROR, blockSource);
-                                }
-                            }
-                            final List<UnknownField> itemUnknownFields = item.getUnknownFields();
-                            if (!itemUnknownFields.isEmpty()) {
-                                // @todo(3195) add field-number based sorting here.
-                                throw new VerificationSessionFailedException(
-                                        blockNumber, SessionFailureType.UNABLE_TO_PARSE, blockSource);
+                            final SessionFailureType failure = processItem(item, blockItemsRecord.blockNumber());
+                            if (failure != null) {
+                                throw new VerificationSessionFailedException(blockNumber, failure, blockSource);
                             }
                         }
                     }
@@ -244,6 +195,234 @@ public final class BlockHasher implements Supplier<HashingResult> {
         return isCanceled.get() || Thread.currentThread().isInterrupted();
     }
 
+    /// Processes a single block item: hashes it into the correct subtree and captures block
+    /// level data (header, footer, proofs) along the way.
+    ///
+    /// The switch below is deliberately an exhaustive switch expression with no default branch.
+    /// When a new item type is added to the `BlockItem` schema, compilation fails here until the
+    /// new type is given an explicit handling decision. An item type that is unknown to the
+    /// compiled schema altogether surfaces as `UNSET` with the data preserved as an unknown
+    /// field, and is handled by the forward compatibility numbering rule in
+    /// [#processFutureItem].
+    /// @param item the block item to process
+    /// @param itemsBlockNumber the block number carried by the current block items record
+    /// @return null on success, or the failure type when the block must be refused
+    /// @throws ParseException if a known item fails to parse
+    private SessionFailureType processItem(final BlockItemUnparsed item, final long itemsBlockNumber)
+            throws ParseException {
+        final BlockItemUnparsed.ItemOneOfType kind = item.item().kind();
+        final List<UnknownField> unknownFields = item.getUnknownFields();
+        final SessionFailureType failure;
+        if (kind != BlockItemUnparsed.ItemOneOfType.UNSET && !unknownFields.isEmpty()) {
+            // A BlockItem is a protobuf oneof, so a valid item carries exactly one field. A known
+            // item type alongside unknown fields parses fine, but is not a processable stream.
+            failure = SessionFailureType.UNSUPPORTED_STREAM_FORMAT;
+        } else {
+            failure = switch (kind) {
+                case BLOCK_HEADER -> {
+                    if (this.blockHeader != null) {
+                        // a mandatory once per block item appearing more than once is a valid
+                        // encoding, but not a processable stream
+                        yield SessionFailureType.UNSUPPORTED_STREAM_FORMAT;
+                    } else {
+                        this.blockHeader = standardParse(BlockHeader.PROTOBUF, item.blockHeader());
+                        this.hapiProtoVersion = this.blockHeader.hapiProtoVersion();
+                        if (this.hapiProtoVersion == null) {
+                            yield SessionFailureType.MISSING_MANDATORY_FIELD;
+                        } else {
+                            outputTreeHasher.addLeaf(getBlockItemHash(item));
+                            yield null;
+                        }
+                    }
+                }
+                case ROUND_HEADER, EVENT_HEADER -> {
+                    consensusHeaderHasher.addLeaf(getBlockItemHash(item));
+                    yield null;
+                }
+                case SIGNED_TRANSACTION -> {
+                    inputTreeHasher.addLeaf(getBlockItemHash(item));
+                    if (itemsBlockNumber == 0 && !verificationDataProvider.hasTssData()) {
+                        final LedgerIdPublicationTransactionBody publication =
+                                findLedgerIdPublication(item.signedTransaction());
+                        if (publication != null) {
+                            // publish TSS Data
+                            final TssData tssData = VerificationHelper.extractTssData(publication, blockNumber);
+                            verificationDataProvider.safeUpdateTssData(tssData, true);
+                        }
+                    }
+                    yield null;
+                }
+                case TRANSACTION_RESULT, TRANSACTION_OUTPUT -> {
+                    outputTreeHasher.addLeaf(getBlockItemHash(item));
+                    yield null;
+                }
+                case STATE_CHANGES -> {
+                    stateChangesHasher.addLeaf(getBlockItemHash(item));
+                    yield null;
+                }
+                case TRACE_DATA -> {
+                    traceDataHasher.addLeaf(getBlockItemHash(item));
+                    yield null;
+                }
+                case RECORD_FILE -> {
+                    if (this.rawRecordFileItemProtoBytes != null) {
+                        // a mandatory once per block item appearing more than once is a valid
+                        // encoding, but not a processable stream
+                        yield SessionFailureType.UNSUPPORTED_STREAM_FORMAT;
+                    } else {
+                        this.rawRecordFileItemProtoBytes = item.recordFileOrThrow();
+                        outputTreeHasher.addLeaf(getBlockItemHash(item));
+                        yield null;
+                    }
+                }
+                case BLOCK_FOOTER -> {
+                    if (this.blockFooter != null) {
+                        // a mandatory once per block item appearing more than once is a valid
+                        // encoding, but not a processable stream
+                        yield SessionFailureType.UNSUPPORTED_STREAM_FORMAT;
+                    } else {
+                        this.blockFooter = standardParse(BlockFooter.PROTOBUF, item.blockFooter());
+                        yield null;
+                    }
+                }
+                case BLOCK_PROOF -> {
+                    blockProofs.add(standardParse(BlockProof.PROTOBUF, item.blockProof()));
+                    yield null;
+                }
+                // item types this version of the node cannot process currently
+                case REDACTED_ITEM, FILTERED_SINGLE_ITEM -> SessionFailureType.UNSUPPORTED_ITEM_TYPE;
+                case UNSET -> processFutureItem(item, unknownFields);
+            };
+        }
+        return failure;
+    }
+
+    /// Handles an item whose type is unknown to the compiled schema, applying the block stream
+    /// forward compatibility numbering rule: for a field numbered 20 or above, the hashing
+    /// category is the field number modulo 20. Categories that map to a defined subtree are
+    /// hashed like any other item, not-hashed categories are read and ignored, and everything
+    /// else refuses the block, because guessing could produce a hash that disagrees with an
+    /// upgraded node.
+    /// @param item the block item carrying the unknown field
+    /// @param unknownFields the unknown fields of the item
+    /// @return null on success, or the failure type when the block must be refused
+    private SessionFailureType processFutureItem(final BlockItemUnparsed item, final List<UnknownField> unknownFields) {
+        final SessionFailureType failure;
+        if (unknownFields.isEmpty()) {
+            // an item with no field at all, nothing valid to process
+            failure = SessionFailureType.UNKNOWN_ERROR;
+        } else if (unknownFields.size() > 1) {
+            // a BlockItem is a oneof, so a valid item carries exactly one field; more than one
+            // unknown field parses fine, but is not a processable stream
+            failure = SessionFailureType.UNSUPPORTED_STREAM_FORMAT;
+        } else {
+            final int fieldNumber = unknownFields.getFirst().field();
+            if (fieldNumber < FIRST_FORWARD_COMPATIBLE_FIELD_NUMBER) {
+                // an unknown field below 20 is a first release field reserved for item types that
+                // require specific handling this version does not know
+                hashingMetrics.futureItemsRefused().increment();
+                failure = SessionFailureType.UNSUPPORTED_ITEM_TYPE;
+            } else {
+                final int category = fieldNumber % CATEGORY_MODULUS;
+                failure = switch (category) {
+                    case 0, 19 -> {
+                        // not part of the block proof merkle tree, read and ignore
+                        hashingMetrics.futureItemsNotHashed().increment();
+                        yield null;
+                    }
+                    case 1, 2 -> {
+                        // requires specific handling
+                        hashingMetrics.futureItemsRefused().increment();
+                        yield SessionFailureType.UNSUPPORTED_ITEM_TYPE;
+                    }
+                    case 3 -> hashFutureItem(item, consensusHeaderHasher);
+                    case 4 -> hashFutureItem(item, inputTreeHasher);
+                    case 5 -> hashFutureItem(item, outputTreeHasher);
+                    case 6 -> hashFutureItem(item, stateChangesHasher);
+                    case 7 -> hashFutureItem(item, traceDataHasher);
+                    case 8 -> {
+                        extensionHasherZero = createIfNull(extensionHasherZero);
+                        yield hashFutureItem(item, extensionHasherZero);
+                    }
+                    case 9 -> {
+                        extensionHasherOne = createIfNull(extensionHasherOne);
+                        yield hashFutureItem(item, extensionHasherOne);
+                    }
+                    case 10 -> {
+                        extensionHasherTwo = createIfNull(extensionHasherTwo);
+                        yield hashFutureItem(item, extensionHasherTwo);
+                    }
+                    case 11 -> {
+                        extensionHasherThree = createIfNull(extensionHasherThree);
+                        yield hashFutureItem(item, extensionHasherThree);
+                    }
+                    case 12 -> {
+                        extensionHasherFour = createIfNull(extensionHasherFour);
+                        yield hashFutureItem(item, extensionHasherFour);
+                    }
+                    case 13 -> {
+                        extensionHasherFive = createIfNull(extensionHasherFive);
+                        yield hashFutureItem(item, extensionHasherFive);
+                    }
+                    case 14 -> {
+                        extensionHasherSix = createIfNull(extensionHasherSix);
+                        yield hashFutureItem(item, extensionHasherSix);
+                    }
+                    case 15 -> {
+                        extensionHasherSeven = createIfNull(extensionHasherSeven);
+                        yield hashFutureItem(item, extensionHasherSeven);
+                    }
+                    // categories 16 to 18 are reserved with no subtree in the block root tree
+                    case 16, 17, 18 -> {
+                        // categories 16 to 18 are reserved with no subtree in the block root tree
+                        hashingMetrics.futureItemsRefused().increment();
+                        yield SessionFailureType.UNSUPPORTED_ITEM_TYPE;
+                    }
+                    default -> SessionFailureType.UNKNOWN_ERROR;
+                };
+            }
+        }
+        return failure;
+    }
+
+    /// Hashes a future item into the given subtree hasher.
+    /// @param item the block item to hash
+    /// @param hasher the subtree hasher the item's category maps to
+    /// @return always null, the item was hashed successfully
+    private SessionFailureType hashFutureItem(final BlockItemUnparsed item, final NaiveStreamingTreeHasher hasher) {
+        hasher.addLeaf(getBlockItemHash(item));
+        hashingMetrics.futureItemsHashed().increment();
+        return null;
+    }
+
+    /// Returns the given extension subtree hasher, or a new one when it does not exist yet.
+    /// @param hasher the current extension subtree hasher, or null when not yet created
+    /// @return the given hasher, or a new one when the given hasher is null
+    private static NaiveStreamingTreeHasher createIfNull(final NaiveStreamingTreeHasher hasher) {
+        final NaiveStreamingTreeHasher result;
+        if (hasher == null) {
+            result = new NaiveStreamingTreeHasher();
+        } else {
+            result = hasher;
+        }
+        return result;
+    }
+
+    /// Returns the root hash of the given extension subtree hasher, or null when the hasher was
+    /// never created, meaning the corresponding leaf of the block root tree carries no data in
+    /// this block.
+    /// @param hasher the extension subtree hasher, or null when never created
+    /// @return the root hash of the subtree, or null when the hasher is null
+    private static byte[] extensionSubtreeRoot(final NaiveStreamingTreeHasher hasher) {
+        final byte[] root;
+        if (hasher == null) {
+            root = null;
+        } else {
+            root = hasher.rootHash().join().toByteArray();
+        }
+        return root;
+    }
+
     /// Finish the hashing operation.
     /// This method will finalize the hashing process. Root hash will be calculated and
     /// a [HashingResult] will be returned.
@@ -268,7 +447,15 @@ public final class BlockHasher implements Supplier<HashingResult> {
                         outputTreeHasher,
                         consensusHeaderHasher,
                         stateChangesHasher,
-                        traceDataHasher);
+                        traceDataHasher,
+                        extensionSubtreeRoot(extensionHasherZero),
+                        extensionSubtreeRoot(extensionHasherOne),
+                        extensionSubtreeRoot(extensionHasherTwo),
+                        extensionSubtreeRoot(extensionHasherThree),
+                        extensionSubtreeRoot(extensionHasherFour),
+                        extensionSubtreeRoot(extensionHasherFive),
+                        extensionSubtreeRoot(extensionHasherSix),
+                        extensionSubtreeRoot(extensionHasherSeven));
                 final BlockUnparsed block = BlockUnparsed.newBuilder()
                         .blockItems(accumulatedBlockItems)
                         .build();

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/metrics/HashingMetrics.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/metrics/HashingMetrics.java
@@ -10,10 +10,32 @@ import org.hiero.metrics.core.MetricRegistry;
 
 /// Holder for metrics used by [org.hiero.block.node.block.verification.hasher.BlockHasher]
 /// @param hashingBlockTimeNs a [LongCounter.Measurement] of the time spent hashing a block
-public record HashingMetrics(Measurement hashingBlockTimeNs) {
+/// @param futureItemsHashed a [LongCounter.Measurement] counting future (unknown to this
+///     version) block item types placed into a subtree by the forward compatibility numbering rule
+/// @param futureItemsNotHashed a [LongCounter.Measurement] counting future block item types
+///     safely ignored as not hashed per the forward compatibility numbering rule
+/// @param futureItemsRefused a [LongCounter.Measurement] counting future block item types that
+///     caused a block to be refused because this version cannot process them (upgrade required)
+public record HashingMetrics(
+        Measurement hashingBlockTimeNs,
+        Measurement futureItemsHashed,
+        Measurement futureItemsNotHashed,
+        Measurement futureItemsRefused) {
     /// Metric key for block hashing time.
     private static final MetricKey<LongCounter> METRIC_HASHING_BLOCK_TIME =
             MetricKey.of("hashing_block_time", LongCounter.class).addCategory(METRICS_CATEGORY);
+
+    /// Metric key for future item types hashed via the forward compatibility numbering rule.
+    private static final MetricKey<LongCounter> METRIC_FUTURE_ITEMS_HASHED =
+            MetricKey.of("hashing_future_items_hashed", LongCounter.class).addCategory(METRICS_CATEGORY);
+
+    /// Metric key for future item types ignored as not hashed.
+    private static final MetricKey<LongCounter> METRIC_FUTURE_ITEMS_NOT_HASHED =
+            MetricKey.of("hashing_future_items_not_hashed", LongCounter.class).addCategory(METRICS_CATEGORY);
+
+    /// Metric key for future item types that caused a block to be refused.
+    private static final MetricKey<LongCounter> METRIC_FUTURE_ITEMS_REFUSED =
+            MetricKey.of("hashing_future_items_refused", LongCounter.class).addCategory(METRICS_CATEGORY);
 
     /// Initialize and return a new [HashingMetrics] instance.
     /// @param metricRegistry used to create and initialize metrics
@@ -22,6 +44,21 @@ public record HashingMetrics(Measurement hashingBlockTimeNs) {
         final Measurement hashingBlockTimeNs = metricRegistry
                 .register(LongCounter.builder(METRIC_HASHING_BLOCK_TIME).setDescription("Hashing time per block (ns)"))
                 .getOrCreateNotLabeled();
-        return new HashingMetrics(hashingBlockTimeNs);
+        final Measurement futureItemsHashed = metricRegistry
+                .register(LongCounter.builder(METRIC_FUTURE_ITEMS_HASHED)
+                        .setDescription("Future block item types hashed into a subtree"
+                                + " by the forward compatibility numbering rule"))
+                .getOrCreateNotLabeled();
+        final Measurement futureItemsNotHashed = metricRegistry
+                .register(LongCounter.builder(METRIC_FUTURE_ITEMS_NOT_HASHED)
+                        .setDescription("Future block item types safely ignored as not hashed"
+                                + " per the forward compatibility numbering rule"))
+                .getOrCreateNotLabeled();
+        final Measurement futureItemsRefused = metricRegistry
+                .register(LongCounter.builder(METRIC_FUTURE_ITEMS_REFUSED)
+                        .setDescription("Future block item types that caused a block to be refused"
+                                + " because this version cannot process them (upgrade required)"))
+                .getOrCreateNotLabeled();
+        return new HashingMetrics(hashingBlockTimeNs, futureItemsHashed, futureItemsNotHashed, futureItemsRefused);
     }
 }

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/SessionFailureType.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/SessionFailureType.java
@@ -21,6 +21,14 @@ public enum SessionFailureType {
     UNRECOGNIZED_PROOF_TYPE,
     /// This type indicates that the block is of unsupported HAPI version
     UNSUPPORTED_HAPI_VERSION,
+    /// This type indicates that the block contains an item type this version of the
+    /// Block Node cannot process (a reserved or specific-handling field number per the
+    /// block stream forward compatibility numbering rule); an upgrade is required
+    UNSUPPORTED_ITEM_TYPE,
+    /// This type indicates that the wire encoding parsed successfully, but the content
+    /// is not a processable block stream (for example an item that carries more than one
+    /// field, or a mandatory once per block item that appears more than once)
+    UNSUPPORTED_STREAM_FORMAT,
     /// This type indicates that the session was cancelled
     CANCELLED,
     /// This type indicates that an unknown error occurred
@@ -37,6 +45,8 @@ public enum SessionFailureType {
             case MISSING_VERIFICATION_DATA -> FailureType.MISSING_VERIFICATION_DATA;
             case UNRECOGNIZED_PROOF_TYPE -> FailureType.UNRECOGNIZED_PROOF_TYPE;
             case UNSUPPORTED_HAPI_VERSION -> FailureType.UNSUPPORTED_HAPI_VERSION;
+            case UNSUPPORTED_ITEM_TYPE -> FailureType.UNSUPPORTED_ITEM_TYPE;
+            case UNSUPPORTED_STREAM_FORMAT -> FailureType.UNSUPPORTED_STREAM_FORMAT;
             case CANCELLED -> FailureType.CANCELLED;
             case UNKNOWN_ERROR -> FailureType.UNKNOWN_ERROR;
         };

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/verifier/StateProofVerifier.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/verifier/StateProofVerifier.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.block.verification.verifier;
 
+import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.WARNING;
 import static org.hiero.block.common.hasher.HashingUtilities.hashInternalNode;
 import static org.hiero.block.common.hasher.HashingUtilities.hashInternalNodeSingleChild;
@@ -83,11 +84,14 @@ public final class StateProofVerifier implements ProofVerifier {
     /// computed block root hash, which ties the proof to the block content.
     ///
     /// The proof is rejected when the structure is malformed: fewer than three
-    /// paths, a non-leaf first path, an out-of-range next index, a leaf pointing
-    /// to another leaf, a duplicate checkpoint, unvisited paths, or leftover
-    /// checkpoints after the walk. Note that the non-leaf first path check may be
-    /// relaxed in the future: a state proof creator might order the paths
-    /// slightly differently and still produce a valid state proof.
+    /// paths, an out-of-range next index, a leaf pointing to another leaf, a
+    /// duplicate checkpoint, unvisited paths, or leftover checkpoints after the
+    /// walk. The first path is not required to be a leaf: a state proof creator
+    /// might order the paths slightly differently and still produce a valid
+    /// state proof, so a non-leaf first path is only logged. A path counts as
+    /// visited only when it is actually processed (a leaf that is walked, or a
+    /// join point that is followed), so any path the walk never reaches, such
+    /// as a join point no leaf leads to, rejects the proof.
     ///
     /// Once reconstructed, the signed block root is verified against the
     /// signature carried by the proof. A signature verifier is required for this
@@ -106,10 +110,10 @@ public final class StateProofVerifier implements ProofVerifier {
         if (allPaths.size() < 3) {
             LOGGER.log(WARNING, "Block {0} state proof has {1} paths, expected >= 3", blockNumber, allPaths.size());
             result = SessionFailureType.BAD_BLOCK_PROOF;
-        } else if (!isLeaf(allPaths.getFirst())) {
-            LOGGER.log(WARNING, "Block {0} state proof has non-leaf first path", blockNumber);
-            result = SessionFailureType.BAD_BLOCK_PROOF;
         } else {
+            if (!isLeaf(allPaths.getFirst())) {
+                LOGGER.log(INFO, "Block {0} state proof has non-leaf first path", blockNumber);
+            }
             // Iterate over all paths, processing leafs in the order they are encountered until we have reconstructed
             // the signed block root.
             final boolean[] visited = new boolean[allPaths.size()];
@@ -121,8 +125,8 @@ public final class StateProofVerifier implements ProofVerifier {
                     return SessionFailureType.CANCELLED;
                 } else {
                     final MerklePath currentPath = allPaths.get(leafStartingIndex);
-                    visited[leafStartingIndex] = true;
                     if (isLeaf(currentPath)) {
+                        visited[leafStartingIndex] = true;
                         // First process the found leaf
                         final byte[] leafResult = processLeaf(currentPath);
                         // Now we must follow the next index, which must always be a join point,
@@ -204,8 +208,8 @@ public final class StateProofVerifier implements ProofVerifier {
                 return SessionFailureType.BAD_BLOCK_PROOF;
             } else {
                 final MerklePath nextPath = allPaths.get(currentJoinPointIndex);
-                visited[currentJoinPointIndex] = true;
                 if (isJoinPoint(nextPath)) {
+                    visited[currentJoinPointIndex] = true;
                     final MergeCheckpoint checkpoint = checkpoints.remove(currentJoinPointIndex);
                     if (checkpoint != null) {
                         // now we need to merge this with the checkpoint

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/verifier/StateProofVerifier.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/verifier/StateProofVerifier.java
@@ -2,6 +2,7 @@
 package org.hiero.block.node.block.verification.verifier;
 
 import static java.lang.System.Logger.Level.INFO;
+import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
 import static org.hiero.block.common.hasher.HashingUtilities.hashInternalNode;
 import static org.hiero.block.common.hasher.HashingUtilities.hashInternalNodeSingleChild;
@@ -136,6 +137,8 @@ public final class StateProofVerifier implements ProofVerifier {
                         if (followPathResult != null) {
                             return followPathResult;
                         }
+                    } else if (visited[leafStartingIndex]) {
+                        LOGGER.log(TRACE, "Index {0} of block {1} is already visited", leafStartingIndex, blockNumber);
                     }
                 }
             }
@@ -208,8 +211,8 @@ public final class StateProofVerifier implements ProofVerifier {
                 return SessionFailureType.BAD_BLOCK_PROOF;
             } else {
                 final MerklePath nextPath = allPaths.get(currentJoinPointIndex);
+                visited[currentJoinPointIndex] = true;
                 if (isJoinPoint(nextPath)) {
-                    visited[currentJoinPointIndex] = true;
                     final MergeCheckpoint checkpoint = checkpoints.remove(currentJoinPointIndex);
                     if (checkpoint != null) {
                         // now we need to merge this with the checkpoint

--- a/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/hasher/BlockHasherTest.java
+++ b/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/hasher/BlockHasherTest.java
@@ -4,6 +4,7 @@ package org.hiero.block.node.block.verification.hasher;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.hiero.block.node.base.ParseHelper.standardParse;
 
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.BlockItem.ItemOneOfType;
@@ -14,10 +15,14 @@ import com.hedera.hapi.block.stream.output.BlockFooter;
 import com.hedera.hapi.block.stream.output.BlockHeader;
 import com.hedera.hapi.node.base.BlockHashAlgorithm;
 import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -52,6 +57,7 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /// Tests for the [BlockHasher] class.
 @Timeout(unit = TimeUnit.SECONDS, value = 5)
@@ -528,7 +534,8 @@ class BlockHasherTest {
                     });
         }
 
-        /// This test aims to verify that if an unsupported item type is received, we will fail hashing.
+        /// This test aims to verify that if an item type this version cannot process is
+        /// received, we will fail hashing.
         @ParameterizedTest
         @MethodSource(UNSUPPORTED_ITEM_TYPES)
         @DisplayName("get() fail when getting an unsupported ")
@@ -552,13 +559,14 @@ class BlockHasherTest {
                                 .returns(blockNumber, VerificationSessionFailedException::getBlockNumber)
                                 .returns(blockSource, VerificationSessionFailedException::getBlockSource)
                                 .returns(
-                                        SessionFailureType.UNABLE_TO_PARSE,
+                                        SessionFailureType.UNSUPPORTED_ITEM_TYPE,
                                         VerificationSessionFailedException::getFailureType);
                     });
         }
 
         /// This test aims to assert that when a block with multiple items of specific types is received, we fail.
-        /// Some item types are required to only be present once for a block
+        /// Some item types are required to only be present once for a block: the items parse
+        /// fine, but the stream is not processable.
         @ParameterizedTest
         @MethodSource(ITEM_TYPES_ALLOWED_ONLY_ONCE_PER_BLOCK)
         @DisplayName("get() failed when block has multiple items when only one of specific type is allowed")
@@ -581,7 +589,7 @@ class BlockHasherTest {
                                 .returns(blockNumber, VerificationSessionFailedException::getBlockNumber)
                                 .returns(blockSource, VerificationSessionFailedException::getBlockSource)
                                 .returns(
-                                        SessionFailureType.UNABLE_TO_PARSE,
+                                        SessionFailureType.UNSUPPORTED_STREAM_FORMAT,
                                         VerificationSessionFailedException::getFailureType);
                     });
         }
@@ -618,6 +626,388 @@ class BlockHasherTest {
                                         SessionFailureType.MISSING_MANDATORY_ITEM,
                                         VerificationSessionFailedException::getFailureType);
                     });
+        }
+    }
+
+    /// Tests for the forward compatibility handling of [BlockHasher]: block item types unknown
+    /// to the compiled schema are placed into a hashing category by the block stream forward
+    /// compatibility numbering rule (category is the field number modulo 20 for fields numbered
+    /// 20 and above). Expected hashes are produced by a local reference implementation of the
+    /// HIP-1424 block root tree, independent of the production code.
+    @Nested
+    @DisplayName("Forward Compatibility Tests")
+    class ForwardCompatibilityTests {
+        private static final Bytes FUTURE_PAYLOAD = Bytes.wrap("future item payload");
+        /// Block number 1 so hashing does not enter the genesis block TSS bootstrap path.
+        private static final long BLOCK_NUMBER = 1L;
+
+        /// This test aims to assert that a future item type mapping to a not hashed category
+        /// (0 or 19) is read and ignored: the block root hash is identical to the hash of the
+        /// same block without the item.
+        @ParameterizedTest
+        @ValueSource(ints = {20, 39, 40, 59})
+        @DisplayName("get() future item in a not hashed category leaves the root hash unchanged")
+        void testNotHashedFutureItemLeavesRootUnchanged(final int fieldNumber) throws ParseException {
+            final List<BlockItemUnparsed> baseItems = TestBlockBuilder.generateBlockWithNumber(BLOCK_NUMBER)
+                    .blockUnparsed()
+                    .blockItems();
+            final Bytes baseRootHash = hashBlockItems(baseItems).rootHash();
+            final List<BlockItemUnparsed> withFutureItem =
+                    insertBeforeFooter(baseItems, futureItem(fieldNumber, FUTURE_PAYLOAD));
+            final HashingResult actual = hashBlockItems(withFutureItem);
+            assertThat(actual.rootHash()).isEqualTo(baseRootHash);
+        }
+
+        /// This test aims to assert that a future item type mapping to one of the five defined
+        /// category subtrees (categories 3 to 7) is hashed into that subtree exactly like a
+        /// known item: the root hash matches the reference implementation and differs from the
+        /// hash of the block without the item.
+        @ParameterizedTest
+        @ValueSource(ints = {23, 24, 25, 26, 27, 43, 47})
+        @DisplayName("get() future item in a defined category is hashed into that subtree")
+        void testFutureItemHashedIntoExistingSubtree(final int fieldNumber) throws ParseException {
+            final List<BlockItemUnparsed> baseItems = TestBlockBuilder.generateBlockWithNumber(BLOCK_NUMBER)
+                    .blockUnparsed()
+                    .blockItems();
+            final Bytes baseRootHash = hashBlockItems(baseItems).rootHash();
+            final List<BlockItemUnparsed> withFutureItem =
+                    insertBeforeFooter(baseItems, futureItem(fieldNumber, FUTURE_PAYLOAD));
+            final HashingResult actual = hashBlockItems(withFutureItem);
+            assertThat(actual.rootHash()).isEqualTo(referenceRootHash(withFutureItem));
+            assertThat(actual.rootHash()).isNotEqualTo(baseRootHash);
+        }
+
+        /// This test aims to assert that a future item type mapping to an extension category
+        /// (categories 8 to 15) is hashed into the corresponding extension subtree at leaf
+        /// positions 9 to 16 of the block root tree: the root hash matches the reference
+        /// implementation and differs from the hash of the block without the item.
+        @ParameterizedTest
+        @ValueSource(ints = {28, 29, 30, 31, 32, 33, 34, 35, 48, 55})
+        @DisplayName("get() future item in an extension category is hashed into the extension subtree")
+        void testFutureItemHashedIntoExtensionSubtree(final int fieldNumber) throws ParseException {
+            final List<BlockItemUnparsed> baseItems = TestBlockBuilder.generateBlockWithNumber(BLOCK_NUMBER)
+                    .blockUnparsed()
+                    .blockItems();
+            final Bytes baseRootHash = hashBlockItems(baseItems).rootHash();
+            final List<BlockItemUnparsed> withFutureItem =
+                    insertBeforeFooter(baseItems, futureItem(fieldNumber, FUTURE_PAYLOAD));
+            final HashingResult actual = hashBlockItems(withFutureItem);
+            assertThat(actual.rootHash()).isEqualTo(referenceRootHash(withFutureItem));
+            assertThat(actual.rootHash()).isNotEqualTo(baseRootHash);
+        }
+
+        /// This test aims to assert that a block carrying future items across several
+        /// categories at once, including repeated items in the same extension subtree and a
+        /// not hashed item, produces the root hash computed by the reference implementation.
+        @Test
+        @DisplayName("get() future items across several categories hash correctly together")
+        void testMultipleFutureItemsAcrossSubtrees() throws ParseException {
+            final List<BlockItemUnparsed> baseItems = TestBlockBuilder.generateBlockWithNumber(BLOCK_NUMBER)
+                    .blockUnparsed()
+                    .blockItems();
+            List<BlockItemUnparsed> items = baseItems;
+            for (final int fieldNumber : new int[] {23, 28, 31, 35, 35, 40}) {
+                items = insertBeforeFooter(items, futureItem(fieldNumber, Bytes.wrap("payload " + fieldNumber)));
+            }
+            final HashingResult actual = hashBlockItems(items);
+            assertThat(actual.rootHash()).isEqualTo(referenceRootHash(items));
+        }
+
+        /// This test aims to assert that a future item type this version cannot process
+        /// refuses the block: categories 1 and 2 (requires specific handling) and categories
+        /// 16 to 18 (reserved, no subtree in the block root tree).
+        @ParameterizedTest
+        @ValueSource(ints = {21, 22, 36, 37, 38, 41, 42})
+        @DisplayName("get() future item in a reserved or specific handling category refuses the block")
+        void testUnsupportedFutureItemRefusesBlock(final int fieldNumber) throws ParseException {
+            assertHashingFails(futureItem(fieldNumber, FUTURE_PAYLOAD), SessionFailureType.UNSUPPORTED_ITEM_TYPE);
+        }
+
+        /// This test aims to assert that an unknown field numbered below 20 refuses the block:
+        /// such fields are first release fields reserved for item types that require specific
+        /// handling this version does not know.
+        @ParameterizedTest
+        @ValueSource(ints = {13, 18})
+        @DisplayName("get() unknown first release field refuses the block")
+        void testUnknownFirstReleaseFieldRefusesBlock(final int fieldNumber) throws ParseException {
+            assertHashingFails(futureItem(fieldNumber, FUTURE_PAYLOAD), SessionFailureType.UNSUPPORTED_ITEM_TYPE);
+        }
+
+        /// This test aims to assert that an item carrying a known item type together with an
+        /// unknown field is rejected: a BlockItem is a protobuf oneof, so a valid item carries
+        /// exactly one field, and such an item parses fine but is not a processable stream.
+        @Test
+        @DisplayName("get() known item type with unknown fields is rejected")
+        void testKnownItemWithUnknownFieldRejected() throws ParseException {
+            final Bytes knownAndUnknown = Bytes.merge(
+                    // transaction_result is field 5, a known item type
+                    fieldBytes(5, Bytes.wrap("transaction result bytes")), futureItemBytes(23, FUTURE_PAYLOAD));
+            final BlockItemUnparsed item = standardParse(BlockItemUnparsed.PROTOBUF, knownAndUnknown);
+            assertHashingFails(item, SessionFailureType.UNSUPPORTED_STREAM_FORMAT);
+        }
+
+        /// This test aims to assert that an item carrying more than one unknown field is
+        /// rejected: a BlockItem is a protobuf oneof, so a valid item carries exactly one
+        /// field, and such an item parses fine but is not a processable stream.
+        @Test
+        @DisplayName("get() multiple unknown fields are rejected")
+        void testMultipleUnknownFieldsRejected() throws ParseException {
+            final Bytes twoUnknowns =
+                    Bytes.merge(futureItemBytes(23, FUTURE_PAYLOAD), futureItemBytes(27, FUTURE_PAYLOAD));
+            final BlockItemUnparsed item = standardParse(BlockItemUnparsed.PROTOBUF, twoUnknowns);
+            assertHashingFails(item, SessionFailureType.UNSUPPORTED_STREAM_FORMAT);
+        }
+
+        /// This test aims to assert that an item carrying no field at all is refused: there is
+        /// nothing valid to process, so something unexpected is happening.
+        @Test
+        @DisplayName("get() an item with no field at all is refused as unknown error")
+        void testEmptyItemRefusedAsUnknownError() {
+            final BlockItemUnparsed emptyItem = BlockItemUnparsed.newBuilder().build();
+            assertHashingFails(emptyItem, SessionFailureType.UNKNOWN_ERROR);
+        }
+
+        /// This test aims to assert that a future item survives the parse and serialize round
+        /// trip byte for byte. The leaf hash of a future item is computed over the item's
+        /// serialized bytes, so the round trip must reproduce the exact bytes the producing
+        /// node hashed.
+        @ParameterizedTest
+        @ValueSource(ints = {20, 23, 28, 39, 500})
+        @DisplayName("future item serialization round trips byte identical")
+        void testFutureItemSerializationRoundTripsByteIdentical(final int fieldNumber) throws ParseException {
+            final Bytes original = futureItemBytes(fieldNumber, FUTURE_PAYLOAD);
+            final BlockItemUnparsed parsed = standardParse(BlockItemUnparsed.PROTOBUF, original);
+            assertThat(BlockItemUnparsed.PROTOBUF.toBytes(parsed)).isEqualTo(original);
+        }
+
+        /// Runs a [BlockHasher] over the given items supplied as one complete block.
+        private HashingResult hashBlockItems(final List<BlockItemUnparsed> items) {
+            final ConcurrentLinkedDeque<BlockItems> blockItemsDeque = new ConcurrentLinkedDeque<>();
+            final BlockHasher toTest = new BlockHasher(
+                    new AtomicBoolean(false),
+                    blockItemsDeque,
+                    metrics.hashingMetrics(),
+                    BLOCK_NUMBER,
+                    BlockSource.PUBLISHER,
+                    verificationDataProvider);
+            blockItemsDeque.add(new BlockItems(items, BLOCK_NUMBER, true, true));
+            return toTest.get();
+        }
+
+        /// Asserts that hashing a block containing the given item fails with the expected
+        /// failure type.
+        private void assertHashingFails(final BlockItemUnparsed item, final SessionFailureType expectedFailure) {
+            final ConcurrentLinkedDeque<BlockItems> blockItemsDeque = new ConcurrentLinkedDeque<>();
+            final BlockSource blockSource = BlockSource.PUBLISHER;
+            final BlockHasher toTest = new BlockHasher(
+                    new AtomicBoolean(false),
+                    blockItemsDeque,
+                    metrics.hashingMetrics(),
+                    BLOCK_NUMBER,
+                    blockSource,
+                    verificationDataProvider);
+            blockItemsDeque.offer(new BlockItems(List.of(item), BLOCK_NUMBER, false, false));
+            assertThatThrownBy(toTest::get)
+                    .isInstanceOf(VerificationSessionFailedException.class)
+                    .asInstanceOf(type(VerificationSessionFailedException.class))
+                    .satisfies(e -> {
+                        assertThat(e)
+                                .returns(BLOCK_NUMBER, VerificationSessionFailedException::getBlockNumber)
+                                .returns(blockSource, VerificationSessionFailedException::getBlockSource)
+                                .returns(expectedFailure, VerificationSessionFailedException::getFailureType);
+                    });
+        }
+    }
+
+    /// Returns a copy of the given items with the given item inserted just before the footer.
+    private static List<BlockItemUnparsed> insertBeforeFooter(
+            final List<BlockItemUnparsed> items, final BlockItemUnparsed toInsert) {
+        final List<BlockItemUnparsed> result = new ArrayList<>(items);
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i).hasBlockFooter()) {
+                result.add(i, toInsert);
+                return result;
+            }
+        }
+        throw new IllegalArgumentException("Items contain no footer");
+    }
+
+    /// Builds a block item carrying a single field unknown to the compiled schema, the way an
+    /// old node sees a future block item type: the crafted wire bytes are parsed with unknown
+    /// field collection enabled.
+    private static BlockItemUnparsed futureItem(final int fieldNumber, final Bytes payload) throws ParseException {
+        return standardParse(BlockItemUnparsed.PROTOBUF, futureItemBytes(fieldNumber, payload));
+    }
+
+    /// Builds the wire bytes of a block item carrying a single field with the given field
+    /// number, as a newer producing node would serialize a future item type.
+    private static Bytes futureItemBytes(final int fieldNumber, final Bytes payload) {
+        return fieldBytes(fieldNumber, payload);
+    }
+
+    /// Encodes one length delimited protobuf field: tag varint, length varint, payload.
+    private static Bytes fieldBytes(final int fieldNumber, final Bytes payload) {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final int wireTypeDelimited = 2;
+        writeVarInt(out, (fieldNumber << 3) | wireTypeDelimited);
+        writeVarInt(out, (int) payload.length());
+        out.writeBytes(payload.toByteArray());
+        return Bytes.wrap(out.toByteArray());
+    }
+
+    /// Writes a protobuf varint to the given stream.
+    private static void writeVarInt(final ByteArrayOutputStream out, final int value) {
+        int remaining = value;
+        while ((remaining & ~0x7F) != 0) {
+            out.write((remaining & 0x7F) | 0x80);
+            remaining >>>= 7;
+        }
+        out.write(remaining);
+    }
+
+    /// Reference implementation of the block root hash per HIP-1424, independent of the
+    /// production hashing code: items are placed into their category (known types by their
+    /// fixed assignment, unknown types by field number modulo 20), each category is folded
+    /// with the streaming merkle tree algorithm, and the category roots are combined into the
+    /// fixed 16 leaf block root tree with absent extension leaves excluded and single child
+    /// nodes prefixed with 0x01.
+    private static Bytes referenceRootHash(final List<BlockItemUnparsed> items) throws ParseException {
+        final List<byte[]> consensusLeaves = new ArrayList<>();
+        final List<byte[]> inputLeaves = new ArrayList<>();
+        final List<byte[]> outputLeaves = new ArrayList<>();
+        final List<byte[]> stateChangesLeaves = new ArrayList<>();
+        final List<byte[]> traceLeaves = new ArrayList<>();
+        final List<List<byte[]>> extensionLeaves = new ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            extensionLeaves.add(new ArrayList<>());
+        }
+        BlockFooter footer = null;
+        Timestamp timestamp = null;
+        for (final BlockItemUnparsed item : items) {
+            final byte[] leaf = refLeaf(BlockItemUnparsed.PROTOBUF.toBytes(item).toByteArray());
+            switch (item.item().kind()) {
+                case BLOCK_HEADER -> {
+                    timestamp = standardParse(BlockHeader.PROTOBUF, item.blockHeader())
+                            .blockTimestamp();
+                    outputLeaves.add(leaf);
+                }
+                case ROUND_HEADER, EVENT_HEADER -> consensusLeaves.add(leaf);
+                case SIGNED_TRANSACTION -> inputLeaves.add(leaf);
+                case TRANSACTION_RESULT, TRANSACTION_OUTPUT, RECORD_FILE -> outputLeaves.add(leaf);
+                case STATE_CHANGES -> stateChangesLeaves.add(leaf);
+                case TRACE_DATA -> traceLeaves.add(leaf);
+                case BLOCK_FOOTER -> footer = standardParse(BlockFooter.PROTOBUF, item.blockFooter());
+                case BLOCK_PROOF -> {
+                    // not hashed
+                }
+                case UNSET -> {
+                    final int category = item.getUnknownFields().getFirst().field() % 20;
+                    switch (category) {
+                        case 0, 19 -> {
+                            // not hashed
+                        }
+                        case 3 -> consensusLeaves.add(leaf);
+                        case 4 -> inputLeaves.add(leaf);
+                        case 5 -> outputLeaves.add(leaf);
+                        case 6 -> stateChangesLeaves.add(leaf);
+                        case 7 -> traceLeaves.add(leaf);
+                        default -> extensionLeaves.get(category - 8).add(leaf);
+                    }
+                }
+                default ->
+                    throw new IllegalArgumentException(
+                            "Unsupported item type: " + item.item().kind());
+            }
+        }
+        final byte[] leftHalf = refNode(
+                refNode(
+                        refNode(
+                                footer.previousBlockRootHash().toByteArray(),
+                                footer.rootHashOfAllBlockHashesTree().toByteArray()),
+                        refNode(footer.startOfBlockStateRootHash().toByteArray(), refStreamingRoot(consensusLeaves))),
+                refNode(
+                        refNode(refStreamingRoot(inputLeaves), refStreamingRoot(outputLeaves)),
+                        refNode(refStreamingRoot(stateChangesLeaves), refStreamingRoot(traceLeaves))));
+        final byte[][] extensionRoots = new byte[8][];
+        for (int i = 0; i < 8; i++) {
+            extensionRoots[i] = extensionLeaves.get(i).isEmpty() ? null : refStreamingRoot(extensionLeaves.get(i));
+        }
+        final byte[] rightHalf = refCombineOptional(
+                refCombineOptional(
+                        refCombineOptional(extensionRoots[0], extensionRoots[1]),
+                        refCombineOptional(extensionRoots[2], extensionRoots[3])),
+                refCombineOptional(
+                        refCombineOptional(extensionRoots[4], extensionRoots[5]),
+                        refCombineOptional(extensionRoots[6], extensionRoots[7])));
+        final byte[] mountainTop = rightHalf == null ? refSingle(leftHalf) : refNode(leftHalf, rightHalf);
+        final byte[] timestampLeaf =
+                refLeaf(Timestamp.PROTOBUF.toBytes(timestamp).toByteArray());
+        return Bytes.wrap(refNode(timestampLeaf, mountainTop));
+    }
+
+    /// Reference streaming merkle tree root over the given leaf hashes: fold complete sibling
+    /// pairs as leaves arrive, then fold the remaining open branches right to left. An empty
+    /// tree is the hash of a single zero byte.
+    private static byte[] refStreamingRoot(final List<byte[]> leafHashes) {
+        if (leafHashes.isEmpty()) {
+            return refSha384(new byte[] {0x00});
+        }
+        final List<byte[]> hashList = new ArrayList<>();
+        for (int i = 0; i < leafHashes.size(); i++) {
+            hashList.add(leafHashes.get(i));
+            for (long n = i; (n & 1L) == 1; n >>= 1) {
+                final byte[] right = hashList.removeLast();
+                final byte[] left = hashList.removeLast();
+                hashList.add(refNode(left, right));
+            }
+        }
+        byte[] root = hashList.getLast();
+        for (int i = hashList.size() - 2; i >= 0; i--) {
+            root = refNode(hashList.get(i), root);
+        }
+        return root;
+    }
+
+    /// Reference hash of an internal node whose children may be absent.
+    private static byte[] refCombineOptional(final byte[] left, final byte[] right) {
+        final byte[] node;
+        if (left == null && right == null) {
+            node = null;
+        } else if (left == null) {
+            node = refSingle(right);
+        } else if (right == null) {
+            node = refSingle(left);
+        } else {
+            node = refNode(left, right);
+        }
+        return node;
+    }
+
+    /// Reference leaf hash with the 0x00 domain separation prefix.
+    private static byte[] refLeaf(final byte[] data) {
+        return refSha384(new byte[] {0x00}, data);
+    }
+
+    /// Reference single child internal node hash with the 0x01 domain separation prefix.
+    private static byte[] refSingle(final byte[] child) {
+        return refSha384(new byte[] {0x01}, child);
+    }
+
+    /// Reference two children internal node hash with the 0x02 domain separation prefix.
+    private static byte[] refNode(final byte[] left, final byte[] right) {
+        return refSha384(new byte[] {0x02}, left, right);
+    }
+
+    /// SHA-384 over the concatenation of the given parts.
+    private static byte[] refSha384(final byte[]... parts) {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-384");
+            for (final byte[] part : parts) {
+                digest.update(part);
+            }
+            return digest.digest();
+        } catch (final NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
         }
     }
 

--- a/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/session/SessionFailureTypeTest.java
+++ b/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/session/SessionFailureTypeTest.java
@@ -49,6 +49,18 @@ class SessionFailureTypeTest {
     }
 
     @Test
+    void unsupportedItemTypeMapsToCorrectFailureType() {
+        assertThat(SessionFailureType.UNSUPPORTED_ITEM_TYPE.asFailureType())
+                .isEqualTo(FailureType.UNSUPPORTED_ITEM_TYPE);
+    }
+
+    @Test
+    void unsupportedStreamFormatMapsToCorrectFailureType() {
+        assertThat(SessionFailureType.UNSUPPORTED_STREAM_FORMAT.asFailureType())
+                .isEqualTo(FailureType.UNSUPPORTED_STREAM_FORMAT);
+    }
+
+    @Test
     void cancelledMapsToCorrectFailureType() {
         assertThat(SessionFailureType.CANCELLED.asFailureType()).isEqualTo(FailureType.CANCELLED);
     }
@@ -67,6 +79,6 @@ class SessionFailureTypeTest {
 
     @Test
     void enumValueCount_matchesExpected() {
-        assertThat(SessionFailureType.values()).hasSize(9);
+        assertThat(SessionFailureType.values()).hasSize(11);
     }
 }

--- a/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/verifier/StateProofVerifierTest.java
+++ b/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/verifier/StateProofVerifierTest.java
@@ -225,10 +225,69 @@ class StateProofVerifierTest {
     }
 
     @Test
-    @DisplayName("verify() reject when first path is not a leaf")
-    void testShouldRejectFirstPathNotLeaf() throws IOException, ParseException {
+    @DisplayName("verify() passes for valid state proof that does not start with a leaf")
+    void testPassingStateProofWithNonLeafFirstPath() throws IOException, ParseException {
         initializeTssData(verificationDataProvider, ResourceTestBlockBuilder.load(StateProof.BLOCK_0));
-        // Swap state proof
+        // Reorder the paths of a real, valid state proof so the final join point comes first:
+        // [leaf, leaf, join] becomes [join, leaf, leaf], with every next path index remapped
+        // to the join point's new position. A state proof creator might order the paths this
+        // way, and the proof content is unchanged, so verification must pass.
+        final ResourceTestBlock block = ResourceTestBlockBuilder.load(StateProof.BLOCK_3);
+        final List<MerklePath> original = statePaths(block);
+        final MerklePath join = original.get(2);
+        final MerklePath firstLeaf =
+                original.get(0).copyBuilder().nextPathIndex(0).build();
+        final MerklePath secondLeaf =
+                original.get(1).copyBuilder().nextPathIndex(0).build();
+        final ResourceTestBlock reorderedBlock = swapPaths(block, List.of(join, firstLeaf, secondLeaf));
+        final HashingResult hashingResult = runHashing(verificationDataProvider, reorderedBlock);
+        final StateProofVerifier toTest = new StateProofVerifier(
+                isCanceled,
+                metricsHolder.proofVerificationMetrics(),
+                reorderedBlock.number(),
+                hashingResult.blockProofs().getFirst().blockStateProof(),
+                hashingResult.rootHash(),
+                verificationDataProvider);
+        final SessionFailureType actual = toTest.verify();
+        assertThat(actual).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2})
+    @DisplayName("verify() reject valid state proof carrying a join point that is never followed")
+    void testShouldRejectJoinPointNeverFollowed(final int orphanIndex) throws IOException, ParseException {
+        initializeTssData(verificationDataProvider, ResourceTestBlockBuilder.load(StateProof.BLOCK_0));
+        // Insert an unreferenced join point into the paths of a real, valid state proof,
+        // remapping the real indices for the shift. Every other aspect of the proof stays
+        // valid, so only the accurate visited tracking can catch the orphan path: a path
+        // counts as visited only when the walk actually processes it.
+        final ResourceTestBlock block = ResourceTestBlockBuilder.load(StateProof.BLOCK_3);
+        final List<MerklePath> original = statePaths(block);
+        final List<MerklePath> paths = new ArrayList<>();
+        // the real join point lands at index 3 for every tested insertion position
+        paths.add(original.get(0).copyBuilder().nextPathIndex(3).build());
+        paths.add(original.get(1).copyBuilder().nextPathIndex(3).build());
+        paths.add(original.get(2));
+        paths.add(orphanIndex, generateGenericMerklePath(false));
+        final ResourceTestBlock tamperedBlock = swapPaths(block, paths);
+        final HashingResult hashingResult = runHashing(verificationDataProvider, tamperedBlock);
+        final StateProofVerifier toTest = new StateProofVerifier(
+                isCanceled,
+                metricsHolder.proofVerificationMetrics(),
+                tamperedBlock.number(),
+                hashingResult.blockProofs().getFirst().blockStateProof(),
+                hashingResult.rootHash(),
+                verificationDataProvider);
+        final SessionFailureType actual = toTest.verify();
+        assertThat(actual).isNotNull().isEqualTo(SessionFailureType.BAD_BLOCK_PROOF);
+    }
+
+    @Test
+    @DisplayName("verify() reject when no leaf leads to a join point")
+    void testShouldRejectUnreachableJoinPoint() throws IOException, ParseException {
+        initializeTssData(verificationDataProvider, ResourceTestBlockBuilder.load(StateProof.BLOCK_0));
+        // The first path is allowed to be a non-leaf, but a join point that no leaf leads to
+        // is never visited and must reject the proof.
         final List<MerklePath> paths = new ArrayList<>();
         paths.add(generateGenericMerklePath(false));
         paths.add(generateGenericMerklePath(true));
@@ -409,6 +468,25 @@ class StateProofVerifierTest {
                 block.number(),
                 new BlockUnparsed(TestBlockBuilder.convertToUnparsedItems(resultItems)),
                 block.blockRootHash());
+    }
+
+    /// Returns the merkle paths of the block's real state proof, asserting the expected
+    /// structure ([leaf, leaf, join] with both leaves pointing at the join and the join
+    /// carrying the final next index) so reordering tests can remap the indices safely.
+    private List<MerklePath> statePaths(final ResourceTestBlock block) {
+        assertThat(block.proofs()).size().isEqualTo(1);
+        final com.hedera.hapi.block.stream.StateProof stateProof =
+                block.proofs().getFirst().blockStateProof();
+        assertThat(stateProof).isNotNull();
+        final List<MerklePath> paths = stateProof.paths();
+        assertThat(paths).hasSize(3);
+        assertThat(paths.get(0).content().kind()).isNotEqualTo(MerklePath.ContentOneOfType.UNSET);
+        assertThat(paths.get(1).content().kind()).isNotEqualTo(MerklePath.ContentOneOfType.UNSET);
+        assertThat(paths.get(2).content().kind()).isEqualTo(MerklePath.ContentOneOfType.UNSET);
+        assertThat(paths.get(0).nextPathIndex()).isEqualTo(2);
+        assertThat(paths.get(1).nextPathIndex()).isEqualTo(2);
+        assertThat(paths.get(2).nextPathIndex()).isEqualTo(-1);
+        return paths;
     }
 
     private ResourceTestBlock swapPaths(final ResourceTestBlock block, final List<MerklePath> paths) {

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/VerificationNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/VerificationNotification.java
@@ -45,6 +45,14 @@ public record VerificationNotification(
         UNRECOGNIZED_PROOF_TYPE,
         /// This type indicates that the block is of unsupported HAPI version
         UNSUPPORTED_HAPI_VERSION,
+        /// This type indicates that the block contains an item type this version of the
+        /// Block Node cannot process (a reserved or specific-handling field number per the
+        /// block stream forward compatibility numbering rule); an upgrade is required
+        UNSUPPORTED_ITEM_TYPE,
+        /// This type indicates that the wire encoding parsed successfully, but the content
+        /// is not a processable block stream (for example an item that carries more than one
+        /// field, or a mandatory once per block item that appears more than once)
+        UNSUPPORTED_STREAM_FORMAT,
         /// This type indicates that the session was cancelled
         CANCELLED,
         /// This type indicates that an unknown error occurred

--- a/common/src/main/java/org/hiero/block/common/hasher/HashingUtilities.java
+++ b/common/src/main/java/org/hiero/block/common/hasher/HashingUtilities.java
@@ -283,7 +283,8 @@ public final class HashingUtilities {
     }
 
     /**
-     * Computes the final block hash from the given block footer, timestamp and tree hashers.
+     * Computes the final block hash from the given block footer, timestamp and tree hashers,
+     * with no extension subtree leaves present.
      * @param blockTimestamp the block timestamp
      * @param previousBlockHash the previous block hash
      * @param rootHashOfAllPreviousBlockHashes root Hash of All previous Block Hashes
@@ -295,7 +296,7 @@ public final class HashingUtilities {
      * @param traceDataHasher the trace data hasher
      * @return the final block hash
      */
-    public static Bytes computeFinalBlockHash(
+    public static Bytes computeFinalBlockHash( // @todo(3372) re-evaluate this signature
             @NonNull final Timestamp blockTimestamp,
             @NonNull final Bytes previousBlockHash,
             @NonNull final Bytes rootHashOfAllPreviousBlockHashes,
@@ -305,6 +306,84 @@ public final class HashingUtilities {
             @NonNull final StreamingTreeHasher consensusHeaderHasher,
             @NonNull final StreamingTreeHasher stateChangesHasher,
             @NonNull final StreamingTreeHasher traceDataHasher) {
+        return computeFinalBlockHash(
+                blockTimestamp,
+                previousBlockHash,
+                rootHashOfAllPreviousBlockHashes,
+                startOfBlockStateRootHash,
+                inputTreeHasher,
+                outputTreeHasher,
+                consensusHeaderHasher,
+                stateChangesHasher,
+                traceDataHasher,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    /**
+     * Computes the final block hash from the given block footer, timestamp, tree hashers and
+     * extension subtree roots.
+     * <p>
+     * The block root tree is the fixed 16-leaf "Merkle Mountain Top" defined by HIP-1424. Leaves
+     * 1 to 8 are the previous block hash, the root of all previous block hashes, the start of
+     * block state root and the five block item category subtrees. Leaves 9 to 16 are the
+     * extension subtrees, reserved for future block item categories. An extension leaf that has
+     * no items is excluded from the tree entirely; its parent is hashed with the single-child
+     * {@code 0x01} prefix instead of the two-child {@code 0x02} prefix, and a parent with no
+     * children at all is likewise excluded. When no extension subtree is present, the right half
+     * of the mountain top collapses completely and the resulting hash is byte-identical to the
+     * historical 8-leaf computation.
+     * @param blockTimestamp the block timestamp
+     * @param previousBlockHash the previous block hash
+     * @param rootHashOfAllPreviousBlockHashes root Hash of All previous Block Hashes
+     * @param startOfBlockStateRootHash the start of block state root hash
+     * @param inputTreeHasher the input tree hasher
+     * @param outputTreeHasher the output tree hasher
+     * @param consensusHeaderHasher the consensus header hasher
+     * @param stateChangesHasher the state changes hasher
+     * @param traceDataHasher the trace data hasher
+     * @param extensionSubtreeRootZero the root of the Extension 0 subtree at leaf position 9,
+     *     or {@code null} when the subtree carries no data in this block
+     * @param extensionSubtreeRootOne the root of the Extension 1 subtree at leaf position 10,
+     *     or {@code null} when the subtree carries no data in this block
+     * @param extensionSubtreeRootTwo the root of the Extension 2 subtree at leaf position 11,
+     *     or {@code null} when the subtree carries no data in this block
+     * @param extensionSubtreeRootThree the root of the Extension 3 subtree at leaf position 12,
+     *     or {@code null} when the subtree carries no data in this block
+     * @param extensionSubtreeRootFour the root of the Extension 4 subtree at leaf position 13,
+     *     or {@code null} when the subtree carries no data in this block
+     * @param extensionSubtreeRootFive the root of the Extension 5 subtree at leaf position 14,
+     *     or {@code null} when the subtree carries no data in this block
+     * @param extensionSubtreeRootSix the root of the Extension 6 subtree at leaf position 15,
+     *     or {@code null} when the subtree carries no data in this block
+     * @param extensionSubtreeRootSeven the root of the Extension 7 subtree at leaf position 16,
+     *     or {@code null} when the subtree carries no data in this block
+     * @return the final block hash
+     */
+    public static Bytes computeFinalBlockHash( // @todo(3372) re-evaluate this signature
+            @NonNull final Timestamp blockTimestamp,
+            @NonNull final Bytes previousBlockHash,
+            @NonNull final Bytes rootHashOfAllPreviousBlockHashes,
+            @NonNull final Bytes startOfBlockStateRootHash,
+            @NonNull final StreamingTreeHasher inputTreeHasher,
+            @NonNull final StreamingTreeHasher outputTreeHasher,
+            @NonNull final StreamingTreeHasher consensusHeaderHasher,
+            @NonNull final StreamingTreeHasher stateChangesHasher,
+            @NonNull final StreamingTreeHasher traceDataHasher,
+            final byte[] extensionSubtreeRootZero,
+            final byte[] extensionSubtreeRootOne,
+            final byte[] extensionSubtreeRootTwo,
+            final byte[] extensionSubtreeRootThree,
+            final byte[] extensionSubtreeRootFour,
+            final byte[] extensionSubtreeRootFive,
+            final byte[] extensionSubtreeRootSix,
+            final byte[] extensionSubtreeRootSeven) {
         Objects.requireNonNull(blockTimestamp);
         Objects.requireNonNull(previousBlockHash);
         Objects.requireNonNull(rootHashOfAllPreviousBlockHashes);
@@ -337,13 +416,81 @@ public final class HashingUtilities {
         final byte[] depth4Node2 = hashInternalNode(depth5Node3, depth5Node4);
         // Depth 3
         final byte[] depth3Node1 = hashInternalNode(depth4Node1, depth4Node2);
-        // Depth 2: reserved subtree (single child, right side is null/reserved)
-        final byte[] fixedRootTree = hashInternalNodeSingleChild(depth3Node1);
+        // Depth 3, right side: root over the extension subtrees (leaf positions 9 to 16), or null
+        // when no extension subtree is present
+        final byte[] depth3Node2 = combineExtensionSubtreeRoots(
+                extensionSubtreeRootZero,
+                extensionSubtreeRootOne,
+                extensionSubtreeRootTwo,
+                extensionSubtreeRootThree,
+                extensionSubtreeRootFour,
+                extensionSubtreeRootFive,
+                extensionSubtreeRootSix,
+                extensionSubtreeRootSeven);
+        // Depth 2: two children when any extension subtree is present, single child otherwise
+        final byte[] fixedRootTree = depth3Node2 == null
+                ? hashInternalNodeSingleChild(depth3Node1)
+                : hashInternalNode(depth3Node1, depth3Node2);
         // Root: combine timestamp leaf with fixed root tree
         final byte[] timestampLeaf =
                 hashLeaf(Timestamp.PROTOBUF.toBytes(blockTimestamp).toByteArray());
         final byte[] rootHash = hashInternalNode(timestampLeaf, fixedRootTree);
 
         return Bytes.wrap(rootHash);
+    }
+
+    /**
+     * Combines the eight extension subtree roots (leaf positions 9 to 16 of the block root fixed
+     * size tree) into the root of the right half of the tree. Absent leaves ({@code null}
+     * roots) are excluded per HIP-1424: a parent with a single present child is hashed with the
+     * {@code 0x01} prefix and a parent with no present children is itself excluded.
+     * @param rootZero the Extension 0 subtree root at leaf position 9, or {@code null} when absent
+     * @param rootOne the Extension 1 subtree root at leaf position 10, or {@code null} when absent
+     * @param rootTwo the Extension 2 subtree root at leaf position 11, or {@code null} when absent
+     * @param rootThree the Extension 3 subtree root at leaf position 12, or {@code null} when absent
+     * @param rootFour the Extension 4 subtree root at leaf position 13, or {@code null} when absent
+     * @param rootFive the Extension 5 subtree root at leaf position 14, or {@code null} when absent
+     * @param rootSix the Extension 6 subtree root at leaf position 15, or {@code null} when absent
+     * @param rootSeven the Extension 7 subtree root at leaf position 16, or {@code null} when absent
+     * @return the root of the extension half of the tree, or {@code null} when all leaves are absent
+     */
+    private static byte[] combineExtensionSubtreeRoots(
+            final byte[] rootZero,
+            final byte[] rootOne,
+            final byte[] rootTwo,
+            final byte[] rootThree,
+            final byte[] rootFour,
+            final byte[] rootFive,
+            final byte[] rootSix,
+            final byte[] rootSeven) {
+        final byte[] depth5Node5 = combineOptionalNodes(rootZero, rootOne);
+        final byte[] depth5Node6 = combineOptionalNodes(rootTwo, rootThree);
+        final byte[] depth5Node7 = combineOptionalNodes(rootFour, rootFive);
+        final byte[] depth5Node8 = combineOptionalNodes(rootSix, rootSeven);
+        final byte[] depth4Node3 = combineOptionalNodes(depth5Node5, depth5Node6);
+        final byte[] depth4Node4 = combineOptionalNodes(depth5Node7, depth5Node8);
+        return combineOptionalNodes(depth4Node3, depth4Node4);
+    }
+
+    /**
+     * Hashes an internal node whose children may be absent: two present children use the
+     * {@code 0x02} prefix, a single present child uses the {@code 0x01} prefix, and no present
+     * children means the node itself is absent.
+     * @param left the left child hash, or {@code null} when absent
+     * @param right the right child hash, or {@code null} when absent
+     * @return the node hash, or {@code null} when both children are absent
+     */
+    private static byte[] combineOptionalNodes(final byte[] left, final byte[] right) {
+        final byte[] node;
+        if (left == null && right == null) {
+            node = null;
+        } else if (left == null) {
+            node = hashInternalNodeSingleChild(right);
+        } else if (right == null) {
+            node = hashInternalNodeSingleChild(left);
+        } else {
+            node = hashInternalNode(left, right);
+        }
+        return node;
     }
 }

--- a/common/src/main/java/org/hiero/block/common/hasher/StreamingTreeHasher.java
+++ b/common/src/main/java/org/hiero/block/common/hasher/StreamingTreeHasher.java
@@ -31,5 +31,5 @@ public interface StreamingTreeHasher {
      * any more leaf items.
      * @return a future that completes with the root hash of the tree of items
      */
-    CompletableFuture<Bytes> rootHash();
+    CompletableFuture<Bytes> rootHash(); // @todo(3372) re-evaluate the returned CompletableFuture
 }

--- a/common/src/test/java/org/hiero/block/common/hasher/HashingUtilitiesTest.java
+++ b/common/src/test/java/org/hiero/block/common/hasher/HashingUtilitiesTest.java
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.common.hasher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Random;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/// Tests for the [HashingUtilities] class, focused on the extension subtree aware final block
+/// hash computation. Expected values are produced by a local reference implementation of the
+/// HIP-1424 block root tree ("Merkle Mountain Top"), independent of the production code, so the
+/// two implementations must agree.
+@DisplayName("Hashing Utilities Tests")
+class HashingUtilitiesTest {
+    private static final int HASH_SIZE = 48;
+    /// Deterministic seed so failures are reproducible.
+    private static final Random RANDOM = new Random(6431582L);
+
+    /// Tests for [HashingUtilities#computeFinalBlockHash] with extension subtree roots.
+    @Nested
+    @DisplayName("Final Block Hash Extension Subtree Tests")
+    class FinalBlockHashExtensionSubtreeTests {
+        /// This test aims to assert that the legacy overload without extension subtree roots
+        /// produces the exact same hash as the extension aware overload with no extension
+        /// subtree present, which is also the historical 8 leaf computation.
+        @Test
+        @DisplayName("computeFinalBlockHash() no extensions matches legacy overload")
+        void testNoExtensionsMatchesLegacyOverload() {
+            final FixedTreeInputs inputs = randomInputs();
+            final Bytes legacy = HashingUtilities.computeFinalBlockHash(
+                    inputs.timestamp(),
+                    inputs.previousBlockHash(),
+                    inputs.rootOfAllPreviousBlockHashes(),
+                    inputs.startOfBlockStateRootHash(),
+                    inputs.inputTreeHasher(),
+                    inputs.outputTreeHasher(),
+                    inputs.consensusHeaderHasher(),
+                    inputs.stateChangesHasher(),
+                    inputs.traceDataHasher());
+            final Bytes extensionAware = computeWithExtensions(inputs, new byte[8][]);
+            assertThat(extensionAware).isEqualTo(legacy);
+            assertThat(extensionAware).isEqualTo(referenceRootHash(inputs, new byte[8][]));
+        }
+
+        /// This test aims to assert that every presence pattern of the eight extension
+        /// subtree leaves produces the block root hash computed by the reference
+        /// implementation of the HIP-1424 tree. Patterns are supplied as bitmasks where bit N
+        /// marks Extension N as present.
+        @ParameterizedTest
+        @ValueSource(ints = {0b00000001, 0b00000010, 0b10000000, 0b00001001, 0b01100110, 0b11111111})
+        @DisplayName("computeFinalBlockHash() extension presence patterns match reference")
+        void testExtensionPresencePatternsMatchReference(final int presenceMask) {
+            final FixedTreeInputs inputs = randomInputs();
+            final byte[][] extensionRoots = new byte[8][];
+            for (int i = 0; i < extensionRoots.length; i++) {
+                if ((presenceMask & (1 << i)) != 0) {
+                    extensionRoots[i] = randomHash();
+                }
+            }
+            final Bytes actual = computeWithExtensions(inputs, extensionRoots);
+            assertThat(actual).isEqualTo(referenceRootHash(inputs, extensionRoots));
+        }
+
+        /// This test aims to assert that a presence pattern with extension items produces a
+        /// different root hash than the same inputs with no extension items, so extension
+        /// items can never be dropped without changing the block hash.
+        @Test
+        @DisplayName("computeFinalBlockHash() extension presence changes the root hash")
+        void testExtensionPresenceChangesRootHash() {
+            final FixedTreeInputs inputs = randomInputs();
+            final byte[][] noExtensions = new byte[8][];
+            final byte[][] withExtension = new byte[8][];
+            withExtension[0] = randomHash();
+            final Bytes without = computeWithExtensions(inputs, noExtensions);
+            final Bytes with = computeWithExtensions(inputs, withExtension);
+            assertThat(with).isNotEqualTo(without);
+        }
+
+        /// Calls the extension aware [HashingUtilities#computeFinalBlockHash] overload,
+        /// expanding the given roots (Extension 0 to Extension 7) into the individual
+        /// extension subtree root parameters.
+        private Bytes computeWithExtensions(final FixedTreeInputs inputs, final byte[][] extensionRoots) {
+            return HashingUtilities.computeFinalBlockHash(
+                    inputs.timestamp(),
+                    inputs.previousBlockHash(),
+                    inputs.rootOfAllPreviousBlockHashes(),
+                    inputs.startOfBlockStateRootHash(),
+                    inputs.inputTreeHasher(),
+                    inputs.outputTreeHasher(),
+                    inputs.consensusHeaderHasher(),
+                    inputs.stateChangesHasher(),
+                    inputs.traceDataHasher(),
+                    extensionRoots[0],
+                    extensionRoots[1],
+                    extensionRoots[2],
+                    extensionRoots[3],
+                    extensionRoots[4],
+                    extensionRoots[5],
+                    extensionRoots[6],
+                    extensionRoots[7]);
+        }
+    }
+
+    /// The inputs to a final block hash computation.
+    private record FixedTreeInputs(
+            Timestamp timestamp,
+            Bytes previousBlockHash,
+            Bytes rootOfAllPreviousBlockHashes,
+            Bytes startOfBlockStateRootHash,
+            StreamingTreeHasher inputTreeHasher,
+            StreamingTreeHasher outputTreeHasher,
+            StreamingTreeHasher consensusHeaderHasher,
+            StreamingTreeHasher stateChangesHasher,
+            StreamingTreeHasher traceDataHasher) {}
+
+    /// Builds deterministic pseudo random inputs: the block level values and the five category
+    /// subtree hashers with varying leaf counts, including an empty one.
+    private static FixedTreeInputs randomInputs() {
+        return new FixedTreeInputs(
+                new Timestamp(RANDOM.nextLong(0, Long.MAX_VALUE), RANDOM.nextInt(0, 1_000_000_000)),
+                Bytes.wrap(randomHash()),
+                Bytes.wrap(randomHash()),
+                Bytes.wrap(randomHash()),
+                hasherWithLeaves(1),
+                hasherWithLeaves(3),
+                hasherWithLeaves(0),
+                hasherWithLeaves(4),
+                hasherWithLeaves(2));
+    }
+
+    private static StreamingTreeHasher hasherWithLeaves(final int leafCount) {
+        final NaiveStreamingTreeHasher hasher = new NaiveStreamingTreeHasher();
+        for (int i = 0; i < leafCount; i++) {
+            hasher.addLeaf(ByteBuffer.wrap(randomHash()));
+        }
+        return hasher;
+    }
+
+    private static byte[] randomHash() {
+        final byte[] hash = new byte[HASH_SIZE];
+        RANDOM.nextBytes(hash);
+        return hash;
+    }
+
+    /// Reference implementation of the block root hash per HIP-1424: a fixed 16 leaf tree whose
+    /// left half holds the eight assigned leaves and whose right half holds the extension
+    /// subtrees, with absent leaves excluded and single child nodes prefixed with 0x01. The
+    /// root combines the consensus timestamp leaf with the tree.
+    private static Bytes referenceRootHash(final FixedTreeInputs inputs, final byte[][] extensionRoots) {
+        final byte[] consensusRoot =
+                inputs.consensusHeaderHasher().rootHash().join().toByteArray();
+        final byte[] inputsRoot = inputs.inputTreeHasher().rootHash().join().toByteArray();
+        final byte[] outputsRoot = inputs.outputTreeHasher().rootHash().join().toByteArray();
+        final byte[] stateChangesRoot =
+                inputs.stateChangesHasher().rootHash().join().toByteArray();
+        final byte[] traceRoot = inputs.traceDataHasher().rootHash().join().toByteArray();
+        final byte[] leftHalf = refNode(
+                refNode(
+                        refNode(
+                                inputs.previousBlockHash().toByteArray(),
+                                inputs.rootOfAllPreviousBlockHashes().toByteArray()),
+                        refNode(inputs.startOfBlockStateRootHash().toByteArray(), consensusRoot)),
+                refNode(refNode(inputsRoot, outputsRoot), refNode(stateChangesRoot, traceRoot)));
+        final byte[] rightHalf = refCombineOptional(
+                refCombineOptional(
+                        refCombineOptional(extensionRoots[0], extensionRoots[1]),
+                        refCombineOptional(extensionRoots[2], extensionRoots[3])),
+                refCombineOptional(
+                        refCombineOptional(extensionRoots[4], extensionRoots[5]),
+                        refCombineOptional(extensionRoots[6], extensionRoots[7])));
+        final byte[] mountainTop = rightHalf == null ? refSingle(leftHalf) : refNode(leftHalf, rightHalf);
+        final byte[] timestampLeaf =
+                refLeaf(Timestamp.PROTOBUF.toBytes(inputs.timestamp()).toByteArray());
+        return Bytes.wrap(refNode(timestampLeaf, mountainTop));
+    }
+
+    private static byte[] refCombineOptional(final byte[] left, final byte[] right) {
+        final byte[] node;
+        if (left == null && right == null) {
+            node = null;
+        } else if (left == null) {
+            node = refSingle(right);
+        } else if (right == null) {
+            node = refSingle(left);
+        } else {
+            node = refNode(left, right);
+        }
+        return node;
+    }
+
+    private static byte[] refLeaf(final byte[] data) {
+        return refSha384(new byte[] {0x00}, data);
+    }
+
+    private static byte[] refSingle(final byte[] child) {
+        return refSha384(new byte[] {0x01}, child);
+    }
+
+    private static byte[] refNode(final byte[] left, final byte[] right) {
+        return refSha384(new byte[] {0x02}, left, right);
+    }
+
+    private static byte[] refSha384(final byte[]... parts) {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-384");
+            for (final byte[] part : parts) {
+                digest.update(part);
+            }
+            return digest.digest();
+        } catch (final NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
* Add forward compatible item handling to BlockHasher: category is field number modulo 20 for fields 20 and above
  * Hash categories 3 to 7 into the existing subtrees and categories 8 to 15 into the eight extension subtrees
  * Ignore not hashed categories 0 and 19
  * Refuse categories 1, 2, 16 to 18 and unknown fields below 20 with the new UNSUPPORTED_ITEM_TYPE failure type
* Rework item processing into an exhaustive switch expression, so new item types fail compilation until handled
* Add UNSUPPORTED_STREAM_FORMAT failure type for encodings that parse but are not a processable block stream
  * Reject oneof violations with it: a known item type plus unknown fields, or multiple unknown fields
  * Reject mandatory once per block items (header, footer, record file) appearing more than once with it
* Refuse redacted and filtered items with UNSUPPORTED_ITEM_TYPE instead of UNABLE_TO_PARSE, which now strictly means a wire level parse failure
* Extend HashingUtilities.computeFinalBlockHash with the extension subtree roots per HIP-1424
  * Exclude absent extension leaves with single child 0x01 promotion, keeping current block hashes unchanged
* Add metrics counting future items hashed, not hashed and refused
* Add tests
  * Independent HIP-1424 reference implementation verifying agreement for every category, extension and refusal case
  * Not hashed items leave the root unchanged, future items round trip byte identical
  * Failure type mappings and the new failure scenarios for UNSUPPORTED_STREAM_FORMAT

Resolves #3195

**NOTE** a visualization of the tree structure can be seen here:
https://raw.githubusercontent.com/hiero-ledger/hiero-improvement-proposals/d1bf49d33473b9dbe4f6c018e460f802f293aa3c/assets/hip-1424/expanded-merkle-mountain-top.svg

Also, hip 1424 can be used as reference and a newly created forward compatibility doc here #3251