### PR TITLE
chore: Update HAPI version to `0.76.1`

### DIFF
--- a/protobuf-sources/build.gradle.kts
+++ b/protobuf-sources/build.gradle.kts
@@ -13,7 +13,7 @@ tasks.javadoc { enabled = false }
 // proto/internal/unparsed.proto matches structure for
 // block-node-protobuf/block/stream/block_item.proto after update otherwise Verification
 // might fail
-val cnVersion = "0.73.0-rc.1"
+val cnVersion = "0.76.1"
 
 // make cnVersion visible to other projects
 extra["cnVersion"] = cnVersion


### PR DESCRIPTION
## Reviewer Notes
We've forgotten to update the HAPI version since `0.73`, so we need to update.
We should probably add updating the HAPI version to the release process.

## Related Issue(s)
 Use keywords `Fix, Fixes, Fixed, Close, Closes, Closed, Resolve, Resolves, Resolved`
to connect an issue to be closed by this pull request.
