### PR TITLE
fix(test): eliminate flakiness in backfill and slowdown E2E tests

### DIFF
--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
@@ -321,6 +321,7 @@ public abstract class BaseSuite {
                 .withEnv("VERSION", blockNodeVersion)
                 .withEnv("BACKFILL_BLOCK_NODE_SOURCES_PATH", config.backfillSourcePath())
                 .withEnv("BACKFILL_INITIAL_DELAY", "5000") // 5 seconds
+                .withEnv("BACKFILL_SCAN_INTERVAL", "10000") // 10 seconds — shorter than the default 60s
                 .withEnv("SERVER_PORT", String.valueOf(blockNodePort))
                 .withEnv(config.envOverrides())
                 .withEnv(

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/subscriber/positive/PositiveSingleSubscriberTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/subscriber/positive/PositiveSingleSubscriberTests.java
@@ -186,24 +186,30 @@ public class PositiveSingleSubscriberTests extends BaseSuite {
         final Future<?> consumerSimulatorThread = startSimulatorInThread(consumerSimulator);
         simulators.add(consumerSimulatorThread);
 
-        long previousBlockTime = System.currentTimeMillis();
-        boolean slowdownValidated = true;
-
-        for (long block = startBlock; block <= endBlock; block++) {
-            while (consumerSimulator.getStreamStatus().consumedBlocks() < block) {
-                Thread.sleep(1); // Wait for the block to be consumed
-            }
-            final long currentBlockTime = System.currentTimeMillis();
-            final long timeDifference = currentBlockTime - previousBlockTime;
-
-            if (timeDifference < expectedSlowdownMillis) {
-                slowdownValidated = false;
-                break;
-            }
-            previousBlockTime = currentBlockTime;
+        // Wait for the first block to be consumed before starting the clock. Block 1 has no
+        // slowdown applied (the consumer's internal counter is 0 when block 1 arrives, which is
+        // outside the configured range 1-10), so it arrives quickly and serves as a warm-up gate.
+        while (consumerSimulator.getStreamStatus().consumedBlocks() < startBlock) {
+            Thread.sleep(5);
         }
+        final long startTime = System.currentTimeMillis();
 
-        assertTrue(slowdownValidated, "The expected 2ms slowdown was not validated for all blocks.");
+        // Wait for blocks startBlock+1 through endBlock. Each of these 9 blocks triggers the 2ms
+        // slowdown inside the consumer's gRPC onNext() thread, delaying the END_OF_BLOCK response
+        // that increments the consumedBlocks counter.
+        while (consumerSimulator.getStreamStatus().consumedBlocks() < endBlock) {
+            Thread.sleep(5);
+        }
+        final long elapsed = System.currentTimeMillis() - startTime;
+
+        // 9 inter-block intervals × 2ms each = 18ms minimum. Measuring total duration rather than
+        // per-block intervals avoids a race where the test's poll thread observes two consecutive
+        // block increments in the same wake-up cycle and records a near-zero interval for one of them.
+        final long expectedMinimumMs = (endBlock - startBlock) * expectedSlowdownMillis;
+        assertTrue(
+                elapsed >= expectedMinimumMs,
+                "Slowdown check failed: elapsed=%dms, expected>=%dms (range=%d-%d, slowdown=%dms)"
+                        .formatted(elapsed, expectedMinimumMs, startBlock, endBlock, expectedSlowdownMillis));
         assertEquals(endBlock, consumerSimulator.getStreamStatus().consumedBlocks());
     }
 

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/subscriber/positive/PositiveSingleSubscriberTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/subscriber/positive/PositiveSingleSubscriberTests.java
@@ -75,10 +75,8 @@ public class PositiveSingleSubscriberTests extends BaseSuite {
         simulators.add(consumerSimulatorThread);
 
         boolean isConsumingBlocks = false;
-        // We assign lastConsumedBlock as the last published, so that we can track it later.
-        // This will help us determine whether we are actually consuming blocks.
-        long lastConsumedBlock = publisherSimulator.getStreamStatus().publishedBlocks();
-        int retries = 3;
+        long lastConsumedBlock = 0;
+        int retries = 10;
 
         while (retries > 0) {
             if (consumerSimulator.getStreamStatus().consumedBlocks() > lastConsumedBlock) {

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/subscriber/positive/PositiveSingleSubscriberTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/subscriber/positive/PositiveSingleSubscriberTests.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Future;
 import org.hiero.block.simulator.BlockStreamSimulatorApp;
+import org.hiero.block.simulator.config.data.StreamStatus;
 import org.hiero.block.suites.BaseSuite;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -115,9 +116,12 @@ public class PositiveSingleSubscriberTests extends BaseSuite {
         final Future<?> publisherSimulatorThread = startSimulatorInstance(publisherSimulator);
         simulators.add(publisherSimulatorThread);
         boolean publisherReachedEndBlock = false;
-        while (!publisherReachedEndBlock) {
-            if (publisherSimulator.getStreamStatus().publishedBlocks() > endBlock) {
+        while (!publisherReachedEndBlock && publisherSimulator.isRunning()) {
+            final StreamStatus status = publisherSimulator.getStreamStatus();
+            if (status != null && status.publishedBlocks() > endBlock) {
                 publisherReachedEndBlock = true;
+            } else {
+                Thread.sleep(10);
             }
         }
         // ===== Start consumer and try to request blocks ===========================================
@@ -125,7 +129,7 @@ public class PositiveSingleSubscriberTests extends BaseSuite {
         simulators.add(consumerSimulatorThread);
 
         boolean isConsumingBlocks = false;
-        int retries = 3;
+        int retries = 10;
 
         while (retries > 0) {
             if (consumerSimulator.getStreamStatus().consumedBlocks() > 0
@@ -174,9 +178,12 @@ public class PositiveSingleSubscriberTests extends BaseSuite {
         simulators.add(publisherSimulatorThread);
 
         boolean publisherReachedEndBlock = false;
-        while (!publisherReachedEndBlock) {
-            if (publisherSimulator.getStreamStatus().publishedBlocks() > endBlock) {
+        while (!publisherReachedEndBlock && publisherSimulator.isRunning()) {
+            final StreamStatus status = publisherSimulator.getStreamStatus();
+            if (status != null && status.publishedBlocks() > endBlock) {
                 publisherReachedEndBlock = true;
+            } else {
+                Thread.sleep(10);
             }
         }
 


### PR DESCRIPTION
## Summary

Four E2E test flakiness sources fixed in this PR.

### 1. `testAutonomousBackfill` — backfill scanner got only one chance within the poll window

The test already overrides `BACKFILL_INITIAL_DELAY=5000ms` but never overrode `BACKFILL_SCAN_INTERVAL`, which defaults to 60,000ms (the production value). With the existing 60s `awaitBackfilledBlocks` poll, any transient failure on the first scan (e.g. live-storage not yet reporting its range after a Docker restart) meant the second scan wouldn't fire until T+65s — one second after the poll had already expired.

**Fix:** add `BACKFILL_SCAN_INTERVAL=10000ms` (10s) alongside the existing `BACKFILL_INITIAL_DELAY=5000ms` in `BaseSuite.createContainer(config)`. This gives 6 scan opportunities within the 60s window, so any single bad scan is a retry away from success — not a test failure.

### 2. `shouldValidateSlowdownAfterEachBlock` — per-block interval measurement was racy

The test measured wall-clock time between successive `consumedBlocks()` increments and required each interval to be ≥ 2ms. This was fragile because:
- `System.currentTimeMillis()` has ~10–15ms resolution on Linux CI runners vs. a 2ms threshold
- The 1ms polling loop could observe two consecutive block increments in one wake-up, recording a ≈0ms interval for the second block
- The consumer uses two separate internal counters (`blocksConsumed` AtomicLong for slowdown gating vs. `LiveBlocksConsumed` metric used by `getStreamStatus()`), adding an independent desync path

**Fix:** replace the per-block loop with a total-duration measurement anchored to when block 1 is first observed. The 9 remaining blocks (2-10) each carry the 2ms delay, so the minimum total is 9 × 2ms = 18ms — well above any OS timer resolution — and the check is immune to the batch-detection race entirely.

### 3. `shouldSubscribeForHistoricalAndLiveBlocks` — consumer baseline chased a moving publisher target (closes #2285)

The same baseline-initialisation bug fixed in PR #3314 for `PositiveMultipleSubscribersTests` was missed in the single-subscriber counterpart. Setting `lastConsumedBlock = publisherSimulator.publishedBlocks()` as the initial threshold forced the consumer to beat a moving target (the publisher keeps publishing) within only 3 retries (3s), which fails under CI load.

**Fix:** reset baseline to 0 and extend retries to 10 (10s) — consistent with the multi-subscriber fix in PR #3314.

### 4. Publisher spin loops — NPE and CPU starvation on simulator failure

Two busy-wait loops in `shouldSubscribeForHistoricalBlocks` and `shouldValidateSlowdownAfterEachBlock` spun unconditionally on `publisherSimulator.getStreamStatus().publishedBlocks()`. When the simulator receives a gRPC `UNAVAILABLE` (e.g. block node container shutting down mid-test) it stops itself and `getStreamStatus()` returns null, causing an NPE at the call site. The spin also consumed 100% CPU, starving the simulator thread.

**Fix:** guard each loop with `publisherSimulator.isRunning()` so it exits cleanly on failure, null-check the returned `StreamStatus` to cover the TOCTOU window between the guard and the call, and add a `Thread.sleep(10)` to yield the CPU each iteration. Also raise `shouldSubscribeForHistoricalBlocks` consumer retries from 3 to 10 for consistency.

## Test plan
- [ ] `./gradlew :suites:runSuites` passes consistently with the block-node image
- [ ] No regressions in remaining `PositiveMultiplePublishersTests` or `PositiveSingleSubscriberTests` cases
- [ ] CI green

Closes #2266
Closes #2285