### PR TITLE
fix: BackFillPlugin - Backdown the live tail high water mark when a block fails

### DIFF
--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPlugin.java
@@ -97,7 +97,10 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
 
     // State touched by multiple threads
     private final AtomicLong pendingBackfillBlocks = new AtomicLong(0);
-    // Deduplication: highest block scheduled for live-tail (prevents overlapping submissions)
+    // Deduplication: highest block scheduled for live-tail (prevents overlapping submissions between the
+    // periodic scan and on-demand notifications). Advanced on submission, and only ever pulled back down -
+    // never treated as a promise that the range actually landed. See handlePersisted() for why: a submitted
+    // range whose persistence later fails en masse must remain eligible for the periodic scan to rediscover.
     private final AtomicLong liveTailHighWaterMark = new AtomicLong(-1);
 
     // Cached stored+available snapshot delivered by the last onContextUpdate() call. The Application
@@ -547,12 +550,17 @@ public class BackfillPlugin implements BlockNodePlugin, BlockNotificationHandler
                             "Backfill persistence failed for block=[{0}], re-queuing for on-demand backfill";
                     LOGGER.log(INFO, backfillPersistFailedMsg, blockNumber);
                 } else {
-                    // The live-tail scheduler is unavailable (plugin not yet started) or its queue is full.
-                    // This block will now be picked up during the next periodic autonomous scan of
-                    // detectAndScheduleGaps, which will see the block missing from stored ranges on its next tick
-                    // and re-detect/resubmit it as a gap
+                    // The live-tail scheduler is unavailable (plugin not yet started) or its queue is full -
+                    // most likely because a mass failure (e.g. MISSING_VERIFICATION_DATA while the node is
+                    // still loading TSS data) is overwhelming it with individual retries. The high-water mark
+                    // was already advanced past this block when its gap was first submitted, so without
+                    // action here it would look permanently "handled" even though it never landed. Pull the
+                    // mark back down so the next periodic detectAndScheduleGaps scan sees this block (and
+                    // anything after it) as still missing and re-submits the range as a whole.
+                    liveTailHighWaterMark.updateAndGet(current -> Math.min(current, blockNumber - 1));
                     final String requeueFailedMsg =
-                            "Unable to requeue block=[{0}] for on-demand backfill (scheduler unavailable or queue full)";
+                            "Unable to requeue block=[{0}] for on-demand backfill (scheduler unavailable or queue full), "
+                                    + "reset live-tail high-water mark for re-detection";
                     LOGGER.log(INFO, requeueFailedMsg, blockNumber);
                 }
             }

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 import org.hiero.block.internal.BlockNodeSource;
 import org.hiero.block.internal.BlockNodeSourceConfig;
 import org.hiero.block.node.app.fixtures.blocks.BlockUtils;
@@ -1685,6 +1686,75 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
                 0,
                 getMetricValue(BackfillPlugin.METRIC_BACKFILL_FETCH_ERRORS),
                 "Should not record fetch errors when skipping the peer's known gap");
+    }
+
+    @Test
+    @DisplayName("Mass live-tail persistence failure does not permanently block re-detection")
+    void testMassLiveTailPersistenceFailureIsReDetectedAfterQueueOverflow() {
+        // Peer serves a range that lands entirely as LIVE_TAIL on an empty store (no historical boundary yet).
+        final int blockCount = 15;
+        final TestBlockNodeServer server = new TestBlockNodeServer(0, getHistoricalBlockFacility(0, blockCount - 1));
+        testBlockNodeServers.add(server);
+        BlockNodeSource backfillSource = BlockNodeSource.newBuilder()
+                .nodes(BlockNodeSourceConfig.newBuilder()
+                        .address("localhost")
+                        .port(server.port())
+                        .priority(1)
+                        .build())
+                .build();
+        final String backfillSourcePath = testTempDir + "/backfill-source-mass-failure.json";
+        createTestBlockNodeSourcesFile(backfillSource, backfillSourcePath);
+
+        // Fast scan so several cycles happen quickly.
+        Map<String, String> configOverride = BackfillConfigBuilder.NewBuilder()
+                .backfillSourcePath(backfillSourcePath)
+                .greedy(true)
+                .fetchBatchSize(100)
+                .initialDelay(50)
+                .scanInterval(300)
+                .build();
+        // Live-tail queue capacity well below blockCount, so the per-block retries handlePersisted()
+        // issues below overflow it for most of them - mirroring a real mass MISSING_VERIFICATION_DATA burst.
+        configOverride.put("backfill.liveTailQueueCapacity", "2");
+
+        // Empty store: the whole peer range is classified LIVE_TAIL.
+        start(new BackfillPlugin(), new SimpleInMemoryHistoricalBlockFacility(), configOverride);
+
+        // Wait for the first autonomous scan to detect and submit the initial gap.
+        assertTrue(
+                waitUntil(10_000, () -> getMetricValue(BackfillPlugin.METRIC_BACKFILL_GAPS_SUBMITTED) >= 1),
+                "First scan should submit the initial live-tail gap");
+        final long submissionsBeforeFailure = getMetricValue(BackfillPlugin.METRIC_BACKFILL_GAPS_SUBMITTED);
+
+        // Simulate every block in the gap failing verification/persistence en masse. handlePersisted()
+        // retries each one directly against the tiny live-tail queue, so most of these are dropped
+        // (queue full) rather than actually requeued - none of these blocks ever land in the store.
+        for (long blockNumber = 0; blockNumber < blockCount; blockNumber++) {
+            blockMessaging.sendBlockPersisted(new PersistedNotification(blockNumber, false, 10, BlockSource.BACKFILL));
+        }
+        assertEquals(
+                blockCount,
+                getMetricValue(BackfillPlugin.METRIC_BACKFILL_PERSISTENCE_FAILURES),
+                "All injected failures should be recorded");
+
+        // The range is still genuinely missing from the store, so a later scan must re-detect and
+        // resubmit it rather than treating it as already handled because of a stale high-water mark.
+        assertTrue(
+                waitUntil(
+                        10_000,
+                        () -> getMetricValue(BackfillPlugin.METRIC_BACKFILL_GAPS_SUBMITTED) > submissionsBeforeFailure),
+                "A subsequent scan should resubmit the still-missing live-tail range after the mass failure");
+    }
+
+    private boolean waitUntil(long timeoutMillis, BooleanSupplier condition) {
+        final long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+        while (System.nanoTime() < deadlineNanos) {
+            if (condition.getAsBoolean()) {
+                return true;
+            }
+            parkNanos(50_000_000L);
+        }
+        return condition.getAsBoolean();
     }
 
     private void createTestBlockNodeSourcesFile(BlockNodeSource backfillSource, String configPath) {

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -21,7 +22,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BooleanSupplier;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.hiero.block.internal.BlockNodeSource;
 import org.hiero.block.internal.BlockNodeSourceConfig;
 import org.hiero.block.node.app.fixtures.blocks.BlockUtils;
@@ -1690,7 +1691,7 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
 
     @Test
     @DisplayName("Mass live-tail persistence failure does not permanently block re-detection")
-    void testMassLiveTailPersistenceFailureIsReDetectedAfterQueueOverflow() {
+    void testMassLiveTailPersistenceFailureIsReDetectedAfterQueueOverflow() throws InterruptedException {
         // Peer serves a range that lands entirely as LIVE_TAIL on an empty store (no historical boundary yet).
         final int blockCount = 15;
         final TestBlockNodeServer server = new TestBlockNodeServer(0, getHistoricalBlockFacility(0, blockCount - 1));
@@ -1717,14 +1718,34 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         // issues below overflow it for most of them - mirroring a real mass MISSING_VERIFICATION_DATA burst.
         configOverride.put("backfill.liveTailQueueCapacity", "2");
 
+        // Counts how many times each block has been fetched from the peer. The first fetch of any block
+        // signals the initial gap was submitted; a second fetch of the same block can only happen if a
+        // later scan re-detected and resubmitted it - the exact behavior under test.
+        final Map<Long, AtomicInteger> fetchCountsByBlock = new ConcurrentHashMap<>();
+        final CountDownLatch firstFetchLatch = new CountDownLatch(1);
+        final CountDownLatch resubmitFetchLatch = new CountDownLatch(1);
+        blockMessaging.registerBlockNotificationHandler(
+                new BlockNotificationHandler() {
+                    @Override
+                    public void handleBackfilled(BackfilledBlockNotification notification) {
+                        int fetchCount = fetchCountsByBlock
+                                .computeIfAbsent(notification.blockNumber(), b -> new AtomicInteger())
+                                .incrementAndGet();
+                        if (fetchCount == 1) {
+                            firstFetchLatch.countDown();
+                        } else if (fetchCount == 2) {
+                            resubmitFetchLatch.countDown();
+                        }
+                    }
+                },
+                false,
+                "test-mass-failure-fetch-handler");
+
         // Empty store: the whole peer range is classified LIVE_TAIL.
         start(new BackfillPlugin(), new SimpleInMemoryHistoricalBlockFacility(), configOverride);
 
-        // Wait for the first autonomous scan to detect and submit the initial gap.
-        assertTrue(
-                waitUntil(10_000, () -> getMetricValue(BackfillPlugin.METRIC_BACKFILL_GAPS_SUBMITTED) >= 1),
-                "First scan should submit the initial live-tail gap");
-        final long submissionsBeforeFailure = getMetricValue(BackfillPlugin.METRIC_BACKFILL_GAPS_SUBMITTED);
+        // Wait for the first autonomous scan to detect, submit, and start fetching the initial gap.
+        assertTrue(firstFetchLatch.await(10, TimeUnit.SECONDS), "First scan should submit the initial live-tail gap");
 
         // Simulate every block in the gap failing verification/persistence en masse. handlePersisted()
         // retries each one directly against the tiny live-tail queue, so most of these are dropped
@@ -1738,23 +1759,11 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
                 "All injected failures should be recorded");
 
         // The range is still genuinely missing from the store, so a later scan must re-detect and
-        // resubmit it rather than treating it as already handled because of a stale high-water mark.
+        // resubmit it (triggering a second fetch of at least one block) rather than treating it as
+        // already handled because of a stale high-water mark.
         assertTrue(
-                waitUntil(
-                        10_000,
-                        () -> getMetricValue(BackfillPlugin.METRIC_BACKFILL_GAPS_SUBMITTED) > submissionsBeforeFailure),
-                "A subsequent scan should resubmit the still-missing live-tail range after the mass failure");
-    }
-
-    private boolean waitUntil(long timeoutMillis, BooleanSupplier condition) {
-        final long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
-        while (System.nanoTime() < deadlineNanos) {
-            if (condition.getAsBoolean()) {
-                return true;
-            }
-            parkNanos(50_000_000L);
-        }
-        return condition.getAsBoolean();
+                resubmitFetchLatch.await(10, TimeUnit.SECONDS),
+                "A subsequent scan should re-fetch the still-missing live-tail range after the mass failure");
     }
 
     private void createTestBlockNodeSourcesFile(BlockNodeSource backfillSource, String configPath) {


### PR DESCRIPTION
## Reviewer Notes
If handlePersisted() can't get a failed block's individual retry into the queue, it now pulls liveTailHighWaterMark back down to blockNumber - 1 allowing the next detectAndScheduleGaps() scan see the block — and anything after it — as still missing, re-submitting the range as a whole.


## Related Issue(s)
Closes #3419