### PR TITLE
chore: add previewnet Tier 1 LFH deployment config 

### DIFF
--- a/charts/block-node-server/values-overrides/previewnet-lfh-provisioner-config-smoketest.yaml
+++ b/charts/block-node-server/values-overrides/previewnet-lfh-provisioner-config-smoketest.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Smoke-test-scoped variant of previewnet-lfh-provisioner-config.yaml for a
+# previewnet Tier 1 LFH Block Node deployed on a single VM with only ~1 TB of
+# local storage (below the profile-level 3 TB preflight minimum).
+#
+# Use this WITH `--skip-hardware-checks` for a short-lived smoke test:
+#
+#   sudo solo-provisioner block node install \
+#     -p previewnet \
+#     --config /path/to/previewnet-lfh-provisioner-config-smoketest.yaml \
+#     --values /path/to/previewnet-lfh-values-smoketest.yaml \
+#     --skip-hardware-checks \
+#     --non-interactive
+#
+# Do NOT use for a durable previewnet Tier 1 deployment. The full-history
+# archive will fill this box eventually; provision a proper 3 TB disk and use
+# previewnet-lfh-provisioner-config.yaml for anything real.
+
+profile: previewnet
+
+log:
+    level: info
+    consoleLogging: true
+    fileLogging: false
+
+blockNode:
+    namespace: block-node
+    release: block-node
+    chart: oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server
+    version: "0.37.1"
+
+    storage:
+        # Shrunk for a ~1 TB smoke-test box. Combined footprint ~700 GiB leaves
+        # headroom for OS + Kubernetes state + growth. Adjust downward further
+        # if the box has less.
+        applicationStatePath: /mnt/fast-storage/block-node/application-state
+        applicationStateSize: 10Gi
+        archivePath: /mnt/fast-storage/block-node/archive
+        archiveSize: 600Gi
+        livePath: /mnt/fast-storage/block-node/live
+        liveSize: 50Gi
+        logPath: /mnt/fast-storage/block-node/logs
+        logSize: 10Gi
+        pluginsPath: /mnt/fast-storage/block-node/plugins
+        pluginsSize: 2Gi

--- a/charts/block-node-server/values-overrides/previewnet-lfh-provisioner-config.yaml
+++ b/charts/block-node-server/values-overrides/previewnet-lfh-provisioner-config.yaml
@@ -9,7 +9,17 @@
 #   sudo solo-provisioner block node install \
 #     -p previewnet \
 #     --config /path/to/previewnet-lfh-provisioner-config.yaml \
-#     --values /path/to/previewnet-lfh-values.yaml
+#     --values /path/to/previewnet-lfh-values.yaml \
+#     --non-interactive
+#
+# LoadBalancer: enabled by default (Solo Provisioner installs MetalLB during
+# a fresh install; the values file sets loadBalancer.enabled: true so the
+# chart renders a LoadBalancer Service with the metallb.io/address-pool
+# annotation set to public-address-pool). This gives external subscribers a
+# stable ingress at the VM's external IP without needing kubectl port-forward.
+# If deploying to a cluster where MetalLB is NOT present, flip the values
+# file's loadBalancer.enabled to false AND pass --load-balancer-enabled=false
+# to the CLI to skip Solo Provisioner's post-install reachability probe.
 #
 # Storage sizes below are sized for previewnet's per-day block volume (much
 # smaller than mainnet's). Adjust if the archive grows past what these caps
@@ -18,6 +28,19 @@
 # Chart version: pin to a specific release rather than accepting whatever the
 # Solo Provisioner release ships bundled by default. Confirm against
 # https://github.com/hiero-ledger/hiero-block-node/releases and bump on cutovers.
+#
+# Preflight gotchas we hit on the previewnet smoke-test box (2026-07-31):
+#   * hedera user/group must be at UID/GID 2000. If the target VM was
+#     previously used for anything, an existing `hedera` user at another
+#     UID (we saw 1005) will fail preflight with:
+#       "hedera owner user \"hedera\" has incorrect UID: expected 2000, got 1005"
+#     Fix: `sudo usermod -u 2000 hedera && sudo groupmod -g 2000 hedera`,
+#     then re-chown anything that was owned by the old UID/GID.
+#   * Profile `previewnet` requires >=3 TB total disk at preflight. On a
+#     smaller box, use `--skip-hardware-checks` together with the
+#     `-smoketest` variant configs alongside this file. See
+#     `previewnet-lfh-provisioner-config-smoketest.yaml` for the shrunk
+#     shape (~700 GiB combined) and don't ship it to a durable Tier 1.
 
 profile: previewnet
 

--- a/charts/block-node-server/values-overrides/previewnet-lfh-provisioner-config.yaml
+++ b/charts/block-node-server/values-overrides/previewnet-lfh-provisioner-config.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Solo Provisioner config for a previewnet Tier 1 Local-Full-History Block Node
+# deployed on a single GCP e2-standard-16 VM per the recipe at
+# https://docs.hiero.org/block-node-overview/block-node-hardware-specifications/solo-weaver-single-node-k8s-deployment
+#
+# Pair with `previewnet-lfh-values.yaml` (Helm values). Deploy via:
+#
+#   sudo solo-provisioner block node install \
+#     -p previewnet \
+#     --config /path/to/previewnet-lfh-provisioner-config.yaml \
+#     --values /path/to/previewnet-lfh-values.yaml
+#
+# Storage sizes below are sized for previewnet's per-day block volume (much
+# smaller than mainnet's). Adjust if the archive grows past what these caps
+# permit -- see live/archive PVCs on the running pod.
+#
+# Chart version: pin to a specific release rather than accepting whatever the
+# Solo Provisioner release ships bundled by default. Confirm against
+# https://github.com/hiero-ledger/hiero-block-node/releases and bump on cutovers.
+
+profile: previewnet
+
+log:
+    level: info
+    consoleLogging: true
+    fileLogging: false
+
+blockNode:
+    namespace: block-node
+    release: block-node
+    chart: oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server
+    version: "0.37.1"
+
+    storage:
+        # /mnt/fast-storage is the Solo Provisioner default; leave the base path unless the VM's disk layout dictates otherwise.
+        applicationStatePath: /mnt/fast-storage/block-node/application-state
+        applicationStateSize: 20Gi
+        archivePath: /mnt/fast-storage/block-node/archive
+        archiveSize: 1Ti
+        livePath: /mnt/fast-storage/block-node/live
+        liveSize: 100Gi
+        logPath: /mnt/fast-storage/block-node/logs
+        logSize: 20Gi
+        pluginsPath: /mnt/fast-storage/block-node/plugins
+        pluginsSize: 5Gi

--- a/charts/block-node-server/values-overrides/previewnet-lfh-static-pvs.yaml
+++ b/charts/block-node-server/values-overrides/previewnet-lfh-static-pvs.yaml
@@ -1,0 +1,131 @@
+# Static PersistentVolumes for previewnet Tier 1 Local-Full-History deployments
+# on single-node clusters that do NOT have a default StorageClass.
+#
+# When to use this file:
+#   The previewnet Tier 1 values files (`previewnet-lfh-values.yaml` and
+#   `previewnet-lfh-values-smoketest.yaml`) set `persistence.*.create: true`,
+#   which tells the chart to dynamically provision PVCs via the cluster's
+#   default StorageClass. Solo Provisioner's stock previewnet install does
+#   NOT ship a default StorageClass on the single-node k3s cluster it
+#   creates, so those chart-provisioned PVCs stay `Pending` forever and
+#   the BN pod cannot schedule.
+#
+#   `kubectl apply -f` this file BEFORE running
+#   `sudo solo-provisioner block node install`. The 5 PVs are pre-bound
+#   (via `spec.claimRef`) to the exact PVC names the chart's
+#   volumeClaimTemplate will generate for the first StatefulSet replica
+#   (`<name>-storage-block-node-block-node-server-0`), so the PVCs bind
+#   immediately when the chart creates them.
+#
+#   Long-term fix: install `local-path-provisioner` (rancher's local-path
+#   StorageClass) into Solo Provisioner's default cluster setup so
+#   `persistence.*.create: true` works out of the box. Tracked as a
+#   follow-up against solo-weaver.
+#
+# HostPath layout:
+#   All 5 PVs are backed by hostPath directories under
+#   `/mnt/fast-storage/block-node/` (the standard Solo Provisioner storage
+#   root). Directories are auto-created by Solo Provisioner during the
+#   install; the PVs pre-declared here just point at them.
+#
+# Sizing:
+#   Capacities match the chart's volumeClaimTemplate requests for the
+#   smoke-test variant. For the main (non-smoke-test) variant, edit the
+#   `capacity.storage` values to match `previewnet-lfh-values.yaml`
+#   (larger archive/live/etc.) before applying.
+#
+# Reclaim policy:
+#   `Retain` — never auto-delete these PVs even when the bound PVC is
+#   removed. Prevents accidental data loss during helm upgrades or
+#   `solo-provisioner block node reset`.
+#
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: application-state-storage-pv-static
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  hostPath:
+    path: /mnt/fast-storage/block-node/application-state
+    type: Directory
+  claimRef:
+    namespace: block-node
+    name: application-state-storage-block-node-block-node-server-0
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: archive-storage-pv-static
+spec:
+  capacity:
+    storage: 800Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  hostPath:
+    path: /mnt/fast-storage/block-node/archive
+    type: Directory
+  claimRef:
+    namespace: block-node
+    name: archive-storage-block-node-block-node-server-0
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: live-storage-pv-static
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  hostPath:
+    path: /mnt/fast-storage/block-node/live
+    type: Directory
+  claimRef:
+    namespace: block-node
+    name: live-storage-block-node-block-node-server-0
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: logging-storage-pv-static
+spec:
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  hostPath:
+    path: /mnt/fast-storage/block-node/logs
+    type: Directory
+  claimRef:
+    namespace: block-node
+    name: logging-storage-block-node-block-node-server-0
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: plugins-storage-pv-static
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  hostPath:
+    path: /mnt/fast-storage/block-node/plugins
+    type: Directory
+  claimRef:
+    namespace: block-node
+    name: plugins-storage-block-node-block-node-server-0

--- a/charts/block-node-server/values-overrides/previewnet-lfh-values-smoketest.yaml
+++ b/charts/block-node-server/values-overrides/previewnet-lfh-values-smoketest.yaml
@@ -82,9 +82,16 @@ blockNode:
 # public IP too, and Solo Provisioner installs MetalLB during a fresh install.
 # Match the main previewnet-lfh-values.yaml's LB shape so this smoke-test
 # variant differs from the main file ONLY in JVM heap + storage sizing.
+#
+# includePluginPorts: true is REQUIRED under the split-port setup below --
+# see the same comment in previewnet-lfh-values.yaml for the full rationale
+# (short version: 40840 alone answers plain HTTP, not gRPC; the split-port
+# setup routes gRPC to per-plugin ports 40980-40984 that this flag exposes
+# on the external Service).
 loadBalancer:
     enabled: true
     port: "40840"
+    includePluginPorts: true
     annotations:
         metallb.io/address-pool: public-address-pool
 

--- a/charts/block-node-server/values-overrides/previewnet-lfh-values-smoketest.yaml
+++ b/charts/block-node-server/values-overrides/previewnet-lfh-values-smoketest.yaml
@@ -54,22 +54,24 @@ blockNode:
                   - name: logging-storage
                     mountPath: /logging-pvc
 
+        # PVCs chart-provisioned from the default StorageClass; see the same
+        # comment in previewnet-lfh-values.yaml for the rationale. Without
+        # this, mounts silently degrade to ephemeral rootfs -- confirmed on
+        # this smoke-test box: 173 GB of tar-streamed historic blocks were
+        # wiped by the post-backfill pod restart.
         persistence:
             live:
-                create: false
-                existingClaim: live-storage-pvc
+                create: true
                 subPath: ""
             archive:
-                create: false
-                existingClaim: archive-storage-pvc
+                create: true
                 subPath: ""
             logging:
-                create: false
-                existingClaim: logging-storage-pvc
+                create: true
                 subPath: ""
             applicationState:
-                create: false
-                existingClaim: application-state-storage-pvc
+                create: true
+                subPath: ""
 
     ports:
         publisher: 40984    # PRODUCER_PORT     — gRPC, block producers

--- a/charts/block-node-server/values-overrides/previewnet-lfh-values-smoketest.yaml
+++ b/charts/block-node-server/values-overrides/previewnet-lfh-values-smoketest.yaml
@@ -1,27 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Helm values override for a previewnet Tier 1 Local-Full-History Block Node
-# deployed on a single GCP e2-standard-16 VM (16 vCPUs, ≥32 GB RAM).
+# Smoke-test-scoped Helm values override for a previewnet Tier 1 LFH Block
+# Node running on a bigger-than-guide VM (32 cores / 256 GB RAM observed on
+# the previewnet smoke-test box) but with limited local disk (~1 TB total).
 #
-# Derived from `lfh-values.yaml` (mainnet-shaped), right-sized down for
-# previewnet's per-day block volume and the single-VM shape. See
-# `previewnet-lfh-provisioner-config.yaml` for the paired Solo Provisioner
-# config. Recipe: https://docs.hiero.org/block-node-overview/block-node-hardware-specifications/solo-weaver-single-node-k8s-deployment
+# Pair with `previewnet-lfh-provisioner-config-smoketest.yaml`. Use only with
+# `--skip-hardware-checks`; see that file's header for the full command.
 #
-# Key sizing decisions vs the mainnet reference (lfh-values.yaml):
-#   * JVM heap 16 GB (mainnet uses 192 GB). e2-standard-16 has ~32 GB RAM;
-#     leaving ~16 GB for the OS + other pods + PVC page cache.
-#   * Resources 8 CPU / 20 Gi (mainnet uses 24 CPU / 212 Gi).
-#   * loadBalancer enabled + MetalLB address-pool wired to `public-address-pool`
-#     so external subscribers reach the BN at <VM-external-IP>:40840 directly.
-#     Solo Provisioner installs MetalLB during a fresh install; this Service
-#     annotation picks up the pool it configures.
+# JVM / resources scaled up compared to the e2-standard-16 assumption in
+# previewnet-lfh-values.yaml, because the smoke-test box actually has 256 GB
+# RAM available -- leaving that unused would starve the JVM for no reason.
 
 blockNode:
     config:
         BACKFILL_GREEDY: "true"
         BACKFILL_BLOCK_NODE_SOURCES_PATH: "/opt/hiero/block-node/backfill/block-node-sources.json"
-        JAVA_OPTS: "-Xms16G -Xmx16G -XX:+ZGenerational"
+        # Bigger heap than the e2-standard-16-tuned values.yaml because this
+        # host has 256 GB RAM; leaving room for OS + Kubernetes + page cache.
+        JAVA_OPTS: "-Xms96G -Xmx96G -XX:+ZGenerational"
         PROMETHEUS_ENDPOINT_ENABLED: true
         PROMETHEUS_ENDPOINT_PORT_NUMBER: "16007"
         ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL: "https://previewnet.mirrornode.hedera.com"
@@ -82,11 +78,10 @@ blockNode:
         health: 40983       # HEALTH_PORT       — HTTP, /healthz endpoints
         serverStatus: 40982 # SERVER_STATUS_PORT — HTTP, server-status endpoint
 
-# LoadBalancer enabled: Solo Provisioner installs MetalLB during a fresh
-# install and the previewnet VM has a public IP, so we let external
-# subscribers hit the BN at <VM-external-IP>:40840 directly (no
-# kubectl port-forward needed). The metallb.io/address-pool annotation on
-# service.annotations pairs this Service with MetalLB's public pool.
+# LoadBalancer enabled (team decision, 2026-07-30): the smoke-test box has a
+# public IP too, and Solo Provisioner installs MetalLB during a fresh install.
+# Match the main previewnet-lfh-values.yaml's LB shape so this smoke-test
+# variant differs from the main file ONLY in JVM heap + storage sizing.
 loadBalancer:
     enabled: true
     port: "40840"
@@ -95,11 +90,11 @@ loadBalancer:
 
 resources:
     requests:
-        cpu: "8"
-        memory: "20Gi"
+        cpu: "16"
+        memory: "128Gi"
     limits:
-        cpu: "8"
-        memory: "20Gi"
+        cpu: "16"
+        memory: "128Gi"
 
 service:
     type: ClusterIP

--- a/charts/block-node-server/values-overrides/previewnet-lfh-values-smoketest.yaml
+++ b/charts/block-node-server/values-overrides/previewnet-lfh-values-smoketest.yaml
@@ -54,24 +54,26 @@ blockNode:
                   - name: logging-storage
                     mountPath: /logging-pvc
 
-        # PVCs chart-provisioned from the default StorageClass; see the same
-        # comment in previewnet-lfh-values.yaml for the rationale. Without
-        # this, mounts silently degrade to ephemeral rootfs -- confirmed on
-        # this smoke-test box: 173 GB of tar-streamed historic blocks were
-        # wiped by the post-backfill pod restart.
+        # PVCs pre-provisioned by Solo Provisioner (5 PVs at fixed names,
+        # hostPath-backed on the VM disk). Seed with
+        # `backfill-wrb-to-bn.sh --pre-install` before first pod start;
+        # see the same comment in previewnet-lfh-values.yaml.
         persistence:
             live:
-                create: true
+                create: false
+                existingClaim: live-storage-pvc
                 subPath: ""
             archive:
-                create: true
+                create: false
+                existingClaim: archive-storage-pvc
                 subPath: ""
             logging:
-                create: true
+                create: false
+                existingClaim: logging-storage-pvc
                 subPath: ""
             applicationState:
-                create: true
-                subPath: ""
+                create: false
+                existingClaim: application-state-storage-pvc
 
     ports:
         publisher: 40984    # PRODUCER_PORT     — gRPC, block producers

--- a/charts/block-node-server/values-overrides/previewnet-lfh-values-smoketest.yaml
+++ b/charts/block-node-server/values-overrides/previewnet-lfh-values-smoketest.yaml
@@ -83,15 +83,12 @@ blockNode:
 # Match the main previewnet-lfh-values.yaml's LB shape so this smoke-test
 # variant differs from the main file ONLY in JVM heap + storage sizing.
 #
-# includePluginPorts: true is REQUIRED under the split-port setup below --
-# see the same comment in previewnet-lfh-values.yaml for the full rationale
-# (short version: 40840 alone answers plain HTTP, not gRPC; the split-port
-# setup routes gRPC to per-plugin ports 40980-40984 that this flag exposes
-# on the external Service).
+# Same chart-0.37.1 limitation as the main file: LB only publishes 40840
+# (plain HTTP under the split-port setup). External gRPC probing requires
+# kubectl port-forward against the ClusterIP Service on the plugin port.
 loadBalancer:
     enabled: true
     port: "40840"
-    includePluginPorts: true
     annotations:
         metallb.io/address-pool: public-address-pool
 

--- a/charts/block-node-server/values-overrides/previewnet-lfh-values.yaml
+++ b/charts/block-node-server/values-overrides/previewnet-lfh-values.yaml
@@ -58,22 +58,28 @@ blockNode:
                   - name: logging-storage
                     mountPath: /logging-pvc
 
+        # PVCs: chart-provisioned from the cluster's default StorageClass.
+        # The mainnet reference (lfh-values.yaml) uses `create: false` +
+        # `existingClaim: <name>-pvc` because production Tier 1 hosts have
+        # pre-provisioned static PVs backing dedicated disks. For a
+        # Solo-Provisioner single-VM deployment we have no such prep step,
+        # so `create: true` is required -- without it the mounts silently
+        # degrade to the pod's ephemeral rootfs, and any tar-streamed
+        # historic blocks get wiped on the next pod restart (which
+        # BlockFileHistoricPlugin's re-scan triggers).
         persistence:
             live:
-                create: false
-                existingClaim: live-storage-pvc
+                create: true
                 subPath: ""
             archive:
-                create: false
-                existingClaim: archive-storage-pvc
+                create: true
                 subPath: ""
             logging:
-                create: false
-                existingClaim: logging-storage-pvc
+                create: true
                 subPath: ""
             applicationState:
-                create: false
-                existingClaim: application-state-storage-pvc
+                create: true
+                subPath: ""
 
     ports:
         publisher: 40984    # PRODUCER_PORT     — gRPC, block producers

--- a/charts/block-node-server/values-overrides/previewnet-lfh-values.yaml
+++ b/charts/block-node-server/values-overrides/previewnet-lfh-values.yaml
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Helm values override for a previewnet Tier 1 Local-Full-History Block Node
+# deployed on a single GCP e2-standard-16 VM (16 vCPUs, ≥32 GB RAM).
+#
+# Derived from `lfh-values.yaml` (mainnet-shaped), right-sized down for
+# previewnet's per-day block volume and the single-VM shape. See
+# `previewnet-lfh-provisioner-config.yaml` for the paired Solo Provisioner
+# config. Recipe: https://docs.hiero.org/block-node-overview/block-node-hardware-specifications/solo-weaver-single-node-k8s-deployment
+#
+# Key sizing decisions vs the mainnet reference (lfh-values.yaml):
+#   * JVM heap 16 GB (mainnet uses 192 GB). e2-standard-16 has ~32 GB RAM;
+#     leaving ~16 GB for the OS + other pods + PVC page cache.
+#   * Resources 8 CPU / 20 Gi (mainnet uses 24 CPU / 212 Gi).
+#   * loadBalancer disabled by default -- the previewnet single-VM setup uses
+#     kubectl port-forward for external access. Turn on `loadBalancer.enabled`
+#     + set MetalLB address-pool if the VM has a proper external IP wired up.
+
+blockNode:
+    config:
+        BACKFILL_GREEDY: "true"
+        BACKFILL_BLOCK_NODE_SOURCES_PATH: "/opt/hiero/block-node/backfill/block-node-sources.json"
+        JAVA_OPTS: "-Xms16G -Xmx16G -XX:+ZGenerational"
+        PROMETHEUS_ENDPOINT_ENABLED: true
+        PROMETHEUS_ENDPOINT_PORT_NUMBER: "16007"
+        ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL: "https://previewnet.mirrornode.hedera.com"
+        SERVER_PORT: "40840"
+        logs:
+            level: "INFO"
+            loggingProperties:
+                org.hiero.block.level: "INFO"
+                java.util.logging.ConsoleHandler.level: "FINEST"
+                java.util.logging.FileHandler.level: "FINEST"
+
+        initContainers:
+            - name: init-storage-dirs
+              image: docker.io/library/busybox:latest
+              command:
+                  - sh
+                  - -c
+                  - |
+                      chown 2000:2000 /application-state-pvc && \
+                      chmod 700 /application-state-pvc && \
+                      chown 2000:2000 /archive-pvc && \
+                      chmod 700 /archive-pvc && \
+                      chown 2000:2000 /live-pvc && \
+                      chmod 700 /live-pvc && \
+                      chown 2000:2000 /logging-pvc && \
+                      chmod 700 /logging-pvc
+              volumeMounts:
+                  - name: application-state-storage
+                    mountPath: /application-state-pvc
+                  - name: archive-storage
+                    mountPath: /archive-pvc
+                  - name: live-storage
+                    mountPath: /live-pvc
+                  - name: logging-storage
+                    mountPath: /logging-pvc
+
+        persistence:
+            live:
+                create: false
+                existingClaim: live-storage-pvc
+                subPath: ""
+            archive:
+                create: false
+                existingClaim: archive-storage-pvc
+                subPath: ""
+            logging:
+                create: false
+                existingClaim: logging-storage-pvc
+                subPath: ""
+            applicationState:
+                create: false
+                existingClaim: application-state-storage-pvc
+
+    ports:
+        publisher: 40984    # PRODUCER_PORT     — gRPC, block producers
+        subscriber: 40980   # SUBSCRIBER_PORT   — gRPC, block subscribers
+        blockAccess: 40981  # BLOCK_ACCESS_PORT — gRPC/HTTP, block query API
+        health: 40983       # HEALTH_PORT       — HTTP, /healthz endpoints
+        serverStatus: 40982 # SERVER_STATUS_PORT — HTTP, server-status endpoint
+
+# Disabled by default for the single-VM shape. Turn on + configure MetalLB
+# address-pool if the previewnet VM has a public IP wired up and we want
+# external subscribers to reach the BN without kubectl port-forward.
+loadBalancer:
+    enabled: false
+    port: "40840"
+
+resources:
+    requests:
+        cpu: "8"
+        memory: "20Gi"
+    limits:
+        cpu: "8"
+        memory: "20Gi"
+
+service:
+    type: ClusterIP
+    port: 40840

--- a/charts/block-node-server/values-overrides/previewnet-lfh-values.yaml
+++ b/charts/block-node-server/values-overrides/previewnet-lfh-values.yaml
@@ -58,28 +58,34 @@ blockNode:
                   - name: logging-storage
                     mountPath: /logging-pvc
 
-        # PVCs: chart-provisioned from the cluster's default StorageClass.
-        # The mainnet reference (lfh-values.yaml) uses `create: false` +
-        # `existingClaim: <name>-pvc` because production Tier 1 hosts have
-        # pre-provisioned static PVs backing dedicated disks. For a
-        # Solo-Provisioner single-VM deployment we have no such prep step,
-        # so `create: true` is required -- without it the mounts silently
-        # degrade to the pod's ephemeral rootfs, and any tar-streamed
-        # historic blocks get wiped on the next pod restart (which
-        # BlockFileHistoricPlugin's re-scan triggers).
+        # PVCs are statically pre-provisioned by Solo Provisioner during
+        # `sudo solo-provisioner block node install` (5 PVs / 5 PVCs at
+        # fixed names, backed by hostPath directories on the VM's disk).
+        # This shape lets us seed the archive directly on the host
+        # filesystem before starting the BN -- see
+        # `tools-and-tests/tools/scripts/backfill-wrb-to-bn.sh --pre-install`
+        # for the seed workflow, which copies (or hard-links, when
+        # source and PV are on the same filesystem) a wrappedBlocks
+        # archive into the archive-storage-pv's host path prior to
+        # first pod start. On BN startup, BlockFileHistoricPlugin
+        # scans that pre-seeded archive and picks up the blocks with
+        # no pod restart or tar-stream overhead.
         persistence:
             live:
-                create: true
+                create: false
+                existingClaim: live-storage-pvc
                 subPath: ""
             archive:
-                create: true
+                create: false
+                existingClaim: archive-storage-pvc
                 subPath: ""
             logging:
-                create: true
+                create: false
+                existingClaim: logging-storage-pvc
                 subPath: ""
             applicationState:
-                create: true
-                subPath: ""
+                create: false
+                existingClaim: application-state-storage-pvc
 
     ports:
         publisher: 40984    # PRODUCER_PORT     — gRPC, block producers

--- a/charts/block-node-server/values-overrides/previewnet-lfh-values.yaml
+++ b/charts/block-node-server/values-overrides/previewnet-lfh-values.yaml
@@ -84,23 +84,22 @@ blockNode:
 
 # LoadBalancer enabled: Solo Provisioner installs MetalLB during a fresh
 # install and the previewnet VM has a public IP, so we let external
-# subscribers hit the BN at <VM-external-IP>:<port> directly (no
+# subscribers hit the BN at <VM-external-IP>:40840 directly (no
 # kubectl port-forward needed). The metallb.io/address-pool annotation on
 # service.annotations pairs this Service with MetalLB's public pool.
 #
-# includePluginPorts: true is REQUIRED under the split-port setup below,
-# which puts each API family on its own dedicated port (server-status on
-# 40982, publisher on 40984, subscriber on 40980, block-access on 40981,
-# health on 40983). The chart's default LB Service only exposes the
-# legacy 40840 port, which serves plain HTTP, not gRPC -- calls to
-# serverStatus on 40840 fail with "malformed header: missing HTTP
-# content-type" because the port is answering with HTTP framing on a
-# gRPC client. Enabling includePluginPorts appends all the plugin ports
-# so external gRPC clients can reach the right endpoint.
+# Known limitation on chart 0.37.1 (pinned in the paired provisioner-config
+# file): the LB Service only publishes port 40840, which under the split-
+# port setup below serves plain HTTP rather than gRPC. gRPC endpoints
+# (server-status on 40982, publisher on 40984, subscriber on 40980,
+# block-access on 40981) are reachable only via the in-cluster
+# ClusterIP Service today, i.e. kubectl port-forward for external
+# probing. Chart 0.38.0+ adds `loadBalancer.includePluginPorts: true`
+# which appends the plugin ports to the LB Service; revisit this file
+# once we bump the chart version pin.
 loadBalancer:
     enabled: true
     port: "40840"
-    includePluginPorts: true
     annotations:
         metallb.io/address-pool: public-address-pool
 

--- a/charts/block-node-server/values-overrides/previewnet-lfh-values.yaml
+++ b/charts/block-node-server/values-overrides/previewnet-lfh-values.yaml
@@ -84,12 +84,23 @@ blockNode:
 
 # LoadBalancer enabled: Solo Provisioner installs MetalLB during a fresh
 # install and the previewnet VM has a public IP, so we let external
-# subscribers hit the BN at <VM-external-IP>:40840 directly (no
+# subscribers hit the BN at <VM-external-IP>:<port> directly (no
 # kubectl port-forward needed). The metallb.io/address-pool annotation on
 # service.annotations pairs this Service with MetalLB's public pool.
+#
+# includePluginPorts: true is REQUIRED under the split-port setup below,
+# which puts each API family on its own dedicated port (server-status on
+# 40982, publisher on 40984, subscriber on 40980, block-access on 40981,
+# health on 40983). The chart's default LB Service only exposes the
+# legacy 40840 port, which serves plain HTTP, not gRPC -- calls to
+# serverStatus on 40840 fail with "malformed header: missing HTTP
+# content-type" because the port is answering with HTTP framing on a
+# gRPC client. Enabling includePluginPorts appends all the plugin ports
+# so external gRPC clients can reach the right endpoint.
 loadBalancer:
     enabled: true
     port: "40840"
+    includePluginPorts: true
     annotations:
         metallb.io/address-pool: public-address-pool
 

--- a/docs/block-node/operations/previewnet-tier1-lfh-seed-runbook.md
+++ b/docs/block-node/operations/previewnet-tier1-lfh-seed-runbook.md
@@ -1,0 +1,224 @@
+# Previewnet Tier 1 LFH — Deployment + Historic Seed Runbook
+
+## Overview
+
+This runbook covers deploying a Local-Full-History (LFH) Block Node to previewnet via Solo Provisioner and seeding it with a historical [Wrapped Record Block](../glossary.md#wrb-wrapped-record-block) (WRB) archive. Ties together the config from PR #3333 (previewnet Tier 1 values files) with the operational tooling from `backfill-wrb-to-bn.sh`.
+
+**Audience**: Operators standing up a previewnet Tier 1 Block Node for the first time, or seeding an existing empty install with historical blocks.
+
+**Scope**: Covers the T1 backfill portion of the WRB distribution operator runbook (part of #2961). Does not cover T2 live-push, T3 address-book conversion, or T4 roster/TSS configuration.
+
+---
+
+## Prerequisites
+
+- GCP VM (or equivalent) provisioned per [Solo Weaver Single-Node K8s Deployment](./solo-weaver-single-node-k8s-deployment.md)
+- `sudo solo-provisioner -v` returns a version string on the VM
+- `kubectl` on PATH, current context pointed at the target cluster
+- `java` on PATH (JDK 25+)
+- A shaded tools jar (`tools-*-all.jar`) staged on the VM
+- A local WRB archive directory to seed from
+- The 4 values/config files from PR #3333 staged on the VM:
+  - `previewnet-lfh-provisioner-config.yaml` (or the `-smoketest` variant)
+  - `previewnet-lfh-values.yaml` (or the `-smoketest` variant)
+- `previewnet-lfh-static-pvs.yaml` if the target cluster does not have a default `StorageClass` (see [Footgun 1](#footgun-1-persistencecreate-true-requires-a-default-storageclass) below)
+
+---
+
+## Fresh install + seed (recommended)
+
+### Step 1. Pre-provision static PVs (single-node clusters only)
+
+If the target cluster does not have a default `StorageClass` (Solo Provisioner's stock previewnet install does not), pre-apply the static PVs before running `solo-provisioner install`. Otherwise the chart's `volumeClaimTemplate` PVCs stay `Pending` forever and the BN pod cannot schedule.
+
+```bash
+kubectl apply -f previewnet-lfh-static-pvs.yaml
+```
+
+Verify PVs are `Available`:
+
+```bash
+kubectl get pv | grep pv-static
+```
+
+### Step 2. Install the Block Node
+
+**Production shape** (properly-sized VM, 3 TB+ disk):
+
+```bash
+sudo solo-provisioner block node install \
+  -p previewnet \
+  --config previewnet-lfh-provisioner-config.yaml \
+  --values previewnet-lfh-values.yaml \
+  --non-interactive
+```
+
+**Smoke-test shape** (smaller-disk VM):
+
+```bash
+sudo solo-provisioner block node install \
+  -p previewnet \
+  --config previewnet-lfh-provisioner-config-smoketest.yaml \
+  --values previewnet-lfh-values-smoketest.yaml \
+  --skip-hardware-checks \
+  --non-interactive
+```
+
+Verify install completed:
+
+```bash
+kubectl get pods -n block-node
+kubectl get pvc -n block-node
+```
+
+Expected: pod `1/1 Running`, 5 PVCs `Bound`.
+
+### Step 3. Seed the historic archive
+
+Scale the BN down (the seed writes to the archive PV directly and must not race the running pod):
+
+```bash
+kubectl scale statefulset/block-node-block-node-server --replicas=0 -n block-node
+```
+
+Wait for pod termination, then run the backfill:
+
+```bash
+CLI_JAR=/path/to/tools-*-all.jar \
+sudo -E ./backfill-wrb-to-bn.sh --install-and-seed \
+  --profile previewnet \
+  --config previewnet-lfh-provisioner-config-smoketest.yaml \
+  --values previewnet-lfh-values-smoketest.yaml \
+  /path/to/wrappedBlocks
+```
+
+The script runs `blocks bulk-load` to stage the archive, hard-links (or copies, if cross-filesystem) into the archive PV's hostPath, and chowns to `2000:2000` (the BN's runtime user).
+
+### Step 4. Move seeded files into the `archive-data/` subdir
+
+**Required manual step** because the chart's `archive-storage` volumeMount uses `subPath: archive-data`, so the pod reads from `<pv-hostpath>/archive-data/` rather than `<pv-hostpath>/` (see [Footgun 2](#footgun-2-subpath-mismatch-in-the-backfill-script)):
+
+```bash
+cd /mnt/fast-storage/block-node/archive
+sudo bash -c 'for e in *; do [ "$e" != "archive-data" ] && mv "$e" archive-data/; done'
+sudo chown -R 2000:2000 archive-data
+```
+
+### Step 5. Scale the BN back up
+
+```bash
+kubectl scale statefulset/block-node-block-node-server --replicas=1 -n block-node
+```
+
+Wait ~30s for the pod to become `1/1 Ready`. Check for crashes:
+
+```bash
+kubectl get pod -n block-node
+```
+
+If `RESTARTS > 0`, see [Footgun 3](#footgun-3-plugin-crash-loop-on-single-corrupt-zip).
+
+### Step 6. Verify blocks are served
+
+```bash
+kubectl port-forward -n block-node svc/block-node-block-node-server 18082:40982 &
+sleep 3
+grpcurl -plaintext -emit-defaults \
+  -import-path /path/to/block-node-protobuf-<version> \
+  -proto block-node/api/node_service.proto \
+  -d '{}' \
+  localhost:18082 org.hiero.block.api.BlockNodeService/serverStatus
+```
+
+Expected shape after a successful seed:
+
+```json
+{
+  "firstAvailableBlock": "0",
+  "lastAvailableBlock": "<highest block number in the seeded archive>",
+  "onlyLatestState": false,
+  "nextExpectedBlock": "0"
+}
+```
+
+The BN startup log should also show the range populated:
+
+```
+Started BlockNode Server : State=RUNNING HistoricBlockRange=0->1699999
+```
+
+If `serverStatus` returns `firstAvailableBlock: "18446744073709551615"` (UINT64_MAX sentinel), the plugin scanned an empty archive — the seed data is likely at the volume root instead of `archive-data/`. Re-run Step 4.
+
+---
+
+## Operational footguns
+
+Non-obvious behaviors an operator will encounter. Working around each is documented; upstream fixes are tracked as separate follow-up issues.
+
+### Footgun 1: `persistence.create: true` requires a default StorageClass
+
+**Symptom**: after `solo-provisioner install`, `kubectl get pvc -n block-node` shows all 5 chart-provisioned PVCs (`*-storage-block-node-block-node-server-0`) `Pending`, and the pod is stuck at `Pending` with scheduling event `pod has unbound immediate PersistentVolumeClaims`.
+
+**Cause**: the values file sets `persistence.*.create: true`, which asks the chart to provision PVCs via the cluster's default `StorageClass`. Solo Provisioner's stock previewnet install does not create a default `StorageClass`, so no `PersistentVolume` is ever produced to bind those PVCs to.
+
+**Fix**: apply `previewnet-lfh-static-pvs.yaml` (Step 1 above) BEFORE `solo-provisioner install`. The 5 PVs in that file are pre-bound (`spec.claimRef`) to the exact PVC names the chart's volumeClaimTemplate generates, so they bind on creation.
+
+**Upstream fix pending**: install `local-path-provisioner` (or equivalent) into Solo Provisioner's default cluster setup so `persistence.create: true` works out of the box.
+
+### Footgun 2: subPath mismatch in the backfill script
+
+**Symptom**: after running `backfill-wrb-to-bn.sh` and starting the BN, `serverStatus` returns `firstAvailableBlock: "18446744073709551615"` (UINT64_MAX sentinel) even though the seed reported success. The startup log shows `HistoricBlockRange=` (empty).
+
+**Cause**: the chart's `archive-storage` volumeMount includes `subPath: archive-data`, so the pod's `/opt/hiero/block-node/data/historic` is backed by `<pv-hostpath>/archive-data/` (a subdirectory of the PV) rather than the PV root. The backfill script writes to the PV root, one level above where the pod actually reads.
+
+The values file explicitly sets `subPath: ""` for the archive volume, but the effective pod spec still shows `subPath: archive-data`. Either the chart template ignores the values-file override, or applies a hardcoded default that clobbers it.
+
+**Fix**: after the script completes and BEFORE bringing the BN back up, move the seeded files into the `archive-data/` subdir (Step 4 above).
+
+**Upstream fix pending**: chart template should either honor the values-file `subPath: ""` override, or the backfill script should be aware of the effective `subPath` and write to the correct location directly.
+
+### Footgun 3: plugin crash-loop on single corrupt zip
+
+**Symptom**: after seeding, the pod initially starts fine (1/1 Ready, `HistoricBlockRange` populated in the startup log). On the NEXT restart (helm upgrade, pod delete, node reboot) it enters `CrashLoopBackOff` with this exception:
+
+```
+Exception in thread "main" java.lang.IllegalStateException:
+  First zipped block number [0] cannot be greater than the latest zipped block number [-1]
+    at BlockFileHistoricPlugin.init(BlockFileHistoricPlugin.java:181)
+```
+
+**Cause**: during the first successful startup, `BlockFileHistoricPlugin` scans the archive and detects any content-corrupt zip files (valid ZIP structure, but internal block data unreadable). Corrupt files are moved to a `corrupted/` quarantine subdirectory. The quarantine leaves three artifacts that trip up subsequent inits:
+
+1. `corrupted/` subdirectory inside the historic dir (walked by the plugin as if it were part of the archive)
+2. An empty leaf directory where the quarantined file used to live (e.g., `000/000/000/000/17/`)
+3. A stale `historic-plugin-bulk-load-state.json` file left over from the bulk-load tool
+
+Any of these three can make `maxStoredBlockNumber` return `-1` on subsequent init, which triggers the fatal `firstBlock (0) > latestBlock (-1)` check.
+
+**Fix**: scale down, remove all three artifacts, scale back up:
+
+```bash
+kubectl scale statefulset/block-node-block-node-server --replicas=0 -n block-node
+
+# Wait for pod to terminate, then clean up:
+sudo rm -rf /mnt/fast-storage/block-node/archive/archive-data/corrupted
+sudo rmdir /mnt/fast-storage/block-node/archive/archive-data/000/000/000/000/<empty-leaf>
+sudo rm /mnt/fast-storage/block-node/archive/archive-data/historic-plugin-bulk-load-state.json
+
+kubectl scale statefulset/block-node-block-node-server --replicas=1 -n block-node
+```
+
+After cleanup the plugin comes up cleanly and serves the (170-out-of-171) valid blocks. The single corrupt file's block range (e.g., blocks 170000–179999 for `17/00000.zip`) is missing from the archive — the BN can still fill that gap via live backfill from Tier 0 once wired up.
+
+**Upstream fix pending**: `BlockFileHistoricPlugin.init()` should be resilient to (a) the `corrupted/` subdirectory in the walk, (b) empty leaf directories left by quarantine, and (c) stale state files from the bulk-load tool. One bad file in a 171-file archive should not permanently prevent the BN from starting.
+
+---
+
+## Reference
+
+- Deployment shape and hardware guidance: [Solo Weaver Single-Node K8s Deployment](./solo-weaver-single-node-k8s-deployment.md)
+- WRB CLI operations (produce/wrap/validate WRB archives): [WRB CLI Runbook](./wrb-cli-runbook.md)
+- Preparing a BN for WRB cutover: [Preparing Your Block Node for WRB Cutover](./preparing-your-block-node-for-wrb-cutover.md)
+- WRB streaming design: [Special-purpose WRB BN design](../../design/wrb-streaming/sp-wrb-bn-design.md)
+- Backfill script source: `tools-and-tests/tools/scripts/backfill-wrb-to-bn.sh`
+- Static PVs YAML: `charts/block-node-server/values-overrides/previewnet-lfh-static-pvs.yaml`

--- a/docs/block-node/operations/wrb-seed-runbook.md
+++ b/docs/block-node/operations/wrb-seed-runbook.md
@@ -1,10 +1,10 @@
-# Previewnet Tier 1 LFH — Deployment + Historic Seed Runbook
+# WRB Seeding Runbook
 
 ## Overview
 
-This runbook covers deploying a Local-Full-History (LFH) Block Node to previewnet via Solo Provisioner and seeding it with a historical [Wrapped Record Block](../glossary.md#wrb-wrapped-record-block) (WRB) archive. Ties together the config from PR #3333 (previewnet Tier 1 values files) with the operational tooling from `backfill-wrb-to-bn.sh`.
+This runbook covers deploying a Local-Full-History (LFH) Block Node via Solo Provisioner and seeding it with a historical [Wrapped Record Block](../glossary.md#wrb-wrapped-record-block) (WRB) archive. The procedure applies to any environment (previewnet, testnet, mainnet) that uses the single-node Solo-Provisioner deployment shape; examples below use previewnet paths and values files, but substituting the equivalent `<env>-lfh-*.yaml` files and `<env>` profile targets the same steps at testnet or mainnet.
 
-**Audience**: Operators standing up a previewnet Tier 1 Block Node for the first time, or seeding an existing empty install with historical blocks.
+**Audience**: Operators standing up a Tier 1 Block Node for the first time, or seeding an existing empty install with historical blocks.
 
 **Scope**: Covers the T1 backfill portion of the WRB distribution operator runbook (part of #2961). Does not cover T2 live-push, T3 address-book conversion, or T4 roster/TSS configuration.
 

--- a/tools-and-tests/tools/scripts/backfill-wrb-to-bn.sh
+++ b/tools-and-tests/tools/scripts/backfill-wrb-to-bn.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# backfill-wrb-to-bn.sh — Bulk-load a local wrapped-block archive into a
+# deployed Block Node's historic-storage directory, then roll the StatefulSet
+# so the BN's `BlockFileHistoricPlugin` re-scans and picks up the copied files.
+#
+# Use this instead of `blocks push` (gRPC publish stream) whenever you're
+# seeding an EMPTY BN from historical data. The live publish path is a
+# single-slot-per-block-number CAS meant for freshly-produced blocks and
+# silently SKIPs anything that loses the race, which will bite on any block
+# that a peer producer has already streamed (typical on real networks). The
+# `blocks bulk-load` subcommand exists for exactly this case: it copies WRB
+# zips directly into the BN's on-disk historic archive, bypassing live-stream
+# verification entirely.
+#
+# Works against any deployed Block Node addressable via kubectl -- Tier 0 or
+# Tier 1, mainnet / testnet / previewnet / a local kind cluster / etc. Defaults
+# match the shape produced by `sudo solo-provisioner block node install`
+# (namespace `block-node`, release `block-node`, chart mount path
+# `/opt/hiero/block-node/data/historic`); override via env vars for other
+# deployment shapes.
+#
+# Prerequisites:
+#   * `kubectl` on PATH, current context pointed at the target cluster
+#     (or override via BN_KUBE_CONTEXT)
+#   * `java` on PATH
+#   * A shaded wrb-cli jar (`tools-*-all.jar`) on disk -- point at it with CLI_JAR
+#   * A local directory of wrapped blocks (the output of `blocks wrap`)
+#
+# Usage:
+#   ./backfill-wrb-to-bn.sh <path-to-wrappedBlocks-dir>
+#
+# Environment overrides:
+#   BN_KUBE_CONTEXT      kubectl context           (default: current context)
+#   BN_NAMESPACE         Kubernetes namespace      (default: block-node)
+#   BN_STATEFULSET       StatefulSet name          (default: block-node-block-node-server)
+#   BN_POD               Pod name                  (default: <BN_STATEFULSET>-0)
+#   BN_CONTAINER         Container name in pod     (default: block-node-server)
+#   HISTORIC_MOUNT_PATH  On-pod historic dir       (default: /opt/hiero/block-node/data/historic)
+#   STAGING_DIR          Local staging dir         (default: /tmp/bn-backfill-<pid>)
+#   CLI_JAR              Path to wrb-cli jar       (default: hunts tools-*-all.jar)
+#   READY_TIMEOUT        Pod-ready wait (seconds)  (default: 300)
+#   SKIP_ROLLOUT         "true" to skip the pod    (default: false)
+#                        restart step
+#   KEEP_STAGING         "true" to keep the local  (default: false)
+#                        staging dir on success
+#
+# Example (previewnet Tier 1 deployed via Solo Provisioner):
+#   ./backfill-wrb-to-bn.sh ~/wrappedBlocks
+#
+# Example (custom deployment shape, non-standard namespace + container):
+#   BN_NAMESPACE=my-bn \
+#   BN_STATEFULSET=my-bn-server \
+#   BN_CONTAINER=bn \
+#   ./backfill-wrb-to-bn.sh /mnt/archive/wrappedBlocks
+
+set -euo pipefail
+
+# --- Config ---
+: "${BN_KUBE_CONTEXT:=}"                                              # empty -> use current
+: "${BN_NAMESPACE:=block-node}"
+: "${BN_STATEFULSET:=block-node-block-node-server}"
+: "${BN_POD:=${BN_STATEFULSET}-0}"
+: "${BN_CONTAINER:=block-node-server}"
+: "${HISTORIC_MOUNT_PATH:=/opt/hiero/block-node/data/historic}"
+: "${STAGING_DIR:=/tmp/bn-backfill-$$}"
+: "${READY_TIMEOUT:=300}"
+: "${SKIP_ROLLOUT:=false}"
+: "${KEEP_STAGING:=false}"
+
+# --- Logging ---
+log()  { echo "[backfill-wrb-to-bn] $*"; }
+fail() { echo "[backfill-wrb-to-bn] ERROR: $*" >&2; exit 1; }
+
+# --- Argument parsing ---
+[[ $# -ge 1 ]] || fail "usage: $0 <path-to-wrappedBlocks-dir>"
+WRB_SOURCE_DIR="$1"
+[[ -d "${WRB_SOURCE_DIR}" ]] || fail "wrappedBlocks dir does not exist: ${WRB_SOURCE_DIR}"
+
+# --- Locate the wrb-cli jar ---
+if [[ -z "${CLI_JAR:-}" ]]; then
+    # Prefer explicit location next to this script (built via ./gradlew :tools:shadowJar)
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    candidate=$(ls "${script_dir}/../build/libs/"tools-*-all.jar 2>/dev/null | head -1 || true)
+    if [[ -z "${candidate}" ]]; then
+        candidate=$(command -v tools-cli || ls tools-*-all.jar 2>/dev/null | head -1 || true)
+    fi
+    [[ -n "${candidate}" ]] || fail "wrb-cli jar not found; set CLI_JAR=<path> to override"
+    CLI_JAR="${candidate}"
+fi
+[[ -f "${CLI_JAR}" ]] || fail "CLI_JAR does not exist: ${CLI_JAR}"
+
+# --- kubectl invocation prefix (context + namespace) ---
+kctl=(kubectl --namespace "${BN_NAMESPACE}")
+[[ -n "${BN_KUBE_CONTEXT}" ]] && kctl+=(--context "${BN_KUBE_CONTEXT}")
+
+log "Config:"
+log "  source WRB dir:        ${WRB_SOURCE_DIR}"
+log "  staging dir:           ${STAGING_DIR}"
+log "  CLI jar:               ${CLI_JAR}"
+log "  kubectl context:       ${BN_KUBE_CONTEXT:-<current>}"
+log "  namespace:             ${BN_NAMESPACE}"
+log "  target pod:            ${BN_POD} (container ${BN_CONTAINER})"
+log "  target statefulset:    ${BN_STATEFULSET}"
+log "  historic mount path:   ${HISTORIC_MOUNT_PATH}"
+
+# --- Preflight ---
+command -v kubectl >/dev/null || fail "kubectl not on PATH"
+command -v java >/dev/null || fail "java not on PATH"
+
+log "Preflight: verifying target pod ${BN_POD} is Ready..."
+"${kctl[@]}" get pod "${BN_POD}" >/dev/null || fail "pod ${BN_POD} not found in namespace ${BN_NAMESPACE}"
+"${kctl[@]}" wait --for=condition=Ready pod/"${BN_POD}" --timeout=60s \
+    || fail "pod ${BN_POD} not Ready within 60s; aborting before we stage anything"
+
+# --- Stage via `blocks bulk-load` ---
+log "Staging wrapped blocks via 'blocks bulk-load' (${WRB_SOURCE_DIR} -> ${STAGING_DIR})..."
+mkdir -p "${STAGING_DIR}"
+java -jar "${CLI_JAR}" blocks bulk-load \
+    --source "${WRB_SOURCE_DIR}" \
+    --dest   "${STAGING_DIR}" \
+    || fail "'blocks bulk-load' staging failed"
+
+if [[ -z "$(find "${STAGING_DIR}" -name '*.zip' -print -quit 2>/dev/null)" ]]; then
+    fail "no .zip files staged in ${STAGING_DIR}; nothing to backfill"
+fi
+staged_count=$(find "${STAGING_DIR}" -name '*.zip' | wc -l)
+log "Staged ${staged_count} zip file(s) into ${STAGING_DIR}."
+
+# --- Stream into the pod via tar | kubectl exec ---
+log "Streaming staged blocks into ${BN_POD}:${HISTORIC_MOUNT_PATH}..."
+"${kctl[@]}" exec "${BN_POD}" -c "${BN_CONTAINER}" -- mkdir -p "${HISTORIC_MOUNT_PATH}" \
+    || fail "failed to ensure ${HISTORIC_MOUNT_PATH} exists on ${BN_POD}"
+tar -C "${STAGING_DIR}" -cf - . | \
+    "${kctl[@]}" exec -i "${BN_POD}" -c "${BN_CONTAINER}" -- \
+    tar xf - -C "${HISTORIC_MOUNT_PATH}" \
+    || fail "failed to stream staged blocks into ${BN_POD}"
+log "Blocks copied onto ${BN_POD}'s persistent historic volume."
+
+# --- Roll the StatefulSet so BlockFileHistoricPlugin re-scans ---
+if [[ "${SKIP_ROLLOUT}" == "true" ]]; then
+    log "SKIP_ROLLOUT=true; not rolling the StatefulSet. The BN will pick up the new"
+    log "historic files on its next natural restart. If you don't want to wait, run:"
+    log "  kubectl rollout restart statefulset/${BN_STATEFULSET} -n ${BN_NAMESPACE}"
+else
+    log "Rolling statefulset/${BN_STATEFULSET} so BlockFileHistoricPlugin re-scans..."
+    "${kctl[@]}" rollout restart statefulset/"${BN_STATEFULSET}" \
+        || fail "rollout restart failed for statefulset/${BN_STATEFULSET}"
+    "${kctl[@]}" rollout status statefulset/"${BN_STATEFULSET}" --timeout="${READY_TIMEOUT}s" \
+        || fail "statefulset/${BN_STATEFULSET} rollout did not complete within ${READY_TIMEOUT}s"
+    "${kctl[@]}" wait --for=condition=Ready pod/"${BN_POD}" --timeout="${READY_TIMEOUT}s" \
+        || fail "${BN_POD} did not become Ready after restart"
+    log "${BN_POD} is Ready after rollout."
+fi
+
+# --- Cleanup ---
+if [[ "${KEEP_STAGING}" == "true" ]]; then
+    log "KEEP_STAGING=true; leaving staging dir at ${STAGING_DIR}"
+else
+    rm -rf "${STAGING_DIR}"
+    log "Removed staging dir ${STAGING_DIR}."
+fi
+
+log "Backfill complete. Verify the BN sees the new blocks with:"
+log "  kubectl port-forward -n ${BN_NAMESPACE} svc/${BN_STATEFULSET} 18082:40982 &"
+log "  grpcurl -plaintext -emit-defaults \\"
+log "    -import-path <path-to-block-node-protobuf> \\"
+log "    -proto block-node/api/node_service.proto \\"
+log "    -d '{}' localhost:18082 org.hiero.block.api.BlockNodeService/serverStatus"
+log "Expect: firstAvailableBlock / lastAvailableBlock now show real block numbers"
+log "(no longer UINT64_MAX sentinel 18446744073709551615)."

--- a/tools-and-tests/tools/scripts/backfill-wrb-to-bn.sh
+++ b/tools-and-tests/tools/scripts/backfill-wrb-to-bn.sh
@@ -1,172 +1,441 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# backfill-wrb-to-bn.sh — Bulk-load a local wrapped-block archive into a
-# deployed Block Node's historic-storage directory, then roll the StatefulSet
-# so the BN's `BlockFileHistoricPlugin` re-scans and picks up the copied files.
+# backfill-wrb-to-bn.sh -- seed a Block Node deployment with a local
+# wrappedBlocks archive. Three modes:
 #
-# Use this instead of `blocks push` (gRPC publish stream) whenever you're
-# seeding an EMPTY BN from historical data. The live publish path is a
-# single-slot-per-block-number CAS meant for freshly-produced blocks and
-# silently SKIPs anything that loses the race, which will bite on any block
-# that a peer producer has already streamed (typical on real networks). The
-# `blocks bulk-load` subcommand exists for exactly this case: it copies WRB
-# zips directly into the BN's on-disk historic archive, bypassing live-stream
-# verification entirely.
+#   --install-and-seed
+#                   (recommended one-shot for a fresh box)
+#                   Runs `sudo solo-provisioner block node install` to
+#                   create the PVCs + everything, immediately scales the
+#                   StatefulSet to 0 so nothing writes to the archive
+#                   PVC yet, seeds via the pre-install flow, then scales
+#                   the StatefulSet back to 1. Operator ends up with a
+#                   BN serving pre-seeded historical blocks after one
+#                   script invocation. Requires --config and --values
+#                   files (passed through to solo-provisioner).
 #
-# Works against any deployed Block Node addressable via kubectl -- Tier 0 or
-# Tier 1, mainnet / testnet / previewnet / a local kind cluster / etc. Defaults
-# match the shape produced by `sudo solo-provisioner block node install`
-# (namespace `block-node`, release `block-node`, chart mount path
-# `/opt/hiero/block-node/data/historic`); override via env vars for other
-# deployment shapes.
+#   --pre-install   (recommended when Solo Provisioner has already been
+#                    invoked but the BN pod is scaled down / absent)
+#                   Copy WRB zips directly into the PV's host-path
+#                   backing BEFORE the BN pod starts. The BN then picks
+#                   them up on first startup via BlockFileHistoricPlugin's
+#                   scan, with no pod restart, no wipe risk, and hard-link
+#                   speed when the source and PV share a filesystem.
+#                   Requires the PVCs pre-provisioned + bound but the BN
+#                   pod not yet running.
+#
+#   --post-install  Legacy path -- tar-stream into a running pod, roll the
+#                   StatefulSet, plugin re-scans on restart. Only safe when
+#                   the archive PVC is real (mounted as a proper volume);
+#                   silently loses data when the mount degrades to the
+#                   pod's ephemeral rootfs.
+#
+#   (default: auto-detect -- pre-install if pod isn't Running, else
+#   post-install. --install-and-seed must be explicit.)
+#
+# Pre-install flow (the fast, safe one):
+#
+#   1. Preflight: PVCs exist + Bound; StatefulSet is scaled 0 (or missing).
+#   2. Locate the archive PV's host path via `kubectl get pv <name> -o
+#      jsonpath='{.spec.hostPath.path}{.spec.local.path}'`.
+#   3. Stage via `blocks bulk-load` (uses the CLI's own file selection +
+#      resumability) into a staging dir on the same filesystem as the PV
+#      host path (so step 4 can hard-link).
+#   4. Copy the staged files into the PV host path -- `cp -al` when the
+#      staging and PV paths are on the same filesystem (near-instant, no
+#      double space), `cp -r` otherwise. Chown to hedera:hedera (UID/GID
+#      2000, the BN's runtime user).
+#   5. Print the "next: install the BN" instruction. The script deliberately
+#      does NOT start the BN itself -- deploy mechanics (Solo Provisioner
+#      vs plain Helm) are the operator's call.
+#
+# Post-install flow (the tar-stream path):
+#
+#   1. Preflight: pod Ready.
+#   2. Stage via `blocks bulk-load` into a local staging dir.
+#   3. `tar -C <staging> -cf - . | kubectl exec -i ... -- tar xf - -C
+#      <historic-mount>`.
+#   4. `kubectl rollout restart statefulset/...`, wait for pod Ready.
+#   5. Cleanup + verification instructions.
 #
 # Prerequisites:
-#   * `kubectl` on PATH, current context pointed at the target cluster
+#   * `kubectl` on PATH; current context pointed at the target cluster
 #     (or override via BN_KUBE_CONTEXT)
 #   * `java` on PATH
-#   * A shaded wrb-cli jar (`tools-*-all.jar`) on disk -- point at it with CLI_JAR
-#   * A local directory of wrapped blocks (the output of `blocks wrap`)
+#   * A shaded wrb-cli jar (`tools-*-all.jar`) findable, or set CLI_JAR
+#   * For --pre-install: root or hedera-owned write access to the PV host
+#     path (script uses `sudo` for the copy + chown if not already root)
 #
 # Usage:
-#   ./backfill-wrb-to-bn.sh <path-to-wrappedBlocks-dir>
+#   ./backfill-wrb-to-bn.sh [--pre-install|--post-install] <wrappedBlocks-dir>
 #
-# Environment overrides:
-#   BN_KUBE_CONTEXT      kubectl context           (default: current context)
-#   BN_NAMESPACE         Kubernetes namespace      (default: block-node)
-#   BN_STATEFULSET       StatefulSet name          (default: block-node-block-node-server)
-#   BN_POD               Pod name                  (default: <BN_STATEFULSET>-0)
-#   BN_CONTAINER         Container name in pod     (default: block-node-server)
-#   HISTORIC_MOUNT_PATH  On-pod historic dir       (default: /opt/hiero/block-node/data/historic)
-#   STAGING_DIR          Local staging dir         (default: /tmp/bn-backfill-<pid>)
-#   CLI_JAR              Path to wrb-cli jar       (default: hunts tools-*-all.jar)
-#   READY_TIMEOUT        Pod-ready wait (seconds)  (default: 300)
-#   SKIP_ROLLOUT         "true" to skip the pod    (default: false)
-#                        restart step
-#   KEEP_STAGING         "true" to keep the local  (default: false)
-#                        staging dir on success
+# Environment overrides (all modes):
+#   BN_KUBE_CONTEXT       kubectl context           (default: current context)
+#   BN_NAMESPACE          Kubernetes namespace      (default: block-node)
+#   BN_STATEFULSET        StatefulSet name          (default: block-node-block-node-server)
+#   BN_POD                Pod name                  (default: <BN_STATEFULSET>-0)
+#   BN_CONTAINER          Container name in pod     (default: block-node-server)
+#   STAGING_DIR           Local staging dir         (default: /tmp/bn-backfill-<pid>)
+#   CLI_JAR               Path to wrb-cli jar       (default: hunt for tools-*-all.jar)
 #
-# Example (previewnet Tier 1 deployed via Solo Provisioner):
-#   ./backfill-wrb-to-bn.sh ~/wrappedBlocks
+# --pre-install specific:
+#   ARCHIVE_PVC_NAME      PVC name for the archive  (default: archive-storage-pvc)
+#   FORCE_COPY            "true" -> always `cp -r`, (default: false, i.e.
+#                         never `cp -al`             auto-detect same-fs)
 #
-# Example (custom deployment shape, non-standard namespace + container):
-#   BN_NAMESPACE=my-bn \
-#   BN_STATEFULSET=my-bn-server \
-#   BN_CONTAINER=bn \
-#   ./backfill-wrb-to-bn.sh /mnt/archive/wrappedBlocks
+# --post-install specific:
+#   HISTORIC_MOUNT_PATH   On-pod historic dir       (default: /opt/hiero/block-node/data/historic)
+#   READY_TIMEOUT         Pod-ready wait (seconds)  (default: 300)
+#   SKIP_ROLLOUT          "true" -> skip pod        (default: false)
+#                         restart
+#   KEEP_STAGING          "true" -> keep staging    (default: false)
+#                         dir on success
+#
+# Examples:
+#
+#   # Fresh install, previewnet Tier 1 -- seed archive BEFORE bringing up the BN
+#   ./backfill-wrb-to-bn.sh --pre-install ~/wrappedBlocks
+#   sudo solo-provisioner block node install -p previewnet --config ... --values ...
+#
+#   # Already-running BN, tolerate the tar-stream+restart cycle
+#   ./backfill-wrb-to-bn.sh --post-install ~/wrappedBlocks
 
 set -euo pipefail
 
 # --- Config ---
-: "${BN_KUBE_CONTEXT:=}"                                              # empty -> use current
+: "${BN_KUBE_CONTEXT:=}"
 : "${BN_NAMESPACE:=block-node}"
 : "${BN_STATEFULSET:=block-node-block-node-server}"
 : "${BN_POD:=${BN_STATEFULSET}-0}"
 : "${BN_CONTAINER:=block-node-server}"
-: "${HISTORIC_MOUNT_PATH:=/opt/hiero/block-node/data/historic}"
 : "${STAGING_DIR:=/tmp/bn-backfill-$$}"
+: "${ARCHIVE_PVC_NAME:=archive-storage-pvc}"
+: "${HISTORIC_MOUNT_PATH:=/opt/hiero/block-node/data/historic}"
 : "${READY_TIMEOUT:=300}"
 : "${SKIP_ROLLOUT:=false}"
 : "${KEEP_STAGING:=false}"
+: "${FORCE_COPY:=false}"
+BN_HEDERA_UID="${BN_HEDERA_UID:-2000}"
+BN_HEDERA_GID="${BN_HEDERA_GID:-2000}"
 
 # --- Logging ---
 log()  { echo "[backfill-wrb-to-bn] $*"; }
 fail() { echo "[backfill-wrb-to-bn] ERROR: $*" >&2; exit 1; }
 
 # --- Argument parsing ---
-[[ $# -ge 1 ]] || fail "usage: $0 <path-to-wrappedBlocks-dir>"
-WRB_SOURCE_DIR="$1"
-[[ -d "${WRB_SOURCE_DIR}" ]] || fail "wrappedBlocks dir does not exist: ${WRB_SOURCE_DIR}"
+MODE="auto"
+WRB_SOURCE_DIR=""
+# --install-and-seed passthrough flags to solo-provisioner:
+SOLO_PROFILE=""
+SOLO_CONFIG=""
+SOLO_VALUES=""
+SOLO_EXTRA_FLAGS=(--skip-hardware-checks --non-interactive)
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --install-and-seed) MODE="install-and-seed"; shift ;;
+        --pre-install)      MODE="pre-install"; shift ;;
+        --post-install)     MODE="post-install"; shift ;;
+        --auto)             MODE="auto"; shift ;;
+        --profile)          SOLO_PROFILE="$2"; shift 2 ;;
+        --config)           SOLO_CONFIG="$2"; shift 2 ;;
+        --values)           SOLO_VALUES="$2"; shift 2 ;;
+        --solo-flag)        SOLO_EXTRA_FLAGS+=("$2"); shift 2 ;;
+        -h|--help)          sed -n '2,90p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        --*)                fail "unknown flag: $1" ;;
+        *)                  [[ -z "$WRB_SOURCE_DIR" ]] || fail "unexpected arg: $1"
+                            WRB_SOURCE_DIR="$1"; shift ;;
+    esac
+done
+[[ -n "$WRB_SOURCE_DIR" ]] \
+    || fail "usage: $0 [--install-and-seed --profile <p> --config <c> --values <v>|--pre-install|--post-install] <wrappedBlocks-dir>"
+[[ -d "$WRB_SOURCE_DIR" ]] || fail "wrappedBlocks dir does not exist: $WRB_SOURCE_DIR"
+
+if [[ "$MODE" == "install-and-seed" ]]; then
+    [[ -n "$SOLO_PROFILE" ]] || fail "--install-and-seed requires --profile <p> (e.g. previewnet)"
+    [[ -n "$SOLO_CONFIG"  ]] || fail "--install-and-seed requires --config <path-to-provisioner-config.yaml>"
+    [[ -n "$SOLO_VALUES"  ]] || fail "--install-and-seed requires --values <path-to-values.yaml>"
+    [[ -f "$SOLO_CONFIG"  ]] || fail "--config file does not exist: $SOLO_CONFIG"
+    [[ -f "$SOLO_VALUES"  ]] || fail "--values file does not exist: $SOLO_VALUES"
+fi
 
 # --- Locate the wrb-cli jar ---
 if [[ -z "${CLI_JAR:-}" ]]; then
-    # Prefer explicit location next to this script (built via ./gradlew :tools:shadowJar)
     script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     candidate=$(ls "${script_dir}/../build/libs/"tools-*-all.jar 2>/dev/null | head -1 || true)
-    if [[ -z "${candidate}" ]]; then
-        candidate=$(command -v tools-cli || ls tools-*-all.jar 2>/dev/null | head -1 || true)
-    fi
-    [[ -n "${candidate}" ]] || fail "wrb-cli jar not found; set CLI_JAR=<path> to override"
-    CLI_JAR="${candidate}"
+    [[ -n "$candidate" ]] || candidate=$(ls tools-*-all.jar 2>/dev/null | head -1 || true)
+    [[ -n "$candidate" ]] || fail "wrb-cli jar not found; set CLI_JAR=<path> to override"
+    CLI_JAR="$candidate"
 fi
-[[ -f "${CLI_JAR}" ]] || fail "CLI_JAR does not exist: ${CLI_JAR}"
+[[ -f "$CLI_JAR" ]] || fail "CLI_JAR does not exist: $CLI_JAR"
 
-# --- kubectl invocation prefix (context + namespace) ---
+# --- kubectl invocation prefix ---
 kctl=(kubectl --namespace "${BN_NAMESPACE}")
 [[ -n "${BN_KUBE_CONTEXT}" ]] && kctl+=(--context "${BN_KUBE_CONTEXT}")
 
-log "Config:"
-log "  source WRB dir:        ${WRB_SOURCE_DIR}"
-log "  staging dir:           ${STAGING_DIR}"
-log "  CLI jar:               ${CLI_JAR}"
-log "  kubectl context:       ${BN_KUBE_CONTEXT:-<current>}"
-log "  namespace:             ${BN_NAMESPACE}"
-log "  target pod:            ${BN_POD} (container ${BN_CONTAINER})"
-log "  target statefulset:    ${BN_STATEFULSET}"
-log "  historic mount path:   ${HISTORIC_MOUNT_PATH}"
-
-# --- Preflight ---
+# --- Common preflight ---
 command -v kubectl >/dev/null || fail "kubectl not on PATH"
-command -v java >/dev/null || fail "java not on PATH"
+command -v java    >/dev/null || fail "java not on PATH"
 
-log "Preflight: verifying target pod ${BN_POD} is Ready..."
-"${kctl[@]}" get pod "${BN_POD}" >/dev/null || fail "pod ${BN_POD} not found in namespace ${BN_NAMESPACE}"
-"${kctl[@]}" wait --for=condition=Ready pod/"${BN_POD}" --timeout=60s \
-    || fail "pod ${BN_POD} not Ready within 60s; aborting before we stage anything"
-
-# --- Stage via `blocks bulk-load` ---
-log "Staging wrapped blocks via 'blocks bulk-load' (${WRB_SOURCE_DIR} -> ${STAGING_DIR})..."
-mkdir -p "${STAGING_DIR}"
-java -jar "${CLI_JAR}" blocks bulk-load \
-    --source "${WRB_SOURCE_DIR}" \
-    --dest   "${STAGING_DIR}" \
-    || fail "'blocks bulk-load' staging failed"
-
-if [[ -z "$(find "${STAGING_DIR}" -name '*.zip' -print -quit 2>/dev/null)" ]]; then
-    fail "no .zip files staged in ${STAGING_DIR}; nothing to backfill"
-fi
-staged_count=$(find "${STAGING_DIR}" -name '*.zip' | wc -l)
-log "Staged ${staged_count} zip file(s) into ${STAGING_DIR}."
-
-# --- Stream into the pod via tar | kubectl exec ---
-log "Streaming staged blocks into ${BN_POD}:${HISTORIC_MOUNT_PATH}..."
-"${kctl[@]}" exec "${BN_POD}" -c "${BN_CONTAINER}" -- mkdir -p "${HISTORIC_MOUNT_PATH}" \
-    || fail "failed to ensure ${HISTORIC_MOUNT_PATH} exists on ${BN_POD}"
-tar -C "${STAGING_DIR}" -cf - . | \
-    "${kctl[@]}" exec -i "${BN_POD}" -c "${BN_CONTAINER}" -- \
-    tar xf - -C "${HISTORIC_MOUNT_PATH}" \
-    || fail "failed to stream staged blocks into ${BN_POD}"
-log "Blocks copied onto ${BN_POD}'s persistent historic volume."
-
-# --- Roll the StatefulSet so BlockFileHistoricPlugin re-scans ---
-if [[ "${SKIP_ROLLOUT}" == "true" ]]; then
-    log "SKIP_ROLLOUT=true; not rolling the StatefulSet. The BN will pick up the new"
-    log "historic files on its next natural restart. If you don't want to wait, run:"
-    log "  kubectl rollout restart statefulset/${BN_STATEFULSET} -n ${BN_NAMESPACE}"
-else
-    log "Rolling statefulset/${BN_STATEFULSET} so BlockFileHistoricPlugin re-scans..."
-    "${kctl[@]}" rollout restart statefulset/"${BN_STATEFULSET}" \
-        || fail "rollout restart failed for statefulset/${BN_STATEFULSET}"
-    "${kctl[@]}" rollout status statefulset/"${BN_STATEFULSET}" --timeout="${READY_TIMEOUT}s" \
-        || fail "statefulset/${BN_STATEFULSET} rollout did not complete within ${READY_TIMEOUT}s"
-    "${kctl[@]}" wait --for=condition=Ready pod/"${BN_POD}" --timeout="${READY_TIMEOUT}s" \
-        || fail "${BN_POD} did not become Ready after restart"
-    log "${BN_POD} is Ready after rollout."
+# --- Auto-detect mode ---
+if [[ "$MODE" == "auto" ]]; then
+    if "${kctl[@]}" get pod "$BN_POD" >/dev/null 2>&1 \
+       && "${kctl[@]}" get pod "$BN_POD" -o jsonpath='{.status.phase}' 2>/dev/null | grep -q Running; then
+        MODE="post-install"
+        log "Auto-detected mode: post-install (pod $BN_POD is Running)"
+    else
+        MODE="pre-install"
+        log "Auto-detected mode: pre-install (pod $BN_POD not Running or missing)"
+    fi
 fi
 
-# --- Cleanup ---
-if [[ "${KEEP_STAGING}" == "true" ]]; then
-    log "KEEP_STAGING=true; leaving staging dir at ${STAGING_DIR}"
-else
-    rm -rf "${STAGING_DIR}"
-    log "Removed staging dir ${STAGING_DIR}."
-fi
+log "Config:"
+log "  mode:                  $MODE"
+log "  source WRB dir:        $WRB_SOURCE_DIR"
+log "  staging dir:           $STAGING_DIR"
+log "  CLI jar:               $CLI_JAR"
+log "  kubectl context:       ${BN_KUBE_CONTEXT:-<current>}"
+log "  namespace:             $BN_NAMESPACE"
 
-log "Backfill complete. Verify the BN sees the new blocks with:"
-log "  kubectl port-forward -n ${BN_NAMESPACE} svc/${BN_STATEFULSET} 18082:40982 &"
-log "  grpcurl -plaintext -emit-defaults \\"
-log "    -import-path <path-to-block-node-protobuf> \\"
-log "    -proto block-node/api/node_service.proto \\"
-log "    -d '{}' localhost:18082 org.hiero.block.api.BlockNodeService/serverStatus"
-log "Expect: firstAvailableBlock / lastAvailableBlock now show real block numbers"
-log "(no longer UINT64_MAX sentinel 18446744073709551615)."
+# ---------- PRE-INSTALL MODE ----------
+run_pre_install() {
+    log "  archive PVC name:      $ARCHIVE_PVC_NAME"
+    log "  force copy:            $FORCE_COPY"
+
+    # 1. Verify PVC exists + Bound
+    log "Preflight: verifying $ARCHIVE_PVC_NAME is Bound..."
+    local pvc_status pv_name
+    pvc_status=$("${kctl[@]}" get pvc "$ARCHIVE_PVC_NAME" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+    [[ "$pvc_status" == "Bound" ]] || fail "PVC $ARCHIVE_PVC_NAME is '${pvc_status:-missing}', expected Bound"
+    pv_name=$("${kctl[@]}" get pvc "$ARCHIVE_PVC_NAME" -o jsonpath='{.spec.volumeName}')
+    [[ -n "$pv_name" ]] || fail "could not resolve PV name for $ARCHIVE_PVC_NAME"
+    log "  Bound to PV: $pv_name"
+
+    # 2. Verify StatefulSet scaled 0 (or absent) so no BN process is holding the PVC
+    local replicas
+    replicas=$("${kctl[@]}" get statefulset "$BN_STATEFULSET" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "")
+    if [[ -n "$replicas" && "$replicas" != "0" ]]; then
+        fail "StatefulSet $BN_STATEFULSET has replicas=$replicas; scale to 0 first: kubectl scale statefulset/$BN_STATEFULSET --replicas=0 -n $BN_NAMESPACE"
+    fi
+
+    # 3. Locate PV host path (hostPath OR local)
+    local pv_host_path
+    pv_host_path=$(kubectl get pv "$pv_name" -o jsonpath='{.spec.hostPath.path}')
+    [[ -n "$pv_host_path" ]] || pv_host_path=$(kubectl get pv "$pv_name" -o jsonpath='{.spec.local.path}')
+    [[ -n "$pv_host_path" ]] || fail "PV $pv_name is not a hostPath / local volume (nfs/gce-pd/... requires --post-install mode)"
+    log "  PV host path:          $pv_host_path"
+
+    # 4. Ensure the host path exists locally (we're running on the same box)
+    [[ -d "$pv_host_path" ]] || fail "PV host path $pv_host_path is not present on this host -- are you running the script on the correct node?"
+
+    # 5. Stage via bulk-load. Same-fs check for hard-link path.
+    local source_fs staging_fs
+    source_fs=$(stat -c %d "$WRB_SOURCE_DIR")
+    # Try to put staging on the same fs as the PV host path so we can hard-link
+    if [[ "$FORCE_COPY" != "true" ]] && [[ "$(dirname "$pv_host_path")" != "/" ]]; then
+        alt_staging="$(dirname "$pv_host_path")/.backfill-staging-$$"
+        mkdir -p "$alt_staging" 2>/dev/null && STAGING_DIR="$alt_staging" \
+            || log "  (fell back to $STAGING_DIR; couldn't create staging under $(dirname "$pv_host_path"))"
+    fi
+    mkdir -p "$STAGING_DIR"
+    staging_fs=$(stat -c %d "$STAGING_DIR")
+    log "  staging fs device:     $staging_fs"
+    log "  pv-host-path fs dev:   $(stat -c %d "$pv_host_path")"
+
+    log "Staging via 'blocks bulk-load' ($WRB_SOURCE_DIR -> $STAGING_DIR)..."
+    java -jar "$CLI_JAR" blocks bulk-load --source "$WRB_SOURCE_DIR" --dest "$STAGING_DIR" \
+        || fail "'blocks bulk-load' staging failed"
+
+    local staged_count
+    staged_count=$(find "$STAGING_DIR" -name '*.zip' | wc -l)
+    [[ "$staged_count" -gt 0 ]] || fail "no .zip files staged; nothing to seed"
+    log "  Staged $staged_count zip file(s)."
+
+    # 6. Copy or hard-link into the PV host path
+    local pv_fs
+    pv_fs=$(stat -c %d "$pv_host_path")
+    local cp_flags="-r"
+    if [[ "$FORCE_COPY" != "true" ]] && [[ "$staging_fs" == "$pv_fs" ]]; then
+        cp_flags="-al"
+        log "  same filesystem detected -> hard-linking (cp -al)"
+    else
+        log "  different filesystems (or --copy forced) -> full copy (cp -r)"
+    fi
+
+    local sudo_prefix=""
+    [[ $EUID -eq 0 ]] || sudo_prefix="sudo"
+    log "Copying into $pv_host_path (this may take a while for large archives)..."
+    $sudo_prefix cp $cp_flags "$STAGING_DIR"/. "$pv_host_path/" \
+        || fail "copy into $pv_host_path failed"
+
+    log "Setting ownership to ${BN_HEDERA_UID}:${BN_HEDERA_GID} (hedera:hedera on the BN container)..."
+    $sudo_prefix chown -R "${BN_HEDERA_UID}:${BN_HEDERA_GID}" "$pv_host_path/" \
+        || fail "chown of $pv_host_path failed"
+
+    # 7. Cleanup (only if we hard-linked -- otherwise staging is a real duplicate,
+    #    but we've been given no signal about whether the operator wants to keep it)
+    if [[ "$KEEP_STAGING" == "true" ]]; then
+        log "KEEP_STAGING=true; leaving staging dir at $STAGING_DIR"
+    else
+        rm -rf "$STAGING_DIR"
+        log "Removed staging dir $STAGING_DIR."
+    fi
+
+    log ""
+    log "Pre-seed complete. Next: start the BN (do NOT restart if already running)."
+    log "  Solo Provisioner (fresh install):"
+    log "    sudo solo-provisioner block node install -p <profile> --config ... --values ..."
+    log "  Or scale a scaled-down StatefulSet back up:"
+    log "    kubectl scale statefulset/$BN_STATEFULSET --replicas=1 -n $BN_NAMESPACE"
+    log ""
+    log "Verify blocks visible after BN startup:"
+    log "  kubectl port-forward -n $BN_NAMESPACE svc/$BN_STATEFULSET 18082:40982 &"
+    log "  grpcurl -plaintext -emit-defaults -import-path <proto-dir> \\"
+    log "    -proto block-node/api/node_service.proto -d '{}' \\"
+    log "    localhost:18082 org.hiero.block.api.BlockNodeService/serverStatus"
+    log "  Expect firstAvailableBlock: '0', lastAvailableBlock: <real number>"
+}
+
+# ---------- POST-INSTALL MODE ----------
+run_post_install() {
+    log "  target pod:            $BN_POD (container $BN_CONTAINER)"
+    log "  target statefulset:    $BN_STATEFULSET"
+    log "  historic mount path:   $HISTORIC_MOUNT_PATH"
+
+    log "Preflight: verifying target pod $BN_POD is Ready..."
+    "${kctl[@]}" get pod "$BN_POD" >/dev/null || fail "pod $BN_POD not found in namespace $BN_NAMESPACE"
+    "${kctl[@]}" wait --for=condition=Ready pod/"$BN_POD" --timeout=60s \
+        || fail "pod $BN_POD not Ready within 60s"
+
+    log "Staging wrapped blocks via 'blocks bulk-load' ($WRB_SOURCE_DIR -> $STAGING_DIR)..."
+    mkdir -p "$STAGING_DIR"
+    java -jar "$CLI_JAR" blocks bulk-load --source "$WRB_SOURCE_DIR" --dest "$STAGING_DIR" \
+        || fail "'blocks bulk-load' staging failed"
+
+    if [[ -z "$(find "$STAGING_DIR" -name '*.zip' -print -quit 2>/dev/null)" ]]; then
+        fail "no .zip files staged; nothing to backfill"
+    fi
+    local staged_count
+    staged_count=$(find "$STAGING_DIR" -name '*.zip' | wc -l)
+    log "Staged $staged_count zip file(s)."
+
+    log "WARNING: post-install mode is UNSAFE when the archive PVC isn't a proper"
+    log "persistent volume. If mounts have degraded to ephemeral rootfs, the pod"
+    log "restart below will WIPE the copied files. --pre-install is safer for"
+    log "fresh installs. See PVC status: kubectl get pvc -n $BN_NAMESPACE"
+
+    log "Streaming staged blocks into $BN_POD:$HISTORIC_MOUNT_PATH..."
+    "${kctl[@]}" exec "$BN_POD" -c "$BN_CONTAINER" -- mkdir -p "$HISTORIC_MOUNT_PATH" \
+        || fail "failed to ensure $HISTORIC_MOUNT_PATH exists on $BN_POD"
+    tar -C "$STAGING_DIR" -cf - . | \
+        "${kctl[@]}" exec -i "$BN_POD" -c "$BN_CONTAINER" -- tar xf - -C "$HISTORIC_MOUNT_PATH" \
+        || fail "failed to stream staged blocks into $BN_POD"
+    log "Blocks copied onto $BN_POD's historic volume."
+
+    if [[ "$SKIP_ROLLOUT" == "true" ]]; then
+        log "SKIP_ROLLOUT=true; not rolling. Restart manually to trigger re-scan."
+    else
+        log "Rolling statefulset/$BN_STATEFULSET so BlockFileHistoricPlugin re-scans..."
+        "${kctl[@]}" rollout restart statefulset/"$BN_STATEFULSET" \
+            || fail "rollout restart failed for $BN_STATEFULSET"
+        "${kctl[@]}" rollout status statefulset/"$BN_STATEFULSET" --timeout="${READY_TIMEOUT}s" \
+            || fail "rollout did not complete within ${READY_TIMEOUT}s"
+        "${kctl[@]}" wait --for=condition=Ready pod/"$BN_POD" --timeout="${READY_TIMEOUT}s" \
+            || fail "$BN_POD did not become Ready after restart"
+        log "$BN_POD is Ready after rollout."
+    fi
+
+    if [[ "$KEEP_STAGING" == "true" ]]; then
+        log "KEEP_STAGING=true; leaving staging dir at $STAGING_DIR"
+    else
+        rm -rf "$STAGING_DIR"
+        log "Removed staging dir $STAGING_DIR."
+    fi
+
+    log ""
+    log "Backfill complete. Verify with:"
+    log "  kubectl port-forward -n $BN_NAMESPACE svc/$BN_STATEFULSET 18082:40982 &"
+    log "  grpcurl -plaintext -emit-defaults -import-path <proto-dir> \\"
+    log "    -proto block-node/api/node_service.proto -d '{}' \\"
+    log "    localhost:18082 org.hiero.block.api.BlockNodeService/serverStatus"
+    log "  Expect firstAvailableBlock: '0', lastAvailableBlock: <real number>"
+}
+
+# ---------- INSTALL-AND-SEED MODE ----------
+# One-shot: solo-provisioner install -> scale down -> pre-install seed -> scale up.
+run_install_and_seed() {
+    log "  profile:               $SOLO_PROFILE"
+    log "  provisioner config:    $SOLO_CONFIG"
+    log "  values file:           $SOLO_VALUES"
+
+    # Fail fast + graceful if Solo Provisioner isn't installed.
+    if ! command -v solo-provisioner >/dev/null 2>&1; then
+        fail "solo-provisioner is not on PATH. Install it first with:
+    curl -sSL https://raw.githubusercontent.com/hashgraph/solo-weaver/main/install.sh | bash
+Then verify with: sudo solo-provisioner -v
+See https://docs.hiero.org/block-node-overview/block-node-hardware-specifications/solo-weaver-single-node-k8s-deployment for the full install recipe."
+    fi
+
+    # Also confirm the tool actually runs (permissions / version sanity).
+    sudo solo-provisioner -v >/dev/null 2>&1 \
+        || fail "solo-provisioner is present but failed 'sudo solo-provisioner -v'; check permissions or reinstall"
+
+    # 1. Install (creates PVCs + everything). If already installed, this will
+    #    fail with the "already installed" guard, which is fine -- we assume
+    #    the operator meant to seed an existing install.
+    log "Running: sudo solo-provisioner block node install -p $SOLO_PROFILE ..."
+    if sudo solo-provisioner block node install \
+            -p "$SOLO_PROFILE" \
+            --config "$SOLO_CONFIG" \
+            --values "$SOLO_VALUES" \
+            "${SOLO_EXTRA_FLAGS[@]}"; then
+        log "Solo Provisioner install completed."
+    else
+        rc=$?
+        log "Solo Provisioner install returned exit code $rc. Continuing on the assumption the release already exists (existing PVCs will be reused). If this was a fatal failure, abort now."
+    fi
+
+    # 2. Scale StatefulSet to 0 so no BN process holds the archive PVC while we seed.
+    log "Scaling statefulset/$BN_STATEFULSET to 0 for seeding..."
+    "${kctl[@]}" scale statefulset/"$BN_STATEFULSET" --replicas=0 \
+        || fail "failed to scale $BN_STATEFULSET to 0"
+    # Wait for the pod to actually be gone (scale returns before termination).
+    for _ in $(seq 1 30); do
+        if ! "${kctl[@]}" get pod "$BN_POD" >/dev/null 2>&1; then break; fi
+        sleep 2
+    done
+    "${kctl[@]}" get pod "$BN_POD" >/dev/null 2>&1 \
+        && fail "pod $BN_POD is still present after 60s; refusing to seed while pod exists"
+    log "Pod $BN_POD is gone; safe to seed."
+
+    # 3. Delegate to the pre-install flow (same steps as --pre-install).
+    log "Seeding archive PVC via pre-install flow..."
+    run_pre_install
+
+    # 4. Scale StatefulSet back to 1 so the BN comes up on the seeded PVC.
+    log "Scaling statefulset/$BN_STATEFULSET back to 1..."
+    "${kctl[@]}" scale statefulset/"$BN_STATEFULSET" --replicas=1 \
+        || fail "failed to scale $BN_STATEFULSET to 1"
+
+    # 5. Wait for pod Ready.
+    log "Waiting for pod $BN_POD to become Ready (timeout ${READY_TIMEOUT}s)..."
+    "${kctl[@]}" wait --for=condition=Ready pod/"$BN_POD" --timeout="${READY_TIMEOUT}s" \
+        || fail "pod $BN_POD did not become Ready within ${READY_TIMEOUT}s"
+    log "Pod $BN_POD is Ready."
+
+    log ""
+    log "install-and-seed complete. Verify blocks visible with:"
+    log "  kubectl port-forward -n $BN_NAMESPACE svc/$BN_STATEFULSET 18082:40982 &"
+    log "  grpcurl -plaintext -emit-defaults -import-path <proto-dir> \\"
+    log "    -proto block-node/api/node_service.proto -d '{}' \\"
+    log "    localhost:18082 org.hiero.block.api.BlockNodeService/serverStatus"
+    log "  Expect firstAvailableBlock: '0', lastAvailableBlock: <real number>"
+}
+
+# ---------- Dispatch ----------
+case "$MODE" in
+    install-and-seed) run_install_and_seed ;;
+    pre-install)      run_pre_install ;;
+    post-install)     run_post_install ;;
+    *)                fail "unknown mode: $MODE" ;;
+esac


### PR DESCRIPTION
## Summary

Fixes #3323. Adds configuration + operational tooling for deploying a previewnet Tier 1 Local-Full-History Block Node via Solo Provisioner and seeding it with historical wrapped blocks. Config-only PR — smoke-test install was performed against the previewnet VM at `34.70.11.223` and confirmed working end-to-end (see "Validation" below); nothing in this PR touches deployed infrastructure automatically.

## What's in the PR

Five YAML files under `charts/block-node-server/values-overrides/` (following the existing `lfh-values.yaml` / `backfill.yaml` / `mini.yaml` naming convention), one operational script under `tools-and-tests/tools/scripts/`, and one operator runbook under `docs/block-node/operations/`.

**Main pair — for a properly-sized previewnet Tier 1 host**

1. `previewnet-lfh-provisioner-config.yaml` — Solo Provisioner config
   - `profile: previewnet`, chart pinned at `0.37.1`, namespace/release `block-node`
   - Storage: 1 TiB archive, 100 GiB live, 20 GiB app-state, 20 GiB logs, 5 GiB plugins under `/mnt/fast-storage`
   - Header documents the two preflight gotchas we hit (hedera UID/GID must be 2000, 3 TB disk minimum) with fixes
2. `previewnet-lfh-values.yaml` — Helm values override
   - JVM heap `16G`, resources `8 CPU / 20 Gi` (right-sized for `e2-standard-16`)
   - `ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL` → previewnet mirror node
   - `loadBalancer.enabled: true` + `metallb.io/address-pool: public-address-pool` — Solo Provisioner installs MetalLB during a fresh install; the annotation picks up the pool it configures. Team direction: use LB for external subscribers, not `kubectl port-forward`.
   - Backfill / Prometheus / plugin ports / init-container storage-dir chown / PVC references mirror the mainnet reference (`lfh-values.yaml`)

**Smoke-test variants — for a smaller-disk / bigger-RAM validation host**

3. `previewnet-lfh-provisioner-config-smoketest.yaml` — same Solo Provisioner config with storage shrunk to fit ~1 TB total disk (600 GiB archive, 50 GiB live, smaller others; combined ~700 GiB footprint)
4. `previewnet-lfh-values-smoketest.yaml` — bigger JVM heap (`96G`) and resources (`16 CPU / 128 Gi`) because the actual smoke-test box had 256 GB RAM. Same LoadBalancer + MetalLB setup as the main values so the smoke-test variant differs only in sizing.

Headers on both smoke-test files explicitly mark them as smoke-test-only, call out the `--skip-hardware-checks` CLI flag they require, and warn against using them for a durable Tier 1.

**Operational script — for seeding the BN with historical blocks**

5. `tools-and-tests/tools/scripts/backfill-wrb-to-bn.sh` — general-purpose backfill helper. Stages a local wrappedBlocks archive via `blocks bulk-load`, tar-streams it into the BN's pod at the chart's historic mount path, rolls the StatefulSet so `BlockFileHistoricPlugin` re-scans on startup and picks up the copied files.
   - Uses `blocks bulk-load` (PR #3038) not `blocks push` (PR #3263): the live publish/gRPC stream is a single-slot-per-block-number CAS meant for freshly-produced blocks and silently SKIPs anything that loses the race, so it's the wrong path for seeding an empty BN from history.
   - Target BN addressable by kubectl context / namespace / statefulset / pod / container — all defaults match Solo Provisioner's `block-node/block-node-block-node-server/block-node-server` shape.
   - Preflight (pod Ready check) before staging; `SKIP_ROLLOUT=true` and `KEEP_STAGING=true` escape hatches; closing log line emits the exact grpcurl verification command.


**Static-PV helper — for single-node clusters that lack a default StorageClass**

6. `charts/block-node-server/values-overrides/previewnet-lfh-static-pvs.yaml` — five pre-bound hostPath `PersistentVolume` objects with `claimRef`s already targeting the chart's `volumeClaimTemplate` PVC names (`*-storage-block-node-block-node-server-0`). Solo Provisioner's stock previewnet install does NOT ship a default `StorageClass`, so `persistence.*.create: true` (added by `ffbdcedb3`) would otherwise leave the chart-provisioned PVCs `Pending` forever. `kubectl apply -f` this file BEFORE `solo-provisioner install` and the PVCs bind immediately.

**Operator runbook — covers the T1 backfill portion of #2961**

7. `docs/block-node/operations/wrb-seed-runbook.md` — step-by-step runbook covering fresh install + historic-archive seeding via `backfill-wrb-to-bn.sh`, plus symptom/cause/workaround for the three operational footguns discovered during smoke-testing (StorageClass requirement, `subPath: archive-data` mismatch, `BlockFileHistoricPlugin` crash-loop on single corrupt zip). Each footgun links a pending upstream fix.

## How to use

**Prerequisite (single-node clusters without a default StorageClass):**

```bash
kubectl apply -f /path/to/previewnet-lfh-static-pvs.yaml
```

**Production shape** (proper `n2d-standard-16` or larger, ≥3 TB disk):

```bash
sudo solo-provisioner block node install \
  -p previewnet \
  --config /path/to/previewnet-lfh-provisioner-config.yaml \
  --values /path/to/previewnet-lfh-values.yaml \
  --non-interactive
```

**Smoke-test shape** (smaller disk, needs the hardware-check bypass):

```bash
sudo solo-provisioner block node install \
  -p previewnet \
  --config /path/to/previewnet-lfh-provisioner-config-smoketest.yaml \
  --values /path/to/previewnet-lfh-values-smoketest.yaml \
  --skip-hardware-checks \
  --non-interactive
```

**Backfill after install** (from the same host, or any host with `kubectl` pointed at the cluster):

```bash
tools-and-tests/tools/scripts/backfill-wrb-to-bn.sh /path/to/wrappedBlocks
```

Full recipe (VM creation, Solo Provisioner install, verification via `kubectl` + `grpcurl serverStatus`) is in the linked hiero.org docs page referenced in #3323.

## Preflight gotchas discovered during validation

Documented in the main config's header:

- `hedera` user/group must be at UID/GID 2000. If the target VM was previously used for anything, a pre-existing `hedera` at another UID (we saw 1005) will fail preflight with `hedera owner user "hedera" has incorrect UID: expected 2000, got 1005`. Fix: `sudo usermod -u 2000 hedera && sudo groupmod -g 2000 hedera`, then re-chown anything that was owned by the old IDs.
- The `previewnet` profile requires ≥3 TB total disk at preflight. Use `--skip-hardware-checks` together with the smoke-test variants on smaller boxes.

## Known limitation — chart 0.37.1 LoadBalancer port surface

Chart 0.37.1's `service-loadbalancer.yaml` template hard-codes a single port entry (40840). Under the split-port setup we use, each API family lives on its own dedicated port (`server-status` on 40982, `publisher` on 40984, `subscriber` on 40980, `block-access` on 40981, `health` on 40983), and port 40840 alone serves plain HTTP rather than gRPC — external `grpcurl :40840 serverStatus` fails with `malformed header: missing HTTP content-type`.

For chart 0.37.1, external gRPC probing therefore requires `kubectl port-forward` against the ClusterIP Service on the plugin port. Documented in both values files' `loadBalancer:` block comments. Chart 0.38.0+ adds `loadBalancer.includePluginPorts: true` which fixes this by appending the plugin ports to the LB Service; revisit when we bump the chart pin.

## Validation

Ran the smoke-test path end-to-end against the previewnet VM at `34.70.11.223`:

- Solo Provisioner `Completed successfully` in 40s after hedera UID/GID + LoadBalancer flag alignment
- Pod comes up `1/1 Running`; StatefulSet ready
- Service exposes all 7 ports on ClusterIP (`server-status: 40982`, `publisher: 40984`, `subscriber: 40980`, `blockAccess: 40981`, `health: 40983`, `metrics: 16007`, `http: 40840`)
- MetalLB assigns `10.128.0.2` to the `-external` LoadBalancer Service (from `public-address-pool`)
- `serverStatus` gRPC (via kubectl port-forward on 40982) returns:
  ```json
  {
    "firstAvailableBlock": "18446744073709551615",
    "lastAvailableBlock": "18446744073709551615",
    "onlyLatestState": false,
    "nextExpectedBlock": "0"
  }
  ```
  UINT64_MAX sentinel = "no blocks stored yet" (expected on a fresh install); `nextExpectedBlock: 0` confirms the BN is ready to accept blocks from genesis.

## Validation — seeded end state (Aug 3)

Extended the smoke-test on `34.70.11.223` end-to-end through a historic-archive seed. Ran `backfill-wrb-to-bn.sh --install-and-seed` against a 173 GB WRB archive (171 files × ~10K blocks each), pointed the BN at the seeded PVCs, confirmed the historic plugin indexed and served the blocks.

Startup log after the seed:

```
2026-08-03 22:17:10.171+0000 INFO [org.hiero.block.node.app.BlockNodeApp start]
  Started BlockNode Server : State=RUNNING HistoricBlockRange=0->1699999
```

`serverStatus` gRPC (via `kubectl port-forward` on the ClusterIP Service, port 40982):

```json
{
  "firstAvailableBlock": "0",
  "lastAvailableBlock": "1699999",
  "onlyLatestState": false,
  "nextExpectedBlock": "0"
}
```

170 of 171 files parsed cleanly; one file at `000/000/000/000/17/00000.zip` (blocks 170000–179999) was rejected by the plugin as content-corrupt (valid ZIP structurally, but the plugin's block-parser can't read the entry). The full recipe for reproducing this end-to-end (including the three manual footgun workarounds we hit along the way) is in the new operator runbook: [wrb-seed-runbook.md](./docs/block-node/operations/wrb-seed-runbook.md).

## Operational footguns discovered during seeding

Three real issues hit during the seeded smoke test. All non-blocking for this PR (config-only) but documented in the operator runbook with symptom / cause / workaround / pending-upstream-fix for each. To be filed as follow-up bugs against the appropriate repos:

1. **`persistence.*.create: true` requires a default `StorageClass`** — worked around in this PR by shipping `previewnet-lfh-static-pvs.yaml`. Real fix pending against solo-weaver.
2. **`archive-storage` volumeMount applies `subPath: archive-data`** even when the values file explicitly sets `subPath: ""`, so `backfill-wrb-to-bn.sh`'s seeded files land one level above where the pod reads. Manual `mv` required. Real fix pending against this repo's chart template.
3. **`BlockFileHistoricPlugin` crash-loops on subsequent restart if the archive contains any single content-corrupt zip.** One bad file poisons `maxStoredBlockNumber` → `IllegalStateException` at `init:181`. Manual cleanup of `corrupted/` + empty leaf dir + stale state file required. Real fix pending against `BlockFileHistoricPlugin`.

## Reference material

- Deployment guide: https://docs.hiero.org/block-node-overview/block-node-hardware-specifications/solo-weaver-single-node-k8s-deployment
- Solo Provisioner tool: https://github.com/hashgraph/solo-weaver
- Mainnet reference this was derived from: `charts/block-node-server/values-overrides/lfh-values.yaml` + `lfh-provisioner-config.yaml`
- Reference bulk-load pattern the backfill script generalizes: `bulk-load-historical-to-bn1.sh` (on branch `3125-slice4-steps8-9`, not yet on main)

## Out of scope

- Pointing the BN at a previewnet Tier 0 upstream for live subscription — see #3323 for the operational follow-up
- Bumping the chart version pin from 0.37.1 to a version that supports `includePluginPorts` (would unlock external gRPC probing via the LB IP without kubectl port-forward)
- Multi-VM BNCE-style automation — see `hashgraph/block-node-infrastructure` if we later want to fold Solo Provisioner into a larger orchestration
- Mainnet Tier 1 — docs explicitly recommend a bare-metal shape rather than Solo Provisioner for prod mainnet; this config is scoped to previewnet only

