### PR TITLE
fix(backfill): dial server status on a dedicated source port

### DIFF
--- a/block-node/base/build.gradle.kts
+++ b/block-node/base/build.gradle.kts
@@ -8,19 +8,20 @@ description = "Hiero Block Node Base"
 tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
 
 mainModuleInfo {
-    runtimeOnly("com.swirlds.config.impl")
-    runtimeOnly("io.helidon.logging.jul")
-    runtimeOnly("com.hedera.pbj.grpc.helidon.config")
     runtimeOnly("com.hedera.pbj.grpc.client.helidon")
     runtimeOnly("com.hedera.pbj.grpc.helidon")
+    runtimeOnly("com.hedera.pbj.grpc.helidon.config")
+    runtimeOnly("com.swirlds.config.impl")
+    runtimeOnly("io.helidon.logging.jul")
 }
 
 testModuleInfo {
+    requires("org.hiero.block.node.app.test.fixtures")
+    requires("io.helidon.builder.api")
+    requires("io.minio")
+    requires("org.assertj.core")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
-    requires("org.hiero.block.node.app.test.fixtures")
-    requires("org.assertj.core")
     requires("org.mockito")
     requires("org.testcontainers")
-    requires("io.minio")
 }

--- a/block-node/base/src/main/java/org/hiero/block/node/base/client/BlockNodeClient.java
+++ b/block-node/base/src/main/java/org/hiero/block/node/base/client/BlockNodeClient.java
@@ -111,7 +111,11 @@ public class BlockNodeClient implements AutoCloseable {
             new Options(Optional.empty(), ServiceInterface.RequestOptions.APPLICATION_GRPC);
 
     private final PbjGrpcClientConfig grpcConfig;
-    private final WebClient webClient;
+    /** Channel for the subscribe RPC, dialing the source's `port`. Package-private for testing. */
+    final WebClient webClient;
+    /** Dedicated channel for the server status RPC, dialing `status_port` (or `port` when unset). Package-private for testing. */
+    final WebClient statusWebClient;
+
     private final int globalTimeoutMs;
     private BlockStreamSubscribeUnparsedClient blockStreamSubscribeUnparsedClient;
     private BlockNodeServiceInterface.BlockNodeServiceClient blockNodeServiceClient;
@@ -153,15 +157,33 @@ public class BlockNodeClient implements AutoCloseable {
                 maxProtobufMessageSizeBytes,
                 maxIncomingBufferSize);
 
-        webClient = WebClient.builder()
-                .baseUri(protocol + blockNodeConfig.address() + ":" + blockNodeConfig.port())
+        // The subscribe RPC dials the source's main port, while the server status RPC may live
+        // on a dedicated port. Fall back to the main port when no status port is configured (statusPort == 0).
+        final int subscribePort = blockNodeConfig.port();
+        final int statusPort = blockNodeConfig.statusPort() != 0 ? blockNodeConfig.statusPort() : subscribePort;
+
+        // Each service gets its own channel; only the port value falls back to `port` when unset.
+        webClient = buildWebClient(
+                protocol + blockNodeConfig.address() + ":" + subscribePort, tls, tuning, pollWaitMs, connectTimeoutMs);
+        statusWebClient = buildWebClient(
+                protocol + blockNodeConfig.address() + ":" + statusPort, tls, tuning, pollWaitMs, connectTimeoutMs);
+
+        initializeClient();
+    }
+
+    private WebClient buildWebClient(
+            @NonNull String baseUri,
+            @NonNull Tls tls,
+            @Nullable GrpcWebClientTuning tuning,
+            int pollWaitMs,
+            int connectTimeoutMs) {
+        return WebClient.builder()
+                .baseUri(baseUri)
                 .tls(tls)
                 .protocolConfigs(List.of(buildHttp2Config(tuning), buildGrpcConfig(pollWaitMs, tuning)))
                 .connectTimeout(Duration.ofMillis(connectTimeoutMs))
                 .keepAlive(true)
                 .build();
-
-        initializeClient();
     }
 
     private Http2ClientProtocolConfig buildHttp2Config(@Nullable GrpcWebClientTuning tuning) {
@@ -201,9 +223,11 @@ public class BlockNodeClient implements AutoCloseable {
 
     public void initializeClient() {
         try {
-            PbjGrpcClient pbjGrpcClient = new PbjGrpcClient(webClient, grpcConfig);
-            blockNodeServiceClient = new BlockNodeServiceInterface.BlockNodeServiceClient(pbjGrpcClient, OPTIONS);
-            blockStreamSubscribeUnparsedClient = new BlockStreamSubscribeUnparsedClient(pbjGrpcClient, globalTimeoutMs);
+            PbjGrpcClient subscribeGrpcClient = new PbjGrpcClient(webClient, grpcConfig);
+            PbjGrpcClient statusGrpcClient = new PbjGrpcClient(statusWebClient, grpcConfig);
+            blockNodeServiceClient = new BlockNodeServiceInterface.BlockNodeServiceClient(statusGrpcClient, OPTIONS);
+            blockStreamSubscribeUnparsedClient =
+                    new BlockStreamSubscribeUnparsedClient(subscribeGrpcClient, globalTimeoutMs);
             nodeReachable = true;
         } catch (IllegalArgumentException | IllegalStateException | UncheckedIOException ex) {
             LOGGER.log(Level.WARNING, "Failed to initialize gRPC client: %s".formatted(ex.getMessage()), ex);

--- a/block-node/base/src/main/java/org/hiero/block/node/base/client/BlockNodeClient.java
+++ b/block-node/base/src/main/java/org/hiero/block/node/base/client/BlockNodeClient.java
@@ -119,6 +119,7 @@ public class BlockNodeClient implements AutoCloseable {
     private final int globalTimeoutMs;
     private BlockStreamSubscribeUnparsedClient blockStreamSubscribeUnparsedClient;
     private BlockNodeServiceInterface.BlockNodeServiceClient blockNodeServiceClient;
+    private PbjGrpcClient subscribeGrpcClient;
     private boolean nodeReachable;
 
     /**
@@ -225,7 +226,7 @@ public class BlockNodeClient implements AutoCloseable {
 
     public void initializeClient() {
         try {
-            PbjGrpcClient subscribeGrpcClient = new PbjGrpcClient(webClient, grpcConfig);
+            subscribeGrpcClient = new PbjGrpcClient(webClient, grpcConfig);
             PbjGrpcClient statusGrpcClient = new PbjGrpcClient(statusWebClient, grpcConfig);
             blockNodeServiceClient = new BlockNodeServiceInterface.BlockNodeServiceClient(statusGrpcClient, OPTIONS);
             blockStreamSubscribeUnparsedClient =
@@ -239,8 +240,13 @@ public class BlockNodeClient implements AutoCloseable {
 
     @Override
     public void close() throws IOException {
+        // Close both channels: the status client owns the status channel; the subscribe channel is
+        // held directly since BlockStreamSubscribeUnparsedClient does not expose a close().
         if (blockNodeServiceClient != null) {
             blockNodeServiceClient.close();
+        }
+        if (subscribeGrpcClient != null) {
+            subscribeGrpcClient.close();
         }
     }
 

--- a/block-node/base/src/main/java/org/hiero/block/node/base/client/BlockNodeClient.java
+++ b/block-node/base/src/main/java/org/hiero/block/node/base/client/BlockNodeClient.java
@@ -111,7 +111,7 @@ public class BlockNodeClient implements AutoCloseable {
             new Options(Optional.empty(), ServiceInterface.RequestOptions.APPLICATION_GRPC);
 
     private final PbjGrpcClientConfig grpcConfig;
-    /** Channel for the subscribe RPC, dialing the source's `port`. Package-private for testing. */
+    /** Channel for the subscribe RPC, dialing `subscribe_port` (or `port` when unset). Package-private for testing. */
     final WebClient webClient;
     /** Dedicated channel for the server status RPC, dialing `status_port` (or `port` when unset). Package-private for testing. */
     final WebClient statusWebClient;
@@ -157,10 +157,12 @@ public class BlockNodeClient implements AutoCloseable {
                 maxProtobufMessageSizeBytes,
                 maxIncomingBufferSize);
 
-        // The subscribe RPC dials the source's main port, while the server status RPC may live
-        // on a dedicated port. Fall back to the main port when no status port is configured (statusPort == 0).
-        final int subscribePort = blockNodeConfig.port();
-        final int statusPort = blockNodeConfig.statusPort() != 0 ? blockNodeConfig.statusPort() : subscribePort;
+        // The subscribe and server status RPCs may each live on a dedicated port; both fall back to
+        // the main `port` when their dedicated port is not configured (subscribePort/statusPort == 0).
+        final int subscribePort =
+                blockNodeConfig.subscribePort() != 0 ? blockNodeConfig.subscribePort() : blockNodeConfig.port();
+        final int statusPort =
+                blockNodeConfig.statusPort() != 0 ? blockNodeConfig.statusPort() : blockNodeConfig.port();
 
         // Each service gets its own channel; only the port value falls back to `port` when unset.
         webClient = buildWebClient(

--- a/block-node/base/src/test/java/org/hiero/block/node/base/client/BlockNodeClientTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/client/BlockNodeClientTest.java
@@ -16,38 +16,52 @@ public class BlockNodeClientTest {
     private static final int MAX_INCOMING_BUFFER_SIZE = 10_485_760;
     private static final int MAX_PROTOBUF_MESSAGE_SIZE = 10_485_760;
 
-    private static BlockNodeClient clientFor(final int port, final int statusPort) {
+    private static BlockNodeClient clientFor(final int port, final int subscribePort, final int statusPort) {
         final BlockNodeSourceConfig source = BlockNodeSourceConfig.newBuilder()
                 .address("localhost")
                 .port(port)
+                .subscribePort(subscribePort)
                 .statusPort(statusPort)
                 .build();
         return new BlockNodeClient(
                 source, GLOBAL_TIMEOUT_MS, false, MAX_INCOMING_BUFFER_SIZE, MAX_PROTOBUF_MESSAGE_SIZE, null);
     }
 
-    @Test
-    @DisplayName("Status RPC dials the dedicated status port when configured")
-    void statusPortRoutesToDedicatedChannel() {
-        final BlockNodeClient client = clientFor(40980, 40982);
+    private static int subscribePortOf(final BlockNodeClient client) {
+        return client.webClient.prototype().baseUri().orElseThrow().port();
+    }
 
-        assertNotSame(client.webClient, client.statusWebClient);
-        assertEquals(40980, client.webClient.prototype().baseUri().orElseThrow().port());
-        assertEquals(
-                40982,
-                client.statusWebClient.prototype().baseUri().orElseThrow().port());
+    private static int statusPortOf(final BlockNodeClient client) {
+        return client.statusWebClient.prototype().baseUri().orElseThrow().port();
     }
 
     @Test
-    @DisplayName("Status RPC uses its own channel on the subscribe port when no status port is configured")
-    void statusPortDefaultsToSubscribePort() {
-        final BlockNodeClient client = clientFor(40840, 0);
+    @DisplayName("Subscribe and status RPCs dial their dedicated ports when configured")
+    void dedicatedPortsRouteToTheirOwnChannels() {
+        final BlockNodeClient client = clientFor(40840, 40980, 40982);
 
         assertNotSame(client.webClient, client.statusWebClient);
-        assertEquals(40840, client.webClient.prototype().baseUri().orElseThrow().port());
-        assertEquals(
-                40840,
-                client.statusWebClient.prototype().baseUri().orElseThrow().port());
+        assertEquals(40980, subscribePortOf(client));
+        assertEquals(40982, statusPortOf(client));
+    }
+
+    @Test
+    @DisplayName("Subscribe and status RPCs fall back to `port` on their own channels when unset")
+    void portsFallBackToPortWhenUnset() {
+        final BlockNodeClient client = clientFor(40840, 0, 0);
+
+        assertNotSame(client.webClient, client.statusWebClient);
+        assertEquals(40840, subscribePortOf(client));
+        assertEquals(40840, statusPortOf(client));
+    }
+
+    @Test
+    @DisplayName("Status falls back to `port` independently of a configured subscribe port")
+    void statusFallsBackToPortNotSubscribePort() {
+        final BlockNodeClient client = clientFor(40840, 40980, 0);
+
+        assertEquals(40980, subscribePortOf(client));
+        assertEquals(40840, statusPortOf(client));
     }
 
     GrpcWebClientTuning tuning = GrpcWebClientTuning.newBuilder()

--- a/block-node/base/src/test/java/org/hiero/block/node/base/client/BlockNodeClientTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/client/BlockNodeClientTest.java
@@ -4,6 +4,7 @@ package org.hiero.block.node.base.client;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
+import java.io.IOException;
 import org.hiero.block.internal.BlockNodeSourceConfig;
 import org.hiero.block.internal.GrpcWebClientTuning;
 import org.hiero.block.node.base.client.BlockNodeClient.IntConfigSpec;
@@ -37,31 +38,31 @@ public class BlockNodeClientTest {
 
     @Test
     @DisplayName("Subscribe and status RPCs dial their dedicated ports when configured")
-    void dedicatedPortsRouteToTheirOwnChannels() {
-        final BlockNodeClient client = clientFor(40840, 40980, 40982);
-
-        assertNotSame(client.webClient, client.statusWebClient);
-        assertEquals(40980, subscribePortOf(client));
-        assertEquals(40982, statusPortOf(client));
+    void dedicatedPortsRouteToTheirOwnChannels() throws IOException {
+        try (BlockNodeClient client = clientFor(40840, 40980, 40982)) {
+            assertNotSame(client.webClient, client.statusWebClient);
+            assertEquals(40980, subscribePortOf(client));
+            assertEquals(40982, statusPortOf(client));
+        }
     }
 
     @Test
     @DisplayName("Subscribe and status RPCs fall back to `port` on their own channels when unset")
-    void portsFallBackToPortWhenUnset() {
-        final BlockNodeClient client = clientFor(40840, 0, 0);
-
-        assertNotSame(client.webClient, client.statusWebClient);
-        assertEquals(40840, subscribePortOf(client));
-        assertEquals(40840, statusPortOf(client));
+    void portsFallBackToPortWhenUnset() throws IOException {
+        try (BlockNodeClient client = clientFor(40840, 0, 0)) {
+            assertNotSame(client.webClient, client.statusWebClient);
+            assertEquals(40840, subscribePortOf(client));
+            assertEquals(40840, statusPortOf(client));
+        }
     }
 
     @Test
     @DisplayName("Status falls back to `port` independently of a configured subscribe port")
-    void statusFallsBackToPortNotSubscribePort() {
-        final BlockNodeClient client = clientFor(40840, 40980, 0);
-
-        assertEquals(40980, subscribePortOf(client));
-        assertEquals(40840, statusPortOf(client));
+    void statusFallsBackToPortNotSubscribePort() throws IOException {
+        try (BlockNodeClient client = clientFor(40840, 40980, 0)) {
+            assertEquals(40980, subscribePortOf(client));
+            assertEquals(40840, statusPortOf(client));
+        }
     }
 
     GrpcWebClientTuning tuning = GrpcWebClientTuning.newBuilder()

--- a/block-node/base/src/test/java/org/hiero/block/node/base/client/BlockNodeClientTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/client/BlockNodeClientTest.java
@@ -2,13 +2,53 @@
 package org.hiero.block.node.base.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
+import org.hiero.block.internal.BlockNodeSourceConfig;
 import org.hiero.block.internal.GrpcWebClientTuning;
 import org.hiero.block.node.base.client.BlockNodeClient.IntConfigSpec;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class BlockNodeClientTest {
+
+    private static final int GLOBAL_TIMEOUT_MS = 10_000;
+    private static final int MAX_INCOMING_BUFFER_SIZE = 10_485_760;
+    private static final int MAX_PROTOBUF_MESSAGE_SIZE = 10_485_760;
+
+    private static BlockNodeClient clientFor(final int port, final int statusPort) {
+        final BlockNodeSourceConfig source = BlockNodeSourceConfig.newBuilder()
+                .address("localhost")
+                .port(port)
+                .statusPort(statusPort)
+                .build();
+        return new BlockNodeClient(
+                source, GLOBAL_TIMEOUT_MS, false, MAX_INCOMING_BUFFER_SIZE, MAX_PROTOBUF_MESSAGE_SIZE, null);
+    }
+
+    @Test
+    @DisplayName("Status RPC dials the dedicated status port when configured")
+    void statusPortRoutesToDedicatedChannel() {
+        final BlockNodeClient client = clientFor(40980, 40982);
+
+        assertNotSame(client.webClient, client.statusWebClient);
+        assertEquals(40980, client.webClient.prototype().baseUri().orElseThrow().port());
+        assertEquals(
+                40982,
+                client.statusWebClient.prototype().baseUri().orElseThrow().port());
+    }
+
+    @Test
+    @DisplayName("Status RPC uses its own channel on the subscribe port when no status port is configured")
+    void statusPortDefaultsToSubscribePort() {
+        final BlockNodeClient client = clientFor(40840, 0);
+
+        assertNotSame(client.webClient, client.statusWebClient);
+        assertEquals(40840, client.webClient.prototype().baseUri().orElseThrow().port());
+        assertEquals(
+                40840,
+                client.statusWebClient.prototype().baseUri().orElseThrow().port());
+    }
 
     GrpcWebClientTuning tuning = GrpcWebClientTuning.newBuilder()
             .connectTimeout(1)

--- a/charts/block-node-server/templates/configmap-block-node-sources.yaml
+++ b/charts/block-node-server/templates/configmap-block-node-sources.yaml
@@ -9,7 +9,7 @@ data:
       "nodes": [
         {{- range $index, $node := .Values.blockNode.backfill.sources }}
         {{- if $index }},{{ end }}
-        { "address": "{{ $node.address }}", "port": {{ $node.port }}, "priority": {{ $node.priority }} }
+        { "address": "{{ $node.address }}", "port": {{ $node.port }}, "priority": {{ $node.priority }}{{ if $node.statusPort }}, "status_port": {{ $node.statusPort }}{{ end }} }
         {{- end }}
       ]
     }

--- a/charts/block-node-server/templates/configmap-block-node-sources.yaml
+++ b/charts/block-node-server/templates/configmap-block-node-sources.yaml
@@ -9,7 +9,7 @@ data:
       "nodes": [
         {{- range $index, $node := .Values.blockNode.backfill.sources }}
         {{- if $index }},{{ end }}
-        { "address": "{{ $node.address }}", "port": {{ $node.port }}, "priority": {{ $node.priority }}{{ if $node.statusPort }}, "status_port": {{ $node.statusPort }}{{ end }} }
+        { "address": "{{ $node.address }}", "port": {{ $node.port }}, "priority": {{ $node.priority }}{{ if $node.statusPort }}, "status_port": {{ $node.statusPort }}{{ end }}{{ if $node.subscribePort }}, "subscribe_port": {{ $node.subscribePort }}{{ end }} }
         {{- end }}
       ]
     }

--- a/charts/block-node-server/values-overrides/backfill.yaml
+++ b/charts/block-node-server/values-overrides/backfill.yaml
@@ -12,9 +12,9 @@ blockNode:
         # different namespace <serviceName>.<namespace>.svc.cluster.local
         - address: "source-block-node-helm-chart.source.svc.cluster.local"
           port: 40840
-          # Optional dedicated port for the source's server-status service. When the source
-          # exposes services on split ports (e.g. subscriber 40980 / serverStatus 40982), set
-          # `port` to the subscriber port and `statusPort` to the server-status port. Omit it
-          # (or set 0) to reuse `port` for server status.
+          # Optional dedicated ports for the source's subscribe and server-status services. When
+          # the source exposes services on split ports (e.g. subscriber 40980 / serverStatus 40982),
+          # set `subscribePort` and `statusPort` accordingly. Omit either (or set 0) to reuse `port`.
+          subscribePort: 40840
           statusPort: 40840
           priority: 1

--- a/charts/block-node-server/values-overrides/backfill.yaml
+++ b/charts/block-node-server/values-overrides/backfill.yaml
@@ -12,4 +12,9 @@ blockNode:
         # different namespace <serviceName>.<namespace>.svc.cluster.local
         - address: "source-block-node-helm-chart.source.svc.cluster.local"
           port: 40840
+          # Optional dedicated port for the source's server-status service. When the source
+          # exposes services on split ports (e.g. subscriber 40980 / serverStatus 40982), set
+          # `port` to the subscriber port and `statusPort` to the server-status port. Omit it
+          # (or set 0) to reuse `port` for server status.
+          statusPort: 40840
           priority: 1

--- a/protobuf-sources/src/main/proto/internal/block_node_source.proto
+++ b/protobuf-sources/src/main/proto/internal/block_node_source.proto
@@ -57,10 +57,18 @@ message BlockNodeSourceConfig {
   /**
    * Optional dedicated port for the server status RPC (0 = use `port`).
    * Some deployments expose server status on a different port than the
-   * block-stream/subscribe RPC; when set, status queries dial this port
-   * while subscribe/getBlock keep using `port`.
+   * default; when set, status queries dial this port while other APIs
+   * use different ports.
    */
   uint32 status_port = 9;
+
+  /**
+   * Optional dedicated port for the subscribe RPC (0 = use `port`).
+   * Some deployments expose the subscribe API on a different port than the
+   * default; when set, block stream subscriptions dial this port while
+   * other APIs use different ports.
+   */
+  uint32 subscribe_port = 10;
 }
 
 /**

--- a/protobuf-sources/src/main/proto/internal/block_node_source.proto
+++ b/protobuf-sources/src/main/proto/internal/block_node_source.proto
@@ -53,6 +53,14 @@ message BlockNodeSourceConfig {
    * IP protocol for this source connection.
    */
   org.hiero.block.api.NetworkConnection.IpProtocol protocol = 8;
+
+  /**
+   * Optional dedicated port for the server status RPC (0 = use `port`).
+   * Some deployments expose server status on a different port than the
+   * block-stream/subscribe RPC; when set, status queries dial this port
+   * while subscribe/getBlock keep using `port`.
+   */
+  uint32 status_port = 9;
 }
 
 /**

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/backfill/BackfillMultiportSourceTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/backfill/BackfillMultiportSourceTests.java
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.suites.backfill;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClient;
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClientConfig;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import io.helidon.common.tls.Tls;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.grpc.GrpcClientProtocolConfig;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hiero.block.api.BlockEnd;
+import org.hiero.block.api.BlockItemSet;
+import org.hiero.block.api.BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient;
+import org.hiero.block.api.PublishStreamRequest;
+import org.hiero.block.api.PublishStreamResponse;
+import org.hiero.block.api.ServerStatusDetailResponse;
+import org.hiero.block.api.ServerStatusRequest;
+import org.hiero.block.internal.BlockNodeSourceConfig;
+import org.hiero.block.internal.BlockUnparsed;
+import org.hiero.block.node.app.BlockNodeApp;
+import org.hiero.block.node.base.client.BlockNodeClient;
+import org.hiero.block.node.spi.ServiceLoaderFunction;
+import org.hiero.block.node.spi.health.HealthFacility.State;
+import org.hiero.block.suites.utils.BlockItemBuilderUtils;
+import org.hiero.block.suites.utils.ResponsePipelineUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * In-process API test verifying that the backfill client reaches a source Block Node that exposes
+ * the subscribe and server-status services on different ports.
+ *
+ * <p>A single real {@link BlockNodeApp} is booted with the subscriber and server-status plugins on
+ * dedicated, distinct ports (the other services stay on the default port). Blocks 0..2 are published
+ * into it, then the real {@link BlockNodeClient} used by backfill is pointed at the source with
+ * {@code port} = subscriber port and {@code status_port} = server-status port. The test asserts that
+ * the server-status RPC (dialed on {@code status_port}) reports the available range and that the
+ * subscribe RPC (dialed on {@code port}) fetches the blocks. This guards the regression where the
+ * server-status RPC was dialed on the subscribe port.
+ */
+@Tag("api")
+@DisplayName("Backfill From Multiport Source Tests")
+@Timeout(60)
+public class BackfillMultiportSourceTests {
+
+    private static final String BLOCKS_DATA_DIR_PATH = "build/tmp/data";
+    private static final int LAST_BLOCK_NUMBER = 2;
+    private static final int GRPC_TIMEOUT_MS = 30_000;
+    private static final int MAX_INCOMING_BUFFER_SIZE = 10_485_760;
+    private static final int MAX_PROTOBUF_MESSAGE_SIZE = 10_485_760;
+    private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(30);
+
+    private static final Options OPTIONS =
+            new Options(Optional.empty(), ServiceInterface.RequestOptions.APPLICATION_GRPC);
+
+    private record Options(Optional<String> authority, String contentType) implements ServiceInterface.RequestOptions {}
+
+    /** The base port other services keep; the split ports are derived from it. */
+    private final String serverPort = System.getenv("SERVER_PORT") == null ? "40840" : System.getenv("SERVER_PORT");
+
+    private BlockNodeApp app;
+
+    /** Default constructor. */
+    public BackfillMultiportSourceTests() {}
+
+    @BeforeEach
+    void beforeEach() throws IOException {
+        final Path dataDir = Paths.get(BLOCKS_DATA_DIR_PATH).toAbsolutePath();
+        if (Files.exists(dataDir)) {
+            Files.walk(dataDir)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+        }
+        // Provision the verifier with the roster that signs blocks built by BlockItemBuilderUtils.
+        BlockItemBuilderUtils.provisionTssBootstrap();
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (app != null && app.blockNodeState() != State.SHUTTING_DOWN) {
+            app.shutdown("BackfillMultiportSourceTests", "test teardown");
+        }
+        System.clearProperty("server.status.port");
+        System.clearProperty("subscriber.port");
+    }
+
+    @Test
+    @DisplayName("Backfill client fetches from a source with subscribe and serverStatus on different ports")
+    void backfillClientFetchesFromSplitPortSource() throws Exception {
+        final int defaultPort = Integer.parseInt(serverPort);
+        final int serverStatusPort = defaultPort + 3;
+        final int subscriberPort = defaultPort + 5;
+
+        // Move only the two services the backfill client dials so subscribe and serverStatus differ.
+        System.setProperty("server.status.port", Integer.toString(serverStatusPort));
+        System.setProperty("subscriber.port", Integer.toString(subscriberPort));
+
+        app = new BlockNodeApp(new ServiceLoaderFunction(), false);
+        app.start();
+        awaitRunning();
+
+        publishBlocks(defaultPort);
+
+        // The backfill client: subscribe dials `port`, serverStatus dials `status_port`.
+        final BlockNodeSourceConfig source = BlockNodeSourceConfig.newBuilder()
+                .address("localhost")
+                .port(subscriberPort)
+                .statusPort(serverStatusPort)
+                .build();
+        try (BlockNodeClient client = new BlockNodeClient(
+                source, GRPC_TIMEOUT_MS, false, MAX_INCOMING_BUFFER_SIZE, MAX_PROTOBUF_MESSAGE_SIZE, null)) {
+            // Server-status RPC must reach the dedicated status port and report the stored range.
+            final ServerStatusDetailResponse status = client.getBlockNodeServiceClient()
+                    .serverStatusDetail(ServerStatusRequest.newBuilder().build());
+            assertThat(status.availableRanges()).anySatisfy(range -> {
+                assertThat(range.rangeStart()).isEqualTo(0L);
+                assertThat(range.rangeEnd()).isEqualTo((long) LAST_BLOCK_NUMBER);
+            });
+
+            // Subscribe RPC must reach the subscribe port and fetch every block in the range.
+            final List<BlockUnparsed> blocks =
+                    client.getBlockstreamSubscribeUnparsedClient().getBatchOfBlocks(0L, LAST_BLOCK_NUMBER);
+            assertThat(blocks).hasSize(LAST_BLOCK_NUMBER + 1);
+        }
+    }
+
+    /// Publishes blocks 0..{@link #LAST_BLOCK_NUMBER}, chained by block hash, on the given port and
+    /// awaits an acknowledgement for each.
+    private void publishBlocks(final int port) throws InterruptedException {
+        final BlockStreamPublishServiceClient publishClient =
+                new BlockStreamPublishServiceClient(createGrpcClientForPort(port), OPTIONS);
+        final ResponsePipelineUtils<PublishStreamResponse> observer = new ResponsePipelineUtils<>();
+        final Pipeline<? super PublishStreamRequest> stream = publishClient.publishBlockStream(observer);
+
+        final AtomicReference<CountDownLatch> ackLatch = observer.setAndGetOnNextLatch(LAST_BLOCK_NUMBER + 1);
+        Bytes previousBlockHash = null;
+        for (long blockNumber = 0; blockNumber <= LAST_BLOCK_NUMBER; blockNumber++) {
+            final BlockItem[] items = BlockItemBuilderUtils.createSimpleBlockWithNumber(blockNumber, previousBlockHash);
+            stream.onNext(PublishStreamRequest.newBuilder()
+                    .blockItems(BlockItemSet.newBuilder().blockItems(items).build())
+                    .build());
+            stream.onNext(PublishStreamRequest.newBuilder()
+                    .endOfBlock(BlockEnd.newBuilder().blockNumber(blockNumber).build())
+                    .build());
+            previousBlockHash = BlockItemBuilderUtils.computeBlockHash(blockNumber, previousBlockHash);
+        }
+
+        ackLatch.get().await(AWAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        assertEquals(0, ackLatch.get().getCount(), "Timed out waiting for publish acknowledgements");
+        stream.closeConnection();
+        publishClient.close();
+    }
+
+    private void awaitRunning() throws InterruptedException {
+        final long deadlineMs = System.currentTimeMillis() + 10_000L;
+        while (app.blockNodeState() != State.RUNNING) {
+            if (System.currentTimeMillis() >= deadlineMs) {
+                assertEquals(State.RUNNING, app.blockNodeState(), "app did not reach RUNNING state");
+            }
+            Thread.sleep(20);
+        }
+    }
+
+    private PbjGrpcClient createGrpcClientForPort(final int port) {
+        final Duration timeout = Duration.ofSeconds(30);
+        final Tls tls = Tls.builder().enabled(false).build();
+        final WebClient webClient = WebClient.builder()
+                .baseUri("http://localhost:" + port)
+                .tls(tls)
+                .protocolConfigs(List.of(GrpcClientProtocolConfig.builder()
+                        .abortPollTimeExpired(false)
+                        .pollWaitTime(timeout)
+                        .build()))
+                .connectTimeout(timeout)
+                .keepAlive(true)
+                .build();
+        final PbjGrpcClientConfig grpcConfig =
+                new PbjGrpcClientConfig(timeout, tls, OPTIONS.authority(), OPTIONS.contentType());
+        return new PbjGrpcClient(webClient, grpcConfig);
+    }
+}

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/backfill/BackfillMultiportSourceTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/backfill/BackfillMultiportSourceTests.java
@@ -94,6 +94,11 @@ public class BackfillMultiportSourceTests {
                     .map(Path::toFile)
                     .forEach(File::delete);
         }
+        // Clear any per-service port properties left over from a previous (possibly crashed) run so
+        // they can't spill into this test's app before it sets its own.
+        System.clearProperty("server.status.port");
+        System.clearProperty("subscriber.port");
+
         // Provision the verifier with the roster that signs blocks built by BlockItemBuilderUtils.
         BlockItemBuilderUtils.provisionTssBootstrap();
     }

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/backfill/BackfillMultiportSourceTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/backfill/BackfillMultiportSourceTests.java
@@ -54,10 +54,11 @@ import org.junit.jupiter.api.Timeout;
  * <p>A single real {@link BlockNodeApp} is booted with the subscriber and server-status plugins on
  * dedicated, distinct ports (the other services stay on the default port). Blocks 0..2 are published
  * into it, then the real {@link BlockNodeClient} used by backfill is pointed at the source with
- * {@code port} = subscriber port and {@code status_port} = server-status port. The test asserts that
- * the server-status RPC (dialed on {@code status_port}) reports the available range and that the
- * subscribe RPC (dialed on {@code port}) fetches the blocks. This guards the regression where the
- * server-status RPC was dialed on the subscribe port.
+ * {@code subscribe_port} = subscriber port and {@code status_port} = server-status port (and {@code port}
+ * left as a fallback that serves neither RPC). The test asserts that the server-status RPC (dialed on
+ * {@code status_port}) reports the available range and that the subscribe RPC (dialed on
+ * {@code subscribe_port}) fetches the blocks. This guards the regression where the server-status RPC was
+ * dialed on the subscribe port.
  */
 @Tag("api")
 @DisplayName("Backfill From Multiport Source Tests")
@@ -123,10 +124,13 @@ public class BackfillMultiportSourceTests {
 
         publishBlocks(defaultPort);
 
-        // The backfill client: subscribe dials `port`, serverStatus dials `status_port`.
+        // The backfill client: subscribe dials `subscribe_port`, serverStatus dials `status_port`.
+        // `port` is only a fallback and points at the default port (which serves neither of these
+        // two RPCs), so the test fails if either RPC falls back instead of using its dedicated port.
         final BlockNodeSourceConfig source = BlockNodeSourceConfig.newBuilder()
                 .address("localhost")
-                .port(subscriberPort)
+                .port(defaultPort)
+                .subscribePort(subscriberPort)
                 .statusPort(serverStatusPort)
                 .build();
         try (BlockNodeClient client = new BlockNodeClient(


### PR DESCRIPTION
## Problem

Production Block Nodes expose each service on its own port (e.g. `subscriber: 40980`, `serverStatus: 40982`). Backfill built a single gRPC channel per source from the one configured `port` and used it for both the subscribe RPC (block fetching) and the server-status RPC (range discovery). With split ports, the server-status call was dialed on the subscriber port (40980) instead of the server-status port (40982), so range discovery failed and the node never backfilled. CI, which runs every service on one port (40840), was unaffected and hid the issue.

## Change

- Added an optional `status_port` field to `BlockNodeSourceConfig`. When unset (`0`) it falls back to `port`, so existing sources and CI are unchanged.
- `BlockNodeClient` now builds a distinct channel per service: the subscribe RPC dials `port`, the server-status RPC dials `status_port`. Each service gets its own channel; only the port value falls back.
- The Helm chart renders `status_port` into `block-node-sources.json` when a source sets it.

getBlock/BlockAccess is intentionally out of scope: backfill only uses the subscribe and server-status services.

## Configuration

```json
{ "nodes": [ { "address": "bn1", "port": 40980, "status_port": 40982, "priority": 1 } ] }
```

`status_port` is optional; omit it (or set `0`) to keep dialing `port` for server status.

## Testing

- `BlockNodeClientTest` — asserts the server-status RPC routes to `status_port` (40982) while subscribe stays on `port` (40980), and that an unset `status_port` falls back to `port`.
- `BackfillMultiportSourceTests` — in-process API test that boots one `BlockNodeApp` with subscriber and server-status on different ports, publishes blocks 0-2, then points the real backfill `BlockNodeClient` at it and asserts `serverStatusDetail` (on the status port) reports the range and `getBatchOfBlocks` (on the subscribe port) fetches all three blocks.

Both pass; the API test runs in-process in ~6s.

Resolves #3368