### PR TITLE
fix(ci): bump k6-tests.yml Solo CLI pin from 0.72.0 to 0.84.0

### DIFF
--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew --no-daemon
-  SOLO_VERSION: "0.72.0"
+  SOLO_VERSION: "0.84.0"
 
 jobs:
   k6-tests:


### PR DESCRIPTION
## Summary

`k6-tests.yml` has been failing on every run — timing out after the full 30-minute job timeout. Traced two recent runs (30596097838, 30595720014) and both hang at the exact same point: Solo's own `Check block node readiness` step, immediately after Kubernetes-level pod readiness already passed. No further output is produced until the job gets cancelled at the timeout.

`k6-tests.yml` is the only workflow that installs the Solo CLI directly, and it's hardcoded `SOLO_VERSION: "0.72.0"` — last touched in #2647 and never bumped since. Every other Solo consumer in this repo (`solo-e2e-test.yml`, and `e2e-node-operator.yaml`/`solo-e2e-scheduler.yml` through it) defaults to `0.84.0`. Run history over the same window shows the split cleanly: `e2e-node-operator.yaml` is 5/5 green, `solo-e2e-test.yml` completes (mixed pass/fail, but not hanging), while `k6-tests.yml` is 100% cancelled/timed-out.

## Change

Bump `SOLO_VERSION` in `k6-tests.yml` from `0.72.0` to `0.84.0`, matching the version already proven against the current block-node chart/TSS-overlay combination elsewhere in the repo. No other changes — Node.js is already pinned to 22.x in this workflow, which already satisfies Solo 0.84.0's engine requirement (same version `solo-e2e-test.yml` uses).

## Backward Compatibility

| Scenario | Impact |
|---|---|
| k6 workflow runs (push to `main`/`release/*`, PR open/reopen/sync) | Now installs Solo 0.84.0 instead of 0.72.0 — same CLI surface used elsewhere in the repo |
| Other workflows | Unaffected — this only touches `k6-tests.yml`'s own env var |

## Testing

- `./gradlew spotlessCheck` passes.
- This PR's own CI run of `k6-tests.yml` is the real test — watching it now to confirm the hang at "Check block node readiness" clears with the version bump.

## Related

- Every recent run of `k6-tests.yml` prior to this fix: cancelled/timed out (e.g. https://github.com/hiero-ledger/hiero-block-node/actions/runs/30596097838/job/91048675408, https://github.com/hiero-ledger/hiero-block-node/actions/runs/30595720014/job/91047558848)