### PR TITLE
fix: Superseded Verification Session must not Report a Cancellation

### DIFF
--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/BlockSessionHandler.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/BlockSessionHandler.java
@@ -106,7 +106,17 @@ public final class BlockSessionHandler {
         BlockVerificationSession local = activePublisherSession.get();
         if (blockItems.isStartOfNewBlock()) {
             if (local != null) {
-                local.cancel();
+                if (local.sessionKey().blockNumber() == blockItems.blockNumber()) {
+                    // The new session supersedes the active one for the same block
+                    // (e.g. a publisher severed mid-block and another publisher resends
+                    // the block in full). The stale session must not report a verdict,
+                    // the superseding session reports for the block.
+                    local.cancelSuperseded();
+                } else {
+                    // The stream moved on to a different block, the canceled block is
+                    // lost downstream and the failure report schedules its resend.
+                    local.cancel();
+                }
             }
             local = startNewSession(blockItems, BlockSource.PUBLISHER);
             activePublisherSession.set(local);

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/BlockVerificationSession.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/BlockVerificationSession.java
@@ -35,6 +35,22 @@ public interface BlockVerificationSession {
     /// Cancel and stop the session.
     void cancel();
 
+    /// Cancel and stop the session because a new session for the same block
+    /// supersedes it.
+    ///
+    /// A session canceled this way MUST NOT report a verification verdict to
+    /// messaging. The superseding session owns the fate of the block: it will
+    /// report success or failure itself, and if its stream dies mid-block, the
+    /// publisher plugin schedules a resend. Reporting a CANCELLED failure here
+    /// would race with the superseding session and be treated downstream as a
+    /// real verification failure for a block that is still being processed.
+    ///
+    /// This method MUST only be used for same-block supersession. A session
+    /// canceled for any other reason (a different block started, session
+    /// buffer eviction, shutdown) must use [#cancel()], so the block is
+    /// scheduled for resend and is not lost downstream.
+    void cancelSuperseded();
+
     /// Get the block items deque.
     /// Through this deque, we are able to offer the next block items of the block.
     ConcurrentLinkedDeque<BlockItems> getBlockItemsDeque();

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/CompletableVerificationSession.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/CompletableVerificationSession.java
@@ -30,6 +30,10 @@ public final class CompletableVerificationSession implements BlockVerificationSe
     private final BlockSource blockSource;
     private final ExecutorService executor;
     private final AtomicBoolean isCancelled;
+    /// Set when the session is canceled because a new session for the same
+    /// block supersedes it. Shared with the [SessionResultHandler] so a
+    /// superseded session does not report a verification verdict.
+    private final AtomicBoolean isSuperseded;
     private final BlockNodeContext context;
     private final AtomicLong lastVerifiedBlock;
     private final ConcurrentLinkedDeque<Long> recentlyVerifiedBlocks;
@@ -67,6 +71,7 @@ public final class CompletableVerificationSession implements BlockVerificationSe
         this.blockSource = Objects.requireNonNull(blockSource);
         this.executor = Objects.requireNonNull(executor);
         this.isCancelled = new AtomicBoolean(false);
+        this.isSuperseded = new AtomicBoolean(false);
         this.blockItemsDeque = new ConcurrentLinkedDeque<>();
         this.verificationConfig = Objects.requireNonNull(verificationConfig);
         this.finishedSessions = Objects.requireNonNull(finishedSessions);
@@ -117,7 +122,8 @@ public final class CompletableVerificationSession implements BlockVerificationSe
                 blockNumber,
                 blockSource,
                 finishedSessions,
-                sessionKey);
+                sessionKey,
+                isSuperseded);
         final CompletableFuture<BlockVerificationResult> completionChain = CompletableFuture.supplyAsync(
                         hasher, executor)
                 .thenApply(verifier)
@@ -142,6 +148,14 @@ public final class CompletableVerificationSession implements BlockVerificationSe
         } finally {
             isCancelled.set(true);
         }
+    }
+
+    @Override
+    public void cancelSuperseded() {
+        // The order matters: the flag must be visible before the cancellation
+        // propagates to the session result handler.
+        isSuperseded.set(true);
+        cancel();
     }
 
     @Override

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/SessionResultHandler.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/SessionResultHandler.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import org.hiero.block.internal.BlockItemUnparsed;
@@ -38,6 +39,10 @@ public final class SessionResultHandler implements BiConsumer<BlockVerificationR
     final ConcurrentLinkedDeque<Long> recentlyVerifiedBlocks;
     private final ConcurrentSkipListSet<SessionKey> finishedSessions;
     private final SessionKey sessionKey;
+    /// Set by the session when it is canceled because a new session for the
+    /// same block supersedes it. A superseded session must not report a
+    /// verification verdict, the superseding session owns the fate of the block.
+    private final AtomicBoolean isSuperseded;
 
     /// Constructor.
     public SessionResultHandler(
@@ -50,7 +55,8 @@ public final class SessionResultHandler implements BiConsumer<BlockVerificationR
             final long blockNumber,
             final BlockSource blockSource,
             final ConcurrentSkipListSet<SessionKey> finishedSessions,
-            final SessionKey sessionKey) {
+            final SessionKey sessionKey,
+            final AtomicBoolean isSuperseded) {
         this.context = Objects.requireNonNull(context);
         this.verificationConfig = Objects.requireNonNull(verificationConfig);
         this.sessionResultMetrics = Objects.requireNonNull(sessionResultMetrics);
@@ -60,6 +66,7 @@ public final class SessionResultHandler implements BiConsumer<BlockVerificationR
         this.recentlyVerifiedBlocks = Objects.requireNonNull(recentlyVerifiedBlocks);
         this.finishedSessions = Objects.requireNonNull(finishedSessions);
         this.sessionKey = Objects.requireNonNull(sessionKey);
+        this.isSuperseded = Objects.requireNonNull(isSuperseded);
         if (blockNumber < 0) {
             throw new IllegalArgumentException("Block number must be non-negative");
         } else {
@@ -142,38 +149,51 @@ public final class SessionResultHandler implements BiConsumer<BlockVerificationR
         }
         VerificationNotification notification = null;
         try {
-            notification = switch (throwable) {
-                case CancellationException ignored ->
-                    new VerificationNotification(
-                            false,
-                            getFailureInfo(blockNumber, SessionFailureType.CANCELLED),
-                            blockNumber,
-                            null,
-                            null,
-                            blockSource);
-                case CompletionException ce -> {
-                    LOGGER.log(Level.WARNING, message, ce.getCause() != null ? ce.getCause() : ce);
-                    yield processCompletionException(ce);
-                }
-                default -> {
-                    LOGGER.log(Level.WARNING, message, throwable);
-                    yield new VerificationNotification(
-                            false,
-                            getFailureInfo(blockNumber, SessionFailureType.UNKNOWN_ERROR),
-                            blockNumber,
-                            null,
-                            null,
-                            blockSource);
-                }
-            };
-            safeSendNotification(notification);
-            sessionResultMetrics.verificationBlocksFailed().increment();
+            final VerificationNotification resolved =
+                    switch (throwable) {
+                        case CancellationException ignored ->
+                            new VerificationNotification(
+                                    false,
+                                    getFailureInfo(blockNumber, SessionFailureType.CANCELLED),
+                                    blockNumber,
+                                    null,
+                                    null,
+                                    blockSource);
+                        case CompletionException ce -> {
+                            LOGGER.log(Level.WARNING, message, ce.getCause() != null ? ce.getCause() : ce);
+                            yield processCompletionException(ce);
+                        }
+                        default -> {
+                            LOGGER.log(Level.WARNING, message, throwable);
+                            yield new VerificationNotification(
+                                    false,
+                                    getFailureInfo(blockNumber, SessionFailureType.UNKNOWN_ERROR),
+                                    blockNumber,
+                                    null,
+                                    null,
+                                    blockSource);
+                        }
+                    };
+            if (isSuperseded.get() && resolved.failureInfo().failureType() == FailureType.CANCELLED) {
+                // A session canceled because a new session for the same block superseded it
+                // reports no verdict: the block is still being processed and the superseding
+                // session reports for it. Reporting CANCELLED here would be treated downstream
+                // as a real verification failure for the block.
+                final String supersededMessage =
+                        "Session with id %d for block %d with source %s was superseded, no verdict is reported"
+                                .formatted(sessionKey.uniqueId(), blockNumber, blockSource);
+                LOGGER.log(Level.DEBUG, supersededMessage);
+            } else {
+                notification = resolved;
+                safeSendNotification(notification);
+                sessionResultMetrics.verificationBlocksFailed().increment();
+            }
         } finally {
             if (notification != null) {
                 badBlockDumper.attemptDump(notification, hapiVersion, blockItems);
             }
         }
-        return notification.failureInfo().failureType() == FailureType.UNKNOWN_ERROR;
+        return notification != null && notification.failureInfo().failureType() == FailureType.UNKNOWN_ERROR;
     }
 
     /// Process a completion exception case.

--- a/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/VerificationServicePluginTest.java
+++ b/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/VerificationServicePluginTest.java
@@ -1349,20 +1349,24 @@ class VerificationServicePluginTest {
         /// This test aims to assert that when we receive the start of a new block via the Live RB (Publisher Source),
         /// but we have not yet received the last item for the current live publisher session, the current live
         /// publisher session will be canceled and the newly received block will start a new session.
-        /// The block proof type is irrelevant for this test. Also, it is irrelevant which block will be started
-        /// in the middle of current session.
+        /// The block proof type is irrelevant for this test. The new block must be a different block: a new
+        /// session for the same block supersedes the current one silently instead (see the Session
+        /// Supersession Tests).
         @Test
         @DisplayName(
                 "Live RB Ingestion - Cancel Current Live Session When New Block Received While Not Finished Current One")
         void testLiveRBIngestionCancelLiveSessionWhenNewBlockReceivedAndCurrentNotComplete()
                 throws IOException, ParseException {
             final ResourceTestBlock block0 = ResourceTestBlockBuilder.load(WRAPS.BLOCK_0);
+            final ResourceTestBlock block1 = ResourceTestBlockBuilder.load(WRAPS.BLOCK_1);
             // We push an item to start a session
             final BlockItems headerAsBlockItems =
                     new BlockItems(List.of(block0.getHeaderUnparsed()), block0.number(), true, false);
             plugin.handleBlockItemsReceived(headerAsBlockItems);
-            // Now we push that same item again, which starts a new session
-            plugin.handleBlockItemsReceived(headerAsBlockItems);
+            // Now we push the header of the next block, which starts a new session
+            final BlockItems nextHeaderAsBlockItems =
+                    new BlockItems(List.of(block1.getHeaderUnparsed()), block1.number(), true, false);
+            plugin.handleBlockItemsReceived(nextHeaderAsBlockItems);
             // Now, we expect the cancellation
             final List<VerificationNotification> notifications = blockMessaging.getSentVerificationNotifications(1);
             // Assert cancellation received
@@ -1424,5 +1428,76 @@ class VerificationServicePluginTest {
                 .returns(true, multiProof -> proofToAppend
                         .blockProof()
                         .equals(multiProof.proofs().getLast()));
+    }
+
+    /// Tests for the supersession behavior of verification sessions: an active
+    /// session that is replaced by a new session must report a verdict only when
+    /// the block would otherwise be lost downstream.
+    @Nested
+    @DisplayName("Session Supersession Tests")
+    class SessionSupersessionTests
+            extends PluginTestBase<VerificationServicePlugin, ExecutorService, ScheduledExecutorService> {
+        SessionSupersessionTests() {
+            super(
+                    Executors.newVirtualThreadPerTaskExecutor(),
+                    new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+            start(new VerificationServicePlugin(), new SimpleInMemoryHistoricalBlockFacility());
+        }
+
+        /// This test aims to assert that a session superseded by a new session for
+        /// the same block reports no verdict. A partial block (header only, as when a
+        /// publisher severs its connection mid-block) is followed by the same block
+        /// resent in full. The stale session must stay silent and the only
+        /// notification for the block is the success of the superseding session.
+        /// Reporting a CANCELLED failure instead would be treated downstream as a
+        /// real verification failure for a block that is still being processed,
+        /// which can suppress acknowledgements or disconnect the resending publisher.
+        @Test
+        @DisplayName("Superseded session for the same block reports no verdict")
+        void testSupersededSameBlockSessionReportsNoVerdict() throws IOException, ParseException {
+            final ResourceTestBlock block0 = ResourceTestBlockBuilder.load(WRAPS.BLOCK_0);
+            // The publisher supplies only the header of block 0 and severs mid-block.
+            final BlockItemUnparsed header = block0.blockUnparsed().blockItems().getFirst();
+            plugin.handleBlockItemsReceived(new BlockItems(List.of(header), block0.number(), true, false));
+            // Another publisher resends block 0 in full, superseding the stale session.
+            plugin.handleBlockItemsReceived(block0.asBlockItems());
+            // The first notification must be the success of the superseding session;
+            // the superseded session must not have reported a CANCELLED failure.
+            final List<VerificationNotification> notifications = blockMessaging.getSentVerificationNotifications(1);
+            assertThat(notifications)
+                    .hasSize(1)
+                    .first()
+                    .returns(true, VerificationNotification::success)
+                    .returns(null, VerificationNotification::failureInfo)
+                    .returns(block0.number(), VerificationNotification::blockNumber)
+                    .returns(block0.blockRootHash(), VerificationNotification::blockHash);
+        }
+
+        /// This test aims to assert that a session canceled because the stream moved
+        /// on to a different block still reports a CANCELLED failure, so the
+        /// abandoned block is scheduled for resend and is not lost downstream.
+        @Test
+        @DisplayName("Canceled session for a different block still reports CANCELLED")
+        void testCanceledSessionForDifferentBlockReportsCancelled() throws IOException, ParseException {
+            final ResourceTestBlock block0 = ResourceTestBlockBuilder.load(WRAPS.BLOCK_0);
+            final ResourceTestBlock block1 = ResourceTestBlockBuilder.load(WRAPS.BLOCK_1);
+            // The publisher supplies only the header of block 1 and severs mid-block.
+            final BlockItemUnparsed header = block1.blockUnparsed().blockItems().getFirst();
+            plugin.handleBlockItemsReceived(new BlockItems(List.of(header), block1.number(), true, false));
+            // The stream moves on to a different block, block 1 is abandoned.
+            plugin.handleBlockItemsReceived(block0.asBlockItems());
+            // Two notifications must arrive: a CANCELLED failure for block 1, which
+            // schedules the resend downstream, and a success for block 0.
+            final List<VerificationNotification> notifications = blockMessaging.getSentVerificationNotifications(2);
+            assertThat(notifications).hasSize(2);
+            assertThat(notifications).anySatisfy(notification -> assertThat(notification)
+                    .returns(false, VerificationNotification::success)
+                    .returns(block1.number(), VerificationNotification::blockNumber)
+                    .extracting(VerificationNotification::failureInfo)
+                    .returns(FailureType.CANCELLED, FailureInfo::failureType));
+            assertThat(notifications).anySatisfy(notification -> assertThat(notification)
+                    .returns(true, VerificationNotification::success)
+                    .returns(block0.number(), VerificationNotification::blockNumber));
+        }
     }
 }


### PR DESCRIPTION
* Cancel an active publisher session silently when a new session for the same block supersedes it
  * A stale session left by a publisher severing mid-block raced with the resent block: its CANCELLED failure was treated downstream as a real verification failure, re-adding the in-flight block to blocksToResend and suppressing all further acknowledgements
  * The superseding session owns the fate of the block: it reports success or failure itself, and blockIsEnding schedules a resend if its stream dies
* Keep the CANCELLED failure report when the canceled session is for a different block, so the abandoned block is scheduled for resend and is not lost downstream
* Suppress by failure type, not exception type, so a cancellation surfacing as either CancellationException or a CANCELLED session failure is covered
* Add tests
  * Superseded same block session reports no verdict, only the success of the superseding session
  * Canceled session for a different block still reports CANCELLED
  * Update the existing cancellation test to interrupt with a different block

Resolves #3303 