### PR TITLE
chore(tools): add bn-block-capture and find-state-proof-block scripts

### DIFF
--- a/tools-and-tests/scripts/bn-block-capture/.gitignore
+++ b/tools-and-tests/scripts/bn-block-capture/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+proto-py/
+__pycache__/
+*.pyc
+*.csv

--- a/tools-and-tests/scripts/bn-block-capture/README.md
+++ b/tools-and-tests/scripts/bn-block-capture/README.md
@@ -1,0 +1,136 @@
+# bn-block-capture
+
+Python tooling to capture block recordings from a Hiero Block Node and store them as standard `<n>.blk.zstd` files (binary `Block.SerializeToString()` zstd-compressed — bit-exact to what BNs write to disk).
+
+Designed for sampling blocks at known TPS plateaus (idle, 100, 1.5k, 7k, 10k, ...) and around the Schnorr -> WRAPS TSS signature transition.
+
+## Why grpcurl, not native Python gRPC
+
+Helidon-based Block Nodes reject Python `grpcio`'s HTTP/2 settings frame with `GOAWAY error code 1` immediately after the SETTINGS exchange. `grpcurl` (Go-based) works fine, so `bn_client.py` shells out to `grpcurl`, parses the JSON response, and re-serializes through the generated protobuf classes. The on-disk bytes are still identical to a native binary fetch.
+
+## Prerequisites
+
+- `python3` (>=3.8) with `venv`
+- [`grpcurl`](https://github.com/fullstorydev/grpcurl) on PATH (`brew install grpcurl`)
+- Run from a checkout of the Hiero Block Node repo (the script uses `../../../protobuf-sources/`)
+
+## Setup (one-time)
+
+```
+cd tools-and-tests/scripts/bn-block-capture
+./setup.sh
+```
+
+This creates `.venv/`, installs Python deps, and compiles all `.proto` files into `proto-py/`. Re-run after proto changes.
+
+## Scripts
+
+|     Script     |                                              Purpose                                              |
+|----------------|---------------------------------------------------------------------------------------------------|
+| `bn_client.py` | gRPC client wrapping `grpcurl`. Exposes `BlockNodeClient.server_status()` / `get_block()`.        |
+| `profiler.py`  | Sparse + dense TPS scanner, plus binary-search Schnorr->WRAPS transition finder.                  |
+| `download.py`  | Bulk downloader. Parallel workers, zstd compression, resumable (skips existing files).            |
+| `verify.py`    | Decompresses every file in a bucket, parses the Block, recomputes avg TPS over the actual window. |
+
+All scripts take `--endpoint host:port`.
+
+## Workflow
+
+### 1. Survey the BN
+
+```
+.venv/bin/python profiler.py --endpoint host:port scan \
+  --start 0 --end 778000 --count 150 --parallel 16 --out scan-phase1.csv
+```
+
+CSV gives you the TPS profile: each row is one sampled block with its measured TPS (computed from this block's tx count divided by `ts(N+1) - ts(N)`). Open it and identify plateaus (consecutive samples with similar TPS).
+
+### 2. Find the Schnorr -> WRAPS transition
+
+The first WRAPS block typically lives in `[~300, ~1000]` for current BNCE-style networks.
+
+```
+.venv/bin/python profiler.py --endpoint host:port transition --start 100 --end 1500
+```
+
+Prints `TRANSITION_BLOCK=N` (the first WRAPS block). Note that this block can be ~95 MB raw because it carries the TSS WRAPS-key payload.
+
+### 3. Drill into plateau boundaries (optional)
+
+If a plateau's exact start/end matters, scan it densely:
+
+```
+.venv/bin/python profiler.py --endpoint host:port scan \
+  --start 460000 --end 530000 --count 35 --parallel 16 --out drill-1500-7k.csv
+```
+
+### 4. Download the buckets
+
+Pick centers safely inside each plateau and a window size. The downloader writes `<n:010>.blk.zstd` into the output dir.
+
+Default window is 100 blocks per bucket (configurable via `--count`). Centers below are illustrative — re-derive them from your own scan, since block ranges grow as the network advances.
+
+```
+.venv/bin/python download.py --endpoint host:port --out tps-100 \
+  --start 349500 --count 100 --parallel 20 --timeout 60
+
+.venv/bin/python download.py --endpoint host:port --out tps-1500 \
+  --start 479500 --count 100 --parallel 16 --timeout 120
+
+.venv/bin/python download.py --endpoint host:port --out tps-7000 \
+  --start 513500 --count 100 --parallel 12 --timeout 180
+
+.venv/bin/python download.py --endpoint host:port --out tps-10000 \
+  --start 677000 --count 100 --parallel 8 --timeout 240
+```
+
+Tune `--parallel` per bucket: small blocks (low TPS) tolerate ~20+ workers; 10k-TPS blocks are 20-30 MB each so 6-10 workers is more honest. Transient `NOT_AVAILABLE` failures are normal; re-run the same command — it skips existing files and only retries the misses.
+
+### 5. Verify
+
+```
+.venv/bin/python verify.py tps-100 tps-1500 tps-7000 tps-10000
+```
+
+Reports per-bucket: file count, total transactions, first/last block, duration, **measured avg TPS**, raw vs compressed size.
+
+## Output Format
+
+Each `<n>.blk.zstd` is `zstd(Block.SerializeToString())`. Decompress + use existing block tools:
+
+```
+zstd -d 0000349500.blk.zstd -o 0000349500.blk
+./tool.sh blocks json <dir>
+./tool.sh blocks validate <dir>
+```
+
+## Typical Sizes (zstd level 3)
+
+| Bucket TPS | Avg raw size | Avg zstd size | Compression |
+|------------|--------------|---------------|-------------|
+| 7 (idle)   | ~33 KB       | ~25 KB        | 1.3x        |
+| 100        | ~200 KB      | ~100 KB       | 2.0x        |
+| 1,500      | ~4.7 MB      | ~2.8 MB       | 1.7x        |
+| 7,000      | ~20 MB       | ~12 MB        | 1.7x        |
+| 10,000     | ~30 MB       | ~18 MB        | 1.7x        |
+
+So the default 100 blocks at 10k TPS ≈ ~1.8 GB on disk (1,000 blocks would be ~18 GB).
+
+## Throughput Notes
+
+Per-block fetch time is dominated by JSON serialization on the BN + parse in Python (the grpcurl JSON round-trip). Empirically:
+- ~14 blocks/s at 100 TPS (small blocks)
+- ~1.6 blocks/s at 1.5k TPS
+- ~0.2-0.3 blocks/s at 7-10k TPS
+
+So 1,000 blocks at 10k TPS takes ~1.5h. For bigger captures consider switching to the streaming subscribe service (`subscribeBlockStream`), which keeps a single HTTP/2 connection alive and eliminates per-request startup cost. Not implemented here yet.
+
+## Troubleshooting
+
+- **`GOAWAY received; Error code: 1`** — you're hitting native `grpcio` instead of `grpcurl`. Make sure you're invoking the scripts in this folder, which always shell out to `grpcurl`.
+- **`malformed header: missing HTTP content-type`** — server doesn't speak gRPC reflection. Use the explicit `-proto` flag (which the scripts do).
+- **`NOT_AVAILABLE` on a few blocks in a 1,000-block run** — transient. Just re-run the same command; the downloader is resumable.
+- **Block 361 (or whichever the WRAPS transition is) fails with timeout** — that block is ~95 MB. Bump `--timeout 240` and run with `--parallel 1`.
+- **`platform' is not a package`** — `setup.sh` did not rename the generated `platform/` package to `_bn_platform/`. Re-run `./setup.sh`.
+
+See `.claude/commands/bn-backup.md` for the higher-level workflow doc that wraps this README.

--- a/tools-and-tests/scripts/bn-block-capture/bn_client.py
+++ b/tools-and-tests/scripts/bn-block-capture/bn_client.py
@@ -1,0 +1,175 @@
+"""Block Node client backed by ``grpcurl`` (Python grpcio is incompatible with
+this Helidon-based BN — it rejects the HTTP/2 SETTINGS frame with GOAWAY).
+
+The grpcurl subprocess fetches JSON which we re-parse through the generated
+protobuf classes and re-serialize to binary, so the on-disk file is bit-exact
+to a normally-stored Block message.
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+from typing import Optional, Tuple
+
+PROTO_PY = os.path.join(os.path.dirname(os.path.abspath(__file__)), "proto-py")
+if PROTO_PY not in sys.path:
+    sys.path.insert(0, PROTO_PY)
+
+from google.protobuf import json_format
+
+from block_node.api import block_access_service_pb2, node_service_pb2
+from block.stream import block_pb2
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+API_PROTO_DIR = os.path.join(REPO_ROOT, "protobuf-sources", "src", "main", "proto")
+STREAM_PROTO_DIR = os.path.join(REPO_ROOT, "protobuf-sources", "block-node-protobuf")
+
+MAX_MSG_SIZE = 300 * 1024 * 1024
+
+
+class FetchError(Exception):
+    """Raised when a block fetch fails after retries."""
+
+
+class NotAvailableError(FetchError):
+    """Block is genuinely not available (NOT_FOUND / NOT_AVAILABLE)."""
+
+
+def _run_grpcurl(
+    endpoint: str, proto_file: str, method: str, payload: str, timeout: float = 30.0
+) -> str:
+    cmd = [
+        "grpcurl",
+        "-plaintext",
+        "-import-path",
+        API_PROTO_DIR,
+        "-import-path",
+        STREAM_PROTO_DIR,
+        "-proto",
+        proto_file,
+        "-max-msg-sz",
+        str(MAX_MSG_SIZE),
+        "-d",
+        payload,
+        endpoint,
+        method,
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if proc.returncode != 0:
+        raise FetchError(f"grpcurl failed (rc={proc.returncode}): {proc.stderr.strip()}")
+    return proc.stdout
+
+
+class BlockNodeClient:
+    def __init__(self, endpoint: str, request_timeout: float = 30.0) -> None:
+        for prefix in ("tcp://", "http://", "https://"):
+            if endpoint.startswith(prefix):
+                endpoint = endpoint[len(prefix):]
+        self.endpoint = endpoint.rstrip("/")
+        self.request_timeout = request_timeout
+
+    def server_status(self) -> dict:
+        out = _run_grpcurl(
+            self.endpoint,
+            "block-node/api/node_service.proto",
+            "org.hiero.block.api.BlockNodeService/serverStatus",
+            "{}",
+            timeout=self.request_timeout,
+        )
+        msg = node_service_pb2.ServerStatusResponse()
+        json_format.Parse(out, msg, ignore_unknown_fields=True)
+        return {
+            "first_available_block": int(getattr(msg, "first_available_block", 0)),
+            "last_available_block": int(getattr(msg, "last_available_block", 0)),
+        }
+
+    def get_block(
+        self, block_number: int, retries: int = 5, base_delay: float = 0.5
+    ) -> Tuple[block_pb2.Block, bytes]:
+        """Return ``(Block message, raw bytes)`` for ``block_number``.
+
+        Raises ``NotAvailableError`` if the BN says the block isn't there;
+        raises ``FetchError`` for hard failures after ``retries`` retries.
+        """
+        attempt = 0
+        delay = base_delay
+        while True:
+            try:
+                out = _run_grpcurl(
+                    self.endpoint,
+                    "block-node/api/block_access_service.proto",
+                    "org.hiero.block.api.BlockAccessService/getBlock",
+                    json.dumps({"block_number": block_number}),
+                    timeout=self.request_timeout,
+                )
+            except FetchError as exc:
+                if attempt >= retries:
+                    raise
+                attempt += 1
+                time.sleep(min(delay, 8.0))
+                delay *= 2
+                continue
+
+            # grpcurl might emit nothing if server hangs up — guard against it.
+            stripped = out.strip()
+            if not stripped:
+                if attempt >= retries:
+                    raise FetchError(f"empty response for block {block_number}")
+                attempt += 1
+                time.sleep(min(delay, 8.0))
+                delay *= 2
+                continue
+
+            try:
+                payload = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                if attempt >= retries:
+                    raise FetchError(f"invalid JSON for block {block_number}: {exc}") from exc
+                attempt += 1
+                time.sleep(min(delay, 8.0))
+                delay *= 2
+                continue
+
+            status = payload.get("status", "SUCCESS")
+            if status in ("NOT_FOUND", "NOT_AVAILABLE"):
+                raise NotAvailableError(f"block {block_number}: {status}")
+            if status not in ("SUCCESS", 1, "1"):
+                raise FetchError(f"block {block_number}: status={status}")
+
+            resp = block_access_service_pb2.BlockResponse()
+            json_format.Parse(stripped, resp, ignore_unknown_fields=True)
+            block = resp.block
+            raw = block.SerializeToString()
+            return block, raw
+
+    @staticmethod
+    def estimate_block_metrics(block: block_pb2.Block) -> dict:
+        signed_tx_count = 0
+        item_count = 0
+        timestamp_seconds = 0
+        timestamp_nanos = 0
+        for item in block.items:
+            item_count += 1
+            which = item.WhichOneof("item")
+            if which == "signed_transaction":
+                signed_tx_count += 1
+            elif which == "block_header" and item.block_header.HasField("block_timestamp"):
+                timestamp_seconds = int(item.block_header.block_timestamp.seconds)
+                timestamp_nanos = int(item.block_header.block_timestamp.nanos)
+        return {
+            "signed_tx_count": signed_tx_count,
+            "item_count": item_count,
+            "timestamp_seconds": timestamp_seconds,
+            "timestamp_nanos": timestamp_nanos,
+        }
+
+    @staticmethod
+    def proof_signature_length(block: block_pb2.Block) -> int:
+        for item in block.items:
+            if item.WhichOneof("item") == "block_proof":
+                proof = item.block_proof
+                if proof.HasField("signed_block_proof"):
+                    return len(proof.signed_block_proof.block_signature)
+                return 0
+        return 0

--- a/tools-and-tests/scripts/bn-block-capture/download.py
+++ b/tools-and-tests/scripts/bn-block-capture/download.py
@@ -1,0 +1,119 @@
+"""Bulk-download blocks from a Block Node and store as ``<n>.blk.zstd``.
+
+Each output file is ``zstd(Block.SerializeToString())`` — the standard
+Block Node on-disk format.
+"""
+import argparse
+import concurrent.futures
+import os
+import sys
+import threading
+import time
+from typing import Iterable
+
+import zstandard
+
+from bn_client import BlockNodeClient, FetchError, NotAvailableError
+
+
+class BulkDownloader:
+    def __init__(self, endpoint: str, output_dir: str, level: int = 3, request_timeout: float = 120.0) -> None:
+        os.makedirs(output_dir, exist_ok=True)
+        self.output_dir = output_dir
+        self.level = level
+        self.client = BlockNodeClient(endpoint, request_timeout=request_timeout)
+        self._lock = threading.Lock()
+        self._done = 0
+        self._failed = []
+        self._skipped = 0
+        self._bytes_written = 0
+
+    def _save_one(self, block_number: int) -> str:
+        out_path = os.path.join(self.output_dir, f"{block_number:010d}.blk.zstd")
+        if os.path.exists(out_path) and os.path.getsize(out_path) > 0:
+            with self._lock:
+                self._skipped += 1
+                self._done += 1
+            return "SKIP"
+        try:
+            _, raw = self.client.get_block(block_number, retries=5)
+        except NotAvailableError:
+            with self._lock:
+                self._failed.append((block_number, "NOT_AVAILABLE"))
+                self._done += 1
+            return "NOT_AVAILABLE"
+        except FetchError as exc:
+            with self._lock:
+                self._failed.append((block_number, str(exc)))
+                self._done += 1
+            return f"ERROR:{exc}"
+
+        compressed = zstandard.ZstdCompressor(level=self.level).compress(raw)
+        tmp = out_path + ".tmp"
+        with open(tmp, "wb") as fh:
+            fh.write(compressed)
+        os.replace(tmp, out_path)
+        with self._lock:
+            self._done += 1
+            self._bytes_written += len(compressed)
+        return "OK"
+
+    def run(self, block_numbers: Iterable[int], parallel: int = 16) -> dict:
+        targets = list(block_numbers)
+        total = len(targets)
+        start = time.time()
+        print(f"  Downloading {total} blocks -> {self.output_dir} (parallel={parallel})", file=sys.stderr)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=parallel) as pool:
+            futures = {pool.submit(self._save_one, n): n for n in targets}
+            last_print = time.time()
+            for fut in concurrent.futures.as_completed(futures):
+                try:
+                    fut.result()
+                except Exception as exc:
+                    with self._lock:
+                        self._failed.append((futures[fut], f"EXC:{exc}"))
+                if time.time() - last_print > 5.0:
+                    with self._lock:
+                        d, b, sk = self._done, self._bytes_written, self._skipped
+                    elapsed = time.time() - start
+                    rate = d / elapsed if elapsed > 0 else 0
+                    mb = b / (1024 * 1024)
+                    print(
+                        f"    [{d}/{total}] {rate:.1f} blocks/s, {mb:.1f} MB written, {sk} skipped",
+                        file=sys.stderr,
+                    )
+                    last_print = time.time()
+
+        elapsed = time.time() - start
+        with self._lock:
+            failed = list(self._failed)
+            bytes_written = self._bytes_written
+            skipped = self._skipped
+        ok = total - len(failed) - skipped
+        print(
+            f"  Done: {ok} fetched, {skipped} skipped, {len(failed)} failed in {elapsed:.0f}s, {bytes_written/(1024*1024):.1f} MB written",
+            file=sys.stderr,
+        )
+        if failed:
+            print(f"  First 5 failures: {failed[:5]}", file=sys.stderr)
+        return {"ok": ok, "skipped": skipped, "failed": failed, "bytes_written": bytes_written}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--endpoint", required=True, help="Block Node gRPC endpoint, e.g. host:port")
+    parser.add_argument("--out", required=True, help="Output directory")
+    parser.add_argument("--start", type=int, required=True)
+    parser.add_argument("--count", type=int, required=True)
+    parser.add_argument("--parallel", type=int, default=16)
+    parser.add_argument("--timeout", type=float, default=120.0)
+    args = parser.parse_args()
+
+    dl = BulkDownloader(args.endpoint, args.out, request_timeout=args.timeout)
+    result = dl.run(range(args.start, args.start + args.count), parallel=args.parallel)
+    if result["failed"]:
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools-and-tests/scripts/bn-block-capture/profiler.py
+++ b/tools-and-tests/scripts/bn-block-capture/profiler.py
@@ -1,0 +1,226 @@
+"""TPS profiler / Schnorr->WRAPS transition finder for a Block Node.
+
+Usage:
+  python profiler.py --endpoint HOST:PORT scan       --start N --end M --count K --out file.csv
+  python profiler.py --endpoint HOST:PORT transition --start 300 --end 500
+  python profiler.py --endpoint HOST:PORT drill      --center N --window 200 --out file.csv
+
+CSV columns: block_number, tps, signed_tx_count, item_count, sig_bytes, raw_bytes, ts_seconds, ts_nanos, status
+"""
+import argparse
+import concurrent.futures
+import csv
+import os
+import sys
+import time
+
+from bn_client import BlockNodeClient, FetchError, NotAvailableError
+
+SCHNORR_LO, SCHNORR_HI = 2900, 2940
+WRAPS_LO, WRAPS_HI = 3420, 3460
+
+
+def probe_block(client: BlockNodeClient, block_number: int) -> dict:
+    try:
+        block, raw = client.get_block(block_number, retries=3)
+    except NotAvailableError:
+        return {"block_number": block_number, "status": "NOT_AVAILABLE"}
+    except FetchError as exc:
+        return {"block_number": block_number, "status": f"ERROR:{exc}"}
+    metrics = client.estimate_block_metrics(block)
+    sig_len = client.proof_signature_length(block)
+    return {
+        "block_number": block_number,
+        "status": "OK",
+        "ts_seconds": metrics["timestamp_seconds"],
+        "ts_nanos": metrics["timestamp_nanos"],
+        "signed_tx_count": metrics["signed_tx_count"],
+        "item_count": metrics["item_count"],
+        "sig_bytes": sig_len,
+        "raw_bytes": len(raw),
+    }
+
+
+def probe_many(endpoint: str, block_numbers, parallel: int = 16) -> list:
+    """Probe a list of block numbers concurrently and return rows in input order."""
+    client = BlockNodeClient(endpoint)
+    results = [None] * len(block_numbers)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=parallel) as pool:
+        future_to_idx = {
+            pool.submit(probe_block, client, n): i for i, n in enumerate(block_numbers)
+        }
+        done = 0
+        total = len(block_numbers)
+        for fut in concurrent.futures.as_completed(future_to_idx):
+            idx = future_to_idx[fut]
+            try:
+                results[idx] = fut.result()
+            except Exception as exc:
+                results[idx] = {
+                    "block_number": block_numbers[idx],
+                    "status": f"ERROR:{exc}",
+                }
+            done += 1
+            if done % 10 == 0 or done == total:
+                print(f"  [{done}/{total}]", file=sys.stderr)
+    return results
+
+
+def compute_tps(rows: list) -> list:
+    """Annotate rows with tps (dt to next sample). Rows must be sorted by block_number."""
+    rows_sorted = sorted([r for r in rows if r.get("status") == "OK"], key=lambda r: r["block_number"])
+    by_num = {r["block_number"]: r for r in rows_sorted}
+    for i, row in enumerate(rows_sorted):
+        row["tps"] = None
+        if i + 1 < len(rows_sorted):
+            nxt = rows_sorted[i + 1]
+            block_gap = nxt["block_number"] - row["block_number"]
+            dt = (nxt["ts_seconds"] - row["ts_seconds"]) + (
+                nxt["ts_nanos"] - row["ts_nanos"]
+            ) / 1e9
+            # tps within THIS block: signed_tx_count / per-block duration (= dt / block_gap)
+            if dt > 0 and block_gap > 0:
+                per_block_seconds = dt / block_gap
+                row["tps"] = round(row["signed_tx_count"] / per_block_seconds, 2)
+    return rows_sorted
+
+
+def write_csv(rows: list, path: str) -> None:
+    if not rows:
+        print("No rows to write", file=sys.stderr)
+        return
+    fields = ["block_number", "tps", "signed_tx_count", "item_count", "sig_bytes", "raw_bytes", "ts_seconds", "ts_nanos", "status"]
+    with open(path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fields, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def cmd_scan(args: argparse.Namespace) -> None:
+    start, end, count = args.start, args.end, args.count
+    if count <= 1:
+        block_nums = [start]
+    else:
+        step = max((end - start) // (count - 1), 1)
+        block_nums = list(range(start, end + 1, step))[:count]
+    print(f"Probing {len(block_nums)} blocks across [{start},{end}] (step={block_nums[1] - block_nums[0] if len(block_nums) > 1 else '-'})", file=sys.stderr)
+    raw_rows = probe_many(args.endpoint, block_nums, parallel=args.parallel)
+    # For accurate TPS we need to also fetch each sample's IMMEDIATE next block,
+    # so we can divide tx_count by actual per-block duration.
+    needed_neighbors = [r["block_number"] + 1 for r in raw_rows if r.get("status") == "OK"]
+    neighbor_rows = probe_many(args.endpoint, needed_neighbors, parallel=args.parallel)
+    combined = raw_rows + neighbor_rows
+    annotated = compute_tps(combined)
+    # Filter back to ONLY the originally-requested block numbers
+    requested = set(block_nums)
+    final = [r for r in annotated if r["block_number"] in requested]
+    write_csv(final, args.out)
+    print(f"Wrote {len(final)} rows to {args.out}", file=sys.stderr)
+
+
+def cmd_drill(args: argparse.Namespace) -> None:
+    """Probe a dense window of consecutive blocks around ``--center``."""
+    half = args.window // 2
+    lo = max(args.center - half, 0)
+    hi = args.center + half
+    block_nums = list(range(lo, hi + 1))
+    print(f"Drilling {len(block_nums)} consecutive blocks [{lo},{hi}]", file=sys.stderr)
+    rows = probe_many(args.endpoint, block_nums, parallel=args.parallel)
+    annotated = compute_tps(rows)
+    write_csv(annotated, args.out)
+    print(f"Wrote {len(annotated)} rows to {args.out}", file=sys.stderr)
+
+
+def cmd_transition(args: argparse.Namespace) -> None:
+    """Find the Schnorr->WRAPS proof transition in [start, end]."""
+    client = BlockNodeClient(args.endpoint)
+    start, end = args.start, args.end
+
+    def sig_kind(sig_len: int) -> str:
+        if SCHNORR_LO <= sig_len <= SCHNORR_HI:
+            return "SCHNORR"
+        if WRAPS_LO <= sig_len <= WRAPS_HI:
+            return "WRAPS"
+        if sig_len == 0:
+            return "EMPTY"
+        return f"UNKNOWN({sig_len})"
+
+    print(f"Scanning sigs in [{start},{end}] for Schnorr->WRAPS transition", file=sys.stderr)
+    # Sparse scan every 10 blocks to find the WRAPS side
+    nums = list(range(start, end + 1, 10))
+    rows = probe_many(args.endpoint, nums, parallel=args.parallel)
+    last_schnorr = None
+    first_wraps = None
+    for row in sorted([r for r in rows if r.get("status") == "OK"], key=lambda r: r["block_number"]):
+        kind = sig_kind(row["sig_bytes"])
+        print(f"  block {row['block_number']}: sig={row['sig_bytes']} -> {kind}", file=sys.stderr)
+        if kind == "SCHNORR":
+            last_schnorr = row["block_number"]
+        elif kind == "WRAPS" and first_wraps is None:
+            first_wraps = row["block_number"]
+
+    if first_wraps is None:
+        # Either entire range is Schnorr, or entire range is WRAPS, or neither
+        if last_schnorr is None:
+            print("No SCHNORR or WRAPS blocks seen — proof sig sizes unrecognized.", file=sys.stderr)
+            sys.exit(1)
+        print(f"All Schnorr in [{start},{end}], transition not yet seen.", file=sys.stderr)
+        sys.exit(1)
+    if last_schnorr is None:
+        # WRAPS from the start of range
+        print(f"All WRAPS in [{start},{end}]; transition before {start}.", file=sys.stderr)
+        # Binary search downward from start
+        lo, hi = 0, start
+    else:
+        lo, hi = last_schnorr, first_wraps
+
+    # Binary search for exact transition
+    while hi - lo > 1:
+        mid = (lo + hi) // 2
+        block, _ = client.get_block(mid, retries=5)
+        sig = client.proof_signature_length(block)
+        kind = sig_kind(sig)
+        print(f"    bsearch mid={mid}: sig={sig} -> {kind}", file=sys.stderr)
+        if kind == "SCHNORR":
+            lo = mid
+        else:
+            hi = mid
+
+    print(f"\nFirst WRAPS block: {hi}", file=sys.stderr)
+    print(f"Last  SCHNORR  block: {lo}", file=sys.stderr)
+    print(f"TRANSITION_BLOCK={hi}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--endpoint", required=True, help="Block Node gRPC endpoint, e.g. host:port")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("scan", help="sparse TPS sample across a range")
+    s.add_argument("--start", type=int, required=True)
+    s.add_argument("--end", type=int, required=True)
+    s.add_argument("--count", type=int, default=150)
+    s.add_argument("--parallel", type=int, default=16)
+    s.add_argument("--out", required=True)
+    s.set_defaults(func=cmd_scan)
+
+    d = sub.add_parser("drill", help="dense scan around a center block")
+    d.add_argument("--center", type=int, required=True)
+    d.add_argument("--window", type=int, default=200)
+    d.add_argument("--parallel", type=int, default=16)
+    d.add_argument("--out", required=True)
+    d.set_defaults(func=cmd_drill)
+
+    t = sub.add_parser("transition", help="find Schnorr->WRAPS transition")
+    t.add_argument("--start", type=int, default=300)
+    t.add_argument("--end", type=int, default=500)
+    t.add_argument("--parallel", type=int, default=8)
+    t.set_defaults(func=cmd_transition)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools-and-tests/scripts/bn-block-capture/setup.sh
+++ b/tools-and-tests/scripts/bn-block-capture/setup.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# One-time setup for the bn-block-capture Python tooling:
+#   - creates a local .venv,
+#   - installs grpcio / protobuf / zstandard,
+#   - compiles every proto under ../../protobuf-sources/ to Python.
+#
+# Re-run if proto files change. Idempotent: safe to call again.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+VENV="${SCRIPT_DIR}/.venv"
+PROTO_PY="${SCRIPT_DIR}/proto-py"
+API_PROTO_DIR="${REPO_ROOT}/protobuf-sources/src/main/proto"
+STREAM_PROTO_DIR="${REPO_ROOT}/protobuf-sources/block-node-protobuf"
+
+if [[ ! -d "${API_PROTO_DIR}" || ! -d "${STREAM_PROTO_DIR}" ]]; then
+  echo "ERROR: proto directories missing under ${REPO_ROOT}/protobuf-sources/" >&2
+  exit 1
+fi
+if ! command -v grpcurl &>/dev/null; then
+  echo "ERROR: grpcurl not found in PATH (brew install grpcurl)" >&2
+  exit 1
+fi
+
+echo "==> Creating Python venv at ${VENV}"
+python3 -m venv "${VENV}"
+"${VENV}/bin/pip" install --quiet --upgrade pip
+"${VENV}/bin/pip" install --quiet \
+  grpcio==1.62.3 grpcio-tools==1.62.3 protobuf==4.25.3 zstandard==0.22.0
+
+echo "==> Compiling protos to ${PROTO_PY}"
+rm -rf "${PROTO_PY}"
+mkdir -p "${PROTO_PY}"
+find "${API_PROTO_DIR}" "${STREAM_PROTO_DIR}" -name "*.proto" -print0 \
+  | xargs -0 "${VENV}/bin/python" -m grpc_tools.protoc \
+      -I"${API_PROTO_DIR}" \
+      -I"${STREAM_PROTO_DIR}" \
+      --python_out="${PROTO_PY}" \
+      --grpc_python_out="${PROTO_PY}" 2>&1 \
+  | grep -v "^.*: warning:" || true
+
+# Python's stdlib `platform` module shadows the generated `platform/` package.
+# Rename it and fix the imports so `from _bn_platform.event import ...` works.
+echo "==> Renaming generated platform package -> _bn_platform (stdlib collision)"
+if [[ -d "${PROTO_PY}/platform" ]]; then
+  mv "${PROTO_PY}/platform" "${PROTO_PY}/_bn_platform"
+fi
+grep -rl --include="*.py" "from platform\.\|import platform\." "${PROTO_PY}" \
+  | xargs sed -i.bak \
+      -e 's/from platform\./from _bn_platform./g' \
+      -e 's/import platform\./import _bn_platform./g'
+find "${PROTO_PY}" -name "*.bak" -delete
+
+echo "==> Smoke test"
+"${VENV}/bin/python" -c "
+import sys; sys.path.insert(0, '${PROTO_PY}')
+from block_node.api import block_access_service_pb2, node_service_pb2
+from block.stream import block_pb2
+print('Generated protobuf imports OK')
+"
+echo "==> Done. Invoke profiler.py / download.py / verify.py via .venv/bin/python."

--- a/tools-and-tests/scripts/bn-block-capture/verify.py
+++ b/tools-and-tests/scripts/bn-block-capture/verify.py
@@ -1,0 +1,102 @@
+"""Verify a downloaded block bucket.
+
+For each ``<n>.blk.zstd`` file:
+  - confirm non-empty,
+  - decompress and parse Block,
+  - record signed_transaction count + block_timestamp.
+
+Then compute actual TPS over the bucket as: total_txs / (last_ts - first_ts).
+"""
+import argparse
+import os
+import sys
+
+import zstandard
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "proto-py"))
+from block.stream import block_pb2
+
+from bn_client import BlockNodeClient
+
+
+def verify_bucket(directory: str) -> dict:
+    files = sorted(f for f in os.listdir(directory) if f.endswith(".blk.zstd"))
+    if not files:
+        return {"directory": directory, "count": 0, "error": "no files"}
+
+    decomp = zstandard.ZstdDecompressor()
+    total_txs = 0
+    first_ts = None
+    last_ts = None
+    first_ts_nanos = 0
+    last_ts_nanos = 0
+    first_block = None
+    last_block = None
+    total_raw = 0
+    total_compressed = 0
+    bad = []
+
+    for name in files:
+        path = os.path.join(directory, name)
+        size = os.path.getsize(path)
+        if size == 0:
+            bad.append((name, "empty"))
+            continue
+        with open(path, "rb") as fh:
+            compressed = fh.read()
+        try:
+            raw = decomp.decompress(compressed, max_output_size=512 * 1024 * 1024)
+        except Exception as exc:
+            bad.append((name, f"zstd: {exc}"))
+            continue
+        try:
+            block = block_pb2.Block.FromString(raw)
+        except Exception as exc:
+            bad.append((name, f"proto: {exc}"))
+            continue
+        metrics = BlockNodeClient.estimate_block_metrics(block)
+        total_txs += metrics["signed_tx_count"]
+        total_raw += len(raw)
+        total_compressed += size
+        ts = metrics["timestamp_seconds"] + metrics["timestamp_nanos"] / 1e9
+        block_number = int(name[: -len(".blk.zstd")])
+        if first_ts is None or ts < first_ts:
+            first_ts = ts
+            first_block = block_number
+        if last_ts is None or ts > last_ts:
+            last_ts = ts
+            last_block = block_number
+
+    duration = (last_ts - first_ts) if first_ts is not None else 0
+    tps = total_txs / duration if duration > 0 else 0
+    return {
+        "directory": directory,
+        "count": len(files),
+        "bad": bad,
+        "total_txs": total_txs,
+        "first_block": first_block,
+        "last_block": last_block,
+        "duration_seconds": round(duration, 2),
+        "avg_tps": round(tps, 2),
+        "total_raw_mb": round(total_raw / (1024 * 1024), 1),
+        "total_compressed_mb": round(total_compressed / (1024 * 1024), 1),
+        "compression_ratio": round(total_raw / total_compressed, 2) if total_compressed > 0 else 0,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dirs", nargs="+", help="Bucket directories to verify")
+    args = parser.parse_args()
+
+    for d in args.dirs:
+        result = verify_bucket(d)
+        print(f"=== {d} ===")
+        for k, v in result.items():
+            if k == "bad" and not v:
+                continue
+            print(f"  {k}: {v}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools-and-tests/scripts/find-state-proof-block.sh
+++ b/tools-and-tests/scripts/find-state-proof-block.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Finds any block on a Block Node whose BlockProof carries a `block_state_proof`
+# (indirect / state-based proof) — as fast as possible.
+#
+# Architecture:
+#   - A generator emits block numbers on stdout.
+#   - xargs -P PARALLEL fans them out to concurrent workers; the next available
+#     worker grabs the next block, so a slow/retrying worker does not block faster
+#     ones. No per-batch sync point.
+#   - Transient failures (NOT_AVAILABLE, FETCH_ERROR, CONNECTION_ERROR) are
+#     retried inside the worker with exponential backoff so a flaky block does
+#     not get silently skipped.
+#   - When a worker thinks it found a StateProof, it re-fetches the block and
+#     re-verifies before writing the block number into a shared result file
+#     (atomic rename). The main script polls that file and tears the whole
+#     pipeline down as soon as a verified hit appears.
+#
+# Note: because workers run in parallel, the discovered block is "the first one
+# any worker confirmed", not necessarily the lowest-numbered hit. That's the
+# deliberate trade for speed; goal is to find a state-proof block ASAP.
+#
+# Usage:
+#   ./find-state-proof-block.sh <bn-endpoint> [start-block] [max-block]
+#
+# Arguments:
+#   bn-endpoint   Block Node gRPC endpoint, e.g. localhost:40840 (required)
+#   start-block   Block number to start scanning from (default: 0).
+#                 Clamped up to firstAvailableBlock if the BN doesn't have it.
+#   max-block     Stop and fail if the generator reaches this block without
+#                 finding a state proof (default: 0 = no limit).
+#
+# Environment:
+#   PARALLEL      Number of concurrent getBlock workers (default: 10)
+#   MAX_RETRIES   Per-block retries on transient failures (default: 5).
+#                 Failures after this many retries are skipped.
+#   RETRY_DELAY   Base seconds between retries; doubles up to 8s (default: 1)
+#
+# Output:
+#   On success, prints the matching block number to stdout.
+#   Per-block status goes to stderr.
+#
+# Exit codes:
+#   0  Block with state proof found; block number printed to stdout
+#   1  max-block reached without finding a state proof, or fatal error
+#   2  Persistent connection error reaching the Block Node
+
+set -uo pipefail
+# Enable job control in this non-interactive script so each `&` background
+# job becomes its own process group leader. Without this, Ctrl+C can only kill
+# the foreground poll loop, leaving xargs/workers/grpcurl orphaned.
+set -m
+
+BN_ENDPOINT="${1:?Usage: $0 <bn-endpoint> [start-block] [max-block]}"
+START_BLOCK="${2:-0}"
+MAX_BLOCK="${3:-0}"
+PARALLEL="${PARALLEL:-10}"
+MAX_RETRIES="${MAX_RETRIES:-5}"
+RETRY_DELAY="${RETRY_DELAY:-1}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+API_PROTO_DIR="${REPO_ROOT}/protobuf-sources/src/main/proto"
+STREAM_PROTO_DIR="${REPO_ROOT}/protobuf-sources/block-node-protobuf"
+
+BN_ENDPOINT="${BN_ENDPOINT#tcp://}"
+BN_ENDPOINT="${BN_ENDPOINT#http://}"
+BN_ENDPOINT="${BN_ENDPOINT#https://}"
+BN_ENDPOINT="${BN_ENDPOINT%/}"
+
+MAX_MSG_SIZE=209715200
+TIP_POLL_SECONDS=2
+
+if ! command -v grpcurl &>/dev/null; then
+  echo "ERROR: grpcurl not found in PATH" >&2
+  exit 1
+fi
+if ! command -v python3 &>/dev/null; then
+  echo "ERROR: python3 not found in PATH" >&2
+  exit 1
+fi
+if [[ ! -d "${API_PROTO_DIR}" || ! -d "${STREAM_PROTO_DIR}" ]]; then
+  echo "ERROR: proto directories missing." >&2
+  echo "  Expected: ${API_PROTO_DIR}" >&2
+  echo "  Expected: ${STREAM_PROTO_DIR}" >&2
+  exit 1
+fi
+if [[ "${PARALLEL}" -lt 1 ]]; then
+  echo "ERROR: PARALLEL must be >= 1" >&2
+  exit 1
+fi
+if [[ "${MAX_RETRIES}" -lt 0 ]]; then
+  echo "ERROR: MAX_RETRIES must be >= 0" >&2
+  exit 1
+fi
+
+# Shared run-state directory. Workers signal a confirmed hit by atomically
+# renaming a tmp file to RESULT_FILE. We also write STOP_FILE to tell the
+# generator and other workers to exit immediately.
+RUN_DIR="$(mktemp -d -t find-state-proof-block.XXXXXX)"
+RESULT_FILE="${RUN_DIR}/result"
+STOP_FILE="${RUN_DIR}/stop"
+export RUN_DIR RESULT_FILE STOP_FILE
+
+pipeline_pid=""
+cleanup_done=""
+function shutdown {
+  # Idempotent — trap fires on EXIT after INT/TERM too.
+  [[ -n "${cleanup_done}" ]] && return 0
+  cleanup_done=1
+  : > "${STOP_FILE}" 2>/dev/null || true
+  if [[ -n "${pipeline_pid}" ]]; then
+    # Kill the whole process group of the background pipeline so xargs,
+    # all bash workers, and any in-flight grpcurl children are torn down.
+    kill -TERM -- "-${pipeline_pid}" 2>/dev/null || \
+      kill -TERM "${pipeline_pid}" 2>/dev/null || true
+    # Brief grace period before SIGKILL.
+    for _ in 1 2 3 4; do
+      kill -0 "${pipeline_pid}" 2>/dev/null || break
+      sleep 0.25
+    done
+    kill -KILL -- "-${pipeline_pid}" 2>/dev/null || \
+      kill -KILL "${pipeline_pid}" 2>/dev/null || true
+  fi
+  rm -rf "${RUN_DIR}"
+}
+function on_interrupt {
+  echo "" >&2
+  echo "Interrupted — stopping workers and cleaning up..." >&2
+  shutdown
+  exit 130
+}
+trap shutdown EXIT
+trap on_interrupt INT TERM HUP
+
+# Echoes "<first_available> <last_available>" or "ERROR".
+function query_server_status {
+  local raw
+  raw=$(grpcurl -plaintext \
+    -import-path "${API_PROTO_DIR}" \
+    -import-path "${STREAM_PROTO_DIR}" \
+    -proto "block-node/api/node_service.proto" \
+    -max-msg-sz "${MAX_MSG_SIZE}" \
+    -d '{}' \
+    "${BN_ENDPOINT}" org.hiero.block.api.BlockNodeService/serverStatus 2>&1) || true
+
+  if ! echo "${raw}" | python3 -c "import sys,json; json.loads(sys.stdin.read())" 2>/dev/null; then
+    echo "ERROR"
+    return
+  fi
+  echo "${raw}" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+print(f\"{int(d.get('firstAvailableBlock', 0))} {int(d.get('lastAvailableBlock', 0))}\")
+"
+}
+
+# Classifies one block; echoes a result token to stdout.
+# Result: STATE_PROOF | TSS_PROOF | RSA_PROOF | UNKNOWN_PROOF
+#       | NO_PROOF | NOT_AVAILABLE | FETCH_ERROR | CONNECTION_ERROR
+function inspect_block_once {
+  local block_number="$1"
+  local raw
+  raw=$(grpcurl -plaintext \
+    -import-path "${API_PROTO_DIR}" \
+    -import-path "${STREAM_PROTO_DIR}" \
+    -proto "block-node/api/block_access_service.proto" \
+    -max-msg-sz "${MAX_MSG_SIZE}" \
+    -d "{\"block_number\": ${block_number}}" \
+    "${BN_ENDPOINT}" org.hiero.block.api.BlockAccessService/getBlock 2>&1) || true
+
+  if echo "${raw}" | grep -q '"status": *"NOT_FOUND"\|"status": *"NOT_AVAILABLE"'; then
+    echo "NOT_AVAILABLE"
+    return
+  fi
+  if echo "${raw}" | grep -qiE "connection refused|failed to dial|name resolution|no such host|context deadline"; then
+    echo "CONNECTION_ERROR"
+    return
+  fi
+  if echo "${raw}" | grep -qiE "code: *internal|code: *unknown|code: *resourceexhausted|received message larger than max|unmarshal|unexpected eof"; then
+    echo "FETCH_ERROR"
+    return
+  fi
+  if ! echo "${raw}" | python3 -c "import sys,json; json.loads(sys.stdin.read())" 2>/dev/null; then
+    echo "FETCH_ERROR"
+    return
+  fi
+
+  # Strict detection: require `block.items` to be a list of dicts; require each
+  # candidate `blockProof` to be a dict; require the matching proof key's value
+  # to also be a dict (the message body), not a string or a primitive that
+  # Python's `in` could substring-match by accident.
+  echo "${raw}" | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+block = d.get('block') if isinstance(d, dict) else None
+items = block.get('items') if isinstance(block, dict) else None
+if not isinstance(items, list):
+    print('NO_PROOF'); sys.exit(0)
+
+has_proof_item = False
+for item in items:
+    if not isinstance(item, dict):
+        continue
+    bp = item.get('blockProof')
+    if not isinstance(bp, dict):
+        continue
+    has_proof_item = True
+    if isinstance(bp.get('blockStateProof'), dict):
+        print('STATE_PROOF'); sys.exit(0)
+    if isinstance(bp.get('signedBlockProof'), dict):
+        print('TSS_PROOF'); sys.exit(0)
+    if isinstance(bp.get('signedRecordFileProof'), dict):
+        print('RSA_PROOF'); sys.exit(0)
+print('UNKNOWN_PROOF' if has_proof_item else 'NO_PROOF')
+"
+}
+
+# Worker entry point used by xargs -I {}.
+# - Retries transient failures with exponential backoff (capped at 8s).
+# - On a putative STATE_PROOF: re-fetch and re-verify before signalling success
+#   (defensive against transient malformed responses).
+# - On a confirmed STATE_PROOF: write block number to RESULT_FILE atomically
+#   (via mv from a tmp path in the same dir), touch STOP_FILE, and return 0.
+# - On any STOP_FILE existence check, exit immediately so other workers don't
+#   keep doing useless work after a hit.
+function worker_main {
+  local n="$1"
+  local attempt=0
+  local delay="${RETRY_DELAY}"
+  local result
+
+  # Cheap early-out: another worker already won.
+  [[ -e "${STOP_FILE}" ]] && return 0
+
+  while true; do
+    result=$(inspect_block_once "${n}")
+    [[ -e "${STOP_FILE}" ]] && return 0
+
+    case "${result}" in
+      STATE_PROOF)
+        # Defensive re-verification: a single bad response should not pass.
+        local verify
+        verify=$(inspect_block_once "${n}")
+        if [[ "${verify}" != "STATE_PROOF" ]]; then
+          printf "  Block %d: STATE_PROOF (1st look) but re-verify said %s — treating as %s\n" \
+            "${n}" "${verify}" "${verify}" >&2
+          result="${verify}"
+          # Fall through to the matching case below by looping with the new result.
+          continue
+        fi
+        if [[ "${attempt}" -gt 0 ]]; then
+          printf "  Block %d: StateProof (BlockStateProof) [verified, after %d retr%s]\n" \
+            "${n}" "${attempt}" "$([[ ${attempt} -eq 1 ]] && echo y || echo ies)" >&2
+        else
+          printf "  Block %d: StateProof (BlockStateProof) [verified]\n" "${n}" >&2
+        fi
+        # Atomically publish the result. Two workers writing the same value is
+        # harmless; mv is atomic within the same filesystem.
+        local tmp="${RUN_DIR}/result.$$"
+        printf "%d" "${n}" > "${tmp}"
+        mv "${tmp}" "${RESULT_FILE}" 2>/dev/null || true
+        : > "${STOP_FILE}"
+        return 0
+        ;;
+      TSS_PROOF)
+        if [[ "${attempt}" -gt 0 ]]; then
+          printf "  Block %d: TSS (SignedBlockProof) [after %d retr%s]\n" \
+            "${n}" "${attempt}" "$([[ ${attempt} -eq 1 ]] && echo y || echo ies)" >&2
+        else
+          printf "  Block %d: TSS (SignedBlockProof)\n" "${n}" >&2
+        fi
+        return 0
+        ;;
+      RSA_PROOF)
+        printf "  Block %d: RSA (SignedRecordFileProof)\n" "${n}" >&2
+        return 0
+        ;;
+      UNKNOWN_PROOF)
+        printf "  Block %d: BlockProof present, no recognised key\n" "${n}" >&2
+        return 0
+        ;;
+      NO_PROOF)
+        printf "  Block %d: no BlockProof item\n" "${n}" >&2
+        return 0
+        ;;
+      NOT_AVAILABLE|FETCH_ERROR|CONNECTION_ERROR)
+        if [[ "${attempt}" -ge "${MAX_RETRIES}" ]]; then
+          printf "  Block %d: %s (gave up after %d retr%s)\n" \
+            "${n}" "${result}" "${attempt}" \
+            "$([[ ${attempt} -eq 1 ]] && echo y || echo ies)" >&2
+          return 0
+        fi
+        attempt=$(( attempt + 1 ))
+        printf "  Block %d: %s — retry %d/%d in %ds\n" \
+          "${n}" "${result}" "${attempt}" "${MAX_RETRIES}" "${delay}" >&2
+        sleep "${delay}"
+        if [[ "${delay}" -lt 8 ]]; then
+          delay=$(( delay * 2 ))
+        fi
+        ;;
+      *)
+        printf "  Block %d: %s (unexpected)\n" "${n}" "${result}" >&2
+        return 0
+        ;;
+    esac
+  done
+}
+
+# Emits block numbers on stdout. Stops when STOP_FILE appears or when MAX_BLOCK
+# is reached. Waits on the BN tip when caught up.
+function emit_block_numbers {
+  local start="$1"
+  local last="$2"
+  local b="${start}"
+  while true; do
+    [[ -e "${STOP_FILE}" ]] && return 0
+    if [[ "${MAX_BLOCK}" -gt 0 && "${b}" -gt "${MAX_BLOCK}" ]]; then
+      return 0
+    fi
+    if [[ "${b}" -gt "${last}" ]]; then
+      printf "  Generator: at tip (last_available=%d), waiting" "${last}" >&2
+      local waited=0
+      while [[ "${b}" -gt "${last}" ]]; do
+        [[ -e "${STOP_FILE}" ]] && { printf "\n" >&2; return 0; }
+        sleep "${TIP_POLL_SECONDS}"
+        waited=$(( waited + TIP_POLL_SECONDS ))
+        printf "." >&2
+        local status
+        status=$(query_server_status)
+        if [[ "${status}" == "ERROR" ]]; then
+          printf "\n  Generator: lost connection (workers will retry)\n" >&2
+          sleep "${TIP_POLL_SECONDS}"
+          continue
+        fi
+        last="${status##* }"
+      done
+      printf " (tip now %d, waited %ds)\n" "${last}" "${waited}" >&2
+    fi
+    printf "%d\n" "${b}"
+    b=$(( b + 1 ))
+  done
+}
+
+if [[ "${MAX_BLOCK}" -gt 0 && "${START_BLOCK}" -gt "${MAX_BLOCK}" ]]; then
+  echo "ERROR: start-block (${START_BLOCK}) is greater than max-block (${MAX_BLOCK})" >&2
+  exit 1
+fi
+
+echo "Block Node:     ${BN_ENDPOINT}" >&2
+echo "Parallelism:    ${PARALLEL}" >&2
+echo "Retries/block:  ${MAX_RETRIES} (base delay ${RETRY_DELAY}s, exp backoff cap 8s)" >&2
+echo "Querying serverStatus..." >&2
+status=$(query_server_status)
+if [[ "${status}" == "ERROR" ]]; then
+  echo "ERROR: cannot reach Block Node at ${BN_ENDPOINT}" >&2
+  exit 2
+fi
+first_available="${status%% *}"
+last_available="${status##* }"
+echo "Available:      [${first_available}, ${last_available}]" >&2
+
+block="${START_BLOCK}"
+if [[ "${block}" -lt "${first_available}" ]]; then
+  echo "Note:           start-block ${START_BLOCK} < firstAvailable ${first_available}; advancing to ${first_available}" >&2
+  block="${first_available}"
+fi
+if [[ "${MAX_BLOCK}" -gt 0 ]]; then
+  echo "Scan range:     [${block}, ${MAX_BLOCK}]" >&2
+else
+  echo "Scan range:     [${block}, unlimited]" >&2
+fi
+echo "Searching for any STATE_PROOF (fastest wins; results are verified)..." >&2
+echo "" >&2
+
+export BN_ENDPOINT API_PROTO_DIR STREAM_PROTO_DIR MAX_MSG_SIZE
+export MAX_RETRIES RETRY_DELAY
+export -f inspect_block_once worker_main
+
+# Run the pipeline in the background. With `set -m` enabled above, the
+# subshell `(...) &` becomes its own process group leader, so the cleanup
+# trap can kill the entire tree (xargs + bash workers + grpcurl) at once.
+(
+  emit_block_numbers "${block}" "${last_available}" \
+    | xargs -n 1 -P "${PARALLEL}" -I {} bash -c 'worker_main "$@"' _ {}
+) &
+pipeline_pid=$!
+
+# Poll for the result file. When it appears (or the pipeline exits without
+# a hit), drop out of the loop and let the EXIT trap tear things down.
+while true; do
+  if [[ -e "${RESULT_FILE}" ]]; then
+    break
+  fi
+  if ! kill -0 "${pipeline_pid}" 2>/dev/null; then
+    break
+  fi
+  sleep 0.5
+done
+
+if [[ ! -e "${RESULT_FILE}" ]]; then
+  echo "" >&2
+  if [[ "${MAX_BLOCK}" -gt 0 ]]; then
+    echo "No StateProof found in blocks [${START_BLOCK}, ${MAX_BLOCK}]." >&2
+  else
+    echo "Pipeline ended without finding a StateProof." >&2
+  fi
+  exit 1
+fi
+
+found_block="$(cat "${RESULT_FILE}")"
+echo "" >&2
+echo "================================================================" >&2
+printf "  >>> FOUND: block %s carries a StateProof (BlockStateProof) <<<\n" "${found_block}" >&2
+echo "================================================================" >&2
+echo "${found_block}"
+exit 0


### PR DESCRIPTION
Adds two operational scripts under `tools-and-tests/scripts/`:

- **bn-block-capture** — Python tooling to download blocks from a Block Node at TPS plateaus and store them as `<n>.blk.zstd` files. Includes a profiler, bulk downloader, and verifier. Uses `grpcurl` instead of native `grpcio` (Helidon rejects the Python HTTP/2 SETTINGS frame with GOAWAY).
- **find-state-proof-block.sh** — Bash script that scans a Block Node in parallel to find the first block carrying a `BlockStateProof`. Workers retry on transient failures with exponential backoff; the winning hit is re-verified before being reported.
