### PR TITLE
fix(release): alpha version derivation fails on first alpha for a new base version

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -83,12 +83,13 @@ jobs:
 
             # grep exits 1 when no alpha tags exist yet (first alpha for this base
             # version). With set -eo pipefail that would kill the script before the
-            # ${HIGHEST_ALPHA:-0} fallback is reached. || true absorbs the non-zero
-            # exit so an empty result is treated as counter = 0 → alpha1.
+            # ${HIGHEST_ALPHA:-0} fallback is reached. || true is scoped to grep only
+            # so an empty result is treated as counter = 0 → alpha1, while real
+            # failures from gh api/sed/sort still fail the pipeline via pipefail.
             HIGHEST_ALPHA=$(gh api "repos/${{ github.repository }}/tags" --paginate --jq '.[].name' \
-              | grep -E "^v${BASE}-alpha[0-9]+$" \
+              | { grep -E "^v${BASE}-alpha[0-9]+$" || true; } \
               | sed -E "s/^v${BASE}-alpha//" \
-              | sort -n | tail -1 || true)
+              | sort -n | tail -1)
             COMPUTED_VERSION="${BASE}-alpha$(( ${HIGHEST_ALPHA:-0} + 1 ))"
           else
             # Read version.txt from the dispatching branch — no checkout needed yet.

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -81,10 +81,14 @@ jobs:
               exit 1
             fi
 
+            # grep exits 1 when no alpha tags exist yet (first alpha for this base
+            # version). With set -eo pipefail that would kill the script before the
+            # ${HIGHEST_ALPHA:-0} fallback is reached. || true absorbs the non-zero
+            # exit so an empty result is treated as counter = 0 → alpha1.
             HIGHEST_ALPHA=$(gh api "repos/${{ github.repository }}/tags" --paginate --jq '.[].name' \
               | grep -E "^v${BASE}-alpha[0-9]+$" \
               | sed -E "s/^v${BASE}-alpha//" \
-              | sort -n | tail -1)
+              | sort -n | tail -1 || true)
             COMPUTED_VERSION="${BASE}-alpha$(( ${HIGHEST_ALPHA:-0} + 1 ))"
           else
             # Read version.txt from the dispatching branch — no checkout needed yet.


### PR DESCRIPTION
## Summary

- Fixes `grep` pipefail killing the "Compute Release Version" step when no prior alpha tags exist for the current base version
- Adds `|| true` so a zero-match result produces an empty `HIGHEST_ALPHA`, allowing the `${HIGHEST_ALPHA:-0}` default to compute the correct `alpha1` counter

Closes #3447

## Root Cause

`set -eo pipefail` propagates `grep`'s exit code 1 (no matches found) through the pipeline, terminating the script before the `${HIGHEST_ALPHA:-0}` fallback is reached. Observed failure: https://github.com/hiero-ledger/hiero-block-node/actions/runs/32034528518/job/95401738368

## Test Plan

- [ ] Trigger an alpha release on main when no prior `v<base>-alpha*` tags exist → should compute `alpha1` instead of failing
- [ ] Trigger a second alpha release → should compute `alpha2` (existing path, still works)
