### PR TITLE
fix: backport #3404 — artifact downloads fail in create_release (release/0.40)

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -283,6 +283,7 @@ jobs:
           name: block-node-protobuf-${{ env.RELEASE_TAG }}
           path: ./protobuf-sources/block-node-protobuf-*.tgz
           if-no-files-found: error
+          retention-days: 7
 
       - name: Generate Block-Stream-Tools Artifact
         run: |
@@ -296,6 +297,7 @@ jobs:
           name: block-stream-tools-${{ env.RELEASE_TAG }}
           path: ./tools-and-tests/tools/build/libs/block-stream-tools-${{ env.VERSION }}.jar
           if-no-files-found: error
+          retention-days: 7
 
   generate_notes:
     name: Generate Release Notes
@@ -340,6 +342,7 @@ jobs:
         continue-on-error: true
         run: |
           gh run download "${{ github.run_id }}" \
+            --repo "${{ github.repository }}" \
             --name "release-notes-${RELEASE_TAG}" \
             --dir .
         env:
@@ -353,6 +356,7 @@ jobs:
         continue-on-error: true
         run: |
           gh run download "${{ github.run_id }}" \
+            --repo "${{ github.repository }}" \
             --name "block-node-protobuf-${RELEASE_TAG}" \
             --dir ./protobuf-dl
         env:
@@ -363,6 +367,7 @@ jobs:
         continue-on-error: true
         run: |
           gh run download "${{ github.run_id }}" \
+            --repo "${{ github.repository }}" \
             --name "block-stream-tools-${RELEASE_TAG}" \
             --dir ./tools-dl
         env:

--- a/.github/workflows/release-notes-generator.yaml
+++ b/.github/workflows/release-notes-generator.yaml
@@ -149,4 +149,4 @@ jobs:
           name: release-notes-${{ env.LATEST_TAG }}
           path: release_notes.md
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 7


### PR DESCRIPTION
## Summary

Backport of #3404 to `release/0.40`.

The `create_release` job in `release-automation.yaml` has no `actions/checkout` step. Without a git working tree, the `gh` CLI cannot infer the repository from `git remote get-url origin` and fails immediately:

```
fatal: not a git repository (or any parent up to mount point /home)
```

All three `gh run download` calls were affected. Because each step had `continue-on-error: true`, the failures were silently swallowed — every past rc dispatch created a draft release with zero assets and empty release notes.

**Fixes:**
- `release-automation.yaml` — add `--repo ${{ github.repository }}` to all three `gh run download` calls; add `retention-days: 7` to the two artifact uploads that were missing it
- `release-notes-generator.yaml` — align `retention-days: 30 → 7` (org cap is 7 days regardless)

## Test plan

- [ ] Dispatch `release-automation.yaml` with `release_type: rc` targeting `release/0.40` — confirm `create_release` job completes and the draft release on GitHub contains all three assets (release notes, protobuf archive, block-stream-tools archive)

Backports: #3404
Fixes: #3402