### PR TITLE
feat: Utilize `FailureInfo` on Failed Verification

### DIFF
--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationServicePlugin.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/VerificationServicePlugin.java
@@ -202,8 +202,7 @@ public final class VerificationServicePlugin implements BlockNodePlugin, BlockIt
                 if (validateStartOfBlock(blockItems)) {
                     sessionHandler.processBlockItems(blockItems, source);
                 } else {
-                    safeSendNotification(
-                            blockItems.blockNumber(), source, SessionFailureType.MISSING_VERIFICATION_DATA);
+                    safeSendNotification(blockItems.blockNumber(), source, SessionFailureType.MISSING_MANDATORY_ITEM);
                 }
             } else {
                 LOGGER.log(INFO, "Received null block items on live items ring buffer");
@@ -239,8 +238,7 @@ public final class VerificationServicePlugin implements BlockNodePlugin, BlockIt
                 if (validateStartOfBlock(blockItems)) {
                     sessionHandler.processBlockItems(blockItems, source);
                 } else {
-                    safeSendNotification(
-                            blockItems.blockNumber(), source, SessionFailureType.MISSING_VERIFICATION_DATA);
+                    safeSendNotification(blockItems.blockNumber(), source, SessionFailureType.MISSING_MANDATORY_ITEM);
                 }
             } else {
                 LOGGER.log(INFO, "Received invalid backfill notification: {0}", notification);

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/BlockSessionHandler.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/BlockSessionHandler.java
@@ -146,6 +146,11 @@ public final class BlockSessionHandler {
         }
         // check if we have an active publisher session, if not, then disregard the items
         if (local != null) {
+            if (blockItems.isEndOfBlock()) {
+                // mark before offering so the session never observes the ending
+                // batch in its deque while still considered incomplete
+                local.markEndOfBlockReceived();
+            }
             local.getBlockItemsDeque().offer(blockItems);
         }
         if (blockItems.isEndOfBlock()) {
@@ -161,6 +166,8 @@ public final class BlockSessionHandler {
     private void processBackfilledItems(final BlockItems blockItems) {
         final BlockVerificationSession session = startNewSession(blockItems, BlockSource.BACKFILL);
         activateSession(session);
+        // a backfilled block always arrives complete in a single batch
+        session.markEndOfBlockReceived();
         session.getBlockItemsDeque().offer(blockItems);
     }
 

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/BlockVerificationSession.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/BlockVerificationSession.java
@@ -35,6 +35,16 @@ public interface BlockVerificationSession {
     /// Cancel and stop the session.
     void cancel();
 
+    /// Mark that the end of block has been received for this session.
+    ///
+    /// The supplier of the block items must call this method as soon as it
+    /// supplies the batch that ends the block. If the session ends without
+    /// producing a result, this mark determines whether the failure is
+    /// reported as [SessionFailureType#CANCELLED] (the complete block was
+    /// received) or [SessionFailureType#CANCELLED_INCOMPLETE] (the block was never
+    /// fully received).
+    void markEndOfBlockReceived();
+
     /// Get the block items deque.
     /// Through this deque, we are able to offer the next block items of the block.
     ConcurrentLinkedDeque<BlockItems> getBlockItemsDeque();

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/CompletableVerificationSession.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/CompletableVerificationSession.java
@@ -37,6 +37,10 @@ public final class CompletableVerificationSession implements BlockVerificationSe
     private final ExecutorService executor;
     /// Cancellation flag shared with all stages of the session.
     private final AtomicBoolean isCancelled;
+    /// Flag raised when the batch ending the block has been received, shared
+    /// with the result handling stage so it can discriminate between a
+    /// cancelled complete block and an incomplete one.
+    private final AtomicBoolean endOfBlockReceived;
     /// The block node context, for access to core facilities.
     private final BlockNodeContext context;
     /// The last successfully verified block, shared across sessions.
@@ -96,6 +100,7 @@ public final class CompletableVerificationSession implements BlockVerificationSe
         this.blockSource = Objects.requireNonNull(blockSource);
         this.executor = Objects.requireNonNull(executor);
         this.isCancelled = new AtomicBoolean(false);
+        this.endOfBlockReceived = new AtomicBoolean(false);
         this.blockItemsDeque = new ConcurrentLinkedDeque<>();
         this.verificationConfig = Objects.requireNonNull(verificationConfig);
         this.finishedSessions = Objects.requireNonNull(finishedSessions);
@@ -147,7 +152,8 @@ public final class CompletableVerificationSession implements BlockVerificationSe
                 blockNumber,
                 blockSource,
                 finishedSessions,
-                sessionKey);
+                sessionKey,
+                endOfBlockReceived);
         final CompletableFuture<BlockVerificationResult> completionChain = CompletableFuture.supplyAsync(
                         hasher, executor)
                 .thenApply(verifier)
@@ -178,6 +184,12 @@ public final class CompletableVerificationSession implements BlockVerificationSe
         } finally {
             isCancelled.set(true);
         }
+    }
+
+    /// {@inheritDoc}
+    @Override
+    public void markEndOfBlockReceived() {
+        endOfBlockReceived.set(true);
     }
 
     /// {@inheritDoc}

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/SessionFailureType.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/SessionFailureType.java
@@ -29,8 +29,15 @@ public enum SessionFailureType {
     /// is not a processable block stream (for example an item that carries more than one
     /// field, or a mandatory once per block item that appears more than once)
     UNSUPPORTED_STREAM_FORMAT,
-    /// This type indicates that the session was cancelled
+    /// This type indicates that the session was cancelled after the
+    /// complete block was received, for example evicted from the active
+    /// sessions buffer or shut down before completing
     CANCELLED,
+    /// This type indicates that the session ended before the full block
+    /// was received, for example the publisher started a new block and
+    /// abandoned the current one, or an incomplete session was cancelled
+    /// for any other reason
+    CANCELLED_INCOMPLETE,
     /// This type indicates that an unknown error occurred
     UNKNOWN_ERROR;
 
@@ -48,6 +55,7 @@ public enum SessionFailureType {
             case UNSUPPORTED_ITEM_TYPE -> FailureType.UNSUPPORTED_ITEM_TYPE;
             case UNSUPPORTED_STREAM_FORMAT -> FailureType.UNSUPPORTED_STREAM_FORMAT;
             case CANCELLED -> FailureType.CANCELLED;
+            case CANCELLED_INCOMPLETE -> FailureType.CANCELLED_INCOMPLETE;
             case UNKNOWN_ERROR -> FailureType.UNKNOWN_ERROR;
         };
     }

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/SessionResultHandler.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/SessionResultHandler.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import org.hiero.block.internal.BlockItemUnparsed;
@@ -49,6 +50,10 @@ public final class SessionResultHandler implements BiConsumer<BlockVerificationR
     private final ConcurrentSkipListSet<SessionKey> finishedSessions;
     /// The composite key of the owning session.
     private final SessionKey sessionKey;
+    /// Flag raised by the owning session when the batch ending the block has
+    /// been received, used to discriminate a cancelled complete block from an
+    /// incomplete one.
+    private final AtomicBoolean endOfBlockReceived;
 
     /// Constructor.
     ///
@@ -62,6 +67,8 @@ public final class SessionResultHandler implements BiConsumer<BlockVerificationR
     /// @param blockSource the source of the block, must not be null
     /// @param finishedSessions the set to add the session's key to when handled, must not be null
     /// @param sessionKey the composite key of the owning session, must not be null
+    /// @param endOfBlockReceived flag raised by the owning session when the batch ending the
+    ///     block has been received, must not be null
     public SessionResultHandler(
             final BlockNodeContext context,
             final VerificationConfig verificationConfig,
@@ -72,7 +79,8 @@ public final class SessionResultHandler implements BiConsumer<BlockVerificationR
             final long blockNumber,
             final BlockSource blockSource,
             final ConcurrentSkipListSet<SessionKey> finishedSessions,
-            final SessionKey sessionKey) {
+            final SessionKey sessionKey,
+            final AtomicBoolean endOfBlockReceived) {
         this.context = Objects.requireNonNull(context);
         this.verificationConfig = Objects.requireNonNull(verificationConfig);
         this.sessionResultMetrics = Objects.requireNonNull(sessionResultMetrics);
@@ -82,6 +90,7 @@ public final class SessionResultHandler implements BiConsumer<BlockVerificationR
         this.recentlyVerifiedBlocks = Objects.requireNonNull(recentlyVerifiedBlocks);
         this.finishedSessions = Objects.requireNonNull(finishedSessions);
         this.sessionKey = Objects.requireNonNull(sessionKey);
+        this.endOfBlockReceived = Objects.requireNonNull(endOfBlockReceived);
         if (blockNumber < 0) {
             throw new IllegalArgumentException("Block number must be non-negative");
         } else {
@@ -180,7 +189,7 @@ public final class SessionResultHandler implements BiConsumer<BlockVerificationR
                 case CancellationException ignored ->
                     new VerificationNotification(
                             false,
-                            getFailureInfo(blockNumber, SessionFailureType.CANCELLED),
+                            getFailureInfo(blockNumber, resolveCancellationType()),
                             blockNumber,
                             null,
                             null,
@@ -219,9 +228,16 @@ public final class SessionResultHandler implements BiConsumer<BlockVerificationR
         final Throwable cause = ce.getCause();
         if (cause instanceof VerificationSessionFailedException vfe) {
             // instanceof covers null also
+            // A stage reports a plain cancellation when it is stopped before
+            // producing a result. Only the session knows whether the full
+            // block was received, so the refinement happens here.
+            final SessionFailureType reportedFailureType = vfe.getFailureType();
+            final SessionFailureType actualFailureType = reportedFailureType == SessionFailureType.CANCELLED
+                    ? resolveCancellationType()
+                    : reportedFailureType;
             return new VerificationNotification(
                     false,
-                    getFailureInfo(vfe.getBlockNumber(), vfe.getFailureType()),
+                    getFailureInfo(vfe.getBlockNumber(), actualFailureType),
                     vfe.getBlockNumber(),
                     null,
                     null,
@@ -279,6 +295,17 @@ public final class SessionResultHandler implements BiConsumer<BlockVerificationR
         if (recentlyVerifiedBlocks.size() > verificationConfig.recentlyVerifiedBlocksBufferSize()) {
             recentlyVerifiedBlocks.pollFirst();
         }
+    }
+
+    /// Resolve the failure type for a session that was stopped before
+    /// producing a result. A cancellation of a complete block means the
+    /// supplier considers the block delivered, while an incomplete block was
+    /// abandoned by the supplier before it ever finished.
+    ///
+    /// @return [SessionFailureType#CANCELLED] when the batch ending the block
+    ///     was received, [SessionFailureType#CANCELLED_INCOMPLETE] otherwise
+    private SessionFailureType resolveCancellationType() {
+        return endOfBlockReceived.get() ? SessionFailureType.CANCELLED : SessionFailureType.CANCELLED_INCOMPLETE;
     }
 
     /// Construct a [FailureInfo] in case of a failed session.

--- a/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/VerificationServicePluginTest.java
+++ b/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/VerificationServicePluginTest.java
@@ -1113,7 +1113,7 @@ class VerificationServicePluginTest {
                     .first()
                     .returns(false, VerificationNotification::success)
                     .returns(
-                            FailureInfo.standard(FailureType.MISSING_VERIFICATION_DATA),
+                            FailureInfo.standard(FailureType.MISSING_MANDATORY_ITEM),
                             VerificationNotification::failureInfo)
                     .returns(block0.number(), VerificationNotification::blockNumber)
                     .returns(BlockSource.PUBLISHER, VerificationNotification::source)
@@ -1139,7 +1139,7 @@ class VerificationServicePluginTest {
                     .first()
                     .returns(false, VerificationNotification::success)
                     .returns(
-                            FailureInfo.standard(FailureType.MISSING_VERIFICATION_DATA),
+                            FailureInfo.standard(FailureType.MISSING_MANDATORY_ITEM),
                             VerificationNotification::failureInfo)
                     .returns(reportedBlockNumber, VerificationNotification::blockNumber)
                     .returns(BlockSource.PUBLISHER, VerificationNotification::source)
@@ -1163,7 +1163,7 @@ class VerificationServicePluginTest {
                     .first()
                     .returns(false, VerificationNotification::success)
                     .returns(
-                            FailureInfo.standard(FailureType.MISSING_VERIFICATION_DATA),
+                            FailureInfo.standard(FailureType.MISSING_MANDATORY_ITEM),
                             VerificationNotification::failureInfo)
                     .returns(block0.number(), VerificationNotification::blockNumber)
                     .returns(BlockSource.BACKFILL, VerificationNotification::source)
@@ -1190,7 +1190,7 @@ class VerificationServicePluginTest {
                     .first()
                     .returns(false, VerificationNotification::success)
                     .returns(
-                            FailureInfo.standard(FailureType.MISSING_VERIFICATION_DATA),
+                            FailureInfo.standard(FailureType.MISSING_MANDATORY_ITEM),
                             VerificationNotification::failureInfo)
                     .returns(reportedBlockNumber, VerificationNotification::blockNumber)
                     .returns(BlockSource.BACKFILL, VerificationNotification::source)

--- a/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/VerificationServicePluginTest.java
+++ b/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/VerificationServicePluginTest.java
@@ -924,6 +924,8 @@ class VerificationServicePluginTest {
         /// This test aims to verify that when the active sessions buffer is full and a new session comes,
         /// the lowest active session will be canceled to make room, so long as the lowest active session is not
         /// the one we just submitted.
+        /// Because the evicted session had already received its complete block, the failure is reported
+        /// with the CANCELLED failure type and not CANCELLED_INCOMPLETE.
         @Test
         @DisplayName(
                 "Active Sessions Buffer - cancel lowest session when buffer full and new submission is not the lowest active session")
@@ -943,6 +945,42 @@ class VerificationServicePluginTest {
                     .first()
                     .returns(false, VerificationNotification::success)
                     .returns(FailureInfo.standard(FailureType.CANCELLED), VerificationNotification::failureInfo)
+                    .returns(block2.number(), VerificationNotification::blockNumber)
+                    .returns(BlockSource.PUBLISHER, VerificationNotification::source)
+                    .returns(null, VerificationNotification::block)
+                    .returns(null, VerificationNotification::blockHash);
+        }
+
+        /// This test aims to assert that when the active sessions buffer is full and the lowest active
+        /// session is evicted while it has not yet received the batch that ends its block, the eviction
+        /// is reported with the CANCELLED_INCOMPLETE failure type and not CANCELLED. Here block 2 is
+        /// supplied by the publisher as a header only batch, so its session never receives the end of
+        /// the block. Blocks 3 and 4 are then supplied as backfilled blocks, which do not supersede the
+        /// live publisher session, filling the buffer and forcing the eviction of the incomplete
+        /// session for block 2.
+        @Test
+        @DisplayName(
+                "Active Sessions Buffer - evicted session that has not received its full block reports CANCELLED_INCOMPLETE")
+        void testEvictIncompleteLowestActiveSessionWhenBufferFullReportsIncomplete()
+                throws IOException, ParseException {
+            final List<ResourceTestWRBBlock> loadedBlocks = ResourceTestBlockBuilder.loadMultiple(consecutiveWRBBlocks);
+            final ResourceTestWRBBlock block2 = loadedBlocks.get(2);
+            final ResourceTestWRBBlock block3 = loadedBlocks.get(3);
+            final ResourceTestWRBBlock block4 = loadedBlocks.get(4);
+            updateAddressBook(block2.nodeAddressBook());
+            final BlockItems headerOnly =
+                    new BlockItems(List.of(block2.getHeaderUnparsed()), block2.number(), true, false);
+            plugin.handleBlockItemsReceived(headerOnly);
+            plugin.handleBackfilled(block3.asBackfilledNotification());
+            plugin.handleBackfilled(block4.asBackfilledNotification());
+            final List<VerificationNotification> notifications = blockMessaging.getSentVerificationNotifications(1);
+            assertThat(notifications)
+                    .hasSize(1)
+                    .first()
+                    .returns(false, VerificationNotification::success)
+                    .returns(
+                            FailureInfo.standard(FailureType.CANCELLED_INCOMPLETE),
+                            VerificationNotification::failureInfo)
                     .returns(block2.number(), VerificationNotification::blockNumber)
                     .returns(BlockSource.PUBLISHER, VerificationNotification::source)
                     .returns(null, VerificationNotification::block)
@@ -1310,11 +1348,13 @@ class VerificationServicePluginTest {
         /// This test aims to assert that when we receive the start of a new block via the Live RB (Publisher Source),
         /// but we have not yet received the last item for the current live publisher session, the current live
         /// publisher session will be canceled and the newly received block will start a new session.
-        /// The block proof type is irrelevant for this test. Also, it is irrelevant which block will be started
-        /// in the middle of current session.
+        /// Here the publisher restarts the same block: the new start carries the same block number as the
+        /// active session. Because the superseded session never received the batch that ends its block, the
+        /// failure is reported with the CANCELLED_INCOMPLETE failure type and not CANCELLED.
+        /// The block proof type is irrelevant for this test.
         @Test
         @DisplayName(
-                "Live RB Ingestion - Cancel Current Live Session When New Block Received While Not Finished Current One")
+                "Live RB Ingestion - Cancel Current Live Session When Same Block Restarted While Not Finished Current One")
         void testLiveRBIngestionCancelLiveSessionWhenNewBlockReceivedAndCurrentNotComplete() {
             final org.hiero.block.node.block.verification.harness.HarnessChainBuilder.Signed genesis =
                     org.hiero.block.node.block.verification.harness.HarnessChainBuilder.create(TssBlockSigner.create())
@@ -1331,7 +1371,49 @@ class VerificationServicePluginTest {
                     .hasSize(1)
                     .first()
                     .returns(false, VerificationNotification::success)
-                    .returns(FailureInfo.standard(FailureType.CANCELLED), VerificationNotification::failureInfo)
+                    .returns(
+                            FailureInfo.standard(FailureType.CANCELLED_INCOMPLETE),
+                            VerificationNotification::failureInfo)
+                    .returns(genesis.block().number(), VerificationNotification::blockNumber)
+                    .returns(BlockSource.PUBLISHER, VerificationNotification::source)
+                    .returns(null, VerificationNotification::block)
+                    .returns(null, VerificationNotification::blockHash);
+        }
+
+        /// This test aims to assert that when we receive the start of a different block via the Live RB
+        /// (Publisher Source), but we have not yet received the last item for the current live publisher
+        /// session, the current live publisher session will be canceled and the newly received block will
+        /// start a new session. Here the publisher moves on to the next block, abandoning the current one.
+        /// Because the superseded session never received the batch that ends its block, the failure is
+        /// reported with the CANCELLED_INCOMPLETE failure type and not CANCELLED.
+        /// The block proof type is irrelevant for this test.
+        @Test
+        @DisplayName(
+                "Live RB Ingestion - Cancel Current Live Session When Different Block Received While Not Finished Current One")
+        void testLiveRBIngestionCancelLiveSessionWhenDifferentBlockReceivedAndCurrentNotComplete() {
+            final org.hiero.block.node.block.verification.harness.HarnessChainBuilder chain =
+                    org.hiero.block.node.block.verification.harness.HarnessChainBuilder.create(TssBlockSigner.create());
+            final org.hiero.block.node.block.verification.harness.HarnessChainBuilder.Signed genesis =
+                    chain.genesisWithPublication();
+            final org.hiero.block.node.block.verification.harness.HarnessChainBuilder.Signed nextBlock = chain.next(1L);
+            plugin.handleBlockItemsReceived(new BlockItems(
+                    List.of(genesis.block().getHeaderUnparsed()),
+                    genesis.block().number(),
+                    true,
+                    false));
+            plugin.handleBlockItemsReceived(new BlockItems(
+                    List.of(nextBlock.block().getHeaderUnparsed()),
+                    nextBlock.block().number(),
+                    true,
+                    false));
+            final List<VerificationNotification> notifications = blockMessaging.getSentVerificationNotifications(1);
+            assertThat(notifications)
+                    .hasSize(1)
+                    .first()
+                    .returns(false, VerificationNotification::success)
+                    .returns(
+                            FailureInfo.standard(FailureType.CANCELLED_INCOMPLETE),
+                            VerificationNotification::failureInfo)
                     .returns(genesis.block().number(), VerificationNotification::blockNumber)
                     .returns(BlockSource.PUBLISHER, VerificationNotification::source)
                     .returns(null, VerificationNotification::block)

--- a/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/session/SessionFailureTypeTest.java
+++ b/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/session/SessionFailureTypeTest.java
@@ -66,6 +66,11 @@ class SessionFailureTypeTest {
     }
 
     @Test
+    void cancelledIncompleteMapsToCorrectFailureType() {
+        assertThat(SessionFailureType.CANCELLED_INCOMPLETE.asFailureType()).isEqualTo(FailureType.CANCELLED_INCOMPLETE);
+    }
+
+    @Test
     void unknownErrorMapsToCorrectFailureType() {
         assertThat(SessionFailureType.UNKNOWN_ERROR.asFailureType()).isEqualTo(FailureType.UNKNOWN_ERROR);
     }
@@ -79,6 +84,6 @@ class SessionFailureTypeTest {
 
     @Test
     void enumValueCount_matchesExpected() {
-        assertThat(SessionFailureType.values()).hasSize(11);
+        assertThat(SessionFailureType.values()).hasSize(12);
     }
 }

--- a/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/session/SessionResultHandlerTest.java
+++ b/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/session/SessionResultHandlerTest.java
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.block.verification.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.hiero.block.node.app.fixtures.TestConfigurationBuilder;
+import org.hiero.block.node.app.fixtures.TestUtils;
+import org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility;
+import org.hiero.block.node.block.verification.BadBlockDumper;
+import org.hiero.block.node.block.verification.VerificationConfig;
+import org.hiero.block.node.block.verification.metrics.MetricsHolder;
+import org.hiero.block.node.block.verification.session.BlockVerificationSession.SessionKey;
+import org.hiero.block.node.spi.BlockNodeContext;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureInfo;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/// Tests for the [SessionResultHandler].
+@DisplayName("Session Result Handler Tests")
+class SessionResultHandlerTest {
+    /// The number of the block the handler under test reports for.
+    private static final long BLOCK_NUMBER = 10L;
+    /// Captures the notifications the handler sends.
+    private TestBlockMessagingFacility blockMessaging;
+    /// The flag the owning session raises when the batch ending the block has been received.
+    private AtomicBoolean endOfBlockReceived;
+    /// The instance under test.
+    private SessionResultHandler toTest;
+
+    /// Setup before each test.
+    @BeforeEach
+    void setUp() {
+        blockMessaging = new TestBlockMessagingFacility();
+        final BlockNodeContext context = new BlockNodeContext(
+                null, null, null, blockMessaging, null, null, null, null, null, null, null, null, null);
+        final MetricsHolder metrics = MetricsHolder.create(TestUtils.createMetrics());
+        final VerificationConfig verificationConfig = new TestConfigurationBuilder()
+                .withConfigDataType(VerificationConfig.class)
+                .getOrCreateConfig()
+                .getConfigData(VerificationConfig.class);
+        final BadBlockDumper badBlockDumper = new BadBlockDumper(verificationConfig, "test");
+        endOfBlockReceived = new AtomicBoolean(false);
+        toTest = new SessionResultHandler(
+                context,
+                verificationConfig,
+                metrics.sessionResultMetrics(),
+                badBlockDumper,
+                new AtomicLong(-1),
+                new ConcurrentLinkedDeque<>(),
+                BLOCK_NUMBER,
+                BlockSource.PUBLISHER,
+                new ConcurrentSkipListSet<>(),
+                new SessionKey(BLOCK_NUMBER, 0L),
+                endOfBlockReceived);
+    }
+
+    /// Tests for the classification of sessions that were stopped before
+    /// producing a result. Only the session knows whether the batch ending
+    /// the block was received, so the handler owns the refinement into
+    /// [FailureType#CANCELLED] and [FailureType#CANCELLED_INCOMPLETE].
+    @Nested
+    @DisplayName("Cancellation Classification Tests")
+    class CancellationClassificationTests {
+        /// This test aims to assert that when the session's stage chain is
+        /// cancelled directly (the handler receives a [CancellationException])
+        /// and the batch ending the block was never received, the handler
+        /// reports a failure of type [FailureType#CANCELLED_INCOMPLETE].
+        @Test
+        @DisplayName("accept() reports CANCELLED_INCOMPLETE on CancellationException when end of block not received")
+        void testCancellationExceptionIncompleteBlock() {
+            toTest.accept(null, new CancellationException());
+            assertSingleFailureOfType(FailureType.CANCELLED_INCOMPLETE);
+        }
+
+        /// This test aims to assert that when the session's stage chain is
+        /// cancelled directly (the handler receives a [CancellationException])
+        /// and the batch ending the block was received, the handler reports a
+        /// failure of type [FailureType#CANCELLED].
+        @Test
+        @DisplayName("accept() reports CANCELLED on CancellationException when end of block received")
+        void testCancellationExceptionCompleteBlock() {
+            endOfBlockReceived.set(true);
+            toTest.accept(null, new CancellationException());
+            assertSingleFailureOfType(FailureType.CANCELLED);
+        }
+
+        /// This test aims to assert that when a stage reports a plain
+        /// cancellation (a [VerificationSessionFailedException] of type
+        /// [SessionFailureType#CANCELLED], reachable when a stage is
+        /// interrupted without the chain itself being cancelled, e.g. on an
+        /// executor shutdown) and the batch ending the block was never
+        /// received, the handler refines the failure to
+        /// [FailureType#CANCELLED_INCOMPLETE].
+        @Test
+        @DisplayName(
+                "accept() refines a stage-reported CANCELLED to CANCELLED_INCOMPLETE when end of block not received")
+        void testStageCancellationIncompleteBlock() {
+            toTest.accept(null, stageCancellation());
+            assertSingleFailureOfType(FailureType.CANCELLED_INCOMPLETE);
+        }
+
+        /// This test aims to assert that when a stage reports a plain
+        /// cancellation (a [VerificationSessionFailedException] of type
+        /// [SessionFailureType#CANCELLED], reachable when a stage is
+        /// interrupted without the chain itself being cancelled, e.g. on an
+        /// executor shutdown) and the batch ending the block was received,
+        /// the handler keeps the failure as [FailureType#CANCELLED].
+        @Test
+        @DisplayName("accept() keeps a stage-reported CANCELLED when end of block received")
+        void testStageCancellationCompleteBlock() {
+            endOfBlockReceived.set(true);
+            toTest.accept(null, stageCancellation());
+            assertSingleFailureOfType(FailureType.CANCELLED);
+        }
+
+        /// This test aims to assert that the refinement applies only to
+        /// stage-reported cancellations: a stage failure of any other type is
+        /// reported as is, regardless of whether the batch ending the block
+        /// was received.
+        @ParameterizedTest
+        @EnumSource(value = SessionFailureType.class, names = "CANCELLED", mode = EnumSource.Mode.EXCLUDE)
+        @DisplayName("accept() does not refine stage failures of other types")
+        void testOtherStageFailureNotRefined(final SessionFailureType failureType) {
+            endOfBlockReceived.set(true);
+            toTest.accept(
+                    null,
+                    new CompletionException(
+                            new VerificationSessionFailedException(BLOCK_NUMBER, failureType, BlockSource.PUBLISHER)));
+            assertSingleFailureOfType(failureType.asFailureType());
+        }
+
+        /// Builds the throwable the handler receives when a stage reports a
+        /// plain cancellation.
+        private CompletionException stageCancellation() {
+            return new CompletionException(new VerificationSessionFailedException(
+                    BLOCK_NUMBER, SessionFailureType.CANCELLED, BlockSource.PUBLISHER));
+        }
+
+        /// Asserts that exactly one failure notification was sent, carrying
+        /// the given standard failure type for the expected block.
+        private void assertSingleFailureOfType(final FailureType expectedType) {
+            final List<VerificationNotification> notifications = blockMessaging.getSentVerificationNotifications(1);
+            assertThat(notifications)
+                    .hasSize(1)
+                    .first()
+                    .returns(false, VerificationNotification::success)
+                    .returns(FailureInfo.standard(expectedType), VerificationNotification::failureInfo)
+                    .returns(BLOCK_NUMBER, VerificationNotification::blockNumber)
+                    .returns(BlockSource.PUBLISHER, VerificationNotification::source)
+                    .returns(null, VerificationNotification::block)
+                    .returns(null, VerificationNotification::blockHash);
+        }
+    }
+}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/VerificationNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/VerificationNotification.java
@@ -53,8 +53,15 @@ public record VerificationNotification(
         /// is not a processable block stream (for example an item that carries more than one
         /// field, or a mandatory once per block item that appears more than once)
         UNSUPPORTED_STREAM_FORMAT,
-        /// This type indicates that the session was cancelled
+        /// This type indicates that the session was cancelled after the
+        /// complete block was received, for example evicted from the active
+        /// sessions buffer or shut down before completing
         CANCELLED,
+        /// This type indicates that the session ended before the full block
+        /// was received, for example the publisher started a new block and
+        /// abandoned the current one, or an incomplete session was cancelled
+        /// for any other reason
+        CANCELLED_INCOMPLETE,
         /// This type indicates that an unknown error occurred
         UNKNOWN_ERROR
     }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -65,6 +65,7 @@ import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification;
 import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification.UpdateType;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureInfo;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureType;
 import org.hiero.block.node.spi.threading.ThreadPoolManager;
 import org.hiero.metrics.LongCounter;
@@ -403,9 +404,15 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     /// facility. Only in cases of failed verification, given that the block
     /// number of the failed block satisfies the conditions of it being
     /// higher than the last persisted and lower than the next unstreamed block,
-    /// we will attempt to handle that failure. That includes allowing
-    /// individual handlers to handle that block, but also scheduling the failed
-    /// block to be resent.
+    /// we will attempt to handle that failure. Failures are classified by
+    /// their failure type: a resend is scheduled for every type except
+    /// incomplete, and depending on the type the supplying handler's stream
+    /// is either left open or ended with the appropriate end of stream code.
+    /// An incomplete session means the block was never fully received, so it
+    /// is already handled elsewhere and no action is taken. An informational
+    /// failure, meaning the same block was already verified successfully
+    /// within reasonable recency, is handled the same as a standard one,
+    /// except that no resend is scheduled.
     @Override
     public void handleVerification(@NonNull final VerificationNotification notification) {
         final long blockNumber = notification.blockNumber();
@@ -418,35 +425,98 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 && blockNumber > lastPersistedBlockNumber.get()
                 && blockNumber < nextUnstreamedBlockNumber.get();
         if (shouldHandle) {
-            // A note for a flaky test fix for #3391 & #3392:
-            // After investigating, we have found out that the new verification
-            // plugin's report of canceled verifications is being picked up
-            // here, but there is no guarantee that we will accurately point to
-            // the actual publisher that has supplied the failed (canceled) block.
-            // This is true because we only see a snapshot of the current activity.
-            // If publisher 1 supplied block 5 that was later canceled, publisher 2
-            // might have started resending block 5, and the current state
-            // of the publisher manager will point a finger to publisher 2 for
-            // the failure of block 5.
-            // There is more work to be done so that we will be more accurate,
-            // this is captured by @todo(3436).
-            // Completely handling the FailureInfo is captured by @todo(2977).
-            if (notification.failureInfo().failureType() == FailureType.CANCELLED) {
-                LOGGER.log(INFO, "Session for block {0} was cancelled", blockNumber);
-            } else {
-                // Schedule a resend for the block before sending the bad block proof message
-                blocksToResend.add(blockNumber);
-                // Iterate over all handlers and attempt to send the
-                // bad block proof message.
-                for (final PublisherHandler handler : handlers.values()) {
-                    if (handler.handleFailedVerification(blockNumber)) {
-                        // There will always be only one handler that will send the
-                        // bad block proof message. Once we have, we can break.
-                        break;
-                    }
-                }
-            }
+            // A scheduled resend goes to all connected publishers, so we do
+            // not care which handler supplied the block that failed. Further
+            // improvements to the actions taken per failure type, like
+            // tailoring the response to the supplying handler, are captured
+            // by @todo(3436).
+            final FailureInfo failureInfo = notification.failureInfo();
+            final FailureActionResult actionResult = resolveFailureAction(blockNumber, failureInfo);
+            actionResult.handle(blockNumber, failureInfo, blocksToResend, handlers);
         }
+    }
+
+    /// Classifies a verification failure type, logs the failure and resolves
+    /// the operations the manager must perform for it. This is intentionally
+    /// an exhaustive switch expression with no default branch so that adding
+    /// a type to or removing a type from [FailureType] breaks compilation and
+    /// forces this policy to be revisited.
+    ///
+    /// @param blockNumber the block number that failed verification
+    /// @param failureInfo the failure information of the verification
+    /// @return the operations to perform for the failed block
+    private FailureActionResult resolveFailureAction(final long blockNumber, final FailureInfo failureInfo) {
+        return switch (failureInfo.failureType()) {
+            // The proof is proven invalid, a clear publisher fault.
+            case BAD_BLOCK_PROOF -> resendAndEndStream(blockNumber, failureInfo, WARNING, Code.BAD_BLOCK_PROOF);
+            // Possibly transient faults, the block is not proven bad,
+            // a retry may succeed, so the supplying stream stays open.
+            case MISSING_VERIFICATION_DATA, UNABLE_TO_PARSE -> resendOnly(blockNumber, failureInfo);
+            // The block is malformed, but the proof itself is not
+            // proven bad, so the stream ends with a generic error.
+            case MISSING_MANDATORY_FIELD, MISSING_MANDATORY_ITEM, UNSUPPORTED_STREAM_FORMAT ->
+                resendAndEndStream(blockNumber, failureInfo, INFO, Code.ERROR);
+            // Node side faults or capability limitations, the block is
+            // not proven bad, so the stream ends with a generic error.
+            case UNKNOWN_ERROR, UNRECOGNIZED_PROOF_TYPE, UNSUPPORTED_HAPI_VERSION, UNSUPPORTED_ITEM_TYPE ->
+                resendAndEndStream(blockNumber, failureInfo, INFO, Code.ERROR);
+            // The complete block was received, but the session was cancelled
+            // before producing a result (e.g. evicted from the active sessions
+            // buffer). The publishers consider the block delivered, so nothing
+            // else will supply it and a resend must be scheduled. Resends go
+            // to all publishers, attribution is irrelevant.
+            case CANCELLED -> resendOnly(blockNumber, failureInfo);
+            // The block was never fully received, so it is already handled:
+            // either a resend was already scheduled, or another source is
+            // supplying it. No action is needed.
+            case CANCELLED_INCOMPLETE -> logOnlyNoAction(blockNumber, failureInfo);
+        };
+    }
+
+    /// Logs the given verification failure at the given level and resolves a
+    /// resend for the failed block with the supplying stream ended with the
+    /// given code.
+    ///
+    /// @param blockNumber the block number that failed verification
+    /// @param failureInfo the failure information of the verification
+    /// @param logLevel the level to log the failure at
+    /// @param endStreamCode the end of stream code to send to the supplier
+    /// @return the operations to perform for the failed block
+    private FailureActionResult resendAndEndStream(
+            final long blockNumber,
+            final FailureInfo failureInfo,
+            final System.Logger.Level logLevel,
+            final Code endStreamCode) {
+        LOGGER.log(
+                logLevel,
+                "Verification of block {0} failed with {1}, ending the supplying stream with {2}",
+                blockNumber,
+                failureInfo,
+                endStreamCode);
+        return new FailureActionResult(true, endStreamCode);
+    }
+
+    /// Logs the given verification failure and resolves a resend for the
+    /// failed block with the supplying stream left open.
+    ///
+    /// @param blockNumber the block number that failed verification
+    /// @param failureInfo the failure information of the verification
+    /// @return the operations to perform for the failed block
+    private FailureActionResult resendOnly(final long blockNumber, final FailureInfo failureInfo) {
+        LOGGER.log(INFO, "Verification of block {0} failed with {1}", blockNumber, failureInfo);
+        return new FailureActionResult(true, null);
+    }
+
+    /// Logs the given verification failure and resolves no operations.
+    /// This is used for failures that require no further action from the
+    /// manager.
+    ///
+    /// @param blockNumber the block number whose session ended with failure
+    /// @param failureInfo the failure information of the verification
+    /// @return the operations to perform for the failed block
+    private FailureActionResult logOnlyNoAction(final long blockNumber, final FailureInfo failureInfo) {
+        LOGGER.log(INFO, "Session for block {0} failed with {1}, no action needed", blockNumber, failureInfo);
+        return new FailureActionResult(false, null);
     }
 
     /// {@inheritDoc}
@@ -1445,6 +1515,50 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 return true;
             } else {
                 return false;
+            }
+        }
+    }
+
+    /// The operations the publisher manager must perform for a verification
+    /// failure, as resolved by
+    /// [#resolveFailureAction(long,FailureInfo)].
+    ///
+    /// @param shouldResend true if a resend must be scheduled for the failed
+    /// block
+    /// @param endStreamCode the end of stream code to send to the supplying
+    /// handler, null if the stream stays open
+    private record FailureActionResult(boolean shouldResend, Code endStreamCode) {
+        /// Performs the resolved operations for the given failed block:
+        /// schedules a resend, unless the failure is informational, meaning
+        /// the same block was already verified successfully within reasonable
+        /// recency, and ends the supplying handler's stream when an end of
+        /// stream code is present. The resend is scheduled before the end of
+        /// stream message is sent.
+        ///
+        /// @param blockNumber    the block number that failed verification
+        /// @param failureInfo    the failure information of the verification
+        /// @param blocksToResend the manager's set of blocks scheduled to be resent
+        /// @param handlers       the manager's currently connected publisher handlers
+        private void handle(
+                final long blockNumber,
+                final FailureInfo failureInfo,
+                final ConcurrentSkipListSet<Long> blocksToResend,
+                final ConcurrentNavigableMap<Long, PublisherHandler> handlers) {
+            // An informational failure happened after the same block was
+            // already verified successfully within reasonable recency, so
+            // no resend is scheduled for it.
+            if (shouldResend && !failureInfo.isInformational()) {
+                // Schedule a resend for the block before sending the end of stream message
+                blocksToResend.add(blockNumber);
+            }
+            if (endStreamCode != null) {
+                for (final PublisherHandler handler : handlers.values()) {
+                    if (handler.handleFailedVerification(blockNumber, endStreamCode)) {
+                        // There will always be only one handler that will send the
+                        // end of stream message. Once we have, we can break.
+                        break;
+                    }
+                }
             }
         }
     }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -405,14 +405,17 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     /// number of the failed block satisfies the conditions of it being
     /// higher than the last persisted and lower than the next unstreamed block,
     /// we will attempt to handle that failure. Failures are classified by
-    /// their failure type: a resend is scheduled for every type except
-    /// incomplete, and depending on the type the supplying handler's stream
-    /// is either left open or ended with the appropriate end of stream code.
-    /// An incomplete session means the block was never fully received, so it
-    /// is already handled elsewhere and no action is taken. An informational
-    /// failure, meaning the same block was already verified successfully
-    /// within reasonable recency, is handled the same as a standard one,
-    /// except that no resend is scheduled.
+    /// their failure type into three stream scopes: a proven publisher fault
+    /// ends only the supplying handler's stream, malformed blocks with no
+    /// indication of malice keep all streams open with a resend scheduled,
+    /// and Block Node faults or capability limitations end every publisher
+    /// stream and clear all block tracking, encouraging publishers to
+    /// connect to a healthy Block Node. An incomplete session means the
+    /// block was never fully received, so it is already handled elsewhere
+    /// and no action is taken. An informational failure, meaning the same
+    /// block was already verified successfully within reasonable recency,
+    /// is handled the same as a standard one, except that no resend is
+    /// scheduled.
     @Override
     public void handleVerification(@NonNull final VerificationNotification notification) {
         final long blockNumber = notification.blockNumber();
@@ -432,7 +435,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             // by @todo(3436).
             final FailureInfo failureInfo = notification.failureInfo();
             final FailureActionResult actionResult = resolveFailureAction(blockNumber, failureInfo);
-            actionResult.handle(blockNumber, failureInfo, blocksToResend, handlers);
+            actionResult.handle(blockNumber, failureInfo, this);
         }
     }
 
@@ -447,19 +450,28 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     /// @return the operations to perform for the failed block
     private FailureActionResult resolveFailureAction(final long blockNumber, final FailureInfo failureInfo) {
         return switch (failureInfo.failureType()) {
-            // The proof is proven invalid, a clear publisher fault.
-            case BAD_BLOCK_PROOF -> resendAndEndStream(blockNumber, failureInfo, WARNING, Code.BAD_BLOCK_PROOF);
-            // Possibly transient faults, the block is not proven bad,
-            // a retry may succeed, so the supplying stream stays open.
-            case MISSING_VERIFICATION_DATA, UNABLE_TO_PARSE -> resendOnly(blockNumber, failureInfo);
-            // The block is malformed, but the proof itself is not
-            // proven bad, so the stream ends with a generic error.
-            case MISSING_MANDATORY_FIELD, MISSING_MANDATORY_ITEM, UNSUPPORTED_STREAM_FORMAT ->
-                resendAndEndStream(blockNumber, failureInfo, INFO, Code.ERROR);
-            // Node side faults or capability limitations, the block is
-            // not proven bad, so the stream ends with a generic error.
-            case UNKNOWN_ERROR, UNRECOGNIZED_PROOF_TYPE, UNSUPPORTED_HAPI_VERSION, UNSUPPORTED_ITEM_TYPE ->
-                resendAndEndStream(blockNumber, failureInfo, INFO, Code.ERROR);
+            // The proof is proven invalid, a clear publisher fault, so the
+            // supplying stream ends with the dedicated code.
+            case BAD_BLOCK_PROOF -> resendAndEndSupplierStream(blockNumber, failureInfo, Code.BAD_BLOCK_PROOF);
+            // The block is unparseable or malformed, but not proven bad and
+            // with no indication of malice; a retry may succeed, so all
+            // streams stay open. Ending a stream sends the publisher through
+            // an expensive reconnect and blacklist loop, which is not worth
+            // it here. Repeated failures from the same source will be
+            // penalized separately, see @todo(3436).
+            case UNABLE_TO_PARSE, MISSING_MANDATORY_FIELD, MISSING_MANDATORY_ITEM, UNSUPPORTED_STREAM_FORMAT ->
+                resendOnly(blockNumber, failureInfo);
+            // Block Node faults or capability limitations: this node cannot
+            // verify the block and the condition is at least locally
+            // persistent, so no retry against this node can succeed. All
+            // publisher streams end to encourage the publishers to connect
+            // to a healthy Block Node. All block tracking is cleared, so no
+            // resend is scheduled.
+            case MISSING_VERIFICATION_DATA,
+                    UNKNOWN_ERROR,
+                    UNRECOGNIZED_PROOF_TYPE,
+                    UNSUPPORTED_HAPI_VERSION,
+                    UNSUPPORTED_ITEM_TYPE -> endAllStreams(blockNumber, failureInfo);
             // The complete block was received, but the session was cancelled
             // before producing a result (e.g. evicted from the active sessions
             // buffer). The publishers consider the block delivered, so nothing
@@ -473,38 +485,51 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         };
     }
 
-    /// Logs the given verification failure at the given level and resolves a
-    /// resend for the failed block with the supplying stream ended with the
-    /// given code.
+    /// Logs the given verification failure and resolves a resend for the
+    /// failed block with the supplying stream ended with the given code.
     ///
     /// @param blockNumber the block number that failed verification
     /// @param failureInfo the failure information of the verification
-    /// @param logLevel the level to log the failure at
     /// @param endStreamCode the end of stream code to send to the supplier
     /// @return the operations to perform for the failed block
-    private FailureActionResult resendAndEndStream(
-            final long blockNumber,
-            final FailureInfo failureInfo,
-            final System.Logger.Level logLevel,
-            final Code endStreamCode) {
+    private FailureActionResult resendAndEndSupplierStream(
+            final long blockNumber, final FailureInfo failureInfo, final Code endStreamCode) {
         LOGGER.log(
-                logLevel,
+                WARNING,
                 "Verification of block {0} failed with {1}, ending the supplying stream with {2}",
                 blockNumber,
                 failureInfo,
                 endStreamCode);
-        return new FailureActionResult(true, endStreamCode);
+        return new FailureActionResult(true, endStreamCode, FailureActionResult.StreamScope.END_SUPPLIER);
+    }
+
+    /// Logs the given verification failure and resolves ending every
+    /// connected publisher's stream with [Code#ERROR]. This is used for
+    /// Block Node faults and capability limitations, where no retry against
+    /// this node can succeed. No resend is resolved because ending all
+    /// streams also clears all block tracking.
+    ///
+    /// @param blockNumber the block number that failed verification
+    /// @param failureInfo the failure information of the verification
+    /// @return the operations to perform for the failed block
+    private FailureActionResult endAllStreams(final long blockNumber, final FailureInfo failureInfo) {
+        LOGGER.log(
+                WARNING,
+                "Verification of block {0} failed with {1}, a Block Node fault, ending all publisher streams",
+                blockNumber,
+                failureInfo);
+        return new FailureActionResult(false, Code.ERROR, FailureActionResult.StreamScope.END_ALL);
     }
 
     /// Logs the given verification failure and resolves a resend for the
-    /// failed block with the supplying stream left open.
+    /// failed block with all streams left open.
     ///
     /// @param blockNumber the block number that failed verification
     /// @param failureInfo the failure information of the verification
     /// @return the operations to perform for the failed block
     private FailureActionResult resendOnly(final long blockNumber, final FailureInfo failureInfo) {
         LOGGER.log(INFO, "Verification of block {0} failed with {1}", blockNumber, failureInfo);
-        return new FailureActionResult(true, null);
+        return new FailureActionResult(true, null, FailureActionResult.StreamScope.NO_STREAM_ACTION);
     }
 
     /// Logs the given verification failure and resolves no operations.
@@ -516,7 +541,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     /// @return the operations to perform for the failed block
     private FailureActionResult logOnlyNoAction(final long blockNumber, final FailureInfo failureInfo) {
         LOGGER.log(INFO, "Session for block {0} failed with {1}, no action needed", blockNumber, failureInfo);
-        return new FailureActionResult(false, null);
+        return new FailureActionResult(false, null, FailureActionResult.StreamScope.NO_STREAM_ACTION);
     }
 
     /// {@inheritDoc}
@@ -582,7 +607,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 }
             } else {
                 if (notification.blockSource() == BlockSource.PUBLISHER) {
-                    endAllHandlersAndClearTracking(blockNumber);
+                    endAllHandlersAndClearTracking(blockNumber, Code.PERSISTENCE_FAILED);
                     // @todo(2240,2236) Mark the publisher plugin _unhealthy_
                     //     when the Health Plugin supports that.
                 }
@@ -602,16 +627,19 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     /// or Latch would be significantly more costly).
     /// This method does reset the flag in a finally block, however, to ensure
     /// that if an exception is thrown the flag is still cleared.
-    private void endAllHandlersAndClearTracking(final long blockNumber) {
+    ///
+    /// @param blockNumber the block number the failure is proximate to
+    /// @param endStreamCode the end of stream code to send to every handler
+    private void endAllHandlersAndClearTracking(final long blockNumber, final Code endStreamCode) {
         resetIsActive.compareAndSet(false, true);
         try {
             nextUnstreamedBlockNumber.set(blockNumber);
             activeStreamHandlerByBlock.clear();
             Collection<PublisherHandler> handlersToClose = handlers.values();
-            // Notify the handlers that persistence failed.
+            // Notify the handlers of the failure with the given code.
             handlersToClose.parallelStream()
                     .unordered()
-                    .forEach((handler) -> handler.endStreamWithCode(Code.PERSISTENCE_FAILED, true, blockNumber));
+                    .forEach((handler) -> handler.endStreamWithCode(endStreamCode, true, blockNumber));
             // Order matters here. Reordering these can lead to _extremely rare_
             // cases where we get unnecessary errors or a block is scheduled to be
             // resent that was never sent.
@@ -1520,45 +1548,60 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     }
 
     /// The operations the publisher manager must perform for a verification
-    /// failure, as resolved by
-    /// [#resolveFailureAction(long,FailureInfo)].
+    /// failure, as resolved by [#resolveFailureAction(long,FailureInfo)].
     ///
     /// @param shouldResend true if a resend must be scheduled for the failed
     /// block
-    /// @param endStreamCode the end of stream code to send to the supplying
-    /// handler, null if the stream stays open
-    private record FailureActionResult(boolean shouldResend, Code endStreamCode) {
-        /// Performs the resolved operations for the given failed block:
-        /// schedules a resend, unless the failure is informational, meaning
-        /// the same block was already verified successfully within reasonable
-        /// recency, and ends the supplying handler's stream when an end of
-        /// stream code is present. The resend is scheduled before the end of
-        /// stream message is sent.
+    /// @param endStreamCode the end of stream code to send when streams end,
+    /// null if the scope is [StreamScope#NO_STREAM_ACTION]
+    /// @param scope the scope of publisher streams to end
+    record FailureActionResult(boolean shouldResend, Code endStreamCode, StreamScope scope) {
+        /// The scope of publisher streams to end for a verification failure.
+        enum StreamScope {
+            /// All streams stay open.
+            NO_STREAM_ACTION,
+            /// Only the stream of the handler that supplied the failed block
+            /// ends; every other stream stays open.
+            END_SUPPLIER,
+            /// Every connected publisher's stream ends and all block tracking
+            /// is cleared.
+            END_ALL
+        }
+
+        /// Performs the resolved operations for the given failed block on
+        /// the given manager. A resend, unless the failure is informational,
+        /// meaning the same block was already verified successfully within
+        /// reasonable recency, is scheduled before any end of stream message
+        /// is sent. Streams then end according to the resolved scope: none,
+        /// only the supplying handler's stream, or every connected
+        /// publisher's stream, the latter also clearing all block tracking.
         ///
-        /// @param blockNumber    the block number that failed verification
-        /// @param failureInfo    the failure information of the verification
-        /// @param blocksToResend the manager's set of blocks scheduled to be resent
-        /// @param handlers       the manager's currently connected publisher handlers
-        private void handle(
-                final long blockNumber,
-                final FailureInfo failureInfo,
-                final ConcurrentSkipListSet<Long> blocksToResend,
-                final ConcurrentNavigableMap<Long, PublisherHandler> handlers) {
+        /// @param blockNumber the block number that failed verification
+        /// @param failureInfo the failure information of the verification
+        /// @param manager the manager to perform the operations on
+        void handle(final long blockNumber, final FailureInfo failureInfo, final LiveStreamPublisherManager manager) {
             // An informational failure happened after the same block was
             // already verified successfully within reasonable recency, so
             // no resend is scheduled for it.
             if (shouldResend && !failureInfo.isInformational()) {
-                // Schedule a resend for the block before sending the end of stream message
-                blocksToResend.add(blockNumber);
+                // Schedule a resend for the block before any end of stream message
+                manager.blocksToResend.add(blockNumber);
             }
-            if (endStreamCode != null) {
-                for (final PublisherHandler handler : handlers.values()) {
-                    if (handler.handleFailedVerification(blockNumber, endStreamCode)) {
-                        // There will always be only one handler that will send the
-                        // end of stream message. Once we have, we can break.
-                        break;
+            switch (scope) {
+                case NO_STREAM_ACTION -> {
+                    // All streams stay open, nothing to end.
+                }
+                case END_SUPPLIER -> {
+                    // Only the handler that supplied the failed block sends
+                    // the end of stream message; every other stream stays
+                    // open.
+                    for (final PublisherHandler handler : manager.handlers.values()) {
+                        if (handler.handleFailedVerification(blockNumber, endStreamCode)) {
+                            break;
+                        }
                     }
                 }
+                case END_ALL -> manager.endAllHandlersAndClearTracking(blockNumber, endStreamCode);
             }
         }
     }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -294,12 +294,13 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
 
     /// This method must be called when a verification fails for a given block.
     /// If this handler was the one that streamed the block, we will attempt to
-    /// send an [EndOfStream] with a [Code#BAD_BLOCK_PROOF] and proceed to
-    /// schedule a shutdown for the handler.
+    /// send an [EndOfStream] with the given code and proceed to schedule a
+    /// shutdown for the handler.
     ///
     /// @param blockNumber of the block that failed verification
-    /// @return true if the handler has sent the [Code#BAD_BLOCK_PROOF] message
-    boolean handleFailedVerification(final long blockNumber) {
+    /// @param endStreamCode the end of stream code to send
+    /// @return true if the handler has sent the end of stream message
+    boolean handleFailedVerification(final long blockNumber, final Code endStreamCode) {
         LOGGER.log(
                 DEBUG,
                 "[{0}] Handler {1} handling failed verification for block {2}",
@@ -308,8 +309,8 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
                 blockNumber);
         if (unacknowledgedStreamedBlocks.remove(blockNumber)) {
             // If the block number that failed verification was sent by this
-            // handler, we need to send an EndOfStream with BAD_BLOCK_PROOF code.
-            endStreamWithCode(Code.BAD_BLOCK_PROOF, false, blockNumber);
+            // handler, we need to send an EndOfStream with the given code.
+            endStreamWithCode(endStreamCode, false, blockNumber);
             return true;
         } else {
             return false;

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -1361,18 +1361,18 @@ class LiveStreamPublisherManagerTest {
                         .containsExactly(block[block.length - 1]);
             }
 
-            // @todo(2977) this test might not be entirely true once we handle failure info
             /// This test aims to assert that the
             /// [LiveStreamPublisherManager#handleVerification(VerificationNotification)]
-            /// ignores a failed verification of type [FailureType#CANCELLED].
-            /// A cancelled verification session cannot be reliably attributed
-            /// to the publisher that supplied the block, so the manager must
-            /// only log the event. No responses of any kind are expected to be
-            /// sent, even by the handler that supplied the block, and no
-            /// metrics are expected to be updated.
+            /// ignores a failed verification of type [FailureType#CANCELLED_INCOMPLETE].
+            /// An incomplete session means the block was never fully received,
+            /// so it is already handled: either a resend was already scheduled,
+            /// or another source is supplying the block. The manager must only
+            /// log the event. No responses of any kind are expected to be sent,
+            /// even by the handler that supplied the block, and no metrics are
+            /// expected to be updated.
             @Test
-            @DisplayName("handleVerification() ignores CANCELLED failures, no responses of any kind sent")
-            void testHandleVerificationCancelledIgnored() {
+            @DisplayName("handleVerification() ignores CANCELLED_INCOMPLETE failures, no responses of any kind sent")
+            void testHandleVerificationIncompleteIgnored() {
                 // We need to send a request via the publisher handler first,
                 // This will properly update the internal state of the manager
                 // so we can assert correctly. We aim to increment the next
@@ -1392,12 +1392,13 @@ class LiveStreamPublisherManagerTest {
                 // was the next expected block.
                 publisherHandler.onNext(request);
                 endThisBlock(publisherHandler, block.number());
-                // Now, the verification session for the targeted block was
-                // cancelled. We can now build a verification notification with
-                // failed verification of type CANCELLED.
+                // Now, the verification session for the targeted block ended
+                // before the full block was received. We can now build a
+                // verification notification with failed verification of type
+                // CANCELLED_INCOMPLETE.
                 final VerificationNotification notification = new VerificationNotification(
                         false,
-                        FailureInfo.standard(FailureType.CANCELLED),
+                        FailureInfo.standard(FailureType.CANCELLED_INCOMPLETE),
                         block.number(),
                         null,
                         null,
@@ -1424,18 +1425,19 @@ class LiveStreamPublisherManagerTest {
                 assertThat(responsePipeline2.getClientEndStreamCalls().get()).isEqualTo(0);
             }
 
-            // @todo(2977) this test might not be entirely true once we handle failure info
             /// This test aims to assert that the
             /// [LiveStreamPublisherManager#handleVerification(VerificationNotification)]
             /// does not schedule a resend for a block whose verification failed
-            /// with [FailureType#CANCELLED]. If a resend were scheduled, the
+            /// with [FailureType#CANCELLED_INCOMPLETE]. An incomplete session means the
+            /// block was never fully received, so it is already handled and no
+            /// action is needed. If a resend were scheduled, the
             /// gap detection in handlePersisted() would clamp acknowledgements
-            /// below the cancelled block. We assert that a subsequent persisted
-            /// notification for the cancelled block is acknowledged normally.
+            /// below the incomplete block. We assert that a subsequent persisted
+            /// notification for the incomplete block is acknowledged normally.
             @Test
             @DisplayName(
-                    "handleVerification() does not schedule a resend for a CANCELLED failure, later persistence is acknowledged")
-            void testHandleVerificationCancelledNoResendScheduled() {
+                    "handleVerification() does not schedule a resend for a CANCELLED_INCOMPLETE failure, later persistence is acknowledged")
+            void testHandleVerificationIncompleteNoResendScheduled() {
                 // Establish lastPersisted=0 and advance nextUnstreamed past block 1 so
                 // handleVerification's failure branch fires.
                 assertThat(toTest.getActionForBlock(0L, null, publisherHandlerId))
@@ -1443,10 +1445,16 @@ class LiveStreamPublisherManagerTest {
                 toTest.handlePersisted(new PersistedNotification(0L, true, 0, BlockSource.PUBLISHER));
                 assertThat(toTest.getActionForBlock(1L, null, publisherHandlerId))
                         .isEqualTo(BlockAction.ACCEPT);
-                // Block 1's verification session is cancelled. The manager must
-                // ignore the notification and must not schedule a resend.
+                // Block 1's verification session ended before the full block
+                // was received. The block is already handled elsewhere, so the
+                // manager must only log the event.
                 toTest.handleVerification(new VerificationNotification(
-                        false, FailureInfo.standard(FailureType.CANCELLED), 1L, null, null, BlockSource.PUBLISHER));
+                        false,
+                        FailureInfo.standard(FailureType.CANCELLED_INCOMPLETE),
+                        1L,
+                        null,
+                        null,
+                        BlockSource.PUBLISHER));
                 // Clear the pipelines because acknowledgements have been sent
                 // due to the persisted notification for block 0.
                 responsePipeline.clear();
@@ -1471,21 +1479,28 @@ class LiveStreamPublisherManagerTest {
                         .returns(1L, acknowledgementBlockNumberExtractor);
             }
 
-            // @todo(2977) this test might not be entirely true once we handle failure info
             /// This test aims to assert that the
             /// [LiveStreamPublisherManager#handleVerification(VerificationNotification)]
-            /// will handle a failed verification of any type other than
-            /// [FailureType#CANCELLED]. The handler that supplied the failed
-            /// block is expected to send an EndOfStream response with
-            /// [Code#BAD_BLOCK_PROOF] and to shut down.
+            /// will handle a failed verification of a type that indicates a
+            /// malformed block or a node side limitation. The handler that
+            /// supplied the failed block is expected to send an EndOfStream
+            /// response with [Code#ERROR] and to shut down, and a resend is
+            /// expected to be scheduled for the failed block.
             @ParameterizedTest
             @EnumSource(
                     value = FailureType.class,
-                    names = {"CANCELLED"},
-                    mode = EnumSource.Mode.EXCLUDE)
+                    names = {
+                        "MISSING_MANDATORY_FIELD",
+                        "MISSING_MANDATORY_ITEM",
+                        "UNSUPPORTED_STREAM_FORMAT",
+                        "UNKNOWN_ERROR",
+                        "UNRECOGNIZED_PROOF_TYPE",
+                        "UNSUPPORTED_HAPI_VERSION",
+                        "UNSUPPORTED_ITEM_TYPE"
+                    })
             @DisplayName(
-                    "handleVerification() BAD_BLOCK_PROOF response is sent for every failure type other than CANCELLED")
-            void testHandleVerificationNonCancelledFailureTypes(final FailureType failureType) {
+                    "handleVerification() ERROR response is sent and a resend is scheduled for malformed block and node limitation failure types")
+            void testHandleVerificationEndStreamErrorFailureTypes(final FailureType failureType) {
                 // We need to send a request via the publisher handler first,
                 // This will properly update the internal state of the manager
                 // so we can assert correctly. We aim to increment the next
@@ -1511,14 +1526,14 @@ class LiveStreamPublisherManagerTest {
                         false, FailureInfo.standard(failureType), block.number(), null, null, BlockSource.PUBLISHER);
                 // Call
                 toTest.handleVerification(notification);
-                // Assert that the response pipeline has received a BAD_BLOCK_PROOF response, because the
+                // Assert that the response pipeline has received an ERROR response, because the
                 // publisher we used has sent the block that failed verification.
                 final List<PublishStreamResponse> onNextCalls = responsePipeline.getOnNextCalls();
                 assertThat(onNextCalls)
                         .hasSize(1)
                         .first()
                         .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
-                        .returns(Code.BAD_BLOCK_PROOF, endStreamResponseCodeExtractor)
+                        .returns(Code.ERROR, endStreamResponseCodeExtractor)
                         // below block number in the response is the latest known, -1L because none are stored
                         .returns(-1L, endStreamBlockNumberExtractor);
                 onNextCalls.clear();
@@ -1539,6 +1554,294 @@ class LiveStreamPublisherManagerTest {
                 assertThat(responsePipeline.getOnErrorCalls()).isEmpty();
                 assertThat(responsePipeline.getOnSubscriptionCalls()).isEmpty();
                 assertThat(responsePipeline.getClientEndStreamCalls().get()).isEqualTo(0);
+                // Assert that a resend was scheduled for the failed block: a
+                // subsequent persisted notification for it must be clamped by
+                // gap detection, so the latest known block must not advance.
+                // We run the queued messaging forwarder first so that the
+                // in-flight queue does not clamp the acknowledgement itself.
+                threadPoolManager.executor().executeAsync(1_000L, false);
+                toTest.handlePersisted(new PersistedNotification(block.number(), true, 0, BlockSource.PUBLISHER));
+                assertThat(toTest.getLatestBlockNumber())
+                        .as("latest known block must not advance, a resend is pending for the failed block")
+                        .isEqualTo(-1L);
+            }
+
+            /// This test aims to assert that the
+            /// [LiveStreamPublisherManager#handleVerification(VerificationNotification)]
+            /// will handle a failed verification of a resend only type by only
+            /// scheduling a resend for the failed block. These are the possibly
+            /// transient types, where a retry may succeed, and the cancelled
+            /// type, where the complete block was received but the session was
+            /// cancelled before producing a result, so the publishers consider
+            /// the block delivered and nothing else will supply it. No end of
+            /// stream is expected to be sent and no handler is expected to be
+            /// shut down, the supplying stream stays open.
+            @ParameterizedTest
+            @EnumSource(
+                    value = FailureType.class,
+                    names = {"MISSING_VERIFICATION_DATA", "UNABLE_TO_PARSE", "CANCELLED"})
+            @DisplayName("handleVerification() schedules a resend and keeps streams open for resend only failure types")
+            void testHandleVerificationResendOnlyFailureTypes(final FailureType failureType) {
+                // Establish lastPersisted=0 and advance nextUnstreamed past block 1 so
+                // handleVerification's failure branch fires.
+                assertThat(toTest.getActionForBlock(0L, null, publisherHandlerId))
+                        .isEqualTo(BlockAction.ACCEPT);
+                toTest.handlePersisted(new PersistedNotification(0L, true, 0, BlockSource.PUBLISHER));
+                assertThat(toTest.getActionForBlock(1L, null, publisherHandlerId))
+                        .isEqualTo(BlockAction.ACCEPT);
+                // Clear the pipelines because acknowledgements have been sent
+                // due to the persisted notification for block 0.
+                responsePipeline.clear();
+                responsePipeline2.clear();
+                // Block 1 fails verification with a resend only type.
+                // The manager must schedule a resend and keep all streams open.
+                toTest.handleVerification(new VerificationNotification(
+                        false, FailureInfo.standard(failureType), 1L, null, null, BlockSource.PUBLISHER));
+                // Assert that no end of stream was sent and no handler was
+                // shut down.
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_ENDOFSTREAM_SENT))
+                        .isEqualTo(0);
+                assertThat(responsePipeline.getOnNextCalls()).isEmpty();
+                assertThat(responsePipeline.getOnCompleteCalls().get()).isEqualTo(0);
+                assertThat(responsePipeline2.getOnNextCalls()).isEmpty();
+                assertThat(responsePipeline2.getOnCompleteCalls().get()).isEqualTo(0);
+                // Block 1 is persisted. Because a resend is pending for it, gap
+                // detection must clamp the acknowledgement below block 1.
+                toTest.handlePersisted(new PersistedNotification(1L, true, 0, BlockSource.PUBLISHER));
+                assertThat(toTest.getLatestBlockNumber())
+                        .as("latest known block must stay at block 0, a resend is pending for block 1")
+                        .isEqualTo(0L);
+                // Assert that no acknowledgement was sent for block 1.
+                assertThat(responsePipeline.getOnNextCalls()).isEmpty();
+                assertThat(responsePipeline2.getOnNextCalls()).isEmpty();
+            }
+
+            /// This test aims to assert that the
+            /// [LiveStreamPublisherManager#handleVerification(VerificationNotification)]
+            /// takes no observable action for an informational failure of a
+            /// type that does not end the supplying stream. An informational
+            /// failure means the same block was already verified successfully
+            /// within reasonable recency, so it is handled the same as a
+            /// standard one, except that no resend is scheduled. For these
+            /// types that leaves nothing to do. No responses of any kind are
+            /// expected to be sent, no resend is expected to be scheduled and
+            /// no metrics are expected to be updated.
+            @ParameterizedTest
+            @EnumSource(
+                    value = FailureType.class,
+                    names = {"MISSING_VERIFICATION_DATA", "UNABLE_TO_PARSE", "CANCELLED", "CANCELLED_INCOMPLETE"})
+            @DisplayName(
+                    "handleVerification() takes no action for informational failures of types that do not end the stream")
+            void testHandleVerificationInformationalIgnored(final FailureType failureType) {
+                // We need to send a request via the publisher handler first,
+                // This will properly update the internal state of the manager
+                // so we can assert correctly. We aim to increment the next
+                // unstreamed block number to 1L so we have a gap between
+                // latest persisted (which should be -1L) and next unstreamed.
+                // This is an expected condition during normal operation.
+                final TestBlock block = TestBlockBuilder.generateBlockWithNumber(0);
+                // Now we build the request
+                final BlockItemSetUnparsed itemSet = block.asItemSetUnparsed();
+                final PublishStreamRequestUnparsed request = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(itemSet)
+                        .build();
+                // We send the request to the publisher handler.
+                // This will update the next unstreamed block number to 1L as
+                // soon as we start streaming, i.e. a handler has queried the
+                // manager for a block action for block 0L and at that point it
+                // was the next expected block.
+                publisherHandler.onNext(request);
+                endThisBlock(publisherHandler, block.number());
+                // The targeted block was already verified successfully within
+                // reasonable recency, so this failure is informational.
+                final VerificationNotification notification = new VerificationNotification(
+                        false,
+                        FailureInfo.informational(failureType),
+                        block.number(),
+                        null,
+                        null,
+                        BlockSource.PUBLISHER);
+                // Call
+                toTest.handleVerification(notification);
+                // Assert that no shared metrics are updated
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_ENDOFSTREAM_SENT))
+                        .isEqualTo(0);
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCKS_RESEND_SENT))
+                        .isEqualTo(0);
+                // Assert that no responses of any kind have been sent.
+                // Notably, the handler that supplied the block must not have
+                // sent an EndOfStream of any kind.
+                assertThat(responsePipeline.getOnNextCalls()).isEmpty();
+                assertThat(responsePipeline.getOnErrorCalls()).isEmpty();
+                assertThat(responsePipeline.getOnSubscriptionCalls()).isEmpty();
+                assertThat(responsePipeline.getOnCompleteCalls().get()).isEqualTo(0);
+                assertThat(responsePipeline.getClientEndStreamCalls().get()).isEqualTo(0);
+                assertThat(responsePipeline2.getOnNextCalls()).isEmpty();
+                assertThat(responsePipeline2.getOnErrorCalls()).isEmpty();
+                assertThat(responsePipeline2.getOnSubscriptionCalls()).isEmpty();
+                assertThat(responsePipeline2.getOnCompleteCalls().get()).isEqualTo(0);
+                assertThat(responsePipeline2.getClientEndStreamCalls().get()).isEqualTo(0);
+                // Assert that no resend was scheduled for the block: a
+                // subsequent persisted notification for it must be
+                // acknowledged normally.
+                // We run the queued messaging forwarder first so that the
+                // in-flight queue does not clamp the acknowledgement.
+                threadPoolManager.executor().executeAsync(1_000L, false);
+                toTest.handlePersisted(new PersistedNotification(block.number(), true, 0, BlockSource.PUBLISHER));
+                assertThat(toTest.getLatestBlockNumber())
+                        .as("latest known block must advance, no resend is pending for the block")
+                        .isEqualTo(block.number());
+            }
+
+            /// This test aims to assert that the
+            /// [LiveStreamPublisherManager#handleVerification(VerificationNotification)]
+            /// handles an informational failure of type
+            /// [FailureType#BAD_BLOCK_PROOF] the same as a standard one,
+            /// except that no resend is scheduled. The handler that supplied
+            /// the failed block is expected to send an EndOfStream response
+            /// with [Code#BAD_BLOCK_PROOF] and to shut down.
+            @Test
+            @DisplayName(
+                    "handleVerification() BAD_BLOCK_PROOF response is sent but no resend is scheduled for an informational bad proof failure")
+            void testHandleVerificationInformationalBadBlockProof() {
+                // We need to send a request via the publisher handler first,
+                // This will properly update the internal state of the manager
+                // so we can assert correctly. We aim to increment the next
+                // unstreamed block number to 1L so we have a gap between
+                // latest persisted (which should be -1L) and next unstreamed.
+                // This is an expected condition during normal operation.
+                final TestBlock block = TestBlockBuilder.generateBlockWithNumber(0);
+                // Now we build the request
+                final BlockItemSetUnparsed itemSet = block.asItemSetUnparsed();
+                final PublishStreamRequestUnparsed request = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(itemSet)
+                        .build();
+                // We send the request to the publisher handler.
+                publisherHandler.onNext(request);
+                endThisBlock(publisherHandler, block.number());
+                // The targeted block was already verified successfully within
+                // reasonable recency, so this failure is informational.
+                final VerificationNotification notification = new VerificationNotification(
+                        false,
+                        FailureInfo.informational(FailureType.BAD_BLOCK_PROOF),
+                        block.number(),
+                        null,
+                        null,
+                        BlockSource.PUBLISHER);
+                // Call
+                toTest.handleVerification(notification);
+                // Assert that the response pipeline has received a
+                // BAD_BLOCK_PROOF response, because the publisher we used has
+                // sent the block that failed verification.
+                final List<PublishStreamResponse> onNextCalls = responsePipeline.getOnNextCalls();
+                assertThat(onNextCalls)
+                        .hasSize(1)
+                        .first()
+                        .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
+                        .returns(Code.BAD_BLOCK_PROOF, endStreamResponseCodeExtractor)
+                        // below block number in the response is the latest known, -1L because none are stored
+                        .returns(-1L, endStreamBlockNumberExtractor);
+                onNextCalls.clear();
+                // We expect a shutdown to be scheduled
+                // We need to send any request or trigger any pipeline method
+                // to do the actual shutdown
+                publisherHandler.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                threadPoolManager.scheduledExecutor().executeSerially();
+                assertThat(responsePipeline.getOnCompleteCalls().get()).isEqualTo(1);
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_ENDOFSTREAM_SENT))
+                        .isEqualTo(1);
+                // Assert that no resend was scheduled for the block: a
+                // subsequent persisted notification for it must be
+                // acknowledged normally.
+                // We run the queued messaging forwarder first so that the
+                // in-flight queue does not clamp the acknowledgement.
+                threadPoolManager.executor().executeAsync(1_000L, false);
+                toTest.handlePersisted(new PersistedNotification(block.number(), true, 0, BlockSource.PUBLISHER));
+                assertThat(toTest.getLatestBlockNumber())
+                        .as("latest known block must advance, no resend is pending for the block")
+                        .isEqualTo(block.number());
+            }
+
+            /// This test aims to assert that the
+            /// [LiveStreamPublisherManager#handleVerification(VerificationNotification)]
+            /// handles an informational failure of a malformed block or node
+            /// limitation type the same as a standard one, except that no
+            /// resend is scheduled. The handler that supplied the failed
+            /// block is expected to send an EndOfStream response with
+            /// [Code#ERROR] and to shut down.
+            @ParameterizedTest
+            @EnumSource(
+                    value = FailureType.class,
+                    names = {
+                        "MISSING_MANDATORY_FIELD",
+                        "MISSING_MANDATORY_ITEM",
+                        "UNSUPPORTED_STREAM_FORMAT",
+                        "UNKNOWN_ERROR",
+                        "UNRECOGNIZED_PROOF_TYPE",
+                        "UNSUPPORTED_HAPI_VERSION",
+                        "UNSUPPORTED_ITEM_TYPE"
+                    })
+            @DisplayName(
+                    "handleVerification() ERROR response is sent but no resend is scheduled for informational failures of malformed block and node limitation types")
+            void testHandleVerificationInformationalEndStreamError(final FailureType failureType) {
+                // We need to send a request via the publisher handler first,
+                // This will properly update the internal state of the manager
+                // so we can assert correctly. We aim to increment the next
+                // unstreamed block number to 1L so we have a gap between
+                // latest persisted (which should be -1L) and next unstreamed.
+                // This is an expected condition during normal operation.
+                final TestBlock block = TestBlockBuilder.generateBlockWithNumber(0);
+                // Now we build the request
+                final BlockItemSetUnparsed itemSet = block.asItemSetUnparsed();
+                final PublishStreamRequestUnparsed request = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(itemSet)
+                        .build();
+                // We send the request to the publisher handler.
+                publisherHandler.onNext(request);
+                endThisBlock(publisherHandler, block.number());
+                // The targeted block was already verified successfully within
+                // reasonable recency, so this failure is informational.
+                final VerificationNotification notification = new VerificationNotification(
+                        false,
+                        FailureInfo.informational(failureType),
+                        block.number(),
+                        null,
+                        null,
+                        BlockSource.PUBLISHER);
+                // Call
+                toTest.handleVerification(notification);
+                // Assert that the response pipeline has received an ERROR
+                // response, because the publisher we used has sent the block
+                // that failed verification.
+                final List<PublishStreamResponse> onNextCalls = responsePipeline.getOnNextCalls();
+                assertThat(onNextCalls)
+                        .hasSize(1)
+                        .first()
+                        .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
+                        .returns(Code.ERROR, endStreamResponseCodeExtractor)
+                        // below block number in the response is the latest known, -1L because none are stored
+                        .returns(-1L, endStreamBlockNumberExtractor);
+                onNextCalls.clear();
+                // We expect a shutdown to be scheduled
+                // We need to send any request or trigger any pipeline method
+                // to do the actual shutdown
+                publisherHandler.onNext(request);
+                // Invoke the delayed shutdown so it actually runs
+                threadPoolManager.scheduledExecutor().executeSerially();
+                assertThat(responsePipeline.getOnCompleteCalls().get()).isEqualTo(1);
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_ENDOFSTREAM_SENT))
+                        .isEqualTo(1);
+                // Assert that no resend was scheduled for the block: a
+                // subsequent persisted notification for it must be
+                // acknowledged normally.
+                // We run the queued messaging forwarder first so that the
+                // in-flight queue does not clamp the acknowledgement.
+                threadPoolManager.executor().executeAsync(1_000L, false);
+                toTest.handlePersisted(new PersistedNotification(block.number(), true, 0, BlockSource.PUBLISHER));
+                assertThat(toTest.getLatestBlockNumber())
+                        .as("latest known block must advance, no resend is pending for the block")
+                        .isEqualTo(block.number());
             }
         }
 

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -1482,25 +1482,27 @@ class LiveStreamPublisherManagerTest {
             /// This test aims to assert that the
             /// [LiveStreamPublisherManager#handleVerification(VerificationNotification)]
             /// will handle a failed verification of a type that indicates a
-            /// malformed block or a node side limitation. The handler that
-            /// supplied the failed block is expected to send an EndOfStream
-            /// response with [Code#ERROR] and to shut down, and a resend is
-            /// expected to be scheduled for the failed block.
+            /// Block Node fault or capability limitation by ending every
+            /// connected publisher's stream. No retry against this node can
+            /// succeed for these types, so every registered handler,
+            /// including ones that did not supply the failed block, is
+            /// expected to send an EndOfStream response with [Code#ERROR]
+            /// and to shut down, encouraging the publishers to connect to a
+            /// healthy Block Node. All block tracking is cleared, so no
+            /// resend is expected to be scheduled for the failed block.
             @ParameterizedTest
             @EnumSource(
                     value = FailureType.class,
                     names = {
-                        "MISSING_MANDATORY_FIELD",
-                        "MISSING_MANDATORY_ITEM",
-                        "UNSUPPORTED_STREAM_FORMAT",
+                        "MISSING_VERIFICATION_DATA",
                         "UNKNOWN_ERROR",
                         "UNRECOGNIZED_PROOF_TYPE",
                         "UNSUPPORTED_HAPI_VERSION",
                         "UNSUPPORTED_ITEM_TYPE"
                     })
             @DisplayName(
-                    "handleVerification() ERROR response is sent and a resend is scheduled for malformed block and node limitation failure types")
-            void testHandleVerificationEndStreamErrorFailureTypes(final FailureType failureType) {
+                    "handleVerification() ERROR response is sent to all registered handlers for Block Node fault failure types")
+            void testHandleVerificationEndAllStreamsFailureTypes(final FailureType failureType) {
                 // We need to send a request via the publisher handler first,
                 // This will properly update the internal state of the manager
                 // so we can assert correctly. We aim to increment the next
@@ -1526,60 +1528,73 @@ class LiveStreamPublisherManagerTest {
                         false, FailureInfo.standard(failureType), block.number(), null, null, BlockSource.PUBLISHER);
                 // Call
                 toTest.handleVerification(notification);
-                // Assert that the response pipeline has received an ERROR response, because the
-                // publisher we used has sent the block that failed verification.
-                final List<PublishStreamResponse> onNextCalls = responsePipeline.getOnNextCalls();
-                assertThat(onNextCalls)
+                // Assert that the supplying handler's pipeline has received
+                // an ERROR response.
+                assertThat(responsePipeline.getOnNextCalls())
                         .hasSize(1)
                         .first()
                         .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
                         .returns(Code.ERROR, endStreamResponseCodeExtractor)
                         // below block number in the response is the latest known, -1L because none are stored
                         .returns(-1L, endStreamBlockNumberExtractor);
-                onNextCalls.clear();
-                // We expect a shutdown to be scheduled
-                // We need to send any request or trigger any pipeline method
-                // to do the actual shutdown
+                // Assert that the second handler's pipeline has also received
+                // an ERROR response, even though it did not supply the block
+                // that failed verification.
+                assertThat(responsePipeline2.getOnNextCalls())
+                        .hasSize(1)
+                        .first()
+                        .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
+                        .returns(Code.ERROR, endStreamResponseCodeExtractor)
+                        // below block number in the response is the latest known, -1L because none are stored
+                        .returns(-1L, endStreamBlockNumberExtractor);
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_ENDOFSTREAM_SENT))
+                        .isEqualTo(2);
                 // As a pre-check, we expect no onComplete calls
                 assertThat(responsePipeline.getOnCompleteCalls().get()).isZero();
-                publisherHandler.onNext(request);
+                assertThat(responsePipeline2.getOnCompleteCalls().get()).isZero();
                 // Invoke the delayed shutdown so it actually runs
                 threadPoolManager.scheduledExecutor().executeSerially();
-                // Assert that no more responses are sent
-                assertThat(onNextCalls).isEmpty();
+                // Assert that both handlers have completed their pipelines
                 assertThat(responsePipeline.getOnCompleteCalls().get()).isEqualTo(1);
-                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_ENDOFSTREAM_SENT))
-                        .isEqualTo(1);
+                assertThat(responsePipeline2.getOnCompleteCalls().get()).isEqualTo(1);
                 // Assert no other responses sent
                 assertThat(responsePipeline.getOnErrorCalls()).isEmpty();
                 assertThat(responsePipeline.getOnSubscriptionCalls()).isEmpty();
                 assertThat(responsePipeline.getClientEndStreamCalls().get()).isEqualTo(0);
-                // Assert that a resend was scheduled for the failed block: a
-                // subsequent persisted notification for it must be clamped by
-                // gap detection, so the latest known block must not advance.
-                // We run the queued messaging forwarder first so that the
-                // in-flight queue does not clamp the acknowledgement itself.
-                threadPoolManager.executor().executeAsync(1_000L, false);
+                assertThat(responsePipeline2.getOnErrorCalls()).isEmpty();
+                assertThat(responsePipeline2.getOnSubscriptionCalls()).isEmpty();
+                assertThat(responsePipeline2.getClientEndStreamCalls().get()).isEqualTo(0);
+                // Assert that no resend was scheduled for the failed block,
+                // all block tracking was cleared: a subsequent persisted
+                // notification for it must be acknowledged normally.
                 toTest.handlePersisted(new PersistedNotification(block.number(), true, 0, BlockSource.PUBLISHER));
                 assertThat(toTest.getLatestBlockNumber())
-                        .as("latest known block must not advance, a resend is pending for the failed block")
-                        .isEqualTo(-1L);
+                        .as("latest known block must advance, no resend is pending for the failed block")
+                        .isEqualTo(block.number());
             }
 
             /// This test aims to assert that the
             /// [LiveStreamPublisherManager#handleVerification(VerificationNotification)]
             /// will handle a failed verification of a resend only type by only
-            /// scheduling a resend for the failed block. These are the possibly
-            /// transient types, where a retry may succeed, and the cancelled
-            /// type, where the complete block was received but the session was
-            /// cancelled before producing a result, so the publishers consider
-            /// the block delivered and nothing else will supply it. No end of
-            /// stream is expected to be sent and no handler is expected to be
-            /// shut down, the supplying stream stays open.
+            /// scheduling a resend for the failed block. These are the
+            /// unparseable or malformed block types, where the block is not
+            /// proven bad and there is no indication of malice, so a retry
+            /// may succeed, and the cancelled type, where the complete block
+            /// was received but the session was cancelled before producing a
+            /// result, so the publishers consider the block delivered and
+            /// nothing else will supply it. No end of stream is expected to
+            /// be sent and no handler is expected to be shut down, all
+            /// streams stay open.
             @ParameterizedTest
             @EnumSource(
                     value = FailureType.class,
-                    names = {"MISSING_VERIFICATION_DATA", "UNABLE_TO_PARSE", "CANCELLED"})
+                    names = {
+                        "UNABLE_TO_PARSE",
+                        "MISSING_MANDATORY_FIELD",
+                        "MISSING_MANDATORY_ITEM",
+                        "UNSUPPORTED_STREAM_FORMAT",
+                        "CANCELLED"
+                    })
             @DisplayName("handleVerification() schedules a resend and keeps streams open for resend only failure types")
             void testHandleVerificationResendOnlyFailureTypes(final FailureType failureType) {
                 // Establish lastPersisted=0 and advance nextUnstreamed past block 1 so
@@ -1629,7 +1644,14 @@ class LiveStreamPublisherManagerTest {
             @ParameterizedTest
             @EnumSource(
                     value = FailureType.class,
-                    names = {"MISSING_VERIFICATION_DATA", "UNABLE_TO_PARSE", "CANCELLED", "CANCELLED_INCOMPLETE"})
+                    names = {
+                        "UNABLE_TO_PARSE",
+                        "MISSING_MANDATORY_FIELD",
+                        "MISSING_MANDATORY_ITEM",
+                        "UNSUPPORTED_STREAM_FORMAT",
+                        "CANCELLED",
+                        "CANCELLED_INCOMPLETE"
+                    })
             @DisplayName(
                     "handleVerification() takes no action for informational failures of types that do not end the stream")
             void testHandleVerificationInformationalIgnored(final FailureType failureType) {
@@ -1765,26 +1787,26 @@ class LiveStreamPublisherManagerTest {
 
             /// This test aims to assert that the
             /// [LiveStreamPublisherManager#handleVerification(VerificationNotification)]
-            /// handles an informational failure of a malformed block or node
-            /// limitation type the same as a standard one, except that no
-            /// resend is scheduled. The handler that supplied the failed
-            /// block is expected to send an EndOfStream response with
-            /// [Code#ERROR] and to shut down.
+            /// handles an informational failure of a Block Node fault or
+            /// capability limitation type the same as a standard one. The
+            /// Block Node fault is present regardless of the same block
+            /// having been verified successfully within reasonable recency,
+            /// so every registered handler is still expected to send an
+            /// EndOfStream response with [Code#ERROR] and to shut down. No
+            /// resend is expected to be scheduled for the failed block.
             @ParameterizedTest
             @EnumSource(
                     value = FailureType.class,
                     names = {
-                        "MISSING_MANDATORY_FIELD",
-                        "MISSING_MANDATORY_ITEM",
-                        "UNSUPPORTED_STREAM_FORMAT",
+                        "MISSING_VERIFICATION_DATA",
                         "UNKNOWN_ERROR",
                         "UNRECOGNIZED_PROOF_TYPE",
                         "UNSUPPORTED_HAPI_VERSION",
                         "UNSUPPORTED_ITEM_TYPE"
                     })
             @DisplayName(
-                    "handleVerification() ERROR response is sent but no resend is scheduled for informational failures of malformed block and node limitation types")
-            void testHandleVerificationInformationalEndStreamError(final FailureType failureType) {
+                    "handleVerification() ERROR response is sent to all registered handlers for informational failures of Block Node fault types")
+            void testHandleVerificationInformationalEndAllStreams(final FailureType failureType) {
                 // We need to send a request via the publisher handler first,
                 // This will properly update the internal state of the manager
                 // so we can assert correctly. We aim to increment the next
@@ -1811,33 +1833,31 @@ class LiveStreamPublisherManagerTest {
                         BlockSource.PUBLISHER);
                 // Call
                 toTest.handleVerification(notification);
-                // Assert that the response pipeline has received an ERROR
-                // response, because the publisher we used has sent the block
-                // that failed verification.
-                final List<PublishStreamResponse> onNextCalls = responsePipeline.getOnNextCalls();
-                assertThat(onNextCalls)
+                // Assert that both handlers' pipelines have received an ERROR
+                // response, the Block Node fault ends every publisher stream.
+                assertThat(responsePipeline.getOnNextCalls())
                         .hasSize(1)
                         .first()
                         .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
                         .returns(Code.ERROR, endStreamResponseCodeExtractor)
                         // below block number in the response is the latest known, -1L because none are stored
                         .returns(-1L, endStreamBlockNumberExtractor);
-                onNextCalls.clear();
-                // We expect a shutdown to be scheduled
-                // We need to send any request or trigger any pipeline method
-                // to do the actual shutdown
-                publisherHandler.onNext(request);
+                assertThat(responsePipeline2.getOnNextCalls())
+                        .hasSize(1)
+                        .first()
+                        .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
+                        .returns(Code.ERROR, endStreamResponseCodeExtractor)
+                        // below block number in the response is the latest known, -1L because none are stored
+                        .returns(-1L, endStreamBlockNumberExtractor);
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_ENDOFSTREAM_SENT))
+                        .isEqualTo(2);
                 // Invoke the delayed shutdown so it actually runs
                 threadPoolManager.scheduledExecutor().executeSerially();
                 assertThat(responsePipeline.getOnCompleteCalls().get()).isEqualTo(1);
-                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_ENDOFSTREAM_SENT))
-                        .isEqualTo(1);
+                assertThat(responsePipeline2.getOnCompleteCalls().get()).isEqualTo(1);
                 // Assert that no resend was scheduled for the block: a
                 // subsequent persisted notification for it must be
                 // acknowledged normally.
-                // We run the queued messaging forwarder first so that the
-                // in-flight queue does not clamp the acknowledgement.
-                threadPoolManager.executor().executeAsync(1_000L, false);
                 toTest.handlePersisted(new PersistedNotification(block.number(), true, 0, BlockSource.PUBLISHER));
                 assertThat(toTest.getLatestBlockNumber())
                         .as("latest known block must advance, no resend is pending for the block")

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherHandlerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherHandlerTest.java
@@ -187,7 +187,7 @@ class PublisherHandlerTest {
                     new PublisherHandler(1L, repliesPipeline, metrics, manager, TEST_CORRELATION_ID);
             manager.addHandler(handler);
 
-            handler.handleFailedVerification(42L);
+            handler.handleFailedVerification(42L, Code.BAD_BLOCK_PROOF);
 
             assertThat(logHandler.getLogMessages()).anyMatch(msg -> msg.startsWith("[" + TEST_CORRELATION_ID + "] "));
         }
@@ -202,7 +202,7 @@ class PublisherHandlerTest {
             final PublisherHandler handler = new PublisherHandler(1L, repliesPipeline, metrics, manager, null);
             manager.addHandler(handler);
 
-            handler.handleFailedVerification(42L);
+            handler.handleFailedVerification(42L, Code.BAD_BLOCK_PROOF);
 
             assertThat(logHandler.getLogMessages())
                     .anyMatch(msg -> msg.startsWith("[]"))
@@ -221,7 +221,7 @@ class PublisherHandlerTest {
             manager.addHandler(handler);
 
             // Triggers a DEBUG log: "Handler {0} handling failed verification for block {1}"
-            handler.handleFailedVerification(10L);
+            handler.handleFailedVerification(10L, Code.BAD_BLOCK_PROOF);
             // FLAKEY WARNING - Tests that rely on log output are rarely reliable.
             // Triggers a DEBUG log: "[{0}] Handler {1} ending with code {2}"
             handler.endStreamWithCode(Code.PERSISTENCE_FAILED, false, 0L);
@@ -247,8 +247,8 @@ class PublisherHandlerTest {
             manager.addHandler(handlerA);
             manager.addHandler(handlerB);
 
-            handlerA.handleFailedVerification(1L);
-            handlerB.handleFailedVerification(2L);
+            handlerA.handleFailedVerification(1L, Code.BAD_BLOCK_PROOF);
+            handlerB.handleFailedVerification(2L, Code.BAD_BLOCK_PROOF);
 
             assertThat(logHandler.getLogMessages())
                     .anyMatch(msg -> msg.startsWith("[" + idA + "] "))
@@ -2483,12 +2483,12 @@ class PublisherHandlerTest {
             }
         }
 
-        /// Tests for the [PublisherHandler#handleFailedVerification(long)]method.
+        /// Tests for the [PublisherHandler#handleFailedVerification(long,Code)] method.
         @Nested
         @DisplayName("handleFailedVerification() Tests")
         class HandleVerificationTests {
             /// This test aims to assert that the
-            /// [PublisherHandler#handleFailedVerification(long)] will
+            /// [PublisherHandler#handleFailedVerification(long,Code)] will
             /// correctly handle a failed verification by sending no response,
             /// when the publisher has not sent the block that failed verification.
             @Test
@@ -2497,7 +2497,7 @@ class PublisherHandlerTest {
             void testHandleVerificationNoResponse() {
                 final long expectedResponseBlockNumber = 0;
                 // Call
-                toTest.handleFailedVerification(expectedResponseBlockNumber);
+                toTest.handleFailedVerification(expectedResponseBlockNumber, Code.BAD_BLOCK_PROOF);
                 // Assert no response is sent and shared metrics is not updated
                 assertThat(repliesPipeline.getOnNextCalls()).isEmpty();
                 assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCKS_RESEND_SENT))
@@ -2510,16 +2510,18 @@ class PublisherHandlerTest {
             }
 
             /// This test aims to assert that the
-            /// [PublisherHandler#handleFailedVerification(long)] will
+            /// [PublisherHandler#handleFailedVerification(long,Code)] will
             /// correctly handle a failed verification by sending a
             /// [org.hiero.block.api.PublishStreamResponse.EndOfStream]
-            /// response with code
-            /// [org.hiero.block.api.PublishStreamResponse.EndOfStream.Code#BAD_BLOCK_PROOF]
+            /// response with the given code
             /// and then scheduling the handler to be shutdown.
-            @Test
+            @ParameterizedTest
+            @EnumSource(
+                    value = Code.class,
+                    names = {"BAD_BLOCK_PROOF", "ERROR"})
             @DisplayName(
-                    "handleFailedVerification() - EndOfStream response with Code BAD_BLOCK_PROOF when handler sent the block that failed verification")
-            void testHandleVerificationBadProof() {
+                    "handleFailedVerification() - EndOfStream response with the given code when handler sent the block that failed verification")
+            void testHandleVerificationBadProof(final Code endStreamCode) {
                 // Generate any block, we do not have an actual verification, we will simulate a failure
                 final TestBlock block = TestBlockBuilder.generateBlockWithNumber(0L);
                 final long expectedBlockNumber = block.number();
@@ -2540,13 +2542,13 @@ class PublisherHandlerTest {
                 final long latestBlockNumber = expectedBlockNumber - 1L;
                 manager.setLatestBlockNumber(latestBlockNumber);
                 // Call
-                toTest.handleFailedVerification(expectedBlockNumber);
-                // Assert single response is EndOfStream with Code BAD_BLOCK_PROOF
+                toTest.handleFailedVerification(expectedBlockNumber, endStreamCode);
+                // Assert single response is EndOfStream with the given code
                 assertThat(repliesPipeline.getOnNextCalls())
                         .hasSize(1)
                         .first()
                         .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
-                        .returns(Code.BAD_BLOCK_PROOF, endStreamResponseCodeExtractor)
+                        .returns(endStreamCode, endStreamResponseCodeExtractor)
                         .returns(latestBlockNumber, endStreamBlockNumberExtractor);
                 // We expect a shutdown to be scheduled
                 // We need to send any request or trigger any pipeline method

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
@@ -44,11 +44,14 @@ import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBloc
 import org.hiero.block.node.app.fixtures.plugintest.TestVerificationPlugin;
 import org.hiero.block.node.app.fixtures.plugintest.VerificationHandlingHistoricalBlockFacility;
 import org.hiero.block.node.spi.BlockNodePlugin;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 /// Tests for the [StreamPublisherPlugin].
 @DisplayName("StreamPublisherPlugin Tests")
@@ -766,11 +769,204 @@ class StreamPublisherPluginTest {
             // End block 1, this will trigger the test verification plugin to fail the verification of block 1.
             endThisBlock(secondPublisher.toPluginPipe(), block1.number());
             // Await and ensure block has failed and the publisher is now closed
-            awaitBadBlockProof(secondPublisher.fromPluginBytes(), block1);
+            awaitEndOfStream(secondPublisher.fromPluginBytes(), block1, Code.BAD_BLOCK_PROOF);
             // Now we can end streaming block 2, we expect to receive the ResendBlock message because the block
             // that failed should be scheduled for a resend.
             endThisBlock(toPluginPipe, block2.number());
             awaitResend(fromPluginBytes, block1);
+        }
+
+        /// This test aims to assert that a failed verification of a malformed block or node limitation type
+        /// ends the supplying stream with the ERROR code and schedules the failed block for a resend. When an
+        /// active publisher finishes its current block, it must receive the ResendBlock message for the failed
+        /// block.
+        @ParameterizedTest
+        @EnumSource(
+                value = FailureType.class,
+                names = {
+                    "MISSING_MANDATORY_FIELD",
+                    "MISSING_MANDATORY_ITEM",
+                    "UNSUPPORTED_STREAM_FORMAT",
+                    "UNKNOWN_ERROR",
+                    "UNRECOGNIZED_PROOF_TYPE",
+                    "UNSUPPORTED_HAPI_VERSION",
+                    "UNSUPPORTED_ITEM_TYPE"
+                })
+        @DisplayName("Test EndOfStream ERROR and ResendBlock on malformed block and node limitation failure types")
+        void testEndOfStreamErrorAndResendReceived(final FailureType failureType) {
+            // Tell the verification plugin to fail block 1 with the parameterized failure type.
+            verificationPlugin.setFailureType(failureType);
+            verificationPlugin.failBlocks(1L);
+            // Create a second publisher, the first one is automatically created by the plugin test base
+            final TestPipeline secondPublisher = createNewPipeline();
+            final List<List<Bytes>> ackReceivers = List.of(fromPluginBytes, secondPublisher.fromPluginBytes());
+            final List<TestBlock> blocks0To2 = TestBlockBuilder.generateBlocksInRange(0, 2);
+            // Stream block 0 successfully so both publishers are acknowledged.
+            streamBlockAndAwaitAcknowledgement(secondPublisher.toPluginPipe(), ackReceivers, blocks0To2.get(0));
+            // Start streaming block 1 from the second publisher, do not end it yet.
+            final TestBlock block1 = blocks0To2.get(1);
+            sendBlock(secondPublisher.toPluginPipe(), block1);
+            // Leave the first publisher mid-block on block 2.
+            final TestBlock block2 = blocks0To2.get(2);
+            sendBlock(toPluginPipe, block2);
+            // End block 1, this will trigger the test verification plugin to fail its verification.
+            endThisBlock(secondPublisher.toPluginPipe(), block1.number());
+            // Await and ensure the block has failed and the supplying stream is ended with ERROR.
+            awaitEndOfStream(secondPublisher.fromPluginBytes(), block1, Code.ERROR);
+            // End block 2, we expect the ResendBlock message because the failed block is scheduled for a resend.
+            endThisBlock(toPluginPipe, block2.number());
+            awaitResend(fromPluginBytes, block1);
+        }
+
+        /// This test aims to assert that a failed verification of a resend only type keeps the
+        /// supplying stream open: no EndOfStream is sent, but the failed block is still scheduled for a
+        /// resend. These are the possibly transient types, where a retry may succeed, and the cancelled
+        /// type, where the complete block was received but the session was cancelled before producing a
+        /// result. When an active publisher finishes its current block, it must receive the ResendBlock
+        /// message for the failed block.
+        @ParameterizedTest
+        @EnumSource(
+                value = FailureType.class,
+                names = {"MISSING_VERIFICATION_DATA", "UNABLE_TO_PARSE", "CANCELLED"})
+        @DisplayName("Test no EndOfStream but ResendBlock on resend only failure types, stream stays open")
+        void testResendOnlyKeepsSupplyingStreamOpen(final FailureType failureType) {
+            // Tell the verification plugin to fail block 1 with the parameterized failure type.
+            verificationPlugin.setFailureType(failureType);
+            verificationPlugin.failBlocks(1L);
+            // Create a second publisher, the first one is automatically created by the plugin test base
+            final TestPipeline secondPublisher = createNewPipeline();
+            final List<List<Bytes>> ackReceivers = List.of(fromPluginBytes, secondPublisher.fromPluginBytes());
+            final List<TestBlock> blocks0To2 = TestBlockBuilder.generateBlocksInRange(0, 2);
+            // Stream block 0 successfully so both publishers are acknowledged.
+            streamBlockAndAwaitAcknowledgement(secondPublisher.toPluginPipe(), ackReceivers, blocks0To2.get(0));
+            // Start streaming block 1 from the second publisher, do not end it yet.
+            final TestBlock block1 = blocks0To2.get(1);
+            sendBlock(secondPublisher.toPluginPipe(), block1);
+            // Leave the first publisher mid-block on block 2.
+            final TestBlock block2 = blocks0To2.get(2);
+            sendBlock(toPluginPipe, block2);
+            // End block 1, this will trigger the test verification plugin to fail its verification.
+            endThisBlock(secondPublisher.toPluginPipe(), block1.number());
+            awaitBlockFailure(block1);
+            // The supplying publisher must not receive any response, its stream stays open.
+            assertThat(secondPublisher.fromPluginBytes()).isEmpty();
+            // End block 2, we expect the ResendBlock message because the failed block is scheduled for a resend.
+            endThisBlock(toPluginPipe, block2.number());
+            awaitResend(fromPluginBytes, block1);
+            // Assert again that the supplying publisher has received nothing throughout.
+            assertThat(secondPublisher.fromPluginBytes()).isEmpty();
+        }
+
+        /// This test aims to assert that an informational failure of a stream ending type is handled the same
+        /// as a standard one, except that no resend is scheduled: the supplying stream is ended with the
+        /// expected code, and when an active publisher finishes its current block, it must receive the
+        /// acknowledgement for that block instead of a ResendBlock message, because no pending resend clamps
+        /// the acknowledgement.
+        @ParameterizedTest
+        @EnumSource(
+                value = FailureType.class,
+                names = {"BAD_BLOCK_PROOF", "UNKNOWN_ERROR"})
+        @DisplayName("Test EndOfStream without ResendBlock on informational failures of stream ending types")
+        void testInformationalEndStreamNoResend(final FailureType failureType) {
+            // Tell the verification plugin to fail block 1 informationally with the parameterized failure type.
+            verificationPlugin.setFailureType(failureType);
+            verificationPlugin.setFailureInformational(true);
+            verificationPlugin.failBlocks(1L);
+            final Code expectedCode;
+            if (failureType == FailureType.BAD_BLOCK_PROOF) {
+                expectedCode = Code.BAD_BLOCK_PROOF;
+            } else {
+                expectedCode = Code.ERROR;
+            }
+            // Create a second publisher, the first one is automatically created by the plugin test base
+            final TestPipeline secondPublisher = createNewPipeline();
+            final List<List<Bytes>> ackReceivers = List.of(fromPluginBytes, secondPublisher.fromPluginBytes());
+            final List<TestBlock> blocks0To2 = TestBlockBuilder.generateBlocksInRange(0, 2);
+            // Stream block 0 successfully so both publishers are acknowledged.
+            streamBlockAndAwaitAcknowledgement(secondPublisher.toPluginPipe(), ackReceivers, blocks0To2.get(0));
+            // Start streaming block 1 from the second publisher, do not end it yet.
+            final TestBlock block1 = blocks0To2.get(1);
+            sendBlock(secondPublisher.toPluginPipe(), block1);
+            // Leave the first publisher mid-block on block 2.
+            final TestBlock block2 = blocks0To2.get(2);
+            sendBlock(toPluginPipe, block2);
+            // End block 1, this will trigger the test verification plugin to fail its verification.
+            endThisBlock(secondPublisher.toPluginPipe(), block1.number());
+            // Await and ensure the block has failed and the supplying stream is ended with the expected code.
+            awaitEndOfStream(secondPublisher.fromPluginBytes(), block1, expectedCode);
+            // End block 2. No resend is scheduled for the failed block, so the acknowledgement for block 2
+            // must not be clamped and must arrive instead of a ResendBlock message.
+            endThisBlock(toPluginPipe, block2.number());
+            awaitAcknowledgements(List.of(fromPluginBytes), block2);
+        }
+
+        /// This test aims to assert that an informational failure of a possibly transient type produces no
+        /// observable action: no EndOfStream is sent, no resend is scheduled, and both publishers stay open
+        /// and receive the acknowledgement for the next persisted block.
+        @ParameterizedTest
+        @EnumSource(
+                value = FailureType.class,
+                names = {"MISSING_VERIFICATION_DATA", "UNABLE_TO_PARSE"})
+        @DisplayName("Test no responses at all on informational failures of possibly transient types")
+        void testInformationalResendOnlyNoAction(final FailureType failureType) {
+            // Tell the verification plugin to fail block 1 informationally with the parameterized failure type.
+            verificationPlugin.setFailureType(failureType);
+            verificationPlugin.setFailureInformational(true);
+            verificationPlugin.failBlocks(1L);
+            // Create a second publisher, the first one is automatically created by the plugin test base
+            final TestPipeline secondPublisher = createNewPipeline();
+            final List<List<Bytes>> ackReceivers = List.of(fromPluginBytes, secondPublisher.fromPluginBytes());
+            final List<TestBlock> blocks0To2 = TestBlockBuilder.generateBlocksInRange(0, 2);
+            // Stream block 0 successfully so both publishers are acknowledged.
+            streamBlockAndAwaitAcknowledgement(secondPublisher.toPluginPipe(), ackReceivers, blocks0To2.get(0));
+            // Start streaming block 1 from the second publisher, do not end it yet.
+            final TestBlock block1 = blocks0To2.get(1);
+            sendBlock(secondPublisher.toPluginPipe(), block1);
+            // Leave the first publisher mid-block on block 2.
+            final TestBlock block2 = blocks0To2.get(2);
+            sendBlock(toPluginPipe, block2);
+            // End block 1, this will trigger the test verification plugin to fail its verification.
+            endThisBlock(secondPublisher.toPluginPipe(), block1.number());
+            awaitBlockFailure(block1);
+            // The supplying publisher must not receive any response, its stream stays open.
+            assertThat(secondPublisher.fromPluginBytes()).isEmpty();
+            // End block 2. No resend is scheduled, so both publishers stay open and must receive the
+            // acknowledgement for block 2 instead of a ResendBlock message.
+            endThisBlock(toPluginPipe, block2.number());
+            awaitAcknowledgements(ackReceivers, block2);
+        }
+
+        /// This test aims to assert that a failed verification of type CANCELLED_INCOMPLETE is only logged: no
+        /// EndOfStream is sent, no resend is scheduled, and both publishers stay open and receive the
+        /// acknowledgement for the next persisted block. An incomplete session means the block was never
+        /// fully received, so it is already handled and no action is needed.
+        @Test
+        @DisplayName("Test no responses at all on a CANCELLED_INCOMPLETE failure, both streams stay open")
+        void testIncompleteNoAction() {
+            // Tell the verification plugin to fail block 1 with the CANCELLED_INCOMPLETE failure type.
+            verificationPlugin.setFailureType(FailureType.CANCELLED_INCOMPLETE);
+            verificationPlugin.failBlocks(1L);
+            // Create a second publisher, the first one is automatically created by the plugin test base
+            final TestPipeline secondPublisher = createNewPipeline();
+            final List<List<Bytes>> ackReceivers = List.of(fromPluginBytes, secondPublisher.fromPluginBytes());
+            final List<TestBlock> blocks0To2 = TestBlockBuilder.generateBlocksInRange(0, 2);
+            // Stream block 0 successfully so both publishers are acknowledged.
+            streamBlockAndAwaitAcknowledgement(secondPublisher.toPluginPipe(), ackReceivers, blocks0To2.get(0));
+            // Start streaming block 1 from the second publisher, do not end it yet.
+            final TestBlock block1 = blocks0To2.get(1);
+            sendBlock(secondPublisher.toPluginPipe(), block1);
+            // Leave the first publisher mid-block on block 2.
+            final TestBlock block2 = blocks0To2.get(2);
+            sendBlock(toPluginPipe, block2);
+            // End block 1, this will trigger the test verification plugin to fail its verification.
+            endThisBlock(secondPublisher.toPluginPipe(), block1.number());
+            awaitBlockFailure(block1);
+            // The supplying publisher must not receive any response, its stream stays open.
+            assertThat(secondPublisher.fromPluginBytes()).isEmpty();
+            // End block 2. No resend is scheduled, so both publishers stay open and must receive the
+            // acknowledgement for block 2 instead of a ResendBlock message.
+            endThisBlock(toPluginPipe, block2.number());
+            awaitAcknowledgements(ackReceivers, block2);
         }
 
         private static void sendBlock(final Pipeline<? super Bytes> requestSender, final TestBlock block) {
@@ -805,36 +1001,37 @@ class StreamPublisherPluginTest {
             acknowledgementReceivers.forEach(List::clear);
         }
 
-        private void awaitBadBlockProof(final List<Bytes> badBlockProofReceiver, final TestBlock block) {
+        /// Waits until the verification plugin has failed the given block and
+        /// asserts that exactly one failure has been recorded for it.
+        private void awaitBlockFailure(final TestBlock block) {
             final long timeout = 5_000_000_000L; // 5 seconds
             final long deadline = System.nanoTime() + timeout;
             while (verificationPlugin.blockFailures(block.number()) <= 0 && System.nanoTime() < deadline) {
                 parkNanos(1_000_000L);
             }
-            awaitPluginResponses(List.of(badBlockProofReceiver), 1);
             // Assert that the block has failed verification
             assertThat(verificationPlugin.blockFailures(block.number())).isOne();
-            // Assert bad block proof received by publisher that has supplied the failing block
-            assertThat(badBlockProofReceiver)
+        }
+
+        private void awaitEndOfStream(
+                final List<Bytes> endOfStreamReceiver, final TestBlock block, final Code expectedCode) {
+            awaitBlockFailure(block);
+            awaitPluginResponses(List.of(endOfStreamReceiver), 1);
+            // Assert the end of stream is received by the publisher that has supplied the failing block
+            assertThat(endOfStreamReceiver)
                     .hasSize(1)
                     .first()
                     .extracting(bytesToPublishStreamResponseMapper)
                     .isNotNull()
                     .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
-                    .returns(Code.BAD_BLOCK_PROOF, endStreamResponseCodeExtractor)
+                    .returns(expectedCode, endStreamResponseCodeExtractor)
                     .returns(historicalBlockFacility.availableBlocks().max(), endStreamResponseBlockNumberExtractor);
-            badBlockProofReceiver.clear();
+            endOfStreamReceiver.clear();
         }
 
         private void awaitResend(final List<Bytes> resendReceiver, final TestBlock block) {
-            final long timeout = 5_000_000_000L; // 5 seconds
-            final long deadline = System.nanoTime() + timeout;
-            while (verificationPlugin.blockFailures(block.number()) <= 0 && System.nanoTime() < deadline) {
-                parkNanos(1_000_000L);
-            }
+            awaitBlockFailure(block);
             awaitPluginResponses(List.of(resendReceiver), 1);
-            // Assert that the block has failed verification
-            assertThat(verificationPlugin.blockFailures(block.number())).isOne();
             final List<PublishStreamResponse> filteredResponses = resendReceiver.stream()
                     .map(bytesToPublishStreamResponseMapper)
                     .filter(PublishStreamResponse::hasResendBlock)

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
@@ -776,24 +776,23 @@ class StreamPublisherPluginTest {
             awaitResend(fromPluginBytes, block1);
         }
 
-        /// This test aims to assert that a failed verification of a malformed block or node limitation type
-        /// ends the supplying stream with the ERROR code and schedules the failed block for a resend. When an
-        /// active publisher finishes its current block, it must receive the ResendBlock message for the failed
-        /// block.
+        /// This test aims to assert that a failed verification of a Block Node fault or capability
+        /// limitation type ends every connected publisher's stream with the ERROR code. No retry against
+        /// this node can succeed for these types, so both publishers, including the one that did not
+        /// supply the failed block, must receive the EndOfStream message, encouraging them to connect to
+        /// a healthy Block Node.
         @ParameterizedTest
         @EnumSource(
                 value = FailureType.class,
                 names = {
-                    "MISSING_MANDATORY_FIELD",
-                    "MISSING_MANDATORY_ITEM",
-                    "UNSUPPORTED_STREAM_FORMAT",
+                    "MISSING_VERIFICATION_DATA",
                     "UNKNOWN_ERROR",
                     "UNRECOGNIZED_PROOF_TYPE",
                     "UNSUPPORTED_HAPI_VERSION",
                     "UNSUPPORTED_ITEM_TYPE"
                 })
-        @DisplayName("Test EndOfStream ERROR and ResendBlock on malformed block and node limitation failure types")
-        void testEndOfStreamErrorAndResendReceived(final FailureType failureType) {
+        @DisplayName("Test EndOfStream ERROR to all publishers on Block Node fault failure types")
+        void testEndAllStreamsOnBlockNodeFaultTypes(final FailureType failureType) {
             // Tell the verification plugin to fail block 1 with the parameterized failure type.
             verificationPlugin.setFailureType(failureType);
             verificationPlugin.failBlocks(1L);
@@ -811,23 +810,29 @@ class StreamPublisherPluginTest {
             sendBlock(toPluginPipe, block2);
             // End block 1, this will trigger the test verification plugin to fail its verification.
             endThisBlock(secondPublisher.toPluginPipe(), block1.number());
-            // Await and ensure the block has failed and the supplying stream is ended with ERROR.
+            // Await and ensure the block has failed and both streams are ended with ERROR, the failure
+            // is a Block Node fault, so it is not attributable to the supplying publisher.
             awaitEndOfStream(secondPublisher.fromPluginBytes(), block1, Code.ERROR);
-            // End block 2, we expect the ResendBlock message because the failed block is scheduled for a resend.
-            endThisBlock(toPluginPipe, block2.number());
-            awaitResend(fromPluginBytes, block1);
+            awaitEndOfStream(fromPluginBytes, block1, Code.ERROR);
         }
 
         /// This test aims to assert that a failed verification of a resend only type keeps the
         /// supplying stream open: no EndOfStream is sent, but the failed block is still scheduled for a
-        /// resend. These are the possibly transient types, where a retry may succeed, and the cancelled
-        /// type, where the complete block was received but the session was cancelled before producing a
-        /// result. When an active publisher finishes its current block, it must receive the ResendBlock
-        /// message for the failed block.
+        /// resend. These are the unparseable or malformed block types, where the block is not proven bad
+        /// and there is no indication of malice, so a retry may succeed, and the cancelled type, where
+        /// the complete block was received but the session was cancelled before producing a result. When
+        /// an active publisher finishes its current block, it must receive the ResendBlock message for
+        /// the failed block.
         @ParameterizedTest
         @EnumSource(
                 value = FailureType.class,
-                names = {"MISSING_VERIFICATION_DATA", "UNABLE_TO_PARSE", "CANCELLED"})
+                names = {
+                    "UNABLE_TO_PARSE",
+                    "MISSING_MANDATORY_FIELD",
+                    "MISSING_MANDATORY_ITEM",
+                    "UNSUPPORTED_STREAM_FORMAT",
+                    "CANCELLED"
+                })
         @DisplayName("Test no EndOfStream but ResendBlock on resend only failure types, stream stays open")
         void testResendOnlyKeepsSupplyingStreamOpen(final FailureType failureType) {
             // Tell the verification plugin to fail block 1 with the parameterized failure type.
@@ -857,27 +862,18 @@ class StreamPublisherPluginTest {
             assertThat(secondPublisher.fromPluginBytes()).isEmpty();
         }
 
-        /// This test aims to assert that an informational failure of a stream ending type is handled the same
-        /// as a standard one, except that no resend is scheduled: the supplying stream is ended with the
-        /// expected code, and when an active publisher finishes its current block, it must receive the
-        /// acknowledgement for that block instead of a ResendBlock message, because no pending resend clamps
-        /// the acknowledgement.
-        @ParameterizedTest
-        @EnumSource(
-                value = FailureType.class,
-                names = {"BAD_BLOCK_PROOF", "UNKNOWN_ERROR"})
-        @DisplayName("Test EndOfStream without ResendBlock on informational failures of stream ending types")
-        void testInformationalEndStreamNoResend(final FailureType failureType) {
-            // Tell the verification plugin to fail block 1 informationally with the parameterized failure type.
-            verificationPlugin.setFailureType(failureType);
+        /// This test aims to assert that an informational failure of type BAD_BLOCK_PROOF is handled the
+        /// same as a standard one, except that no resend is scheduled: the supplying stream is ended with
+        /// the BAD_BLOCK_PROOF code, and when an active publisher finishes its current block, it must
+        /// receive the acknowledgement for that block instead of a ResendBlock message, because no
+        /// pending resend clamps the acknowledgement.
+        @Test
+        @DisplayName("Test EndOfStream without ResendBlock on an informational BAD_BLOCK_PROOF failure")
+        void testInformationalEndStreamNoResend() {
+            // Tell the verification plugin to fail block 1 informationally with a bad proof.
+            verificationPlugin.setFailureType(FailureType.BAD_BLOCK_PROOF);
             verificationPlugin.setFailureInformational(true);
             verificationPlugin.failBlocks(1L);
-            final Code expectedCode;
-            if (failureType == FailureType.BAD_BLOCK_PROOF) {
-                expectedCode = Code.BAD_BLOCK_PROOF;
-            } else {
-                expectedCode = Code.ERROR;
-            }
             // Create a second publisher, the first one is automatically created by the plugin test base
             final TestPipeline secondPublisher = createNewPipeline();
             final List<List<Bytes>> ackReceivers = List.of(fromPluginBytes, secondPublisher.fromPluginBytes());
@@ -893,20 +889,65 @@ class StreamPublisherPluginTest {
             // End block 1, this will trigger the test verification plugin to fail its verification.
             endThisBlock(secondPublisher.toPluginPipe(), block1.number());
             // Await and ensure the block has failed and the supplying stream is ended with the expected code.
-            awaitEndOfStream(secondPublisher.fromPluginBytes(), block1, expectedCode);
+            awaitEndOfStream(secondPublisher.fromPluginBytes(), block1, Code.BAD_BLOCK_PROOF);
             // End block 2. No resend is scheduled for the failed block, so the acknowledgement for block 2
             // must not be clamped and must arrive instead of a ResendBlock message.
             endThisBlock(toPluginPipe, block2.number());
             awaitAcknowledgements(List.of(fromPluginBytes), block2);
         }
 
-        /// This test aims to assert that an informational failure of a possibly transient type produces no
-        /// observable action: no EndOfStream is sent, no resend is scheduled, and both publishers stay open
-        /// and receive the acknowledgement for the next persisted block.
+        /// This test aims to assert that an informational failure of a Block Node fault or capability
+        /// limitation type is handled the same as a standard one. The Block Node fault is present
+        /// regardless of the same block having been verified successfully within reasonable recency, so
+        /// both publishers must still receive the EndOfStream message with the ERROR code.
         @ParameterizedTest
         @EnumSource(
                 value = FailureType.class,
-                names = {"MISSING_VERIFICATION_DATA", "UNABLE_TO_PARSE"})
+                names = {
+                    "MISSING_VERIFICATION_DATA",
+                    "UNKNOWN_ERROR",
+                    "UNRECOGNIZED_PROOF_TYPE",
+                    "UNSUPPORTED_HAPI_VERSION",
+                    "UNSUPPORTED_ITEM_TYPE"
+                })
+        @DisplayName("Test EndOfStream ERROR to all publishers on informational Block Node fault failure types")
+        void testInformationalEndAllStreams(final FailureType failureType) {
+            // Tell the verification plugin to fail block 1 informationally with the parameterized failure type.
+            verificationPlugin.setFailureType(failureType);
+            verificationPlugin.setFailureInformational(true);
+            verificationPlugin.failBlocks(1L);
+            // Create a second publisher, the first one is automatically created by the plugin test base
+            final TestPipeline secondPublisher = createNewPipeline();
+            final List<List<Bytes>> ackReceivers = List.of(fromPluginBytes, secondPublisher.fromPluginBytes());
+            final List<TestBlock> blocks0To2 = TestBlockBuilder.generateBlocksInRange(0, 2);
+            // Stream block 0 successfully so both publishers are acknowledged.
+            streamBlockAndAwaitAcknowledgement(secondPublisher.toPluginPipe(), ackReceivers, blocks0To2.get(0));
+            // Start streaming block 1 from the second publisher, do not end it yet.
+            final TestBlock block1 = blocks0To2.get(1);
+            sendBlock(secondPublisher.toPluginPipe(), block1);
+            // Leave the first publisher mid-block on block 2.
+            final TestBlock block2 = blocks0To2.get(2);
+            sendBlock(toPluginPipe, block2);
+            // End block 1, this will trigger the test verification plugin to fail its verification.
+            endThisBlock(secondPublisher.toPluginPipe(), block1.number());
+            // Await and ensure the block has failed and both streams are ended with ERROR, the failure
+            // is a Block Node fault, so it is not attributable to the supplying publisher.
+            awaitEndOfStream(secondPublisher.fromPluginBytes(), block1, Code.ERROR);
+            awaitEndOfStream(fromPluginBytes, block1, Code.ERROR);
+        }
+
+        /// This test aims to assert that an informational failure of an unparseable or malformed block
+        /// type produces no observable action: no EndOfStream is sent, no resend is scheduled, and both
+        /// publishers stay open and receive the acknowledgement for the next persisted block.
+        @ParameterizedTest
+        @EnumSource(
+                value = FailureType.class,
+                names = {
+                    "UNABLE_TO_PARSE",
+                    "MISSING_MANDATORY_FIELD",
+                    "MISSING_MANDATORY_ITEM",
+                    "UNSUPPORTED_STREAM_FORMAT"
+                })
         @DisplayName("Test no responses at all on informational failures of possibly transient types")
         void testInformationalResendOnlyNoAction(final FailureType failureType) {
             // Tell the verification plugin to fail block 1 informationally with the parameterized failure type.

--- a/docs/design/block-verification.md
+++ b/docs/design/block-verification.md
@@ -149,7 +149,8 @@ sources today:
   guarantees that once a block starts, its items arrive in order. It cannot
   guarantee that a block will finish. If a new block starts before the previous
   one ended, the previous session is cancelled, since the stream has clearly
-  moved on.
+  moved on; because the superseded session never received its full block, it
+  reports a `CANCELLED_INCOMPLETE` failure.
 - **Backfill**: blocks arrive whole, one complete block per notification. Each
   is wrapped as a single batch that is both the start and the end of the block,
   and a session is started for it.
@@ -195,10 +196,11 @@ The session handler keeps all running sessions in a bounded buffer, sized by
 `activeSessionsBufferSize`. Every new session is added to the buffer. If the
 buffer would exceed its size, room is made by **cancelling the session that is
 verifying the lowest block number**, unless that session is the one that was
-just started. A cancelled session reports a `CANCELLED` failure through the
-normal result handling path. This bounds resource usage while preferring to
-keep the most recent work: the oldest, likely stalled or superseded session is
-the one to go.
+just started. An evicted session reports a failure through the normal result
+handling path: `CANCELLED` when it had already received its complete block,
+`CANCELLED_INCOMPLETE` when the block was never fully received. This bounds resource
+usage while preferring to keep the most recent work: the oldest, likely
+stalled or superseded session is the one to go.
 
 ### The Recently Verified Blocks Buffer and Informational Failures
 
@@ -251,17 +253,18 @@ Every failed session reports a failure type in its notification. The
 as informational when the block is in the recently verified buffer, and as
 standard otherwise.
 
-|        Failure type         |                                             Meaning                                             | Can be informational |
-|-----------------------------|-------------------------------------------------------------------------------------------------|----------------------|
-| `BAD_BLOCK_PROOF`           | A proof did not verify against the computed root hash                                           | yes                  |
-| `UNABLE_TO_PARSE`           | The block or one of its items could not be parsed                                               | yes                  |
-| `MISSING_MANDATORY_ITEM`    | A mandatory item (header, footer, at least one usable proof) is missing                         | yes                  |
-| `MISSING_MANDATORY_FIELD`   | A mandatory item is present but a required field has no value                                   | yes                  |
-| `MISSING_VERIFICATION_DATA` | Required verification data is unavailable (TSS data, RSA keys, or a required algorithm)         | yes                  |
-| `UNRECOGNIZED_PROOF_TYPE`   | The proof(s) provided for the block are not of a recognized type                                | yes                  |
-| `UNSUPPORTED_HAPI_VERSION`  | The block declares a HAPI version the node does not support                                     | yes                  |
-| `CANCELLED`                 | The session was cancelled before completing (superseded, evicted from the buffer, or shut down) | yes                  |
-| `UNKNOWN_ERROR`             | An unexpected error occurred during verification                                                | yes                  |
+|        Failure type         |                                                    Meaning                                                     | Can be informational |
+|-----------------------------|----------------------------------------------------------------------------------------------------------------|----------------------|
+| `BAD_BLOCK_PROOF`           | A proof did not verify against the computed root hash                                                          | yes                  |
+| `UNABLE_TO_PARSE`           | The block or one of its items could not be parsed                                                              | yes                  |
+| `MISSING_MANDATORY_ITEM`    | A mandatory item (header, footer, at least one usable proof) is missing                                        | yes                  |
+| `MISSING_MANDATORY_FIELD`   | A mandatory item is present but a required field has no value                                                  | yes                  |
+| `MISSING_VERIFICATION_DATA` | Required verification data is unavailable (TSS data, RSA keys, or a required algorithm)                        | yes                  |
+| `UNRECOGNIZED_PROOF_TYPE`   | The proof(s) provided for the block are not of a recognized type                                               | yes                  |
+| `UNSUPPORTED_HAPI_VERSION`  | The block declares a HAPI version the node does not support                                                    | yes                  |
+| `CANCELLED`                 | The session was cancelled after the complete block was received (evicted from the buffer, or shut down)        | yes                  |
+| `CANCELLED_INCOMPLETE`      | The session ended before the full block was received (superseded, or evicted/shut down while still incomplete) | yes                  |
+| `UNKNOWN_ERROR`             | An unexpected error occurred during verification                                                               | yes                  |
 
 ## Diagram
 
@@ -326,7 +329,7 @@ flowchart TD
     ADD --> FULL{Buffer over its limit?}
     FULL -- no --> RUN[All sessions keep running]
     FULL -- yes --> LOW{"Is the lowest-block session the new one?"}
-    LOW -- no --> CANCEL["Cancel the lowest-block session (reports CANCELLED)"]
+    LOW -- no --> CANCEL["Cancel the lowest-block session (reports CANCELLED or CANCELLED_INCOMPLETE)"]
     LOW -- yes --> RUN
 ```
 
@@ -463,7 +466,8 @@ ends in a verification notification, and the plugin keeps running.
   stage turns it into a failure notification.
 - **Cancellation.** A session cancelled for any reason (superseded by a new
   publisher block, evicted from the active sessions buffer, or plugin shutdown)
-  reports a `CANCELLED` failure.
+  reports a `CANCELLED` failure when it had already received its complete
+  block, and a `CANCELLED_INCOMPLETE` failure when the block was never fully received.
 - **Unexpected errors.** Any unexpected error, in a stage or in the plugin's
   own handling, is reported as `UNKNOWN_ERROR` and counted in the error metric.
   The plugin logs the details and continues.
@@ -492,7 +496,8 @@ ends in a verification notification, and the plugin keeps running.
    success immediately; with `true`, it waits.
 6. **Active sessions buffer.** When more sessions are started than the buffer
    allows, the session verifying the lowest block is cancelled and reports
-   `CANCELLED`; the newest session is never the one evicted.
+   `CANCELLED` when its complete block was received, or `CANCELLED_INCOMPLETE` when it
+   was not; the newest session is never the one evicted.
 7. **Informational failures.** A failure for a block present in the recently
    verified buffer is reported as informational; the same failure for a block
    not in the buffer is standard.
@@ -500,7 +505,7 @@ ends in a verification notification, and the plugin keeps running.
    recently verified block, a subsequent verification failure for that block is
    reported as standard, not informational.
 9. **Publisher supersession.** When a new block starts before the previous one
-   ended, the previous session is cancelled and reports `CANCELLED`, and the
+   ended, the previous session is cancelled and reports `CANCELLED_INCOMPLETE`, and the
    new block verifies normally.
 10. **Failure types.** Each failure type in the table above is produced by the
     condition it describes, and the informational flag is controlled solely by

--- a/docs/design/block-verification.md
+++ b/docs/design/block-verification.md
@@ -458,8 +458,8 @@ The plugin never lets an error escape to its callers. Every error condition
 ends in a verification notification, and the plugin keeps running.
 
 - **Invalid start of block.** The first item of a new block is not a header, or
-  the header's number does not match. A failure notification is sent and no
-  session is started.
+  the header's number does not match. A `MISSING_MANDATORY_ITEM` failure
+  notification is sent and no session is started.
 - **Stage failure.** A stage that cannot continue (parse failure, missing item
   or field, bad proof, missing verification data) raises a session failure
   carrying the block number, source, and failure type. The result handling


### PR DESCRIPTION
* Resolve the publisher action for failed verification with an exhaustive switch expression over `FailureType` so enum changes break compilation
* Return a `FailureActionResult` record carrying whether to schedule a resend and the end of stream code, null when the stream stays open
* Schedule a resend for every failure type except cancelled sessions, which cannot be attributed accurately until #3436
* Send EndOfStream `BAD_BLOCK_PROOF` only for an invalid block proof and `ERROR` for malformed block and node side failure types
* Keep the supplying stream open for possibly transient failure types
* Skip the resend for informational failures, the block was already verified successfully
* Pass the end of stream code through `PublisherHandler.handleFailedVerification`
* Update publisher manager and handler tests for the new classification
* Follow ups received as feedback will be addressed in #3562

Resolves #2977