### PR TITLE
fix: Evict bad client connection so a reconnect can occur

### DIFF
--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillFetcher.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillFetcher.java
@@ -6,11 +6,13 @@ import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.WARNING;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -35,7 +37,7 @@ import org.hiero.metrics.LongCounter;
  * The client is initialized with a path to a block node preference file, which contains
  * a list of block nodes with their addresses, ports, and priorities.
  */
-public class BackfillFetcher implements PriorityHealthBasedStrategy.NodeHealthProvider {
+public class BackfillFetcher implements PriorityHealthBasedStrategy.NodeHealthProvider, AutoCloseable {
     private static final System.Logger LOGGER = System.getLogger(BackfillFetcher.class.getName());
 
     /** Metric for Number of retries during the backfill process. */
@@ -192,21 +194,25 @@ public class BackfillFetcher implements PriorityHealthBasedStrategy.NodeHealthPr
      * @return a BlockNodeClient for the specified node
      */
     protected BlockNodeClient getNodeClient(BlockNodeSourceConfig node) {
-        // Check if existing client is unreachable and remove it to allow recreation
-        BlockNodeClient existingClient = nodeClientMap.get(node);
-        if (existingClient != null && !existingClient.isNodeReachable()) {
-            nodeClientMap.remove(node);
-            LOGGER.log(DEBUG, "Removed unreachable client for node [{0}], will attempt to recreate", node.address());
-        }
-        return nodeClientMap.computeIfAbsent(
-                node,
-                n -> new BlockNodeClient(
-                        n,
-                        globalGrpcTimeoutMs,
-                        enableTls,
-                        maxIncomingBufferSize,
-                        maxProtobufMessageSizeBytes,
-                        n.grpcWebclientTuning()));
+        // Atomic check-close-construct: avoids the window a separate get()+remove()+
+        // computeIfAbsent() would leave between evicting an unreachable client and
+        // constructing its replacement.
+        return nodeClientMap.compute(node, (key, current) -> {
+            if (current != null) {
+                if (current.isNodeReachable()) {
+                    return current;
+                }
+                closeQuietly(key, current);
+                LOGGER.log(DEBUG, "Removed unreachable client for node [{0}], will attempt to recreate", key.address());
+            }
+            return new BlockNodeClient(
+                    key,
+                    globalGrpcTimeoutMs,
+                    enableTls,
+                    maxIncomingBufferSize,
+                    maxProtobufMessageSizeBytes,
+                    key.grpcWebclientTuning());
+        });
     }
 
     /**
@@ -338,7 +344,7 @@ public class BackfillFetcher implements PriorityHealthBasedStrategy.NodeHealthPr
 
     private void markFailure(BlockNodeSourceConfig node) {
         // Evict cached client so a fresh one is created after backoff expires
-        nodeClientMap.remove(node);
+        removeAndClose(node);
         healthMap.compute(node, (n, h) -> {
             if (h == null) {
                 return new SourceHealth(1, System.currentTimeMillis() + initialRetryDelayMs, 0, 0);
@@ -349,6 +355,23 @@ public class BackfillFetcher implements PriorityHealthBasedStrategy.NodeHealthPr
             long nextAllowed = System.currentTimeMillis() + backoff;
             return new SourceHealth(failures, nextAllowed, h.successes, h.totalLatencyNanos);
         });
+    }
+
+    /** Removes and closes the cached client for {@code node}, if present. */
+    private void removeAndClose(BlockNodeSourceConfig node) {
+        BlockNodeClient removed = nodeClientMap.remove(node);
+        if (removed != null) {
+            closeQuietly(node, removed);
+        }
+    }
+
+    /** Closes {@code client}, logging (not throwing) if it fails. */
+    private void closeQuietly(BlockNodeSourceConfig node, BlockNodeClient client) {
+        try {
+            client.close();
+        } catch (IOException e) {
+            LOGGER.log(WARNING, "Unable to close BlockNodeClient [{0}]: {1}", node.address(), e);
+        }
     }
 
     private void markSuccess(BlockNodeSourceConfig node, long latencyNanos) {
@@ -375,13 +398,23 @@ public class BackfillFetcher implements PriorityHealthBasedStrategy.NodeHealthPr
 
     /**
      * Resets the health tracking for all nodes, clearing failure counts and backoff times.
-     * Also clears cached clients so fresh connections are established on the next cycle.
+     * Also closes and clears cached clients so fresh connections are established on the next cycle.
      */
     public void resetHealth() {
         healthMap.clear();
-        nodeClientMap.clear();
+        for (BlockNodeSourceConfig node : nodeClientMap.keySet()) {
+            removeAndClose(node);
+        }
     }
 
     /** Package-private for testing. */
     record SourceHealth(int failures, long nextAllowedMillis, long successes, long totalLatencyNanos) {}
+
+    /** Closes every cached client. Safe to call multiple times. */
+    @Override
+    public void close() throws IOException {
+        for (Entry<BlockNodeSourceConfig, BlockNodeClient> entry : nodeClientMap.entrySet()) {
+            closeQuietly(entry.getKey(), entry.getValue());
+        }
+    }
 }

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -303,6 +303,13 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
                 LOGGER.log(INFO, "Error closing liveTailScheduler: " + e.getMessage(), e);
             }
         }
+        if (autonomousFetcher != null) {
+            try {
+                autonomousFetcher.close();
+            } catch (IOException | RuntimeException e) {
+                LOGGER.log(INFO, "Error closing autonomousFetcher: " + e.getMessage(), e);
+            }
+        }
 
         // 3. Shutdown executors and wait for termination
         shutdownExecutor(historicalExecutor, "historicalExecutor");

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillTaskScheduler.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillTaskScheduler.java
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.backfill;
 
+import static java.lang.System.Logger.Level.WARNING;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -98,6 +101,11 @@ final class BackfillTaskScheduler implements AutoCloseable {
         queue.clear();
         persistenceAwaiter.clear();
         // Note: executor lifecycle is managed by the creator (BackfillPlugin)
+        try {
+            fetcher.close();
+        } catch (IOException e) {
+            LOGGER.log(WARNING, "Error closing fetcher: " + e.getMessage(), e);
+        }
     }
 
     private void ensureWorkerRunning() {

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcher.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/AddressBookFetcher.java
@@ -8,6 +8,7 @@ import static java.lang.System.Logger.Level.WARNING;
 import com.hedera.hapi.node.base.NodeAddress;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import org.hiero.block.api.RangedAddressBookHistory;
 import org.hiero.block.api.RangedNodeAddressBook;
@@ -102,7 +103,7 @@ public class AddressBookFetcher implements AutoCloseable {
                         e.getMessage());
                 metrics.peerErrors().increment();
                 // Remove so a fresh client is created on the next attempt
-                nodeClientMap.remove(node);
+                removeAndClose(node);
             }
         }
         return null;
@@ -119,15 +120,28 @@ public class AddressBookFetcher implements AutoCloseable {
                 if (current.isNodeReachable()) {
                     return current;
                 }
-                try {
-                    current.close();
-                } catch (IOException e) {
-                    LOGGER.log(WARNING, "Unable to close BlockNodeClient [{0}]: {1}", key.name(), e);
-                }
+                closeQuietly(key, current);
+                LOGGER.log(DEBUG, "Client unreachable for peer [{0}], will recreate", key.address());
             }
-            LOGGER.log(DEBUG, "Client unreachable for peer [{0}], will recreate", key.address());
             return fromBlockNodeSourceConfig(key);
         });
+    }
+
+    /** Removes and closes the cached client for {@code node}, if present. */
+    private void removeAndClose(BlockNodeSourceConfig node) {
+        BlockNodeClient removed = nodeClientMap.remove(node);
+        if (removed != null) {
+            closeQuietly(node, removed);
+        }
+    }
+
+    /** Closes {@code client}, logging (not throwing) if it fails. */
+    private void closeQuietly(BlockNodeSourceConfig node, BlockNodeClient client) {
+        try {
+            client.close();
+        } catch (IOException e) {
+            LOGGER.log(WARNING, "Unable to close BlockNodeClient [{0}]: {1}", node.address(), e);
+        }
     }
 
     /// Returns `true` if the book has at least one entry with a non-blank RSA public key.
@@ -145,17 +159,9 @@ public class AddressBookFetcher implements AutoCloseable {
     }
 
     @Override
-    public void close() {
-        for (BlockNodeClient client : nodeClientMap.values()) {
-            try {
-                client.close();
-            } catch (IOException e) {
-                LOGGER.log(
-                        WARNING,
-                        "Unable to close BlockNodeClient [{0}]: {1}",
-                        client.getBlockNodeServiceClient().fullName(),
-                        e);
-            }
+    public void close() throws IOException {
+        for (Entry<BlockNodeSourceConfig, BlockNodeClient> entry : nodeClientMap.entrySet()) {
+            closeQuietly(entry.getKey(), entry.getValue());
         }
     }
 

--- a/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
+++ b/block-node/roster-bootstrap-rsa/src/main/java/org/hiero/block/node/roster/bootstrap/rsa/RsaRosterBootstrapPlugin.java
@@ -568,7 +568,11 @@ public class RsaRosterBootstrapPlugin implements BlockNodePlugin {
         shutdownExecutor(queryBnExecutor, "queryPeerExecutor");
         shutdownExecutor(queryMnExecutor, "queryMnExecutor");
         if (addressBookFetcher != null) {
-            addressBookFetcher.close();
+            try {
+                addressBookFetcher.close();
+            } catch (IOException e) {
+                // ignore IOException
+            }
         }
     }
 

--- a/block-node/roster-bootstrap-tss/src/main/java/org/hiero/block/node/roster/bootstrap/tss/TssDataFetcher.java
+++ b/block-node/roster-bootstrap-tss/src/main/java/org/hiero/block/node/roster/bootstrap/tss/TssDataFetcher.java
@@ -117,6 +117,12 @@ public class TssDataFetcher implements Closeable {
                 final String failedToRetrieveTssData = "Failed to retrieve TssData from node [{0}]: {1}";
                 LOGGER.log(WARNING, failedToRetrieveTssData, node, e.getMessage());
                 metrics.tssDataErrors().increment();
+                // Evict the cached client so a fresh connection is established on the next
+                // poll cycle instead of retrying the same dead one forever — isNodeReachable()
+                // only reflects initial connect success and is never updated by a later RPC
+                // failure, so without this eviction every subsequent poll fails identically
+                // (mirrors BackfillFetcher.markFailure()'s client eviction).
+                nodeClientMap.remove(node);
             }
         }
 

--- a/block-node/roster-bootstrap-tss/src/main/java/org/hiero/block/node/roster/bootstrap/tss/TssDataFetcher.java
+++ b/block-node/roster-bootstrap-tss/src/main/java/org/hiero/block/node/roster/bootstrap/tss/TssDataFetcher.java
@@ -6,10 +6,10 @@ import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.WARNING;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import org.hiero.block.api.ServerStatusDetailResponse;
 import org.hiero.block.api.ServerStatusRequest;
@@ -24,7 +24,7 @@ import org.hiero.block.node.roster.bootstrap.tss.RosterBootstrapTssPlugin.Metric
 ///
 /// The client is initialized with a path to a block node preference file, which contains
 /// a list of block nodes with their addresses, ports, and priorities.
-public class TssDataFetcher implements Closeable {
+public class TssDataFetcher implements AutoCloseable {
     private static final System.Logger LOGGER = System.getLogger(TssDataFetcher.class.getName());
 
     /// Source of block node configurations.
@@ -74,25 +74,25 @@ public class TssDataFetcher implements Closeable {
     /// @param node the BlockNodeSourceConfig to get the client for
     /// @return a BlockNodeClient for the specified node
     protected BlockNodeClient getNodeClient(BlockNodeSourceConfig node) {
-        // Check if existing client is unreachable and remove it to allow recreation
-        BlockNodeClient existingClient = nodeClientMap.get(node);
-        if (existingClient != null && !existingClient.isNodeReachable()) {
-            try {
-                nodeClientMap.remove(node).close();
-            } catch (IOException e) {
-                LOGGER.log(WARNING, "Unable to close BlockNodeClient [{0}]: {1}", node.name(), e);
+        // Atomic check-close-construct: avoids the window a separate get()+remove()+
+        // computeIfAbsent() would leave between evicting an unreachable client and
+        // constructing its replacement.
+        return nodeClientMap.compute(node, (key, current) -> {
+            if (current != null) {
+                if (current.isNodeReachable()) {
+                    return current;
+                }
+                closeQuietly(key, current);
+                LOGGER.log(DEBUG, "Removed unreachable client for node [{0}], will attempt to recreate", key.address());
             }
-            LOGGER.log(DEBUG, "Removed unreachable client for node [{0}], will attempt to recreate", node.address());
-        }
-        return nodeClientMap.computeIfAbsent(
-                node,
-                n -> new BlockNodeClient(
-                        n,
-                        globalGrpcTimeoutMs,
-                        enableTls,
-                        maxIncomingBufferSize,
-                        TSS_DATA_MAX_PROTOBUF_MESSAGE_SIZE_BYTES,
-                        n.grpcWebclientTuning()));
+            return new BlockNodeClient(
+                    key,
+                    globalGrpcTimeoutMs,
+                    enableTls,
+                    maxIncomingBufferSize,
+                    TSS_DATA_MAX_PROTOBUF_MESSAGE_SIZE_BYTES,
+                    key.grpcWebclientTuning());
+        });
     }
 
     /// Perform a serverStatusDetail call per configured node and capture the TssData.
@@ -122,17 +122,34 @@ public class TssDataFetcher implements Closeable {
                 // only reflects initial connect success and is never updated by a later RPC
                 // failure, so without this eviction every subsequent poll fails identically
                 // (mirrors BackfillFetcher.markFailure()'s client eviction).
-                nodeClientMap.remove(node);
+                removeAndClose(node);
             }
         }
 
         return tssDataList;
     }
 
+    /** Removes and closes the cached client for {@code node}, if present. */
+    private void removeAndClose(BlockNodeSourceConfig node) {
+        BlockNodeClient removed = nodeClientMap.remove(node);
+        if (removed != null) {
+            closeQuietly(node, removed);
+        }
+    }
+
+    /** Closes {@code client}, logging (not throwing) if it fails. */
+    private void closeQuietly(BlockNodeSourceConfig node, BlockNodeClient client) {
+        try {
+            client.close();
+        } catch (IOException e) {
+            LOGGER.log(WARNING, "Unable to close BlockNodeClient [{0}]: {1}", node.address(), e);
+        }
+    }
+
     @Override
     public void close() throws IOException {
-        for (BlockNodeClient client : nodeClientMap.values()) {
-            client.close();
+        for (Entry<BlockNodeSourceConfig, BlockNodeClient> entry : nodeClientMap.entrySet()) {
+            closeQuietly(entry.getKey(), entry.getValue());
         }
     }
 }

--- a/block-node/roster-bootstrap-tss/src/test/java/org/hiero/block/node/roster/bootstrap/tss/TssDataFetcherTest.java
+++ b/block-node/roster-bootstrap-tss/src/test/java/org/hiero/block/node/roster/bootstrap/tss/TssDataFetcherTest.java
@@ -2,6 +2,7 @@
 package org.hiero.block.node.roster.bootstrap.tss;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -117,6 +118,31 @@ class TssDataFetcherTest {
             when(blockNodeClient.isNodeReachable()).thenReturn(true);
 
             return blockNodeClient;
+        }
+
+        @Test
+        @DisplayName("evicts cached client after a failed call so the next poll reconnects")
+        void evictsClientOnFailure() {
+            final BlockNodeSourceConfig nodeConfig = node("localhost", 1, 1);
+            final RosterBootstrapTssPlugin.MetricsHolder metrics = createTestMetricsHolder();
+            final TssDataFetcher fetcher = new TssDataFetcher(createSource(nodeConfig), createTestConfig(), metrics);
+
+            BlockNodeServiceInterface.BlockNodeServiceClient serviceClient =
+                    mock(BlockNodeServiceInterface.BlockNodeServiceClient.class);
+            when(serviceClient.serverStatusDetail(any())).thenThrow(new RuntimeException("Socket closed"));
+
+            BlockNodeClient blockNodeClient = mock(BlockNodeClient.class);
+            when(blockNodeClient.getBlockNodeServiceClient()).thenReturn(serviceClient);
+            when(blockNodeClient.isNodeReachable()).thenReturn(true);
+            // Seed the cache directly (package-private field) so getNodeClient()'s real
+            // implementation finds this mock via computeIfAbsent, matching how a client
+            // that connected successfully but later failed a call would look in production.
+            fetcher.nodeClientMap.put(nodeConfig, blockNodeClient);
+
+            assertTrue(fetcher.getTssData().isEmpty());
+            assertFalse(
+                    fetcher.nodeClientMap.containsKey(nodeConfig),
+                    "a client that failed a call should be evicted, not reused on the next poll");
         }
     }
 


### PR DESCRIPTION
## Reviewer Notes
- Mirrors backfill reconnect logic
- make all fetchers auto-closeable
- make client resource closing consistent across fetchers

## Related Issue(s)
Closes #3385