### PR TITLE
chore: update solo version to 0.84.1

### DIFF
--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew --no-daemon
-  SOLO_VERSION: "0.84.0"
+  SOLO_VERSION: "0.84.1"
 
 jobs:
   k6-tests:

--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -223,7 +223,7 @@ jobs:
           if [[ -n "${{ inputs.solo-version }}" ]]; then
             SOLO_VERSION="${{ inputs.solo-version }}"
           else
-            SOLO_VERSION="0.84.0"
+            SOLO_VERSION="0.84.1"
           fi
 
           # Relay version: use input if provided, otherwise default to latest

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -36,7 +36,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         type: string
-        default: "0.84.0"
+        default: "0.84.1"
       solo-source:
         description: "Solo install source: 'npm' or 'git' (build an approved fork/branch)"
         type: string
@@ -145,7 +145,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         required: false
-        default: "0.84.0"
+        default: "0.84.1"
       solo-source:
         description: "Solo install source"
         required: false


### PR DESCRIPTION
## Summary
- Bumps the Solo CLI version from `0.84.0` to `0.84.1` in `k6-tests.yml` (`SOLO_VERSION` env), `solo-e2e-test.yml` (both `solo-version` input defaults), and `solo-e2e-scheduler.yml` (the hardcoded fallback used when no `solo-version` input is supplied to a scheduled run - not caught by the original audit, since it's the actual effective default for cron-triggered runs).