### PR TITLE
fix: BackfillMultiportSourceTests.publishBlocks assumes 1 ACK per block, but acks are watermark-coalesced

### DIFF
--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/backfill/BackfillMultiportSourceTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/backfill/BackfillMultiportSourceTests.java
@@ -156,14 +156,18 @@ public class BackfillMultiportSourceTests {
     }
 
     /// Publishes blocks 0..{@link #LAST_BLOCK_NUMBER}, chained by block hash, on the given port and
-    /// awaits an acknowledgement for each.
+    /// awaits an acknowledgement covering the last block. Acknowledgements are watermark-coalesced by
+    /// the server (an ack for block N implicitly acks all blocks below N), so fewer acks than blocks
+    /// may arrive; waiting for a fixed per-block count would flake (#3401).
     private void publishBlocks(final int port) throws InterruptedException {
         final BlockStreamPublishServiceClient publishClient =
                 new BlockStreamPublishServiceClient(createGrpcClientForPort(port), OPTIONS);
         final ResponsePipelineUtils<PublishStreamResponse> observer = new ResponsePipelineUtils<>();
         final Pipeline<? super PublishStreamRequest> stream = publishClient.publishBlockStream(observer);
 
-        final AtomicReference<CountDownLatch> ackLatch = observer.setAndGetOnNextLatch(LAST_BLOCK_NUMBER + 1);
+        final AtomicReference<CountDownLatch> ackLatch = observer.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
+                        && response.acknowledgement().blockNumber() >= LAST_BLOCK_NUMBER);
         Bytes previousBlockHash = null;
         for (long blockNumber = 0; blockNumber <= LAST_BLOCK_NUMBER; blockNumber++) {
             final BlockItem[] items = BlockItemBuilderUtils.createSimpleBlockWithNumber(blockNumber, previousBlockHash);
@@ -177,7 +181,10 @@ public class BackfillMultiportSourceTests {
         }
 
         ackLatch.get().await(AWAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-        assertEquals(0, ackLatch.get().getCount(), "Timed out waiting for publish acknowledgements");
+        assertEquals(
+                0,
+                ackLatch.get().getCount(),
+                "Timed out waiting for a publish acknowledgement of block >= " + LAST_BLOCK_NUMBER);
         stream.closeConnection();
         publishClient.close();
     }

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeAPITests.java
@@ -471,14 +471,18 @@ public class BlockNodeAPITests {
         final int totalBlocks = 20;
         final long headBlock = totalBlocks - 1L;
 
-        // ==== Step 1: Publish blocks 0..19, chained by block hash, and await all acknowledgements ====
+        // ==== Step 1: Publish blocks 0..19, chained by block hash, and await the head-block acknowledgement ====
         final BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient publishClient =
                 new BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient(
                         publishBlockStreamPbjGrpcClient, OPTIONS);
         final ResponsePipelineUtils<PublishStreamResponse> primaryObserver = new ResponsePipelineUtils<>();
         final Pipeline<? super PublishStreamRequest> primaryStream = publishClient.publishBlockStream(primaryObserver);
 
-        final AtomicReference<CountDownLatch> ackLatch = primaryObserver.setAndGetOnNextLatch(totalBlocks);
+        // Acks are watermark-coalesced by the server (ack of block N implicitly acks all below),
+        // so wait for the watermark to reach the head block rather than for one ack per block (#3401).
+        final AtomicReference<CountDownLatch> ackLatch = primaryObserver.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
+                        && response.acknowledgement().blockNumber() >= headBlock);
         BlockItem[] headBlockItems = null;
         BlockItem[] genesisBlockItems = null;
         Bytes previousBlockHash = null;
@@ -497,12 +501,19 @@ public class BlockNodeAPITests {
             endBlock(blockNumber, primaryStream);
             previousBlockHash = BlockItemBuilderUtils.computeBlockHash(blockNumber, previousBlockHash);
         }
-        awaitLatch(ackLatch, "acknowledgements for blocks 0..19");
-        assertThat(primaryObserver.getOnNextCalls()).hasSize(totalBlocks);
+        awaitLatch(ackLatch, "acknowledgement watermark covering blocks 0..19");
         assertThat(primaryObserver.getOnNextCalls())
                 .last()
                 .returns(PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor)
                 .returns(headBlock, acknowledgementBlockNumberExtractor);
+
+        // Confirm blocks 0..19 are actually persisted, not just acknowledged.
+        final BlockNodeServiceInterface.BlockNodeServiceClient statusClient =
+                new BlockNodeServiceInterface.BlockNodeServiceClient(serverStatusPbjGrpcClient, OPTIONS);
+        final ServerStatusResponse statusAfterPublish = statusClient.serverStatus(SIMPLE_SERVER_STAUS_REQUEST);
+        assertNotNull(statusAfterPublish);
+        assertThat(statusAfterPublish.firstAvailableBlock()).isEqualTo(0);
+        assertThat(statusAfterPublish.lastAvailableBlock()).isEqualTo(headBlock);
 
         // ==== Step 2: Republish head block (distance 0, within window) and expect SkipBlock ====
         final AtomicReference<CountDownLatch> skipLatch = primaryObserver.setAndGetOnNextLatch(1);
@@ -512,8 +523,9 @@ public class BlockNodeAPITests {
         primaryStream.onNext(headBlockRequest);
 
         awaitLatch(skipLatch, "skip response for in-window duplicate");
+        // No response count assertion: the number of step 1 acknowledgements is nondeterministic
+        // under watermark coalescing (#3401), so only the latest response is deterministic.
         assertThat(primaryObserver.getOnNextCalls())
-                .hasSize(totalBlocks + 1)
                 .last()
                 .returns(PublishStreamResponse.ResponseOneOfType.SKIP_BLOCK, responseKindExtractor)
                 .returns(headBlock, skipBlockNumberExtractor);
@@ -657,8 +669,11 @@ public class BlockNodeAPITests {
 
         final int totalBlocks = 8;
         final long headBlock = totalBlocks - 1L;
-        final AtomicReference<CountDownLatch> publishCountDownLatch =
-                responseObserver.setAndGetOnNextLatch(totalBlocks);
+        // Acks are watermark-coalesced by the server (ack of block N implicitly acks all below),
+        // so wait for the watermark to reach the head block rather than for one ack per block (#3401).
+        final AtomicReference<CountDownLatch> publishCountDownLatch = responseObserver.setAndGetOnMatchLatch(
+                response -> response.response().kind() == PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT
+                        && response.acknowledgement().blockNumber() >= headBlock);
         BlockItem[] genesisBlockItems = null;
         Bytes previousBlockHash = null;
         for (long blockNumber = 0; blockNumber < totalBlocks; blockNumber++) {
@@ -674,8 +689,7 @@ public class BlockNodeAPITests {
             previousBlockHash = BlockItemBuilderUtils.computeBlockHash(blockNumber, previousBlockHash);
         }
 
-        awaitLatch(publishCountDownLatch, "socket test acknowledgements for blocks 0..7");
-        assertThat(responseObserver.getOnNextCalls()).hasSize(totalBlocks);
+        awaitLatch(publishCountDownLatch, "socket test acknowledgement watermark covering blocks 0..7");
         assertThat(responseObserver.getOnNextCalls())
                 .last()
                 .returns(PublishStreamResponse.ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor)


### PR DESCRIPTION
* Wait for a single acknowledgement covering the last published block instead of counting one response per block in BackfillMultiportSourceTests.publishBlocks, since the server coalesces acks to the highest persisted block
* Apply the same watermark wait in BlockNodeAPITests duplicateBlockSkipWindowAppliesWithinWindowAndEndsOutsideWindow and e2eSocketClosureTest
* Drop response count assertions that assumed one ack per block, keeping the deterministic last-response checks
* Assert the persisted block range via serverStatus after publishing in the duplicate skip window test so persistence is verified independently of acks

Resolves #3401