### PR TITLE
docs: fix GitBook rendering issues across block-node docs

### DIFF
--- a/docs/block-node/architecture/architecture-overview.md
+++ b/docs/block-node/architecture/architecture-overview.md
@@ -29,7 +29,7 @@ for additional service processing.
 ## System Architecture Diagram
 
 The overall architecture of the Block Node is illustrated below:
-![block-node-app-logic](./../../assets/block-node-app-logic.svg)
+<img src="./../../assets/block-node-app-logic.svg" alt="block-node-app-logic" width="100%" />
 
 Additional details regarding Service interactions are illustrated in [Block-Node-Nano-Services](./../../assets/Block-Node-Nano-Services.svg) diagram.
 

--- a/docs/block-node/architecture/data-flow.md
+++ b/docs/block-node/architecture/data-flow.md
@@ -6,7 +6,7 @@ This document describes multiple data flows between system components using its 
 
 ** Overview should cover block items flow, merkle tree building, verification, persistence, and notification. **
 
-![block-item-publish-flow](./../../assets/block-item-publish-flow.svg)
+<img src="./../../assets/block-item-publish-flow.svg" alt="block-item-publish-flow" width="100%" />
 
 Detailed Steps:
 

--- a/docs/block-node/architecture/plugins.md
+++ b/docs/block-node/architecture/plugins.md
@@ -31,7 +31,7 @@ To add a new plugin:
    `BlockMessagingFacility`) if your plugin replaces or extends block management and messaging capabilities.
 3. Optionally, implement additional interfaces (e.g., a protobuf `ServiceInterface`) for additional capabilities.
 
-![block-node-plugin-class-diagram](./../../assets/block-node-plugin-class-diagram.svg)
+<img src="./../../assets/block-node-plugin-class-diagram.svg" alt="block-node-plugin-class-diagram" width="100%" />
 
 ## Example Plugin Structure
 

--- a/docs/block-node/metrics.md
+++ b/docs/block-node/metrics.md
@@ -1,26 +1,5 @@
 # Hiero Block Node Metrics
 
-## Table of Contents
-
-1. [Summary](#summary)
-2. [Purpose](#purpose)
-3. [Configuration](#configuration)
-4. [How to Access Metrics](#how-to-access-metrics)
-5. [Metrics](#metrics-by-plugin)
-   1. [app](#app)
-   2. [Block Access](#block-access)
-   3. [Block Messaging](#block-messaging)
-   4. [Publisher](#publisher)
-   5. [Subscriber](#subscriber)
-   6. [Verification](#verification)
-   7. [files.recent](#filesrecent)
-   8. [files.historic](#fileshistoric)
-   9. [cloud-storage-archive](#cloud-storage-archive)
-   10. [Server Status API](#server-status-api)
-   11. [Backfill](#backfill)
-   12. [roster-bootstrap-rsa](#roster-bootstrap-rsa)
-   13. [roster-bootstrap-tss](#roster-bootstrap-tss)
-
 ## Summary
 
 This document describes the metrics that are available in the system, its purpose, and how to use them.

--- a/docs/block-node/operations/network-ports-and-protocols.md
+++ b/docs/block-node/operations/network-ports-and-protocols.md
@@ -4,19 +4,21 @@ This document defines the network ports, traffic directions, and TLS posture of 
 
 ## Key terms
 
-<dl>
-<dt>Initiator</dt>
-<dd>The component that opens the TCP connection. For every gRPC flow in this document the initiator is the gRPC client; the Block Node accepts the connection on a listening port.</dd>
+**Initiator**
 
-<dt>Direction</dt>
-<dd>Relative to the Block Node. Inbound traffic terminates on a Block Node port; outbound traffic originates from the Block Node and terminates on a port elsewhere.</dd>
+The component that opens the TCP connection. For every gRPC flow in this document the initiator is the gRPC client; the Block Node accepts the connection on a listening port.
 
-<dt>TLS-in-process</dt>
-<dd>Whether the Block Node binary itself terminates TLS. The Block Node does not terminate TLS in-process for any port; TLS is terminated upstream by a Kubernetes Ingress, load balancer, or similar.</dd>
+**Direction**
 
-<dt>Production exposure</dt>
-<dd>Whether the port is intended to be reachable from outside the Kubernetes cluster in a production deployment. Internal-cluster ports are still subject to <code>NetworkPolicy</code> within the cluster.</dd>
-</dl>
+Relative to the Block Node. Inbound traffic terminates on a Block Node port; outbound traffic originates from the Block Node and terminates on a port elsewhere.
+
+**TLS-in-process**
+
+Whether the Block Node binary itself terminates TLS. The Block Node does not terminate TLS in-process for any port; TLS is terminated upstream by a Kubernetes Ingress, load balancer, or similar.
+
+**Production exposure**
+
+Whether the port is intended to be reachable from outside the Kubernetes cluster in a production deployment. Internal-cluster ports are still subject to `NetworkPolicy` within the cluster.
 
 ---
 

--- a/docs/block-node/quickstart.md
+++ b/docs/block-node/quickstart.md
@@ -1,14 +1,5 @@
 # Quickstart of the Server
 
-## Table of Contents
-
-1. [Configuration](#configuration)
-2. [Running locally](#running-locally)
-   1. [Build the Server](#build-the-server)
-   2. [Run the Server](#run-the-server)
-   3. [Run the Server with Debug](#run-the-server-with-debug)
-   4. [Stop the Server](#stop-the-server)
-
 ## Configuration
 
 Refer to the [Configuration](../configuration.md) for configuration options.


### PR DESCRIPTION
## Reviewer Notes

-  Convert < dl >/< dt >/< dd > Key terms section in network-ports-and-protocols.md to markdown bullets, GitBook strips HTML definition list formatting leaving unrendered text: 
<img width="811" height="530" alt="image" src="https://github.com/user-attachments/assets/af613329-cb6e-4eb8-8e36-ad2d0d06ee85" />

- Remove duplicate Table of Contents sections from metrics.md and quickstart.md:
<img width="1052" height="992" alt="image" src="https://github.com/user-attachments/assets/e7e071a3-e231-4763-becb-e1c35af515ab" />

- Fix SVG image sizing in architecture-overview.md, data-flow.md, and plugins.md by replacing plain markdown image syntax with "< img width="100%" >"  to prevent small rendering in GitBook.
