### PR TITLE
fix(ci): grant issues:write to release-automation.yaml for milestone rollover

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -30,6 +30,7 @@ on:
 permissions:
   contents: write
   actions: write
+  issues: write
 
 defaults:
   run:


### PR DESCRIPTION
## Summary

Every dispatch of `release-automation.yaml` fails outright right now — `startup_failure`, zero jobs run: https://github.com/hiero-ledger/hiero-block-node/actions/runs/31132153997

```
Error calling workflow 'hiero-ledger/hiero-block-node/.github/workflows/milestone-rollover.yaml@...'.
The workflow is requesting 'issues: write', but is only allowed 'issues: none'.
```

`release-automation.yaml`'s `milestone_rollover` job calls `milestone-rollover.yaml` as a reusable workflow, which declares `permissions: issues: write`. Once a caller workflow declares its own explicit `permissions:` block, every scope it doesn't list is implicitly `none` for anything it calls — and a reusable workflow can never be granted more than its caller has. `release-automation.yaml` only declared `contents: write` and `actions: write`, so `issues` was implicitly `none`, and GitHub refuses to even start the run rather than letting the called workflow silently run with less than it asked for.

This broke as soon as #3295 merged and `milestone_rollover` started being called for the first time — nobody had dispatched the workflow since that PR landed until this run.

## Change

Add `issues: write` to `release-automation.yaml`'s top-level `permissions:` block.

Checked `release-notes-generator.yaml` (the other reusable workflow `release-automation.yaml` calls) too — it only needs `contents: read` and `actions: write`, both already covered by the caller's existing `contents: write`/`actions: write`. No other gap.

## Testing

- YAML validated.
- `./gradlew spotlessCheck` passes.
- Can't unit-test workflow-level permission propagation locally; the real test is a `workflow_dispatch` run once merged.

## Related

- https://github.com/hiero-ledger/hiero-block-node/actions/runs/31132153997
- Introduced by #3295 (milestone rollover integration)