### PR TITLE
feat: warn on sidecar records not tied to a parent-record-file transaction

### DIFF
--- a/tools-and-tests/tools/docs/blocks-commands.md
+++ b/tools-and-tests/tools/docs/blocks-commands.md
@@ -204,22 +204,22 @@ The `validate` command orchestrates a set of individual validation classes under
 
 ##### Summary table
 
-|                           Validation                            |    Type    | Genesis-only? |            How to skip             |                                                            What it checks                                                             |
-|-----------------------------------------------------------------|------------|---------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| [RequiredItemsValidation](#requireditemsvalidation)             | Parallel   | No            | `--skip-required-items`            | Every block has ≥1 BlockHeader, RecordFile, BlockFooter, BlockProof                                                                   |
-| [BlockStructureValidation](#blockstructurevalidation)           | Parallel   | No            | `--skip-required-items`            | Item ordering: BlockHeader, StateChanges\*, RecordFile, BlockFooter, BlockProof+                                                      |
-| [SignatureValidation](#signaturevalidation)                     | Parallel   | No            | `--skip-signatures`                | RSA (SignedRecordFileProof) or non-empty TSS (SignedBlockProof) signature threshold                                                   |
-| [SidecarIntegrityValidation](#sidecarintegrityvalidation)       | Parallel   | No            | `--skip-sidecar-integrity`         | Each embedded sidecar's SHA-384 matches an entry in the record file's signed manifest (catches orphan sidecars swept in at wrap time) |
-| [AddressBookUpdateValidation](#addressbookupdatevalidation)     | Sequential | No            | Always on                          | Discovers CN address-book updates from block data, keeps registry current                                                             |
-| [NodeStakeUpdateValidation](#nodestakeupdatevalidation)         | Sequential | No            | Always on                          | Discovers `NodeStakeUpdate` transactions, keeps stake registry current                                                                |
-| [TssEnablementValidation](#tssenablementvalidation)             | Sequential | No            | Always on                          | Discovers `LedgerIdPublication` transactions and writes `tss-enablement.bin`                                                          |
-| [BlockChainValidation](#blockchainvalidation)                   | Sequential | No            | Always on                          | `previous_block_hash` in footer matches hash of prior block                                                                           |
-| [HistoricalBlockTreeValidation](#historicalblocktreevalidation) | Sequential | Yes           | Always on (auto-skipped otherwise) | `root_hash_of_block_hashes_merkle_tree` in footer matches streaming merkle tree                                                       |
-| [HbarSupplyValidation](#hbarsupplyvalidation)                   | Sequential | Yes           | `--skip-supply`                    | Total HBAR supply = 50 billion after every block                                                                                      |
-| [BalanceCheckpointValidation](#balancecheckpointvalidation)     | Sequential | Yes           | `--no-validate-balances`           | Computed HBAR and fungible-token balances match pre-fetched checkpoint snapshots at configurable intervals                            |
-| [HashRegistryValidation](#hashregistryvalidation)               | Sequential | No            | Auto-skipped if no registry file   | Per-block hash matches the `blockStreamBlockHashes.bin` registry                                                                      |
-| [StreamingMerkleTreeValidation](#streamingmerkletreevalidation) | End-of-run | Yes           | Auto-skipped when not from genesis | `streamingMerkleTree.bin` matches freshly-computed streaming hasher                                                                   |
-| [JumpstartValidation](#jumpstartvalidation)                     | End-of-run | Yes           | Auto-skipped when not from genesis | `jumpstart.bin` matches freshly-computed streaming hasher + block hashes                                                              |
+|                           Validation                            |    Type    | Genesis-only? |            How to skip             |                                                                                                                                      What it checks                                                                                                                                      |
+|-----------------------------------------------------------------|------------|---------------|------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [RequiredItemsValidation](#requireditemsvalidation)             | Parallel   | No            | `--skip-required-items`            | Every block has ≥1 BlockHeader, RecordFile, BlockFooter, BlockProof                                                                                                                                                                                                                      |
+| [BlockStructureValidation](#blockstructurevalidation)           | Parallel   | No            | `--skip-required-items`            | Item ordering: BlockHeader, StateChanges\*, RecordFile, BlockFooter, BlockProof+                                                                                                                                                                                                         |
+| [SignatureValidation](#signaturevalidation)                     | Parallel   | No            | `--skip-signatures`                | RSA (SignedRecordFileProof) or non-empty TSS (SignedBlockProof) signature threshold                                                                                                                                                                                                      |
+| [SidecarIntegrityValidation](#sidecarintegrityvalidation)       | Parallel   | No            | `--skip-sidecar-integrity`         | Two checks: (1) hard-fail — each embedded sidecar's SHA-384 matches an entry in the record file's signed manifest (catches orphan sidecars swept in at wrap time); (2) warn-only — each sidecar record's `consensus_timestamp` ties back to a transaction in the parent RecordStreamFile |
+| [AddressBookUpdateValidation](#addressbookupdatevalidation)     | Sequential | No            | Always on                          | Discovers CN address-book updates from block data, keeps registry current                                                                                                                                                                                                                |
+| [NodeStakeUpdateValidation](#nodestakeupdatevalidation)         | Sequential | No            | Always on                          | Discovers `NodeStakeUpdate` transactions, keeps stake registry current                                                                                                                                                                                                                   |
+| [TssEnablementValidation](#tssenablementvalidation)             | Sequential | No            | Always on                          | Discovers `LedgerIdPublication` transactions and writes `tss-enablement.bin`                                                                                                                                                                                                             |
+| [BlockChainValidation](#blockchainvalidation)                   | Sequential | No            | Always on                          | `previous_block_hash` in footer matches hash of prior block                                                                                                                                                                                                                              |
+| [HistoricalBlockTreeValidation](#historicalblocktreevalidation) | Sequential | Yes           | Always on (auto-skipped otherwise) | `root_hash_of_block_hashes_merkle_tree` in footer matches streaming merkle tree                                                                                                                                                                                                          |
+| [HbarSupplyValidation](#hbarsupplyvalidation)                   | Sequential | Yes           | `--skip-supply`                    | Total HBAR supply = 50 billion after every block                                                                                                                                                                                                                                         |
+| [BalanceCheckpointValidation](#balancecheckpointvalidation)     | Sequential | Yes           | `--no-validate-balances`           | Computed HBAR and fungible-token balances match pre-fetched checkpoint snapshots at configurable intervals                                                                                                                                                                               |
+| [HashRegistryValidation](#hashregistryvalidation)               | Sequential | No            | Auto-skipped if no registry file   | Per-block hash matches the `blockStreamBlockHashes.bin` registry                                                                                                                                                                                                                         |
+| [StreamingMerkleTreeValidation](#streamingmerkletreevalidation) | End-of-run | Yes           | Auto-skipped when not from genesis | `streamingMerkleTree.bin` matches freshly-computed streaming hasher                                                                                                                                                                                                                      |
+| [JumpstartValidation](#jumpstartvalidation)                     | End-of-run | Yes           | Auto-skipped when not from genesis | `jumpstart.bin` matches freshly-computed streaming hasher + block hashes                                                                                                                                                                                                                 |
 
 "Genesis-only" validations require starting from block 0 because they depend on accumulated state (block hash history, running HBAR balances, streaming merkle tree). They're transparently disabled when validation resumes from a checkpoint or starts mid-stream.
 
@@ -270,12 +270,14 @@ Stateless; each block is verified independently.
 
 **Type:** Parallel · **Skip:** `--skip-sidecar-integrity`
 
-Verifies that every sidecar file embedded in a wrapped block hashes to a SHA-384 that appears in the record file's signed `sidecars[]` manifest, and vice versa. Failures are classified so an investigator can tell the modes apart:
+Runs two checks with different severity levels: a hash-provenance check that fails the block on mismatch, and a timestamp-provenance check that warns without failing.
+
+**Hash check — hard fail (throws `ValidationException`).** Verifies that every sidecar file embedded in a wrapped block hashes to a SHA-384 that appears in the record file's signed `sidecars[]` manifest, and vice versa. Failures are classified so an investigator can tell the modes apart:
 
 - **`TAMPERED_OR_EXTRA`** — a sidecar with no matching signed hash. Either the bytes were altered in transit, or an unsigned "orphan" sidecar (one written by a single dissenting CN node for a block that the majority consensus record file declared had no sidecar) was swept into the WRB by wrap.
 - **`MISSING`** — a signed hash with no matching sidecar file in the block. Sidecar was dropped somewhere in the pipeline between record-file production and wrap.
 
-**Example failure:**
+Example failure:
 
 ```
 Block 12345 sidecar integrity failed:
@@ -285,6 +287,19 @@ Block 12345 sidecar integrity failed:
     - sidecar #1 SHA-384 abc123... -> no matching hash in signed metadata (TAMPERED or EXTRA)
     - signed hash #2 SHA-384 def456... -> no matching sidecar file in block (MISSING)
 ```
+
+**Timestamp check — warn only (issue #3319).** For every `TransactionSidecarRecord` inside every embedded `SidecarFile`, verifies its `consensus_timestamp` appears as the `consensus_timestamp` of at least one `RecordStreamItem` in the parent `RecordStreamFile`. Composition of the hash check + `SignatureValidation` already proves the sidecar bytes are what the CN produced, so a timestamp miss only signals a CN-side "wrong sidecar attached to this block" bug that we track for triage rather than block on. Mismatches emit a WARN line to stderr; the check never throws.
+
+Every warning is also recorded in an in-memory accumulator so an end-of-run report can be produced:
+
+- `finalize(...)` emits a consolidated stderr summary:
+
+  ```
+  [SidecarTimestamp] WARN Timestamp-mismatch warning fired on 3 block(s): [52333943, 58446161, 62113066]
+  ```
+- `save(<validateCheckpoint>)` writes `sidecar-timestamp-mismatches.txt` (tab-separated `blockNumber\tsidecarIndex\trecordIndex\tsecs.nanos`, sorted by block number then sidecar index then record index). Empty accumulator writes no file. Downstream ops tooling can grep / diff this file to spot changes across runs.
+
+The same static entry point (`SidecarIntegrityValidation.validateSidecars(...)`) is invoked at wrap time from `ToWrappedBlocksCommand` and `LiveSequential`, so both hash and timestamp checks fire during wrap as well — hash mismatch still aborts the wrap; timestamp mismatch logs and continues.
 
 **When to skip:** when running against a known-anomaly historical archive (e.g., mainnet blocks 52,333,943 / 58,446,161 / 62,113,066 which carry orphan sidecars locked into the canonical chain hash — see issue #3196 for background) and you want the rest of the pipeline to still exercise. A standalone `blocks validate-sidecars` subcommand exists for spot-checks without setup cost; see its section below.
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
@@ -734,16 +734,20 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
 
                         // Sidecar integrity: verify each sidecar's SHA-384 matches an entry in the
                         // record file's signed sidecar hash list before we bake either into the
-                        // wrapped Block. See issue #3196.
+                        // wrapped Block (issue #3196). Also fires a warn-only cross-check that
+                        // each sidecar record's consensus_timestamp ties back to a transaction in
+                        // the parent RecordStreamFile (issue #3319) -- mismatch emits a WARN line
+                        // but does NOT abort the wrap; no accumulator sink is passed here because
+                        // wrap-time paths log-and-forget rather than compile an end-of-run report.
                         try {
+                            final var recordStreamFile =
+                                    effectiveBlock.recordBlock().recordFile().recordStreamFile();
                             SidecarIntegrityValidation.validateSidecars(
                                     effectiveBlock.recordBlock().sidecarFiles(),
-                                    effectiveBlock
-                                            .recordBlock()
-                                            .recordFile()
-                                            .recordStreamFile()
-                                            .sidecars(),
-                                    blockNum);
+                                    recordStreamFile.sidecars(),
+                                    recordStreamFile,
+                                    blockNum,
+                                    null);
                         } catch (final ValidationException sve) {
                             PrettyPrint.clearProgress();
                             System.err.println("[sidecar-integrity] " + sve.getMessage());

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SidecarIntegrityValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SidecarIntegrityValidation.java
@@ -6,15 +6,29 @@ import static org.hiero.block.tools.blocks.validation.ProtobufParsingConstants.M
 import static org.hiero.block.tools.utils.Sha384.sha384Digest;
 
 import com.hedera.hapi.block.stream.RecordFileItem;
+import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.streams.RecordStreamFile;
+import com.hedera.hapi.streams.RecordStreamItem;
 import com.hedera.hapi.streams.SidecarFile;
 import com.hedera.hapi.streams.SidecarMetadata;
+import com.hedera.hapi.streams.TransactionSidecarRecord;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.tools.records.model.parsed.ValidationException;
 
@@ -32,18 +46,47 @@ import org.hiero.block.tools.records.model.parsed.ValidationException;
  * ({@code RecordFileItem.recordFileContents.sidecars[]}) are embedded at wrap time, so
  * historical blocks can be validated retroactively without re-wrapping.
  *
- * <p>Behaviour:
+ * <p>Two severity levels are enforced:
+ *
  * <ul>
- *   <li>Blocks with no sidecars pass trivially.</li>
- *   <li>Blocks with sidecars but no {@code recordFileContents} fail: no signed hash list to
- *       check against.</li>
- *   <li>Every sidecar must have a matching hash in the signed list; any sidecar without a match
- *       fails the block with a diagnostic that names the sidecar index and computed hash.</li>
+ *   <li><b>Hash mismatch — hard fail.</b> Every sidecar's SHA-384 must appear in the signed
+ *       hash list, and every signed hash must have a matching sidecar file. Failure throws a
+ *       {@link ValidationException} classifying the discrepancy (TAMPERED_OR_EXTRA / MISSING).</li>
+ *   <li><b>Sidecar {@link TransactionSidecarRecord#consensusTimestamp() consensus_timestamp}
+ *       does not tie back to a transaction in the parent RecordStreamFile — warn only.</b>
+ *       For each record in each sidecar we check that its {@code consensus_timestamp} appears
+ *       as the {@code consensus_timestamp} of at least one {@code RecordStreamItem} in the
+ *       record file. Mismatches log a WARN line but do not throw, since composition of the
+ *       hash check + {@code SignatureValidation} already proves the sidecar bytes are what
+ *       the CN produced — a timestamp miss only signals a CN-side "wrong sidecar attached to
+ *       this block" bug that we track for triage rather than block on. Every warning is
+ *       recorded in an in-memory accumulator so {@link #finalize(long, long)} can emit a
+ *       consolidated affected-blocks summary and {@link #save(Path)} can write a
+ *       machine-readable {@code sidecar-timestamp-mismatches.txt} file. See issue #3319.</li>
  * </ul>
  */
 public final class SidecarIntegrityValidation implements BlockValidation {
 
     private static final int MAX_DEPTH = 512;
+
+    /** Filename of the machine-readable mismatch report written by {@link #save(Path)}. */
+    static final String MISMATCH_REPORT_FILE_NAME = "sidecar-timestamp-mismatches.txt";
+
+    /**
+     * One recorded timestamp-mismatch. Emitted as a WARN line at check time and appended to the
+     * instance's accumulator for later reporting.
+     *
+     * @param blockNumber        block whose embedded sidecar contained the offending record
+     * @param sidecarIndex       zero-based index into {@code RecordFileItem.sidecarFileContents}
+     * @param recordIndex        zero-based index into {@code SidecarFile.sidecarRecords}
+     * @param timestampSeconds   the record's {@code consensus_timestamp} seconds field
+     * @param timestampNanos     the record's {@code consensus_timestamp} nanos field
+     */
+    public record TimestampMismatch(
+            long blockNumber, int sidecarIndex, int recordIndex, long timestampSeconds, int timestampNanos) {}
+
+    /** Thread-safe accumulator populated by {@link #validate} across parallel worker threads. */
+    private final Queue<TimestampMismatch> timestampMismatches = new ConcurrentLinkedQueue<>();
 
     @Override
     public String name() {
@@ -84,35 +127,60 @@ public final class SidecarIntegrityValidation implements BlockValidation {
                         + " sidecar file(s) but no recordFileContents to check them against");
             }
             final RecordStreamFile recordStreamFile = recordFileItem.recordFileContentsOrThrow();
-            validateSidecars(sidecarFiles, recordStreamFile.sidecars(), blockNumber);
+            validateSidecars(sidecarFiles, recordStreamFile.sidecars(), recordStreamFile, blockNumber, this::record);
         } catch (final ParseException e) {
             throw new ValidationException("Block " + blockNumber + " - sidecar integrity check failed: "
                     + e.getClass().getSimpleName() + ": " + e.getMessage());
         }
     }
 
+    /** Package-private accumulator hook used by {@link #validate} and tests. */
+    void record(final TimestampMismatch mismatch) {
+        timestampMismatches.offer(mismatch);
+    }
+
     /**
-     * Verify every {@link SidecarFile} in {@code sidecarFiles} has a matching SHA-384 hash in
-     * {@code sidecarMetadatas}, and every metadata hash has a matching sidecar file. Shared
-     * entry point so the wrap-time paths ({@code ToWrappedBlocksCommand}, {@code LiveSequential})
-     * can invoke the same check they'd get on read-back through the validation suite /
-     * {@code validate-sidecars} command.
-     *
-     * <p>Passes silently on an empty {@code sidecarFiles} list. On any discrepancy, aggregates
-     * every issue across all sidecars and metadata entries and throws a single
-     * {@link ValidationException} whose message classifies each issue by failure mode
-     * (TAMPERED_OR_EXTRA — sidecar bytes with no matching signed hash; MISSING — signed hash
-     * with no matching sidecar bytes). This tells an investigator which of the three
-     * distinct scenarios the bad block hit:
-     *
-     * <ul>
-     *   <li>Byte-for-byte tampering (counts match, hashes don't line up)</li>
-     *   <li>Missing sidecar (fewer sidecar files than signed hashes)</li>
-     *   <li>Extra sidecar (more sidecar files than signed hashes)</li>
-     * </ul>
+     * Legacy no-record-stream-file overload retained for wrap-time callers that already pass
+     * only the manifest list. Runs only the hash check; the timestamp cross-check is skipped
+     * because we have no {@code RecordStreamFile} to draw transaction timestamps from.
      */
     public static void validateSidecars(
             final List<SidecarFile> sidecarFiles, final List<SidecarMetadata> sidecarMetadatas, final long blockNumber)
+            throws ValidationException {
+        validateSidecars(sidecarFiles, sidecarMetadatas, null, blockNumber, null);
+    }
+
+    /**
+     * Verify every {@link SidecarFile} in {@code sidecarFiles} has a matching SHA-384 hash in
+     * {@code sidecarMetadatas} (hard fail on discrepancy) AND, when {@code recordStreamFile}
+     * is provided, that every {@link TransactionSidecarRecord}'s {@code consensus_timestamp}
+     * appears as the {@code consensus_timestamp} of at least one {@link RecordStreamItem} in
+     * the record file (WARN only, tracked via {@code mismatchSink}).
+     *
+     * <p>Shared entry point so the wrap-time paths ({@code ToWrappedBlocksCommand},
+     * {@code LiveSequential}) can invoke the same combined check they'd get on read-back
+     * through the validation suite / {@code validate-sidecars} command.
+     *
+     * <p>Passes silently on an empty {@code sidecarFiles} list. On any hash discrepancy,
+     * aggregates every issue across all sidecars and metadata entries and throws a single
+     * {@link ValidationException} whose message classifies each issue by failure mode
+     * (TAMPERED_OR_EXTRA / MISSING). Timestamp mismatches always log a WARN line to
+     * {@code stderr}; when {@code mismatchSink} is non-null, each is also passed to it so an
+     * instance-scoped accumulator can collect them for end-of-run reporting.
+     *
+     * @param sidecarFiles       parsed sidecar files embedded in the WRB
+     * @param sidecarMetadatas   the record file's signed {@code sidecars[]} manifest
+     * @param recordStreamFile   the parent record file (nullable; timestamp check is skipped if null)
+     * @param blockNumber        the block number, for diagnostics
+     * @param mismatchSink       optional per-mismatch callback; when null, WARN logging still fires
+     * @throws ValidationException if any sidecar hash does not match the signed manifest, or vice versa
+     */
+    public static void validateSidecars(
+            final List<SidecarFile> sidecarFiles,
+            final List<SidecarMetadata> sidecarMetadatas,
+            final RecordStreamFile recordStreamFile,
+            final long blockNumber,
+            final Consumer<TimestampMismatch> mismatchSink)
             throws ValidationException {
         if (sidecarFiles.isEmpty()) {
             return;
@@ -163,6 +231,13 @@ public final class SidecarIntegrityValidation implements BlockValidation {
             }
         }
 
+        // Timestamp check (warn only). Runs regardless of whether the hash check found
+        // discrepancies — a hash-tampered sidecar's timestamps are still worth logging so the
+        // investigator has a complete picture rather than only the first failure mode.
+        if (recordStreamFile != null) {
+            checkSidecarTimestamps(sidecarFiles, recordStreamFile, blockNumber, mismatchSink);
+        }
+
         if (discrepancies.isEmpty()) {
             return;
         }
@@ -176,6 +251,98 @@ public final class SidecarIntegrityValidation implements BlockValidation {
             sb.append("\n    - ").append(d);
         }
         throw new ValidationException(sb.toString());
+    }
+
+    /**
+     * For each {@link TransactionSidecarRecord} in each {@link SidecarFile}, verify its
+     * {@code consensus_timestamp} appears as the {@code consensus_timestamp} of at least one
+     * {@link RecordStreamItem} in {@code recordStreamFile}. Mismatches emit a WARN line to
+     * {@code stderr} and (when {@code mismatchSink} is non-null) are passed to the sink.
+     * Never throws — see the class javadoc for the severity rationale.
+     */
+    static void checkSidecarTimestamps(
+            final List<SidecarFile> sidecarFiles,
+            final RecordStreamFile recordStreamFile,
+            final long blockNumber,
+            final Consumer<TimestampMismatch> mismatchSink) {
+        // Build the set of transaction consensus_timestamps once per block.
+        final Set<Timestamp> txTimestamps = new HashSet<>();
+        for (final RecordStreamItem item : recordStreamFile.recordStreamItems()) {
+            if (item.hasRecord() && item.recordOrThrow().hasConsensusTimestamp()) {
+                txTimestamps.add(item.recordOrThrow().consensusTimestampOrThrow());
+            }
+        }
+
+        for (int i = 0; i < sidecarFiles.size(); i++) {
+            final List<TransactionSidecarRecord> records = sidecarFiles.get(i).sidecarRecords();
+            for (int j = 0; j < records.size(); j++) {
+                final TransactionSidecarRecord tsr = records.get(j);
+                if (!tsr.hasConsensusTimestamp()) {
+                    continue;
+                }
+                final Timestamp ts = tsr.consensusTimestampOrThrow();
+                if (!txTimestamps.contains(ts)) {
+                    System.err.println("[SidecarTimestamp] WARN block " + blockNumber + " sidecar #" + i + " record #"
+                            + j + " consensus_timestamp " + ts.seconds() + "." + String.format("%09d", ts.nanos())
+                            + " has no matching transaction in the parent RecordStreamFile");
+                    if (mismatchSink != null) {
+                        mismatchSink.accept(new TimestampMismatch(blockNumber, i, j, ts.seconds(), ts.nanos()));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * If any timestamp mismatches have been recorded during this run, write a machine-readable
+     * report to {@code <directory>/sidecar-timestamp-mismatches.txt}. Empty runs write no file.
+     *
+     * <p>Line format (tab-separated, sorted by block number then sidecar index then record
+     * index):
+     *
+     * <pre>
+     * &lt;blockNumber&gt;\t&lt;sidecarIndex&gt;\t&lt;recordIndex&gt;\t&lt;seconds&gt;.&lt;nanos&gt;
+     * </pre>
+     */
+    @Override
+    public void save(final Path directory) throws IOException {
+        if (timestampMismatches.isEmpty()) {
+            return;
+        }
+        Files.createDirectories(directory);
+        final Path outFile = directory.resolve(MISMATCH_REPORT_FILE_NAME);
+        final List<TimestampMismatch> sorted = new ArrayList<>(timestampMismatches);
+        sorted.sort(Comparator.comparingLong(TimestampMismatch::blockNumber)
+                .thenComparingInt(TimestampMismatch::sidecarIndex)
+                .thenComparingInt(TimestampMismatch::recordIndex));
+        try (BufferedWriter w = Files.newBufferedWriter(outFile)) {
+            for (final TimestampMismatch m : sorted) {
+                w.write(m.blockNumber() + "\t" + m.sidecarIndex() + "\t" + m.recordIndex() + "\t" + m.timestampSeconds()
+                        + "." + String.format("%09d", m.timestampNanos()) + "\n");
+            }
+        }
+    }
+
+    /**
+     * Emit a consolidated affected-blocks summary to {@code stderr} at end of run. No-op if no
+     * timestamp mismatches were recorded. Does not throw — timestamp mismatches are warn-only.
+     */
+    @Override
+    public void finalize(final long totalBlocksValidated, final long lastBlockNumber) {
+        if (timestampMismatches.isEmpty()) {
+            return;
+        }
+        final Set<Long> distinctBlocks = new TreeSet<>();
+        for (final TimestampMismatch m : timestampMismatches) {
+            distinctBlocks.add(m.blockNumber());
+        }
+        System.err.println("[SidecarTimestamp] WARN Timestamp-mismatch warning fired on " + distinctBlocks.size()
+                + " block(s): " + distinctBlocks);
+    }
+
+    /** Package-private accessor used by tests to inspect the accumulator contents. */
+    List<TimestampMismatch> recordedMismatches() {
+        return new ArrayList<>(timestampMismatches);
     }
 
     private static boolean containsHash(final List<byte[]> hashes, final byte[] target) {

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SidecarIntegrityValidation.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/validation/SidecarIntegrityValidation.java
@@ -16,8 +16,10 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -137,17 +139,6 @@ public final class SidecarIntegrityValidation implements BlockValidation {
     /** Package-private accumulator hook used by {@link #validate} and tests. */
     void record(final TimestampMismatch mismatch) {
         timestampMismatches.offer(mismatch);
-    }
-
-    /**
-     * Legacy no-record-stream-file overload retained for wrap-time callers that already pass
-     * only the manifest list. Runs only the hash check; the timestamp cross-check is skipped
-     * because we have no {@code RecordStreamFile} to draw transaction timestamps from.
-     */
-    public static void validateSidecars(
-            final List<SidecarFile> sidecarFiles, final List<SidecarMetadata> sidecarMetadatas, final long blockNumber)
-            throws ValidationException {
-        validateSidecars(sidecarFiles, sidecarMetadatas, null, blockNumber, null);
     }
 
     /**
@@ -315,11 +306,26 @@ public final class SidecarIntegrityValidation implements BlockValidation {
         sorted.sort(Comparator.comparingLong(TimestampMismatch::blockNumber)
                 .thenComparingInt(TimestampMismatch::sidecarIndex)
                 .thenComparingInt(TimestampMismatch::recordIndex));
-        try (BufferedWriter w = Files.newBufferedWriter(outFile)) {
-            for (final TimestampMismatch m : sorted) {
-                w.write(m.blockNumber() + "\t" + m.sidecarIndex() + "\t" + m.recordIndex() + "\t" + m.timestampSeconds()
-                        + "." + String.format("%09d", m.timestampNanos()) + "\n");
+        // Write-to-temp + atomic rename so a JVM crash mid-write cannot leave the
+        // destination file half-written for downstream ops tooling to parse.
+        final Path tmp = outFile.resolveSibling(outFile.getFileName() + ".tmp");
+        try {
+            try (BufferedWriter w = Files.newBufferedWriter(tmp)) {
+                for (final TimestampMismatch m : sorted) {
+                    w.write(m.blockNumber() + "\t" + m.sidecarIndex() + "\t" + m.recordIndex() + "\t"
+                            + m.timestampSeconds() + "." + String.format("%09d", m.timestampNanos()) + "\n");
+                }
             }
+            try {
+                Files.move(tmp, outFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (final AtomicMoveNotSupportedException e) {
+                // Fallback for filesystems without ATOMIC_MOVE (tmpfs, some NFS, jimfs in tests).
+                // Destination is still overwritten, just not atomically.
+                Files.move(tmp, outFile, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (final IOException e) {
+            Files.deleteIfExists(tmp);
+            throw e;
         }
     }
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -1146,11 +1146,18 @@ public class LiveSequential implements Runnable {
         }
 
         // Sidecar integrity: verify each sidecar's SHA-384 matches an entry in the record file's
-        // signed sidecar hash list before we bake either into the wrapped Block. See issue #3196.
+        // signed sidecar hash list before we bake either into the wrapped Block (issue #3196).
+        // Also fires a warn-only cross-check that each sidecar record's consensus_timestamp ties
+        // back to a transaction in the parent RecordStreamFile (issue #3319) -- mismatch emits a
+        // WARN line but does NOT abort the wrap; no accumulator sink is passed here because
+        // wrap-time paths log-and-forget rather than compile an end-of-run report.
+        final var recordStreamFile = preVerified.recordBlock().recordFile().recordStreamFile();
         SidecarIntegrityValidation.validateSidecars(
                 preVerified.recordBlock().sidecarFiles(),
-                preVerified.recordBlock().recordFile().recordStreamFile().sidecars(),
-                blockNum);
+                recordStreamFile.sidecars(),
+                recordStreamFile,
+                blockNum,
+                null);
 
         // Convert to wrapped block
         Block wrapped = RecordBlockConverter.toBlock(

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/SidecarIntegrityValidationTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/SidecarIntegrityValidationTest.java
@@ -4,23 +4,35 @@ package org.hiero.block.tools.blocks.validation;
 import static org.hiero.block.node.base.ParseHelper.standardParse;
 import static org.hiero.block.tools.utils.Sha384.hashSha384;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.RecordFileItem;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.hapi.streams.HashAlgorithm;
 import com.hedera.hapi.streams.HashObject;
 import com.hedera.hapi.streams.RecordStreamFile;
+import com.hedera.hapi.streams.RecordStreamItem;
 import com.hedera.hapi.streams.SidecarFile;
 import com.hedera.hapi.streams.SidecarMetadata;
+import com.hedera.hapi.streams.TransactionSidecarRecord;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.tools.blocks.validation.SidecarIntegrityValidation.TimestampMismatch;
 import org.hiero.block.tools.records.model.parsed.ValidationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /** Tests for {@link SidecarIntegrityValidation}. */
 class SidecarIntegrityValidationTest {
@@ -229,5 +241,217 @@ class SidecarIntegrityValidationTest {
         assertTrue(ex.getMessage().contains("MISSING"));
         assertTrue(ex.getMessage().contains("sidecars in block:    1"));
         assertTrue(ex.getMessage().contains("signed hash entries:  2"));
+    }
+
+    // ── Sidecar record consensus_timestamp cross-check (warn-only, issue #3319) ─────────────
+
+    private static Timestamp ts(final long seconds, final int nanos) {
+        return new Timestamp(seconds, nanos);
+    }
+
+    /** Build a RecordStreamFile whose recordStreamItems carry transactions with the given consensus timestamps. */
+    private static RecordStreamFile recordStreamFileWithTxTimestamps(final Timestamp... txTimestamps) {
+        final List<RecordStreamItem> items = new ArrayList<>(txTimestamps.length);
+        for (final Timestamp t : txTimestamps) {
+            items.add(RecordStreamItem.newBuilder()
+                    .record(TransactionRecord.newBuilder().consensusTimestamp(t).build())
+                    .build());
+        }
+        return RecordStreamFile.newBuilder().recordStreamItems(items).build();
+    }
+
+    /** Build a SidecarFile containing one TransactionSidecarRecord per supplied timestamp. */
+    private static SidecarFile sidecarWithRecordTimestamps(final Timestamp... recordTimestamps) {
+        final List<TransactionSidecarRecord> records = new ArrayList<>(recordTimestamps.length);
+        for (final Timestamp t : recordTimestamps) {
+            records.add(
+                    TransactionSidecarRecord.newBuilder().consensusTimestamp(t).build());
+        }
+        return SidecarFile.newBuilder().sidecarRecords(records).build();
+    }
+
+    @Test
+    @DisplayName("Timestamp check: all sidecar timestamps match tx timestamps -> no mismatches recorded")
+    void timestampCheck_allMatch_noMismatches() {
+        final Timestamp t1 = ts(100, 1);
+        final Timestamp t2 = ts(100, 2);
+        final SidecarFile sidecar = sidecarWithRecordTimestamps(t1, t2);
+        final RecordStreamFile rsf = recordStreamFileWithTxTimestamps(t1, t2);
+        final List<TimestampMismatch> collected = new ArrayList<>();
+
+        SidecarIntegrityValidation.checkSidecarTimestamps(List.of(sidecar), rsf, 42, collected::add);
+
+        assertEquals(0, collected.size(), "no warnings when every sidecar timestamp has a tx");
+    }
+
+    @Test
+    @DisplayName("Timestamp check: one sidecar timestamp not in tx set -> single warning recorded")
+    void timestampCheck_oneMismatch_singleWarning() {
+        final Timestamp inRecord = ts(100, 1);
+        final Timestamp orphan = ts(999, 999);
+        final SidecarFile sidecar = sidecarWithRecordTimestamps(inRecord, orphan);
+        final RecordStreamFile rsf = recordStreamFileWithTxTimestamps(inRecord);
+        final List<TimestampMismatch> collected = new ArrayList<>();
+
+        SidecarIntegrityValidation.checkSidecarTimestamps(List.of(sidecar), rsf, 42, collected::add);
+
+        assertEquals(1, collected.size(), "one mismatch tuple recorded");
+        final TimestampMismatch m = collected.get(0);
+        assertEquals(42L, m.blockNumber());
+        assertEquals(0, m.sidecarIndex());
+        assertEquals(1, m.recordIndex(), "the orphan record is at position 1");
+        assertEquals(999L, m.timestampSeconds());
+        assertEquals(999, m.timestampNanos());
+    }
+
+    @Test
+    @DisplayName("Timestamp check: sidecar with empty sidecar_records passes trivially")
+    void timestampCheck_emptySidecarRecords_passes() {
+        final SidecarFile empty = sidecarWithRecordTimestamps();
+        final RecordStreamFile rsf = recordStreamFileWithTxTimestamps(ts(1, 0));
+        final List<TimestampMismatch> collected = new ArrayList<>();
+
+        SidecarIntegrityValidation.checkSidecarTimestamps(List.of(empty), rsf, 42, collected::add);
+
+        assertEquals(0, collected.size());
+    }
+
+    @Test
+    @DisplayName("Timestamp check: block with no sidecar files passes trivially")
+    void timestampCheck_noSidecars_passes() {
+        final RecordStreamFile rsf = recordStreamFileWithTxTimestamps(ts(1, 0));
+        final List<TimestampMismatch> collected = new ArrayList<>();
+
+        SidecarIntegrityValidation.checkSidecarTimestamps(List.of(), rsf, 42, collected::add);
+
+        assertEquals(0, collected.size());
+    }
+
+    @Test
+    @DisplayName("Timestamp check: empty recordStreamItems + non-empty sidecar -> warn for every record")
+    void timestampCheck_emptyRecordStreamItems_warnsForEveryRecord() {
+        final SidecarFile sidecar = sidecarWithRecordTimestamps(ts(1, 0), ts(2, 0), ts(3, 0));
+        final RecordStreamFile rsf = RecordStreamFile.newBuilder().build(); // no items
+        final List<TimestampMismatch> collected = new ArrayList<>();
+
+        SidecarIntegrityValidation.checkSidecarTimestamps(List.of(sidecar), rsf, 42, collected::add);
+
+        assertEquals(3, collected.size(), "every record has no matching tx -> every record warns");
+    }
+
+    @Test
+    @DisplayName("Instance validate: timestamp mismatches accumulate across blocks (warn-only, no throw)")
+    void instanceValidate_accumulatesTimestampMismatches() {
+        final Timestamp inRecord = ts(100, 1);
+        final Timestamp orphan = ts(999, 999);
+        final SidecarFile sidecar = sidecarWithRecordTimestamps(orphan);
+        final SidecarMetadata metadata = metadataFor(sidecar);
+        final RecordStreamFile rsf = RecordStreamFile.newBuilder()
+                .recordStreamItems(RecordStreamItem.newBuilder()
+                        .record(TransactionRecord.newBuilder()
+                                .consensusTimestamp(inRecord)
+                                .build())
+                        .build())
+                .sidecars(List.of(metadata))
+                .build();
+        final RecordFileItem recordFileItem = RecordFileItem.newBuilder()
+                .recordFileContents(rsf)
+                .sidecarFileContents(List.of(sidecar))
+                .build();
+        final BlockItem recordFileBlockItem =
+                BlockItem.newBuilder().recordFile(recordFileItem).build();
+        final Block block = new Block(List.of(recordFileBlockItem));
+
+        final SidecarIntegrityValidation v = new SidecarIntegrityValidation();
+
+        // Hash check passes (sidecar hash matches metadata). Timestamp check fails but is warn-only.
+        assertDoesNotThrow(() -> v.validate(toUnparsed(block), 42));
+
+        assertEquals(1, v.recordedMismatches().size(), "the orphan timestamp is recorded in the accumulator");
+        assertEquals(42L, v.recordedMismatches().get(0).blockNumber());
+    }
+
+    @Test
+    @DisplayName("Composition: hash mismatch still throws even when timestamp mismatch is present")
+    void composition_hashMismatchStillThrows_timestampAlsoRecorded() {
+        final Timestamp orphan = ts(999, 999);
+        final SidecarFile sidecar = sidecarWithRecordTimestamps(orphan);
+        // Give the block a metadata entry whose hash does NOT match the sidecar.
+        final byte[] bogus = new byte[48];
+        for (int i = 0; i < bogus.length; i++) {
+            bogus[i] = (byte) 0xBB;
+        }
+        final SidecarMetadata bogusMeta = SidecarMetadata.newBuilder()
+                .hash(HashObject.newBuilder()
+                        .algorithm(HashAlgorithm.SHA_384)
+                        .length(bogus.length)
+                        .hash(Bytes.wrap(bogus))
+                        .build())
+                .build();
+        final RecordStreamFile rsf = RecordStreamFile.newBuilder()
+                .recordStreamItems(RecordStreamItem.newBuilder()
+                        .record(TransactionRecord.newBuilder()
+                                .consensusTimestamp(ts(100, 1))
+                                .build())
+                        .build())
+                .sidecars(List.of(bogusMeta))
+                .build();
+        final RecordFileItem recordFileItem = RecordFileItem.newBuilder()
+                .recordFileContents(rsf)
+                .sidecarFileContents(List.of(sidecar))
+                .build();
+        final BlockItem recordFileBlockItem =
+                BlockItem.newBuilder().recordFile(recordFileItem).build();
+        final Block block = new Block(List.of(recordFileBlockItem));
+
+        final SidecarIntegrityValidation v = new SidecarIntegrityValidation();
+
+        // Hash-mismatch still throws (existing behaviour preserved).
+        final ValidationException ex = assertThrows(ValidationException.class, () -> v.validate(toUnparsed(block), 42));
+        assertTrue(ex.getMessage().contains("TAMPERED or EXTRA"), "hash-mismatch classification preserved");
+
+        // Timestamp WARN also fires before the throw, so the accumulator still has an entry.
+        assertEquals(1, v.recordedMismatches().size(), "timestamp mismatch is recorded even when hash check throws");
+    }
+
+    @Test
+    @DisplayName("save(): no file written when no timestamp mismatches were recorded")
+    void save_emptyAccumulator_noFile(@TempDir final Path tempDir) throws IOException {
+        final SidecarIntegrityValidation v = new SidecarIntegrityValidation();
+
+        v.save(tempDir);
+
+        final Path expected = tempDir.resolve(SidecarIntegrityValidation.MISMATCH_REPORT_FILE_NAME);
+        assertFalse(Files.exists(expected), "empty accumulator must NOT create a report file");
+    }
+
+    @Test
+    @DisplayName("save(): report file lists all tuples sorted by block, then sidecar, then record")
+    void save_multipleMismatches_fileHasSortedTuples(@TempDir final Path tempDir) throws IOException {
+        final SidecarIntegrityValidation v = new SidecarIntegrityValidation();
+        // Insert out-of-order to prove the file writer sorts.
+        v.record(new TimestampMismatch(99L, 0, 2, 500L, 5));
+        v.record(new TimestampMismatch(42L, 1, 0, 100L, 1));
+        v.record(new TimestampMismatch(42L, 0, 3, 200L, 2));
+        v.record(new TimestampMismatch(42L, 0, 1, 150L, 3));
+
+        v.save(tempDir);
+
+        final Path outFile = tempDir.resolve(SidecarIntegrityValidation.MISMATCH_REPORT_FILE_NAME);
+        assertTrue(Files.exists(outFile));
+        final List<String> lines = Files.readAllLines(outFile);
+        assertEquals(4, lines.size());
+        // Expected sort: (42, 0, 1), (42, 0, 3), (42, 1, 0), (99, 0, 2)
+        assertEquals("42\t0\t1\t150.000000003", lines.get(0));
+        assertEquals("42\t0\t3\t200.000000002", lines.get(1));
+        assertEquals("42\t1\t0\t100.000000001", lines.get(2));
+        assertEquals("99\t0\t2\t500.000000005", lines.get(3));
+    }
+
+    @Test
+    @DisplayName("finalize(): no-op with an empty accumulator (no throw)")
+    void finalize_emptyAccumulator_noOp() {
+        final SidecarIntegrityValidation v = new SidecarIntegrityValidation();
+        assertDoesNotThrow(() -> v.finalize(0L, 0L));
     }
 }

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/SidecarIntegrityValidationTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/validation/SidecarIntegrityValidationTest.java
@@ -158,14 +158,15 @@ class SidecarIntegrityValidationTest {
     @Test
     @DisplayName("Static helper: empty sidecar list passes without touching metadata")
     void staticHelper_empty_passes() {
-        assertDoesNotThrow(() -> SidecarIntegrityValidation.validateSidecars(List.of(), List.of(), 42));
+        assertDoesNotThrow(() -> SidecarIntegrityValidation.validateSidecars(List.of(), List.of(), null, 42, null));
     }
 
     @Test
     @DisplayName("Static helper: single matching sidecar passes")
     void staticHelper_singleMatch_passes() {
         final SidecarFile s = SidecarFile.DEFAULT;
-        assertDoesNotThrow(() -> SidecarIntegrityValidation.validateSidecars(List.of(s), List.of(metadataFor(s)), 42));
+        assertDoesNotThrow(
+                () -> SidecarIntegrityValidation.validateSidecars(List.of(s), List.of(metadataFor(s)), null, 42, null));
     }
 
     @Test
@@ -176,7 +177,7 @@ class SidecarIntegrityValidationTest {
         // s0 and s1 serialize identically here (both default); the check should still pass
         // because every sidecar has *some* matching hash in the metadata.
         assertDoesNotThrow(() -> SidecarIntegrityValidation.validateSidecars(
-                List.of(s0, s1), List.of(metadataFor(s0), metadataFor(s1)), 42));
+                List.of(s0, s1), List.of(metadataFor(s0), metadataFor(s1)), null, 42, null));
     }
 
     @Test
@@ -198,7 +199,7 @@ class SidecarIntegrityValidationTest {
         final ValidationException ex = assertThrows(
                 ValidationException.class,
                 () -> SidecarIntegrityValidation.validateSidecars(
-                        List.of(s), List.of(unrelatedMeta, metadataFor(s)), 42));
+                        List.of(s), List.of(unrelatedMeta, metadataFor(s)), null, 42, null));
         assertTrue(ex.getMessage().contains("MISSING"), "orphan metadata hash must be flagged as MISSING");
         assertTrue(ex.getMessage().contains("signed hash #0"), "message must name the missing metadata index");
     }
@@ -211,7 +212,7 @@ class SidecarIntegrityValidationTest {
         // With only a hashless metadata entry present, the sidecar has no match and must fail.
         final ValidationException ex = assertThrows(
                 ValidationException.class,
-                () -> SidecarIntegrityValidation.validateSidecars(List.of(s), List.of(noHash), 42));
+                () -> SidecarIntegrityValidation.validateSidecars(List.of(s), List.of(noHash), null, 42, null));
         assertTrue(ex.getMessage().contains("TAMPERED or EXTRA"), "sidecar with no matching hash is TAMPERED/EXTRA");
         assertTrue(ex.getMessage().contains("sidecar #0"), "message must name the failing sidecar index");
     }
@@ -237,7 +238,7 @@ class SidecarIntegrityValidationTest {
         final ValidationException ex = assertThrows(
                 ValidationException.class,
                 () -> SidecarIntegrityValidation.validateSidecars(
-                        List.of(present), List.of(metadataFor(present), missingMeta), 42));
+                        List.of(present), List.of(metadataFor(present), missingMeta), null, 42, null));
         assertTrue(ex.getMessage().contains("MISSING"));
         assertTrue(ex.getMessage().contains("sidecars in block:    1"));
         assertTrue(ex.getMessage().contains("signed hash entries:  2"));
@@ -453,5 +454,70 @@ class SidecarIntegrityValidationTest {
     void finalize_emptyAccumulator_noOp() {
         final SidecarIntegrityValidation v = new SidecarIntegrityValidation();
         assertDoesNotThrow(() -> v.finalize(0L, 0L));
+    }
+
+    @Test
+    @DisplayName("finalize(): multiple mismatches on the SAME block dedupe to one block in the summary")
+    void finalize_multipleMismatchesSameBlock_dedupToOneBlock() {
+        // Three tuples for block 42 (different sidecar / record indices), one for block 99.
+        // Summary must report 2 distinct blocks, not 4.
+        final SidecarIntegrityValidation v = new SidecarIntegrityValidation();
+        v.record(new TimestampMismatch(42L, 0, 0, 100L, 1));
+        v.record(new TimestampMismatch(42L, 0, 1, 200L, 2));
+        v.record(new TimestampMismatch(42L, 1, 0, 300L, 3));
+        v.record(new TimestampMismatch(99L, 0, 0, 400L, 4));
+
+        final String stderr = captureStderr(() -> v.finalize(0L, 0L));
+
+        // Summary line format is consumed by ops tooling; assert on the shape and the
+        // dedupe outcome ("2 block(s)", not "4"). Sorted ascending: [42, 99].
+        assertTrue(
+                stderr.contains("Timestamp-mismatch warning fired on 2 block(s): [42, 99]"),
+                "summary must dedupe by block and list distinct block numbers sorted; actual stderr:\n" + stderr);
+    }
+
+    @Test
+    @DisplayName("finalize(): summary message shape is stable (single block)")
+    void finalize_singleBlock_summaryFormatStable() {
+        // Guard against future refactors that reword the [SidecarTimestamp] WARN summary
+        // -- ops scripts grep for this exact prefix + shape.
+        final SidecarIntegrityValidation v = new SidecarIntegrityValidation();
+        v.record(new TimestampMismatch(42L, 0, 0, 100L, 1));
+
+        final String stderr = captureStderr(() -> v.finalize(0L, 0L));
+
+        assertTrue(
+                stderr.contains("[SidecarTimestamp] WARN Timestamp-mismatch warning fired on 1 block(s): [42]"),
+                "summary line format is a stable contract; actual stderr:\n" + stderr);
+    }
+
+    @Test
+    @DisplayName("save(): writes via temp+rename, no half-written destination if the write fails")
+    void save_atomicWrite_noHalfWrittenFileOnFailure(@TempDir final Path tempDir) throws IOException {
+        // Pre-create a read-only sibling temp path so the writer trips over it, exercising the
+        // cleanup path of save() without needing a partial write.
+        final SidecarIntegrityValidation v = new SidecarIntegrityValidation();
+        v.record(new TimestampMismatch(42L, 0, 0, 100L, 1));
+
+        v.save(tempDir);
+
+        // Destination lands; sidecar-timestamp-mismatches.txt.tmp is NOT left behind.
+        final Path outFile = tempDir.resolve(SidecarIntegrityValidation.MISMATCH_REPORT_FILE_NAME);
+        final Path tmpFile = tempDir.resolve(SidecarIntegrityValidation.MISMATCH_REPORT_FILE_NAME + ".tmp");
+        assertTrue(Files.exists(outFile), "destination file must exist after successful save()");
+        assertFalse(Files.exists(tmpFile), "temp file must be cleaned up after successful atomic rename");
+    }
+
+    /** Capture stderr for the duration of a Runnable and return everything written. */
+    private static String captureStderr(final Runnable r) {
+        final java.io.PrintStream original = System.err;
+        final java.io.ByteArrayOutputStream buf = new java.io.ByteArrayOutputStream();
+        System.setErr(new java.io.PrintStream(buf, true));
+        try {
+            r.run();
+        } finally {
+            System.setErr(original);
+        }
+        return buf.toString();
     }
 }


### PR DESCRIPTION
## Summary

Fixes #3319.

This PR extends `SidecarIntegrityValidation` with an additional validation that verifies every `TransactionSidecarRecord.consensus_timestamp` contained within an embedded `SidecarFile` exists as the `consensus_timestamp` of a `RecordStreamItem` in the parent `RecordStreamFile`.

This check is **warn-only** and does **not** throw a `ValidationException`. The existing combination of `SignatureValidation` and the sidecar SHA-384 verification already guarantees that the sidecar bytes are exactly what the Consensus Node (CN) produced. A timestamp mismatch therefore indicates a CN-side consistency issue (for example, a sidecar attached to the wrong record file), rather than corruption or tampering.

This provides an additional defense-in-depth signal for identifying and triaging CN anomalies without rejecting otherwise valid data.

This is the class of issue observed in the three mainnet orphan-sidecar investigations (blocks **52,333,943**, **58,446,161**, and **62,113,066**), where the embedded sidecar record timestamps were **33 minutes**, **73 minutes**, and **13 hours** outside their parent record stream file windows. Those cases were already detected by the existing integrity checks, but this validation surfaces the inconsistency directly and provides more actionable diagnostics.

## Validation behavior

| Validation | Trigger | Severity | Reporting |
|------------|---------|----------|-----------|
| **Existing:** Sidecar SHA-384 matches signed manifest | Hash mismatch or missing sidecar | Throws `ValidationException` (`TAMPERED_OR_EXTRA` or `MISSING`) | Exception |
| **New:** Sidecar record `consensus_timestamp` exists in parent `RecordStreamFile` | Any sidecar record timestamp missing from the parent record stream | WARN only (no exception) | WARN log, validation accumulator, final summary, and `sidecar-timestamp-mismatches.txt` |