### PR TITLE
feat: Update publisher to use ApplicationStateFacility for block set ranges

### DIFF
--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -751,10 +751,15 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         // streamed, but _only_ on startup. After that there should always be
         // a delta (next unstreamed must always be strictly greater than the current
         // streaming block number).
-        final List<BlockRange> storedBlocks = serverContext.storedBlocks();
-        final long latestKnownBlock = storedBlocks.isEmpty()
-                ? UNKNOWN_BLOCK_NUMBER
-                : storedBlocks.getLast().rangeEnd();
+        final long latestKnownBlock;
+        if (serverContext != null && serverContext.storedBlocks() != null) {
+            final List<BlockRange> storedBlocks = serverContext.storedBlocks();
+            latestKnownBlock = storedBlocks.isEmpty()
+                    ? UNKNOWN_BLOCK_NUMBER
+                    : storedBlocks.getLast().rangeEnd();
+        } else {
+            latestKnownBlock = UNKNOWN_BLOCK_NUMBER;
+        }
         // Always set the last persisted block number, even if there are no
         // known blocks.
         lastPersistedBlockNumber.set(latestKnownBlock);

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
+import org.hiero.block.api.BlockRange;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.api.PublishStreamResponse.EndOfStream.Code;
 import org.hiero.block.internal.BlockItemSetUnparsed;
@@ -750,8 +751,12 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         // streamed, but _only_ on startup. After that there should always be
         // a delta (next unstreamed must always be strictly greater than the current
         // streaming block number).
-        final long latestKnownBlock =
-                serverContext.historicalBlockProvider().availableBlocks().max();
+        final List<BlockRange> storedBlocks = serverContext.storedBlocks();
+        final long highestStoredBlock = storedBlocks.isEmpty()
+                ? UNKNOWN_BLOCK_NUMBER
+                : storedBlocks.getLast().rangeEnd();
+        final long latestKnownBlock = Math.max(
+                serverContext.historicalBlockProvider().availableBlocks().max(), highestStoredBlock);
         // Always set the last persisted block number, even if there are no
         // known blocks.
         lastPersistedBlockNumber.set(latestKnownBlock);

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -752,11 +752,9 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         // a delta (next unstreamed must always be strictly greater than the current
         // streaming block number).
         final List<BlockRange> storedBlocks = serverContext.storedBlocks();
-        final long highestStoredBlock = storedBlocks.isEmpty()
+        final long latestKnownBlock = storedBlocks.isEmpty()
                 ? UNKNOWN_BLOCK_NUMBER
                 : storedBlocks.getLast().rangeEnd();
-        final long latestKnownBlock = Math.max(
-                serverContext.historicalBlockProvider().availableBlocks().max(), highestStoredBlock);
         // Always set the last persisted block number, even if there are no
         // known blocks.
         lastPersistedBlockNumber.set(latestKnownBlock);

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
@@ -105,7 +105,7 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
     private static final System.Logger LOGGER = System.getLogger(StreamPublisherPlugin.class.getName());
 
     /// The block node context, for access to core facilities.
-    private BlockNodeContext context;
+    private volatile BlockNodeContext context;
     /// The publisher block manager, which connects handlers to the messaging facility.
     private StreamPublisherManager publisherManager;
 
@@ -180,6 +180,15 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
     public void stop() {
         context.blockMessaging().unregisterBlockNotificationHandler(publisherManager);
         publisherManager.shutdown();
+    }
+
+    /**
+     * {@inheritDoc}
+     * This method is called on a separate thread. Make sure this.context is marked as `volatile`
+     */
+    @Override
+    public void onContextUpdate(final BlockNodeContext context) {
+        this.context = context;
     }
 
     /// This method is called when a new publisher handler is created.

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
@@ -105,7 +105,7 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
     private static final System.Logger LOGGER = System.getLogger(StreamPublisherPlugin.class.getName());
 
     /// The block node context, for access to core facilities.
-    private volatile BlockNodeContext context;
+    private BlockNodeContext context;
     /// The publisher block manager, which connects handlers to the messaging facility.
     private StreamPublisherManager publisherManager;
 
@@ -184,7 +184,6 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
 
     /**
      * {@inheritDoc}
-     * This method is called on a separate thread. Make sure this.context is marked as `volatile`
      */
     @Override
     public void onContextUpdate(final BlockNodeContext context) {

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
@@ -190,7 +190,9 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
      */
     @Override
     public void onContextUpdate(final BlockNodeContext context) {
-        this.context.set(Objects.requireNonNull(context));
+        if (context != null) {
+            this.context.set(context);
+        }
     }
 
     /// This method is called when a new publisher handler is created.

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
@@ -9,6 +9,7 @@ import com.hedera.pbj.runtime.grpc.Pipelines;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import org.hiero.block.api.BlockStreamPublishServiceInterface;
 import org.hiero.block.api.PublishStreamRequest;
 import org.hiero.block.api.PublishStreamResponse;
@@ -105,7 +106,7 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
     private static final System.Logger LOGGER = System.getLogger(StreamPublisherPlugin.class.getName());
 
     /// The block node context, for access to core facilities.
-    private BlockNodeContext context;
+    private final AtomicReference<BlockNodeContext> context = new AtomicReference<>();
     /// The publisher block manager, which connects handlers to the messaging facility.
     private StreamPublisherManager publisherManager;
 
@@ -136,7 +137,7 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
                 (BlockStreamPublishServiceMethod) method;
 
         final int maxMessageSize =
-                context.configuration().getConfigData(ServerConfig.class).maxMessageSizeBytes();
+                context.get().configuration().getConfigData(ServerConfig.class).maxMessageSizeBytes();
 
         final String rawCorrelationId = options.metadata().getOrDefault("hiero-correlation-id", "");
         final String correlationId = truncateCorrelationId(rawCorrelationId);
@@ -155,7 +156,7 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
 
     @Override
     public void init(@NonNull final BlockNodeContext context, @NonNull final ServiceBuilder serviceBuilder) {
-        this.context = Objects.requireNonNull(context);
+        this.context.set(Objects.requireNonNull(context));
         // register us as a service, we need to register the gRPC service in
         // the init method, otherwise the server will be started and we will not
         // have registered at all. A null port (the default) shares server.port.
@@ -166,19 +167,21 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
 
     @Override
     public void start() {
+        final BlockNodeContext currentContext = context.get();
         // Initialize plugin metrics
-        initMetrics(context.metricRegistry());
+        initMetrics(currentContext.metricRegistry());
         // Initialize the publisher manager
-        publisherManager = new LiveStreamPublisherManager(context, managerMetrics);
+        publisherManager = new LiveStreamPublisherManager(currentContext, managerMetrics);
         // register the manager as a notification handler
-        context.blockMessaging()
+        currentContext
+                .blockMessaging()
                 .registerBlockNotificationHandler(
                         publisherManager, false, LiveStreamPublisherManager.class.getSimpleName());
     }
 
     @Override
     public void stop() {
-        context.blockMessaging().unregisterBlockNotificationHandler(publisherManager);
+        context.get().blockMessaging().unregisterBlockNotificationHandler(publisherManager);
         publisherManager.shutdown();
     }
 
@@ -187,7 +190,7 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
      */
     @Override
     public void onContextUpdate(final BlockNodeContext context) {
-        this.context = context;
+        this.context.set(Objects.requireNonNull(context));
     }
 
     /// This method is called when a new publisher handler is created.

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Function;
+import org.hiero.block.api.BlockRange;
 import org.hiero.block.api.PublishStreamRequest.EndStream;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.api.PublishStreamResponse.EndOfStream.Code;
@@ -452,6 +453,56 @@ class LiveStreamPublisherManagerTest {
                         .isEqualTo(BlockAction.ACCEPT);
                 assertThat(embManager.getNextUnstreamed()).isEqualTo(51L);
                 assertThat(testApplicationState.nextExpectedBlock()).isEqualTo(-1L);
+            }
+        }
+
+        @Nested
+        @DisplayName("Startup block-number seeding Tests")
+        class StartupBlockNumberSeedingTests {
+
+            @Test
+            @DisplayName("initializeBlockNumbers seeds from storedBlocks() when higher than availableBlocks() max")
+            void seedsFromStoredBlocksWhenHigherThanAvailableBlocksMax() {
+                final SimpleInMemoryHistoricalBlockFacility localHistorical =
+                        new SimpleInMemoryHistoricalBlockFacility();
+                final SimpleBlockRangeSet localAvailable = new SimpleBlockRangeSet();
+                localAvailable.add(0L, 10L);
+                localHistorical.setTemporaryAvailableBlocks(localAvailable);
+
+                final BlockNodeContext baseContext =
+                        generateContext(localHistorical, threadPoolManager, messagingFacility);
+                localHistorical.init(baseContext, null);
+                final BlockNodeContext contextWithStoredBlocks = new BlockNodeContext.Builder(baseContext)
+                        .storedBlocks(List.of(new BlockRange(0L, 50L)))
+                        .build();
+
+                final LiveStreamPublisherManager seededManager =
+                        new LiveStreamPublisherManager(contextWithStoredBlocks, generateManagerMetrics());
+
+                assertThat(seededManager.getLatestBlockNumber()).isEqualTo(50L);
+                assertThat(seededManager.getNextUnstreamed()).isEqualTo(51L);
+            }
+
+            @Test
+            @DisplayName("initializeBlockNumbers seeds from storedBlocks() when there is no local block provider (RHF)")
+            void seedsFromStoredBlocksWhenNoBlockProvidersAvailable() {
+                // RHF has no block providers configured, so the historical facility never has any
+                // locally available blocks; availableBlocks() stays empty for the lifetime of the node.
+                final SimpleInMemoryHistoricalBlockFacility localHistorical =
+                        new SimpleInMemoryHistoricalBlockFacility();
+
+                final BlockNodeContext baseContext =
+                        generateContext(localHistorical, threadPoolManager, messagingFacility);
+                localHistorical.init(baseContext, null);
+                final BlockNodeContext contextWithStoredBlocks = new BlockNodeContext.Builder(baseContext)
+                        .storedBlocks(List.of(new BlockRange(0L, 50L)))
+                        .build();
+
+                final LiveStreamPublisherManager seededManager =
+                        new LiveStreamPublisherManager(contextWithStoredBlocks, generateManagerMetrics());
+
+                assertThat(seededManager.getLatestBlockNumber()).isEqualTo(50L);
+                assertThat(seededManager.getNextUnstreamed()).isEqualTo(51L);
             }
         }
 

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -504,6 +504,20 @@ class LiveStreamPublisherManagerTest {
                 assertThat(seededManager.getLatestBlockNumber()).isEqualTo(50L);
                 assertThat(seededManager.getNextUnstreamed()).isEqualTo(51L);
             }
+
+            @Test
+            @DisplayName("initializeBlockNumbers treats a null storedBlocks() as no known blocks")
+            void treatsNullStoredBlocksAsNoKnownBlocks() {
+                final BlockNodeContext contextWithNullStoredBlocks = new BlockNodeContext.Builder(generateContext())
+                        .storedBlocks(null)
+                        .build();
+
+                final LiveStreamPublisherManager seededManager =
+                        new LiveStreamPublisherManager(contextWithNullStoredBlocks, generateManagerMetrics());
+
+                assertThat(seededManager.getLatestBlockNumber()).isEqualTo(-1L);
+                assertThat(seededManager.getNextUnstreamed()).isEqualTo(0L);
+            }
         }
 
         /// Test for [LiveStreamPublisherManager#getLatestBlockNumber()].

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -554,8 +554,14 @@ class LiveStreamPublisherManagerTest {
                 // Persist the block in the local historical block facility, we do not need to send a notification.
                 localHistoricalBlockFacility.handleBlockItemsReceived(block.asBlockItems(), false);
                 // Construct a new LiveStreamPublisherManager with the local historical block facility.
-                final LiveStreamPublisherManager localToTest = new LiveStreamPublisherManager(
-                        generateContext(localHistoricalBlockFacility), generateManagerMetrics());
+                // Mirrors production, where BlockNodeApp merges availableBlocks into storedBlocks
+                // before a plugin ever sees the context.
+                final BlockNodeContext context = new BlockNodeContext.Builder(
+                                generateContext(localHistoricalBlockFacility))
+                        .storedBlocks(List.of(new BlockRange(block.number(), block.number())))
+                        .build();
+                final LiveStreamPublisherManager localToTest =
+                        new LiveStreamPublisherManager(context, generateManagerMetrics());
                 // After construction, the latest block number should be the one we just persisted.
                 // Call
                 final long actual = localToTest.getLatestBlockNumber();

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Function;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.hiero.block.api.BlockItemSet;
+import org.hiero.block.api.BlockRange;
 import org.hiero.block.api.PublishStreamRequest;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.api.PublishStreamResponse.EndOfStream.Code;
@@ -37,6 +38,8 @@ import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
 import org.hiero.block.node.app.fixtures.blocks.TestBlock;
 import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
 import org.hiero.block.node.app.fixtures.plugintest.GrpcPluginTestBase;
+import org.hiero.block.node.app.fixtures.plugintest.RecordingServiceBuilder;
+import org.hiero.block.node.app.fixtures.plugintest.SimpleBlockRangeSet;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
 import org.hiero.block.node.app.fixtures.plugintest.TestVerificationPlugin;
 import org.hiero.block.node.app.fixtures.plugintest.VerificationHandlingHistoricalBlockFacility;
@@ -834,6 +837,69 @@ class StreamPublisherPluginTest {
                     .returns(ResponseOneOfType.RESEND_BLOCK, responseKindExtractor)
                     .returns(block.number(), resendBlockNumberExtractor);
             resendReceiver.clear();
+        }
+    }
+
+    /// Verifies [StreamPublisherPlugin] reacts to `onContextUpdate()` so the publisher
+    /// watermark is seeded from the stored-block range delivered after `init()`, not the
+    /// stale context captured at `init()` time. Drives `init()` -> `onContextUpdate()` ->
+    /// `start()` via [#doInit] and [#replaceStoredBlocks], mirroring production startup order.
+    @Nested
+    @DisplayName("Plugin Tests ASF Watermark Seeding")
+    class PluginTestsAsfWatermarkSeeding
+            extends GrpcPluginTestBase<StreamPublisherPlugin, ExecutorService, ScheduledBlockingExecutor> {
+        /// Does not call `start()` — the test method drives `doInit()`/`replaceStoredBlocks()`/
+        /// `doStart()` in sequence instead.
+        PluginTestsAsfWatermarkSeeding() {
+            super(Executors.newSingleThreadExecutor(), new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+            historicalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
+            verificationPlugin = new TestVerificationPlugin();
+        }
+
+        /// Like [GrpcPluginTestBase#start], but splits `init()`/`start()` so
+        /// [#replaceStoredBlocks] can run in between.
+        private void activatePluginWithStoredBlocksDeliveredBeforeStart(
+                final StreamPublisherPlugin toTest, final List<BlockRange> storedBlocksAfterInit) {
+            doInit(toTest, historicalBlockFacility, List.of(verificationPlugin), null, Map.of());
+            replaceStoredBlocks(storedBlocksAfterInit);
+            doStart();
+            method = toTest.methods().getFirst();
+            if (webserviceBuilder instanceof RecordingServiceBuilder recordingBuilder
+                    && !recordingBuilder.grpcServiceRegistrations().isEmpty()) {
+                serviceInterface =
+                        recordingBuilder.grpcServiceRegistrations().getLast().service();
+            }
+            setupNewPipelines();
+        }
+
+        /// Historical provider has blocks 0-10; the stored-block range delivered before
+        /// `start()` reports up to 50. If the watermark seeded from 50, publishing block
+        /// 11 is rejected as a duplicate carrying watermark 50. If the update was missed,
+        /// the watermark stays at 10 and block 11 is accepted as the next expected block.
+        @Test
+        @DisplayName("start() seeds watermark from ASF stored blocks delivered via onContextUpdate before start()")
+        void testWatermarkSeedsFromStoredBlocksDeliveredBeforeStart() {
+            final SimpleBlockRangeSet availableBlocks = new SimpleBlockRangeSet();
+            availableBlocks.add(0, 10);
+            historicalBlockFacility.setTemporaryAvailableBlocks(availableBlocks);
+            final StreamPublisherPlugin toTest = new StreamPublisherPlugin();
+            activatePluginWithStoredBlocksDeliveredBeforeStart(toTest, List.of(new BlockRange(0L, 50L)));
+
+            final long staleBlockNumber = 11L;
+            final TestBlock block = TestBlockBuilder.generateBlockWithNumber(staleBlockNumber);
+            final PublishStreamRequestUnparsed request = PublishStreamRequestUnparsed.newBuilder()
+                    .blockItems(block.asItemSetUnparsed())
+                    .build();
+            toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(request));
+            awaitPluginResponses(1);
+            assertThat(fromPluginBytes)
+                    .hasSize(1)
+                    .first()
+                    .extracting(bytesToPublishStreamResponseMapper)
+                    .isNotNull()
+                    .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
+                    .returns(Code.DUPLICATE_BLOCK, endStreamResponseCodeExtractor)
+                    .returns(50L, endStreamResponseBlockNumberExtractor);
         }
     }
 

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
@@ -445,6 +445,9 @@ class StreamPublisherPluginTest {
             for (final TestBlock block : blocks) {
                 historicalBlockFacility.handleBlockItemsReceived(block.asBlockItems(), false);
             }
+            // Mirrors production, where BlockNodeApp merges availableBlocks into storedBlocks
+            // before a plugin ever sees the context.
+            storedBlocks = List.of(new BlockRange(earliestPersistedBlock, expectedLatestPersistedBlock));
             activatePlugin(10L);
             // Assert that the historical block facility has blocks 3-5
             assertThat(blockNodeContext
@@ -491,6 +494,9 @@ class StreamPublisherPluginTest {
             for (final TestBlock block : blocks) {
                 historicalBlockFacility.handleBlockItemsReceived(block.asBlockItems(), false);
             }
+            // Mirrors production, where BlockNodeApp merges availableBlocks into storedBlocks
+            // before a plugin ever sees the context.
+            storedBlocks = List.of(new BlockRange(earliestPersistedBlock, latestPersistedBlock));
             activatePlugin(10L);
             // Assert that the historical block facility has blocks 0-5
             assertThat(blockNodeContext
@@ -531,6 +537,10 @@ class StreamPublisherPluginTest {
             final int expectedLatestPersistedBlockNumber = 10;
             final TestBlock block10 = TestBlockBuilder.generateBlockWithNumber(expectedLatestPersistedBlockNumber);
             historicalBlockFacility.handleBlockItemsReceived(block10.asBlockItems(), false);
+            // Mirrors production, where BlockNodeApp merges availableBlocks into storedBlocks
+            // before a plugin ever sees the context.
+            storedBlocks =
+                    List.of(new BlockRange(expectedLatestPersistedBlockNumber, expectedLatestPersistedBlockNumber));
             activatePlugin(10L);
             // Assert that the historical block facility has block 10
             assertThat(blockNodeContext


### PR DESCRIPTION
## Reviewer Notes

### Publisher startup watermark now also considers ApplicationStateFacility stored blocks

`LiveStreamPublisherManager.initializeBlockNumbers` previously seeded `lastPersistedBlockNumber` only from `historicalBlockProvider().availableBlocks().max()`. That is wrong for a node with no local block provider (RHF), since `availableBlocks()` stays empty for the node's whole lifetime even though ASF has a persisted stored-block range. The watermark now takes `Math.max` of the historical provider's max and `context.storedBlocks()`'s last range end.

### `StreamPublisherPlugin.context` needs `onContextUpdate()` wired up, and `volatile`

`BlockNodeApp` calls `init()` with an empty-lists context, then delivers a rebuilt context carrying the ASF-synced stored blocks via `onContextUpdate()`, and only then calls `start()`. The plugin was not overriding `onContextUpdate()`, so `start()` was seeding the watermark from the stale, empty-lists context and silently dropping the ASF update. Field is marked `volatile` since `onContextUpdate()` runs on a separate thread from `start()`.

## Related Issue(s)

Closes #2822 