### PR TITLE
fix(ci): GA automation should release the latest RC version, if one exists, else the release branch

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -85,6 +85,17 @@ jobs:
               exit 1
             fi
 
+            # For a GA release, CURRENT is the last rc/alpha tagged by a previous
+            # run of this workflow (e.g. v0.38.0-rc2). GA must be built from that
+            # exact tag, not from whatever the release branch currently points
+            # to, so a stray commit landing on the branch after the last rc
+            # can't sneak into the GA release untested. If no rc/alpha ever
+            # existed for this version (KIND=snapshot), SOURCE_TAG stays unset
+            # and GA falls back to building from the release branch tip.
+            if [[ "$KIND" == "rc" || "$KIND" == "alpha" ]]; then
+              echo "SOURCE_TAG=v$CURRENT" >> "$GITHUB_ENV"
+            fi
+
             case "$INPUT_RELEASE_TYPE" in
               rc)
                 [[ "$KIND" == "rc" ]] \
@@ -157,6 +168,8 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
       - name: Create and Switch to Release Branch
+        env:
+          INPUT_RELEASE_TYPE: ${{ github.event.inputs.release_type }}
         run: |
           git fetch origin
           if ! git ls-remote --exit-code --heads --quiet origin refs/heads/${RELEASE_BRANCH}; then
@@ -166,6 +179,11 @@ jobs:
             # create a PR to bump main branch to the next snapshot version
             echo "CREATE_PR=true" >> $GITHUB_ENV
             echo "PR_TITLE=chore(release): Bump versions for v$NEXT_VERSION_SNAPSHOT" >> $GITHUB_ENV
+          elif [[ "$INPUT_RELEASE_TYPE" == "GA" && -n "$SOURCE_TAG" ]]; then
+            # Build GA from the exact commit tagged as the last rc/alpha,
+            # ignoring any drift on the release branch since then.
+            git fetch origin "refs/tags/${SOURCE_TAG}:refs/tags/${SOURCE_TAG}"
+            git checkout --detach "refs/tags/${SOURCE_TAG}"
           else
             git checkout ${RELEASE_BRANCH}
           fi
@@ -183,6 +201,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Commit and Tag
+        if: ${{ github.event.inputs.release_type != 'GA' }}
         uses: step-security/git-auto-commit-action@749bc1cc775376092cc4227ba537137f445ca7c3 # v7.1.1
         with:
           commit_author: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
@@ -191,6 +210,22 @@ jobs:
           commit_user_name: ${{ steps.gpg_importer.outputs.name }}
           commit_user_email: ${{ steps.gpg_importer.outputs.email }}
           tagging_message: ${{ env.RELEASE_TAG }}
+
+      - name: Commit and Tag (GA)
+        if: ${{ github.event.inputs.release_type == 'GA' }}
+        env:
+          GIT_AUTHOR_NAME: ${{ steps.gpg_importer.outputs.name }}
+          GIT_AUTHOR_EMAIL: ${{ steps.gpg_importer.outputs.email }}
+          GIT_COMMITTER_NAME: ${{ steps.gpg_importer.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.gpg_importer.outputs.email }}
+        run: |
+          # GA is built on a detached HEAD (see "Create and Switch to Release
+          # Branch") so, unlike the rc/alpha path above, only the tag is
+          # pushed here — the release branch ref is intentionally left alone.
+          git add -A
+          git commit --no-verify --signoff -m "Bump versions for ${RELEASE_TAG}"
+          git tag -a "${RELEASE_TAG}" -m "${RELEASE_TAG}"
+          git push origin "refs/tags/${RELEASE_TAG}"
 
       - name: Install git-cliff
         run: |

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -221,11 +221,32 @@ jobs:
         run: |
           # GA is built on a detached HEAD (see "Create and Switch to Release
           # Branch") so, unlike the rc/alpha path above, only the tag is
-          # pushed here — the release branch ref is intentionally left alone.
+          # pushed here. The release branch itself is synced separately (see
+          # "Sync Release Branch with GA Tag") via a merge rather than here.
           git add -A
           git commit --no-verify --signoff -m "Bump versions for ${RELEASE_TAG}"
-          git tag -a "${RELEASE_TAG}" -m "${RELEASE_TAG}"
+          git tag -s "${RELEASE_TAG}" -m "${RELEASE_TAG}"
           git push origin "refs/tags/${RELEASE_TAG}"
+
+      - name: Sync Release Branch with GA Tag
+        if: ${{ github.event.inputs.release_type == 'GA' }}
+        env:
+          GIT_AUTHOR_NAME: ${{ steps.gpg_importer.outputs.name }}
+          GIT_AUTHOR_EMAIL: ${{ steps.gpg_importer.outputs.email }}
+          GIT_COMMITTER_NAME: ${{ steps.gpg_importer.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.gpg_importer.outputs.email }}
+        run: |
+          # Bring the release branch's version.txt up to date with the GA tag
+          # via a merge — never a force-push — so any commit that drifted onto
+          # the branch after the last rc is preserved rather than discarded.
+          # This fast-forwards when there's no drift, or creates a merge
+          # commit when there is. A genuine conflict (a drifted commit also
+          # touching the bumped files) fails the step so a human can resolve
+          # it rather than having the workflow guess.
+          git fetch origin "${RELEASE_BRANCH}"
+          git checkout -B "${RELEASE_BRANCH}" "origin/${RELEASE_BRANCH}"
+          git merge --no-edit "${RELEASE_TAG}"
+          git push origin "${RELEASE_BRANCH}"
 
       - name: Install git-cliff
         run: |

--- a/docs/release.md
+++ b/docs/release.md
@@ -40,9 +40,12 @@ The release process is automated using a GitHub Actions workflow (`release-autom
 1. **Create or Update Release Branch**:
    - Create a new release branch `release/0.n` if it doesn't exist.
    - If the release branch was created, means it's a new release, create a PR on the main branch to increase the snapshot version to the next version.
-   - Bump the version to the input provided in the release branch.
+   - For `rc`, `alpha`, and `custom` releases, bump the version to the input provided directly on the release branch.
+   - For `GA` releases, build from the exact commit tagged as the last rc/alpha instead of the release branch tip, so any drift on the branch since the last rc can't sneak into GA untested. If no rc/alpha was ever released for this version, GA falls back to building from the release branch tip.
 2. **Tagging**:
-   - After bumping the version on the release branch, tag the version as `vX.n.p` (where `X.n.p` is the input).
+   - After bumping the version, tag the version as `vX.n.p` (where `X.n.p` is the input).
+   - For `rc`, `alpha`, and `custom` releases, the version bump commit and tag are both pushed to the release branch.
+   - For `GA` releases, only the tag is pushed — the release branch ref itself is left untouched.
    - Push the tag, triggering the `Publish Release Workflow`.
 3. **Release Notes and Milestone**:
    - Create release notes for the new Tag.
@@ -101,6 +104,7 @@ The meta process typically follows these steps:
    - Perform integration and performance testing on this version.
 2. **General Availability (GA)**:
    - Once testing is successful, trigger the Release Automation Workflow again for the same version but as a GA version (e.g., `x.n.0`).
+   - The GA release is built from the exact commit tagged as the last rc, not from whatever the release branch currently points to, so any commit that landed on the branch after the last rc is excluded from GA.
 3. **Patch Versions**:
    - For any patch versions, changes will be merged (cherry-picked from main) into the release branch.
    - Start a new release automation process for the patch version (e.g., `x.n.p`).


### PR DESCRIPTION
## Reviewer Notes

Summary of changes to [release-automation.yaml](.github/workflows/release-automation.yaml):

- **`Compute Release Version`**: now exports `SOURCE_TAG=v$CURRENT` when the version on the dispatch ref is an rc/alpha (this is exactly the tag a prior run of the workflow created). Stays unset if there was never an rc/alpha (snapshot).
- **`Create and Switch to Release Branch`**: for GA with a resolved `SOURCE_TAG`, fetches and checks out that tag detached instead of the release branch tip. Falls back to the existing `git checkout ${RELEASE_BRANCH}` behavior in every other case (non-GA, or GA with no prior rc/alpha).
- **`Commit and Tag`**: now skipped for GA (`if: release_type != 'GA'`), unchanged for rc/alpha/custom.
- **New `Commit and Tag (GA)`**: manually commits the version bump and creates the signed annotated tag, then pushes only `refs/tags/<tag>` — it never pushes/updates the release branch ref, whether GA was built from the rc tag or (fallback) from the branch tip.

Validated the YAML parses correctly and the step list still resolves as expected. 

## Related Issue(s)
 Closes #3300
