### PR TITLE
fix(sync): preserve hiero-docs-only landing pages on every sync

### DIFF
--- a/.github/workflows/sync-docs-to-gitbook.yaml
+++ b/.github/workflows/sync-docs-to-gitbook.yaml
@@ -40,7 +40,6 @@ jobs:
 
       - name: Copy docs
         run: |
-          rm -rf hiero-docs/block-node
           mkdir -p hiero-docs/block-node
           cp -r block-node/docs/. hiero-docs/block-node/
 


### PR DESCRIPTION
The sync workflow ran `rm -rf hiero-docs/block-node` before copying docs, which deleted [GitBook card-view landing pages](https://docs.hiero.org/block-node-home) that exist only in hiero-docs. Because `git add block-node/` stages deletions, every sync PR was silently removing these files.

Removing the `rm -rf` means `cp` only adds or overwrites files - it never deletes. Landing pages that have no counterpart in hiero-block-node/docs are never staged for deletion and survive every sync.

