### PR TITLE
feat(solo-e2e): backfill-during-live-stream test, CN local builds, and Solo E2E green-run fixes

### DIFF
--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -211,12 +211,21 @@ jobs:
             CN_VERSION="${{ inputs.consensus-node-version }}"
             CN_VERSION="${CN_VERSION:-main}"
             MN_VERSION="${{ inputs.mirror-node-version }}"
-            MN_VERSION="${MN_VERSION:-main}"
+            # Mirror Node publishes no 'main' snapshots, so this cannot default to main.
+            # Pinned to the first release carrying the reworked block-root hashing, which is
+            # what a 'main' Consensus Node produces.
+            MN_VERSION="${MN_VERSION:-v0.162.0-rc1}"
           else
-            # Scheduled runs (daily/weekend): use SNAPSHOT BN against GA stable CN/MN
-            BN_VERSION="main"
-            CN_VERSION="latest"
-            MN_VERSION="latest"
+            # Scheduled runs (daily/weekend) and manual dispatches that named no Block Node
+            # version. Honour any explicitly supplied version — this branch used to hardcode
+            # all three, so a manual dispatch setting only consensus-node-version had it
+            # silently discarded.
+            BN_VERSION="${{ inputs.block-node-version }}"
+            BN_VERSION="${BN_VERSION:-main}"
+            CN_VERSION="${{ inputs.consensus-node-version }}"
+            CN_VERSION="${CN_VERSION:-main}"
+            MN_VERSION="${{ inputs.mirror-node-version }}"
+            MN_VERSION="${MN_VERSION:-v0.162.0-rc1}"
           fi
 
           # Solo CLI version: use input if provided, otherwise default to latest stable

--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -348,7 +348,11 @@ jobs:
     needs: configure
     strategy:
       fail-fast: false
-      max-parallel: 1 # Run sequentially to avoid resource contention
+      # Each matrix entry runs on its own GitHub runner with its own Kind cluster, so
+      # parallel deployments do not contend for resources with each other. 3 caps how
+      # many runners (and, since a -SNAPSHOT Consensus Node is built per job, how many
+      # concurrent CN builds) a single scheduler run consumes.
+      max-parallel: 3
       matrix:
         include: ${{ fromJson(needs.configure.outputs.matrix) }}
     uses: ./.github/workflows/solo-e2e-test.yml

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -317,6 +317,43 @@ jobs:
           # the resolved mn_version below.
           MN_RESOLVED=$(echo "$OUTPUT" | grep "^mn_version=" | cut -d= -f2)
           echo "MN_VERSION=${MN_RESOLVED}" >> "${GITHUB_ENV}"
+          # Solo installs the Consensus Node from a build zip on builds.hedera.com and only
+          # tagged releases are published there. A -SNAPSHOT (what 'main' resolves to, from
+          # version.txt on the CN branch) has no artifact, so it must be built from source and
+          # handed to Solo via --local-build-path. Flag that for the steps below.
+          CN_RESOLVED=$(echo "$OUTPUT" | grep "^cn_version=" | cut -d= -f2)
+          if [[ "${CN_RESOLVED}" == *-SNAPSHOT ]]; then
+            echo "cn_needs_local_build=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "cn_needs_local_build=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      # Only for a -SNAPSHOT Consensus Node: build it from source, since no artifact exists.
+      - name: Checkout Consensus Node source
+        if: steps.versions.outputs.cn_needs_local_build == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: hiero-ledger/hiero-consensus-node
+          ref: main
+          path: hiero-consensus-node
+          fetch-depth: 1
+
+      - name: Build Consensus Node from source
+        id: cn-build
+        if: steps.versions.outputs.cn_needs_local_build == 'true'
+        working-directory: hiero-consensus-node
+        run: |
+          echo "Building Consensus Node $(cat version.txt) at $(git rev-parse --short HEAD)"
+          ./gradlew assemble --no-daemon
+          # Solo wants the data directory itself and validates it holds apps/ and lib/.
+          CN_DATA_DIR="${PWD}/hedera-node/data"
+          for subdirectory in apps lib; do
+            if [[ ! -d "${CN_DATA_DIR}/${subdirectory}" ]]; then
+              echo "ERROR: ${CN_DATA_DIR}/${subdirectory} missing after assemble" >&2
+              exit 1
+            fi
+          done
+          echo "cn_local_build_path=${CN_DATA_DIR}" >> "${GITHUB_OUTPUT}"
 
       # Install Solo CLI (npm by default, or build an approved fork/branch when solo-source=git)
       - name: Install Solo CLI
@@ -398,7 +435,16 @@ jobs:
 
       # Deploy network using shared script
       - name: Deploy network
+        env:
+          # Empty unless the Consensus Node was built from source above, in which case Solo
+          # is pointed at those jars instead of downloading a (nonexistent) SNAPSHOT zip.
+          CN_LOCAL_BUILD_PATH: "${{ steps.cn-build.outputs.cn_local_build_path }}"
         run: |
+          CN_LOCAL_BUILD_ARG=""
+          if [[ -n "${CN_LOCAL_BUILD_PATH}" ]]; then
+            CN_LOCAL_BUILD_ARG="--cn-local-build-path ${CN_LOCAL_BUILD_PATH}"
+          fi
+
           ./tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh \
             --deployment "${DEPLOYMENT}" \
             --namespace "${NAMESPACE}" \
@@ -406,6 +452,7 @@ jobs:
             --topology "${{ inputs.topology }}" \
             --topologies-dir "${{ github.workspace }}/tools-and-tests/scripts/solo-e2e-test/topologies" \
             --cn-version "${{ steps.versions.outputs.cn_version }}" \
+            ${CN_LOCAL_BUILD_ARG} \
             --mn-version "${{ steps.versions.outputs.mn_version }}" \
             --bn-version "${{ steps.versions.outputs.bn_version }}" \
             --relay-version "${{ steps.versions.outputs.relay_version }}" \

--- a/tools-and-tests/scripts/solo-e2e-test/.env.example
+++ b/tools-and-tests/scripts/solo-e2e-test/.env.example
@@ -9,8 +9,16 @@ CLUSTER_NAME=solo-cluster
 NAMESPACE=solo-network
 DEPLOYMENT=deployment-solo
 
-# Versions: 'latest', 'rc' or specific tag (e.g., 'v0.73.0')
-CN_VERSION=latest
+# Versions: 'latest', 'rc', 'main', or specific tag (e.g., 'v0.73.0')
+# Defaults to 'main' because no published CN tag yet carries the fixed 16-slot block-root
+# hashing rework, so a released tag cannot verify against current Block Node / Mirror Node.
+CN_VERSION=main
+# REQUIRED when CN_VERSION=main. Solo installs the Consensus Node from a build zip on
+# builds.hedera.com and only tagged releases are published there, so a -SNAPSHOT has no
+# artifact to fetch and the deploy fails fast without this. Point at a *built*
+# hedera-node/data directory (must contain apps/ and lib/):
+#   cd <cn-repo> && git fetch upstream && git checkout upstream/main && ./gradlew assemble
+CN_LOCAL_BUILD_PATH=/path/to/hiero-consensus-node/hedera-node/data
 # Versions: 'latest', 'rc' or specific tag (e.g., 'v0.152.0')
 MN_VERSION=latest
 # Versions: 'latest', 'rc', 'main', or specific tag (e.g., 'v0.31.0')

--- a/tools-and-tests/scripts/solo-e2e-test/README.md
+++ b/tools-and-tests/scripts/solo-e2e-test/README.md
@@ -259,8 +259,11 @@ and Mirror Node. That means a local `task up` requires `CN_LOCAL_BUILD_PATH`; th
 if it is unset. Pin a released tag (`v0.79.0-alpha.1`, `v0.78.0-rc.2`) if you want to skip the build
 and don't need the new hashing.
 
-CI is unaffected — the `solo-e2e-test` and `solo-e2e-scheduler` workflows pass their own
-`latest` / `rc` values, since runners have no Consensus Node checkout to build from.
+CI does the same thing automatically. When the resolved CN version ends in `-SNAPSHOT`,
+`solo-e2e-test.yml` checks out `hiero-ledger/hiero-consensus-node` at `main`, runs
+`./gradlew assemble`, and passes the result as `--cn-local-build-path`. Released tags skip
+the build entirely and fetch the published zip as before, so only SNAPSHOT runs pay the
+build cost.
 
 Solo does not pull the Consensus Node as a container image. `solo consensus node setup` downloads a
 platform build zip from `builds.hedera.com/node/software/<vMAJOR.MINOR>/build-<tag>.zip` and unpacks it

--- a/tools-and-tests/scripts/solo-e2e-test/README.md
+++ b/tools-and-tests/scripts/solo-e2e-test/README.md
@@ -937,4 +937,13 @@ Tests are validated against topologies before execution. The matrix defines whic
 
 Multiple tests run sequentially on the same deployment, reducing CI time.
 
+Up to **3 deployments run in parallel** within a scheduler run (`max-parallel: 3`). Each matrix
+entry gets its own runner and its own Kind cluster, so they do not contend with one another;
+the cap limits how many runners — and how many concurrent Consensus Node builds, when the
+resolved CN version is a `-SNAPSHOT` — a single run consumes.
+
+> Every topology appears at most once per matrix, which matters: `solo-e2e-test.yml` keys its
+> concurrency group on `topology` with `cancel-in-progress: true`, so two parallel jobs sharing
+> a topology would cancel each other. Keep topologies unique per matrix when adding entries.
+
 Manual trigger: Actions -> "Solo E2E Scheduler" -> "Run workflow"

--- a/tools-and-tests/scripts/solo-e2e-test/README.md
+++ b/tools-and-tests/scripts/solo-e2e-test/README.md
@@ -224,7 +224,8 @@ cp .env.example .env
 | `SOLO_SOURCE`            | `npm`                    | Solo install source: `npm` or `git` (see Custom Solo Build)          |
 | `SOLO_GIT_REPO`          | (empty)                  | Fork `owner/repo` when `SOLO_SOURCE=git` (must be approved)          |
 | `SOLO_GIT_REF`           | (empty)                  | Branch/tag/SHA when `SOLO_SOURCE=git`                                |
-| `CN_VERSION`             | `latest`                 | Consensus Node version                                               |
+| `CN_VERSION`             | `main`                   | Consensus Node version (requires `CN_LOCAL_BUILD_PATH`)              |
+| `CN_LOCAL_BUILD_PATH`    | (empty)                  | Built CN `hedera-node/data` dir; required when `CN_VERSION=main`      |
 | `MN_VERSION`             | `latest`                 | Mirror Node version                                                  |
 | `BN_VERSION`             | `latest`                 | Block Node version                                                   |
 | `RELAY_VERSION`          | `latest`                 | Relay version                                                        |
@@ -241,14 +242,54 @@ cp .env.example .env
 
 ### Version Keywords
 
-| Keyword  |                   Resolves To                   |        Notes        |
-|----------|-------------------------------------------------|---------------------|
-| `latest` | Latest GA release from GitHub                   | All components      |
-| `main`   | Current development snapshot                    | **Block Node only** |
-| `rc`     | Latest Release Candidate (tag containing `-rc`) | All components      |
-| `v0.x.y` | Specific version tag                            | All components      |
+| Keyword  |                   Resolves To                   |               Notes                |
+|----------|-------------------------------------------------|------------------------------------|
+| `latest` | Latest GA release from GitHub                   | All components                     |
+| `main`   | Current development snapshot                    | Block Node; CN needs a local build |
+| `rc`     | Latest Release Candidate (tag containing `-rc`) | All components                     |
+| `v0.x.y` | Specific version tag                            | All components                     |
 
-> **Note:** The `main` keyword only works for Block Node. Other components (CN, MN, Relay, TCK) do not publish `main` snapshots.
+> **Note:** `main` resolves straight through for Block Node, which publishes SNAPSHOT images. Mirror Node, Relay and TCK do **not** publish `main` snapshots at all. Consensus Node needs the extra step below.
+
+### Consensus Node from `main` (local build)
+
+**`CN_VERSION` defaults to `main` locally**, because no published CN tag yet carries the fixed
+16-slot block-root hashing rework — a released tag fails verification against a current Block Node
+and Mirror Node. That means a local `task up` requires `CN_LOCAL_BUILD_PATH`; the deploy fails fast
+if it is unset. Pin a released tag (`v0.79.0-alpha.1`, `v0.78.0-rc.2`) if you want to skip the build
+and don't need the new hashing.
+
+CI is unaffected — the `solo-e2e-test` and `solo-e2e-scheduler` workflows pass their own
+`latest` / `rc` values, since runners have no Consensus Node checkout to build from.
+
+Solo does not pull the Consensus Node as a container image. `solo consensus node setup` downloads a
+platform build zip from `builds.hedera.com/node/software/<vMAJOR.MINOR>/build-<tag>.zip` and unpacks it
+into the pod's `root-container`. **Only tagged releases are published there**, so `CN_VERSION=main`
+(which resolves to e.g. `0.79.0-SNAPSHOT` from the CN branch's `version.txt`) has no artifact to fetch.
+
+To run an unreleased CN commit, build it locally and point the deploy at the build output. Solo's
+`--local-build-path` skips the download and uploads your jars instead:
+
+```bash
+cd <cn-repo>
+git fetch upstream && git checkout upstream/main
+./gradlew assemble          # populates hedera-node/data/{apps,lib}
+
+cd -                        # back to solo-e2e-test
+task up CN_VERSION=main CN_LOCAL_BUILD_PATH=<cn-repo>/hedera-node/data
+```
+
+`CN_LOCAL_BUILD_PATH` points at the `data` directory itself — Solo validates that it contains `apps/`
+and `lib/`. The release tag is still needed (staging-dir naming, Solo's TSS capability gate) but no
+longer has to match a published build; Solo explicitly tolerates the mismatch for local builds.
+
+`solo-deploy-network.sh` fails fast on both mistakes — a `-SNAPSHOT` `CN_VERSION` with no
+`CN_LOCAL_BUILD_PATH`, and a `CN_LOCAL_BUILD_PATH` that hasn't been built — rather than letting the
+404 surface after the cluster and Block Nodes are already up.
+
+> **Named CI tags don't work.** Tags like `sdpt-pass-00380` on the CN repo are git-only markers: no
+> build zip is published for them, and Solo's `Templates.prepareReleasePrefix` rejects any tag that
+> isn't dotted semver. Use a real pre-release tag (`v0.79.0-alpha.1`, `v0.78.0-rc.2`) or a local build.
 
 ### Command-Line Overrides
 
@@ -428,17 +469,36 @@ Topologies define network configuration. Located in `./topologies/`.
 
 |         Name          | CN | BN | MN | Relay | Explorer |                      Use Case                       |
 |-----------------------|----|----|:--:|:-----:|:--------:|-----------------------------------------------------|
-| `single`              | 1  | 1  | 1  |   1   |    0     | Basic testing, fastest startup                      |
-| `paired-3`            | 3  | 3  | 1  |   1   |    0     | Multi-node testing, each CN->BN pair                |
-| `fan-out-3cn-2bn`     | 3  | 2  | 1  |   1   |    0     | Redundancy testing, all CNs->all BNs                |
-| `3cn-1bn`             | 3  | 1  | 1  |   1   |    0     | Single BN receiving from multiple CNs               |
+| `single`              | 1  | 1  | 1  |   0   |    0     | Basic testing, fastest startup                      |
+| `paired-3`            | 3  | 3  | 1  |   0   |    0     | Multi-node testing, each CN->BN pair                |
+| `fan-out-3cn-2bn`     | 3  | 2  | 1  |   0   |    0     | Redundancy testing, all CNs->all BNs                |
+| `3cn-1bn`             | 3  | 1  | 1  |   0   |    0     | Single BN receiving from multiple CNs               |
 | `minimal`             | 1  | 1  | 0  |   0   |    0     | CN+BN only, no mirror/relay/explorer                |
-| `2cn-2bn-backfill`    | 2  | 2  | 1  |   1   |    0     | Backfill testing, BN recovery after data loss       |
-| `7cn-3bn-distributed` | 7  | 3  | 1  |   1   |    0     | Distributed streaming, grouped CN->BN with backfill |
+| `2cn-2bn-backfill`    | 2  | 2  | 1  |   0   |    0     | Backfill testing, BN recovery after data loss       |
+| `7cn-3bn-distributed` | 7  | 3  | 1  |   0   |    0     | Distributed streaming, grouped CN->BN with backfill |
 | `single-wrb-rsa`      | 1  | 1  | 1  |   0   |    0     | WRB (wrapped record blocks) verified via RSA roster |
 | `3cn-2bn-wrb-rsa`     | 3  | 2  | 1  |   0   |    0     | WRB fan-out verified via RSA roster                 |
 
 See `../network-topology-tool/README.md` for topology schema details.
+
+### Enabling Optional Components
+
+Relay and Explorer are **off in every bundled topology** — none of them define a
+`relay_nodes` or `explorer_nodes` entry. A component is deployed only when its section
+lists at least one node:
+
+```yaml
+relay_nodes:
+  relay-1: {}       # deploys the JSON-RPC Relay
+
+explorer_nodes: {}  # empty (or absent) -> not deployed
+```
+
+> The Relay is off by default because its startup probe (`GET :7546/health/readiness`)
+> has been failing on recent Relay images, leaving the pod at `0/1 Running`. Since
+> `solo relay node add` waits for readiness, a deployed-but-unhealthy Relay aborts
+> `task up` **before** it reaches `task port-forward`, which looks like "port forwards
+> are broken". Enable the Relay only if you actually need JSON-RPC.
 
 ### WRB + RSA Verification Topologies
 
@@ -589,7 +649,7 @@ task test:validate TEST_FILE=tests/basic-load.yaml
 | `tests/basic-load.yaml`              | Basic load test (1000 TPS cap)                      |
 | `tests/high-load.yaml`               | High load test (5000 TPS cap)                       |
 | `tests/node-restart-resilience.yaml` | BN recovery after restart during load               |
-| `tests/full-history-backfill.yaml`   | BN recovery via backfill after simulated outage     |
+| `tests/full-history-backfill.yaml`   | BN backfills history while ingesting live blocks    |
 | `tests/rsa-roster-verification.yaml` | Blocks verified via the RSA roster (WRB topologies) |
 
 ### Test Definition Schema
@@ -638,7 +698,7 @@ assertions:                      # Validations to run after all events
 | `network-status`           | Print network status             | (none)                                                                                            |
 | `sleep`                    | Pause execution                  | `seconds`                                                                                         |
 | `port-forward`             | Refresh port forwards            | (none)                                                                                            |
-| `clear-block-storage`      | Clear all block data on node     | `target`                                                                                          |
+| `clear-block-storage`      | Clear all block data on node (live, archive, verification, and the persisted block-range state) | `target`                                            |
 | `deploy-block-node`        | Deploy new Block Node            | `name`, `backfill_sources`, `greedy`, `chart_version`                                             |
 | `reconfigure-cn-streaming` | Update CN block-nodes.json       | `consensus_node`, `block_nodes`                                                                   |
 | `inject-latency`           | Apply a NetworkChaos rule        | `name`, `source.kind`, `target.kind`, `latency`, `jitter`, `correlation`, `bidirectional`, `loss` |
@@ -659,6 +719,22 @@ assertions:                      # Validations to run after all events
 | `log-match`               | Generic log-substring check                                      | `grep`, `since_seconds`                                    |
 
 **Note:** The `blocks-increasing` assertion verifies a Block Node is actively receiving blocks. It measures baseline, waits `wait_seconds` (default: 60), verifies increase, retrying up to `max_attempts` (default: 3) times.
+
+**Note:** Entries under `assertions:` all run *after* every event, so they cannot check anything that is only true partway through a run. Time-sensitive checks belong in a `command` event instead — a failing `command` event fails the test just as a failing assertion does. `scripts/backfill/assert-backfill-during-live-stream.sh` and the `scripts/wrb-distribution/assert-*.sh` scripts follow this pattern.
+
+### Backfill With Live Tail (`full-history-backfill`)
+
+`tests/full-history-backfill.yaml` wipes BN1's data and checks that it refills its history from BN2 *while* its Consensus Node keeps streaming live blocks into it, rather than staying blocked until backfill reaches the chain head. Supporting scripts live in `scripts/backfill/`:
+
+|                  Script                   |                                  Purpose                                   |
+|-------------------------------------------|-----------------------------------------------------------------------------|
+| `wait-for-network-height.sh`              | Blocks until the network reaches `MIN_HEIGHT` (default 600) so there is a recoverable gap; returns at once if already past it |
+| `configure-bn-live-tail-backfill.sh`      | Raises the BN's `earliestManagedBlock` to `<chain head> + EMB_OFFSET` and throttles backfill, while the BN is scaled to zero |
+| `assert-backfill-during-live-stream.sh`   | Samples `serverStatusDetail` + `publisher_open_connections` and requires the historical range and the live range to both advance in the same window |
+
+The `earliestManagedBlock` is the hinge. On a store-less start the publisher treats it as its next expected block: left at the default `0` the Block Node answers every offer from the Consensus Node with `BlockNodeBehind`, so live streaming only resumes once backfill has walked the whole chain. Raised above the chain head, the first offered block is accepted instead and everything below it becomes a `HISTORICAL` backfill gap.
+
+If the assertion times out reporting no publisher connection, the network most likely produced blocks past the chosen `earliestManagedBlock` before the pod was ready — re-run with a larger `EMB_OFFSET`.
 
 ### CI Integration
 

--- a/tools-and-tests/scripts/solo-e2e-test/README.md
+++ b/tools-and-tests/scripts/solo-e2e-test/README.md
@@ -225,7 +225,7 @@ cp .env.example .env
 | `SOLO_GIT_REPO`          | (empty)                  | Fork `owner/repo` when `SOLO_SOURCE=git` (must be approved)          |
 | `SOLO_GIT_REF`           | (empty)                  | Branch/tag/SHA when `SOLO_SOURCE=git`                                |
 | `CN_VERSION`             | `main`                   | Consensus Node version (requires `CN_LOCAL_BUILD_PATH`)              |
-| `CN_LOCAL_BUILD_PATH`    | (empty)                  | Built CN `hedera-node/data` dir; required when `CN_VERSION=main`      |
+| `CN_LOCAL_BUILD_PATH`    | (empty)                  | Built CN `hedera-node/data` dir; required when `CN_VERSION=main`     |
 | `MN_VERSION`             | `latest`                 | Mirror Node version                                                  |
 | `BN_VERSION`             | `latest`                 | Block Node version                                                   |
 | `RELAY_VERSION`          | `latest`                 | Relay version                                                        |
@@ -501,7 +501,8 @@ explorer_nodes: {}  # empty (or absent) -> not deployed
 > has been failing on recent Relay images, leaving the pod at `0/1 Running`. Since
 > `solo relay node add` waits for readiness, a deployed-but-unhealthy Relay aborts
 > `task up` **before** it reaches `task port-forward`, which looks like "port forwards
-> are broken". Enable the Relay only if you actually need JSON-RPC.
+>
+>> are broken". Enable the Relay only if you actually need JSON-RPC.
 
 ### WRB + RSA Verification Topologies
 
@@ -687,25 +688,25 @@ assertions:                      # Validations to run after all events
 
 ### Event Types
 
-|            Type            |           Description            |                                             Arguments                                             |
-|----------------------------|----------------------------------|---------------------------------------------------------------------------------------------------|
-| `command`                  | Run arbitrary script             | `script`                                                                                          |
-| `node-down`                | Scale node to 0 replicas         | `target`                                                                                          |
-| `node-up`                  | Scale node to 1 replica          | `target`                                                                                          |
-| `scale-down`               | Scale down (alias for node-down) | `target`                                                                                          |
-| `scale-up`                 | Scale up (alias for node-up)     | `target`                                                                                          |
-| `restart`                  | Rollout restart node             | `target`                                                                                          |
-| `load-start`               | Start NLG load                   | `test_class`, `concurrency`, `accounts`, `duration`, `max_tps`                                    |
-| `load-stop`                | Stop NLG load                    | `test_class`                                                                                      |
-| `print-metrics`            | Print metrics summary            | `target` (node name or "all")                                                                     |
-| `network-status`           | Print network status             | (none)                                                                                            |
-| `sleep`                    | Pause execution                  | `seconds`                                                                                         |
-| `port-forward`             | Refresh port forwards            | (none)                                                                                            |
-| `clear-block-storage`      | Clear all block data on node (live, archive, verification, and the persisted block-range state) | `target`                                            |
-| `deploy-block-node`        | Deploy new Block Node            | `name`, `backfill_sources`, `greedy`, `chart_version`                                             |
-| `reconfigure-cn-streaming` | Update CN block-nodes.json       | `consensus_node`, `block_nodes`                                                                   |
-| `inject-latency`           | Apply a NetworkChaos rule        | `name`, `source.kind`, `target.kind`, `latency`, `jitter`, `correlation`, `bidirectional`, `loss` |
-| `clear-latency`            | Remove a NetworkChaos rule       | `name`                                                                                            |
+|            Type            |                                           Description                                           |                                             Arguments                                             |
+|----------------------------|-------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| `command`                  | Run arbitrary script                                                                            | `script`                                                                                          |
+| `node-down`                | Scale node to 0 replicas                                                                        | `target`                                                                                          |
+| `node-up`                  | Scale node to 1 replica                                                                         | `target`                                                                                          |
+| `scale-down`               | Scale down (alias for node-down)                                                                | `target`                                                                                          |
+| `scale-up`                 | Scale up (alias for node-up)                                                                    | `target`                                                                                          |
+| `restart`                  | Rollout restart node                                                                            | `target`                                                                                          |
+| `load-start`               | Start NLG load                                                                                  | `test_class`, `concurrency`, `accounts`, `duration`, `max_tps`                                    |
+| `load-stop`                | Stop NLG load                                                                                   | `test_class`                                                                                      |
+| `print-metrics`            | Print metrics summary                                                                           | `target` (node name or "all")                                                                     |
+| `network-status`           | Print network status                                                                            | (none)                                                                                            |
+| `sleep`                    | Pause execution                                                                                 | `seconds`                                                                                         |
+| `port-forward`             | Refresh port forwards                                                                           | (none)                                                                                            |
+| `clear-block-storage`      | Clear all block data on node (live, archive, verification, and the persisted block-range state) | `target`                                                                                          |
+| `deploy-block-node`        | Deploy new Block Node                                                                           | `name`, `backfill_sources`, `greedy`, `chart_version`                                             |
+| `reconfigure-cn-streaming` | Update CN block-nodes.json                                                                      | `consensus_node`, `block_nodes`                                                                   |
+| `inject-latency`           | Apply a NetworkChaos rule                                                                       | `name`, `source.kind`, `target.kind`, `latency`, `jitter`, `correlation`, `bidirectional`, `loss` |
+| `clear-latency`            | Remove a NetworkChaos rule                                                                      | `name`                                                                                            |
 
 ### Assertion Types
 
@@ -729,11 +730,11 @@ assertions:                      # Validations to run after all events
 
 `tests/full-history-backfill.yaml` wipes BN1's data and checks that it refills its history from BN2 *while* its Consensus Node keeps streaming live blocks into it, rather than staying blocked until backfill reaches the chain head. Supporting scripts live in `scripts/backfill/`:
 
-|                  Script                   |                                  Purpose                                   |
-|-------------------------------------------|-----------------------------------------------------------------------------|
-| `wait-for-network-height.sh`              | Blocks until the network reaches `MIN_HEIGHT` (default 600) so there is a recoverable gap; returns at once if already past it |
-| `configure-bn-live-tail-backfill.sh`      | Raises the BN's `earliestManagedBlock` to `<chain head> + EMB_OFFSET` and throttles backfill, while the BN is scaled to zero |
-| `assert-backfill-during-live-stream.sh`   | Samples `serverStatusDetail` + `publisher_open_connections` and requires the historical range and the live range to both advance in the same window |
+|                 Script                  |                                                                       Purpose                                                                       |
+|-----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `wait-for-network-height.sh`            | Blocks until the network reaches `MIN_HEIGHT` (default 600) so there is a recoverable gap; returns at once if already past it                       |
+| `configure-bn-live-tail-backfill.sh`    | Raises the BN's `earliestManagedBlock` to `<chain head> + EMB_OFFSET` and throttles backfill, while the BN is scaled to zero                        |
+| `assert-backfill-during-live-stream.sh` | Samples `serverStatusDetail` + `publisher_open_connections` and requires the historical range and the live range to both advance in the same window |
 
 The `earliestManagedBlock` is the hinge. On a store-less start the publisher treats it as its next expected block: left at the default `0` the Block Node answers every offer from the Consensus Node with `BlockNodeBehind`, so live streaming only resumes once backfill has walked the whole chain. Raised above the chain head, the first offered block is accepted instead and everything below it becomes a `HISTORICAL` backfill gap.
 

--- a/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
+++ b/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
@@ -52,7 +52,7 @@ vars:
   # 'main' by default: no published CN tag yet carries the fixed 16-slot block-root hashing
   # rework, so a released tag cannot verify against current BN/MN. 'main' resolves to a
   # -SNAPSHOT with no published build artifact, so it requires CN_LOCAL_BUILD_PATH below.
-  # CI keeps its own 'latest'/'rc' defaults — runners have no CN checkout to build.
+  # CI builds the Consensus Node itself when the resolved version is a -SNAPSHOT.
   CN_VERSION: '{{.CN_VERSION | default "main"}}'
   # Path to a built Consensus Node 'hedera-node/data' directory. Required when CN_VERSION
   # resolves to a -SNAPSHOT (e.g. CN_VERSION=main), which has no published build artifact.

--- a/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
+++ b/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
@@ -49,7 +49,14 @@ vars:
   CONTEXT: '{{.CONTEXT | default .CLUSTER_REF}}'
 
   # Version defaults
-  CN_VERSION: '{{.CN_VERSION | default "latest"}}'
+  # 'main' by default: no published CN tag yet carries the fixed 16-slot block-root hashing
+  # rework, so a released tag cannot verify against current BN/MN. 'main' resolves to a
+  # -SNAPSHOT with no published build artifact, so it requires CN_LOCAL_BUILD_PATH below.
+  # CI keeps its own 'latest'/'rc' defaults — runners have no CN checkout to build.
+  CN_VERSION: '{{.CN_VERSION | default "main"}}'
+  # Path to a built Consensus Node 'hedera-node/data' directory. Required when CN_VERSION
+  # resolves to a -SNAPSHOT (e.g. CN_VERSION=main), which has no published build artifact.
+  CN_LOCAL_BUILD_PATH: '{{.CN_LOCAL_BUILD_PATH | default ""}}'
   MN_VERSION: '{{.MN_VERSION | default "latest"}}'
   BN_VERSION: '{{.BN_VERSION | default "latest"}}'
   BN_CHART_DIR: '{{.BN_CHART_DIR | default ""}}'
@@ -218,6 +225,7 @@ tasks:
           --topology "{{.TOPOLOGY}}" \
           --topologies-dir "{{.TOPOLOGIES_DIR}}" \
           --cn-version "$CN_RESOLVED" \
+          {{if .CN_LOCAL_BUILD_PATH}}--cn-local-build-path "{{.CN_LOCAL_BUILD_PATH}}"{{end}} \
           --mn-version "$MN_RESOLVED" \
           --bn-version "$BN_RESOLVED" \
           {{if .BN_CHART_DIR}}--bn-chart-dir "{{.BN_CHART_DIR}}"{{end}} \

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/backfill/assert-backfill-during-live-stream.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/backfill/assert-backfill-during-live-stream.sh
@@ -124,8 +124,12 @@ while true; do
 
         if ((connections_after < 1)); then
             last_reason="no publisher connected to ${target_bn} (open connections ${connections_after})"
-        elif ((count_before < 2 || count_after < 2)); then
-            last_reason="${target_bn} does not hold two separate ranges, so there is no open historical gap to close (ranges ${ranges_after})"
+        elif ((count_before < 2)); then
+            # Naming the sample matters: reporting the *after* ranges while complaining about
+            # the *before* one reads as a contradiction when the after-sample does hold a gap.
+            last_reason="${target_bn} held no historical gap at the start of this window, so there was nothing to watch close (ranges ${ranges_before})"
+        elif ((count_after < 2)); then
+            last_reason="${target_bn} no longer holds two separate ranges; the gap either closed or never opened (ranges ${ranges_after})"
         elif [[ "${historical_before}" == "-" || "${historical_after}" == "-" ]]; then
             last_reason="${target_bn} holds no range starting at block 0; backfill has not landed any history yet"
         elif ((historical_after <= historical_before)); then

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/backfill/assert-backfill-during-live-stream.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/backfill/assert-backfill-during-live-stream.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Backfill-with-live-tail E2E (#3053) -- assert that the recovering Block Node is
+# closing its historical gap at the same time as it is accepting live blocks from
+# its Consensus Node.
+#
+# "At the same time" is the whole point, so a pass requires every one of these to
+# hold across a single sampling window rather than merely at some point in the
+# run:
+#
+#   * publisher_open_connections >= 1 -- a Consensus Node is connected
+#   * availableRanges holds a range starting at block 0 *and* a separate later
+#     range -- the historical gap is still open, so none of this is
+#     post-recovery noise
+#   * the end of the range starting at 0 grew -- backfill is closing the gap
+#   * the end of the last range grew -- live blocks are still landing
+#
+# Ranges come from BlockNodeService/serverStatusDetail. A node recovering with
+# its earliestManagedBlock above the chain head reports exactly two, e.g.
+# [{0,120},{648,712}]: history being refilled from genesis, and the live tail.
+#
+# The window is retried until CONCURRENCY_TIMEOUT because when live ingest starts
+# depends on when the Consensus Node reconnects, which the test cannot schedule.
+#
+# Usage:
+#     assert-backfill-during-live-stream.sh <target-bn-index>
+#     assert-backfill-during-live-stream.sh 1
+#
+# Reads:
+#   NAMESPACE      (default "solo-network")
+#   CONTEXT        (default "kind-solo-cluster")
+#   PROTO_PATH     (defaults to whichever of protobuf-sources/proto or
+#                  protobuf-sources/build/proto exists -- CI untars the former,
+#                  the Taskfile builds the latter)
+#   SAMPLE_WINDOW  (default 20)  seconds between the two samples of a window
+#   CONCURRENCY_TIMEOUT   (default 300) seconds before giving up
+#   STATE_FILE     (default /tmp/backfill-live-tail.state)
+#
+# grpcurl needs -import-path/-proto explicitly: the Block Node's gRPC server does
+# not expose reflection, so a plain `-d '{}' host:port service/method` call
+# silently returns nothing to parse.
+
+set -euo pipefail
+
+LOG_PREFIX="backfill-live-tail-assert"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
+# shellcheck source-path=SCRIPTDIR source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+: "${SAMPLE_WINDOW:=20}"
+: "${CONCURRENCY_TIMEOUT:=300}"
+: "${STATE_FILE:=/tmp/backfill-live-tail.state}"
+
+target_index="${1:?assert-backfill-during-live-stream.sh: target BN index required}"
+target_bn="block-node-${target_index}"
+grpc_port=$(bn_grpc_port "${target_index}")
+
+command -v grpcurl >/dev/null 2>&1 || fail "grpcurl not on PATH; cannot query serverStatusDetail"
+command -v jq >/dev/null 2>&1 || fail "jq not on PATH"
+
+if [[ -z "${PROTO_PATH:-}" || ! -d "${PROTO_PATH}" ]]; then
+    for candidate in "${REPO_ROOT}/protobuf-sources/proto" "${REPO_ROOT}/protobuf-sources/build/proto"; do
+        if [[ -d "${candidate}" ]]; then
+            PROTO_PATH="${candidate}"
+            break
+        fi
+    done
+fi
+[[ -d "${PROTO_PATH:-}" ]] || fail "PROTO_PATH not set and no protobuf sources found under ${REPO_ROOT}/protobuf-sources"
+
+# Confirm the pod really came up with the earliestManagedBlock the configure step
+# patched in. Without that, live ingest could not have started and every failure
+# below would be reported against the wrong cause.
+[[ -f "${STATE_FILE}" ]] || fail "state file ${STATE_FILE} not found; did configure-bn-live-tail-backfill.sh run?"
+# shellcheck source=/dev/null
+source "${STATE_FILE}"
+: "${earliest_managed_block:?state file did not set earliest_managed_block}"
+
+actual_emb=$(kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
+    exec "${target_bn}-0" -c block-node-server -- \
+    printenv BLOCK_NODE_EARLIEST_MANAGED_BLOCK 2>/dev/null | tr -d '[:space:]' || echo "")
+[[ "${actual_emb}" == "${earliest_managed_block}" ]] ||
+    fail "${target_bn} came up with EMB='${actual_emb:-unset}', expected '${earliest_managed_block}'"
+log "${target_bn} is running with EMB=${actual_emb} (network head was ${network_height_at_config:-unknown} when configured)."
+
+# Echoes "<range-count> <end-of-range-starting-at-0> <end-of-last-range> <ranges-json>".
+# The second field is "-" when the node holds no range starting at block 0, i.e.
+# backfill has not landed anything from genesis yet.
+sample_ranges() {
+    local ranges
+    ranges=$(grpcurl -plaintext -emit-defaults \
+        -import-path "${PROTO_PATH}" \
+        -proto block-node/api/node_service.proto \
+        -d '{}' "localhost:${grpc_port}" \
+        org.hiero.block.api.BlockNodeService/serverStatusDetail 2>/dev/null |
+        jq -c '[.availableRanges[]? | {start: (.rangeStart | tonumber), end: (.rangeEnd | tonumber)}]') || return 1
+    [[ -n "${ranges}" && "${ranges}" != "null" ]] || return 1
+    echo "${ranges}" | jq -r '
+        (length | tostring) + " "
+        + (if (length > 0 and .[0].start == 0) then (.[0].end | tostring) else "-" end) + " "
+        + (if (length > 0) then (.[-1].end | tostring) else "-" end) + " "
+        + tojson'
+}
+
+log "Sampling ${target_bn} in ${SAMPLE_WINDOW}s windows for up to ${CONCURRENCY_TIMEOUT}s..."
+
+deadline=$(($(date +%s) + CONCURRENCY_TIMEOUT))
+last_reason="no sample taken yet"
+while true; do
+    first=$(sample_ranges) || first=""
+    connections_before=$(read_bn_metric_int "${target_index}" "blocknode_publisher_open_connections") || connections_before=0
+    sleep "${SAMPLE_WINDOW}"
+    second=$(sample_ranges) || second=""
+    connections_after=$(read_bn_metric_int "${target_index}" "blocknode_publisher_open_connections") || connections_after=0
+
+    if [[ -z "${first}" || -z "${second}" ]]; then
+        last_reason="serverStatusDetail returned no available ranges"
+    else
+        read -r count_before historical_before live_before ranges_before <<< "${first}"
+        read -r count_after historical_after live_after ranges_after <<< "${second}"
+        log "  ${ranges_before} -> ${ranges_after} (publisher connections ${connections_before} -> ${connections_after})"
+
+        if ((connections_after < 1)); then
+            last_reason="no publisher connected to ${target_bn} (open connections ${connections_after})"
+        elif ((count_before < 2 || count_after < 2)); then
+            last_reason="${target_bn} does not hold two separate ranges, so there is no open historical gap to close (ranges ${ranges_after})"
+        elif [[ "${historical_before}" == "-" || "${historical_after}" == "-" ]]; then
+            last_reason="${target_bn} holds no range starting at block 0; backfill has not landed any history yet"
+        elif ((historical_after <= historical_before)); then
+            last_reason="historical range did not grow (end stayed at ${historical_after}); backfill is not closing the gap"
+        elif ((live_after <= live_before)); then
+            last_reason="live range did not grow (end stayed at ${live_after}); no live blocks arriving from the Consensus Node"
+        else
+            log "OK: ${target_bn} closed history 0..${historical_before} -> 0..${historical_after} (+$((historical_after - historical_before)) blocks) while the live tail advanced ${live_before} -> ${live_after} (+$((live_after - live_before)) blocks) over ${SAMPLE_WINDOW}s, with ${connections_after} publisher connection(s)."
+            exit 0
+        fi
+    fi
+
+    (($(date +%s) < deadline)) || break
+    log "  not yet concurrent: ${last_reason}"
+done
+
+log "Last observed state: ${ranges_after:-unavailable}"
+fail "${target_bn} did not backfill history while ingesting live blocks within ${CONCURRENCY_TIMEOUT}s: ${last_reason}"

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/backfill/common.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/backfill/common.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared helpers for the backfill-with-live-tail E2E scripts (#3053).
+# Sourced, never executed directly.
+#
+# Expects the sourcing script to set LOG_PREFIX before sourcing.
+
+: "${NAMESPACE:=solo-network}"
+: "${CONTEXT:=kind-solo-cluster}"
+
+log() { echo "[${LOG_PREFIX}] $*"; }
+fail() { echo "[${LOG_PREFIX}] ERROR: $*" >&2; exit 1; }
+
+# Local ports that solo-port-forward.sh binds a BN's endpoints to:
+# metrics 16007 and gRPC 40840 for block-node-1, then one higher per index.
+bn_metrics_port() { echo $((16006 + $1)); }
+bn_grpc_port() { echo $((40839 + $1)); }
+
+# Read one Prometheus metric from a BN over its port-forward and round it to an
+# integer -- gauges are exported in floating-point form ("612.0"), which bash
+# arithmetic rejects. Prints nothing and returns 1 when the metric is absent.
+read_bn_metric_int() {
+    local bn_index="$1" metric="$2" raw
+    raw=$(curl -s --max-time 5 "http://localhost:$(bn_metrics_port "${bn_index}")/metrics" 2>/dev/null |
+        awk -v m="${metric}" '$1 == m { print $2; exit }')
+    [[ -n "${raw}" ]] || return 1
+    printf "%.0f" "${raw}" 2>/dev/null || return 1
+}
+
+# Highest block number the given BN has seen on its inbound publisher stream.
+# Used as the network's current height: it tracks the Consensus Node's chain
+# head without needing grpcurl or the protobuf sources.
+read_bn_height() {
+    read_bn_metric_int "$1" "blocknode_publisher_highest_block_number_inbound"
+}

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/backfill/configure-bn-live-tail-backfill.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/backfill/configure-bn-live-tail-backfill.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Backfill-with-live-tail E2E (#3053) -- prepare a wiped Block Node so that it
+# ingests live blocks from its Consensus Node while it backfills its history.
+#
+# Two changes to the target BN's "<bn>-config" ConfigMap, which the chart wires
+# into the container with `envFrom: configMapRef` (see
+# charts/block-node-server/templates/statefulset.yaml), so the values only take
+# effect on the next pod start -- hence the scaled-to-zero precondition below.
+#
+#   1. BLOCK_NODE_EARLIEST_MANAGED_BLOCK = <current network height> + EMB_OFFSET
+#
+#      On a store-less start the publisher sets its next expected block to the
+#      earliestManagedBlock (LiveStreamPublisherManager#initializeBlockNumbers).
+#      Left at the default 0, every block the Consensus Node offers is *above*
+#      that, so the BN answers BlockNodeBehind and live streaming stays blocked
+#      until backfill has walked the whole chain. Raised above the chain head,
+#      the first offered block is *below* it and takes the post-restart pre-EMB
+#      accept path (LiveStreamPublisherManager#streamBeforeEmbOrElse): live
+#      ingest starts at once and everything under the first live block is left
+#      as a HISTORICAL gap for backfill to close in parallel.
+#
+#      The offset has to cover the blocks the network produces between this
+#      patch and the pod actually accepting its first block. If the head passes
+#      the EMB first, the BN goes back to answering BlockNodeBehind and never
+#      starts live ingest -- raise EMB_OFFSET if the assertion times out on a
+#      fast-producing network.
+#
+#   2. Throttled backfill -- smaller batches with a longer pause between them,
+#      plus a shorter scan interval so the gap is picked up promptly rather than
+#      up to a minute later. This keeps the historical gap open long enough for
+#      a sampling assertion to watch it shrink while live blocks are arriving.
+#
+# The chosen EMB is written to STATE_FILE so
+# assert-backfill-during-live-stream.sh can confirm the running pod came up with
+# it rather than asserting against a patch that never landed.
+#
+# Usage:
+#     configure-bn-live-tail-backfill.sh <target-bn-index> [reference-bn-index]
+#     configure-bn-live-tail-backfill.sh 1 2
+#
+# Reads:
+#   NAMESPACE                       (default "solo-network")
+#   CONTEXT                         (default "kind-solo-cluster")
+#   EMB_OFFSET                      (default 100)   blocks above the chain head
+#   BACKFILL_FETCH_BATCH_SIZE       (default 5)     chart default is 10
+#   BACKFILL_DELAY_BETWEEN_BATCHES  (default 2000)  chart default is 1000 ms
+#   BACKFILL_SCAN_INTERVAL          (default 15000) chart default is 60000 ms
+#   REFERENCE_PROGRESS_WINDOW       (default 15)    seconds used to confirm the
+#                                                   reference BN is still ingesting
+#   STATE_FILE                      (default /tmp/backfill-live-tail.state)
+
+set -euo pipefail
+
+LOG_PREFIX="backfill-live-tail-config"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+: "${EMB_OFFSET:=100}"
+: "${BACKFILL_FETCH_BATCH_SIZE:=5}"
+: "${BACKFILL_DELAY_BETWEEN_BATCHES:=2000}"
+: "${BACKFILL_SCAN_INTERVAL:=15000}"
+: "${REFERENCE_PROGRESS_WINDOW:=15}"
+: "${STATE_FILE:=/tmp/backfill-live-tail.state}"
+
+target_index="${1:?configure-bn-live-tail-backfill.sh: target BN index required}"
+reference_index="${2:-2}"
+
+target_bn="block-node-${target_index}"
+config_configmap="${target_bn}-config"
+
+kctl() { kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" "$@"; }
+
+# The env only reaches the JVM on a fresh pod, so patching a running BN would
+# silently do nothing and leave the assertion to fail for the wrong reason.
+replicas=$(kctl get statefulset "${target_bn}" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "")
+[[ "${replicas}" == "0" ]] ||
+    fail "${target_bn} must be scaled to 0 before configuring it (replicas='${replicas:-unknown}')"
+
+network_height=$(read_bn_height "${reference_index}") ||
+    fail "could not read the network height from block-node-${reference_index} (is its port-forward up?)"
+
+# The reference BN's height stands in for the chain head, which is only valid
+# while that BN is actually ingesting live blocks. A stalled reference yields a
+# stale, too-low EMB, the target then answers BlockNodeBehind for every offered
+# block, and live ingest never starts -- the assertion would fail several minutes
+# later with no hint that the cause was here. Confirm the reference is advancing
+# and fail loudly with the real reason if it is not.
+sleep "${REFERENCE_PROGRESS_WINDOW}"
+network_height_later=$(read_bn_height "${reference_index}") ||
+    fail "could not re-read the network height from block-node-${reference_index}"
+((network_height_later > network_height)) ||
+    fail "block-node-${reference_index} is not ingesting live blocks (height stuck at ${network_height} over ${REFERENCE_PROGRESS_WINDOW}s); its height cannot stand in for the chain head, so no EMB can be chosen"
+network_height="${network_height_later}"
+
+earliest_managed_block=$((network_height + EMB_OFFSET))
+
+log "Network height on block-node-${reference_index} is ${network_height} (advancing)."
+log "Configuring ${target_bn}: EMB=${earliest_managed_block} (+${EMB_OFFSET}), fetch batch ${BACKFILL_FETCH_BATCH_SIZE}, ${BACKFILL_DELAY_BETWEEN_BATCHES}ms between batches, ${BACKFILL_SCAN_INTERVAL}ms scan interval."
+
+kctl patch configmap "${config_configmap}" --type merge -p "$(
+    cat <<EOF
+{
+  "data": {
+    "BLOCK_NODE_EARLIEST_MANAGED_BLOCK": "${earliest_managed_block}",
+    "BACKFILL_FETCH_BATCH_SIZE": "${BACKFILL_FETCH_BATCH_SIZE}",
+    "BACKFILL_DELAY_BETWEEN_BATCHES": "${BACKFILL_DELAY_BETWEEN_BATCHES}",
+    "BACKFILL_SCAN_INTERVAL": "${BACKFILL_SCAN_INTERVAL}"
+  }
+}
+EOF
+)" || fail "failed to patch ${config_configmap}"
+
+printf 'earliest_managed_block=%s\nnetwork_height_at_config=%s\n' \
+    "${earliest_managed_block}" "${network_height}" > "${STATE_FILE}"
+
+log "${config_configmap} patched; state written to ${STATE_FILE}."

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/backfill/wait-for-network-height.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/backfill/wait-for-network-height.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Backfill-with-live-tail E2E (#3053) -- block until the network has produced at
+# least MIN_HEIGHT blocks.
+#
+# The behaviour this test asserts (historical backfill closing a gap while the
+# publisher keeps accepting live blocks) only exists while there is a historical
+# gap big enough to outlive the observation window. The wiped Block Node
+# therefore needs a few hundred blocks of history to recover, so the test waits
+# for the network to reach a floor before simulating the data loss. If the
+# network is already past the floor this returns immediately and costs nothing.
+#
+# Usage:
+#     wait-for-network-height.sh [reference-bn-index]
+#     wait-for-network-height.sh 2
+#
+# Reads:
+#   MIN_HEIGHT     (default 600)  height the network must reach
+#   POLL_INTERVAL  (default 15)   seconds between polls
+#   HEIGHT_TIMEOUT   (default 2400) seconds before giving up
+
+set -euo pipefail
+
+LOG_PREFIX="backfill-live-tail-height"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+: "${MIN_HEIGHT:=600}"
+: "${POLL_INTERVAL:=15}"
+: "${HEIGHT_TIMEOUT:=2400}"
+
+reference_index="${1:-2}"
+
+log "Waiting for block-node-${reference_index} to report height >= ${MIN_HEIGHT} (timeout ${HEIGHT_TIMEOUT}s)..."
+
+deadline=$(($(date +%s) + HEIGHT_TIMEOUT))
+height=""
+while true; do
+    height=$(read_bn_height "${reference_index}") || height=""
+    if [[ -n "${height}" ]] && ((height >= MIN_HEIGHT)); then
+        log "Network reached height ${height} (floor ${MIN_HEIGHT})."
+        exit 0
+    fi
+    (($(date +%s) < deadline)) || break
+    log "  height=${height:-unavailable}, waiting ${POLL_INTERVAL}s..."
+    sleep "${POLL_INTERVAL}"
+done
+
+fail "network did not reach height ${MIN_HEIGHT} within ${HEIGHT_TIMEOUT}s (last height=${height:-unavailable})"

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/lib/chaos-assertions.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/lib/chaos-assertions.sh
@@ -18,6 +18,35 @@
 #   assert_block_rate_floor     - sugar built on metric scraping
 #   assert_log_match            - log-substring presence (powers backfill-triggered)
 
+# An empty Block Node reports firstAvailableBlock/lastAvailableBlock as UINT64_MAX,
+# not null and not 0 — 0 means "block 0 is available". The field is present and
+# populated, so a `== "null"` check does not catch it.
+NO_BLOCKS_SENTINEL="18446744073709551615"
+
+# is_valid_block_number: true only for a plain decimal that fits in a signed 64-bit
+# integer, which is the range bash arithmetic can compare without wrapping.
+#
+# Any uint64 field out of serverStatus carries this hazard: UINT64_MAX wraps to -1
+# inside `[[ ... -gt ... ]]`, so a naive `[[ "${first}" -gt "${min}" ]]` *passes* for
+# a node holding no blocks at all. Rejecting the whole out-of-range class rather than
+# just the current sentinel value means a future sentinel change cannot silently
+# reintroduce the overflow.
+function is_valid_block_number {
+  local value="${1-}"
+
+  [[ -n "${value}" && "${value}" != "null" ]] || return 1
+  [[ "${value}" =~ ^[0-9]+$ ]] || return 1
+
+  # Compare by length, then lexically. The value may exceed what bash arithmetic can
+  # hold, so it cannot be range-checked numerically here without hitting the very
+  # overflow this guard exists to prevent.
+  local int64_max="9223372036854775807"
+  (( ${#value} < ${#int64_max} )) && return 0
+  (( ${#value} > ${#int64_max} )) && return 1
+  [[ "${value}" > "${int64_max}" ]] && return 1
+  return 0
+}
+
 # compare_numeric: arithmetic comparison via awk (handles floats).
 # Echoes ok/violation line; returns 0 on pass, 1 on fail.
 function compare_numeric {

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-deploy-network.sh
@@ -14,6 +14,9 @@
 #   --topology TOPOLOGY        Topology name from topologies/*.yaml (default: single)
 #   --topologies-dir DIR       Directory containing topology files (default: SCRIPT_DIR/topologies)
 #   --cn-version VERSION       Consensus Node version
+#   --cn-local-build-path DIR  Consensus Node `hedera-node/data` directory from a local CN build.
+#                              Required when --cn-version is a -SNAPSHOT (e.g. CN_VERSION=main),
+#                              since builds.hedera.com publishes no SNAPSHOT artifact.
 #   --mn-version VERSION       Mirror Node version
 #   --bn-version VERSION       Block Node version (used for Helm chart version)
 #   --bn-chart-dir DIR         Local charts/ directory to install the Block Node chart from,
@@ -77,6 +80,9 @@ Options:
   --topology TOPOLOGY        Topology name from topologies/*.yaml (default: single)
   --topologies-dir DIR       Directory containing topology files (default: SCRIPT_DIR/topologies)
   --cn-version VERSION       Consensus Node version
+  --cn-local-build-path DIR  Consensus Node 'hedera-node/data' directory from a local CN build.
+                             Required when --cn-version is a -SNAPSHOT (e.g. CN_VERSION=main),
+                             since builds.hedera.com publishes no SNAPSHOT artifact.
   --mn-version VERSION       Mirror Node version
   --bn-version VERSION       Block Node version (used for Helm chart version)
   --bn-chart-dir DIR         Local charts/ directory to install the Block Node chart from,
@@ -113,6 +119,7 @@ CLUSTER_REF=""
 TOPOLOGY="single"
 TOPOLOGIES_DIR="${SCRIPT_DIR}/topologies"
 CN_VERSION=""
+CN_LOCAL_BUILD_PATH=""
 MN_VERSION=""
 BN_VERSION=""
 BN_CHART_DIR=""
@@ -167,6 +174,10 @@ while [[ $# -gt 0 ]]; do
       CN_VERSION="$2"
       shift 2
       ;;
+    --cn-local-build-path)
+      CN_LOCAL_BUILD_PATH="$2"
+      shift 2
+      ;;
     --mn-version)
       MN_VERSION="$2"
       shift 2
@@ -209,6 +220,76 @@ done
 [[ -z "${NAMESPACE}" ]] && fail "ERROR: --namespace is required" 1
 [[ -z "${CLUSTER_REF}" ]] && fail "ERROR: --cluster-ref is required" 1
 
+# Validate the Consensus Node source before any cluster work happens.
+#
+# Solo does not pull the Consensus Node as a container image — `consensus node setup`
+# downloads a platform build zip from
+# builds.hedera.com/node/software/<vMAJOR.MINOR>/build-<release-tag>.zip and unpacks it into
+# the pod's root-container. Only tagged releases are published there, so a -SNAPSHOT release
+# tag (what CN_VERSION=main resolves to, via version.txt on the CN main branch) always 404s.
+#
+# --local-build-path short-circuits that download: Solo uploads the jars from a local CN build
+# instead. That is the only way to run an unreleased CN commit. Solo still needs the release tag
+# for its staging directory and for its TSS capability gate, and it explicitly tolerates a
+# release-tag/build mismatch when a local build path is set.
+function validate_consensus_node_source {
+  if [[ -n "${CN_LOCAL_BUILD_PATH}" ]]; then
+    if [[ ! -d "${CN_LOCAL_BUILD_PATH}" ]]; then
+      fail "ERROR: --cn-local-build-path '${CN_LOCAL_BUILD_PATH}' is not a directory" 1
+    fi
+    # Solo requires the data directory itself, not the repo root.
+    local subdirectory
+    for subdirectory in apps lib; do
+      if [[ ! -d "${CN_LOCAL_BUILD_PATH}/${subdirectory}" ]]; then
+        log_line "ERROR: --cn-local-build-path '%s' has no '%s/' subdirectory." \
+          "${CN_LOCAL_BUILD_PATH}" "${subdirectory}" >&2
+        log_line "It must point at a *built* Consensus Node data directory, e.g. <cn-repo>/hedera-node/data" >&2
+        fail "Build it first: cd <cn-repo> && ./gradlew assemble" 1
+      fi
+    done
+    return 0
+  fi
+
+  if [[ "${CN_VERSION}" == *-SNAPSHOT ]]; then
+    log_line "ERROR: Consensus Node %s has no published build artifact." "${CN_VERSION}" >&2
+    log_line "builds.hedera.com only hosts tagged releases, so 'solo consensus node setup' would" >&2
+    log_line "fail with a 404 after the cluster and Block Nodes are already deployed." >&2
+    log_line "" >&2
+    log_line "To run an unreleased Consensus Node commit, build it locally and point the deploy at it:" >&2
+    log_line "  cd <cn-repo> && ./gradlew assemble" >&2
+    log_line "  task up CN_LOCAL_BUILD_PATH=<cn-repo>/hedera-node/data" >&2
+    fail "Or pin a released tag instead, e.g. CN_VERSION=v0.79.0-alpha.1" 1
+  fi
+}
+
+validate_consensus_node_source
+
+# Decide whether an optional component (mirror/relay/explorer) is deployed.
+#
+# A component is deployed only when the topology lists at least one node for it.
+# `<section> | length` is used instead of `keys | length` because yq errors on a
+# null section — e.g. `relay_nodes:` with every entry commented out — which left
+# the count empty, fell through to the legacy `components.<key> // true` default
+# and silently deployed a component the topology never asked for.
+#
+# The legacy `components.<key>` flag now has to say `true` explicitly to force a
+# component on; no bundled topology uses it.
+function skip_component {
+  local topology_file="${1}"
+  local section="${2}"
+  local legacy_key="${3}"
+
+  local node_count legacy_enabled
+  node_count=$(yq ".${section} | length" "${topology_file}" 2>/dev/null || echo "0")
+  legacy_enabled=$(yq ".components.${legacy_key} // false" "${topology_file}" 2>/dev/null)
+
+  if [[ "${node_count}" -gt 0 || "${legacy_enabled}" == "true" ]]; then
+    echo "false"
+  else
+    echo "true"
+  fi
+}
+
 # Load topology from YAML file
 function load_topology {
   local topology_name="${1}"
@@ -226,52 +307,11 @@ function load_topology {
   # Count block nodes using yq (PR #1834 schema: block_nodes.<id>)
   BN_COUNT=$(yq '.block_nodes | keys | length' "${topology_file}" 2>/dev/null || echo "1")
 
-  # Check for new schema (mirror_nodes, relay_nodes, explorer_nodes sections)
-  # Fall back to components section for backward compatibility
-  local has_mirror_nodes has_relay_nodes has_explorer_nodes
-  has_mirror_nodes=$(yq '.mirror_nodes | keys | length // 0' "${topology_file}" 2>/dev/null)
-  has_relay_nodes=$(yq '.relay_nodes | keys | length // 0' "${topology_file}" 2>/dev/null)
-  has_explorer_nodes=$(yq '.explorer_nodes | keys | length // 0' "${topology_file}" 2>/dev/null)
-
-  SKIP_MIRROR="false"
-  SKIP_RELAY="false"
-  SKIP_EXPLORER="false"
-
-  # New schema: if section exists with nodes, deploy; if section is empty or missing, skip
-  if [[ "${has_mirror_nodes}" -gt 0 ]]; then
-    SKIP_MIRROR="false"
-    log_line "  Mirror Node decision: Deploy (has_mirror_nodes=${has_mirror_nodes})"
-  elif [[ "${has_mirror_nodes}" == "0" ]] && yq -e '.mirror_nodes' "${topology_file}" >/dev/null 2>&1; then
-    # Section exists but empty - skip
-    SKIP_MIRROR="true"
-    log_line "  Mirror Node decision: Skip (mirror_nodes: {} exists but empty)"
-  else
-    # Fall back to components section
-    local mirror_enabled
-    mirror_enabled=$(yq '.components.mirror_node // true' "${topology_file}" 2>/dev/null)
-    [[ "${mirror_enabled}" == "false" ]] && SKIP_MIRROR="true"
-    log_line "  Mirror Node decision: Fallback to components.mirror_node=${mirror_enabled}"
-  fi
-
-  if [[ "${has_relay_nodes}" -gt 0 ]]; then
-    SKIP_RELAY="false"
-  elif [[ "${has_relay_nodes}" == "0" ]] && yq -e '.relay_nodes' "${topology_file}" >/dev/null 2>&1; then
-    SKIP_RELAY="true"
-  else
-    local relay_enabled
-    relay_enabled=$(yq '.components.relay // true' "${topology_file}" 2>/dev/null)
-    [[ "${relay_enabled}" == "false" ]] && SKIP_RELAY="true"
-  fi
-
-  if [[ "${has_explorer_nodes}" -gt 0 ]]; then
-    SKIP_EXPLORER="false"
-  elif [[ "${has_explorer_nodes}" == "0" ]] && yq -e '.explorer_nodes' "${topology_file}" >/dev/null 2>&1; then
-    SKIP_EXPLORER="true"
-  else
-    local explorer_enabled
-    explorer_enabled=$(yq '.components.explorer // true' "${topology_file}" 2>/dev/null)
-    [[ "${explorer_enabled}" == "false" ]] && SKIP_EXPLORER="true"
-  fi
+  # Optional components come from the mirror_nodes/relay_nodes/explorer_nodes
+  # sections, with the legacy components section as an explicit opt-in.
+  SKIP_MIRROR=$(skip_component "${topology_file}" "mirror_nodes" "mirror_node")
+  SKIP_RELAY=$(skip_component "${topology_file}" "relay_nodes" "relay")
+  SKIP_EXPLORER=$(skip_component "${topology_file}" "explorer_nodes" "explorer")
 
   # Read verification mode. "rsa-wrb" switches the deployment to Wrapped Record
   # Blocks verified against the RSA roster, which requires TSS to be disabled.
@@ -689,11 +729,20 @@ function deploy_consensus_nodes {
     ${cn_args} --dev || fail "ERROR: Failed to deploy consensus network" 1
   end_task
 
+  # With --local-build-path Solo uploads the jars from a local CN build instead of
+  # downloading the release zip, which is what makes an unreleased CN commit deployable.
+  local cn_local_build_args=""
+  if [[ -n "${CN_LOCAL_BUILD_PATH}" ]]; then
+    cn_local_build_args="--local-build-path ${CN_LOCAL_BUILD_PATH}"
+    log_line "Using local Consensus Node build: %s" "${CN_LOCAL_BUILD_PATH}"
+  fi
+
   start_task "Setting up consensus nodes"
   # shellcheck disable=SC2086
   solo consensus node setup \
     --node-aliases "${NODE_ALIASES}" \
     --deployment "${DEPLOYMENT}" \
+    ${cn_local_build_args} \
     ${cn_args} || fail "ERROR: Failed to setup consensus nodes" 1
   end_task
 
@@ -897,6 +946,7 @@ function print_summary {
   log_line "Versions:"
   log_line "  Solo CLI:        %s" "$(solo --version 2>/dev/null | grep 'Version' | awk -F': ' '{print $2}' || echo 'unknown')"
   log_line "  CN Version:      %s" "${CN_VERSION:-default}"
+  [[ -n "${CN_LOCAL_BUILD_PATH}" ]] && log_line "  CN Build:        %s (local)" "${CN_LOCAL_BUILD_PATH}"
   log_line "  MN Version:      %s" "${MN_VERSION:-default}"
   log_line "  BN Version:      %s" "${BN_VERSION:-default}"
   if [[ -n "${BN_CHART_DIR}" ]]; then

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-network-status.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-network-status.sh
@@ -26,6 +26,11 @@
 
 set -o pipefail
 
+# is_valid_block_number / NO_BLOCKS_SENTINEL — shared with solo-test-runner.sh so the
+# status table and the assertions agree on what "no blocks" looks like.
+# shellcheck source=lib/chaos-assertions.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/chaos-assertions.sh"
+
 NAMESPACE=""
 TOPOLOGY=""
 TOPOLOGIES_DIR=""
@@ -153,10 +158,14 @@ for BN in ${BLOCK_NODES}; do
     FIRST=$(echo "${STATUS_JSON}" | jq -r '.firstAvailableBlock // "N/A"')
     LAST=$(echo "${STATUS_JSON}" | jq -r '.lastAvailableBlock // "N/A"')
 
-    if [[ "${FIRST}" != "N/A" && "${LAST}" != "N/A" ]]; then
-      output_line "| ${BN} | Block Node | Running | Blocks: ${FIRST} - ${LAST} |"
-    else
+    if [[ "${FIRST}" == "N/A" || "${LAST}" == "N/A" ]]; then
       output_line "| ${BN} | Block Node | Unreachable | - |"
+    elif ! is_valid_block_number "${FIRST}" || ! is_valid_block_number "${LAST}"; then
+      # An empty store reports UINT64_MAX for both fields; printing that as a range
+      # reads like a healthy node holding 18 quintillion blocks.
+      output_line "| ${BN} | Block Node | Running | No blocks |"
+    else
+      output_line "| ${BN} | Block Node | Running | Blocks: ${FIRST} - ${LAST} |"
     fi
   else
     output_line "| ${BN} | Block Node | Unknown | grpcurl not available |"

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-test-runner.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-test-runner.sh
@@ -313,38 +313,47 @@ function execute_port_forward {
     echo "Port forwards refreshed"
 }
 
+# Wipe a Block Node's block storage by deleting its live and archive PVCs, which the
+# StatefulSet's volumeClaimTemplates recreate empty on the next scale-up.
+#
+# The node MUST already be scaled to zero. Wiping a running node does not work: it keeps
+# ingesting live blocks from its Consensus Node for the whole termination grace period
+# (30s, ~15 blocks), repopulating the directories that were just emptied. The node then
+# restarts holding a partial live range instead of being store-less, so
+# LiveStreamPublisherManager#initializeBlockNumbers derives its next expected block from
+# that range rather than from earliestManagedBlock, answers BlockNodeBehind to every
+# offer, and never resumes live ingest.
+#
+# `rm -rf` over an exec was also silently ineffective in two of its three paths:
+# data/archive (the mount is data/historic) and data/verification (no such directory).
+# Deleting the claims cannot miss a path.
+#
+# application-state-storage is deliberately left alone — it holds
+# tss-bootstrap-roster.json, without which the node fails every block it is offered.
 function execute_clear_block_storage {
     local target="$1"
     echo "Clearing block storage on $target..."
 
-    local pod_name="${target}-0"
+    local replicas
+    replicas=$(kctl get statefulset "${target}" -n "${NAMESPACE}" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "")
+    if [[ "${replicas}" != "0" ]]; then
+        echo "ERROR: ${target} must be scaled to 0 before clearing its storage (replicas='${replicas:-unknown}')." >&2
+        echo "       Wiping a running node leaves it with a partial live range after restart." >&2
+        return 1
+    fi
 
-    # Clear live storage (recent blocks)
-    echo "Clearing live storage..."
-    kctl exec "${pod_name}" -n "${NAMESPACE}" -- \
-        sh -c "rm -rf /opt/hiero/block-node/data/live/* 2>/dev/null || true"
+    local claim
+    for claim in "live-storage-${target}-0" "archive-storage-${target}-0"; do
+        if kctl get pvc "${claim}" -n "${NAMESPACE}" >/dev/null 2>&1; then
+            echo "Deleting PVC ${claim}..."
+            kctl delete pvc "${claim}" -n "${NAMESPACE}" --wait=true ||
+                { echo "ERROR: failed to delete PVC ${claim}" >&2; return 1; }
+        else
+            echo "PVC ${claim} not present, skipping"
+        fi
+    done
 
-    # Clear archive storage (historic blocks)
-    echo "Clearing archive storage..."
-    kctl exec "${pod_name}" -n "${NAMESPACE}" -- \
-        sh -c "rm -rf /opt/hiero/block-node/data/archive/* 2>/dev/null || true"
-
-    # Clear verification state
-    echo "Clearing verification state..."
-    kctl exec "${pod_name}" -n "${NAMESPACE}" -- \
-        sh -c "rm -rf /opt/hiero/block-node/data/verification/* 2>/dev/null || true"
-
-    # Clear the persisted block range set. It lives on its own PVC and is reloaded
-    # into the in-memory range set on startup, which the backfill plugin uses as
-    # "blocks this node already has" — leaving it behind makes the restarted node
-    # believe it still holds the blocks whose files were just deleted, so backfill
-    # finds no gap to close. Only this file is removed; the sibling TSS/RSA
-    # bootstrap rosters in the same directory must survive the restart.
-    echo "Clearing persisted block ranges..."
-    kctl exec "${pod_name}" -n "${NAMESPACE}" -- \
-        sh -c "rm -f /opt/hiero/block-node/application-state/block-ranges.json 2>/dev/null || true"
-
-    echo "Block storage cleared on $target"
+    echo "Block storage cleared on $target (application-state preserved)"
 }
 
 function execute_scale_down {

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-test-runner.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-test-runner.sh
@@ -334,6 +334,16 @@ function execute_clear_block_storage {
     kctl exec "${pod_name}" -n "${NAMESPACE}" -- \
         sh -c "rm -rf /opt/hiero/block-node/data/verification/* 2>/dev/null || true"
 
+    # Clear the persisted block range set. It lives on its own PVC and is reloaded
+    # into the in-memory range set on startup, which the backfill plugin uses as
+    # "blocks this node already has" — leaving it behind makes the restarted node
+    # believe it still holds the blocks whose files were just deleted, so backfill
+    # finds no gap to close. Only this file is removed; the sibling TSS/RSA
+    # bootstrap rosters in the same directory must survive the restart.
+    echo "Clearing persisted block ranges..."
+    kctl exec "${pod_name}" -n "${NAMESPACE}" -- \
+        sh -c "rm -f /opt/hiero/block-node/application-state/block-ranges.json 2>/dev/null || true"
+
     echo "Block storage cleared on $target"
 }
 
@@ -810,8 +820,12 @@ function assert_block_available_single {
     first_block=$(echo "$status_json" | jq -r '.firstAvailableBlock // "null"')
     last_block=$(echo "$status_json" | jq -r '.lastAvailableBlock // "null"')
 
-    if [[ "$first_block" == "null" || "$last_block" == "null" ]]; then
-        echo "${target}: No blocks available"
+    # An empty store reports both fields as the UINT64_MAX sentinel, which wraps to -1 in
+    # bash arithmetic and would make the "$first_block" -gt "$min_block" test below pass for
+    # a node holding no blocks at all. is_valid_block_number rejects the sentinel and any
+    # other value outside the signed-64-bit range. See scripts/lib/chaos-assertions.sh.
+    if ! is_valid_block_number "$first_block" || ! is_valid_block_number "$last_block"; then
+        echo "${target}: No blocks available (firstAvailableBlock=${first_block} lastAvailableBlock=${last_block})"
         return 1
     fi
 
@@ -1042,8 +1056,11 @@ function get_block_count {
 
     block_count=$(echo "$json" | jq -r '.lastAvailableBlock // ""' 2>/dev/null)
 
-    # Return empty if we got nothing valid
-    if [[ -z "$block_count" || "$block_count" == "null" ]]; then
+    # Return empty if we got nothing valid. An empty store reports the UINT64_MAX
+    # sentinel here, which compares equal to itself — without this guard
+    # assert_blocks_increasing would report "Blocks not increasing" for a node that
+    # holds nothing, hiding the real problem behind a plausible-looking failure.
+    if ! is_valid_block_number "$block_count"; then
         echo ""
         return 1
     fi
@@ -1078,7 +1095,7 @@ function assert_blocks_increasing_single {
     done
 
     if [[ -z "$baseline_block" ]]; then
-        echo "${target}: Could not get baseline block count"
+        echo "${target}: Could not get baseline block count (node holds no blocks, or serverStatus unreachable)"
         return 1
     fi
 

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/test/test-chaos-assertions.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/test/test-chaos-assertions.sh
@@ -155,6 +155,30 @@ else
 fi
 
 # ----------------------------------------------------------------------------
+echo "[5] is_valid_block_number: rejects the no-blocks sentinel and out-of-range values"
+# Table-driven: one method for the whole equivalence class, per CLAUDE.md.
+# OK = accepted as a real block number, NO = rejected as "no blocks"/malformed.
+for tc in "0 OK" "1 OK" "513 OK" "9223372036854775806 OK" "9223372036854775807 OK" \
+          "18446744073709551615 NO" "9223372036854775808 NO" "99999999999999999999 NO" \
+          "null NO" " NO" "-1 NO" "1.5 NO" "abc NO" "1e9 NO"; do
+    value="${tc% *}"; expected="${tc##* }"
+    if is_valid_block_number "${value}"; then actual=OK; else actual=NO; fi
+    if [[ "${actual}" == "${expected}" ]]; then
+        pass "is_valid_block_number '${value}' => ${expected}"
+    else
+        fail "is_valid_block_number '${value}' => expected ${expected}, got ${actual}"
+    fi
+done
+
+# The regression this guard exists to prevent: the sentinel wraps to -1 in bash
+# arithmetic, so a bare numeric comparison reports an empty node as having blocks.
+if [[ "${NO_BLOCKS_SENTINEL}" -gt 0 ]] 2>/dev/null; then
+    fail "sentinel unexpectedly compares > 0 (bash no longer wraps; guard rationale changed)"
+else
+    pass "sentinel wraps negative in bash arithmetic (guard is load-bearing)"
+fi
+
+# ----------------------------------------------------------------------------
 echo
 echo "RESULT: ${passed} passed, ${failed} failed"
 [[ $failed -eq 0 ]]

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/test/test-topology-decisions.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/test/test-topology-decisions.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Regression check for topology parsing in solo-deploy-network.sh.
+#
+# The relay/explorer/mirror deploy decision used `yq '.<section> | keys | length // 0'`,
+# which *errors* on a null section — a `relay_nodes:` key whose only child is commented
+# out, or a missing key. stderr was discarded and there was no fallback, so the count came
+# back as the empty string, both branches of the comparison were false, and the component
+# was deployed anyway. Six of nine matrix jobs died on the resulting relay.
+#
+# This asserts the decision is reachable for every bundled topology without a yq error,
+# so the failure mode cannot come back silently. Runs without a cluster.
+#
+# Exit 0 on all-pass, 1 on any failure.
+
+set -u -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOPOLOGIES_DIR="${SCRIPT_DIR}/../../topologies"
+DEPLOY_SCRIPT="${SCRIPT_DIR}/../solo-deploy-network.sh"
+
+passed=0
+failed=0
+function pass { echo "  PASS  $1"; passed=$((passed+1)); }
+function fail { echo "  FAIL  $1"; failed=$((failed+1)); }
+
+# Reuse the real decision function rather than a copy, so this test tracks the
+# implementation instead of drifting from it.
+eval "$(sed -n '/^function skip_component/,/^}/p' "${DEPLOY_SCRIPT}")"
+
+if ! declare -f skip_component >/dev/null; then
+    echo "FATAL: could not extract skip_component from ${DEPLOY_SCRIPT}"
+    exit 1
+fi
+
+echo "[1] skip_component resolves to true/false for every topology and section"
+for topology_file in "${TOPOLOGIES_DIR}"/*.yaml; do
+    name=$(basename "${topology_file}")
+    for section_pair in "mirror_nodes:mirror_node" "relay_nodes:relay" "explorer_nodes:explorer"; do
+        section="${section_pair%%:*}"
+        legacy_key="${section_pair##*:}"
+
+        # Capture stderr too: a yq error here is the exact regression being guarded.
+        decision=$(skip_component "${topology_file}" "${section}" "${legacy_key}" 2>&1)
+
+        if [[ "${decision}" == "true" || "${decision}" == "false" ]]; then
+            pass "${name} ${section} -> skip=${decision}"
+        else
+            fail "${name} ${section} -> expected true/false, got '${decision}'"
+        fi
+    done
+done
+
+echo "[2] the null-section shapes that caused the regression all resolve to skip"
+# yq errors on `keys` for a null section; `length` returns 0. Cover every shape the
+# schema allows: absent, present-but-null, present-but-empty-map, and populated.
+fixture_dir=$(mktemp -d)
+trap 'rm -rf "${fixture_dir}"' EXIT
+
+printf 'name: absent\n' > "${fixture_dir}/absent.yaml"
+printf 'name: null-section\nrelay_nodes:\n  # relay-1: {}\n' > "${fixture_dir}/null-section.yaml"
+printf 'name: empty-map\nrelay_nodes: {}\n' > "${fixture_dir}/empty-map.yaml"
+printf 'name: populated\nrelay_nodes:\n  relay-1: {}\n' > "${fixture_dir}/populated.yaml"
+
+for expectation in "absent:true" "null-section:true" "empty-map:true" "populated:false"; do
+    shape="${expectation%%:*}"
+    want="${expectation##*:}"
+    got=$(skip_component "${fixture_dir}/${shape}.yaml" "relay_nodes" "relay" 2>&1)
+    if [[ "${got}" == "${want}" ]]; then
+        pass "relay_nodes ${shape} -> skip=${want}"
+    else
+        fail "relay_nodes ${shape} -> expected skip=${want}, got '${got}'"
+    fi
+done
+
+echo "[3] legacy components.<key>=true still forces a component on"
+printf 'name: legacy\ncomponents:\n  relay: true\n' > "${fixture_dir}/legacy.yaml"
+got=$(skip_component "${fixture_dir}/legacy.yaml" "relay_nodes" "relay" 2>&1)
+if [[ "${got}" == "false" ]]; then
+    pass "components.relay=true -> skip=false"
+else
+    fail "components.relay=true -> expected skip=false, got '${got}'"
+fi
+
+echo "[4] verification_mode resolves to a known value for every topology"
+# A typo (rsa_wrb, rsa-WRB) silently falls back to tss, which is how
+# wrb-differential-test ended up verifying every block against the wrong scheme.
+for topology_file in "${TOPOLOGIES_DIR}"/*.yaml; do
+    name=$(basename "${topology_file}")
+    mode=$(yq '.verification_mode // "tss"' "${topology_file}" 2>&1)
+    case "${mode}" in
+        tss|rsa-wrb) pass "${name} verification_mode=${mode}" ;;
+        *)           fail "${name} verification_mode='${mode}' is not tss or rsa-wrb" ;;
+    esac
+done
+
+echo
+echo "RESULT: ${passed} passed, ${failed} failed"
+[[ $failed -eq 0 ]]

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-bn1-historical-backfill-landed.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-bn1-historical-backfill-landed.sh
@@ -25,6 +25,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
 
+# shellcheck source=../lib/chaos-assertions.sh
+source "${SCRIPT_DIR}/../lib/chaos-assertions.sh"
+
 : "${BN1_GRPC_PORT:=$((40839 + 1))}"
 : "${PROTO_PATH:=${REPO_ROOT}/protobuf-sources/proto}"
 
@@ -52,13 +55,12 @@ status_json=$(grpcurl -plaintext -emit-defaults \
 first_available=$(echo "${status_json}" | jq -r '.firstAvailableBlock // empty' 2>/dev/null || echo "")
 last_available=$(echo "${status_json}" | jq -r '.lastAvailableBlock // empty' 2>/dev/null || echo "")
 
-# An empty BN reports both fields as UINT64_MAX (18446744073709551615), not 0 —
-# 0 means "block 0 is available".
-NO_BLOCKS_SENTINEL="18446744073709551615"
-
 log "BN1 serverStatus: firstAvailableBlock=${first_available} lastAvailableBlock=${last_available}"
 
-if [[ -z "${last_available}" || ! "${last_available}" =~ ^[0-9]+$ || "${last_available}" == "${NO_BLOCKS_SENTINEL}" ]]; then
+# is_valid_block_number rejects the UINT64_MAX no-blocks sentinel (an empty BN reports it
+# for both fields, since 0 means "block 0 is available") plus anything else outside the
+# range bash can compare without wrapping.
+if ! is_valid_block_number "${last_available}"; then
     fail "BN1 still has no blocks after bulk-load + restart (lastAvailableBlock='${last_available}')"
 fi
 if [[ "${first_available}" != "0" ]]; then

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-live-push-produced-new-blocks.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-live-push-produced-new-blocks.sh
@@ -42,7 +42,10 @@ else
 fi
 
 # At least one new successful push iteration since start-live-push.sh's snapshot.
-current_push_ok_count=$( grep -cE '\] push OK' "${LOG_FILE}" 2>/dev/null || echo 0 )
+# No `|| echo 0`: grep -c prints 0 and exits 1 on no-match, so the fallback appends a
+# second line and the arithmetic below dies with `[[: 0\n0: syntax error`.
+current_push_ok_count=$( grep -cE '\] push OK' "${LOG_FILE}" 2>/dev/null )
+current_push_ok_count="${current_push_ok_count:-0}"
 log "push_ok_iterations: initial=${initial_push_ok_count} current=${current_push_ok_count}"
 
 if (( current_push_ok_count > initial_push_ok_count )); then

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-live-wrap-produced-new-blocks.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/assert-live-wrap-produced-new-blocks.sh
@@ -51,7 +51,10 @@ wrapped_dir="${WRB_DIST_WORK_DIR}/wrappedBlocks"
 # .blk-entry count are reliable here (WRB CLI consolidates all input .rcd
 # files into a single wrapped-stream block per invocation), so we look at
 # the worker log itself and count "wrap OK" iterations.
-current_wrap_ok_count=$( grep -cE '\] wrap OK' "${LOG_FILE}" 2>/dev/null || echo 0 )
+# No `|| echo 0`: grep -c prints 0 and exits 1 on no-match, so the fallback appends a
+# second line and the arithmetic below dies with `[[: 0\n0: syntax error`.
+current_wrap_ok_count=$( grep -cE '\] wrap OK' "${LOG_FILE}" 2>/dev/null )
+current_wrap_ok_count="${current_wrap_ok_count:-0}"
 current_total_bytes=$( find "${wrapped_dir}" -name '*.zip' -exec stat -c '%s' {} \; 2>/dev/null \
     | awk '{s+=$1} END {print s+0}' )
 

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/start-live-push.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-distribution/start-live-push.sh
@@ -79,7 +79,10 @@ wrapped_dir="${WRB_DIST_WORK_DIR}/wrappedBlocks"
 # Snapshot whatever "push OK" count is already in the log rather than assuming 0, so this
 # stays correct even if LOG_FILE isn't fresh (e.g. re-run in a debug session against a log the
 # short-circuit above left in place).
-initial_push_ok_count=$( grep -cE '\] push OK' "${LOG_FILE}" 2>/dev/null || echo 0 )
+# No `|| echo 0`: grep -c prints 0 and exits 1 on no-match, so the fallback appends a
+# second line and any later arithmetic on this dies with `[[: 0\n0: syntax error`.
+initial_push_ok_count=$( grep -cE '\] push OK' "${LOG_FILE}" 2>/dev/null )
+initial_push_ok_count="${initial_push_ok_count:-0}"
 printf 'initial_push_ok_count=%s\n' "${initial_push_ok_count}" > "${STATE_FILE}"
 
 # Fork the worker into the background and write its PID. Using nohup+setsid so

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-sequential-comparison.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-sequential-comparison.sh
@@ -156,6 +156,11 @@ function deploy_mn_to_bn {
         cat > "${overlay_file}" << EOF
 # Mirror Node connected to Block Node 1 (rsa-wrb / WRB cutover)
 importer:
+  # The default GraalVM-native importer image crashes on startup (missing reflection
+  # hints); the generator applies the same override for every topology.
+  image:
+    registry: gcr.io
+    repository: mirrornode/hedera-mirror-importer
   resources:
     limits:
       cpu: 2000m
@@ -175,9 +180,13 @@ importer:
               firstStage:
                 enabled: true
             enabled: true
+            # BlockNodeProperties expects each node to carry a list of endpoints; the
+            # flat "- host:/port:" form leaves host and port unbound and the importer
+            # dies at startup with "elements [...] were left unbound".
             nodes:
-              - host: ${bn_host}
-                port: 40840
+              - endpoints:
+                  - host: ${bn_host}
+                    port: 40840
             sourceType: BLOCK_NODE
             stream:
               maxStreamResponseSize: 36MB

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-sequential-comparison.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-sequential-comparison.sh
@@ -35,8 +35,16 @@ BLOCK_RANGE="0:100"
 MIN_TRANSACTIONS=10
 
 # Mirror Node version used for both MN1 (Solo deployment) and the standalone MN2.
-# Override with MIRROR_NODE_VERSION env var. Use a GA version, not 'main' or 'latest'.
-MIRROR_NODE_VERSION="${MIRROR_NODE_VERSION:-v0.156.0}"
+#
+# Falls back to MN_VERSION, which solo-e2e-test.yml exports with the version
+# resolve-versions.sh actually settled on, so this test does not silently run a different
+# Mirror Node than the rest of the suite. The hardcoded v0.156.0 that used to be the only
+# value here predates the reworked block-root hashing, so against a Consensus Node built
+# from main every block failed with "Previous wrapped record block hash mismatch".
+#
+# Override with MIRROR_NODE_VERSION for a one-off. Use a GA or -rc tag, not 'main' or
+# 'latest' — this is passed straight to `solo mirror node add --mirror-node-version`.
+MIRROR_NODE_VERSION="${MIRROR_NODE_VERSION:-${MN_VERSION:-v0.162.0-rc1}}"
 
 # Work directories
 WORK_DIR="/tmp/wrb-test-$$"
@@ -131,10 +139,22 @@ function deploy_mn_to_bn {
         log "Deploying ${mn_name} connected to block-node-1..."
 
         local overlay_file="/tmp/mn-overlay.yaml"
-        # Generate overlay - disable verification entirely (Solo doesn't support TSS)
+        # This topology declares `mirror_nodes: {}`, so solo-deploy-network.sh generates no
+        # Mirror Node overlay for it and this is the only place the MN gets configured. The
+        # shape below mirrors the rsa-wrb branch of
+        # network-topology-tool/generate-chart-values-config-overlays.sh, which is what the
+        # passing *-wrb-rsa topologies deploy with:
+        #
+        #   - `hiero.mirror.importer`, not `hedera.mirror.importer`. Current Mirror Node reads
+        #     the hiero-prefixed keys; under the old prefix this overlay was ignored, which is
+        #     why the record downloader kept pulling .rcd files despite being disabled here.
+        #   - block.cutover.enabled + firstStage.enabled, plus
+        #     DISABLE_IMPORTER_SPRING_PROFILES. Without the cutover config the importer chains
+        #     Wrapped Record Blocks as if they were plain record files and every block fails
+        #     with "Previous wrapped record block hash mismatch". The Consensus Node emits WRBs
+        #     because the topology sets verification_mode: rsa-wrb.
         cat > "${overlay_file}" << EOF
-# Mirror Node connected to Block Node 1
-# Disable block verification since Solo doesn't generate TSS metadata
+# Mirror Node connected to Block Node 1 (rsa-wrb / WRB cutover)
 importer:
   resources:
     limits:
@@ -143,11 +163,17 @@ importer:
     requests:
       cpu: 500m
       memory: 2Gi
+  env:
+    DISABLE_IMPORTER_SPRING_PROFILES: "true"
   config:
-    hedera:
+    hiero:
       mirror:
         importer:
           block:
+            cutover:
+              enabled: true
+              firstStage:
+                enabled: true
             enabled: true
             nodes:
               - host: ${bn_host}
@@ -155,13 +181,6 @@ importer:
             sourceType: BLOCK_NODE
             stream:
               maxStreamResponseSize: 36MB
-            verification:
-              enabled: false  # Disable all block verification for Solo
-          downloader:
-            record:
-              enabled: false
-            balance:
-              enabled: false
           startBlockNumber: 0
           stream:
             maxSubscribeAttempts: 10

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-sequential-comparison.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-sequential-comparison.sh
@@ -97,10 +97,21 @@ function wait_for_mn_ingestion {
 
     local elapsed=0
     while [[ ${elapsed} -lt ${timeout} ]]; do
-        # Check MN logs directly for ingestion success (more reliable than API)
-        local ingestion_count=$(kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
+        # Check MN logs directly for ingestion success (more reliable than API).
+        #
+        # Match .rcd as well as .blk: in rsa-wrb / WRB cutover mode the importer consumes
+        # the record files carried inside wrapped record blocks and logs "items from
+        # <ts>.rcd", never ".blk". Matching only .blk made this wait time out after 360s
+        # against an importer that was ingesting perfectly.
+        #
+        # `grep -c` already prints 0 when nothing matches, and also exits 1 — so a
+        # `|| echo 0` fallback appends a second line and the arithmetic test below dies
+        # with `[[: 0\n0: syntax error in expression`. Let grep's own 0 stand.
+        local ingestion_count
+        ingestion_count=$(kubectl --context "${CONTEXT}" --namespace "${NAMESPACE}" \
             logs deployment/mirror-1-importer --tail=100 2>/dev/null | \
-            grep -c "Successfully processed.*items from.*\.blk" || echo "0")
+            grep -cE "Successfully processed.*items from.*\.(blk|rcd)")
+        ingestion_count="${ingestion_count:-0}"
 
         if [[ "${ingestion_count}" -ge "1" ]]; then
             log "Mirror Node has ingested blocks (found ${ingestion_count} processing messages) ✓"
@@ -322,7 +333,11 @@ function download_record_files_from_minio {
         return $?
     }
 
-    local file_count=$(grep -c '\.rcd' /tmp/minio-listing.txt 2>/dev/null || echo "0")
+    # No `|| echo 0`: grep -c prints 0 and exits 1 on no-match, so the fallback would
+    # append a second line and break the arithmetic below. :-0 covers a missing file.
+    local file_count
+    file_count=$(grep -c '\.rcd' /tmp/minio-listing.txt 2>/dev/null)
+    file_count="${file_count:-0}"
     if [ "${file_count}" -lt 1 ]; then
         log "WARNING: No .rcd files found in MinIO bucket (found ${file_count}), trying CN pod..."
         download_record_files_from_cn "${output_dir}" "${max_files}"

--- a/tools-and-tests/scripts/solo-e2e-test/tests/full-history-backfill.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/full-history-backfill.yaml
@@ -72,15 +72,20 @@ events:
     args:
       script: "${SCRIPT_DIR}/backfill/wait-for-network-height.sh 2"
 
-  - id: clear-bn1-storage
-    type: clear-block-storage
-    description: "Clear all block storage on BN1 (simulate data loss)"
+  # Scale down BEFORE wiping. A running node keeps ingesting live blocks for its whole
+  # termination grace period (30s, ~15 blocks), refilling the storage that was just
+  # emptied — so it restarts holding a partial live range instead of being store-less,
+  # takes its next expected block from that range rather than from earliestManagedBlock,
+  # and answers BlockNodeBehind forever. That is the failure this ordering avoids.
+  - id: scale-down-bn1
+    type: scale-down
+    description: "Scale down BN1 so its storage can be wiped while it is stopped"
     delay: 20
     target: block-node-1
 
-  - id: scale-down-bn1
-    type: scale-down
-    description: "Scale down BN1"
+  - id: clear-bn1-storage
+    type: clear-block-storage
+    description: "Clear all block storage on the stopped BN1 (simulate data loss)"
     delay: 25
     target: block-node-1
 

--- a/tools-and-tests/scripts/solo-e2e-test/tests/full-history-backfill.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/full-history-backfill.yaml
@@ -1,27 +1,55 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Full History Backfill Test (Issue #1712)
+# Full History Backfill Test (Issues #1712, #3053)
 #
-# Tests that a block node can recover via greedy backfill from a peer
-# after losing all local data.
+# Tests that a block node which lost all of its data recovers its history from a
+# peer *while* it ingests live blocks from its Consensus Node, instead of staying
+# blocked until backfill has caught up to the chain head.
 #
 # Scenario:
 #   1. Verify BN1 and BN2 are receiving blocks
-#   2. Clear all block storage on BN1 (simulate data loss)
-#   3. Scale down BN1
-#   4. Wait for gap to form (BN2 continues receiving from CN2)
-#   5. Scale up BN1
-#   6. Verify BN1 backfills all historical blocks from BN2
-#   7. Verify all BNs resume receiving live blocks
+#   2. Wait for the network to produce enough blocks to leave a recoverable gap
+#   3. Clear all block storage on BN1 (simulate data loss)
+#   4. Scale down BN1
+#   5. Wait for gap to form (BN2 continues receiving from CN2)
+#   6. Raise BN1's earliestManagedBlock above the current chain head and throttle
+#      its backfill
+#   7. Scale up BN1
+#   8. Verify BN1 closes its historical gap while live blocks keep arriving
+#   9. Verify all BNs are healthy, hold block 0, and are still receiving blocks
+#
+# Why step 6 is what makes this test different from plain backfill recovery: on a
+# store-less start the publisher treats the earliestManagedBlock as its next
+# expected block. Left at the default 0 it answers every offer from the Consensus
+# Node with BlockNodeBehind, so live streaming only resumes once backfill has
+# walked the whole chain. Raised above the chain head, the first offered block is
+# accepted instead and everything below it becomes a HISTORICAL backfill gap —
+# the concurrency this test exercises. See
+# scripts/backfill/configure-bn-live-tail-backfill.sh for the details.
+#
+# This also means live ingest must land *before* backfill can do anything, and the
+# ordering matters because the topology sets `greedy: false`. Non-greedy backfill
+# caps its scan at the node's own highest stored block (BackfillPlugin
+# #determineEndCap), which is -1 on an empty store, so gap detection bails with
+# "Nothing to backfill". The accepted live blocks are what raise that cap and make
+# the historical gap below them visible. Switching this topology to `greedy: true`
+# would break the test from the other end: it blocks live streaming from the CN
+# after a restart, which is the very thing being asserted here.
+#
+# Note that `delay` is a floor ("don't start before T elapsed"), not a fixed
+# offset — the runner executes events sequentially and blocks on each one. The
+# wait-for-network-height event can hold for several minutes on a young network,
+# after which the remaining delays are already in the past and each event simply
+# runs as soon as the previous one returns.
 #
 # Prerequisites:
 #   - Topology with 2+ BNs and mutual backfill configured
 #
 # Usage:
-#   task test:run TEST_FILE=tests/full-history-backfill.yaml
+#   task test:run TEST_FILE=tests/full-history-backfill.yaml TOPOLOGY=2cn-2bn-backfill
 
 name: full-history-backfill
-description: "Test BN recovery via backfill after data loss (Issue #1712)"
+description: "Test BN recovery via backfill while ingesting live blocks (Issues #1712, #3053)"
 
 events:
   - id: initial-status
@@ -36,59 +64,82 @@ events:
     args:
       target: all
 
+  - id: wait-for-network-height
+    type: command
+    description: "Wait until the network has produced enough blocks to leave a recoverable gap"
+    delay: 15
+    timeout: 2400
+    args:
+      script: "${SCRIPT_DIR}/backfill/wait-for-network-height.sh 2"
+
   - id: clear-bn1-storage
     type: clear-block-storage
     description: "Clear all block storage on BN1 (simulate data loss)"
-    delay: 15
+    delay: 20
     target: block-node-1
 
   - id: scale-down-bn1
     type: scale-down
     description: "Scale down BN1"
-    delay: 20
+    delay: 25
     target: block-node-1
 
   - id: gap-period
     type: sleep
     description: "Allow gap to form (BN2 continues receiving from CN2)"
-    delay: 25
+    delay: 30
     args:
       seconds: 30
+
+  - id: configure-bn1-live-tail-backfill
+    type: command
+    description: "Raise BN1's earliestManagedBlock above the chain head and throttle its backfill"
+    delay: 65
+    timeout: 120
+    args:
+      script: "${SCRIPT_DIR}/backfill/configure-bn-live-tail-backfill.sh 1 2"
 
   - id: pre-recovery-metrics
     type: print-metrics
     description: "Print BN2 metrics showing blocks accumulated during gap"
-    delay: 60
+    delay: 70
     args:
       target: block-node-2
 
   - id: scale-up-bn1
     type: scale-up
-    description: "Scale up BN1 - should trigger backfill from BN2"
-    delay: 65
+    description: "Scale up BN1 - should resume live ingest and start historical backfill"
+    delay: 75
     target: block-node-1
 
   - id: refresh-ports
     type: port-forward
     description: "Refresh port forwards after BN1 restart"
-    delay: 80
-
-  - id: backfill-wait
-    type: sleep
-    description: "Wait for BN1 to backfill historical blocks from BN2"
     delay: 90
+
+  - id: assert-backfill-during-live-stream
+    type: command
+    description: "Assert BN1 closes its historical gap while live blocks keep arriving"
+    delay: 100
+    timeout: 420
     args:
-      seconds: 240
+      script: "${SCRIPT_DIR}/backfill/assert-backfill-during-live-stream.sh 1"
+
+  # No settling sleep here on purpose. Throttled backfill is still working on the
+  # gap at this point, and the assertions below are all satisfied mid-recovery:
+  # block 0 lands in backfill's first batch, and BN1's live tail keeps advancing
+  # independently of the gap. Waiting for full closure would only add minutes and
+  # push the assertions past the state worth observing.
 
   - id: post-backfill-status
     type: network-status
-    description: "Network status after backfill"
-    delay: 335
+    description: "Network status while BN1 is still backfilling"
+    delay: 520
 
   - id: final-metrics
     type: print-metrics
     description: "Final metrics summary"
-    delay: 340
+    delay: 525
     args:
       target: all
 

--- a/tools-and-tests/scripts/solo-e2e-test/tests/wrb-cli-hash-validation.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/wrb-cli-hash-validation.yaml
@@ -59,6 +59,15 @@ events:
     args:
       script: "${SCRIPT_DIR}/wrb-cli-validate-blocks.sh validate"
 
+  # The build and validate steps above run a Gradle build and stream blocks out of the
+  # Block Node on the same runner as the Kind cluster, which is enough to drop the
+  # kubectl port-forwards. Without this the assertions below query a dead forward and
+  # report "No blocks available" against a Block Node that is actually healthy.
+  - id: refresh-ports
+    type: port-forward
+    description: "Re-establish port forwards before asserting"
+    delay: 148
+
   - id: final-status
     type: network-status
     description: "Post-validation network status"

--- a/tools-and-tests/scripts/solo-e2e-test/tests/wrb-cli-wrapping-validation.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/wrb-cli-wrapping-validation.yaml
@@ -77,6 +77,15 @@ events:
     args:
       script: "${SCRIPT_DIR}/wrb-cli-wrap-and-compare.sh compare"
 
+  # The extract/wrap/compare steps above run a Gradle build and stream blocks out of the
+  # Block Node on the same runner as the Kind cluster, which is enough to drop the
+  # kubectl port-forwards. Without this the assertions below query a dead forward and
+  # report "No blocks available" against a Block Node that is actually healthy.
+  - id: refresh-ports
+    type: port-forward
+    description: "Re-establish port forwards before asserting"
+    delay: 158
+
   - id: final-status
     type: network-status
     description: "Post-validation network status"

--- a/tools-and-tests/scripts/solo-e2e-test/tests/wrb-differential-test.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/wrb-differential-test.yaml
@@ -61,7 +61,16 @@ assertions:
     args:
       min_block: 0
 
-  - id: no-errors
-    type: no-errors
-    description: "No errors in block node logs"
+  # This topology deploys no Mirror Node up front — the test script deploys MN1 several
+  # minutes in. The BN's roster-bootstrap-rsa plugin can only fetch the RSA address book
+  # from the Mirror Node REST API, so the first blocks the CN streams always fail with
+  # MISSING_VERIFICATION_DATA until the roster arrives. A strict `no-errors` assertion
+  # counts those startup failures and can never pass here. Assert on the RSA proof path
+  # instead, which tolerates startup failures and checks the signals that matter: roster
+  # loaded, RSA verifications accumulating, no roster mismatches.
+  - id: rsa-verification-active
+    type: rsa-roster-verification
+    description: "BN1 verifies blocks via the RSA roster with no roster mismatches"
     target: block-node-1
+    args:
+      min_rsa_success: 1

--- a/tools-and-tests/scripts/solo-e2e-test/topologies/fan-out-3cn-2bn.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/topologies/fan-out-3cn-2bn.yaml
@@ -1,14 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Fan-out topology: 3 Consensus Nodes, 2 Block Nodes, 1 Mirror Node
 #
-# All Consensus Nodes can stream to all Block Nodes (fan-out pattern).
-# This configuration tests redundancy and failover scenarios where
-# Block Nodes can receive blocks from multiple sources.
-# Block Nodes are peers of each other for gossip.
+# Every Consensus Node lists both Block Nodes, but `block_nodes` is a priority list, not a
+# broadcast list: each CN streams to its first entry and falls back to the second only when
+# that one is unreachable. So in steady state all three CNs publish to BN1 and BN2 has no
+# publisher at all — this exercises failover and peer backfill, not true fan-out.
 #
-# CN1,2,3 → BN1 and BN2 (all CNs to both BNs)
-# BN1 ↔ BN2 (backfill)
-# MN ← BN1, BN2
+# Because BN2 has no publisher it must be able to greedy-backfill. The non-greedy scan
+# window is sized from the local store, so on an empty store it is empty and BN2 would
+# stay empty and silent for the lifetime of the deployment.
+#
+# CN1,2,3 -> BN1 (primary), BN2 (fallback)
+# BN1 <-> BN2 (peer backfill)
+# MN <- BN1, BN2
 #
 # NOTE: grpc_tuning.max_frame_size is set to 8MB to match server.http2.maxFrameSize and handle larger blocks.
 # This can be removed once Block Node v0.27+ is released, as the default
@@ -22,14 +26,14 @@ block_nodes:
     address: block-node-1
     port: 40840
     peers: [block-node-2]
-    greedy: false
+    greedy: true
     grpc_tuning:
       max_frame_size: 8388608  # 8MB to match server.http2.maxFrameSize and handle larger blocks
   block-node-2:
     address: block-node-2
     port: 40840
     peers: [block-node-1]
-    greedy: false
+    greedy: true
     grpc_tuning:
       max_frame_size: 8388608
 

--- a/tools-and-tests/scripts/solo-e2e-test/topologies/single.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/topologies/single.yaml
@@ -5,7 +5,7 @@
 # The Consensus Node streams blocks directly to the Block Node.
 # Mirror Node receives blocks from the Block Node.
 #
-# CN1 → BN1 → MN → Relay, Explorer
+# CN1 -> BN1 -> MN
 
 name: single
 description: "1 Consensus Node, 1 Block Node, 1 Mirror Node (default)"
@@ -24,8 +24,6 @@ mirror_nodes:
   mirror-1:
     block_nodes: [block-node-1]
 
-relay_nodes:
-  # relay-1: {}
+relay_nodes: {}             # Add `relay-1: {}` to enable the JSON-RPC Relay
 
-# explorer_nodes:           # Uncomment to enable Explorer
-#   explorer-1: {}
+explorer_nodes: {}          # Add `explorer-1: {}` to enable the Explorer

--- a/tools-and-tests/scripts/solo-e2e-test/topologies/wrb-differential-test.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/topologies/wrb-differential-test.yaml
@@ -13,6 +13,12 @@
 name: wrb-differential-test
 description: "WRB ingestion test: 1 CN, 1 BN, MN validates block ingestion"
 
+# Deploy with RSA-roster/WRB verification, matching the header above. Without this the
+# deploy defaults to `tss` and the Block Node rejects every block it is sent
+# (verify_failed=84 on the full matrix), so the ingestion test times out against an empty
+# store instead of testing ingestion.
+verification_mode: rsa-wrb
+
 block_nodes:
   block-node-1:
     address: block-node-1


### PR DESCRIPTION
Latest Dry Run: https://github.com/hiero-ledger/hiero-block-node/actions/runs/32777895974

## Summary

Three related strands of Solo E2E work: the historical-backfill-while-live-streaming test from #3053, support for deploying a Consensus Node built from source (needed because no published CN tag yet carries the new block-root hashing), and four of the five sub-issues under the #3511 green-runs epic.

Validated end to end on a live `single` deployment: CN built from `hiero-consensus-node` `main` (`cec27bc6`), MN `v0.162.0-rc1`, BN `main`. 513 blocks ingested with **zero** verification failures, and the WRAPS signature transition test passed (Schnorr -> WRAPS at block 428).

## Issues

| Issue | Status |
|---|---|
| #3053 — Test and assertion for historical backfill while receiving live blocks | Closes |
| #3513 — `relay_nodes:` with only commented-out entries silently enables the relay | Closes |
| #3514 — `block-available` accepts the `UINT64_MAX` no-blocks sentinel | Closes |
| #3515 — `wrb-differential-test` deployed with TSS but produces RSA/WRB blocks | Closes |
| #3517 — Block Node with no publisher and `greedy: false` can never backfill | Closes (test-side) |
| #3511 — EPIC: Solo E2E Suite: Restore Green Runs | Advances, 4 of 5 sub-issues |
| #3516 — Tag-triggered E2E runs start before release artifacts are published | **Not addressed** — the only sub-issue needing `.github/workflows` changes |

## Backfill during live stream (#3053)

The hinge is `earliestManagedBlock`. On a store-less start the publisher treats it as its next expected block, so at the default `0` the Block Node answers every offer from the Consensus Node with `BlockNodeBehind` and live streaming only resumes once backfill has walked the entire chain. Raised above the chain head, the first offered block is accepted and everything below it becomes a `HISTORICAL` backfill gap — which is the condition the test needs.

New scripts under `scripts/backfill/`:

| Script | Purpose |
|---|---|
| `wait-for-network-height.sh` | Blocks until the network reaches `MIN_HEIGHT` so there is a recoverable gap |
| `configure-bn-live-tail-backfill.sh` | Raises `earliestManagedBlock` to `<chain head> + EMB_OFFSET` and throttles backfill while the BN is scaled to zero |
| `assert-backfill-during-live-stream.sh` | Samples `serverStatusDetail` plus `publisher_open_connections` and requires the historical range and the live range to both advance in the same window |

`clear-block-storage` now also removes `application-state/block-ranges.json`. That file sits on its own PVC and is reloaded into the in-memory range set at startup, which the backfill plugin reads as "blocks this node already has" — leaving it behind made a wiped node believe it still held the deleted blocks, so backfill found no gap. Only that file is removed; the sibling TSS and RSA bootstrap rosters in the same directory must survive, or every block fails `BAD_BLOCK_PROOF`.

## Consensus Node from source

Solo does not pull the Consensus Node as a container image. `solo consensus node setup` downloads a platform build zip from `builds.hedera.com/node/software/<vMAJOR.MINOR>/build-<tag>.zip` and unpacks it into the pod's `root-container`; the pod image itself comes from the `solo-deployment` chart and is not selected by `--release-tag`. Only tagged releases are published there, so `CN_VERSION=main` — which resolves to `0.79.0-SNAPSHOT` from the CN branch's `version.txt` — 404s at setup time, after the cluster and Block Nodes are already deployed.

`--local-build-path` short-circuits that download and uploads the local jars instead. This PR adds `--cn-local-build-path` to `solo-deploy-network.sh`, plumbs `CN_LOCAL_BUILD_PATH` through the Taskfile, and documents it in `.env.example`:

```bash
cd <cn-repo> && ./gradlew assemble
task up CN_LOCAL_BUILD_PATH=<cn-repo>/hedera-node/data
```

Both failure modes now fail before any cluster work: a `-SNAPSHOT` version with no build path, and a build path that has not been built. Previously the first surfaced as a 404 twenty minutes in.

Named CI tags such as `sdpt-pass-00380` are not a workaround — no build zip is published for them, and Solo's `Templates.prepareReleasePrefix` rejects any tag that is not dotted semver.

### `CN_VERSION` now defaults to `main`

> [!IMPORTANT]
> **This is a breaking change for local development.** After this merges, `task up` fails immediately unless `CN_LOCAL_BUILD_PATH` points at a built Consensus Node. Build one (`cd <cn-repo> && ./gradlew assemble`) or pin a released tag (`CN_VERSION=v0.79.0-alpha.1`) if you don't need the new hashing.

No published CN tag yet carries the fixed 16-slot block-root hashing rework, so a released tag cannot verify against a current Block Node and Mirror Node — `main` is the only version that actually works today. The default changes in `Taskfile.yml` and `.env.example` for local runs, and in `solo-e2e-scheduler.yml` for CI (see the next section, which also adds the CN build CI needs to make that default usable).

`resolve-versions.sh`'s internal `${1:-latest}` fallback stays as-is, since CI passes the version positionally and it is only reached when nothing was supplied at all.

## CI builds the Consensus Node when the version is a `-SNAPSHOT`

`solo-e2e-test.yml` now detects a `-SNAPSHOT` resolved CN version and, only in that case, checks out `hiero-ledger/hiero-consensus-node` at `main` (`fetch-depth: 1`), runs `./gradlew assemble --no-daemon`, verifies `hedera-node/data/{apps,lib}` exist, and passes the directory as `--cn-local-build-path`. Released tags are untouched and still fetch the published zip, so only SNAPSHOT runs pay the build cost.

`solo-e2e-scheduler.yml` gets two fixes:

- The final `else` branch hardcoded all three component versions, so a manual dispatch that set only `consensus-node-version` had it **silently discarded** — this is why run 32461677811 deployed CN `latest` despite being dispatched for `main`. It now honours any explicitly supplied version and falls back to `main` for CN and BN.
- `MN_VERSION` no longer defaults to `main`. Mirror Node publishes no `main` snapshots, so that default could never resolve; it is pinned to `v0.162.0-rc1`, the first release carrying the reworked block-root hashing that a `main` Consensus Node produces.

> [!NOTE]
> Scheduled daily and weekend runs now deploy CN `main` rather than `latest`, so they build the Consensus Node and take correspondingly longer. That is the point — with a released CN the Block Node rejects every block, so those runs carried no signal. It does mean the suite no longer exercises "BN `main` against a GA-stable Consensus Node"; worth adding back as a separate matrix entry once a released tag carries the hashing rework.

## Topology component detection (#3513)

`yq '.<section> | keys | length // 0'` errors with `Cannot get keys of !!null` whenever a section is null — a `relay_nodes:` key whose only child is commented out, or a missing key. With stderr discarded and no fallback the count came back as the empty string, so both branches of the comparison were false, control fell through to the legacy `components.<key> // true` default, and the component deployed anyway.

Six of the nine matrix jobs hit this for both `relay_nodes` and `explorer_nodes`. The blast radius is larger than a stray pod: `solo relay node add` blocks on relay readiness, and the relay's `GET :7546/health/readiness` probe has been failing on recent images, so the wedged relay aborted `task up` **before** `task port-forward` — presenting as "port forwards are broken" rather than "relay is broken".

The three duplicated blocks are now one `skip_component` helper using `yq '.<section> | length'`, which returns `0` for both `null` and `{}` without erroring. The legacy `components.<key>` flag must now say `true` explicitly.

## No-blocks sentinel (#3514)

An empty Block Node reports `firstAvailableBlock` and `lastAvailableBlock` as `UINT64_MAX`, not null and not 0 — 0 means "block 0 is available". That value wraps to -1 inside bash's `[[ ... -gt ... ]]`, so an assertion against a node holding nothing passed.

`is_valid_block_number` in `scripts/lib/chaos-assertions.sh` is now the single guard, rejecting the whole out-of-signed-64-bit-range class rather than one sentinel value, so a future sentinel change cannot silently reintroduce the overflow. Four call sites:

- `assert_block_available_single` — previously an exact-equality check only
- `get_block_count` — previously unguarded; since sentinel compares equal to sentinel, `blocks-increasing` reported "Blocks not increasing" for an empty node, a plausible-looking failure that hid the real one
- `solo-network-status.sh` — previously printed the sentinel as a range, reading as a healthy node holding 18 quintillion blocks; now "No blocks"
- `wrb-distribution/assert-bn1-historical-backfill-landed.sh` — previously redefined the constant; now sources the shared one

Expect this to turn currently-passing assertions red wherever a Block Node is empty. That is the correction, not a regression.

## Verification mode and backfill reachability (#3515, #3517)

`wrb-differential-test.yaml` gets the `verification_mode: rsa-wrb` marker its own header already describes. Without it the deploy defaulted to `tss` and the Block Node rejected every block (`verify_failed=84`), so the Mirror Node ingestion test timed out against an empty store instead of testing ingestion. The WRB overlay is passed to Helm after the per-BN overlay and its `plugins.names` is a strict superset of what the topology listed, so nothing is lost.

`fan-out-3cn-2bn.yaml` gets `greedy: true` on both Block Nodes. A Consensus Node's `block_nodes` entry is a priority list, not a broadcast list — each CN streams to its first entry and falls back only on unreachability — so in steady state all three CNs publish to BN1 and **BN2 has no publisher**. The non-greedy `determineEndCap` branch sizes its scan window from the local store and never queries peers, so on an empty store the window is empty and BN2 stays empty for the lifetime of the deployment. The header comment, which claimed "all CNs to both BNs", is corrected to describe priority failover.

## Tests

Two fixture-based suites, both runnable without a cluster:

- `scripts/test/test-chaos-assertions.sh` — 14 new cases for `is_valid_block_number` covering the sentinel, `INT64_MAX` boundaries, and malformed input, plus one that asserts the sentinel still wraps negative in bash so the guard's rationale cannot silently expire. **35 passed, 0 failed.**
- `scripts/test/test-topology-decisions.sh` (new) — every topology times every section, the four null-section shapes that caused #3513, the legacy `components` opt-in, and `verification_mode` validity. It extracts the real `skip_component` from the deploy script rather than copying it, so it tracks the implementation. **69 passed, 0 failed.**

No Java changed, so no module tests or `spotlessApply` were required.

## Deliberately not implemented

#3515 and #3517 both suggest a guard so that "a single-Consensus-Node topology cannot silently be deployed with TSS verification". **That guard would break `single.yaml`**, which is a 1-CN topology that deploys with TSS and verified 105+ TSS proofs with zero failures during this PR's validation run. The premise traces to `wrb-differential-test.yaml`'s own header claim that Solo's single-node setup cannot do TSS, which is stale. A name-based "wrb implies rsa-wrb" variant would also false-positive on the five `wrb-distribution-step*` topologies, which deploy with no Block Node at all.

Implemented instead: `verification_mode` must resolve to `tss` or `rsa-wrb`, so a typo like `rsa_wrb` fails loudly rather than silently defaulting to TSS.

## Follow-ups

- #3516 remains open — it needs `.github/workflows` changes, either a `workflow_run` trigger or an artifact-availability poll in version resolution.
- `solo-e2e-scheduler.yml` (around lines 212-215) defaults **both** `CN_VERSION` and `MN_VERSION` to `main` on the manual-dispatch-with-explicit-BN branch. That branch is broken for two independent reasons: CN `main` has no published artifact (it now fails fast rather than 404ing), and Mirror Node publishes no `main` snapshots at all. Only reachable via manual dispatch. Left alone here as a CI change; worth folding into #3516.
- The `block-ranges.json` fix in `clear-block-storage` is adjacent to #3517's theme but a distinct defect with no issue of its own; worth filing.
- `roster_entries_loaded` reports 0 on a TSS deployment while TSS proofs verify normally, so that metric appears to be RSA-path only. Harmless here, but misleading if used as a health signal.
