### PR TITLE
fix: artifact downloads fail and retention is too high in create_release run

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -283,6 +283,7 @@ jobs:
           name: block-node-protobuf-${{ env.RELEASE_TAG }}
           path: ./protobuf-sources/block-node-protobuf-*.tgz
           if-no-files-found: error
+          retention-days: 7
 
       - name: Generate Block-Stream-Tools Artifact
         run: |
@@ -296,6 +297,7 @@ jobs:
           name: block-stream-tools-${{ env.RELEASE_TAG }}
           path: ./tools-and-tests/tools/build/libs/block-stream-tools-${{ env.VERSION }}.jar
           if-no-files-found: error
+          retention-days: 7
 
   generate_notes:
     name: Generate Release Notes
@@ -340,6 +342,7 @@ jobs:
         continue-on-error: true
         run: |
           gh run download "${{ github.run_id }}" \
+            --repo "${{ github.repository }}" \
             --name "release-notes-${RELEASE_TAG}" \
             --dir .
         env:
@@ -353,6 +356,7 @@ jobs:
         continue-on-error: true
         run: |
           gh run download "${{ github.run_id }}" \
+            --repo "${{ github.repository }}" \
             --name "block-node-protobuf-${RELEASE_TAG}" \
             --dir ./protobuf-dl
         env:
@@ -363,6 +367,7 @@ jobs:
         continue-on-error: true
         run: |
           gh run download "${{ github.run_id }}" \
+            --repo "${{ github.repository }}" \
             --name "block-stream-tools-${RELEASE_TAG}" \
             --dir ./tools-dl
         env:

--- a/.github/workflows/release-notes-generator.yaml
+++ b/.github/workflows/release-notes-generator.yaml
@@ -149,4 +149,4 @@ jobs:
           name: release-notes-${{ env.LATEST_TAG }}
           path: release_notes.md
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 7


### PR DESCRIPTION
## Summary

Fixes two issues found during the first real end-to-end dispatch of `release-automation.yaml` (run [31227201088](https://github.com/hiero-ledger/hiero-block-node/actions/runs/31227201088), v0.40.0-rc1).

### Issue 1 — `create_release` downloads always fail (critical)

The `create_release` job has no `actions/checkout` step. Without a git repo in the working directory, the `gh` CLI cannot infer which repo to operate against and fails immediately:

```
fatal: not a git repository (or any parent up to mount point /home)
```

All three `gh run download` calls were affected. Because every download step has `continue-on-error: true`, the failures were masked as green — the draft release was created with **zero assets and empty release notes silently on every run**.

**Fix:** add `--repo ${{ github.repository }}` to all three `gh run download` calls. No checkout step needed.

### Issue 2 — artifact retention inconsistency (cosmetic)

All three release artifacts expire after 7 days due to an org-level cap regardless of what the YAML requests. The `release-notes` upload requested 30 days; the `protobuf` and `block-stream-tools` uploads had no setting (defaulting to 90 days). All three are now explicitly set to `retention-days: 7` to match observed reality and avoid silently ballooning if the org cap is ever relaxed.

## Files changed

- `.github/workflows/release-automation.yaml` — `--repo` flag on all three downloads; `retention-days: 7` on protobuf and block-stream-tools uploads
- `.github/workflows/release-notes-generator.yaml` — `retention-days: 30 → 7` on release-notes upload

Closes #3402