### PR TITLE
fix: raise idleConnectionTimeout to 2h to prevent subscriber stream drops

### DIFF
--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ServerConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/ServerConfig.java
@@ -22,8 +22,9 @@ import org.hiero.block.node.base.Loggable;
  * @param maxTcpConnections the maximum number of TCP connections
  * @param idleConnectionPeriodMinutes how often (minutes) the idle-connection reaper runs
  * @param idleConnectionTimeoutMinutes how long (minutes) a connection may sit idle before it is
- *     closed; kept short so idle sockets are reclaimed well before they accumulate to
- *     {@code maxTcpConnections} and the server starts refusing new connections
+ *     closed; set to 120 (2 h) by default so that long-lived gRPC server-streaming connections
+ *     (e.g. {@code subscribeBlockStream}) are not torn down by the Helidon idle-connection reaper
+ *     while they are still actively receiving outbound DATA frames
  * @param tcpNoDelay whether to use TCP no delay
  * @param backlogSize the maximum length of the queue of incoming connections on the server socket.
  * @param writeQueueLength the number of buffers queued for write operations
@@ -38,7 +39,7 @@ public record ServerConfig(
         @Loggable @ConfigProperty(defaultValue = "500") int shutdownDelayMillis,
         @Loggable @ConfigProperty(defaultValue = "1000") int maxTcpConnections,
         @Loggable @ConfigProperty(defaultValue = "5") @Min(1) @Max(60) int idleConnectionPeriodMinutes,
-        @Loggable @ConfigProperty(defaultValue = "30") @Min(1) @Max(1_440) int idleConnectionTimeoutMinutes,
+        @Loggable @ConfigProperty(defaultValue = "120") @Min(1) @Max(1_440) int idleConnectionTimeoutMinutes,
         @Loggable @ConfigProperty(defaultValue = "true") boolean tcpNoDelay,
         @Loggable @ConfigProperty(defaultValue = "8_192") int backlogSize,
         @Loggable @ConfigProperty(defaultValue = "8_192") int writeQueueLength) {}


### PR DESCRIPTION
## Summary

Fixes mirror node subscription streams closing every ~35 minutes with
`UNAVAILABLE: Network closed for unknown reason`.

**Root cause:** Helidon's idle-connection reaper closes connections that have
received no inbound HTTP/2 requests for `idleConnectionTimeoutMinutes` (default
30 min). `subscribeBlockStream` is a server-streaming RPC — after the initial
subscribe, only outbound DATA frames flow. Helidon sees no inbound HEADERS and
classifies the connection as idle, tearing it down at the next reaper tick
(explaining the ~35 min, not exactly 30 min, observed interval).

**Fix:** Raise the default from 30 to 120 minutes (2 h). Active streaming
connections are protected; genuinely idle connections (no frames for 2 h) are
still reclaimed by the 5-minute reaper.

**Why not a PING-based keep-alive?** Helidon 4.5.0 does not reset its idle
timer on PING frames — only inbound HEADERS frames update `lastRequestTimestamp`.
A server-side fix requires an upstream Helidon change. Client subscribers should
also configure gRPC channel keep-alive (`keepAliveWithoutCalls(true)`) to
protect against intermediate infrastructure (load balancers, firewalls) enforcing
their own idle limits.

## Files changed

| File | Change |
|---|---|
| `block-node/app-config/.../ServerConfig.java` | `idleConnectionTimeoutMinutes` default: `"30"` → `"120"` + updated Javadoc |

closes #3221