### PR TITLE
fix: fix flakey output redirection in tools tests

### DIFF
--- a/tools-and-tests/tools/src/test/resources/junit-platform.properties
+++ b/tools-and-tests/tools/src/test/resources/junit-platform.properties
@@ -1,6 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-junit.jupiter.execution.parallel.enabled=true
-junit.jupiter.execution.parallel.mode.default=concurrent
-junit.jupiter.execution.parallel.mode.classes.default=concurrent
-junit.jupiter.execution.parallel.config.strategy=dynamic
-junit.jupiter.execution.parallel.config.dynamic.factor=1
+#
+# Intra-JVM (within-fork) parallel test execution is intentionally DISABLED for this module.
+#
+# picocli's CommandLine.execute() re-reads the global System.out/System.err when it runs a
+# command. Several command tests here capture output by temporarily swapping
+# System.out/System.err (NetworkCapacityTest, ValidateBlocksCommandTest,
+# ToWrappedBlocksCommandTest, AmendmentProviderTest, SidecarIntegrityValidationTest). When
+# those ran concurrently with another command test in the same JVM fork, the swap raced with
+# the other test's execute(): its usage/output went to the wrong stream, leaving the captured
+# buffer empty and making assertions such as BlocksCommandTest.noSubcommand_printsUsageHelp
+# ("Should contain command name") fail intermittently.
+#
+# Running tests serially within each fork removes that race. Cross-fork parallelism is still
+# provided by `maxParallelForks` in build.gradle.kts -- each fork is a separate JVM with its
+# own System.out/System.err -- so overall test throughput is preserved.
+junit.jupiter.execution.parallel.enabled=false


### PR DESCRIPTION
## Reviewer Notes
* Fixed with the simplest possible option by removing parallelism
   * The command execution is not thread safe if another thread replaces `System.out` or
     `System.err` at the wrong time.
   * The "proper" fix (replace most use of system out/err with `@Spec` and
     `spec.commandLine().`getOut()/getErr() impacts a lot of other code and
      affects several hundred lines.
   * Chose the smallest/safest approach, and documented the larger approach for
     future consideration.

## Related Issue(s)
 Fixes #3248
