### PR TITLE
fix: BlockNodeClient Connection Cache should be private

### DIFF
--- a/block-node/base/src/main/java/org/hiero/block/node/base/client/BlockNodeClient.java
+++ b/block-node/base/src/main/java/org/hiero/block/node/base/client/BlockNodeClient.java
@@ -186,6 +186,14 @@ public class BlockNodeClient implements AutoCloseable {
                 .protocolConfigs(List.of(buildHttp2Config(tuning), buildGrpcConfig(pollWaitMs, tuning)))
                 .connectTimeout(Duration.ofMillis(connectTimeoutMs))
                 .keepAlive(true)
+                // Helidon shares one JVM-wide HTTP/2 connection cache across all WebClient instances by
+                // default (shareConnectionCache=true). That defeats getNodeClient()'s evict-and-recreate
+                // logic: a "fresh" BlockNodeClient still points at the same shared cache, so if it holds a
+                // dead connection handler for this peer (e.g. the peer's server restarted), the new client
+                // reuses that stale entry instead of dialing a new connection — surfacing as a persistent
+                // SocketException: Socket closed on every retry. A private, non-shared cache per client
+                // ensures eviction actually forces a fresh connection.
+                .shareConnectionCache(false)
                 .build();
     }
 

--- a/block-node/base/src/test/java/org/hiero/block/node/base/client/BlockNodeClientTest.java
+++ b/block-node/base/src/test/java/org/hiero/block/node/base/client/BlockNodeClientTest.java
@@ -2,6 +2,7 @@
 package org.hiero.block.node.base.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 import java.io.IOException;
@@ -73,6 +74,21 @@ public class BlockNodeClientTest {
             .pingTimeout(11)
             .readTimeout(0)
             .build();
+
+    @Test
+    @DisplayName("WebClients do not share Helidon's JVM-wide HTTP/2 connection cache")
+    void connectionCacheIsNotShared() throws IOException {
+        // Helidon's HttpClientConfigBlueprint defaults shareConnectionCache to true, which would let a
+        // freshly-constructed client (e.g. after getNodeClient() evicts an unreachable peer) reuse a
+        // stale connection handler for the same host:port from the JVM-wide Http2ConnectionCache.SHARED
+        // singleton instead of dialing a new connection — surfacing as a persistent
+        // "SocketException: Socket closed" after the peer restarts. Each client must use its own
+        // private cache so eviction actually forces a fresh connection.
+        try (BlockNodeClient client = clientFor(40840, 0, 0)) {
+            assertFalse(client.webClient.prototype().shareConnectionCache());
+            assertFalse(client.statusWebClient.prototype().shareConnectionCache());
+        }
+    }
 
     @Test
     @DisplayName("Test null GrpcWebClientTuning")


### PR DESCRIPTION
- added .shareConnectionCache(false) to the webclient builder so that a private, non-shared cache per client ensures eviction actually forces a fresh connection.

____________________________________________________________________

## Reviewer Notes

## Related Issue(s)
 Use keywords `Fix, Fixes, Fixed, Close, Closes, Closed, Resolve, Resolves, Resolved`
to connect an issue to be closed by this pull request.
