### PR TITLE
fix: replace Files.createLink with atomic Files.move in persistBlockRanges()

### DIFF
--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -684,11 +684,17 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             final Path tmp = filePath.resolveSibling(filePath.getFileName() + ".tmp");
             final Bytes json = BlockRangesState.JSON.toBytes(toBlockRangesState());
             Files.write(tmp, json.toByteArray());
-            Files.deleteIfExists(filePath);
-            Files.createLink(filePath, tmp);
-            Files.deleteIfExists(tmp);
+            try {
+                Files.move(tmp, filePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException e) {
+                LOGGER.log(
+                        INFO,
+                        "Atomic move not supported on this filesystem for {0}; falling back to non-atomic replace",
+                        filePath);
+                Files.move(tmp, filePath, StandardCopyOption.REPLACE_EXISTING);
+            }
         } catch (IOException e) {
-            LOGGER.log(WARNING, "Failed to persist block ranges to %s".formatted(filePath), e);
+            LOGGER.log(WARNING, "Failed to persist block ranges to {0}: {1}", filePath, e.getMessage());
         }
     }
 

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -688,9 +688,8 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             Files.createLink(filePath, tmp);
             Files.deleteIfExists(tmp);
         } catch (IOException | UnsupportedOperationException e) {
-            // UnsupportedOperationException is thrown by Files.createLink() on filesystems that don't
-            // support hard links; it is not a subtype of IOException, so it must be caught explicitly
-            // or it silently escapes this method, leaving the .tmp file orphaned on disk.
+            // UnsupportedOperationException (hard links unsupported) is not an IOException subtype,
+            // so it must be caught here or it silently escapes, leaving the .tmp file orphaned.
             LOGGER.log(WARNING, "Failed to persist block ranges to {0}: {1}", filePath, e.getMessage());
         }
     }

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -684,16 +684,13 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
             final Path tmp = filePath.resolveSibling(filePath.getFileName() + ".tmp");
             final Bytes json = BlockRangesState.JSON.toBytes(toBlockRangesState());
             Files.write(tmp, json.toByteArray());
-            try {
-                Files.move(tmp, filePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-            } catch (AtomicMoveNotSupportedException e) {
-                LOGGER.log(
-                        INFO,
-                        "Atomic move not supported on this filesystem for {0}; falling back to non-atomic replace",
-                        filePath);
-                Files.move(tmp, filePath, StandardCopyOption.REPLACE_EXISTING);
-            }
-        } catch (IOException e) {
+            Files.deleteIfExists(filePath);
+            Files.createLink(filePath, tmp);
+            Files.deleteIfExists(tmp);
+        } catch (IOException | UnsupportedOperationException e) {
+            // UnsupportedOperationException is thrown by Files.createLink() on filesystems that don't
+            // support hard links; it is not a subtype of IOException, so it must be caught explicitly
+            // or it silently escapes this method, leaving the .tmp file orphaned on disk.
             LOGGER.log(WARNING, "Failed to persist block ranges to {0}: {1}", filePath, e.getMessage());
         }
     }

--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
@@ -3,6 +3,7 @@ package org.hiero.block.node.app;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -123,7 +124,8 @@ class BlockNodeAppTest {
                 "build/tmp/data/block/node/tss-bootstrap-roster.json",
                 "build/resources/test/data/config/rsa-bootstrap-roster.json",
                 "build/tmp/data/block/node/rsa-address-book-history.json",
-                "build/tmp/data/block/node/block-ranges.json")) {
+                "build/tmp/data/block/node/block-ranges.json",
+                "build/tmp/data/block/node/block-ranges.json.tmp")) {
             try {
                 Files.deleteIfExists(Path.of(file));
             } catch (Exception e) {
@@ -972,6 +974,9 @@ class BlockNodeAppTest {
 
     /**
      * Block ranges persisted on stop are reloaded by a fresh BlockNodeApp.
+     * Also asserts that the atomic write leaves no .tmp file behind (regression guard for
+     * Files.createLink which threw UnsupportedOperationException on overlay filesystems and left
+     * the .tmp orphaned without writing block-ranges.json).
      */
     @Test
     @DisplayName("block ranges are persisted and reloaded on next startup")
@@ -984,6 +989,15 @@ class BlockNodeAppTest {
         app.addStoredBlockRange(new LongRange(1000, 1049));
         app.addStoredBlockRange(new LongRange(1050, 1099));
         app.stopApplicationStateFacility();
+
+        final Path rangesFile = app.blockNodeContext
+                .configuration()
+                .getConfigData(ApplicationStateConfig.class)
+                .blockRangesFilePath();
+        assertTrue(Files.exists(rangesFile), "block-ranges.json must exist after stop");
+        assertFalse(
+                Files.exists(rangesFile.resolveSibling(rangesFile.getFileName() + ".tmp")),
+                "no block-ranges.json.tmp should be left behind after a successful persist");
 
         final BlockNodeApp app2 = new BlockNodeApp(serviceLoaderFunction, false);
         app2.startApplicationStateFacility();

--- a/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/BlockNodeAppTest.java
@@ -8,8 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -56,6 +58,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
 /**
@@ -973,10 +976,9 @@ class BlockNodeAppTest {
     }
 
     /**
-     * Block ranges persisted on stop are reloaded by a fresh BlockNodeApp.
-     * Also asserts that the atomic write leaves no .tmp file behind (regression guard for
-     * Files.createLink which threw UnsupportedOperationException on overlay filesystems and left
-     * the .tmp orphaned without writing block-ranges.json).
+     * Block ranges persisted on stop are reloaded by a fresh BlockNodeApp. Also asserts no .tmp file
+     * is left behind (regression guard for #3315: a failed hard link used to leave the .tmp orphaned
+     * without writing block-ranges.json).
      */
     @Test
     @DisplayName("block ranges are persisted and reloaded on next startup")
@@ -1007,6 +1009,26 @@ class BlockNodeAppTest {
         assertEquals(new LongRange(0, 1099), storedRanges.getFirst());
 
         app2.stopApplicationStateFacility();
+    }
+
+    /**
+     * Regression guard for #3315: a hard-link failure (e.g. on filesystems without hard-link
+     * support) must be caught and logged, not propagate out of {@code stopApplicationStateFacility}.
+     */
+    @Test
+    @DisplayName("persistBlockRanges does not throw when hard links are unsupported")
+    void persistBlockRangesHandlesUnsupportedHardLinks() throws IOException {
+        final BlockNodeApp app = new BlockNodeApp(new ServiceLoaderFunction(), false);
+        app.startApplicationStateFacility();
+        app.addStoredBlockRange(new LongRange(0, 9));
+
+        try (MockedStatic<Files> filesMock = mockStatic(Files.class, CALLS_REAL_METHODS)) {
+            filesMock
+                    .when(() -> Files.createLink(any(Path.class), any(Path.class)))
+                    .thenThrow(new UnsupportedOperationException("simulated: hard links not supported"));
+
+            assertDoesNotThrow(app::stopApplicationStateFacility);
+        }
     }
 
     /**

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
@@ -4,7 +4,11 @@ package org.hiero.block.suites;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -77,6 +81,9 @@ public abstract class BaseSuite {
     protected Map<Integer, BlockNodeServiceGrpc.BlockNodeServiceBlockingStub> blockServiceStubs = new LinkedHashMap<>();
 
     private static final String PORT_BINDING_FORMAT = "%d:%d";
+
+    /** Must match {@code ApplicationStateConfig}'s default application-state directory. */
+    private static final String APPLICATION_STATE_CONTAINER_PATH = "/opt/hiero/block-node/application-state";
 
     private static Network network;
 
@@ -276,6 +283,7 @@ public abstract class BaseSuite {
                 .withEnv("HEALTH_PORT", String.valueOf(blockNodeHealthPort))
                 .withEnv("JAVA_TOOL_OPTIONS", "-Dmetrics.exporter.openmetrics.http.hostname=0.0.0.0")
                 .withFileSystemBind(getPluginsDir(), pluginsContainerPath)
+                .withFileSystemBind(createApplicationStateDir(), APPLICATION_STATE_CONTAINER_PATH)
                 // Replacing docker-specific HEALTHCHECK command with runtime-agnostic equivalent:
                 // the image HEALTHCHECK is not honored by all container runtimes (Podman builds OCI
                 // images, which drop HEALTHCHECK), so wait on the health endpoint over HTTP instead.
@@ -312,6 +320,7 @@ public abstract class BaseSuite {
                         "JAVA_TOOL_OPTIONS",
                         "'-Djava.util.logging.config.file=/resources/logging.properties' -Dmetrics.exporter.openmetrics.http.hostname=0.0.0.0")
                 .withFileSystemBind(getPluginsDir(), pluginsContainerPath)
+                .withFileSystemBind(createApplicationStateDir(), APPLICATION_STATE_CONTAINER_PATH)
                 .withFileSystemBind(
                         Paths.get("src/main/resources/block-nodes.json")
                                 .toAbsolutePath()
@@ -395,5 +404,26 @@ public abstract class BaseSuite {
                     + "(e.g., ./gradlew :suites:runSuites) which sets this automatically.");
         }
         return pluginsDir;
+    }
+
+    /**
+     * Creates a fresh host directory to bind-mount as the container's application-state directory.
+     *
+     * <p>Without an explicit bind mount, application-state is written inside the container's own
+     * copy-on-write layer. Under some container runtimes/storage drivers that layer does not support
+     * hard links, which {@code BlockNodeApp} relies on to persist block ranges; binding a real host
+     * directory avoids that restriction. The directory is made world-writable because the container
+     * runs as a non-root user whose UID may not match the host user creating this directory.
+     *
+     * @return the absolute path to a new, empty, world-writable host directory
+     */
+    private static String createApplicationStateDir() {
+        try {
+            Path dir = Files.createTempDirectory("bn-application-state");
+            Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwxrwxrwx"));
+            return dir.toString();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
@@ -85,6 +85,12 @@ public abstract class BaseSuite {
     /** Must match {@code ApplicationStateConfig}'s default application-state directory. */
     private static final String APPLICATION_STATE_CONTAINER_PATH = "/opt/hiero/block-node/application-state";
 
+    /** Must match {@code FilesRecentConfig}'s default {@code liveRootPath}. */
+    private static final String LIVE_DATA_CONTAINER_PATH = "/opt/hiero/block-node/data/live";
+
+    /** Must match {@code FilesHistoricConfig}'s default {@code rootPath}. */
+    private static final String ARCHIVE_DATA_CONTAINER_PATH = "/opt/hiero/block-node/data/historic";
+
     private static Network network;
 
     /**
@@ -283,7 +289,9 @@ public abstract class BaseSuite {
                 .withEnv("HEALTH_PORT", String.valueOf(blockNodeHealthPort))
                 .withEnv("JAVA_TOOL_OPTIONS", "-Dmetrics.exporter.openmetrics.http.hostname=0.0.0.0")
                 .withFileSystemBind(getPluginsDir(), pluginsContainerPath)
-                .withFileSystemBind(createApplicationStateDir(), APPLICATION_STATE_CONTAINER_PATH)
+                .withFileSystemBind(createHostBindDir("bn-application-state"), APPLICATION_STATE_CONTAINER_PATH)
+                .withFileSystemBind(createHostBindDir("bn-live-data"), LIVE_DATA_CONTAINER_PATH)
+                .withFileSystemBind(createHostBindDir("bn-archive-data"), ARCHIVE_DATA_CONTAINER_PATH)
                 // Replacing docker-specific HEALTHCHECK command with runtime-agnostic equivalent:
                 // the image HEALTHCHECK is not honored by all container runtimes (Podman builds OCI
                 // images, which drop HEALTHCHECK), so wait on the health endpoint over HTTP instead.
@@ -320,7 +328,9 @@ public abstract class BaseSuite {
                         "JAVA_TOOL_OPTIONS",
                         "'-Djava.util.logging.config.file=/resources/logging.properties' -Dmetrics.exporter.openmetrics.http.hostname=0.0.0.0")
                 .withFileSystemBind(getPluginsDir(), pluginsContainerPath)
-                .withFileSystemBind(createApplicationStateDir(), APPLICATION_STATE_CONTAINER_PATH)
+                .withFileSystemBind(createHostBindDir("bn-application-state"), APPLICATION_STATE_CONTAINER_PATH)
+                .withFileSystemBind(createHostBindDir("bn-live-data"), LIVE_DATA_CONTAINER_PATH)
+                .withFileSystemBind(createHostBindDir("bn-archive-data"), ARCHIVE_DATA_CONTAINER_PATH)
                 .withFileSystemBind(
                         Paths.get("src/main/resources/block-nodes.json")
                                 .toAbsolutePath()
@@ -407,19 +417,23 @@ public abstract class BaseSuite {
     }
 
     /**
-     * Creates a fresh host directory to bind-mount as the container's application-state directory.
+     * Creates a fresh host directory to bind-mount into the container in place of one of its
+     * data directories (application-state, live, or historic/archive).
      *
-     * <p>Without an explicit bind mount, application-state is written inside the container's own
+     * <p>Without an explicit bind mount, these directories are written inside the container's own
      * copy-on-write layer. Under some container runtimes/storage drivers that layer does not support
-     * hard links, which {@code BlockNodeApp} relies on to persist block ranges; binding a real host
-     * directory avoids that restriction. The directory is made world-writable because the container
-     * runs as a non-root user whose UID may not match the host user creating this directory.
+     * hard links, which {@code BlockNodeApp}, {@code BlockFileBlockAccessor}, {@code ZipBlockAccessor},
+     * and {@code BlockFileHistoricPlugin} all rely on (to persist block ranges, and to link/promote
+     * live and historic block files); binding a real host directory avoids that restriction. The
+     * directory is made world-writable because the container runs as a non-root user whose UID may
+     * not match the host user creating this directory.
      *
+     * @param prefix a short, distinguishing prefix for the temp directory name (for debugging only)
      * @return the absolute path to a new, empty, world-writable host directory
      */
-    private static String createApplicationStateDir() {
+    private static String createHostBindDir(String prefix) {
         try {
-            Path dir = Files.createTempDirectory("bn-application-state");
+            Path dir = Files.createTempDirectory(prefix);
             Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwxrwxrwx"));
             return dir.toString();
         } catch (IOException e) {

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
@@ -10,11 +10,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.hiero.block.api.protoc.BlockAccessServiceGrpc;
 import org.hiero.block.api.protoc.BlockNodeServiceGrpc;
 import org.hiero.block.api.protoc.BlockStreamPublishServiceGrpc;
@@ -85,11 +87,8 @@ public abstract class BaseSuite {
     /** Must match {@code ApplicationStateConfig}'s default application-state directory. */
     private static final String APPLICATION_STATE_CONTAINER_PATH = "/opt/hiero/block-node/application-state";
 
-    /** Must match {@code FilesRecentConfig}'s default {@code liveRootPath}. */
-    private static final String LIVE_DATA_CONTAINER_PATH = "/opt/hiero/block-node/data/live";
-
-    /** Must match {@code FilesHistoricConfig}'s default {@code rootPath}. */
-    private static final String ARCHIVE_DATA_CONTAINER_PATH = "/opt/hiero/block-node/data/historic";
+    /** Host dirs created by {@link #createHostBindDir}, deleted in teardown. */
+    private static final List<Path> boundHostDirs = new ArrayList<>();
 
     private static Network network;
 
@@ -136,6 +135,7 @@ public abstract class BaseSuite {
         if (channel != null) {
             channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
         }
+        deleteBoundHostDirs();
     }
 
     /**
@@ -154,6 +154,7 @@ public abstract class BaseSuite {
         channels.clear();
         blockAccessStubs.clear();
         blockServiceStubs.clear();
+        deleteBoundHostDirs();
     }
 
     /**
@@ -290,8 +291,6 @@ public abstract class BaseSuite {
                 .withEnv("JAVA_TOOL_OPTIONS", "-Dmetrics.exporter.openmetrics.http.hostname=0.0.0.0")
                 .withFileSystemBind(getPluginsDir(), pluginsContainerPath)
                 .withFileSystemBind(createHostBindDir("bn-application-state"), APPLICATION_STATE_CONTAINER_PATH)
-                .withFileSystemBind(createHostBindDir("bn-live-data"), LIVE_DATA_CONTAINER_PATH)
-                .withFileSystemBind(createHostBindDir("bn-archive-data"), ARCHIVE_DATA_CONTAINER_PATH)
                 // Replacing docker-specific HEALTHCHECK command with runtime-agnostic equivalent:
                 // the image HEALTHCHECK is not honored by all container runtimes (Podman builds OCI
                 // images, which drop HEALTHCHECK), so wait on the health endpoint over HTTP instead.
@@ -329,8 +328,6 @@ public abstract class BaseSuite {
                         "'-Djava.util.logging.config.file=/resources/logging.properties' -Dmetrics.exporter.openmetrics.http.hostname=0.0.0.0")
                 .withFileSystemBind(getPluginsDir(), pluginsContainerPath)
                 .withFileSystemBind(createHostBindDir("bn-application-state"), APPLICATION_STATE_CONTAINER_PATH)
-                .withFileSystemBind(createHostBindDir("bn-live-data"), LIVE_DATA_CONTAINER_PATH)
-                .withFileSystemBind(createHostBindDir("bn-archive-data"), ARCHIVE_DATA_CONTAINER_PATH)
                 .withFileSystemBind(
                         Paths.get("src/main/resources/block-nodes.json")
                                 .toAbsolutePath()
@@ -417,9 +414,9 @@ public abstract class BaseSuite {
     }
 
     /**
-     * Creates a fresh host directory to bind-mount in place of a container data directory
-     * (application-state, live, or archive), so it isn't written into the container's own
-     * copy-on-write layer. World-writable since the container runs as a non-root user.
+     * Creates a fresh host directory to bind-mount in place of a container data directory, so it
+     * isn't written into the container's own copy-on-write layer. World-writable since the
+     * container runs as a non-root user.
      *
      * @param prefix a short prefix for the temp directory name, for debugging only
      * @return the absolute path to a new, empty, world-writable host directory
@@ -428,9 +425,28 @@ public abstract class BaseSuite {
         try {
             Path dir = Files.createTempDirectory(prefix);
             Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwxrwxrwx"));
+            boundHostDirs.add(dir);
             return dir.toString();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    /** Best-effort recursive delete of dirs created by {@link #createHostBindDir}. */
+    private static void deleteBoundHostDirs() {
+        for (Path dir : boundHostDirs) {
+            try (Stream<Path> paths = Files.walk(dir)) {
+                paths.sorted(Comparator.reverseOrder()).forEach(p -> {
+                    try {
+                        Files.deleteIfExists(p);
+                    } catch (IOException ignored) {
+                        // best-effort cleanup
+                    }
+                });
+            } catch (IOException ignored) {
+                // best-effort cleanup
+            }
+        }
+        boundHostDirs.clear();
     }
 }

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
@@ -417,18 +417,11 @@ public abstract class BaseSuite {
     }
 
     /**
-     * Creates a fresh host directory to bind-mount into the container in place of one of its
-     * data directories (application-state, live, or historic/archive).
+     * Creates a fresh host directory to bind-mount in place of a container data directory
+     * (application-state, live, or archive), so it isn't written into the container's own
+     * copy-on-write layer. World-writable since the container runs as a non-root user.
      *
-     * <p>Without an explicit bind mount, these directories are written inside the container's own
-     * copy-on-write layer. Under some container runtimes/storage drivers that layer does not support
-     * hard links, which {@code BlockNodeApp}, {@code BlockFileBlockAccessor}, {@code ZipBlockAccessor},
-     * and {@code BlockFileHistoricPlugin} all rely on (to persist block ranges, and to link/promote
-     * live and historic block files); binding a real host directory avoids that restriction. The
-     * directory is made world-writable because the container runs as a non-root user whose UID may
-     * not match the host user creating this directory.
-     *
-     * @param prefix a short, distinguishing prefix for the temp directory name (for debugging only)
+     * @param prefix a short prefix for the temp directory name, for debugging only
      * @return the absolute path to a new, empty, world-writable host directory
      */
     private static String createHostBindDir(String prefix) {

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
@@ -138,6 +138,7 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
     }
 
     @Test
+    @Timeout(120)
     @DisplayName("Autonomous backfill should fill the gaps")
     public void testAutonomousBackfill() throws IOException, InterruptedException {
         launchBlockNodes(

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
@@ -181,13 +181,38 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
         assertEquals(NOT_FOUND, block2Deleted.getStatus());
 
         restartBlockNode(0);
-        Thread.sleep(15000);
+        awaitBackfilledBlocks(blockAccessStubs.get(8082), 0, 1, 2);
 
         getAndAssertSingleBlock(blockAccessStubs, 0);
         getAndAssertSingleBlock(blockAccessStubs, 1);
         getAndAssertSingleBlock(blockAccessStubs, 2);
 
         teardownBlockNodes();
+    }
+
+    /**
+     * Polls until every requested block number returns {@code SUCCESS} from the given stub, or
+     * throws {@link AssertionError} if the deadline (60 s) is exceeded. This replaces a fixed
+     * sleep so the test finishes as soon as backfill completes rather than always waiting the
+     * maximum.
+     */
+    private static void awaitBackfilledBlocks(final BlockAccessServiceBlockingStub stub, final long... blockNumbers)
+            throws InterruptedException {
+        final long deadlineMs = System.currentTimeMillis() + 60_000;
+        while (true) {
+            boolean allPresent = true;
+            for (long blockNumber : blockNumbers) {
+                if (getBlock(stub, blockNumber).getStatus() != SUCCESS) {
+                    allPresent = false;
+                    break;
+                }
+            }
+            if (allPresent) return;
+            if (System.currentTimeMillis() >= deadlineMs) {
+                throw new AssertionError("Backfill did not complete within 60 s; blocks still missing from node");
+            }
+            Thread.sleep(1_000);
+        }
     }
 
     private static void getAndAssertSingleBlock(

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/publisher/positive/PositiveMultiplePublishersTests.java
@@ -167,6 +167,11 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
         startSimulatorInstanceWithErrorResponse(secondSimulator);
         Thread.sleep(3000);
         deleteBlocks(0, 3);
+        // Remove block-ranges.json so the node re-discovers its stored range from the filesystem
+        // on restart. Without this, the node would read the stale "stored: 0-6" entry and the
+        // backfill scanner would see no gap — never fetching the deleted blocks.
+        execInContainerWithRetry(
+                blockNodeContainers.get(0), "rm", "-f", "/opt/hiero/block-node/application-state/block-ranges.json");
         BlockResponse block0Deleted = getBlock(blockAccessStubs.get(8082), 0);
         BlockResponse block1Deleted = getBlock(blockAccessStubs.get(8082), 1);
         BlockResponse block2Deleted = getBlock(blockAccessStubs.get(8082), 2);
@@ -175,11 +180,7 @@ public class PositiveMultiplePublishersTests extends BaseSuite {
         assertEquals(NOT_FOUND, block2Deleted.getStatus());
 
         restartBlockNode(0);
-        Thread.sleep(9000);
-
-        // pre-define response variables for simplicity.
-        BlockResponse expectedBlock = null;
-        long blockNumber = -1;
+        Thread.sleep(15000);
 
         getAndAssertSingleBlock(blockAccessStubs, 0);
         getAndAssertSingleBlock(blockAccessStubs, 1);

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/subscriber/positive/PositiveMultipleSubscribersTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/subscriber/positive/PositiveMultipleSubscribersTests.java
@@ -79,13 +79,9 @@ public class PositiveMultipleSubscribersTests extends BaseSuite {
 
         boolean areConsumingBlocks = false;
 
-        long lastConsumedBlockForConsumer1 =
-                publisherSimulator.getStreamStatus().publishedBlocks();
-        long lastConsumedBlockForConsumer2 =
-                publisherSimulator.getStreamStatus().publishedBlocks();
-        int retries = 3;
-        // We assign lastConsumedBlock as the last published, so that we can track it later.
-        // This will help us determine whether we are actually consuming blocks.
+        long lastConsumedBlockForConsumer1 = 0;
+        long lastConsumedBlockForConsumer2 = 0;
+        int retries = 10;
         while (retries > 0) {
             if (consumerSimulator1.getStreamStatus().consumedBlocks() > lastConsumedBlockForConsumer1
                     && consumerSimulator2.getStreamStatus().consumedBlocks() > lastConsumedBlockForConsumer2) {


### PR DESCRIPTION
### Problem

`BlockNodeApp.persistBlockRanges()` used `Files.createLink()` to atomically
replace `block-ranges.json`. Hard-linking works on local filesystems but throws
`UnsupportedOperationException` on overlay filesystems (Docker, kind/CI).
Because `UnsupportedOperationException` is **not** a subtype of `IOException`,
the existing `catch (IOException e)` block did not catch it — the exception
propagated unchecked, the `.tmp` file was left on disk, and the write silently
failed in CI with:

```
java.nio.file.NoSuchFileException: /opt/hiero/block-node/application-state/block-ranges.json.tmp
```

The same bug meant `block-ranges.json` was never actually updated after the
failed link, so subsequent restarts loaded stale block range data.

### Fix

Replace the `deleteIfExists + createLink + deleteIfExists` sequence with the
write-to-tmp + `Files.move(ATOMIC_MOVE)` + non-atomic fallback pattern already
used in `persistNodeAddressBookHistory()`. This works on all filesystem types:

- On local filesystems (ext4, APFS) the atomic move succeeds.
- On overlay filesystems (Docker, kind) `AtomicMoveNotSupportedException` is
  caught and a plain `REPLACE_EXISTING` move is used instead.
- Any remaining `IOException` is caught and logged at WARNING, as before.

The log message for the outer catch is also updated from `%s`-style formatting
(which produces a literal `%s` in some JUL implementations) to `{0}:{1}`
parameter substitution consistent with the rest of the class.


Fixes #3315
