### PR TITLE
chore: Follow up on improvements raised for PR 3245

### DIFF
--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTask.java
@@ -205,11 +205,18 @@ public class BlockUploadTask implements Callable<UploadResult> {
     private void completeMultipartUploadWithRetry(S3Client s3, String uploadId, List<String> etags)
             throws S3ResponseException, IOException {
         try {
-            s3.completeMultipartUpload(key, uploadId, etags);
+            doCompleteMultipartUpload(s3, uploadId, etags);
         } catch (S3ResponseException | IOException e) {
             LOGGER.log(DEBUG, "Failed to complete multipart upload for key {0}; retrying once", key, e);
-            s3.completeMultipartUpload(key, uploadId, etags);
+            doCompleteMultipartUpload(s3, uploadId, etags);
         }
+    }
+
+    /// Delegates to [S3Client#completeMultipartUpload].  Overridable so tests can inject completion
+    /// failures without a live S3 endpoint.
+    void doCompleteMultipartUpload(S3Client s3, String uploadId, List<String> etags)
+            throws S3ResponseException, IOException {
+        s3.completeMultipartUpload(key, uploadId, etags);
     }
 
     /// Takes one block from [blockQueue], encodes it as a tar entry, and appends it to `buffer`.

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTask.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTask.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.cloud.storage.archive;
 
+import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.TRACE;
 import static java.util.Objects.requireNonNull;
@@ -193,13 +194,25 @@ public class BlockUploadTask implements Callable<UploadResult> {
             }
 
             if (result == UploadResult.SUCCESS) {
-                s3.completeMultipartUpload(key, uploadId, etags);
+                completeMultipartUploadWithRetry(s3, uploadId, etags);
             }
         }
         return result;
     }
 
-    /// Takes one block from [blockQueue], encodes it as a tar entry, and appends it to [buffer].
+    /// Retries once: idempotent with the same `etags`, and cheaper than falling back to
+    /// [StartupRecoveryTask], which discards and re-derives the last block on this boundary.
+    private void completeMultipartUploadWithRetry(S3Client s3, String uploadId, List<String> etags)
+            throws S3ResponseException, IOException {
+        try {
+            s3.completeMultipartUpload(key, uploadId, etags);
+        } catch (S3ResponseException | IOException e) {
+            LOGGER.log(DEBUG, "Failed to complete multipart upload for key {0}; retrying once", key, e);
+            s3.completeMultipartUpload(key, uploadId, etags);
+        }
+    }
+
+    /// Takes one block from [blockQueue], encodes it as a tar entry, and appends it to `buffer`.
     ///
     /// @param blockNum the block number to accumulate (used as the tar entry name)
     /// @param buffer   the current accumulation buffer
@@ -212,7 +225,7 @@ public class BlockUploadTask implements Callable<UploadResult> {
         return new BlockData(S3UploadUtils.concat(buffer, tarEntry), item.source());
     }
 
-    /// Flushes a fixed-size part to S3 when [buffer] has reached [partSizeBytes], then sends
+    /// Flushes a fixed-size part to S3 when `buffer` has reached [partSizeBytes], then sends
     /// [PersistedNotification]s for every block whose bytes are now durably stored.
     ///
     /// @param blockNum      the block number just accumulated (used for failure notifications and logging)
@@ -221,7 +234,7 @@ public class BlockUploadTask implements Callable<UploadResult> {
     /// @param s3            the S3 client for this upload session
     /// @param uploadId      the multipart upload ID
     /// @param etags         the list of part ETags collected so far (mutated in place)
-    /// @param blocksInBuffer map of block number → source for blocks whose bytes are in [buffer]
+    /// @param blocksInBuffer map of block number → source for blocks whose bytes are in `buffer`
     ///                       (mutated in place)
     /// @return the remainder buffer after the flush, or `null` if the part upload failed
     ///         (false [PersistedNotification]s have already been sent for all affected blocks)
@@ -279,17 +292,17 @@ public class BlockUploadTask implements Callable<UploadResult> {
         }
     }
 
-    /// Uploads [buffer] as the final multipart part and sends a [PersistedNotification] for the
-    /// last block in [blocksInBuffer].
+    /// Uploads `buffer` as the final multipart part and sends a [PersistedNotification] for the
+    /// last block in `blocksInBuffer`.
     ///
     /// Called after the main loop when leftover bytes did not fill a complete part. Assumes
-    /// [buffer] is non-empty and that the upload has not already failed.
+    /// `buffer` is non-empty and that the upload has not already failed.
     ///
     /// @param buffer         the leftover bytes that did not fill a complete part during the loop
     /// @param s3             the S3 client for this upload session
     /// @param uploadId       the multipart upload ID
     /// @param etags          the list of part ETags collected so far (mutated in place)
-    /// @param blocksInBuffer map of block number → source for blocks whose bytes are in [buffer]
+    /// @param blocksInBuffer map of block number → source for blocks whose bytes are in `buffer`
     /// @return [UploadResult#SUCCESS] if the part was uploaded and a success notification was sent,
     ///         [UploadResult#FAILED] otherwise (a failure notification has already been sent)
     private UploadResult uploadFinalPart(
@@ -333,7 +346,7 @@ public class BlockUploadTask implements Callable<UploadResult> {
         S3UploadUtils.uploadPart(buffer, key, s3, uploadId, etags);
     }
 
-    /// Splits [buffer] at [partSizeBytes], uploads the first part via [doUploadPart], and returns
+    /// Splits `buffer` at [partSizeBytes], uploads the first part via [doUploadPart], and returns
     /// the remainder.
     @NonNull
     private byte[] uploadPart(byte[] buffer, S3Client s3, String uploadId, List<String> etags)

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
@@ -231,63 +231,40 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     /// {@inheritDoc}
     @Override
     public void handleVerification(VerificationNotification notification) {
-        try {
-            if (notification != null && notification.success() && notification.block() != null) {
-                // If the task was cancelled (i.e. stop() was called), do not start a new task or process
-                // the current block since the plugin is shutting down.
-                if (!checkCompletedUpload()) {
-                    checkAndDrainTempUploadResults();
-                    drainPendingResumedArchives();
-                    drainOverflowStash();
-                    checkAndDrainConsolidations();
-                    // While recovery is running, stash every block.  routeVerifiedBlock() sends
-                    // it directly to blocksStash without any extra logic.
-                    completeRecoveryIfReady();
-                    final long blockNumber = notification.blockNumber();
-                    // Route the verified block into the regular or temp pipeline, or stash it
-                    // while recovery is in progress.
-                    routeVerifiedBlock(blockNumber, notification);
-                }
-            } else {
-                logInvalidOrFailedNotification(notification);
+        if (notification != null && notification.success() && notification.block() != null) {
+            // If the task was cancelled (i.e. stop() was called), do not start a new task or process
+            // the current block since the plugin is shutting down.
+            if (!checkCompletedUpload()) {
+                checkAndDrainTempUploadResults();
+                drainPendingResumedArchives();
+                drainOverflowStash();
+                checkAndDrainConsolidations();
+                // While recovery is running, stash every block.  routeVerifiedBlock() sends
+                // it directly to blocksStash without any extra logic.
+                completeRecoveryIfReady();
+                final long blockNumber = notification.blockNumber();
+                // Route the verified block into the regular or temp pipeline, or stash it
+                // while recovery is in progress.
+                routeVerifiedBlock(blockNumber, notification);
             }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } catch (ExecutionException e) {
-            metricsHolder.failedTasks().increment();
-            // Capture before triggerMidRunRecovery() runs, since it nulls currentUploadFuture itself.
-            final boolean fromUploadTask = currentUploadFuture != null;
-            triggerMidRunRecovery();
-            if (fromUploadTask) {
-                // routeVerifiedBlock() was never reached (the exception bypassed it), so stash the
-                // triggering block manually — it is safe to use blocksStash directly because
-                // triggerMidRunRecovery() already set currentGroupStart to -1.
-                LOGGER.log(WARNING, "Block upload task failed", e.getCause());
-                blocksStash.put(
-                        notification.blockNumber(), new BlockWithSource(notification.block(), notification.source()));
-            } else {
-                // Exception from the recovery task itself; recoveryFuture is already null (cleared in
-                // completeRecoveryIfReady() before this was thrown), so the triggerMidRunRecovery() call
-                // above submits a retry.
-                LOGGER.log(WARNING, "Could not complete uploading blocks to cloud archive storage", e.getCause());
-            }
+        } else {
+            logInvalidOrFailedNotification(notification);
         }
     }
 
     /// Checks whether the active [BlockUploadTask] has finished and cleans up its state.
     /// Returns `true` if the task was cancelled, signalling the caller to skip further processing.
-    private boolean checkCompletedUpload() throws ExecutionException, InterruptedException {
+    private boolean checkCompletedUpload() {
         boolean cancelled = false;
         if (currentUploadFuture != null && currentUploadFuture.isDone()) {
             final FutureOutcome<UploadResult> outcome = awaitOutcome(currentUploadFuture);
             if (outcome.isCancelled()) {
                 LOGGER.log(TRACE, "Block upload task was cancelled");
                 cancelled = true;
-            } else if (outcome.failure() != null) {
-                throw outcome.failure();
-            } else if (outcome.result() == UploadResult.FAILED) {
-                LOGGER.log(WARNING, "Block upload task failed");
+            } else if (outcome.failure() != null || outcome.result() == UploadResult.FAILED) {
+                LOGGER.log(WARNING, "Block upload task failed", outcome.failure());
                 metricsHolder.failedTasks().increment();
+                currentUploadFuture = null;
                 // False PersistedNotifications were already sent by the task for the affected blocks.
                 // Trigger S3 recovery so the next task resumes from the last confirmed part boundary.
                 triggerMidRunRecovery();
@@ -302,8 +279,9 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     }
 
     /// Outcome of awaiting a [Future]: on normal completion exactly one of [result] or [failure] is
-    /// non-null; both are `null` when the future was cancelled.
-    private record FutureOutcome<T>(T result, ExecutionException failure) {
+    /// non-null; both are `null` when the future was cancelled.  [failure] is the task's cause when
+    /// one is available, otherwise the exception observed while awaiting.
+    private record FutureOutcome<T>(T result, Throwable failure) {
         /// Returns `true` when the underlying [Future] was cancelled, i.e. neither a result nor a
         /// failure was captured.
         boolean isCancelled() {
@@ -311,16 +289,23 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
         }
     }
 
-    /// Awaits `future`, which must already be [Future#isDone()], wrapping any [ExecutionException]
-    /// into the returned [FutureOutcome] instead of throwing it. Returns a [FutureOutcome] with both
-    /// fields `null` when `future` was cancelled, without calling [Future#get()] at all.
-    private static <T> FutureOutcome<T> awaitOutcome(Future<T> future) throws InterruptedException {
+    /// Awaits `future`, which must already be [Future#isDone()], returning any failure in the
+    /// [FutureOutcome] rather than throwing it.  Returns a [FutureOutcome] with both fields `null`
+    /// when `future` was cancelled, without calling [Future#get()] at all.
+    ///
+    /// [InterruptedException] cannot occur for a future that is already done unless the calling
+    /// thread was interrupted beforehand; it is reported as a failure like any other, after the
+    /// interrupt flag is restored.
+    private static <T> FutureOutcome<T> awaitOutcome(Future<T> future) {
         if (future.isCancelled()) {
             return new FutureOutcome<>(null, null);
         }
         try {
             return new FutureOutcome<>(future.get(), null);
         } catch (ExecutionException e) {
+            return new FutureOutcome<>(null, e.getCause() != null ? e.getCause() : e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             return new FutureOutcome<>(null, e);
         }
     }
@@ -330,7 +315,7 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     /// [TempArchiveUploadTask] calls `ApplicationStateFacility.addStoredBlockRange()` once after
     /// both the multipart upload and the meta file write succeed, so no additional range
     /// registration is needed here.
-    private void checkAndDrainTempUploadResults() throws InterruptedException {
+    private void checkAndDrainTempUploadResults() {
         final Iterator<Map.Entry<Long, Future<TempArchiveEntry>>> it =
                 tempUploadFutures.entrySet().iterator();
         while (it.hasNext()) {
@@ -348,7 +333,7 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                         WARNING,
                         "Temp archive upload failed for firstBlock %d; triggering mid-run recovery"
                                 .formatted(entry.getKey()),
-                        outcome.failure().getCause());
+                        outcome.failure());
                 metricsHolder.failedTasks().increment();
                 triggerMidRunRecovery();
             } else {
@@ -364,7 +349,7 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     }
 
     /// Submits pending [ConsolidationTask]s and drains completed ones.
-    private void checkAndDrainConsolidations() throws InterruptedException {
+    private void checkAndDrainConsolidations() {
         // Process completed consolidations.
         final Iterator<Map.Entry<Long, Future<UploadResult>>> it =
                 consolidationFutures.entrySet().iterator();
@@ -383,7 +368,7 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                 LOGGER.log(
                         WARNING,
                         "Consolidation task threw exception for group %d".formatted(groupStart),
-                        outcome.failure().getCause());
+                        outcome.failure());
                 metricsHolder.failedTasks().increment();
                 checkGroupCoverage(groupStart);
             } else {
@@ -481,20 +466,22 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     ///
     /// When the result is a fresh start, no upload task is created and the next call to
     /// [handleVerification] will fall through to [tryStartNewUploadTask] as normal.
-    private void completeRecoveryIfReady() throws ExecutionException, InterruptedException {
+    private void completeRecoveryIfReady() {
         if (recoveryFuture != null && recoveryFuture.isDone()) {
             final FutureOutcome<RecoveryResult> outcome = awaitOutcome(recoveryFuture);
             if (outcome.isCancelled()) {
                 LOGGER.log(TRACE, "Startup recovery task was cancelled");
                 recoveryFuture = null;
-                return;
-            }
-            try {
-                if (outcome.failure() != null) {
-                    throw outcome.failure();
-                }
+            } else if (outcome.failure() != null) {
+                LOGGER.log(WARNING, "Could not complete uploading blocks to cloud archive storage", outcome.failure());
+                metricsHolder.failedTasks().increment();
+                // Clear before triggerMidRunRecovery() so that it submits a retry rather than
+                // seeing a recovery already in progress.
+                recoveryFuture = null;
+                triggerMidRunRecovery();
+            } else {
                 final RecoveryResult result = outcome.result();
-
+                recoveryFuture = null;
                 // Rebuild the temporary-archive tracker from startup recovery.  These archives
                 // survived a restart so their block ranges must be re-registered with the state
                 // facility (the upload task's per-run registration did not survive the restart).
@@ -552,8 +539,6 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                     }
                 }
                 tryReplayStash();
-            } finally {
-                recoveryFuture = null;
             }
         }
     }

--- a/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
+++ b/block-node/cloud-storage-archive/src/main/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePlugin.java
@@ -279,26 +279,50 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     private boolean checkCompletedUpload() throws ExecutionException, InterruptedException {
         boolean cancelled = false;
         if (currentUploadFuture != null && currentUploadFuture.isDone()) {
-            if (currentUploadFuture.isCancelled()) {
+            final FutureOutcome<UploadResult> outcome = awaitOutcome(currentUploadFuture);
+            if (outcome.isCancelled()) {
                 LOGGER.log(TRACE, "Block upload task was cancelled");
                 cancelled = true;
+            } else if (outcome.failure() != null) {
+                throw outcome.failure();
+            } else if (outcome.result() == UploadResult.FAILED) {
+                LOGGER.log(WARNING, "Block upload task failed");
+                metricsHolder.failedTasks().increment();
+                // False PersistedNotifications were already sent by the task for the affected blocks.
+                // Trigger S3 recovery so the next task resumes from the last confirmed part boundary.
+                triggerMidRunRecovery();
             } else {
-                final UploadResult uploadResult = currentUploadFuture.get();
-                if (uploadResult == UploadResult.FAILED) {
-                    LOGGER.log(WARNING, "Block upload task failed");
-                    metricsHolder.failedTasks().increment();
-                    // False PersistedNotifications were already sent by the task for the affected blocks.
-                    // Trigger S3 recovery so the next task resumes from the last confirmed part boundary.
-                    triggerMidRunRecovery();
-                } else {
-                    metricsHolder.successfulTasks().increment();
-                    currentUploadFuture = null;
-                    currentGroupPending = new ConcurrentSkipListMap<>();
-                    LOGGER.log(TRACE, "Upload task completed successfully");
-                }
+                metricsHolder.successfulTasks().increment();
+                currentUploadFuture = null;
+                currentGroupPending = new ConcurrentSkipListMap<>();
+                LOGGER.log(TRACE, "Upload task completed successfully");
             }
         }
         return cancelled;
+    }
+
+    /// Outcome of awaiting a [Future]: on normal completion exactly one of [result] or [failure] is
+    /// non-null; both are `null` when the future was cancelled.
+    private record FutureOutcome<T>(T result, ExecutionException failure) {
+        /// Returns `true` when the underlying [Future] was cancelled, i.e. neither a result nor a
+        /// failure was captured.
+        boolean isCancelled() {
+            return result == null && failure == null;
+        }
+    }
+
+    /// Awaits `future`, which must already be [Future#isDone()], wrapping any [ExecutionException]
+    /// into the returned [FutureOutcome] instead of throwing it. Returns a [FutureOutcome] with both
+    /// fields `null` when `future` was cancelled, without calling [Future#get()] at all.
+    private static <T> FutureOutcome<T> awaitOutcome(Future<T> future) throws InterruptedException {
+        if (future.isCancelled()) {
+            return new FutureOutcome<>(null, null);
+        }
+        try {
+            return new FutureOutcome<>(future.get(), null);
+        } catch (ExecutionException e) {
+            return new FutureOutcome<>(null, e);
+        }
     }
 
     /// Drains completed [TempArchiveUploadTask] futures and updates the tracker.
@@ -314,28 +338,27 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
             if (!entry.getValue().isDone()) {
                 continue;
             }
-            if (entry.getValue().isCancelled()) {
-                it.remove();
+            final FutureOutcome<TempArchiveEntry> outcome = awaitOutcome(entry.getValue());
+            it.remove();
+            if (outcome.isCancelled()) {
                 continue;
             }
-            try {
-                final TempArchiveEntry result = entry.getValue().get();
-                it.remove();
+            if (outcome.failure() != null) {
+                LOGGER.log(
+                        WARNING,
+                        "Temp archive upload failed for firstBlock %d; triggering mid-run recovery"
+                                .formatted(entry.getKey()),
+                        outcome.failure().getCause());
+                metricsHolder.failedTasks().increment();
+                triggerMidRunRecovery();
+            } else {
+                final TempArchiveEntry result = outcome.result();
                 tempArchiveTracker.put(result.firstBlock(), result);
                 tempSegmentLastBlock.remove(result.firstBlock());
                 metricsHolder.successfulTasks().increment();
                 final long groupStart = (result.firstBlock() / groupSize) * groupSize;
                 checkGroupCoverage(groupStart);
                 LOGGER.log(TRACE, "Temp archive completed: blocks [{0}, {1}]", result.firstBlock(), result.lastBlock());
-            } catch (ExecutionException e) {
-                it.remove();
-                LOGGER.log(
-                        WARNING,
-                        "Temp archive upload failed for firstBlock %d; triggering mid-run recovery"
-                                .formatted(entry.getKey()),
-                        e.getCause());
-                metricsHolder.failedTasks().increment();
-                triggerMidRunRecovery();
             }
         }
     }
@@ -351,23 +374,23 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
                 continue;
             }
             final long groupStart = entry.getKey();
-            if (entry.getValue().isCancelled()) {
-                it.remove();
+            final FutureOutcome<UploadResult> outcome = awaitOutcome(entry.getValue());
+            it.remove();
+            if (outcome.isCancelled()) {
                 continue;
             }
-            try {
-                entry.getValue().get();
-                it.remove();
+            if (outcome.failure() != null) {
+                LOGGER.log(
+                        WARNING,
+                        "Consolidation task threw exception for group %d".formatted(groupStart),
+                        outcome.failure().getCause());
+                metricsHolder.failedTasks().increment();
+                checkGroupCoverage(groupStart);
+            } else {
                 tempArchiveTracker.subMap(groupStart, groupStart + groupSize).clear();
                 tempGroupNextExpected.remove(groupStart);
                 metricsHolder.successfulTasks().increment();
                 LOGGER.log(TRACE, "Consolidation completed for group {0}", groupStart);
-            } catch (ExecutionException e) {
-                it.remove();
-                LOGGER.log(
-                        WARNING, "Consolidation task threw exception for group %d".formatted(groupStart), e.getCause());
-                metricsHolder.failedTasks().increment();
-                checkGroupCoverage(groupStart);
             }
         }
 
@@ -460,13 +483,17 @@ public class CloudStorageArchivePlugin implements BlockNodePlugin, BlockNotifica
     /// [handleVerification] will fall through to [tryStartNewUploadTask] as normal.
     private void completeRecoveryIfReady() throws ExecutionException, InterruptedException {
         if (recoveryFuture != null && recoveryFuture.isDone()) {
-            if (recoveryFuture.isCancelled()) {
+            final FutureOutcome<RecoveryResult> outcome = awaitOutcome(recoveryFuture);
+            if (outcome.isCancelled()) {
                 LOGGER.log(TRACE, "Startup recovery task was cancelled");
                 recoveryFuture = null;
                 return;
             }
             try {
-                final RecoveryResult result = recoveryFuture.get();
+                if (outcome.failure() != null) {
+                    throw outcome.failure();
+                }
+                final RecoveryResult result = outcome.result();
 
                 // Rebuild the temporary-archive tracker from startup recovery.  These archives
                 // survived a restart so their block ranges must be re-registered with the state

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTaskTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/BlockUploadTaskTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.bucky.S3Client;
+import com.hedera.bucky.S3ResponseException;
 import com.hedera.hapi.node.base.NodeAddressBook;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -277,6 +278,45 @@ class BlockUploadTaskTest {
             assertThat(n.succeeded()).isTrue();
             assertThat(n.blockSource()).isEqualTo(BlockSource.PUBLISHER);
         });
+    }
+
+    /// Verifies that a transient failure of the multipart completion is retried once and that the
+    /// retry produces the same tar object as an uninterrupted upload, so no recovery is needed.
+    @Test
+    @DisplayName("Failed multipart completion is retried once and the upload still succeeds")
+    void testCompleteMultipartUploadIsRetriedOnce() throws Exception {
+        final int groupingLevel = 1;
+        final int groupSize = (int) Math.pow(10, groupingLevel);
+        final TestBlockMessagingFacility messaging = new TestBlockMessagingFacility();
+        final BlockingQueue<BlockWithSource> queue = new LinkedBlockingQueue<>();
+
+        final ConfigurationBuilder builder =
+                ConfigurationBuilder.create().withConfigDataType(CloudStorageArchiveConfig.class);
+        pluginConfig(groupingLevel, PART_SIZE_MB).forEach(builder::withValue);
+        final CloudStorageArchiveConfig config = builder.build().getConfigData(CloudStorageArchiveConfig.class);
+        final FailFirstCompleteTask task = new FailFirstCompleteTask(
+                config, messaging, 0, groupSize, queue, createMetricsHolder(new TestMetricsExporter()), noOpAsf());
+
+        final Random rng = new Random(0xDEADBEEFL);
+        for (int i = 0; i < groupSize; i++) {
+            final byte[] data = new byte[100];
+            rng.nextBytes(data);
+            final BlockItemUnparsed item = new BlockItemUnparsed(
+                    new OneOf<>(BlockItemUnparsed.ItemOneOfType.SIGNED_TRANSACTION, Bytes.wrap(data)));
+            queue.put(new BlockWithSource(
+                    BlockUnparsed.newBuilder()
+                            .blockItems(new BlockItemUnparsed[] {item})
+                            .build(),
+                    BlockSource.PUBLISHER));
+        }
+
+        assertThat(task.call()).isEqualTo(UploadResult.SUCCESS);
+        assertThat(task.completionAttempts).isEqualTo(2);
+        assertThat(getAllObjects()).contains(ArchiveKey.format(0, groupingLevel, config.objectKeyPrefix()));
+
+        final List<PersistedNotification> notifications = messaging.getSentPersistedNotifications();
+        assertThat(notifications).isNotEmpty().allSatisfy(n -> assertThat(n.succeeded())
+                .isTrue());
     }
 
     /// Verifies that the last block's [BlockSource] is preserved in its [PersistedNotification].
@@ -702,6 +742,33 @@ class BlockUploadTaskTest {
         @Override
         void doUploadPart(byte[] buffer, S3Client s3, String uploadId, List<String> etags) throws IOException {
             throw new IOException("Simulated S3 final part upload failure");
+        }
+    }
+
+    /// [BlockUploadTask] subclass whose first multipart completion fails, so the retry inside
+    /// [BlockUploadTask#completeMultipartUploadWithRetry] is the call that actually completes it.
+    private static final class FailFirstCompleteTask extends BlockUploadTask {
+        private int completionAttempts = 0;
+
+        FailFirstCompleteTask(
+                CloudStorageArchiveConfig config,
+                BlockMessagingFacility blockMessaging,
+                long firstBlock,
+                int groupSize,
+                BlockingQueue<BlockWithSource> queue,
+                CloudStorageArchivePlugin.MetricsHolder metricsHolder,
+                ApplicationStateFacility applicationStateFacility) {
+            super(config, blockMessaging, firstBlock, groupSize, queue, metricsHolder, applicationStateFacility);
+        }
+
+        @Override
+        void doCompleteMultipartUpload(S3Client s3, String uploadId, List<String> etags)
+                throws S3ResponseException, IOException {
+            completionAttempts++;
+            if (completionAttempts == 1) {
+                throw new IOException("Simulated transient completion failure");
+            }
+            super.doCompleteMultipartUpload(s3, uploadId, etags);
         }
     }
 

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
@@ -1324,6 +1324,48 @@ class CloudStorageArchivePluginTest {
             assertThat(blockMessaging.getBlockNotificationHandlerCount()).isZero();
         }
 
+        /// Verifies that a notification arriving after the active [BlockUploadTask] future was
+        /// cancelled is skipped entirely: the cancelled future is left in place rather than being
+        /// treated as a failure, and no replacement task is submitted.
+        @Test
+        @DisplayName("Cancelled upload future makes the plugin skip the notification")
+        void testCancelledUploadFutureSkipsNotification() {
+            final List<TestBlock> blocks = TestBlockBuilder.generateBlocksInRange(0, 1);
+            sendVerification(blocks.getFirst());
+            assertThat(plugin.currentUploadFuture).isNotNull();
+            final int queuedTasks = pluginExecutor.getQueue().size();
+
+            plugin.currentUploadFuture.cancel(false);
+            sendVerification(blocks.get(1));
+
+            // A cancelled future must not be cleared (that is the FAILED path) and must not cause a
+            // new task to be queued -- the plugin is shutting down.
+            assertThat(plugin.currentUploadFuture).isNotNull();
+            assertThat(plugin.currentUploadFuture.isCancelled()).isTrue();
+            assertThat(plugin.currentGroupPending).doesNotContainKey(1L);
+            assertThat(pluginExecutor.getQueue()).hasSize(queuedTasks);
+        }
+
+        /// Verifies that cancelled [TempArchiveUploadTask] and [ConsolidationTask] futures are
+        /// dropped from their tracking maps without being counted as failed tasks.
+        @Test
+        @DisplayName("Cancelled temp archive and consolidation futures are drained without failing")
+        void testCancelledTempAndConsolidationFuturesAreDrained() {
+            final CompletableFuture<TempArchiveEntry> tempFuture = new CompletableFuture<>();
+            final CompletableFuture<UploadResult> consolFuture = new CompletableFuture<>();
+            tempFuture.cancel(false);
+            consolFuture.cancel(false);
+            plugin.tempUploadFutures.put(10L, tempFuture);
+            plugin.consolidationFutures.put(0L, consolFuture);
+
+            sendVerification(TestBlockBuilder.generateBlocksInRange(0, 0).getFirst());
+
+            assertThat(plugin.tempUploadFutures).isEmpty();
+            assertThat(plugin.consolidationFutures).isEmpty();
+            assertThat(getMetricValue(CloudStorageArchivePlugin.METRIC_CLOUD_ARCHIVE_FAILED_TASKS))
+                    .isZero();
+        }
+
         private void sendVerification(TestBlock block) {
             blockMessaging.sendBlockVerification(new VerificationNotification(
                     true, null, block.number(), Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
@@ -1366,6 +1408,24 @@ class CloudStorageArchivePluginTest {
                 pluginExecutor.executeSerially();
             } catch (java.util.concurrent.CancellationException ignored) {
             }
+        }
+
+        /// Verifies that a verification notification still in flight when [CloudStorageArchivePlugin#stop]
+        /// cancelled the startup recovery task clears the cancelled future instead of trying to read
+        /// its result.
+        @Test
+        @DisplayName("Cancelled startup recovery future is cleared, not read, on the next notification")
+        void testCancelledRecoveryFutureIsCleared() {
+            plugin.stop();
+            // A cancelled future is also a done future, so recovery looks "complete" here.
+            assertThat(plugin.isRecoveryComplete()).isTrue();
+
+            final TestBlock block = TestBlockBuilder.generateBlocksInRange(0, 0).getFirst();
+            plugin.handleVerification(new VerificationNotification(
+                    true, null, block.number(), Bytes.EMPTY, block.blockUnparsed(), BlockSource.PUBLISHER));
+
+            // completeRecoveryIfReady() dropped the cancelled future without calling get() on it.
+            assertThat(plugin.isRecoveryComplete()).isFalse();
         }
     }
 

--- a/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
+++ b/block-node/cloud-storage-archive/src/test/java/org/hiero/block/node/cloud/storage/archive/CloudStorageArchivePluginTest.java
@@ -2270,11 +2270,10 @@ class CloudStorageArchivePluginTest {
             // RuntimeException.
             assertThatThrownBy(executor::executeSerially).isInstanceOf(RuntimeException.class);
 
-            // Block 10 triggers handleVerification() -> checkCompletedUpload() calls
-            // currentUploadFuture.get(), which throws ExecutionException, propagating up to
-            // handleVerification()'s catch block. It logs the real cause via e.getCause(), then
-            // calls triggerMidRunRecovery() (moves currentGroupPending blocks 5-9 to stash) and
-            // manually stashes block 10 itself, since routeVerifiedBlock(10) is never reached.
+            // Block 10 triggers handleVerification() -> checkCompletedUpload(), where awaitOutcome()
+            // reports the task's failure. It logs the real cause and calls triggerMidRunRecovery()
+            // (moves currentGroupPending blocks 5-9 to stash); block 10 itself is then stashed by
+            // routeVerifiedBlock(), since recovery is now in progress.
             sendVerification(blocks.get(10));
 
             assertThat(plugin.currentUploadFuture).isNull();


### PR DESCRIPTION
## Reviewer Notes

Addressed three leftover comments from PR #3245 

* One more retry in `completeMultipartUpload` as it is cheaper than the recovery task and also it avoids re-retrieving the boundary component
* All 4 `Future.get()` call sites were already guard with isCancelled(), so comment 2 brought no code changes
* Added `FutureOutcome<T>` record and `awaitOutcome(Future<T>)` helper

## Related Issue(s)

Closes #3264 