### PR TITLE
test(simulator): lastKnownStatuses deques are not thread-safe, causing NPE flakes in e2e suites

### DIFF
--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/ConsumerStreamGrpcClientImpl.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/ConsumerStreamGrpcClientImpl.java
@@ -8,9 +8,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
-import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.CountDownLatch;
 import javax.inject.Inject;
 import org.hiero.block.api.protoc.BlockStreamSubscribeServiceGrpc;
@@ -64,7 +64,7 @@ public class ConsumerStreamGrpcClientImpl implements ConsumerStreamGrpcClient {
         this.metricsService = requireNonNull(metricsService);
         this.consumerConfig = requireNonNull(consumerConfig);
         this.lastKnownStatusesCapacity = blockStreamConfig.lastKnownStatusesCapacity();
-        this.lastKnownStatuses = new ArrayDeque<>(lastKnownStatusesCapacity);
+        this.lastKnownStatuses = new ConcurrentLinkedDeque<>();
     }
 
     @Override

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
@@ -13,10 +13,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
-import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import javax.inject.Inject;
@@ -83,7 +83,7 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
         this.metricsService = requireNonNull(metricsService);
         this.streamEnabled = requireNonNull(streamEnabled);
         this.lastKnownStatusesCapacity = blockStreamConfig.lastKnownStatusesCapacity();
-        this.lastKnownStatuses = new ArrayDeque<>(this.lastKnownStatusesCapacity);
+        this.lastKnownStatuses = new ConcurrentLinkedDeque<>();
         this.startupData = requireNonNull(startupData);
         this.publishStreamObserver =
                 new PublishStreamObserver(startupData, streamEnabled, lastKnownStatuses, lastKnownStatusesCapacity);

--- a/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcServerImpl.java
+++ b/tools-and-tests/simulator/src/main/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcServerImpl.java
@@ -10,9 +10,9 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import javax.inject.Inject;
 import org.hiero.block.api.protoc.BlockStreamPublishServiceGrpc;
 import org.hiero.block.api.protoc.PublishStreamRequest;
@@ -61,7 +61,7 @@ public class PublishStreamGrpcServerImpl implements PublishStreamGrpcServer {
         this.metricsService = requireNonNull(metricsService);
 
         this.lastKnownStatusesCapacity = blockStreamConfig.lastKnownStatusesCapacity();
-        lastKnownStatuses = new ArrayDeque<>(this.lastKnownStatusesCapacity);
+        lastKnownStatuses = new ConcurrentLinkedDeque<>();
     }
 
     /**

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/ConsumerStreamGrpcClientImplTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/ConsumerStreamGrpcClientImplTest.java
@@ -2,6 +2,7 @@
 package org.hiero.block.simulator.grpc.impl;
 
 import static org.hiero.block.simulator.fixtures.TestUtils.findFreePort;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,6 +16,11 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.hiero.block.api.protoc.BlockEnd;
 import org.hiero.block.api.protoc.BlockItemSet;
 import org.hiero.block.api.protoc.BlockStreamSubscribeServiceGrpc;
@@ -152,6 +158,40 @@ public class ConsumerStreamGrpcClientImplTest {
 
         assertThrows(
                 IllegalArgumentException.class, () -> consumerStreamGrpcClientImpl.requestBlocks(startBlock, endBlock));
+    }
+
+    /**
+     * Regression test for concurrent access to lastKnownStatuses. The gRPC callback thread
+     * appends statuses while another thread snapshots them via getLastKnownStatuses(). With
+     * a non-thread-safe deque the snapshot can observe a torn toArray() containing null
+     * slots and List.copyOf throws NullPointerException.
+     */
+    @Test
+    void getLastKnownStatuses_ConcurrentMutation() {
+        final long startBlock = 0;
+        final long endBlock = 500;
+        final AtomicBoolean consumptionDone = new AtomicBoolean(false);
+        final ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            final Future<?> consumerFuture = executor.submit(() -> {
+                try {
+                    consumerStreamGrpcClientImpl.requestBlocks(startBlock, endBlock);
+                } finally {
+                    consumptionDone.set(true);
+                }
+                return null;
+            });
+            final Future<?> readerFuture = executor.submit(() -> {
+                while (!consumptionDone.get()) {
+                    consumerStreamGrpcClientImpl.getLastKnownStatuses();
+                }
+                return null;
+            });
+            assertDoesNotThrow(() -> consumerFuture.get(30, TimeUnit.SECONDS));
+            assertDoesNotThrow(() -> readerFuture.get(30, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     @Test

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 import com.google.protobuf.ByteString;
@@ -27,7 +29,12 @@ import io.grpc.stub.StreamObserver;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.hiero.block.api.protoc.BlockItemSet;
@@ -411,6 +418,49 @@ class PublishStreamGrpcClientImplTest {
         publishStreamGrpcClient.init();
         Thread.sleep(200);
         assertFalse(server.isShutdown());
+    }
+
+    /**
+     * Regression test for concurrent access to lastKnownStatuses. The gRPC callback thread
+     * appends acknowledgement statuses while another thread snapshots them via
+     * getLastKnownStatuses(). With a non-thread-safe deque the snapshot can observe a torn
+     * toArray() containing null slots and List.copyOf throws NullPointerException.
+     */
+    @Test
+    void testGetLastKnownStatusesWithConcurrentMutation() throws IOException {
+        final int streamedBlocks = 200;
+        final AtomicLong lastAckedBlock = new AtomicLong(-1L);
+        // The observer reports every acknowledgement to the startup data before appending the
+        // status, so the reader can keep snapshotting until the last mutation is in flight.
+        doAnswer(invocation -> {
+                    lastAckedBlock.set(invocation.getArgument(0));
+                    return null;
+                })
+                .when(startupDataMock)
+                .updateLatestAckBlockStartupData(anyLong());
+
+        publishStreamGrpcClient.init();
+        final Consumer<PublishStreamResponse> publishStreamResponseConsumer = response -> {};
+        final ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            final Future<?> writerFuture = executor.submit(() -> {
+                for (int i = 0; i < streamedBlocks; i++) {
+                    publishStreamGrpcClient.streamBlock(constructBlock(i, false), publishStreamResponseConsumer);
+                }
+                return null;
+            });
+            final Future<?> readerFuture = executor.submit(() -> {
+                final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+                while (lastAckedBlock.get() < streamedBlocks - 1 && System.nanoTime() < deadline) {
+                    publishStreamGrpcClient.getLastKnownStatuses();
+                }
+                return null;
+            });
+            assertDoesNotThrow(() -> writerFuture.get(30, TimeUnit.SECONDS));
+            assertDoesNotThrow(() -> readerFuture.get(60, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     private Block constructBlock(long number, boolean withItems) {

--- a/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcServerImplTest.java
+++ b/tools-and-tests/simulator/src/test/java/org/hiero/block/simulator/grpc/impl/PublishStreamGrpcServerImplTest.java
@@ -2,6 +2,7 @@
 package org.hiero.block.simulator.grpc.impl;
 
 import static org.hiero.block.simulator.fixtures.TestUtils.findFreePort;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -17,7 +18,11 @@ import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.hiero.block.api.protoc.BlockItemSet;
 import org.hiero.block.api.protoc.BlockStreamPublishServiceGrpc;
 import org.hiero.block.api.protoc.PublishStreamRequest;
@@ -144,6 +149,72 @@ class PublishStreamGrpcServerImplTest {
         List<String> statuses = publishStreamGrpcServer.getLastKnownStatuses();
         assertFalse(statuses.isEmpty());
         assertEquals(3, publishStreamGrpcServer.getProcessedBlocks());
+    }
+
+    /**
+     * Regression test for concurrent access to lastKnownStatuses. The gRPC server thread
+     * appends request statuses while another thread snapshots them via
+     * getLastKnownStatuses(). With a non-thread-safe deque the snapshot can observe a torn
+     * toArray() containing null slots and List.copyOf throws NullPointerException.
+     */
+    @Test
+    void testGetLastKnownStatusesWithConcurrentMutation() throws InterruptedException {
+        final int streamedBlocks = 500;
+        final CountDownLatch completionLatch = new CountDownLatch(1);
+        final AtomicBoolean publishingDone = new AtomicBoolean(false);
+
+        final BlockStreamPublishServiceGrpc.BlockStreamPublishServiceStub stub =
+                BlockStreamPublishServiceGrpc.newStub(channel);
+        final StreamObserver<PublishStreamResponse> responseObserver = new StreamObserver<>() {
+            @Override
+            public void onNext(PublishStreamResponse response) {
+                // No verification needed, the test only exercises concurrent status access
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                completionLatch.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+                completionLatch.countDown();
+            }
+        };
+
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            final Future<?> readerFuture = executor.submit(() -> {
+                while (!publishingDone.get()) {
+                    publishStreamGrpcServer.getLastKnownStatuses();
+                }
+                return null;
+            });
+
+            final StreamObserver<PublishStreamRequest> requestObserver = stub.publishBlockStream(responseObserver);
+            for (int i = 0; i < streamedBlocks; i++) {
+                final BlockItem blockItemHeader = BlockItem.newBuilder()
+                        .setBlockHeader(BlockHeader.newBuilder().setNumber(i).build())
+                        .build();
+                final BlockItem blockItemProof = BlockItem.newBuilder()
+                        .setBlockProof(BlockProof.newBuilder().setBlock(i).build())
+                        .build();
+                final BlockItemSet blockItems = BlockItemSet.newBuilder()
+                        .addBlockItems(blockItemHeader)
+                        .addBlockItems(blockItemProof)
+                        .build();
+                requestObserver.onNext(PublishStreamRequest.newBuilder()
+                        .setBlockItems(blockItems)
+                        .build());
+            }
+            requestObserver.onCompleted();
+
+            assertTrue(completionLatch.await(30, TimeUnit.SECONDS));
+            publishingDone.set(true);
+            assertDoesNotThrow(() -> readerFuture.get(30, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     @Test

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/BaseSuite.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.suites;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
@@ -9,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -16,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Stream;
 import org.hiero.block.api.protoc.BlockAccessServiceGrpc;
 import org.hiero.block.api.protoc.BlockNodeServiceGrpc;
@@ -426,6 +430,32 @@ public abstract class BaseSuite {
                 throw new RuntimeException(e);
             }
         });
+    }
+
+    /**
+     * Polls the given condition until it becomes true, sleeping briefly between polls. Fails the
+     * calling test if the condition is not met within the timeout, so a dead counterpart (for
+     * example a simulator that never produced a status) fails fast instead of spinning until the
+     * CI job times out.
+     *
+     * @param condition the condition to poll
+     * @param timeout the maximum time to wait for the condition
+     */
+    protected static void waitFor(final BooleanSupplier condition, final Duration timeout) {
+        final long deadline = System.nanoTime() + timeout.toNanos();
+        boolean conditionMet = condition.getAsBoolean();
+        while (!conditionMet && System.nanoTime() < deadline) {
+            try {
+                Thread.sleep(50L);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                fail("Interrupted while waiting for condition", e);
+            }
+            conditionMet = condition.getAsBoolean();
+        }
+        if (!conditionMet) {
+            fail("Condition not met within %s".formatted(timeout));
+        }
     }
 
     /**

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/subscriber/negative/NegativeSingleSubscriberTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/subscriber/negative/NegativeSingleSubscriberTests.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,9 @@ import org.junit.jupiter.api.Test;
  */
 @DisplayName("Negative Single Subscriber Tests")
 public class NegativeSingleSubscriberTests extends BaseSuite {
+    /** Bounds every status poll so a dead simulator fails the test instead of spinning forever. */
+    private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(30);
+
     private final List<Future<?>> simulators = new ArrayList<>();
     private final List<BlockStreamSimulatorApp> simulatorAppsRef = new ArrayList<>();
 
@@ -81,20 +85,15 @@ public class NegativeSingleSubscriberTests extends BaseSuite {
         // ===== Start consumer and try to request blocks ===========================================
         final Future<?> consumerSimulatorThread = startSimulatorInThread(consumerSimulator);
         simulators.add(consumerSimulatorThread);
-        String consumerStatus = "";
-        long consumedBlocks = -1L;
-        while (consumerStatus.isEmpty()) {
-            if (!consumerSimulator
-                    .getStreamStatus()
-                    .lastKnownConsumersStatuses()
-                    .isEmpty()) {
-                consumerStatus = consumerSimulator
+        waitFor(
+                () -> !consumerSimulator
                         .getStreamStatus()
                         .lastKnownConsumersStatuses()
-                        .getLast();
-                consumedBlocks = consumerSimulator.getStreamStatus().consumedBlocks();
-            }
-        }
+                        .isEmpty(),
+                WAIT_TIMEOUT);
+        final String consumerStatus =
+                consumerSimulator.getStreamStatus().lastKnownConsumersStatuses().getLast();
+        final long consumedBlocks = consumerSimulator.getStreamStatus().consumedBlocks();
 
         assertTrue(consumerStatus.contains("INVALID_END_BLOCK_NUMBER"));
         assertEquals(0L, consumedBlocks);
@@ -130,20 +129,15 @@ public class NegativeSingleSubscriberTests extends BaseSuite {
         // ===== Start consumer and try to request blocks ===========================================
         final Future<?> consumerSimulatorThread = startSimulatorInThread(consumerSimulator);
         simulators.add(consumerSimulatorThread);
-        String consumerStatus = "";
-        long consumedBlocks = -1L;
-        while (consumerStatus.isEmpty()) {
-            if (!consumerSimulator
-                    .getStreamStatus()
-                    .lastKnownConsumersStatuses()
-                    .isEmpty()) {
-                consumerStatus = consumerSimulator
+        waitFor(
+                () -> !consumerSimulator
                         .getStreamStatus()
                         .lastKnownConsumersStatuses()
-                        .getLast();
-                consumedBlocks = consumerSimulator.getStreamStatus().consumedBlocks();
-            }
-        }
+                        .isEmpty(),
+                WAIT_TIMEOUT);
+        final String consumerStatus =
+                consumerSimulator.getStreamStatus().lastKnownConsumersStatuses().getLast();
+        final long consumedBlocks = consumerSimulator.getStreamStatus().consumedBlocks();
 
         assertTrue(consumerStatus.contains("INVALID_START_BLOCK_NUMBER"));
         assertEquals(0L, consumedBlocks);
@@ -179,20 +173,15 @@ public class NegativeSingleSubscriberTests extends BaseSuite {
         // ===== Start consumer and try to request blocks ===========================================
         final Future<?> consumerSimulatorThread = startSimulatorInThread(consumerSimulator);
         simulators.add(consumerSimulatorThread);
-        String consumerStatus = "";
-        long consumedBlocks = -1L;
-        while (consumerStatus.isEmpty()) {
-            if (!consumerSimulator
-                    .getStreamStatus()
-                    .lastKnownConsumersStatuses()
-                    .isEmpty()) {
-                consumerStatus = consumerSimulator
+        waitFor(
+                () -> !consumerSimulator
                         .getStreamStatus()
                         .lastKnownConsumersStatuses()
-                        .getLast();
-                consumedBlocks = consumerSimulator.getStreamStatus().consumedBlocks();
-            }
-        }
+                        .isEmpty(),
+                WAIT_TIMEOUT);
+        final String consumerStatus =
+                consumerSimulator.getStreamStatus().lastKnownConsumersStatuses().getLast();
+        final long consumedBlocks = consumerSimulator.getStreamStatus().consumedBlocks();
 
         assertTrue(consumerStatus.contains("INVALID_END_BLOCK_NUMBER"));
         assertEquals(0L, consumedBlocks);
@@ -272,15 +261,15 @@ public class NegativeSingleSubscriberTests extends BaseSuite {
 
         final Future<?> simulatorThread = startSimulatorInThread(simulator);
         simulators.add(simulatorThread);
-        String simulatorStatus = null;
-        while (simulator.getStreamStatus().lastKnownPublisherClientStatuses().size() < statusesRequired) {
-            if (!simulator.getStreamStatus().lastKnownPublisherClientStatuses().isEmpty()) {
-                simulatorStatus = simulator
-                        .getStreamStatus()
-                        .lastKnownPublisherClientStatuses()
-                        .getLast();
-            }
-        }
+        waitFor(
+                () -> simulator
+                                .getStreamStatus()
+                                .lastKnownPublisherClientStatuses()
+                                .size()
+                        >= statusesRequired,
+                WAIT_TIMEOUT);
+        final String simulatorStatus =
+                simulator.getStreamStatus().lastKnownPublisherClientStatuses().getLast();
         assertNotNull(simulatorStatus);
         assertTrue(simulator.isRunning());
         return simulatorThread;


### PR DESCRIPTION
* replace ArrayDeque with ConcurrentLinkedDeque for lastKnownStatuses in PublishStreamGrpcClientImpl, ConsumerStreamGrpcClientImpl and PublishStreamGrpcServerImpl
* add concurrency regression tests that snapshot statuses while gRPC callback threads mutate them
* add waitFor poll-sleep-timeout helper to BaseSuite
* replace busy-spin status polls in NegativeSingleSubscriberTests with bounded waitFor calls

Resolves #3446