### PR TITLE
chore: solo chaos review followups

### DIFF
--- a/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
+++ b/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
@@ -97,6 +97,7 @@ tasks:
         command -v kind >/dev/null 2>&1 || { echo "ERROR: kind not found"; exit 1; }
         command -v solo >/dev/null 2>&1 || { echo "ERROR: solo not found. Install with: npm i @hashgraph/solo -g (or 'task solo:install' for a custom fork/branch build)"; exit 1; }
         command -v yq >/dev/null 2>&1 || { echo "ERROR: yq not found. Install from: https://github.com/mikefarah/yq"; exit 1; }
+        command -v envsubst >/dev/null 2>&1 || { echo "ERROR: envsubst not found. Install gettext: brew install gettext (macOS) or apt-get install gettext (Linux)"; exit 1; }
         echo "All prerequisites found!"
         echo ""
         echo "Versions:"
@@ -536,6 +537,11 @@ tasks:
         ls -la "{{.ROOT_DIR}}/tests/"*.yaml 2>/dev/null || echo "No test files found in tests/"
         echo ""
         echo "Run a test with: task test:run TEST_FILE=tests/<name>.yaml"
+
+  test:scripts:
+    desc: Run bash unit tests for chaos/assertion scripts (no cluster needed)
+    cmds:
+      - 'bash "{{.SCRIPTS_DIR}}/test/test-chaos-assertions.sh"'
 
   # ============================================================================
   # TCK-SDK Tests (matches consensus-node approach: uses latest tags)

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-test-runner.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-test-runner.sh
@@ -538,7 +538,7 @@ function chaos_slug {
 function chaos_resource_name {
     local scenario_name="$1"
     local n="$(chaos_slug "${TEST_NAME}")--$(chaos_slug "${scenario_name}")"
-    echo "${n:0:63}"
+    echo "${n:0:63}" | sed 's/-*$//'
 }
 
 function execute_inject_latency {
@@ -550,7 +550,7 @@ function execute_inject_latency {
     latency=$(echo "$args" | yq '.latency // "0ms"')
     jitter=$(echo "$args" | yq '.jitter // "0ms"')
     correlation=$(echo "$args" | yq '.correlation // "0"')
-    bidirectional=$(echo "$args" | yq '.bidirectional // true')
+    bidirectional=$(echo "$args" | yq 'if has("bidirectional") then .bidirectional else true end')
     loss=$(echo "$args" | yq '.loss // ""')
 
     [[ -z "$name" || "$name" == "null" ]] && { echo "ERROR: inject-latency requires args.name"; return 1; }

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/sample-logs-with-backfill.txt
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/sample-logs-with-backfill.txt
@@ -1,6 +1,6 @@
 2026-05-11T20:01:00Z INFO  org.hiero.block.node.backfill.BackfillFetcher - Loaded backfill source node: block-node-2.solo-network.svc.cluster.local:40840
 2026-05-11T20:01:05Z INFO  org.hiero.block.node.NetworkApp - Block Node started successfully
-2026-05-11T20:01:10Z DEBUG org.hiero.block.node.verification.VerificationServicePlugin - Received backfill notification for block=412
-2026-05-11T20:01:11Z DEBUG org.hiero.block.node.verification.VerificationServicePlugin - Received backfill notification for block=413
-2026-05-11T20:01:12Z DEBUG org.hiero.block.node.verification.VerificationServicePlugin - Received backfill notification for block=414
+2026-05-11T20:01:10Z DEBUG org.hiero.block.node.block.verification.VerificationServicePlugin - Received backfill notification for block=412
+2026-05-11T20:01:11Z DEBUG org.hiero.block.node.block.verification.VerificationServicePlugin - Received backfill notification for block=413
+2026-05-11T20:01:12Z DEBUG org.hiero.block.node.block.verification.VerificationServicePlugin - Received backfill notification for block=414
 2026-05-11T20:01:15Z INFO  org.hiero.block.node.publisher.PublisherHandler - New publisher connection from network-node1


### PR DESCRIPTION
## Summary

Addresses all non-blocking review comments captured in #3312 from PR #2798 (solo-chaos latency framework).

## Changes

**Bug fixes (`solo-test-runner.sh`)**
- `yq '.bidirectional // true'` silently coerces boolean `false` to `true` because yq treats falsy values as null. Fixed with `if has("bidirectional") then .bidirectional else true end`.
- `chaos_resource_name` slices the combined slug to 63 chars with `${n:0:63}`, which can leave a trailing `-` that `kubectl apply` rejects. Fixed by stripping trailing dashes after the slice.

**Already fixed at merge:** `chaos-cleanup.sh` `--all` / `-l` mutual exclusion (item 1 in #3312) was addressed in the PR before it merged — the branching logic was already present on main.

**Cleanup (`Taskfile.yml`, test fixture)**
- Added `envsubst` to the `check` prerequisite task — it is required by `execute_inject_latency` to render `network-latency.yaml.tmpl` but was previously unvalidated.
- Added `test:scripts` Taskfile task to run `test-chaos-assertions.sh` without a live cluster (was previously manual-only).
- Updated `sample-logs-with-backfill.txt` fixture: class name was `org.hiero.block.node.verification.VerificationServicePlugin` (old module path); corrected to `org.hiero.block.node.block.verification.VerificationServicePlugin`.

## Test Plan

- [ ] `task test:scripts` runs all 20 bash unit tests with 0 failures
- [ ] Verified `bidirectional: false` in a scenario YAML now correctly sets `direction="to"` instead of `"both"`
- [ ] Verified resource names longer than 63 chars are truncated without a trailing `-`

Closes #3312