### PR TITLE
chore(chart): clarify health port Services logic and update outdated values references

### DIFF
--- a/charts/block-node-server/templates/_helpers.tpl
+++ b/charts/block-node-server/templates/_helpers.tpl
@@ -119,11 +119,12 @@ Usage: include "hiero-block-node.pluginPortEnvVars" .
 
 {{/*
 Emit Service port entries for each non-null plugin port in blockNode.ports.
-The health port is intentionally excluded: probes go directly to the pod port
-(by number) and do not need a Service entry. Excluding it prevents health from
-appearing on a public LoadBalancer when includePluginPorts is true. Operators
-who want health in a Service (either ClusterIP or LB) can add it explicitly
-via loadBalancer.extraPorts or service.extraPorts.
+The health port is intentionally excluded from both the ClusterIP and the
+LoadBalancer Service: probes go directly to the pod port by number and do not
+need a Service entry, so advertising 40983 in any Service serves no functional
+purpose and would expose the /healthz endpoint on the public LB when
+includePluginPorts is true. Operators who want health in a Service for any
+reason can add it explicitly via loadBalancer.extraPorts.
 Multiple plugins that share the same port number emit only one Service port entry
 (Kubernetes rejects duplicate port numbers within a Service).
 Usage: include "hiero-block-node.pluginServicePorts" . | nindent 4

--- a/charts/block-node-server/values-overrides/lfh-provisioner-config.yaml
+++ b/charts/block-node-server/values-overrides/lfh-provisioner-config.yaml
@@ -7,7 +7,7 @@ blockNode:
     namespace: block-node
     release: block-node
     chart: oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server
-    version: "0.37.1"
+    version: "0.40.1"
     storage:
         applicationStatePath: /mnt/fast-storage/block-node/application-state
         applicationStateSize: 50Gi

--- a/charts/block-node-server/values-overrides/lfh-values.yaml
+++ b/charts/block-node-server/values-overrides/lfh-values.yaml
@@ -72,7 +72,9 @@ blockNode:
 loadBalancer:
     enabled: true
     port: "40840"
-    metallb.io/address-pool: public-address-pool
+    includePluginPorts: true
+    annotations:
+        metallb.io/address-pool: "public-address-pool"
 
 resources:
     requests:

--- a/charts/block-node-server/values.yaml
+++ b/charts/block-node-server/values.yaml
@@ -64,10 +64,10 @@ loadBalancer:
     # - 35.191.0.0/16   # GCP health check (example)
     # - 130.211.0.0/22  # GCP health check (example)
   # When true, all non-null blockNode.ports entries (except health) are added to the LB Service
-  # in addition to the primary port. The health port (40983) is always excluded because it is
-  # ClusterIP-internal only (liveness/readiness probes); add it explicitly via extraPorts if
-  # you have a specific reason to expose it publicly. Requires each included plugin port to be
-  # distinct from loadBalancer.port.
+  # in addition to the primary port. The health port (40983) is excluded from all Services —
+  # probes go directly to the pod port by number and do not require a Service entry. Add it
+  # explicitly via extraPorts only if you have a specific reason to expose it. Requires each
+  # included plugin port to be distinct from loadBalancer.port.
   includePluginPorts: false
   # Explicit additional ports to expose on the LB Service (beyond the primary port and any
   # plugin ports included via includePluginPorts). Each entry must have a unique name and port.
@@ -189,6 +189,9 @@ blockNode:
     # HTTP port for /healthz endpoints (env: HEALTH_PORT). hostPorts key: health
     # The health plugin runs on its own dedicated web server; this is that port, and the liveness/
     # readiness probes are automatically directed to it. Defaults to the app's health port (40983).
+    # Note: this is declared as a containerPort in the StatefulSet so probes and hostPort bindings
+    # work, but it is NOT added to any Service (ClusterIP or LB) by default. Use
+    # loadBalancer.extraPorts to expose it on the LB if needed.
     health: 40983
     # HTTP port for server-status endpoint (env: SERVER_STATUS_PORT). hostPorts key: server-status
     serverStatus: null


### PR DESCRIPTION
## Summary

- Docstring and comments cleanup following `berryware`'s unresolved review comments on #3470, tracked in #3496.
- Correction of two config errors in the LFH production values overrides.

### Health port docstring cleanup (closes #3496)

- **`_helpers.tpl`**: removes the non-existent `service.extraPorts` reference and explicitly states that health (40983) is excluded from **both** the ClusterIP and LB Services — `pluginServicePorts` is called from both `service.yaml` and `service-loadbalancer.yaml`.
- **`values.yaml` `includePluginPorts` comment**: corrects "ClusterIP-internal only" to "excluded from all Services".
- **`values.yaml` `blockNode.ports.health` comment**: adds a note that 40983 is a containerPort declaration (probes and hostPort bindings work) but is not added to any Service by default; directs operators to `loadBalancer.extraPorts` for explicit LB exposure.

### LFH production values corrections

- **`lfh-provisioner-config.yaml`**: bumps chart version from `0.37.1` to `0.40.1`.
- **`lfh-values.yaml`**: moves `metallb.io/address-pool` under the `annotations:` parent key (the bare key form is not a valid `loadBalancer` field and would be ignored by Helm); adds `includePluginPorts: true` so the plugin service ports are exposed on the LoadBalancer.

## Test plan

- [ ] `helm template` with `includePluginPorts: true` does not include a `health` port in either `service.yaml` or `service-loadbalancer.yaml` output
- [ ] `helm template` with health in `loadBalancer.extraPorts` includes it on the LB (opt-in still works)
- [ ] `helm template` with `lfh-values.yaml` renders `metallb.io/address-pool` under `annotations:` in the LB Service manifest