### PR TITLE
docs(production-guide): correct firewall table access description for public-facing ports

### DIFF
--- a/docs/block-node/operations/production-guide/prerequisites.md
+++ b/docs/block-node/operations/production-guide/prerequisites.md
@@ -74,14 +74,14 @@ The Block Node exposes per-service ports. Lock inbound access to the **publisher
 per-service ports are accessible to their respective clients. Deny all other inbound by
 default.
 
-| Port  |    Service    |                  Restrict to                   |
-|-------|---------------|------------------------------------------------|
-| 40984 | Publisher     | Consensus Node source IPs (Hashgraph-provided) |
-| 40980 | Subscriber    | Mirror Nodes and peer Block Nodes              |
-| 40981 | Block Access  | Authorized clients                             |
-| 40982 | Server Status | Monitoring and operators                       |
-| 40983 | Health        | Monitoring and operators                       |
-| 40840 | LoadBalancer  | External clients (MetalLB front-end)           |
+| Port  |    Service    |                            Access                             |
+|-------|---------------|---------------------------------------------------------------|
+| 40984 | Publisher     | Consensus Node source IPs (Hashgraph-provided)                |
+| 40980 | Subscriber    | Generally public; BNs and MNs prioritized via traffic shaping |
+| 40981 | Block Access  | Generally public; BNs and MNs prioritized via traffic shaping |
+| 40982 | Server Status | Globally available (CNs, MNs, other BNs, general public)      |
+| 40983 | Health        | Monitoring and operators                                      |
+| 40840 | LoadBalancer  | External clients (MetalLB front-end)                          |
 
 ```bash
 # nftables

--- a/docs/block-node/operations/production-guide/prerequisites.md
+++ b/docs/block-node/operations/production-guide/prerequisites.md
@@ -74,14 +74,14 @@ The Block Node exposes per-service ports. Lock inbound access to the **publisher
 per-service ports are accessible to their respective clients. Deny all other inbound by
 default.
 
-| Port  |    Service    |                            Access                             |
-|-------|---------------|---------------------------------------------------------------|
-| 40984 | Publisher     | Consensus Node source IPs (Hashgraph-provided)                |
-| 40980 | Subscriber    | Generally public; BNs and MNs prioritized via traffic shaping |
-| 40981 | Block Access  | Generally public; BNs and MNs prioritized via traffic shaping |
-| 40982 | Server Status | Globally available (CNs, MNs, other BNs, general public)      |
-| 40983 | Health        | Monitoring and operators                                      |
-| 40840 | LoadBalancer  | External clients (MetalLB front-end)                          |
+| Port  |    Service    |                                        Access                                        |
+|-------|---------------|--------------------------------------------------------------------------------------|
+| 40984 | Publisher     | Consensus Node source IPs (Hashgraph-provided)                                       |
+| 40980 | Subscriber    | Generally public; BNs and MNs prioritized via traffic shaping                        |
+| 40981 | Block Access  | Generally public; BNs and MNs prioritized via traffic shaping                        |
+| 40982 | Server Status | Globally available (CNs, MNs, other BNs, general public); subject to traffic shaping |
+| 40983 | Health        | Monitoring and operators                                                             |
+| 40840 | LoadBalancer  | External clients (MetalLB front-end)                                                 |
 
 ```bash
 # nftables


### PR DESCRIPTION
## Reviewer Notes
Subscriber (40980) and Block Access (40981) are generally public with traffic shaping to prioritize BNs and MNs; Server Status (40982) is globally available to CNs, MNs, other BNs, and the general public. The old descriptions ('Authorized clients', 'Mirror Nodes and peer Block Nodes', 'Monitoring and operators') contradicted the actual firewall rules, which accept all traffic on these ports with no source IP filter. Column header renamed from 'Restrict to' to 'Access' to align with the mixed-access model.

All the feedback mentioned in the issue has already been implemented. 

## Related Issue(s)
Closes #3276
