### PR TITLE
fix: Increase performance of serverStatus and serverStatusDetails gRpc calls.

### DIFF
--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
@@ -108,10 +108,11 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
         // serverStatus has the latest max available block. serverStatusDetail has an up to .5s old
         // snapshot. This will align the lastBlock range end with what serverStatus would report without
         // having to rebuild the entire available Blocks list.
+        final long liveMax = blockProvider.availableBlocks().max();
         List<BlockRange> fixedAvailable = !context.availableBlocks().isEmpty()
-                        && context.availableBlocks().getLast().rangeEnd()
-                                != blockProvider.availableBlocks().max()
-                ? fixAvailable(context.availableBlocks())
+                        && liveMax != UNKNOWN_BLOCK_NUMBER
+                        && context.availableBlocks().getLast().rangeEnd() != liveMax
+                ? fixAvailable(context.availableBlocks(), liveMax)
                 : context.availableBlocks();
 
         // Return detailed block node status information. Every field is read from the
@@ -130,18 +131,18 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
 
     /**
      * Returns a copy of {@code availableBlocks} whose last range end is aligned with the live
-     * {@code blockProvider.availableBlocks().max()}. A copy is returned because the supplied list is
-     * the shared, immutable context snapshot (see {@code ApplicationStateUtility.toBlockRange}); it
-     * must never be mutated in place.
+     * {@code liveMax}. A copy is returned because the supplied list is the shared, immutable context
+     * snapshot (see {@code ApplicationStateUtility.toBlockRange}); it must never be mutated in place.
      *
      * @param availableBlocks the context snapshot of available ranges (never empty)
+     * @param liveMax the live maximum available block number to align the last range end with
      * @return a new list with the last range end aligned to the live max
      */
-    private List<BlockRange> fixAvailable(final List<BlockRange> availableBlocks) {
+    private List<BlockRange> fixAvailable(final List<BlockRange> availableBlocks, final long liveMax) {
         final BlockRange lastBlockRange = availableBlocks.getLast();
         final BlockRange newLastBlockRange = BlockRange.newBuilder()
                 .rangeStart(lastBlockRange.rangeStart())
-                .rangeEnd(blockProvider.availableBlocks().max())
+                .rangeEnd(liveMax)
                 .build();
 
         final List<BlockRange> aligned = new ArrayList<>(availableBlocks);

--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
@@ -5,6 +5,7 @@ import static java.lang.System.Logger.Level.TRACE;
 import static java.util.Objects.requireNonNull;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
 import java.util.List;
 import org.hiero.block.api.BlockNodeServiceInterface;
 import org.hiero.block.api.BlockRange;
@@ -127,15 +128,25 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
                 .build();
     }
 
-    List<BlockRange> fixAvailable(List<BlockRange> availableBlocks) {
-        BlockRange lastBlockRange = availableBlocks.getLast();
-        BlockRange newLastBlockRange = BlockRange.newBuilder()
+    /**
+     * Returns a copy of {@code availableBlocks} whose last range end is aligned with the live
+     * {@code blockProvider.availableBlocks().max()}. A copy is returned because the supplied list is
+     * the shared, immutable context snapshot (see {@code ApplicationStateUtility.toBlockRange}); it
+     * must never be mutated in place.
+     *
+     * @param availableBlocks the context snapshot of available ranges (never empty)
+     * @return a new list with the last range end aligned to the live max
+     */
+    private List<BlockRange> fixAvailable(final List<BlockRange> availableBlocks) {
+        final BlockRange lastBlockRange = availableBlocks.getLast();
+        final BlockRange newLastBlockRange = BlockRange.newBuilder()
                 .rangeStart(lastBlockRange.rangeStart())
                 .rangeEnd(blockProvider.availableBlocks().max())
                 .build();
 
-        availableBlocks.set(availableBlocks.size() - 1, newLastBlockRange);
-        return availableBlocks;
+        final List<BlockRange> aligned = new ArrayList<>(availableBlocks);
+        aligned.set(aligned.size() - 1, newLastBlockRange);
+        return aligned;
     }
 
     // ==== BlockNodePlugin Methods ====================================================================================

--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
@@ -5,10 +5,7 @@ import static java.lang.System.Logger.Level.TRACE;
 import static java.util.Objects.requireNonNull;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.ArrayList;
-import java.util.List;
 import org.hiero.block.api.BlockNodeServiceInterface;
-import org.hiero.block.api.BlockRange;
 import org.hiero.block.api.ServerStatusDetailResponse;
 import org.hiero.block.api.ServerStatusRequest;
 import org.hiero.block.api.ServerStatusResponse;
@@ -17,8 +14,8 @@ import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.historicalblocks.BlockRangeSet;
 import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
-import org.hiero.block.node.spi.historicalblocks.LongRange;
 import org.hiero.metrics.LongCounter;
 import org.hiero.metrics.core.MetricKey;
 import org.hiero.metrics.core.MetricRegistry;
@@ -60,8 +57,10 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
 
         final ApplicationStateFacility stateFacility = blockNodeContext.applicationStateFacility();
         final ServerStatusResponse.Builder serverStatusResponseBuilder = ServerStatusResponse.newBuilder();
-        final long firstAvailableBlock = blockProvider.availableBlocks().min();
-        long highestAvailableBlock = blockProvider.availableBlocks().max();
+        // Read min and max from a single reference so both come from a consistent snapshot
+        final BlockRangeSet availableBlocks = blockProvider.availableBlocks();
+        final long firstAvailableBlock = availableBlocks.min();
+        final long highestAvailableBlock = availableBlocks.max();
         long nextExpectedBlock = stateFacility.nextExpectedBlock();
         if (nextExpectedBlock < earliestManagedBlock) {
             nextExpectedBlock = UNKNOWN_BLOCK_NUMBER;
@@ -101,32 +100,15 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
         requestDetailCounter.increment();
 
         // blockNodeContext is volatile, assign to local variable so reference stays consistent
-        BlockNodeContext context = blockNodeContext;
+        final BlockNodeContext context = blockNodeContext;
 
-        ServerStatusDetailResponse.Builder detailsBuilder = ServerStatusDetailResponse.newBuilder();
-
-        // add in version information
-        detailsBuilder.versionInformation(context.blockNodeVersions());
-
-        BlockRange.Builder blockRangeBuilder = BlockRange.newBuilder();
-
-        List<BlockRange> blockRanges = new ArrayList<>();
-
-        for (LongRange longRange : context.historicalBlockProvider()
-                .availableBlocks()
-                .streamRanges()
-                .toList()) {
-            blockRanges.add(blockRangeBuilder
-                    .rangeStart(longRange.start())
-                    .rangeEnd(longRange.end())
-                    .build());
-        }
-
-        // return detailed block node status information.
-        return detailsBuilder
-                .availableRanges(blockRanges)
-                // @todo(3004) change to use context.availableBlocks() when that becomes the source of truth
-                // .availableRanges(context.availableBlocks())
+        // Return detailed block node status information. Every field is read from the
+        // periodically-refreshed context snapshot: this keeps the response internally consistent
+        // and avoids recomputing the merged available ranges on every request (the context already
+        // holds the merged List<BlockRange> maintained by the application state facility).
+        return ServerStatusDetailResponse.newBuilder()
+                .versionInformation(context.blockNodeVersions())
+                .availableRanges(context.availableBlocks())
                 .storedRanges(context.storedBlocks())
                 .tssData(context.tssData())
                 .nodeAddressBook(context.nodeAddressBook())

--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
@@ -5,7 +5,9 @@ import static java.lang.System.Logger.Level.TRACE;
 import static java.util.Objects.requireNonNull;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
 import org.hiero.block.api.BlockNodeServiceInterface;
+import org.hiero.block.api.BlockRange;
 import org.hiero.block.api.ServerStatusDetailResponse;
 import org.hiero.block.api.ServerStatusRequest;
 import org.hiero.block.api.ServerStatusResponse;
@@ -102,18 +104,38 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
         // blockNodeContext is volatile, assign to local variable so reference stays consistent
         final BlockNodeContext context = blockNodeContext;
 
+        // serverStatus has the latest max available block. serverStatusDetail has an up to .5s old
+        // snapshot. This will align the lastBlock range end with what serverStatus would report without
+        // having to rebuild the entire available Blocks list.
+        List<BlockRange> fixedAvailable = !context.availableBlocks().isEmpty()
+                        && context.availableBlocks().getLast().rangeEnd()
+                                != blockProvider.availableBlocks().max()
+                ? fixAvailable(context.availableBlocks())
+                : context.availableBlocks();
+
         // Return detailed block node status information. Every field is read from the
         // periodically-refreshed context snapshot: this keeps the response internally consistent
         // and avoids recomputing the merged available ranges on every request (the context already
         // holds the merged List<BlockRange> maintained by the application state facility).
         return ServerStatusDetailResponse.newBuilder()
                 .versionInformation(context.blockNodeVersions())
-                .availableRanges(context.availableBlocks())
+                .availableRanges(fixedAvailable)
                 .storedRanges(context.storedBlocks())
                 .tssData(context.tssData())
                 .nodeAddressBook(context.nodeAddressBook())
                 .rangedAddressBookHistory(context.rangedAddressBookHistory())
                 .build();
+    }
+
+    List<BlockRange> fixAvailable(List<BlockRange> availableBlocks) {
+        BlockRange lastBlockRange = availableBlocks.getLast();
+        BlockRange newLastBlockRange = BlockRange.newBuilder()
+                .rangeStart(lastBlockRange.rangeStart())
+                .rangeEnd(blockProvider.availableBlocks().max())
+                .build();
+
+        availableBlocks.set(availableBlocks.size() - 1, newLastBlockRange);
+        return availableBlocks;
     }
 
     // ==== BlockNodePlugin Methods ====================================================================================

--- a/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusDetailServicePluginTest.java
+++ b/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusDetailServicePluginTest.java
@@ -43,13 +43,13 @@ import org.junit.jupiter.api.Test;
 public class ServerStatusDetailServicePluginTest
         extends GrpcPluginTestBase<ServerStatusServicePlugin, BlockingExecutor, ScheduledExecutorService> {
     private final ServerStatusServicePlugin plugin = new ServerStatusServicePlugin();
+    private final SimpleInMemoryHistoricalBlockFacility historicalBlockFacility =
+            new SimpleInMemoryHistoricalBlockFacility();
 
     public ServerStatusDetailServicePluginTest() {
         super(
                 new BlockingExecutor(new LinkedBlockingQueue<>()),
                 new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
-        final SimpleInMemoryHistoricalBlockFacility historicalBlockFacility =
-                new SimpleInMemoryHistoricalBlockFacility();
         final SimpleBlockRangeSet temporaryAvailableBlocks = new SimpleBlockRangeSet();
         temporaryAvailableBlocks.add(1_000_000_000_000L, 1_000_000_000_005L);
         temporaryAvailableBlocks.add(0L, 5L);
@@ -240,6 +240,34 @@ public class ServerStatusDetailServicePluginTest
     @DisplayName("Should expose the plugin name")
     void shouldExposePluginName() {
         assertEquals("ServerStatusServicePlugin", plugin.name());
+    }
+
+    /**
+     * Tests that when the live provider reports no blocks (max is unknown), the context snapshot is
+     * returned unchanged rather than having its last range end clobbered to the {@code -1} unknown
+     * sentinel by the drift-alignment path.
+     *
+     * @throws ParseException if there is an error parsing the response
+     */
+    @Test
+    @DisplayName("Should not corrupt last range when live provider is empty")
+    void shouldReturnSnapshotUnchangedWhenLiveProviderIsEmpty() throws ParseException {
+        // Context snapshot holds a non-empty range, but the live provider is empty (max == -1).
+        replaceAvailableBlocks(List.of(new BlockRange(0L, 5L)));
+        historicalBlockFacility.setTemporaryAvailableBlocks(new SimpleBlockRangeSet());
+
+        toPluginPipe.onNext(ServerStatusRequest.PROTOBUF.toBytes(
+                ServerStatusRequest.newBuilder().build()));
+        assertEquals(1, fromPluginBytes.size());
+
+        final ServerStatusDetailResponse response =
+                standardParse(ServerStatusDetailResponse.PROTOBUF, fromPluginBytes.getFirst());
+
+        // Snapshot returned unchanged — no rangeEnd = -1 corruption
+        final List<BlockRange> ranges = response.availableRanges();
+        assertEquals(1, ranges.size());
+        assertEquals(0L, ranges.getFirst().rangeStart());
+        assertEquals(5L, ranges.getFirst().rangeEnd()); // NOT -1
     }
 
     @Test

--- a/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusDetailServicePluginTest.java
+++ b/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusDetailServicePluginTest.java
@@ -198,6 +198,50 @@ public class ServerStatusDetailServicePluginTest
         assertFalse(response.hasNodeAddressBook());
     }
 
+    /**
+     * Tests that when the context snapshot is slightly stale, the last available range end is
+     * aligned with the live max reported by the historical block provider, without mutating the
+     * shared context snapshot list.
+     *
+     * @throws ParseException if there is an error parsing the response
+     */
+    @Test
+    @DisplayName("Should align last available range end with live max when the snapshot has drifted")
+    void shouldAlignLastAvailableRangeEndWhenSnapshotDrifted() throws ParseException {
+        // The historical block provider's live max is 1_000_000_000_005L. Provide a context snapshot
+        // whose last range end lags behind that value to trigger the drift-alignment path. The list is
+        // immutable (List.of) to prove fixAvailable does not mutate the shared snapshot in place.
+        final List<BlockRange> staleAvailableBlocks =
+                List.of(new BlockRange(0L, 5L), new BlockRange(1_000_000_000_000L, 1_000_000_000_000L));
+        replaceAvailableBlocks(staleAvailableBlocks);
+
+        toPluginPipe.onNext(ServerStatusRequest.PROTOBUF.toBytes(
+                ServerStatusRequest.newBuilder().build()));
+        assertEquals(1, fromPluginBytes.size());
+
+        final ServerStatusDetailResponse response =
+                standardParse(ServerStatusDetailResponse.PROTOBUF, fromPluginBytes.getFirst());
+
+        final List<BlockRange> availableRanges = response.availableRanges();
+        assertEquals(2, availableRanges.size());
+        // Earlier ranges are untouched
+        assertEquals(0L, availableRanges.getFirst().rangeStart());
+        assertEquals(5L, availableRanges.getFirst().rangeEnd());
+        // Last range start preserved, end aligned to the live max
+        final BlockRange lastRange = availableRanges.getLast();
+        assertEquals(1_000_000_000_000L, lastRange.rangeStart());
+        assertEquals(1_000_000_000_005L, lastRange.rangeEnd());
+
+        // The shared context snapshot must not have been mutated in place
+        assertEquals(1_000_000_000_000L, staleAvailableBlocks.getLast().rangeEnd());
+    }
+
+    @Test
+    @DisplayName("Should expose the plugin name")
+    void shouldExposePluginName() {
+        assertEquals("ServerStatusServicePlugin", plugin.name());
+    }
+
     @Test
     @DisplayName("Should include NodeAddressBook in response when context carries one")
     void shouldReturnNodeAddressBookWhenLoaded() throws ParseException {


### PR DESCRIPTION
## Reviewer Notes

**`serverStatusDetail`:** Replaced the per-request loop that called `context.historicalBlockProvider().availableBlocks().streamRanges().toList()` and rebuilt a `List<BlockRange>` by hand. That path triggered `CombinedBlockRangeSet.reduceRanges()`, which reconstructs and re-merges a fresh `ConcurrentLongRangeSet` on every call. It now reads the already-merged, periodically-refreshed `context.availableBlocks()` snapshot — the same source already used for `storedRanges`, `tssData`, etc.  

One thing to flag: `context.availableBlocks()` is refreshed on the app-state scan interval (default 500ms), so `availableRanges` is now eventually-consistent (up to one scan interval stale) rather than live-at-request-time. Given every sibling field in this response was already snapshot-based, that's consistent with the existing design.

**`serverStatus`:** Captured `blockProvider.availableBlocks()` into a single local so `min()` and `max()` read from one reference instead of two separate calls. This is a consistency tidy-up, not a meaningful speedup — that call was already O(1)-ish.

## Related Issue(s)
Closes #3004.
Closes #3306.