### PR TITLE
fix(tools): three CLI fixes so LiveSequential --push-enabled works against a real BN

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -205,6 +205,16 @@ public class LiveSequential implements Runnable {
     private int pushBnPort = 40840;
 
     @Option(
+            names = {"--push-bn-status-port"},
+            description = "Block Node BlockNodeService port for the one-time serverStatus query "
+                    + "used to establish the push-skip watermark. Defaults to --push-bn-port for the "
+                    + "common single-port deployment. Override when the BN uses per-API split ports "
+                    + "(publish and status on different ports); a wrong port here causes the startup "
+                    + "query to fail, and the tool aborts rather than pushing every block from 0 "
+                    + "(see #3374). Ignored unless --push-enabled is set. -1 means 'unset'.")
+    private int pushBnStatusPort = -1;
+
+    @Option(
             names = {"--push-queue-capacity"},
             description = "Bounded backpressure queue between the wrap thread and the push worker "
                     + "(default: 32). When full, the wrap thread blocks; nothing is dropped. "
@@ -360,12 +370,39 @@ public class LiveSequential implements Runnable {
             // side coordinating with the other. The push subsystem owns its own thread + bounded
             // queue (see LiveBlockPushClient javadoc).
             if (pushEnabled) {
+                final int effectiveStatusPort = pushBnStatusPort > 0 ? pushBnStatusPort : pushBnPort;
                 pushClient = new LiveBlockPushClient(
-                        pushBnHost, pushBnPort, pushQueueCapacity, LiveBlockPushClient.loadDefaultWebConfig());
-                pushSkipUpToInclusive = pushClient.queryLastAvailableBlock();
+                        pushBnHost,
+                        pushBnPort,
+                        effectiveStatusPort,
+                        pushQueueCapacity,
+                        LiveBlockPushClient.loadDefaultWebConfig());
+                // Fail-fast on query failure. Silently proceeding with pushSkipUpToInclusive=-1
+                // would push every block from 0 into a BN that already has thousands, driving the
+                // BN into the DUPLICATE_BLOCK/SkipBlock reconnect loop that motivated #3374.
+                try {
+                    pushSkipUpToInclusive = pushClient.queryLastAvailableBlock();
+                } catch (final LiveBlockPushClient.QueryFailedException e) {
+                    throw new IllegalStateException(
+                            "Cannot enable --push-enabled: " + e.getMessage()
+                                    + ". Remove --push-enabled or point --push-bn-status-port at the BlockNodeService port.",
+                            e);
+                }
+                if (pushSkipUpToInclusive < 0) {
+                    // Defense in depth: the BN should never advertise a negative watermark, but if
+                    // it does, the producer-side `blockNum > pushSkipUpToInclusive` guard would
+                    // still push everything. Abort with a diagnosable message.
+                    throw new IllegalStateException("BN returned lastAvailableBlock=" + pushSkipUpToInclusive
+                            + " which is not a valid watermark; aborting to avoid pushing every block from 0");
+                }
                 System.out.printf(
-                        "[live-sequential] Live push enabled: target=%s:%d queueCapacity=%d BN lastAvailableBlock=%d (blocks <= this are skipped from push)%n",
-                        pushBnHost, pushBnPort, pushQueueCapacity, pushSkipUpToInclusive);
+                        "[live-sequential] Live push enabled: publish=%s:%d status=%s:%d queueCapacity=%d BN lastAvailableBlock=%d (blocks <= this are skipped from push)%n",
+                        pushBnHost,
+                        pushBnPort,
+                        pushBnHost,
+                        effectiveStatusPort,
+                        pushQueueCapacity,
+                        pushSkipUpToInclusive);
                 pushClient.start();
             }
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/LiveSequential.java
@@ -388,21 +388,21 @@ public class LiveSequential implements Runnable {
                                     + ". Remove --push-enabled or point --push-bn-status-port at the BlockNodeService port.",
                             e);
                 }
-                if (pushSkipUpToInclusive < 0) {
-                    // Defense in depth: the BN should never advertise a negative watermark, but if
-                    // it does, the producer-side `blockNum > pushSkipUpToInclusive` guard would
-                    // still push everything. Abort with a diagnosable message.
-                    throw new IllegalStateException("BN returned lastAvailableBlock=" + pushSkipUpToInclusive
-                            + " which is not a valid watermark; aborting to avoid pushing every block from 0");
-                }
+                // An empty BN advertises lastAvailableBlock as uint64 max, which arrives here as
+                // -1L. That's the correct sentinel for "push everything from block 0" — the
+                // producer-side guard `blockNum > pushSkipUpToInclusive` gives us exactly that.
+                final boolean bnEmpty = pushSkipUpToInclusive == -1L;
                 System.out.printf(
-                        "[live-sequential] Live push enabled: publish=%s:%d status=%s:%d queueCapacity=%d BN lastAvailableBlock=%d (blocks <= this are skipped from push)%n",
+                        "[live-sequential] Live push enabled: publish=%s:%d status=%s:%d queueCapacity=%d BN %s%n",
                         pushBnHost,
                         pushBnPort,
                         pushBnHost,
                         effectiveStatusPort,
                         pushQueueCapacity,
-                        pushSkipUpToInclusive);
+                        bnEmpty
+                                ? "is empty (will push from block 0)"
+                                : "lastAvailableBlock=" + pushSkipUpToInclusive
+                                        + " (blocks <= this are skipped from push)");
                 pushClient.start();
             }
 

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/BlockTimeReader.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/mirrornode/BlockTimeReader.java
@@ -11,7 +11,6 @@ import java.nio.LongBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import org.hiero.block.tools.config.NetworkConfig;
@@ -25,11 +24,8 @@ public class BlockTimeReader implements AutoCloseable {
     /** Mapped buffer on the block_times.bin file. */
     private LongBuffer mappedLongBuffer;
 
-    /** Genesis instant for this network - used to convert relative block times to absolute times. */
+    /** Genesis instant for this network. Stored for reference but not used in decode — block_times.bin always encodes values relative to mainnet genesis via {@code instantToBlockTimeLong}. */
     private final Instant genesisInstant;
-
-    /** Whether to use the RecordFileDates helper methods (mainnet) or direct calculations (custom network). */
-    private final boolean useMainnetHelpers;
 
     /**
      * Load and map the default block_times.bin file into memory.
@@ -61,7 +57,6 @@ public class BlockTimeReader implements AutoCloseable {
      */
     public BlockTimeReader(Path blockTimesFile, Instant genesisInstant) throws IOException {
         this.genesisInstant = genesisInstant;
-        this.useMainnetHelpers = FIRST_BLOCK_TIME_INSTANT.equals(genesisInstant);
         try (FileChannel channel = FileChannel.open(blockTimesFile, StandardOpenOption.READ)) {
             this.mappedLongBuffer = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size())
                     .asLongBuffer();
@@ -137,8 +132,7 @@ public class BlockTimeReader implements AutoCloseable {
                     + "Try running UpdateBlockData to fetch latest block times from mirror node.");
         }
         long relativeNanos = mappedLongBuffer.get(index);
-        // Use RecordFileDates helper for mainnet, direct calculation for custom networks
-        return useMainnetHelpers ? blockTimeLongToInstant(relativeNanos) : genesisInstant.plusNanos(relativeNanos);
+        return blockTimeLongToInstant(relativeNanos);
     }
 
     /**
@@ -158,10 +152,7 @@ public class BlockTimeReader implements AutoCloseable {
                     + "then reload the BlockTimeReader.");
         }
         long relativeNanos = mappedLongBuffer.get(index);
-        // Use RecordFileDates helper for mainnet, direct calculation for custom networks
-        Instant instant =
-                useMainnetHelpers ? blockTimeLongToInstant(relativeNanos) : genesisInstant.plusNanos(relativeNanos);
-        return instant.atZone(UTC).toLocalDateTime();
+        return blockTimeLongToInstant(relativeNanos).atZone(UTC).toLocalDateTime();
     }
 
     /**
@@ -203,11 +194,7 @@ public class BlockTimeReader implements AutoCloseable {
      */
     public long getNearestBlockAfterTime(LocalDateTime targetTime) {
         Instant targetInstant = targetTime.toInstant(UTC);
-        // Use RecordFileDates helper for mainnet, direct calculation for custom networks
-        long relativeNanos = useMainnetHelpers
-                ? instantToBlockTimeLong(targetInstant)
-                : Duration.between(genesisInstant, targetInstant).toNanos();
-        return getNearestBlockAfterTime(relativeNanos);
+        return getNearestBlockAfterTime(instantToBlockTimeLong(targetInstant));
     }
 
     @Override

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import org.hiero.block.api.BlockEnd;
 import org.hiero.block.api.BlockItemSet;
 import org.hiero.block.api.BlockNodeServiceInterface;
 import org.hiero.block.api.BlockStreamPublishServiceInterface;
@@ -363,6 +364,18 @@ public final class LiveBlockPushClient implements AutoCloseable {
                     PublishStreamRequest.newBuilder().blockItems(set).build();
             session.requestPipeline.onNext(req);
         }
+        // Emit the mandatory end_of_block message after the block's items. Without this, the BN's
+        // PublisherHandler stays "mid-block" for qb.blockNumber and never commits it — the next
+        // block's BlockHeader triggers PublisherHandler.handleBlockItemsRequest's mid-block guard,
+        // which fires blockIsEnding() and marks the block for resend. Every subsequent block
+        // repeats the pattern, producing the "Handler N is ending mid-block X" cascade with zero
+        // blocks ever persisted. See BlockStreamPublishService.PublishStreamRequest.oneof: the
+        // publish protocol requires exactly one end_of_block per block, distinct from the item
+        // batches that carry the BlockProof.
+        final BlockEnd endOfBlock =
+                BlockEnd.newBuilder().blockNumber(qb.blockNumber).build();
+        session.requestPipeline.onNext(
+                PublishStreamRequest.newBuilder().endOfBlock(endOfBlock).build());
         // Only increment `submitted` on the first send of a given block — reattempts after a
         // stream reconnect walk in-flight in ascending order, so a block <= the current high
         // watermark has already been counted.

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
@@ -143,6 +143,11 @@ public final class LiveBlockPushClient implements AutoCloseable {
      * mid-block — triggering an unbounded reconnect/SkipBlock loop where nothing ever persists
      * (see {@code #3374}).
      *
+     * <p><b>Empty-BN case:</b> a BN with no blocks advertises {@code lastAvailableBlock} as
+     * unsigned 64-bit max, which surfaces here as {@code -1L}. That is a legitimate
+     * "push everything from block 0" watermark for the producer's {@code blockNum > watermark}
+     * guard — not an error. Callers should not treat a negative return value as failure.
+     *
      * @throws QueryFailedException wrapping the underlying gRPC/network failure; the message
      *     names the {@code host:statusPort} that was tried
      */

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/push/LiveBlockPushClient.java
@@ -61,6 +61,7 @@ public final class LiveBlockPushClient implements AutoCloseable {
 
     private final String host;
     private final int port;
+    private final int statusPort;
     private final HelidonWebClientConfig webConfig;
     private final BlockingQueue<QueuedBlock> queue;
     private final long maxBatchBytes;
@@ -75,18 +76,36 @@ public final class LiveBlockPushClient implements AutoCloseable {
     private final AtomicLong streamReconnects = new AtomicLong();
 
     private Thread worker;
-    private WebClient cachedWebClient; // lazily created once and reused for every session
+    private WebClient cachedPublishWebClient; // lazily created for the publish stream
+    private WebClient cachedStatusWebClient; // lazily created for the BlockNodeService (status) queries
+
+    /**
+     * Same as {@link #LiveBlockPushClient(String, int, int, int, HelidonWebClientConfig)} with
+     * the status port defaulting to the publish port — the common single-port deployment.
+     */
+    public LiveBlockPushClient(
+            final String host, final int port, final int queueCapacity, final HelidonWebClientConfig webConfig) {
+        this(host, port, port, queueCapacity, webConfig);
+    }
 
     /**
      * @param host BN host
-     * @param port BN port (publish service)
+     * @param port BN publish-service port ({@code BlockStreamPublishService})
+     * @param statusPort BN block-node-service port ({@code BlockNodeService}) — different from
+     *     {@code port} in split-port deployments where per-API services listen on distinct ports;
+     *     equal to {@code port} in the common single-port deployment
      * @param queueCapacity backpressure queue size (blocks)
      * @param webConfig Helidon/gRPC tuning; uses {@code serverMaxMessageSizeBytes} for batching
      */
     public LiveBlockPushClient(
-            final String host, final int port, final int queueCapacity, final HelidonWebClientConfig webConfig) {
+            final String host,
+            final int port,
+            final int statusPort,
+            final int queueCapacity,
+            final HelidonWebClientConfig webConfig) {
         this.host = host;
         this.port = port;
+        this.statusPort = statusPort;
         this.webConfig = webConfig;
         this.queue = new ArrayBlockingQueue<>(Math.max(1, queueCapacity));
         this.maxBatchBytes = webConfig.serverMaxMessageSizeBytes();
@@ -114,10 +133,21 @@ public final class LiveBlockPushClient implements AutoCloseable {
         }
     }
 
-    /** Query the target BN once for its current {@code lastAvailableBlock}; returns -1 on error. */
-    public long queryLastAvailableBlock() {
+    /**
+     * Query the target BN once for its current {@code lastAvailableBlock}.
+     *
+     * <p>Throws instead of returning a sentinel: if the query fails the caller MUST NOT proceed
+     * with a made-up watermark. A stale/absent watermark causes the producer to push every block
+     * from 0, which the BN dedups with {@code EndOfStream(DUPLICATE_BLOCK)} and drops the stream
+     * mid-block — triggering an unbounded reconnect/SkipBlock loop where nothing ever persists
+     * (see {@code #3374}).
+     *
+     * @throws QueryFailedException wrapping the underlying gRPC/network failure; the message
+     *     names the {@code host:statusPort} that was tried
+     */
+    public long queryLastAvailableBlock() throws QueryFailedException {
         try {
-            final WebClient web = buildWebClient();
+            final WebClient web = buildStatusWebClient();
             final PbjGrpcClient pbj = new PbjGrpcClient(web, buildGrpcConfig());
             final BlockNodeServiceInterface.BlockNodeServiceClient client =
                     new BlockNodeServiceInterface.BlockNodeServiceClient(pbj, defaultOptions());
@@ -125,8 +155,20 @@ public final class LiveBlockPushClient implements AutoCloseable {
                     client.serverStatus(ServerStatusRequest.newBuilder().build());
             return resp.lastAvailableBlock();
         } catch (final Exception e) {
-            System.err.println("[push] queryLastAvailableBlock failed: " + e.getMessage());
-            return -1;
+            throw new QueryFailedException(host, statusPort, e);
+        }
+    }
+
+    /**
+     * Thrown when {@link #queryLastAvailableBlock()} cannot reach the BN's {@code
+     * BlockNodeService} on {@code host:statusPort}. Common causes: BN not running, wrong port
+     * (in split-port deployments the publish port and status port differ), or firewall.
+     */
+    public static final class QueryFailedException extends Exception {
+        QueryFailedException(final String host, final int statusPort, final Throwable cause) {
+            super("queryLastAvailableBlock failed against " + host + ":" + statusPort + " (" + cause.getMessage()
+                    + "); if the BN uses split ports, pass --push-bn-status-port for its BlockNodeService port");
+            initCause(cause);
         }
     }
 
@@ -382,31 +424,51 @@ public final class LiveBlockPushClient implements AutoCloseable {
 
     // ------- gRPC plumbing -------
 
+    /** Web client for the publish stream ({@code host:port}). Lazily cached. */
     private WebClient buildWebClient() {
-        if (cachedWebClient == null) {
-            final Duration timeout = Duration.ofMillis(webConfig.readTimeoutMillis());
-            final Tls tls = Tls.builder().enabled(false).build();
-            final Http2ClientProtocolConfig http2Config = Http2ClientProtocolConfig.builder()
-                    .flowControlBlockTimeout(Duration.ofMillis(webConfig.flowControlTimeoutMillis()))
-                    .initialWindowSize(webConfig.initialWindowSize())
-                    .maxFrameSize(webConfig.maxFrameSize())
-                    .maxHeaderListSize(webConfig.maxHeaderListSize())
-                    .ping(webConfig.pingEnabled())
-                    .pingTimeout(Duration.ofMillis(webConfig.pingTimeoutMillis()))
-                    .priorKnowledge(webConfig.priorKnowledge())
-                    .build();
-            final GrpcClientProtocolConfig grpcProtocolConfig = GrpcClientProtocolConfig.builder()
-                    .abortPollTimeExpired(false)
-                    .pollWaitTime(timeout)
-                    .build();
-            cachedWebClient = WebClient.builder()
-                    .baseUri("http://" + host + ":" + port)
-                    .tls(tls)
-                    .protocolConfigs(List.of(http2Config, grpcProtocolConfig))
-                    .connectTimeout(timeout)
-                    .build();
+        if (cachedPublishWebClient == null) {
+            cachedPublishWebClient = buildWebClientFor(port);
         }
-        return cachedWebClient;
+        return cachedPublishWebClient;
+    }
+
+    /**
+     * Web client for the BN status query ({@code host:statusPort}). Cached separately from the
+     * publish stream client because in split-port deployments the two services listen on
+     * different ports.
+     */
+    private WebClient buildStatusWebClient() {
+        if (statusPort == port) {
+            return buildWebClient();
+        }
+        if (cachedStatusWebClient == null) {
+            cachedStatusWebClient = buildWebClientFor(statusPort);
+        }
+        return cachedStatusWebClient;
+    }
+
+    private WebClient buildWebClientFor(final int targetPort) {
+        final Duration timeout = Duration.ofMillis(webConfig.readTimeoutMillis());
+        final Tls tls = Tls.builder().enabled(false).build();
+        final Http2ClientProtocolConfig http2Config = Http2ClientProtocolConfig.builder()
+                .flowControlBlockTimeout(Duration.ofMillis(webConfig.flowControlTimeoutMillis()))
+                .initialWindowSize(webConfig.initialWindowSize())
+                .maxFrameSize(webConfig.maxFrameSize())
+                .maxHeaderListSize(webConfig.maxHeaderListSize())
+                .ping(webConfig.pingEnabled())
+                .pingTimeout(Duration.ofMillis(webConfig.pingTimeoutMillis()))
+                .priorKnowledge(webConfig.priorKnowledge())
+                .build();
+        final GrpcClientProtocolConfig grpcProtocolConfig = GrpcClientProtocolConfig.builder()
+                .abortPollTimeExpired(false)
+                .pollWaitTime(timeout)
+                .build();
+        return WebClient.builder()
+                .baseUri("http://" + host + ":" + targetPort)
+                .tls(tls)
+                .protocolConfigs(List.of(http2Config, grpcProtocolConfig))
+                .connectTimeout(timeout)
+                .build();
     }
 
     private PbjGrpcClientConfig buildGrpcConfig() {

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/mirrornode/BlockTimeReaderTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/mirrornode/BlockTimeReaderTest.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -113,59 +112,12 @@ class BlockTimeReaderTest {
     }
 
     @Test
-    @DisplayName("Custom genesis uses direct calculations")
-    void customGenesis_usesDirectCalculations() throws IOException {
-        // Solo network with custom genesis (e.g., testnet reset in Feb 2024)
-        final Instant customGenesis = Instant.parse("2024-02-01T18:35:20.644859297Z");
-
-        // Create file with relative nanoseconds from custom genesis
-        final Path file = tempDir.resolve("block_times.bin");
-        final ByteBuffer buf = ByteBuffer.allocate(3 * Long.BYTES);
-        buf.putLong(0); // Block 0 at genesis
-        buf.putLong(Duration.ofSeconds(1).toNanos()); // Block 1 is 1 second after genesis
-        buf.putLong(Duration.ofSeconds(2).toNanos()); // Block 2 is 2 seconds after genesis
-        Files.write(file, buf.array());
-
-        try (BlockTimeReader reader = new BlockTimeReader(file, customGenesis)) {
-            // Block 0 should be at custom genesis
-            final Instant block0 = reader.getBlockInstant(0);
-            assertEquals(customGenesis, block0);
-
-            // Block 1 should be 1 second after custom genesis
-            final Instant block1 = reader.getBlockInstant(1);
-            assertEquals(customGenesis.plusSeconds(1), block1);
-
-            // Block 2 should be 2 seconds after custom genesis
-            final Instant block2 = reader.getBlockInstant(2);
-            assertEquals(customGenesis.plusSeconds(2), block2);
-        }
-    }
-
-    @Test
     @DisplayName("getBlockLocalDateTime works with mainnet genesis")
     void getBlockLocalDateTime_mainnetGenesis() throws IOException {
         final Path file = createBlockTimesFile(2);
         try (BlockTimeReader reader = new BlockTimeReader(file, FIRST_BLOCK_TIME_INSTANT)) {
             final LocalDateTime result = reader.getBlockLocalDateTime(0);
             assertEquals(FIRST_BLOCK_TIME_INSTANT.atZone(ZoneOffset.UTC).toLocalDateTime(), result);
-        }
-    }
-
-    @Test
-    @DisplayName("getBlockLocalDateTime works with custom genesis")
-    void getBlockLocalDateTime_customGenesis() throws IOException {
-        final Instant customGenesis = Instant.parse("2024-02-01T18:35:20.644859297Z");
-
-        final Path file = tempDir.resolve("block_times.bin");
-        final ByteBuffer buf = ByteBuffer.allocate(Long.BYTES);
-        buf.putLong(Duration.ofHours(1).toNanos()); // 1 hour after genesis
-        Files.write(file, buf.array());
-
-        try (BlockTimeReader reader = new BlockTimeReader(file, customGenesis)) {
-            final LocalDateTime result = reader.getBlockLocalDateTime(0);
-            final LocalDateTime expected =
-                    customGenesis.plusSeconds(3600).atZone(ZoneOffset.UTC).toLocalDateTime();
-            assertEquals(expected, result);
         }
     }
 
@@ -179,28 +131,6 @@ class BlockTimeReaderTest {
                     .plusMillis(2500)
                     .atZone(ZoneOffset.UTC)
                     .toLocalDateTime();
-            final long blockIndex = reader.getNearestBlockAfterTime(targetTime);
-            assertEquals(3, blockIndex);
-        }
-    }
-
-    @Test
-    @DisplayName("getNearestBlockAfterTime with custom genesis uses direct calculations")
-    void getNearestBlockAfterTime_customGenesis() throws IOException {
-        final Instant customGenesis = Instant.parse("2024-02-01T18:35:20.644859297Z");
-
-        // Create blocks at 0s, 10s, 20s, 30s, 40s after custom genesis
-        final Path file = tempDir.resolve("block_times.bin");
-        final ByteBuffer buf = ByteBuffer.allocate(5 * Long.BYTES);
-        for (int i = 0; i < 5; i++) {
-            buf.putLong(Duration.ofSeconds(i * 10).toNanos());
-        }
-        Files.write(file, buf.array());
-
-        try (BlockTimeReader reader = new BlockTimeReader(file, customGenesis)) {
-            // Search for time 25 seconds after custom genesis - should return block 3 (at 30s)
-            final LocalDateTime targetTime =
-                    customGenesis.plusSeconds(25).atZone(ZoneOffset.UTC).toLocalDateTime();
             final long blockIndex = reader.getNearestBlockAfterTime(targetTime);
             assertEquals(3, blockIndex);
         }
@@ -225,43 +155,6 @@ class BlockTimeReaderTest {
         try (BlockTimeReader reader = new BlockTimeReader(file)) {
             final Instant block0 = reader.getBlockInstant(0);
             assertEquals(FIRST_BLOCK_TIME_INSTANT, block0);
-        }
-    }
-
-    @Test
-    @DisplayName("Constructor with NetworkConfig uses correct genesis")
-    void constructorWithNetworkConfig_usesCorrectGenesis() throws IOException {
-        // Create testnet block times
-        final Instant testnetGenesis = Instant.parse("2024-02-01T18:35:20.644859297Z");
-        final Path file = tempDir.resolve("block_times.bin");
-        final ByteBuffer buf = ByteBuffer.allocate(2 * Long.BYTES);
-        buf.putLong(0); // Block 0 at genesis
-        buf.putLong(Duration.ofHours(1).toNanos()); // Block 1 is 1 hour after
-        Files.write(file, buf.array());
-
-        try (BlockTimeReader reader = new BlockTimeReader(file, NetworkConfig.testnet())) {
-            final Instant block0 = reader.getBlockInstant(0);
-            assertEquals(testnetGenesis, block0);
-
-            final Instant block1 = reader.getBlockInstant(1);
-            assertEquals(testnetGenesis.plusSeconds(3600), block1);
-        }
-    }
-
-    @Test
-    @DisplayName("Constructor with NetworkConfig uses correct genesis")
-    void constructorWithNetworkConfig_testnet() throws IOException {
-        final Instant testnetGenesis = Instant.parse("2024-02-01T18:35:20.644859297Z");
-
-        final Path file = tempDir.resolve("block_times.bin");
-        final ByteBuffer buf = ByteBuffer.allocate(Long.BYTES);
-        buf.putLong(0);
-        Files.write(file, buf.array());
-
-        // Directly pass testnet config to avoid NetworkConfig.current() state issues
-        try (BlockTimeReader reader = new BlockTimeReader(file, NetworkConfig.testnet())) {
-            final Instant block0 = reader.getBlockInstant(0);
-            assertEquals(testnetGenesis, block0);
         }
     }
 

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/push/LiveBlockPushClientTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/push/LiveBlockPushClientTest.java
@@ -3,6 +3,7 @@ package org.hiero.block.tools.push;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,9 +29,24 @@ class LiveBlockPushClientTest {
     /** Port 1 is reserved and effectively always refuses TCP connections — used as an unreachable target. */
     private static final int UNREACHABLE_PORT = 1;
 
+    /**
+     * A second reserved/unreachable port, distinct from {@link #UNREACHABLE_PORT}, so a split-port
+     * test can tell which of the two client URIs the code actually contacted.
+     */
+    private static final int UNREACHABLE_STATUS_PORT = 7;
+
     private static LiveBlockPushClient newClient(final int queueCapacity) {
         return new LiveBlockPushClient(
                 "127.0.0.1", UNREACHABLE_PORT, queueCapacity, LiveBlockPushClient.loadDefaultWebConfig());
+    }
+
+    private static LiveBlockPushClient newSplitPortClient(final int queueCapacity) {
+        return new LiveBlockPushClient(
+                "127.0.0.1",
+                UNREACHABLE_PORT,
+                UNREACHABLE_STATUS_PORT,
+                queueCapacity,
+                LiveBlockPushClient.loadDefaultWebConfig());
     }
 
     @Nested
@@ -112,6 +128,30 @@ class LiveBlockPushClientTest {
                         msg.contains("127.0.0.1") && msg.contains(":1"),
                         "Message must name the host:port that was tried so a port mismatch is diagnosable; was: "
                                 + msg);
+            }
+        }
+
+        @Test
+        @DisplayName("queryLastAvailableBlock() uses the status port, not the publish port, in split-port mode")
+        @Timeout(60)
+        void queryUsesStatusPortInSplitPortMode() {
+            // Publish port = 1, status port = 7 — both unreachable, distinct so the message
+            // uniquely identifies which URI the query actually contacted. Guards against a
+            // regression in buildStatusWebClient()/statusPort routing that would otherwise
+            // silently query the publish port and only surface in production against real BNs.
+            try (final LiveBlockPushClient client = newSplitPortClient(8)) {
+                final QueryFailedException thrown =
+                        assertThrows(QueryFailedException.class, client::queryLastAvailableBlock);
+                final String msg = thrown.getMessage();
+                assertTrue(
+                        msg.contains(":" + UNREACHABLE_STATUS_PORT),
+                        "Message must name the STATUS port (" + UNREACHABLE_STATUS_PORT
+                                + ") the query targets — otherwise the split-port routing is broken; was: "
+                                + msg);
+                assertFalse(
+                        msg.contains(":" + UNREACHABLE_PORT + ")") || msg.contains(":" + UNREACHABLE_PORT + " "),
+                        "Message must NOT name the publish port (" + UNREACHABLE_PORT
+                                + ") — that would mean the query went to the wrong port; was: " + msg);
             }
         }
     }

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/push/LiveBlockPushClientTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/push/LiveBlockPushClientTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.hapi.block.stream.Block;
 import org.hiero.block.tools.config.HelidonWebClientConfig;
+import org.hiero.block.tools.push.LiveBlockPushClient.QueryFailedException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -98,12 +99,19 @@ class LiveBlockPushClientTest {
     class UnreachableBn {
 
         @Test
-        @DisplayName("queryLastAvailableBlock() returns -1 when the BN is unreachable")
+        @DisplayName("queryLastAvailableBlock() throws QueryFailedException when the BN is unreachable")
         @Timeout(60)
-        void queryReturnsMinusOneOnUnreachable() {
+        void queryThrowsOnUnreachable() {
             try (final LiveBlockPushClient client = newClient(8)) {
-                final long result = client.queryLastAvailableBlock();
-                assertEquals(-1L, result, "Expected sentinel -1 when BN is unreachable");
+                final QueryFailedException thrown = assertThrows(
+                        QueryFailedException.class,
+                        client::queryLastAvailableBlock,
+                        "Expected QueryFailedException when BN is unreachable (silent -1 return caused #3374)");
+                final String msg = thrown.getMessage();
+                assertTrue(
+                        msg.contains("127.0.0.1") && msg.contains(":1"),
+                        "Message must name the host:port that was tried so a port mismatch is diagnosable; was: "
+                                + msg);
             }
         }
     }


### PR DESCRIPTION
Fixes #3374.

## Summary

Three CLI-side fixes that together make `LiveSequential --push-enabled` actually push blocks in steady state against a real Block Node (single-port or split-port). Each was independently observed on previewnet during validation.

## Fix 1 `LiveBlockPushClient`: fail-fast on serverStatus query failure + `--push-bn-status-port`

**Root cause:** `queryLastAvailableBlock()` returned `-1` on any failure (unreachable BN, port mismatch, gRPC error). The caller stored that sentinel into `pushSkipUpToInclusive`. The producer's `blockNum > pushSkipUpToInclusive` guard then treated `-1` as "push everything from block 0" — flooding a seeded BN with duplicates, triggering the `DUPLICATE_BLOCK` → reconnect → `SkipBlock("another publisher")` loop from the issue.

**Changes:**
- `queryLastAvailableBlock()` throws a new `QueryFailedException` (with the exact `host:statusPort` and a split-port hint) instead of returning `-1`.
- `LiveSequential` aborts startup on `QueryFailedException` with a clear message, and rejects a negative watermark as defense-in-depth.
- New `--push-bn-status-port` flag — the BN's `BlockNodeService` (which owns `serverStatus`) can live on a different port than `BlockStreamPublishService` in split-port deployments (previewnet: publish=40984, status=40982). Defaults to `--push-bn-port`. `LiveBlockPushClient` constructor now takes an optional `statusPort`; two `WebClient`s are cached, one per URI. Existing 4-arg constructor delegates with `statusPort = port`.

## Fix 2 `BlockTimeReader`: always decode `block_times.bin` relative to mainnet genesis

**Root cause:** `block_times.bin` always encodes values as nanoseconds since mainnet genesis via `instantToBlockTimeLong`, regardless of network. The non-mainnet decode path (`genesisInstant.plusNanos`) was adding a second network-genesis offset, shifting all block times forward by the gap between mainnet and the target network genesis (~4 years for testnet, ~6.6 years for previewnet). This is what caused the tool to think block 0 lived in the far future and refuse to process any day tars.

**Changes:** always use `blockTimeLongToInstant` / `instantToBlockTimeLong` for encode and decode. Removes the now-dead `useMainnetHelpers` flag.

## Fix 3 `LiveBlockPushClient`: emit mandatory `end_of_block` after each block's items

**Root cause:** the publish protocol requires a distinct `PublishStreamRequest.end_of_block` (`BlockEnd{blockNumber=N}`) message to commit block N. `sendBlock` was only sending `blockItems` batches. Without the explicit `end_of_block`, the BN's `PublisherHandler` stays "mid-block" for N; when the next block's `BlockHeader` arrives, `handleBlockItemsRequest:427` fires `publisherManager.blockIsEnding(N, handlerId)`, marks N for resend, and starts N+1. Every subsequent block repeats the pattern.

This surfaced *after* Fix 1 got the tool past the initial `DUPLICATE_BLOCK` cascade — steady-state push produced the `Handler N is ending mid-block X` burst pattern on previewnet with zero blocks ever persisted.

**Changes:** emit `PublishStreamRequest(end_of_block = BlockEnd{blockNumber = qb.blockNumber})` after all item batches for a block.

## Test plan

- [x] `./gradlew :tools:test --tests LiveBlockPushClientTest` — green. Existing `queryReturnsMinusOneOnUnreachable` case replaced by `queryThrowsOnUnreachable` asserting `QueryFailedException` + host:port in the message.
- [x] `./gradlew spotlessApply` clean.
- [x] Smoke-tested end-to-end on previewnet: Fix 1 aborted cleanly against wrong port (previously would have looped forever); after passing `--push-bn-status-port 40982` the tool reached steady-state push. Fix 2 unblocked wrap on testnet with corrected block-time decoding. Fix 3 identified by observing `Handler N ending mid-block X` bursts even after Fix 1 landed.
- [ ] Full CI green.


###

```

harpender@previewnet-wrapper:~$ kubectl logs -n block-node block-node-block-node-server-0 --since=10m 2>&1 | \
    grep -iE 'block.*complete|block.*persisted|block.*acked' | tail -20
2026-08-19 03:11:57.057+0000 FINE    [org.hiero.block.node.messaging.BlockMessagingFacilityImpl lambda$sendBlockPersisted$0] Sending block persisted notification: block=1,083,289 succeeded=true source=PUBLISHER
2026-08-19 03:11:57.057+0000 FINE    [org.hiero.block.node.stream.publisher.LiveStreamPublisherManager closeBlock] Completed blocks 9,287
2026-08-19 03:11:57.059+0000 FINE    [org.hiero.block.node.stream.publisher.LiveStreamPublisherManager closeBlock] Completed blocks 9,288
2026-08-19 03:11:57.060+0000 FINE    [org.hiero.block.node.messaging.BlockMessagingFacilityImpl lambda$sendBlockPersisted$0] Sending block persisted notification: block=1,083,290 succeeded=true source=PUBLISHER
2026-08-19 03:11:57.070+0000 FINE    [org.hiero.block.node.messaging.BlockMessagingFacilityImpl lambda$sendBlockPersisted$0] Sending block persisted notification: block=1,083,291 succeeded=true source=PUBLISHER
2026-08-19 03:11:57.080+0000 FINE    [org.hiero.block.node.messaging.BlockMessagingFacilityImpl lambda$sendBlockPersisted$0] Sending block persisted notification: block=1,083,292 succeeded=true source=PUBLISHER
2026-08-19 03:11:57.090+0000 FINE    [org.hiero.block.node.messaging.BlockMessagingFacilityImpl lambda$sendBlockPersisted$0] Sending block persisted notification: block=1,083,293 succeeded=true source=PUBLISHER
2026-08-19 03:11:57.100+0000 FINE    [org.hiero.block.node.messaging.BlockMessagingFacilityImpl lambda$sendBlockPersisted$0] Sending block persisted notification: block=1,083,294 succeeded=true source=PUBLISHER
2026-08-19 03:11:57.191+0000 FINE    [org.hiero.block.node.stream.publisher.LiveStreamPublisherManager closeBlock] Completed blocks 9,289
2026-08-19 03:11:57.194+0000 FINE    [org.hiero.block.node.stream.publisher.LiveStreamPublisherManager closeBlock] Completed blocks 9,290
2026-08-19 03:11:57.195+0000 FINE    [org.hiero.block.node.messaging.BlockMessagingFacilityImpl lambda$sendBlockPersisted$0] Sending block persisted notification: block=1,083,295 succeeded=true source=PUBLISHER
2026-08-19 03:11:57.196+0000 FINE    [org.hiero.block.node.stream.publisher.LiveStreamPublisherManager closeBlock] Completed blocks 9,291
2026-08-19 03:11:57.198+0000 FINE    [org.hiero.block.node.stream.publisher.LiveStreamPublisherManager closeBlock] Completed blocks 9,292
2026-08-19 03:11:57.199+0000 FINE    [org.hiero.block.node.messaging.BlockMessagingFacilityImpl lambda$sendBlockPersisted$0] Sending block persisted notification: block=1,083,296 succeeded=true source=PUBLISHER
2026-08-19 03:11:57.200+0000 FINE    [org.hiero.block.node.stream.publisher.LiveStreamPublisherManager closeBlock] Completed blocks 9,293
2026-08-19 03:11:57.206+0000 FINE    [org.hiero.block.node.messaging.BlockMessagingFacilityImpl lambda$sendBlockPersisted$0] Sending block persisted notification: block=1,083,297 succeeded=true source=PUBLISHER
2026-08-19 03:11:57.216+0000 FINE    [org.hiero.block.node.messaging.BlockMessagingFacilityImpl lambda$sendBlockPersisted$0] Sending block persisted notification: block=1,083,298 succeeded=true source=PUBLISHER
2026-08-19 03:11:57.226+0000 FINE    [org.hiero.block.node.messaging.BlockMessagingFacilityImpl lambda$sendBlockPersisted$0] Sending block persisted notification: block=1,083,299 succeeded=true source=PUBLISHER
2026-08-19 03:11:57.239+0000 FINE    [org.hiero.block.node.stream.publisher.LiveStreamPublisherManager closeBlock] Completed blocks 9,294
2026-08-19 03:11:57.245+0000 FINE    [org.hiero.block.node.messaging.BlockMessagingFacilityImpl lambda$sendBlockPersisted$0] Sending block persisted notification: block=1,083,300 succeeded=true source=PUBLISHER
harpender@previewnet-wrapper:~$

```


BN Status calls:


```

harpender@previewnet-wrapper:~$ ./bn-status.sh
Forwarding from 127.0.0.1:18082 -> 40982
Forwarding from [::1]:18082 -> 40982
Handling connection for 18082
{
  "lastAvailableBlock": "1083890",
  "onlyLatestState": true,
  "nextExpectedBlock": "1083891"
}
harpender@previewnet-wrapper:~$ ./bn-status.sh
Forwarding from 127.0.0.1:18082 -> 40982
Forwarding from [::1]:18082 -> 40982
Handling connection for 18082
{
  "lastAvailableBlock": "1084028",
  "onlyLatestState": true,
  "nextExpectedBlock": "1084030"
}
harpender@previewnet-wrapper:~$
```