### PR TITLE
fix: Stop backfillplugin from advancing past a chunk that is not fully persisted

### DIFF
--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillRunner.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillRunner.java
@@ -119,8 +119,15 @@ final class BackfillRunner {
                 }
                 case SUCCESS -> {
                     List<Long> blockNumbers = extractBlockNumbers(result.blocks());
-                    sendBlocksForPersistence(result.blocks(), blockNumbers, result.chunk());
-                    awaitBlocksPersistence(blockNumbers, result.chunk());
+                    boolean persisted =
+                            sendChunkAndAwaitPersistenceWithRetries(result.blocks(), blockNumbers, result.chunk());
+
+                    if (!persisted) {
+                        final String chunkNeverPersistedMsg = "Chunk [{0}] did not fully persist after [{1}] "
+                                + "attempt(s); stopping this gap scan, remaining range will be re-detected";
+                        logger.log(INFO, chunkNeverPersistedMsg, result.chunk(), config.maxRetries());
+                        break backfillLoop;
+                    }
 
                     lastSuccessfulBlock = result.chunk().end();
                     Thread.sleep(Math.max(0, config.delayBetweenBatches()));
@@ -245,6 +252,58 @@ final class BackfillRunner {
     }
 
     /**
+     * Sends a chunk for persistence once, then awaits it, retrying the wait (never the send) for
+     * whichever blocks are still outstanding whenever some of the chunk fails to persist within
+     * {@code perBlockProcessingTimeout}.
+     * <p>
+     * A block can fail to persist purely because it is still parked in the verification module awaiting
+     * its turn under strict ordering, not because anything actually went wrong with it. If the caller
+     * responded by advancing to the next chunk anyway, it would keep dispatching new backfill blocks on
+     * top of ones still parked from this chunk, growing the number of outstanding, unconfirmed blocks
+     * without bound across the whole gap -- eventually exceeding the verification module's
+     * {@code activeSessionsBufferSize} and causing it to evict the lowest (oldest, still-waiting) session,
+     * which permanently stalls the gap on exactly the block backfill most needs to complete next.
+     * Waiting longer for the same chunk instead keeps the number of outstanding unconfirmed blocks
+     * bounded to at most one chunk ({@code fetchBatchSize}) at a time.
+     * <p>
+     * Re-sending an already in-flight block would not help either: verification sessions are keyed by
+     * {@code (blockNumber, uniqueId)} and explicitly allow multiple sessions per block, so a resend spins
+     * up a second, fully independent session rather than nudging the first one along -- consuming another
+     * slot in the very buffer this is trying to relieve pressure on.
+     *
+     * @param blocks the unparsed blocks to send
+     * @param blockNumbers pre-extracted block numbers (same order as blocks)
+     * @param chunk the range being processed (for logging)
+     * @return {@code true} if every block in the chunk was confirmed persisted within the retry budget
+     */
+    private boolean sendChunkAndAwaitPersistenceWithRetries(
+            List<BlockUnparsed> blocks, List<Long> blockNumbers, LongRange chunk) throws InterruptedException {
+        sendBlocksForPersistence(blocks, blockNumbers, chunk);
+        List<Long> stillPending = blockNumbers;
+        for (int attempt = 1; attempt <= config.maxRetries() && !stillPending.isEmpty(); attempt++) {
+            stillPending = awaitBlocksPersistence(stillPending, chunk);
+            if (stillPending.isEmpty()) {
+                return true;
+            }
+            if (attempt < config.maxRetries()) {
+                final String retryingChunkMsg =
+                        "Chunk [{0}] persistence attempt [{1}/{2}] incomplete for [{3}] block(s), continuing to "
+                                + "wait on the same in-flight session(s)";
+                logger.log(DEBUG, retryingChunkMsg, chunk, attempt, config.maxRetries(), stillPending.size());
+                Thread.sleep(Math.max(0, (long) config.initialRetryDelay() * attempt));
+                // awaitPersistence always clears its own bookkeeping entry once it returns (success,
+                // timeout, or interrupt alike), so without re-tracking here the next await call would
+                // immediately report "already persisted or not tracked" for a block that may still
+                // actually be in flight.
+                for (long blockNumber : stillPending) {
+                    persistenceAwaiter.trackBlock(blockNumber);
+                }
+            }
+        }
+        return stillPending.isEmpty();
+    }
+
+    /**
      * Sends blocks to the messaging facility for persistence.
      * <p>
      * For each block: increments metrics, registers for persistence tracking,
@@ -278,17 +337,23 @@ final class BackfillRunner {
      *
      * @param blockNumbers the block numbers to await
      * @param chunk the range being processed (for logging)
+     * @return the subset of {@code blockNumbers} that did not confirm persistence within the timeout
      */
-    private void awaitBlocksPersistence(List<Long> blockNumbers, LongRange chunk) throws InterruptedException {
+    private List<Long> awaitBlocksPersistence(List<Long> blockNumbers, LongRange chunk) throws InterruptedException {
+        List<Long> stillPending = new ArrayList<>();
         for (long blockNumber : blockNumbers) {
             boolean persisted = persistenceAwaiter.awaitPersistence(blockNumber, config.perBlockProcessingTimeout());
             if (!persisted) {
                 final String persistenceTimedOutMsg = "Block [{0}] persistence timed out, will be re-detected";
                 logger.log(INFO, persistenceTimedOutMsg, blockNumber);
+                stillPending.add(blockNumber);
             }
         }
-        final String allBlocksPersistedMsg = "All blocks in chunk [{0}] persisted";
-        logger.log(TRACE, allBlocksPersistedMsg, chunk);
+        if (stillPending.isEmpty()) {
+            final String allBlocksPersistedMsg = "All blocks in chunk [{0}] persisted";
+            logger.log(TRACE, allBlocksPersistedMsg, chunk);
+        }
+        return stillPending;
     }
 
     /**

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillRunnerTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillRunnerTest.java
@@ -577,6 +577,124 @@ class BackfillRunnerTest {
     }
 
     @Nested
+    @DisplayName("Chunk Persistence Retry Tests")
+    class ChunkPersistenceRetryTests {
+
+        @Test
+        @DisplayName("should retry the wait (not re-dispatch) when persistence confirms late")
+        void shouldRetryWithoutRedispatchWhenPersistenceArrivesLate() throws Exception {
+            // given - a short per-block timeout so the first await times out, but the persisted
+            // notification is delivered a bit later, simulating a block that was merely still
+            // parked in the verification module's ordering buffer rather than actually failed.
+            BackfillConfiguration retryConfig = BackfillPluginTest.BackfillConfigBuilder.NewBuilder()
+                    .delayBetweenBatches(0)
+                    .perBlockProcessingTimeout(100)
+                    .initialRetryDelay(50)
+                    .maxRetries(5)
+                    .buildRecord();
+            BackfillRunner retrySubject = new BackfillRunner(
+                    mockFetcher,
+                    retryConfig,
+                    messaging,
+                    logger,
+                    mockMetricsHolder,
+                    pendingBackfillBlocks,
+                    persistenceAwaiter);
+
+            GapDetector.Gap gap = new GapDetector.Gap(new LongRange(0, 0), GapDetector.Type.HISTORICAL);
+            BlockNodeSourceConfig nodeConfig = mock(BlockNodeSourceConfig.class);
+            Map<BlockNodeSourceConfig, List<LongRange>> availability = new HashMap<>();
+            availability.put(nodeConfig, List.of(new LongRange(0, 0)));
+            BlockUnparsed testBlock = createTestBlock(0L);
+
+            when(mockFetcher.getAvailabilityForRange(any())).thenReturn(availability);
+            when(mockFetcher.selectNextChunk(anyLong(), anyLong(), any()))
+                    .thenReturn(Optional.of(new NodeSelectionStrategy.NodeSelection(nodeConfig, 0L)));
+            when(mockFetcher.fetchBlocksFromNode(eq(nodeConfig), any())).thenReturn(List.of(testBlock));
+
+            messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
+            messaging.registerBlockNotificationHandler(
+                    new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
+                        @Override
+                        public void handleBackfilled(
+                                org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
+                            // Deliver the persisted notification only after the first await's
+                            // 100ms timeout has already elapsed, so only a retried (re-tracked)
+                            // await can pick it up. 175ms lands comfortably inside the second
+                            // attempt's [150ms, 250ms) window (after the 50ms retry backoff)
+                            // rather than right at either edge.
+                            new Thread(() -> {
+                                        try {
+                                            Thread.sleep(175);
+                                        } catch (InterruptedException ignored) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                        messaging.sendBlockPersisted(new PersistedNotification(
+                                                notification.blockNumber(), true, 1, BlockSource.BACKFILL));
+                                    })
+                                    .start();
+                        }
+                    },
+                    false,
+                    "delayed-persistence-handler");
+
+            // when
+            long lastSuccessful = retrySubject.run(gap);
+
+            // then - eventually persisted via retry, and the block was fetched only once (no
+            // duplicate dispatch of a second, independent verification session for it)
+            assertEquals(0L, lastSuccessful, "Should succeed once the delayed persistence notification lands");
+            verify(mockFetcher, times(1)).fetchBlocksFromNode(eq(nodeConfig), any());
+        }
+
+        @Test
+        @DisplayName("should stop the gap scan without advancing when a chunk never persists")
+        void shouldStopGapWithoutAdvancingWhenChunkNeverPersists() throws Exception {
+            // given - block 0 will never receive a persisted notification, so every retry
+            // attempt times out. This must not cause the loop to advance and fetch block 1's
+            // chunk anyway -- that would keep piling new backfill dispatches on top of a block
+            // still stuck, instead of bounding the outstanding/unconfirmed count.
+            BackfillConfiguration retryConfig = BackfillPluginTest.BackfillConfigBuilder.NewBuilder()
+                    .delayBetweenBatches(0)
+                    .perBlockProcessingTimeout(50)
+                    .initialRetryDelay(10)
+                    .maxRetries(2)
+                    .fetchBatchSize(1)
+                    .buildRecord();
+            BackfillRunner retrySubject = new BackfillRunner(
+                    mockFetcher,
+                    retryConfig,
+                    messaging,
+                    logger,
+                    mockMetricsHolder,
+                    pendingBackfillBlocks,
+                    persistenceAwaiter);
+
+            GapDetector.Gap gap = new GapDetector.Gap(new LongRange(0, 1), GapDetector.Type.HISTORICAL);
+            BlockNodeSourceConfig nodeConfig = mock(BlockNodeSourceConfig.class);
+            Map<BlockNodeSourceConfig, List<LongRange>> availability = new HashMap<>();
+            availability.put(nodeConfig, List.of(new LongRange(0, 1)));
+            BlockUnparsed block0 = createTestBlock(0L);
+
+            when(mockFetcher.getAvailabilityForRange(any())).thenReturn(availability);
+            when(mockFetcher.selectNextChunk(anyLong(), anyLong(), any()))
+                    .thenReturn(Optional.of(new NodeSelectionStrategy.NodeSelection(nodeConfig, 0L)));
+            when(mockFetcher.fetchBlocksFromNode(eq(nodeConfig), any())).thenReturn(List.of(block0));
+
+            // Only the awaiter is registered -- nothing ever sends a PersistedNotification, so
+            // block 0 never confirms no matter how many retries are attempted.
+            messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
+
+            // when
+            long lastSuccessful = retrySubject.run(gap);
+
+            // then - stuck on block 0 forever, so block 1's chunk is never fetched
+            assertEquals(-1L, lastSuccessful, "Should never succeed since block 0 never persists");
+            verify(mockFetcher, times(1)).fetchBlocksFromNode(eq(nodeConfig), any());
+        }
+    }
+
+    @Nested
     @DisplayName("lastSuccessfulBlock Return Value Tests")
     class LastSuccessfulBlockTests {
 


### PR DESCRIPTION
## Reviewer Notes
BackfillRunner now stops advancing past a chunk that didn't fully persist. It retries the wait — re-registering tracking for just the still-pending blocks — instead of dispatching new work on top of them, so the total outstanding/unconfirmed blocks stays bounded to one chunk at a time (well under the 100-session buffer). It deliberately never re-sends an already in-flight block: verification sessions allow duplicates by design (keyed by (blockNumber, uniqueId)), so resending would spin up a second independent session and consume another buffer slot instead of relieving pressure. If a chunk still doesn't confirm after maxRetries, the gap scan stops cleanly and the range is picked up again on the next detection cycle.

Covered by two new unit tests in BackfillRunnerTest confirming the retry-without-resend path succeeds when persistence confirms late, and that a chunk which never persists halts the scan without touching the next chunk.


## Related Issue(s)
 Closes #3487
