### PR TITLE
chore(ci): bump solo-provisioner to v0.27.0 and remove seed-plugins workaround (#3388)

### DIFF
--- a/.github/workflows/e2e-node-operator.yaml
+++ b/.github/workflows/e2e-node-operator.yaml
@@ -32,9 +32,9 @@ on:
           - all
         required: false
       solo-provisioner-version:
-        description: "solo-provisioner (solo-weaver) release tag to install (e.g. v0.26.0). Bump as needed."
+        description: "solo-provisioner (solo-weaver) release tag to install (e.g. v0.27.0). Bump as needed."
         required: false
-        default: "v0.26.0"
+        default: "v0.27.0"
   schedule:
     # Nightly Mon-Fri 04:00 UTC (offset from the solo-e2e scheduler at 06:00).
     - cron: "0 4 * * 1-5"
@@ -81,7 +81,7 @@ jobs:
       CHART_REGISTRY: localhost:5001
       # Pinned solo-provisioner (solo-weaver) release for reproducible runs. workflow_dispatch can override
       # via the solo-provisioner-version input; schedule/pull_request fall back to this default.
-      SOLO_PROVISIONER_VERSION: ${{ inputs.solo-provisioner-version || 'v0.26.0' }}
+      SOLO_PROVISIONER_VERSION: ${{ inputs.solo-provisioner-version || 'v0.27.0' }}
     steps:
       # ── PHASE 0: Setup ─────────────────────────────────────────────────────
       - name: Harden Runner
@@ -113,7 +113,7 @@ jobs:
         with:
           cluster_name: operator-test
           node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
-          version: v0.26.0
+          version: v0.27.0
           kubectl_version: v1.31.4
 
       - name: Export KUBECONFIG for sudo solo-provisioner
@@ -302,7 +302,7 @@ jobs:
               # StatefulSet status fields helm actually checks (ready/updated replicas + revisions).
               kubectl get statefulset -n "${NAMESPACE}" -o jsonpath='{range .items[*]}STS {.metadata.name} ready={.status.readyReplicas}/{.status.replicas} updated={.status.updatedReplicas} curRev={.status.currentRevision} updRev={.status.updateRevision}{"\n"}{end}' 2>/dev/null || true
               kubectl get events -n "${NAMESPACE}" --sort-by=.lastTimestamp 2>/dev/null | tail -15 || true
-              # All containers incl. init (seed-plugins/init-storage-dirs) — slow boot vs crashing container.
+              # All containers incl. init (init-storage-dirs) — slow boot vs crashing container.
               kubectl logs -n "${NAMESPACE}" "${RELEASE}-block-node-server-0" --all-containers=true --prefix --tail=20 2>/dev/null || true
               sleep 15
             done ) &
@@ -319,6 +319,7 @@ jobs:
           sudo KUBECONFIG="$KUBECONFIG" solo-provisioner block node install \
             --profile=local --namespace="${NAMESPACE}" --non-interactive \
             --load-balancer-enabled=false \
+            --timeout 15m \
             --config=tools-and-tests/scripts/e2e-node-operator/solo-ci-config.yaml \
             --values=/tmp/solo-ci-values-base.yaml \
             --chart-version="${{ steps.versions.outputs.BASE_VERSION }}"
@@ -401,6 +402,7 @@ jobs:
           sudo KUBECONFIG="$KUBECONFIG" solo-provisioner block node upgrade \
             --profile=local --namespace="${NAMESPACE}" --release-name="${RELEASE}" --non-interactive \
             --no-reuse-values --load-balancer-enabled=false \
+            --timeout 15m \
             --config=/tmp/solo-ci-config-snapshot.yaml \
             --values=/tmp/solo-ci-values-snap.yaml \
             --chart-version="${{ steps.versions.outputs.SNAP_VERSION }}"

--- a/tools-and-tests/scripts/e2e-node-operator/solo-ci-values.yaml
+++ b/tools-and-tests/scripts/e2e-node-operator/solo-ci-values.yaml
@@ -12,7 +12,8 @@
 # hashgraph/solo-weaver#912, fixed in v0.27.0).
 #
 # Permissions: solo-provisioner backs PVCs with root-owned hostPath PVs and fsGroup is not honored, so
-# root init containers must chown the data dirs.
+# root init containers must chown the data dirs — including plugins-storage, which must be writable
+# before the chart's copy-core-modules init container (runs as the BN image user, hedera:2000) runs.
 image:
   repository: ghcr.io/hiero-ledger/hiero-block-node-solo-dev
   tag: "__BN_TAG__"
@@ -42,6 +43,8 @@ blockNode:
       initialDelaySeconds: 15
   # Replaces the chart's default init list (lists replace, not merge). init-storage-dirs runs as
   # root: the hostPath PVC roots are root-owned and the BN runs as non-root 'hedera' (2000).
+  # plugins-storage must also be chowned here — it runs before the chart's copy-core-modules init
+  # container (which runs as hedera:2000 and writes .core-modules.txt into the plugins volume).
   initContainers:
     - name: init-storage-dirs
       image: busybox
@@ -50,12 +53,12 @@ blockNode:
         - -c
         - |
           set -eux
-          # Chown/chmod the data/log/state PVCs to the BN (uid 2000): hostPath PVs are root-owned and
-          # fsGroup is not honored. live/archive use subPath; logs and state mount at the PVC root.
+          # Chown/chmod all PVCs to the BN (uid 2000): hostPath PVs are root-owned and fsGroup is
+          # not honored. live/archive use subPath; logs, state, and plugins mount at the PVC root.
           mkdir -p /live-pvc/live-data /archive-pvc/archive-data
-          chown -R 2000:2000 /live-pvc /archive-pvc /logs-pvc /state-pvc
-          chmod -R 777 /live-pvc /archive-pvc /logs-pvc /state-pvc
-          ls -ln /live-pvc /archive-pvc /logs-pvc /state-pvc
+          chown -R 2000:2000 /live-pvc /archive-pvc /logs-pvc /state-pvc /plugins-pvc
+          chmod -R 777 /live-pvc /archive-pvc /logs-pvc /state-pvc /plugins-pvc
+          ls -ln /live-pvc /archive-pvc /logs-pvc /state-pvc /plugins-pvc
       volumeMounts:
         - name: live-storage
           mountPath: /live-pvc
@@ -65,6 +68,8 @@ blockNode:
           mountPath: /logs-pvc
         - name: application-state-storage
           mountPath: /state-pvc
+        - name: plugins-storage
+          mountPath: /plugins-pvc
   # Only PVC sizes are overridden; volume names/mounts/claims use the chart defaults. On 0.37+ the
   # provisioner-owned state existingClaim persists across the upgrade (tss-parameters.bin + blocks intact).
   persistence:

--- a/tools-and-tests/scripts/e2e-node-operator/solo-ci-values.yaml
+++ b/tools-and-tests/scripts/e2e-node-operator/solo-ci-values.yaml
@@ -3,21 +3,21 @@
 # Helm value overrides for the E2E node-operator lifecycle test in CI (kind), passed to
 # solo-provisioner via --values (add --no-reuse-values on `upgrade`). The workflow sed-replaces two
 # placeholders per phase: __BN_TAG__ (base/snapshot version) and __PLUGIN_NAMES__ (profile plugins to
-# keep; empty = keep all). Sized for a single-node kind cluster with no consensus node.
+# resolve; empty = all-profile, provisioner skips the PVC and baked plugins are used). Sized for a
+# single-node kind cluster with no consensus node.
 #
-# Uses the solo-dev image (all plugins baked in) with plugins.names: "" to skip the chart's Maven
-# resolve-plugins init container, whose ~4-min cold resolve blows solo-provisioner's hard-coded 5-min
-# `helm install --atomic` timeout (upstream: hashgraph/solo-weaver#912). solo-provisioner still
-# force-mounts a managed plugins PVC read-only over the baked plugins dir (#913), so seed-plugins
-# copies them into that PVC below.
+# Uses the standard block-node image with plugins.names set to the selected profile's plugin list.
+# The provisioner manages the plugins PVC and Maven's resolve-plugins init container fetches exactly
+# those plugins. --timeout 15m on install/upgrade gives Maven the room it needs (upstream:
+# hashgraph/solo-weaver#912, fixed in v0.27.0).
 #
 # Permissions: solo-provisioner backs PVCs with root-owned hostPath PVs and fsGroup is not honored, so
-# root init containers must chown the data dirs and own the plugins dir.
+# root init containers must chown the data dirs.
 image:
   repository: ghcr.io/hiero-ledger/hiero-block-node-solo-dev
   tag: "__BN_TAG__"
 plugins:
-  names: ""
+  names: "__PLUGIN_NAMES__"
 
 resources:
   requests:
@@ -40,7 +40,7 @@ blockNode:
       failureThreshold: 6
     readiness:
       initialDelaySeconds: 15
-  # Replaces the chart's default init list (lists replace, not merge) to add seed-plugins. Both run as
+  # Replaces the chart's default init list (lists replace, not merge). init-storage-dirs runs as
   # root: the hostPath PVC roots are root-owned and the BN runs as non-root 'hedera' (2000).
   initContainers:
     - name: init-storage-dirs
@@ -65,39 +65,6 @@ blockNode:
           mountPath: /logs-pvc
         - name: application-state-storage
           mountPath: /state-pvc
-    - name: seed-plugins
-      image: ghcr.io/hiero-ledger/hiero-block-node-solo-dev:__BN_TAG__
-      securityContext:
-        runAsUser: 0
-      command:
-        - sh
-        - -c
-        - |
-          set -eux
-          # CLEAR FIRST: the plugins PVC persists across upgrades, so wipe it before seeding — otherwise a
-          # stale prior-version jar (e.g. old verification) is loaded next to the new one.
-          find /plugins-pvc -mindepth 1 -delete 2>/dev/null || true
-          # Run as root (PVC root is hostPath/root-owned); chmod a+rX so the non-root main container reads them.
-          cp -R /opt/hiero/block-node/app-*/plugins/. /plugins-pvc/
-          # Profile prune: solo-dev bakes ALL plugins and the BN loads every jar, so drop plugin jars
-          # (<name>-<ver>.jar) not in NAMES. Dependency jars have other versions and are kept; empty NAMES keeps all.
-          NAMES="__PLUGIN_NAMES__"
-          VER="__BN_TAG__"
-          if [ -n "${NAMES}" ]; then
-            for jar in /plugins-pvc/*-"${VER}".jar; do
-              [ -e "${jar}" ] || continue
-              base=$(basename "${jar}"); name=${base%-${VER}.jar}
-              case ",${NAMES}," in
-                *",${name},"*) ;;
-                *) echo "pruning plugin not in profile: ${name}"; rm -f "${jar}" ;;
-              esac
-            done
-          fi
-          chmod -R a+rX /plugins-pvc
-          echo "Plugins after profile prune (NAMES=${NAMES:-all}):" && ls -1 /plugins-pvc | wc -l && ls -1 /plugins-pvc
-      volumeMounts:
-        - name: plugins-storage
-          mountPath: /plugins-pvc
   # Only PVC sizes are overridden; volume names/mounts/claims use the chart defaults. On 0.37+ the
   # provisioner-owned state existingClaim persists across the upgrade (tss-parameters.bin + blocks intact).
   persistence:


### PR DESCRIPTION
## Summary

- Bumps the default `SOLO_PROVISIONER_VERSION` from `v0.26.0` to `v0.27.0` (input description, `default:` value, `SOLO_PROVISIONER_VERSION` env var, and the `version:` field under `helm/kind-action`).
- Switches the E2E CI test from the workaround path (solo-dev baked image + seed-plugins init container + `plugins.names: ""`) to the standard managed-PVC path (`plugins.names: "__PLUGIN_NAMES__"`, standard image, Maven resolves exactly the profile's plugins).
- Adds `--timeout 15m` to the `solo-provisioner block node install` and `upgrade` commands so Maven's resolve-plugins init container has enough time (#912 fix).
- No chart template changes — the existing `plugins.names` / PVC provisioning logic already handles everything correctly.

## Upstream fixes in v0.27.0

Both blockers that forced the prior workarounds are now resolved:

- **hashgraph/solo-weaver#913** (closed): provisioner no longer force-mounts the `plugins-storage` PVC when `plugins.names=""`. The `all` profile still results in `plugins.names: ""` (via `__PLUGIN_NAMES__` → empty), so provisioner skips the PVC and the baked image's plugins are used directly.
- **hashgraph/solo-weaver#912** (closed): a `--timeout` flag has been added to `block node install` and `upgrade`, replacing the hard-coded 5-minute Helm budget that Maven's cold-resolve always exceeded.

**Tracking bug:** hiero-ledger/hiero-block-node#3388

## What the CI flow now does

1. `plugin-profile` input (lfh / rfh / all) drives `PLUGIN_NAMES` in the "Determine versions" step.
2. `sed` substitutes both `__BN_TAG__` and `__PLUGIN_NAMES__` into `solo-ci-values.yaml`, setting `plugins.names` to the profile's list (or `""` for `all`).
3. The provisioner provisions the `plugins-storage` PVC (skipped for `all`) and Maven's `resolve-plugins` init container fetches exactly those plugins.
4. `--timeout 15m` gives Maven the room it needs.
5. Profile enforcement (lfh/rfh/all) is now accurate and production-equivalent.

## What was kept (intentionally unchanged)

- `init-storage-dirs` init container — still needed to `chown` root-owned hostPath PVs.
- `plugin-profile` dispatch input and PLUGIN_NAMES resolution logic — more important than ever.
- `crane` install step — still needed for multi-arch image loading into kind.
- "Clear block storage before reset" step.

## Test plan

- [ ] Trigger via `workflow_dispatch` with `plugin-profile=lfh` and default `solo-provisioner-version` (`v0.27.0`). Confirm the full lifecycle (install → verify → upgrade → reset → re-push → uninstall) completes within the 60-minute job timeout.
- [ ] Repeat with `plugin-profile=all`. Confirm provisioner skips the `plugins-storage` PVC and the BN boots using baked plugins.
- [ ] Confirm Maven's `resolve-plugins` init container completes within the 15-minute timeout for the lfh profile.
- [ ] Confirm the nightly schedule run passes on the first nightly after merge.