### PR TITLE
feat(tools): add block-access-port and fix ResourceExhausted in bn-endpoint-checker.sh

### DIFF
--- a/tools-and-tests/scripts/node-operations/bn-endpoint-checker.sh
+++ b/tools-and-tests/scripts/node-operations/bn-endpoint-checker.sh
@@ -52,6 +52,14 @@
 #                           Requires the proto package to contain the
 #                           block_access_service.proto file (same archive as the
 #                           node_service.proto already required).
+#       --block-access-port PORT
+#                           Port to use for BlockAccessService/getBlock calls
+#                           when --latest-block-proof is enabled. Defaults to
+#                           the same port as the positional endpoint argument.
+#                           Set this to the blockAccess port (e.g. 40981) when
+#                           the node exposes separate ports per service — the
+#                           production default has serverStatus on 40982 and
+#                           getBlock on 40981.
 #   -h, --help              Print this help text and exit.
 #
 # ENVIRONMENT
@@ -80,6 +88,12 @@
 #   bn-endpoint-checker.sh --version 0.32.0 --latest-block-proof \
 #     node1.mainnet.blocknode.hashgraph-devops.com:40840 \
 #     node2.mainnet.blocknode.hashgraph-devops.com:40840
+#
+#   # Multi-port production deployment: status on 40982, block-access on 40981
+#   bn-endpoint-checker.sh --version 0.40.0 --latest-block-proof \
+#     --block-access-port 40981 \
+#     lfh01.mainnet.blocknode.hashgraph-devops.com:40982 \
+#     lfh02.mainnet.blocknode.hashgraph-devops.com:40982
 #
 # REQUIREMENTS
 #   grpcurl   Auto-installed if missing (you will be prompted for the
@@ -205,6 +219,7 @@ PROTO_DIR_ARG=""         # --proto-dir flag value (overrides PROTO_DIR env var).
 USE_TLS=false            # When true, grpcurl uses TLS; default is plaintext.
 DETAILED_STATUS=false    # When true, also call serverStatusDetail per endpoint.
 LATEST_BLOCK_PROOF=false # When true, fetch the latest block and report proof type.
+BLOCK_ACCESS_PORT=""     # When set, used as the port for BlockAccessService/getBlock.
 ENDPOINTS=()             # Positional <host:port> arguments collected here.
 
 while [[ $# -gt 0 ]]; do
@@ -221,6 +236,9 @@ while [[ $# -gt 0 ]]; do
       DETAILED_STATUS=true; shift ;;
     --latest-block-proof)
       LATEST_BLOCK_PROOF=true; shift ;;
+    --block-access-port)
+      [[ -n "${2:-}" ]] || { log_err "--block-access-port requires a value"; usage 2; }
+      BLOCK_ACCESS_PORT="$2"; shift 2 ;;
     -h|--help)
       usage 0 ;;
     -*)
@@ -910,10 +928,18 @@ check_endpoint() {
   # Failure is non-fatal: a node may have serverStatus working before it has
   # stored any blocks (e.g. freshly started or syncing). The warning is still
   # printed so the operator knows the block fetch was attempted.
+  #
+  # When --block-access-port is set, getBlock is sent to a different port than
+  # serverStatus — production deployments split these onto separate ports.
+  local block_access_target="${endpoint}"
+  if [[ -n "$BLOCK_ACCESS_PORT" ]]; then
+    block_access_target="${host}:${BLOCK_ACCESS_PORT}"
+  fi
+
   if [[ "$LATEST_BLOCK_PROOF" == "true" ]]; then
     local proof_json proof_line
     t0="$(now_ms)"
-    if proof_json="$(grpc_call_block_proof "$endpoint" 2>&1)"; then
+    if proof_json="$(grpc_call_block_proof "$block_access_target" 2>&1)"; then
       elapsed="$(format_elapsed_ms "$(( $(now_ms) - t0 ))")"
       proof_line="$(print_block_proof "$proof_json")"
       log_success "  🔏 latest block proof  (${elapsed})"
@@ -955,17 +981,19 @@ main() {
   # Build human-readable labels for the run summary header.
   # Explicit if/else avoids the &&/|| ternary idiom, which is fragile: if the
   # true-branch command ever fails, the false-branch fires incorrectly.
-  local tls_label detail_label proof_label
+  local tls_label detail_label proof_label block_access_label
   if [[ "$USE_TLS"             == "true" ]]; then tls_label="TLS";     else tls_label="plaintext"; fi
   if [[ "$DETAILED_STATUS"     == "true" ]]; then detail_label="enabled"; else detail_label="disabled (pass --detailed-server-status to enable)"; fi
   if [[ "$LATEST_BLOCK_PROOF"  == "true" ]]; then proof_label="enabled"; else proof_label="disabled (pass --latest-block-proof to enable)"; fi
+  if [[ -n "$BLOCK_ACCESS_PORT" ]]; then block_access_label="$BLOCK_ACCESS_PORT"; else block_access_label="(same as endpoint)"; fi
 
   echo ""
   log_info "Checking ${#ENDPOINTS[@]} endpoint(s)"
-  log_info "  Proto dir       : ${RESOLVED_PROTO_DIR}"
-  log_info "  Transport       : ${tls_label}"
-  log_info "  Detailed status : ${detail_label}"
-  log_info "  Block proof     : ${proof_label}"
+  log_info "  Proto dir         : ${RESOLVED_PROTO_DIR}"
+  log_info "  Transport         : ${tls_label}"
+  log_info "  Detailed status   : ${detail_label}"
+  log_info "  Block proof       : ${proof_label}"
+  log_info "  Block access port : ${block_access_label}"
 
   # Iterate over every supplied endpoint. Failures are accumulated rather than
   # stopping immediately so the operator gets a complete picture of all nodes in

--- a/tools-and-tests/scripts/node-operations/bn-endpoint-checker.sh
+++ b/tools-and-tests/scripts/node-operations/bn-endpoint-checker.sh
@@ -60,6 +60,14 @@
 #                           the node exposes separate ports per service — the
 #                           production default has serverStatus on 40982 and
 #                           getBlock on 40981.
+#       --max-block-sz BYTES
+#                           Maximum gRPC response size (bytes) accepted from
+#                           BlockAccessService/getBlock. grpcurl's built-in
+#                           default is 4 MiB (4194304), which is too small for
+#                           production blocks that can exceed 16 MiB, causing a
+#                           ResourceExhausted error. Defaults to 67108864
+#                           (64 MiB). Increase further if blocks grow beyond
+#                           that threshold.
 #   -h, --help              Print this help text and exit.
 #
 # ENVIRONMENT
@@ -220,6 +228,7 @@ USE_TLS=false            # When true, grpcurl uses TLS; default is plaintext.
 DETAILED_STATUS=false    # When true, also call serverStatusDetail per endpoint.
 LATEST_BLOCK_PROOF=false # When true, fetch the latest block and report proof type.
 BLOCK_ACCESS_PORT=""     # When set, used as the port for BlockAccessService/getBlock.
+BLOCK_MAX_MSG_SZ=67108864 # Max gRPC response bytes for getBlock (default 64 MiB).
 ENDPOINTS=()             # Positional <host:port> arguments collected here.
 
 while [[ $# -gt 0 ]]; do
@@ -239,6 +248,9 @@ while [[ $# -gt 0 ]]; do
     --block-access-port)
       [[ -n "${2:-}" ]] || { log_err "--block-access-port requires a value"; usage 2; }
       BLOCK_ACCESS_PORT="$2"; shift 2 ;;
+    --max-block-sz)
+      [[ -n "${2:-}" ]] || { log_err "--max-block-sz requires a value"; usage 2; }
+      BLOCK_MAX_MSG_SZ="$2"; shift 2 ;;
     -h|--help)
       usage 0 ;;
     -*)
@@ -528,6 +540,7 @@ grpc_call_block_proof() {
   local -a flags=(
     -import-path "${RESOLVED_PROTO_DIR}"
     -proto        "${BLOCK_ACCESS_PROTO}"
+    -max-msg-sz   "${BLOCK_MAX_MSG_SZ}"
     -d            '{"retrieve_latest": true}'
   )
   [[ "$USE_TLS" == "false" ]] && flags=("-plaintext" "${flags[@]}")
@@ -994,6 +1007,7 @@ main() {
   log_info "  Detailed status   : ${detail_label}"
   log_info "  Block proof       : ${proof_label}"
   log_info "  Block access port : ${block_access_label}"
+  log_info "  Max block size    : ${BLOCK_MAX_MSG_SZ} bytes"
 
   # Iterate over every supplied endpoint. Failures are accumulated rather than
   # stopping immediately so the operator gets a complete picture of all nodes in


### PR DESCRIPTION
## Summary

Fixes two issues observed when running `bn-endpoint-checker.sh --latest-block-proof` against production multi-port block node deployments.

---

### Commit 1 — feat: `--block-access-port` for multi-port deployments (closes #3424)

**Problem:** Production deployments expose `BlockNodeService` (serverStatus / serverStatusDetail) and `BlockAccessService` (getBlock) on **separate ports** (`40982` and `40981` in `lfh-values.yaml`). The script previously sent all gRPC calls — including `getBlock` — to the single port in the positional `host:port` argument, routing getBlock to the wrong service.

**Fix:** Add `--block-access-port PORT`. When set, `grpc_call_block_proof` targets `host:<block-access-port>` while status calls continue using the positional endpoint port. Backward-compatible — when omitted, all calls use the same port as before.

```bash
# Before: only one port, getBlock goes to wrong service in multi-port setups
bn-endpoint-checker.sh --version 0.40.0 --latest-block-proof \
  node1.example.com:40982

# After: status on 40982, getBlock on 40981
bn-endpoint-checker.sh --version 0.40.0 --latest-block-proof \
  --block-access-port 40981 \
  node1.example.com:40982
```

---

### Commit 2 — fix: ResourceExhausted on large blocks (closes #3423)

**Problem:** `grpcurl` has a hard 4 MiB (4,194,304 byte) limit on incoming gRPC response messages. Production blocks can exceed 17 MiB, causing `--latest-block-proof` to fail:

```
🟠 latest block proof WARN (getBlock unavailable or no blocks stored)  (1.3 s)
   ERROR:
     Code: ResourceExhausted
     Message: grpc: received message larger than max (17478344 vs. 4194304)
```

**Fix:** Pass `-max-msg-sz 67108864` (64 MiB) to grpcurl in `grpc_call_block_proof`. Add `--max-block-sz BYTES` so operators can tune the ceiling if blocks grow larger.

---

## Test plan

- [ ] Run `--latest-block-proof --block-access-port 40981` against a multi-port deployment and confirm getBlock succeeds on port 40981
- [ ] Run without `--block-access-port` and confirm existing single-port behaviour is unchanged
- [ ] Run against a node serving large blocks (>4 MiB) and confirm no ResourceExhausted error
- [ ] Run `--help` and confirm both new flags appear in usage
- [ ] Confirm run summary prints `Block access port` and `Max block size` lines correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)