### PR TITLE
docs: Dynamic File Recent Retention Policy

### DIFF
--- a/docs/block-node/metrics.md
+++ b/docs/block-node/metrics.md
@@ -191,6 +191,17 @@ Activity and utilization of the historic on‑disk tier.
 
 ---
 
+### Host / Volume (external)
+
+**Source:** host or platform-level exporter, not emitted by the Block Node process.
+Free disk space for the `live` and `historic` volumes is not tracked by any BN metric, since
+retention on each is governed by a block-count cap rather than a disk-size cap (see the
+[Disk space alerting](./operations/production-guide/steady-state-operations.md#disk-space-alerting-operator)
+operator guide). Track it via a host-level exporter, for example `node_filesystem_avail_bytes`
+from node-exporter, or your platform's equivalent volume-usage metric for each mount.
+
+---
+
 ### cloud-storage-archive
 
 **Plugin:** `cloud-storage-archive`
@@ -289,6 +300,13 @@ As the product matures through beta and rc phases, high severity alerts will be 
 | Severity |       Metric       |      Alert Condition      |
 |----------|--------------------|---------------------------|
 | M        | `app_state_status` | If not equal to `RUNNING` |
+
+**Disk Space**: Host-level alert for the `live` and `historic` volumes, since retention on each
+is a block-count cap, not a disk-size cap (see [Host / Volume](#host--volume-external))
+
+| Severity |            Metric             |                         Alert Condition                         |
+|----------|-------------------------------|-----------------------------------------------------------------|
+| M        | `node_filesystem_avail_bytes` | If free space on the `live` or `historic` mount drops below 15% |
 
 **Publisher**: Alerts related to publisher connections and performance
 

--- a/docs/block-node/operations/production-guide/steady-state-operations.md
+++ b/docs/block-node/operations/production-guide/steady-state-operations.md
@@ -132,6 +132,22 @@ on-call contact provided at handoff.
 
 ---
 
+## Disk space alerting **[OPERATOR]**
+
+The `live` volume's retention policy is a fixed block-count cap
+(`files.recent.blockRetentionThreshold`), not a disk-size cap. If block sizes grow or the configured
+count is set too high for the provisioned volume, disk usage can reach 100% before the
+block-count cap is ever hit.
+
+There is no in-app metric for free disk space; it is host/volume-level, not something the
+Block Node process reports. Monitor it independently (e.g. `node_filesystem_avail_bytes`
+from node-exporter, or your platform's volume-usage metric for the `live` mount) and alert
+operators before the volume fills, for example when free space drops below 15%. Filling
+the `live` volume causes block writes to fail, which stalls ingestion until space is freed
+or the volume is expanded.
+
+---
+
 ## Related documentation
 
 - [Resetting and Upgrading the Block Node](../resetting-and-upgrading-the-block-node.md)

--- a/docs/block-node/operations/production-guide/steady-state-operations.md
+++ b/docs/block-node/operations/production-guide/steady-state-operations.md
@@ -134,17 +134,21 @@ on-call contact provided at handoff.
 
 ## Disk space alerting **[OPERATOR]**
 
-The `live` volume's retention policy is a fixed block-count cap
-(`files.recent.blockRetentionThreshold`), not a disk-size cap. If block sizes grow or the configured
+Both the `live` and `historic` volumes' retention policies are fixed block-count caps
+(`files.recent.blockRetentionThreshold` and `files.historic.blockRetentionThreshold` respectively),
+not disk-size caps. `historic` retention defaults to `0` (disabled - blocks are kept forever), so
+its volume grows unbounded unless a threshold is configured. If block sizes grow or a configured
 count is set too high for the provisioned volume, disk usage can reach 100% before the
 block-count cap is ever hit.
 
 There is no in-app metric for free disk space; it is host/volume-level, not something the
 Block Node process reports. Monitor it independently (e.g. `node_filesystem_avail_bytes`
-from node-exporter, or your platform's volume-usage metric for the `live` mount) and alert
-operators before the volume fills, for example when free space drops below 15%. Filling
-the `live` volume causes block writes to fail, which stalls ingestion until space is freed
-or the volume is expanded.
+from node-exporter, or your platform's volume-usage metric for each mount) and alert
+operators before a volume fills, for example when free space drops below 15%. Filling the
+`live` volume causes block writes to fail, which stalls ingestion until space is freed or
+the volume is expanded; filling the `historic` volume causes historic archival writes to
+fail similarly. See [Host / Volume](../../metrics.md#host--volume-external) and the
+disk-space alert recommendation in the [Metrics Reference](../../metrics.md#alerting-recommendations).
 
 ---
 


### PR DESCRIPTION
## Reviewer Notes

### Steady-state operations guide documents the disk-space gap left by count-based retention

`files.recent.blockRetentionThreshold` caps the `live` volume by block count, not by disk size, so a spike in block size or a threshold set too high for the provisioned volume can fill the disk before the count cap ever triggers. 

Since free disk space is not a metric that the Block Node report itself, the doc tells operators to alert on it externally, suggesting an alert threshold of 15% free space, and explains the failure mode so operators know why the alert matters.

## Related Issue(s)
  
Relates to #3236