### PR TITLE
fix: raise idleConnectionTimeout to 24h to prevent subscriber stream drops

### DIFF
--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ServerConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ServerConfig.java
@@ -22,8 +22,9 @@ import org.hiero.block.node.base.Loggable;
  * @param maxTcpConnections the maximum number of TCP connections
  * @param idleConnectionPeriodMinutes how often (minutes) the idle-connection reaper runs
  * @param idleConnectionTimeoutMinutes how long (minutes) a connection may sit idle before it is
- *     closed; kept short so idle sockets are reclaimed well before they accumulate to
- *     {@code maxTcpConnections} and the server starts refusing new connections
+ *     closed; set to 1440 (24 h) by default so that long-lived gRPC server-streaming connections
+ *     (e.g. {@code subscribeBlockStream}) are not torn down by the Helidon idle-connection reaper
+ *     while they are still actively receiving outbound DATA frames
  * @param tcpNoDelay whether to use TCP no delay
  * @param backlogSize the maximum length of the queue of incoming connections on the server socket.
  * @param writeQueueLength the number of buffers queued for write operations
@@ -38,7 +39,7 @@ public record ServerConfig(
         @Loggable @ConfigProperty(defaultValue = "500") int shutdownDelayMillis,
         @Loggable @ConfigProperty(defaultValue = "1000") int maxTcpConnections,
         @Loggable @ConfigProperty(defaultValue = "5") @Min(1) @Max(60) int idleConnectionPeriodMinutes,
-        @Loggable @ConfigProperty(defaultValue = "30") @Min(1) @Max(1_440) int idleConnectionTimeoutMinutes,
+        @Loggable @ConfigProperty(defaultValue = "1440") @Min(1) @Max(1_440) int idleConnectionTimeoutMinutes,
         @Loggable @ConfigProperty(defaultValue = "true") boolean tcpNoDelay,
         @Loggable @ConfigProperty(defaultValue = "8_192") int backlogSize,
         @Loggable @ConfigProperty(defaultValue = "8_192") int writeQueueLength) {}


### PR DESCRIPTION
## Summary

Fixes mirror node subscription streams closing every ~35 minutes with
`UNAVAILABLE: Network closed for unknown reason` (issue #3221).

### Root cause

Helidon's idle-connection reaper closes connections that have received no
inbound HTTP/2 requests for `idleConnectionTimeoutMinutes` (previously 30
minutes). Long-lived gRPC server-streaming subscriptions (`subscribeBlockStream`)
never send new inbound requests after the initial subscribe call — only
outbound DATA frames flow back to the mirror node. Helidon therefore
classified these active streaming connections as idle and tore them down
after the timeout elapsed.

The ~35-minute observed interval (not exactly 30) is explained by the
5-minute reaper period: a connection becomes eligible at T+30min and is
closed at the next reaper tick, which falls between T+30 and T+35.

### Fix

Raise `idleConnectionTimeoutMinutes` default from 30 to 1440 (24 hours —
the existing `@Max` constraint). Genuine idle connections (no frames of any
kind for 24 hours) are still reclaimed; only active streaming sessions are
protected.

### Why not a keep-alive PING fix?

Helidon 4.5.0 has no server-side PING support. The `pingFrame()` handler in
`Http2Connection.java` explicitly comments `"we do not send pings for now"`,
and client-sent PINGs do not reset the Helidon idle timer — only inbound
HEADERS frames update `lastRequestTimestamp`. A durable server-side keep-alive
mechanism requires an upstream Helidon change.

Client subscribers (e.g. mirror node) are requested to configure client-side
keep-alive on their gRPC channel as a complementary measure to protect against
intermediate cloud infrastructure (load balancers, firewalls) enforcing their
own idle timeouts:

```java
ManagedChannelBuilder.forTarget("block-node:40840")
    .keepAliveTime(60, TimeUnit.SECONDS)
    .keepAliveTimeout(20, TimeUnit.SECONDS)
    .keepAliveWithoutCalls(true)  // required for server-streaming subscriptions
    .build();
```

`keepAliveWithoutCalls(true)` is critical: without it, gRPC-java suppresses
PING frames when the client has no active outbound calls, which is always the
case after the initial subscribe request. This client-side configuration cannot
replace the server-side fix (Helidon does not reset its idle timer on PING
frames), but it does keep TCP state alive through cloud network infrastructure.

### Files changed

| File | Change |
|---|---|
| `block-node/app-config/.../ServerConfig.java` | `idleConnectionTimeoutMinutes` default: `"30"` → `"1440"` + updated Javadoc |

## Test plan

- [ ] Deploy to testnet and confirm mirror node subscription streams survive
  past the 35-minute mark without reconnection
- [ ] Confirm genuinely idle connections (no activity for 24h) are still
  reclaimed by the reaper
- [ ] CI green

Closes #3221