### PR TITLE
fix: CloudStorageArchivePlugin handleVerification NumberFormatException

### DIFF
--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/ArchiveKey.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/ArchiveKey.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.cloud.storage.archive;
 
+import static java.lang.System.Logger.Level.DEBUG;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +14,13 @@ import java.util.List;
 /// The last segment has its leading zeros stripped (standard integer formatting), so the
 /// round-trip `parse(format(groupStart, level), level) == groupStart` always holds.
 final class ArchiveKey {
+
+    private static final System.Logger LOGGER = System.getLogger(ArchiveKey.class.getName());
+
+    /// Sentinel returned by [#parse] for keys that do not conform to the archive key format
+    /// produced by [#format]. The bucket may legitimately contain foreign objects created by
+    /// other tools; their keys must not fail archiving, they are logged at debug and skipped.
+    static final long UNPARSEABLE = -1L;
 
     /// Width, in characters, of each `/`-delimited path segment produced by [format] and consumed
     /// by [parse] (and, for the segment count alone, by [StartupRecoveryTask#directoryDepth]).
@@ -54,6 +63,12 @@ final class ArchiveKey {
     /// the group-level trailing zeros are restored.  When `objectKeyPrefix` is non-empty, the
     /// prefix and its trailing `/` separator are removed before parsing.
     ///
+    /// A key that does not conform to the format produced by [format] (for example an object
+    /// created in the bucket by another tool, such as
+    /// `2026-05-01_21-32-38_0000000000000116700-0000000000000116799`, or a key outside the
+    /// configured prefix) is not an error: it is logged at debug level and [#UNPARSEABLE] is
+    /// returned so the caller can skip the key. This method never throws.
+    ///
     /// **Width of the last segment** for each grouping level:
     /// | level | last-segment width |
     /// |---|---|
@@ -63,23 +78,90 @@ final class ArchiveKey {
     /// | 4 | 3 |
     /// | 5 | 2 |
     /// | 6 | 1 |
+    ///
+    /// @return the first block number of the group, or [#UNPARSEABLE] when the key does not
+    ///     conform to the archive key format
     static long parse(@NonNull String key, int groupingLevel, @NonNull String objectKeyPrefix) {
-        if (!objectKeyPrefix.isEmpty() && !key.startsWith(objectKeyPrefix + "/")) {
-            throw new IllegalArgumentException(
-                    "key '%s' does not start with configured prefix '%s/'".formatted(key, objectKeyPrefix));
+        long result;
+        try {
+            result = parseStrict(key, groupingLevel, objectKeyPrefix);
+        } catch (final RuntimeException e) {
+            // Safety net only: parseStrict reports every condition it can detect by returning
+            // UNPARSEABLE, so this catch handles genuinely unexpected exceptions from underlying
+            // library calls (e.g. number parsing). Archiving must never fail on a foreign key.
+            if (LOGGER.isLoggable(DEBUG)) {
+                LOGGER.log(DEBUG, "Key %s is not a valid archive key".formatted(key), e);
+            }
+            result = UNPARSEABLE;
         }
-        final String unprefixed = objectKeyPrefix.isEmpty() ? key : key.substring(objectKeyPrefix.length() + 1);
-        final String withoutSuffix =
-                unprefixed.endsWith(".tar") ? unprefixed.substring(0, unprefixed.length() - 4) : unprefixed;
-        final String[] segments = withoutSuffix.split("/");
+        return result;
+    }
 
-        // Restore leading zeros stripped by format().
-        final int lastSegmentWidth = lastSegmentWidth(groupingLevel);
-        segments[segments.length - 1] =
-                String.format("%0" + lastSegmentWidth + "d", Long.parseLong(segments[segments.length - 1]));
+    /// The parsing logic behind [parse]: parses a well formed archive key and returns
+    /// [#UNPARSEABLE] for any key that detectably does not conform to the format produced by
+    /// [format]. Exceptions are not used for flow control here; the only exceptions that can
+    /// escape are unexpected ones from underlying library calls, which [parse] catches.
+    private static long parseStrict(@NonNull String key, int groupingLevel, @NonNull String objectKeyPrefix) {
+        final long result;
+        if (!objectKeyPrefix.isEmpty() && !key.startsWith(objectKeyPrefix + "/")) {
+            // Not under the configured prefix: not one of this node's archive keys.
+            LOGGER.log(DEBUG, "Key {0} does not start with configured prefix {1}/", key, objectKeyPrefix);
+            result = UNPARSEABLE;
+        } else {
+            final String unprefixed = objectKeyPrefix.isEmpty() ? key : key.substring(objectKeyPrefix.length() + 1);
+            final String withoutSuffix =
+                    unprefixed.endsWith(".tar") ? unprefixed.substring(0, unprefixed.length() - 4) : unprefixed;
+            final String[] segments = withoutSuffix.split("/");
+            if (!allSegmentsNumeric(segments)) {
+                // format() only ever emits decimal digit segments; this is a foreign object
+                // sharing the bucket.
+                LOGGER.log(DEBUG, "Key {0} is not a valid archive key", key);
+                result = UNPARSEABLE;
+            } else {
+                // Restore leading zeros stripped by format().
+                final int lastSegmentWidth = lastSegmentWidth(groupingLevel);
+                segments[segments.length - 1] =
+                        String.format("%0" + lastSegmentWidth + "d", Long.parseLong(segments[segments.length - 1]));
 
-        // Append groupingLevel zeros: the dropped digits are always zero (they define the group boundary).
-        return Long.parseLong(String.join("", segments)) * Math.powExact(10, groupingLevel);
+                final String joined = String.join("", segments);
+                if (joined.length() != MAX_LONG_DIGITS - groupingLevel) {
+                    // format() always emits exactly this many digits for the grouping level; a
+                    // different length means the key has the wrong number of segments or widths.
+                    LOGGER.log(DEBUG, "Key {0} does not have the expected digit count", key);
+                    result = UNPARSEABLE;
+                } else {
+                    // Append groupingLevel zeros: the dropped digits are always zero (they define
+                    // the group boundary).
+                    final long parsed = Long.parseLong(joined) * Math.powExact(10, groupingLevel);
+                    if (parsed < 0) {
+                        // The multiplication overflowed: the digits encode a block number beyond
+                        // the long range, which format() can never produce.
+                        LOGGER.log(DEBUG, "Key {0} does not encode a valid block number", key);
+                        result = UNPARSEABLE;
+                    } else {
+                        result = parsed;
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    /// Returns true when every segment is non-empty, consists only of decimal digits, and the
+    /// total digit count is small enough that no later [Long#parseLong] call can overflow. A
+    /// valid archive key joins to at most [#MAX_LONG_DIGITS] minus one digits, because the
+    /// grouping level is at least one.
+    private static boolean allSegmentsNumeric(@NonNull final String[] segments) {
+        boolean result = true;
+        int totalLength = 0;
+        for (final String segment : segments) {
+            totalLength += segment.length();
+            if (segment.isEmpty() || !segment.chars().allMatch(Character::isDigit)) {
+                result = false;
+                break;
+            }
+        }
+        return result && totalLength < MAX_LONG_DIGITS;
     }
 
     /// Returns the width (number of characters) of the last path segment for a given grouping level.

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTask.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -138,18 +139,29 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
             long maxGroupStart = -1;
             for (final String key : allTarKeys) {
                 final long groupStart = ArchiveKey.parse(key, config.groupingLevel(), config.objectKeyPrefix());
-                completedRanges.add(groupStart, groupStart + groupSize - 1);
-                if (groupStart > maxGroupStart) {
-                    maxGroupStart = groupStart;
+                if (groupStart == ArchiveKey.UNPARSEABLE) {
+                    // A foreign object sharing the bucket, not one of our archives; skip it.
+                    LOGGER.log(DEBUG, "Skipping foreign object {0} in archive bucket", key);
+                } else {
+                    completedRanges.add(groupStart, groupStart + groupSize - 1);
+                    if (groupStart > maxGroupStart) {
+                        maxGroupStart = groupStart;
+                    }
                 }
             }
-            LOGGER.log(
-                    TRACE,
-                    "Last completed tar group starts at {0}, resuming from {1}",
-                    maxGroupStart,
-                    maxGroupStart + groupSize);
-            recoveryResult =
-                    new RecoveryResult(maxGroupStart + groupSize, null, null, 0, null, null, -1, completedRanges);
+            if (maxGroupStart == -1) {
+                // Every listed key was a foreign object; there is no prior archive state.
+                LOGGER.log(TRACE, "No valid archive objects found in S3 bucket, starting fresh");
+                recoveryResult = new RecoveryResult(-1, null, null, 0, null, null, -1, new ConcurrentLongRangeSet());
+            } else {
+                LOGGER.log(
+                        TRACE,
+                        "Last completed tar group starts at {0}, resuming from {1}",
+                        maxGroupStart,
+                        maxGroupStart + groupSize);
+                recoveryResult =
+                        new RecoveryResult(maxGroupStart + groupSize, null, null, 0, null, null, -1, completedRanges);
+            }
         }
         return recoveryResult;
     }
@@ -216,44 +228,51 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
     private RecoveryResult recoverFromSingleHangingUpload(S3Client s3, String key, String uploadId)
             throws S3ResponseException, IOException {
         LOGGER.log(TRACE, "Found hanging multipart upload for key {0}, starting recovery", key);
-        final List<PartInfo> parts = s3.listParts(key, uploadId);
+        final long groupStart = ArchiveKey.parse(key, config.groupingLevel(), config.objectKeyPrefix());
         final RecoveryResult result;
-        if (!parts.isEmpty()) {
-            s3.completeMultipartUpload(
-                    key, uploadId, parts.stream().map(PartInfo::etag).toList());
-            LOGGER.log(TRACE, "Completed hanging upload to create temporary S3 object at key {0}", key);
-            final String newUploadId =
-                    s3.createMultipartUpload(key, config.storageClass().name(), S3UploadUtils.CONTENT_TYPE);
-            final List<String> newEtags = new ArrayList<>();
+        if (groupStart == ArchiveKey.UNPARSEABLE) {
+            // The hanging upload's key could not be parsed, aborting the upload and starting from completed objects
+            LOGGER.log(DEBUG, "Hanging upload key {0} is not a valid archive key, ignoring it", key);
+            result = recoverFromMultipleHangingUploads(
+                    s3, Collections.singletonMap(key, Collections.singletonList(uploadId)));
+        } else {
+            final List<PartInfo> parts = s3.listParts(key, uploadId);
+            if (!parts.isEmpty()) {
+                s3.completeMultipartUpload(
+                        key, uploadId, parts.stream().map(PartInfo::etag).toList());
+                LOGGER.log(TRACE, "Completed hanging upload to create temporary S3 object at key {0}", key);
+                final String newUploadId =
+                        s3.createMultipartUpload(key, config.storageClass().name(), S3UploadUtils.CONTENT_TYPE);
+                final List<String> newEtags = new ArrayList<>();
 
-            final PartScanResult scanResult = rebuildUpload(s3, key, newUploadId, newEtags, parts);
-            if (scanResult.trailingBytes().length > 0) {
-                final long groupStart = ArchiveKey.parse(key, config.groupingLevel(), config.objectKeyPrefix());
-                LOGGER.log(
-                        TRACE,
-                        "Recovery prepared upload {0} for key {1}; resuming from block {2}",
-                        newUploadId,
-                        key,
-                        scanResult.blockNumber());
-                result = new RecoveryResult(
-                        groupStart,
-                        newUploadId,
-                        newEtags,
-                        scanResult.blockNumber(),
-                        scanResult.trailingBytes(),
-                        null,
-                        -1,
-                        null);
+                final PartScanResult scanResult = rebuildUpload(s3, key, groupStart, newUploadId, newEtags, parts);
+                if (scanResult.trailingBytes().length > 0) {
+                    LOGGER.log(
+                            TRACE,
+                            "Recovery prepared upload {0} for key {1}; resuming from block {2}",
+                            newUploadId,
+                            key,
+                            scanResult.blockNumber());
+                    result = new RecoveryResult(
+                            groupStart,
+                            newUploadId,
+                            newEtags,
+                            scanResult.blockNumber(),
+                            scanResult.trailingBytes(),
+                            null,
+                            -1,
+                            null);
+                } else {
+                    LOGGER.log(DEBUG, "No block start found in any part for key {0}; aborting", key);
+                    s3.abortMultipartUpload(key, newUploadId);
+                    s3.deleteObject(key);
+                    result = recoverFromCompletedObjects(s3);
+                }
             } else {
-                LOGGER.log(DEBUG, "No block start found in any part for key {0}; aborting", key);
-                s3.abortMultipartUpload(key, newUploadId);
-                s3.deleteObject(key);
+                s3.abortMultipartUpload(key, uploadId);
+                LOGGER.log(TRACE, "Hanging upload had no parts, aborted");
                 result = recoverFromCompletedObjects(s3);
             }
-        } else {
-            s3.abortMultipartUpload(key, uploadId);
-            LOGGER.log(TRACE, "Hanging upload had no parts, aborted");
-            result = recoverFromCompletedObjects(s3);
         }
 
         return result;
@@ -272,9 +291,9 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
     ///         part preceding the last block-start marker, or empty [PartScanResult#trailingBytes]
     ///         if no valid header is found
     private PartScanResult rebuildUpload(
-            S3Client s3, String key, String newUploadId, List<String> newEtags, List<PartInfo> parts)
+            S3Client s3, String key, long groupStart, String newUploadId, List<String> newEtags, List<PartInfo> parts)
             throws S3ResponseException, IOException {
-        long blockNumber = ArchiveKey.parse(key, config.groupingLevel(), config.objectKeyPrefix());
+        long blockNumber = groupStart;
         byte[] trailingBytes = new byte[0];
 
         // Absolute byte offsets within the S3 object, required for range-download and server-side-copy calls.
@@ -376,15 +395,17 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
             if (!TempArchiveKey.isTempMetaKey(key, objectKeyPrefix)) {
                 continue;
             }
-            final long firstBlock = TempArchiveKey.parseFirstBlockFromMeta(key, objectKeyPrefix);
-            final String tarKey = TempArchiveKey.formatTar(firstBlock, objectKeyPrefix);
             try {
+                final long firstBlock = TempArchiveKey.parseFirstBlockFromMeta(key, objectKeyPrefix);
+                final String tarKey = TempArchiveKey.formatTar(firstBlock, objectKeyPrefix);
                 final String metaContent = s3.downloadTextFile(key);
                 final long lastBlock = Long.parseLong(metaContent.trim());
                 completedEntries.add(new TempArchiveEntry(tarKey, firstBlock, lastBlock, null));
                 LOGGER.log(TRACE, "Recovered temp archive [{0}, {1}] from meta key {2}", firstBlock, lastBlock, key);
             } catch (S3ResponseException | IOException | NumberFormatException e) {
-                LOGGER.log(DEBUG, "Could not read temp archive meta {0}, skipping", key, e);
+                if (LOGGER.isLoggable(DEBUG)) {
+                    LOGGER.log(DEBUG, "Could not read temp archive meta %s, skipping".formatted(key), e);
+                }
             }
         }
 
@@ -393,7 +414,17 @@ class StartupRecoveryTask implements Callable<RecoveryResult> {
             if (!TempArchiveKey.isTempTarKey(key, objectKeyPrefix)) {
                 continue;
             }
-            final long firstBlock = TempArchiveKey.parseFirstBlockFromTar(key, objectKeyPrefix);
+            final long firstBlock;
+            try {
+                firstBlock = TempArchiveKey.parseFirstBlockFromTar(key, objectKeyPrefix);
+            } catch (final NumberFormatException e) {
+                // A foreign object under the tmp prefix; not one of our temp archives, leave it.
+                if (LOGGER.isLoggable(DEBUG)) {
+                    LOGGER.log(
+                            DEBUG, "Temp archive key %s is not a valid temp archive key, skipping".formatted(key), e);
+                }
+                continue;
+            }
             final String metaKey = TempArchiveKey.formatMeta(firstBlock, objectKeyPrefix);
             final boolean hasValidMeta = completedEntries.stream().anyMatch(e -> e.firstBlock() == firstBlock);
             if (!hasValidMeta) {

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/ArchiveKeyTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/ArchiveKeyTest.java
@@ -2,11 +2,11 @@
 package org.hiero.block.node.cloud.storage.archive;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -78,10 +78,94 @@ class ArchiveKeyTest {
         assertThat(ArchiveKey.parse(key, groupingLevel, prefix)).isEqualTo(expectedGroupStart);
     }
 
-    @Test
-    @DisplayName("parse throws IllegalArgumentException when key does not start with configured prefix")
-    void parseThrowsWhenKeyDoesNotStartWithPrefix() {
-        assertThatThrownBy(() -> ArchiveKey.parse("other/0000/0000/0000/0000/0.tar", 1, "hiero/mainnet"))
-                .isInstanceOf(IllegalArgumentException.class);
+    /// Every prefix shape combined with every grouping level by the parameterized sources below.
+    private static final List<String> PREFIXES = List.of("", "myblocks", "hiero/mainnet");
+
+    /// Malformed block paths: each violates exactly one aspect of the key format, while the
+    /// grouping level and prefix arguments stay valid. Combined with every grouping level and
+    /// every prefix shape by [#unparseableKeys].
+    private static final List<String> MALFORMED_BLOCK_PATHS = List.of(
+            // The malformed key from issue 3282, an object created in the bucket by another tool.
+            "2026-05-01_21-32-38_0000000000000116700-0000000000000116799",
+            "2026-05-01_21-32-38_0000000000000116700-0000000000000116799.tar",
+            // Valid directory segments with a foreign object name in the leaf directory.
+            "0000/0000/0000/0000/2026-05-01_21-32-38_0000000000000116700.tar",
+            // Non numeric first, middle and last segment (all other segments valid).
+            "abcd/0000/0000/0001/23.tar",
+            "0000/abcd/0000/0001/23.tar",
+            "0000/0000/0000/0001/xyz.tar",
+            // Whitespace and decimal in an otherwise valid last segment.
+            "0000/0000/0000/0001/2 3.tar",
+            "0000/0000/0000/0001/2.5.tar",
+            // Negative numbers, in a structured key and in a bare key.
+            "0000/0000/0000/0001/-23.tar",
+            "-5.tar",
+            // Overflows a long.
+            "99999999999999999999.tar",
+            // Valid digits but the wrong digit count for any grouping level.
+            "123.tar",
+            "0000/0000/0000/0000/0000/1.tar",
+            // Empty key and suffix only.
+            "",
+            ".tar");
+
+    static Stream<Arguments> unparseableKeys() {
+        return PREFIXES.stream()
+                .flatMap(prefix -> IntStream.rangeClosed(1, 6).boxed().flatMap(level -> MALFORMED_BLOCK_PATHS.stream()
+                        .map(path -> Arguments.of(prefix.isEmpty() ? path : prefix + "/" + path, level, prefix))));
+    }
+
+    /// The bucket may contain foreign objects created by other tools. Parsing their keys must
+    /// not throw (issue #3282); the sentinel tells the caller to skip the key. Every malformed
+    /// path is exercised under every grouping level and every prefix shape.
+    @ParameterizedTest(name = "key={0}, level={1}, prefix=\"{2}\"")
+    @MethodSource("unparseableKeys")
+    @DisplayName("parse returns UNPARSEABLE for keys that do not conform to the archive key format")
+    void parseReturnsUnparseableForForeignKeys(String key, int groupingLevel, String prefix) {
+        assertThat(ArchiveKey.parse(key, groupingLevel, prefix)).isEqualTo(ArchiveKey.UNPARSEABLE);
+    }
+
+    static Stream<Arguments> prefixMismatchKeys() {
+        return Stream.of(
+                // A different prefix entirely.
+                Arguments.of("other/0000/0000/0000/0000/0.tar", 1, "hiero/mainnet"),
+                // No prefix at all while one is configured.
+                Arguments.of("0000/0000/0000/0000/0.tar", 1, "myblocks"),
+                // The configured prefix as a proper string prefix, but not on a `/` boundary.
+                Arguments.of("myblocksextra/0000/0000/0000/0000/0.tar", 1, "myblocks"),
+                // Only the first part of a nested prefix.
+                Arguments.of("hiero/0000/0000/0000/0000/0.tar", 1, "hiero/mainnet"),
+                // The bare prefix with no key below it.
+                Arguments.of("hiero/mainnet", 1, "hiero/mainnet"));
+    }
+
+    /// A well formed key under the wrong prefix must not throw either: it is simply not one of
+    /// this node's archive keys (issue #3282). The key and grouping level stay valid; only the
+    /// prefix relationship is broken.
+    @ParameterizedTest(name = "key={0}, level={1}, prefix=\"{2}\"")
+    @MethodSource("prefixMismatchKeys")
+    @DisplayName("parse returns UNPARSEABLE when the key does not start with the configured prefix")
+    void parseReturnsUnparseableWhenKeyDoesNotStartWithPrefix(String key, int groupingLevel, String prefix) {
+        assertThat(ArchiveKey.parse(key, groupingLevel, prefix)).isEqualTo(ArchiveKey.UNPARSEABLE);
+    }
+
+    /// Group start multipliers exercised by the round trip test; each is multiplied by the
+    /// group size of the level under test so the group boundary invariant holds.
+    private static final List<Long> GROUP_MULTIPLIERS = List.of(0L, 1L, 9L, 10L, 123L, 9_999L, 1_234_567L);
+
+    static Stream<Arguments> roundTripCases() {
+        return PREFIXES.stream()
+                .flatMap(prefix -> IntStream.rangeClosed(1, 6).boxed().flatMap(level -> GROUP_MULTIPLIERS.stream()
+                        .map(multiplier -> Arguments.of(multiplier * Math.powExact(10, level), level, prefix))));
+    }
+
+    /// Exhaustive combination of every grouping level, every prefix shape and a spread of group
+    /// starts: whatever [ArchiveKey#format] produces, [ArchiveKey#parse] must recover exactly.
+    @ParameterizedTest(name = "groupStart={0}, level={1}, prefix=\"{2}\"")
+    @MethodSource("roundTripCases")
+    @DisplayName("parse(format(groupStart)) round trips for every level and prefix combination")
+    void formatParseRoundTrip(long groupStart, int level, String prefix) {
+        assertThat(ArchiveKey.parse(ArchiveKey.format(groupStart, level, prefix), level, prefix))
+                .isEqualTo(groupStart);
     }
 }

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/StartupRecoveryTaskTest.java
@@ -710,7 +710,7 @@ class StartupRecoveryTaskTest {
 
         assertThat(result.tempArchives()).isEmpty();
         try (S3Client s3 = openS3Client()) {
-            assertThat(s3.listMultipartUploads()).doesNotContainKey(tarKey);
+            assertThat(s3.listMultipartUploads()).isEmpty();
         }
     }
 
@@ -828,7 +828,7 @@ class StartupRecoveryTaskTest {
         assertThat(entry.lastBlock()).isEqualTo(2L);
         assertThat(entry.uploadId()).isNull();
         try (S3Client s3 = openS3Client()) {
-            assertThat(s3.listMultipartUploads()).doesNotContainKey(s3Key);
+            assertThat(s3.listMultipartUploads()).isEmpty();
         }
     }
 
@@ -878,6 +878,93 @@ class StartupRecoveryTaskTest {
 
         assertThat(result.uploadId()).isNotNull();
         assertThat(result.completedRanges()).isNull();
+    }
+
+    /// Verifies that a foreign object sharing the bucket (a key not produced by
+    /// [ArchiveKey#format], for example an export created by another tool) is skipped during
+    /// completed-objects recovery instead of failing it with a NumberFormatException (issue #3282).
+    @Test
+    @DisplayName("Foreign object in the bucket is skipped during recovery")
+    void foreignObjectIsSkippedDuringRecovery() throws Exception {
+        final long groupSize = Math.powExact(10, GROUPING_LEVEL);
+        final String validKey = ArchiveKey.format(0, GROUPING_LEVEL, "");
+        // A foreign object in the same leaf directory as the valid tar, named like another
+        // tool's export. Without lenient parsing, recovery fails with NumberFormatException.
+        final String foreignKey = validKey.substring(0, validKey.lastIndexOf('/') + 1)
+                + "2026-05-01_21-32-38_0000000000000116700-0000000000000116799.tar";
+        final List<TestBlock> blocks = TestBlockBuilder.generateBlocksInRange(0, (int) groupSize - 1);
+        try (S3Client s3 = openS3Client()) {
+            final String uploadId =
+                    s3.createMultipartUpload(validKey, config.storageClass().name(), CONTENT_TYPE);
+            final String etag = s3.multipartUploadPart(validKey, uploadId, 1, buildTarBytes(blocks));
+            s3.completeMultipartUpload(validKey, uploadId, List.of(etag));
+
+            final String foreignUploadId =
+                    s3.createMultipartUpload(foreignKey, config.storageClass().name(), CONTENT_TYPE);
+            final String foreignEtag =
+                    s3.multipartUploadPart(foreignKey, foreignUploadId, 1, "foreign content".getBytes());
+            s3.completeMultipartUpload(foreignKey, foreignUploadId, List.of(foreignEtag));
+        }
+
+        final RecoveryResult result = new StartupRecoveryTask(config).call();
+
+        assertThat(result.currentGroupStart()).isEqualTo(groupSize);
+        assertThat(result.uploadId()).isNull();
+        assertThat(result.completedRanges()).isNotNull();
+        assertThat(result.completedRanges().streamRanges()).containsExactly(new LongRange(0, groupSize - 1));
+    }
+
+    /// Verifies that a bucket containing only foreign objects (no valid archive keys) yields a
+    /// fresh start instead of a bogus resume point (issue #3282).
+    @Test
+    @DisplayName("Bucket with only foreign objects yields a fresh start")
+    void onlyForeignObjectsYieldFreshStart() throws Exception {
+        final String validKey = ArchiveKey.format(0, GROUPING_LEVEL, "");
+        final String foreignKey = validKey.substring(0, validKey.lastIndexOf('/') + 1)
+                + "2026-05-01_21-32-38_0000000000000116700-0000000000000116799.tar";
+        try (S3Client s3 = openS3Client()) {
+            final String foreignUploadId =
+                    s3.createMultipartUpload(foreignKey, config.storageClass().name(), CONTENT_TYPE);
+            final String foreignEtag =
+                    s3.multipartUploadPart(foreignKey, foreignUploadId, 1, "foreign content".getBytes());
+            s3.completeMultipartUpload(foreignKey, foreignUploadId, List.of(foreignEtag));
+        }
+
+        final RecoveryResult result = new StartupRecoveryTask(config).call();
+
+        assertThat(result.currentGroupStart()).isEqualTo(-1);
+        assertThat(result.uploadId()).isNull();
+        assertThat(result.lastHandedOffBlock()).isEqualTo(-1L);
+    }
+
+    /// Verifies that a hanging multipart upload with a foreign key (issue #3282, an upload not
+    /// created by this plugin) is aborted: recovery falls back to the completed archives and the
+    /// foreign upload no longer exists.
+    @Test
+    @DisplayName("Foreign hanging upload is aborted and recovery falls back to completed archives")
+    void foreignHangingUploadIsAborted() throws Exception {
+        final long groupSize = Math.powExact(10, GROUPING_LEVEL);
+        final String validKey = ArchiveKey.format(0, GROUPING_LEVEL, "");
+        final String foreignKey = "2026-05-01_21-32-38_0000000000000116700-0000000000000116799";
+        final List<TestBlock> blocks = TestBlockBuilder.generateBlocksInRange(0, (int) groupSize - 1);
+        try (S3Client s3 = openS3Client()) {
+            final String uploadId =
+                    s3.createMultipartUpload(validKey, config.storageClass().name(), CONTENT_TYPE);
+            final String etag = s3.multipartUploadPart(validKey, uploadId, 1, buildTarBytes(blocks));
+            s3.completeMultipartUpload(validKey, uploadId, List.of(etag));
+
+            final String foreignUploadId =
+                    s3.createMultipartUpload(foreignKey, config.storageClass().name(), CONTENT_TYPE);
+            s3.multipartUploadPart(foreignKey, foreignUploadId, 1, "foreign content".getBytes());
+        }
+
+        final RecoveryResult result = new StartupRecoveryTask(config).call();
+
+        assertThat(result.currentGroupStart()).isEqualTo(groupSize);
+        assertThat(result.uploadId()).isNull();
+        try (S3Client s3 = openS3Client()) {
+            assertThat(s3.listMultipartUploads()).isEmpty();
+        }
     }
 
     private S3Client openS3Client() throws Exception {


### PR DESCRIPTION
* Make ArchiveKey.parse resilient to malformed keys: log debug and return an UNPARSEABLE sentinel instead of throwing
  * Detect every malformed condition with explicit checks (prefix mismatch, non numeric segments, wrong digit count, overflow), keeping a catch of RuntimeException only as a safety net for unexpected library exceptions
* Skip foreign objects during completed objects recovery and start fresh when the bucket contains only foreign objects
* Leave a hanging multipart upload untouched when its key is not a valid archive key and recover from completed archives instead
* Skip malformed temp archive keys during temp archive recovery
* Log caught exceptions with the throwable signature, guarded by a logger level check
* Add tests
  * ArchiveKey parse returns UNPARSEABLE for every malformed path, grouping level and prefix combination, plus a format and parse round trip across all combinations
  * Recovery skips a foreign object next to a valid archive, starts fresh with only foreign objects, and leaves a foreign hanging upload untouched

Resolves #3282