### PR TITLE
fix(release): consolidate release-action calls to prevent duplicate releases and body erasure

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -377,32 +377,22 @@ jobs:
         uses: step-security/release-action@a0d8e0f90f554c15366ca2c9046bf4090d24adbe # v1.21.0
         with:
           allowUpdates: true
+          # Attach all artifacts in a single call to prevent two races:
+          # 1. Multiple calls with allowUpdates:true can create duplicate releases
+          #    when GitHub's API hasn't yet propagated the first create by the
+          #    time a second call performs its lookup-by-tag.
+          # 2. Each subsequent call with omitBodyDuringUpdate:false (the default)
+          #    overwrites the release body with an empty string, erasing the notes.
+          # artifactErrorsFailBuild:false preserves the old per-step behaviour of
+          # skipping gracefully when a preceding download step failed.
+          artifactErrorsFailBuild: false
+          artifacts: "./protobuf-dl/block-node-protobuf-*.tgz,./tools-dl/block-stream-tools-*.jar"
           bodyFile: "${{ env.RELEASE_NOTES_FILENAME }}.md"
           commit: ${{ env.RELEASE_BRANCH }}
           draft: true
           generateReleaseNotes: false
           name: ${{ env.RELEASE_TAG }}
           prerelease: ${{ needs.release.outputs.is_prerelease == 'true' }}
-          tag: ${{ env.RELEASE_TAG }}
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
-
-      - name: Attach Protobuf Artifact to Release
-        if: ${{ steps.download_protobuf.outcome == 'success' }}
-        uses: step-security/release-action@a0d8e0f90f554c15366ca2c9046bf4090d24adbe # v1.21.0
-        with:
-          allowUpdates: true
-          artifacts: ./protobuf-dl/block-node-protobuf-*.tgz
-          draft: true
-          tag: ${{ env.RELEASE_TAG }}
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
-
-      - name: Attach Block-Stream-Tools Artifact to Release
-        if: ${{ steps.download_tools.outcome == 'success' }}
-        uses: step-security/release-action@a0d8e0f90f554c15366ca2c9046bf4090d24adbe # v1.21.0
-        with:
-          allowUpdates: true
-          artifacts: ./tools-dl/block-stream-tools-*.jar
-          draft: true
           tag: ${{ env.RELEASE_TAG }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 


### PR DESCRIPTION
## Summary

Two bugs were observed in the `create_release` job during the v0.40.0 GA release ([run 31539787980](https://github.com/hiero-ledger/hiero-block-node/actions/runs/31539787980/job/93943395420)):

- **Release notes not in release body** — subsequent `release-action` calls with `omitBodyDuringUpdate: false` (the default) overwrote the body with an empty string, erasing whatever the first call set.
- **Duplicate draft releases** — the second `release-action` call fired ~1.6 s after the first. The GitHub API had not yet propagated the newly-created release, so the tag lookup returned nothing and the action created a second release instead of updating the first. This left two `v0.40.0` draft releases (IDs 368882063 and 368882073) with split assets.

## Change

Collapse the three separate `release-action` calls into a single call that creates the release, sets its body, and uploads all artifacts atomically using the comma-separated `artifacts` field:

```yaml
- name: Create Github Release
  uses: step-security/release-action@...
  with:
    allowUpdates: true
    artifactErrorsFailBuild: false      # graceful skip when a download failed
    artifacts: "./protobuf-dl/block-node-protobuf-*.tgz,./tools-dl/block-stream-tools-*.jar"
    bodyFile: "${{ env.RELEASE_NOTES_FILENAME }}.md"
    ...
```

`artifactErrorsFailBuild: false` replicates the old `if: steps.download_*.outcome == 'success'` conditional — if a preceding download step failed the glob matches nothing and the release is still created without that artifact.

Fixes #3416