### PR TITLE
chore(metrics): Add new metrics for latency to dashboards

### DIFF
--- a/block-node/app/docker/metrics/dashboards/performance-metrics.json
+++ b/block-node/app/docker/metrics/dashboards/performance-metrics.json
@@ -1616,6 +1616,178 @@
       },
       "fieldConfig": {
         "defaults": {
+          "decimals": 2,
+          "noValue": "No live traffic",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 20000000
+              },
+              {
+                "color": "yellow",
+                "value": 50000000
+              },
+              {
+                "color": "red",
+                "value": 60000000
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 0,
+        "y": 43
+      },
+      "id": 42,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(increase(blocknode_subscriber_live_send_latency_ns_total[$__range]) / increase(blocknode_subscriber_live_batches_sent_total[$__range]))",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Send Latency Avg (range, worst subscriber)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 20000000
+              },
+              {
+                "color": "yellow",
+                "value": 50000000
+              },
+              {
+                "color": "red",
+                "value": 60000000
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 19,
+        "x": 5,
+        "y": 43
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(blocknode_subscriber_live_send_latency_ns_total[$__rate_interval]) / rate(blocknode_subscriber_live_batches_sent_total[$__rate_interval])",
+          "interval": "15s",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "{{subscriber}}"
+        }
+      ],
+      "title": "Send Latency Avg Rate over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -1634,7 +1806,7 @@
         "h": 6,
         "w": 5,
         "x": 0,
-        "y": 43
+        "y": 49
       },
       "id": 25,
       "options": {
@@ -1692,7 +1864,7 @@
         "h": 6,
         "w": 6,
         "x": 5,
-        "y": 43
+        "y": 49
       },
       "id": 26,
       "options": {
@@ -1786,7 +1958,7 @@
         "h": 6,
         "w": 13,
         "x": 11,
-        "y": 43
+        "y": 49
       },
       "id": 28,
       "options": {
@@ -1822,7 +1994,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 55
       },
       "id": 13,
       "panels": [],
@@ -1860,7 +2032,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 50
+        "y": 56
       },
       "id": 14,
       "options": {
@@ -1978,7 +2150,7 @@
         "h": 9,
         "w": 16,
         "x": 8,
-        "y": 50
+        "y": 56
       },
       "id": 7,
       "options": {

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/TestMetricsExporter.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/TestMetricsExporter.java
@@ -2,7 +2,10 @@
 package org.hiero.block.node.app.fixtures;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.function.Supplier;
+import org.hiero.metrics.core.LabelValues;
 import org.hiero.metrics.core.LongMeasurementSnapshot;
 import org.hiero.metrics.core.MeasurementSnapshot;
 import org.hiero.metrics.core.MetricRegistrySnapshot;
@@ -28,6 +31,10 @@ public class TestMetricsExporter implements MetricsExporter {
 
     /**
      * Returns the current long value of the named metric from the registry snapshot.
+     * <p>
+     * Labels are ignored: for a metric with dynamic labels this returns the first measurement found, which is one
+     * arbitrary label value rather than a total across them. Only use it on metrics that have a single series in the
+     * test at hand.
      *
      * @param metricName fully-qualified metric name
      * @return the current value
@@ -44,6 +51,29 @@ public class TestMetricsExporter implements MetricsExporter {
             }
         }
         throw new IllegalArgumentException("Metric not found: " + metricName);
+    }
+
+    /**
+     * Returns the current long value of every series of the named metric, keyed by its first dynamic label value.
+     * Use this instead of {@link #getMetricValue(String)} for a metric with dynamic labels, where the series present
+     * and the label values they carry are themselves what the test is asserting.
+     *
+     * @param metricName fully-qualified metric name
+     * @return the current value of each series, keyed by first label value, empty if the metric is not found
+     */
+    public Map<String, Long> getMetricValuesByLabel(@NonNull final String metricName) {
+        final Map<String, Long> valuesByLabel = new LinkedHashMap<>();
+        for (MetricSnapshot snapshot : snapshotSupplier.get()) {
+            if (snapshot.name().equals(metricName)) {
+                for (MeasurementSnapshot measurement : snapshot) {
+                    if (measurement instanceof LongMeasurementSnapshot lm) {
+                        final LabelValues labels = lm.getDynamicLabelValues();
+                        valuesByLabel.put(labels.size() == 0 ? "" : labels.get(0), lm.get());
+                    }
+                }
+            }
+        }
+        return valuesByLabel;
     }
 
     /**

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/PluginTestBase.java
@@ -281,12 +281,24 @@ public abstract class PluginTestBase<
     /**
      * Returns the current value of a metric by its MetricKey.
      *
+     * <p>See {@link TestMetricsExporter#getMetricValue(String)} for the caveat on metrics with dynamic labels.
+     *
      * @param metricKey the MetricKey identifying the metric
      * @return the current long value of the metric
      * @throws IllegalArgumentException if no metric with the given name exists in the registry
      */
     protected long getMetricValue(@NonNull final MetricKey<?> metricKey) {
         return testMetricsExporter.getMetricValue(metricKey.name());
+    }
+
+    /**
+     * Returns the current value of every series of a labeled metric, keyed by its first dynamic label value.
+     *
+     * @param metricKey the MetricKey identifying the metric
+     * @return the current value of each series, keyed by first label value, empty if the metric is not found
+     */
+    protected Map<String, Long> getMetricValuesByLabel(@NonNull final MetricKey<?> metricKey) {
+        return testMetricsExporter.getMetricValuesByLabel(metricKey.name());
     }
 
     /**

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
@@ -41,6 +41,7 @@ import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.NoBackPressureBlockItemHandler;
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 import org.hiero.block.node.spi.historicalblocks.BlockRangeSet;
+import org.hiero.block.node.stream.subscriber.SubscriberServicePlugin.MetricsHolder.SessionMetrics;
 
 /**
  * This class is used to represent a session for a single BlockStream subscriber that has connected to the block node.
@@ -100,7 +101,7 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
     /** The pipeline to send responses to the client */
     private final Pipeline<? super SubscribeStreamResponseUnparsed> responsePipeline;
     /** A blocking queue to send blocks from the live handler to the session. */
-    private final BlockingQueue<BlockItems> liveBlockQueue;
+    private final BlockingQueue<QueuedBatch> liveBlockQueue;
     /** A lock to hold the pipeline thread until this session is ready */
     private final CountDownLatch sessionReadyLatch;
     /** A flag indicating if the session should be interrupted */
@@ -130,6 +131,10 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
      * list it maintains, and log the cause of that failure.
      */
     private Exception sessionFailedCause;
+    /** The send measurements this session records to. */
+    private final SessionMetrics sessionMetrics;
+    /** Returns this session's metric label slot to the plugin when the session ends. */
+    private final Runnable releaseMetricsSlotCallback;
 
     /**
      * Constructor for the BlockStreamSubscriberSession class.
@@ -137,16 +142,22 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
      * @param sessionContext The context for this session
      * @param responsePipeline The pipeline to send responses to the client
      * @param context The context for the block node
+     * @param sessionMetrics The measurements this session records its sends to
+     * @param releaseMetricsSlotCallback Run when the session ends, to release its metric label slot for reuse
      */
     public BlockStreamSubscriberSession(
             @NonNull final SessionContext sessionContext,
             @NonNull final Pipeline<? super SubscribeStreamResponseUnparsed> responsePipeline,
             @NonNull final BlockNodeContext context,
-            @NonNull final CountDownLatch sessionReadyLatch) {
+            @NonNull final CountDownLatch sessionReadyLatch,
+            @NonNull final SessionMetrics sessionMetrics,
+            @NonNull final Runnable releaseMetricsSlotCallback) {
         this.responsePipeline = requireNonNull(responsePipeline);
         this.sessionReadyLatch = requireNonNull(sessionReadyLatch);
         this.blockNodeContext = requireNonNull(context);
         this.sessionContext = requireNonNull(sessionContext);
+        this.sessionMetrics = requireNonNull(sessionMetrics);
+        this.releaseMetricsSlotCallback = requireNonNull(releaseMetricsSlotCallback);
         this.maxProtobufMessageSizeBytes = sessionContext.subscriberConfig.maxProtobufMessageSizeBytes();
         this.latestLiveStreamBlock = new AtomicLong(INITIAL_STATE_SENTINEL);
         this.nextBlockToSend = new AtomicLong(INITIAL_STATE_SENTINEL);
@@ -249,6 +260,8 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
         } catch (final RuntimeException | ParseException e) {
             sessionFailedCause = e;
             close(SubscribeStreamResponse.Code.ERROR);
+        } finally {
+            releaseMetricsSlotCallback.run();
         }
         // todo Need to record a metric here with client ID tag, so we can record
         //    requested vs sent metrics.
@@ -272,7 +285,7 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
      */
     private void resolveLiveNextBlockToSend() {
         while (nextBlockToSend.get() == UNKNOWN_BLOCK_NUMBER) {
-            final BlockItems head = liveBlockQueue.peek();
+            final QueuedBatch head = liveBlockQueue.peek();
             if (head != null) {
                 if (!head.isStartOfNewBlock()) {
                     // We are in the middle of a block, so we need to
@@ -509,7 +522,7 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
     }
 
     private boolean nextBatchIsLive() {
-        final BlockItems queueHead = liveBlockQueue.peek();
+        final QueuedBatch queueHead = liveBlockQueue.peek();
         if (queueHead != null && latestLiveStreamBlock.get() >= nextBlockToSend.get()) {
             // @todo(1673) is the below expression correct?
             return !queueHead.isStartOfNewBlock() || queueHead.blockNumber() == nextBlockToSend.get();
@@ -556,28 +569,28 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
         // then we'll also break out of the loop and return to the caller.
         while (!liveBlockQueue.isEmpty()) {
             // Peek at the block item from the queue and _possibly_ process it
-            BlockItems blockItems = liveBlockQueue.peek();
+            QueuedBatch queuedBatch = liveBlockQueue.peek();
             // Live _might_ be ahead or behind the next expected block (particularly if
             // the requested start block is in the future), don't send this block, in that case.
             // If behind, remove that item from the queue; if ahead leave it in the queue.
             final long clientId = sessionContext.clientId;
-            if (blockItems.isStartOfNewBlock() && blockItems.blockNumber() < nextBlockToSend.get()) {
-                LOGGER.log(Level.TRACE, "Skipping block {0} for client {1}", blockItems.blockNumber(), clientId);
-                skipCurrentBlockInQueue(blockItems);
-            } else if (blockItems.blockNumber()
+            if (queuedBatch.isStartOfNewBlock() && queuedBatch.blockNumber() < nextBlockToSend.get()) {
+                LOGGER.log(Level.TRACE, "Skipping block {0} for client {1}", queuedBatch.blockNumber(), clientId);
+                skipCurrentBlockInQueue(queuedBatch);
+            } else if (queuedBatch.blockNumber()
                     == nextBlockToSend.get()) { // todo if block number from block items cannot be -1, we are good here
-                blockItems = liveBlockQueue.poll();
-                if (blockItems != null) {
-                    sendOneBlockItemSet(blockItems, blockItems.isEndOfBlock());
-                    if (blockItems.isEndOfBlock()) {
+                queuedBatch = liveBlockQueue.poll();
+                if (queuedBatch != null) {
+                    sendOneBlockItemSet(queuedBatch, queuedBatch.isEndOfBlock());
+                    if (queuedBatch.isEndOfBlock()) {
                         trimBlockItemQueue(nextBlockToSend.getAndIncrement());
                     }
                 }
-            } else if (blockItems.isStartOfNewBlock() && blockItems.blockNumber() > nextBlockToSend.get()) {
+            } else if (queuedBatch.isStartOfNewBlock() && queuedBatch.blockNumber() > nextBlockToSend.get()) {
                 // This block is _future_, so we need to wait, and try to get the next block from history
                 // first, then come back to this block.
                 LOGGER.log(
-                        Level.TRACE, "Retaining future block {0} for client {1}", blockItems.blockNumber(), clientId);
+                        Level.TRACE, "Retaining future block {0} for client {1}", queuedBatch.blockNumber(), clientId);
             } else {
                 // This is a past or future _partial_ block, so we need to trim the queue.
                 liveBlockQueue.poll(); // discard _this batch only_.
@@ -585,7 +598,7 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
             }
             // Note: We depend here on the rule that there are no gaps between blocks.
             //       The header for block N immediately follows the proof for block N-1.
-            final BlockItems nextBatch = liveBlockQueue.peek();
+            final QueuedBatch nextBatch = liveBlockQueue.peek();
             if (nextBatch != null && nextBatch.isStartOfNewBlock()) {
                 if (nextBatch.blockNumber() != nextBlockToSend.get()) {
                     // Exit this method if we fall behind, the next call will
@@ -615,7 +628,7 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
             // the minimum desired capacity is available), then we will remove
             // one or more _whole blocks_ from the queue (we must _never_ remove
             // a partial block).
-            BlockItems queueHead = liveBlockQueue.peek();
+            QueuedBatch queueHead = liveBlockQueue.peek();
             if (queueHead != null && queueHead.isStartOfNewBlock()) {
                 // After this loop, the head of the queue must be the start of a
                 // new block or empty (and it really _should_ never be empty).
@@ -645,7 +658,7 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
      * the next item in the queue will be the start of a new block (or else
      * the queue will be empty).
      */
-    private void skipCurrentBlockInQueue(BlockItems queueHead) {
+    private void skipCurrentBlockInQueue(QueuedBatch queueHead) {
         // The "head" entry is _not_ already removed, remove it, and the rest of
         // its block. This also handles a partial block at the head of the queue
         // when we cannot process that block (e.g. it's in the future or past from
@@ -673,7 +686,7 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
      * keep the skip logic consistent.
      */
     private void removeHeadBlockFromQueue() {
-        BlockItems queueHead = liveBlockQueue.peek();
+        QueuedBatch queueHead = liveBlockQueue.peek();
         // Remove the "head" entry if it's a block header.
         // Otherwise skip this, because we don't want to remove a partial block.
         if (queueHead != null && queueHead.isStartOfNewBlock()) {
@@ -826,8 +839,12 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
         }
     }
 
-    private void sendOneBlockItemSet(final BlockItems nextBatch, final boolean blockComplete) {
-        sendOneBlockItemSet(nextBatch.blockItems(), blockComplete);
+    private void sendOneBlockItemSet(final QueuedBatch nextBatch, final boolean blockComplete) {
+        sendOneBlockItemSet(nextBatch.batch().blockItems(), blockComplete);
+
+        if (!interruptedStream.get()) {
+            sessionMetrics.recordBatchSent(System.nanoTime() - nextBatch.receivedAtNanos());
+        }
     }
 
     private void sendOneBlockItemSet(final List<BlockItemUnparsed> blockItems, final boolean blockComplete) {
@@ -871,13 +888,13 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
         /** The logger for this class. */
         private final Logger LOGGER = System.getLogger(getClass().getName());
 
-        private final BlockingQueue<BlockItems> liveBlockQueue;
+        private final BlockingQueue<QueuedBatch> liveBlockQueue;
         private final AtomicLong latestLiveStreamBlock;
         private final AtomicBoolean isRegisteredFlag;
         private final String clientId;
 
         private LiveBlockHandler(
-                @NonNull final BlockingQueue<BlockItems> liveBlockQueue,
+                @NonNull final BlockingQueue<QueuedBatch> liveBlockQueue,
                 @NonNull final AtomicLong latestLiveStreamBlock,
                 final String clientId) {
             this.liveBlockQueue = requireNonNull(liveBlockQueue);
@@ -907,10 +924,37 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
             // Blocking so that the client thread has a chance to pull items
             // off the head when it's full.
             try {
-                liveBlockQueue.put(blockItems);
+                liveBlockQueue.put(new QueuedBatch(blockItems));
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
+        }
+    }
+
+    /**
+     * A live batch of block items, plus the time it was handed to this session by the messaging
+     * facility. The timestamp is used to measure how long the batch waited before it was sent on
+     * to the client, and is not part of the batch content.
+     *
+     * @param batch the block items received from the messaging facility
+     * @param receivedAtNanos the {@link System#nanoTime()} value when the batch was handed to this session, taken
+     *     before it is put on the queue, so a blocking put on a full queue counts towards the measured latency
+     */
+    private record QueuedBatch(@NonNull BlockItems batch, long receivedAtNanos) {
+        private QueuedBatch(@NonNull final BlockItems batch) {
+            this(batch, System.nanoTime());
+        }
+
+        private long blockNumber() {
+            return batch.blockNumber();
+        }
+
+        private boolean isStartOfNewBlock() {
+            return batch.isStartOfNewBlock();
+        }
+
+        private boolean isEndOfBlock() {
+            return batch.isEndOfBlock();
         }
     }
 }

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
@@ -13,14 +13,18 @@ import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionService;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.hiero.block.api.BlockStreamSubscribeServiceInterface;
 import org.hiero.block.api.SubscribeStreamRequest;
@@ -32,6 +36,7 @@ import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.stream.subscriber.BlockStreamSubscriberSession.SessionContext;
+import org.hiero.block.node.stream.subscriber.SubscriberServicePlugin.MetricsHolder.SessionMetrics;
 import org.hiero.metrics.LongCounter;
 import org.hiero.metrics.LongGauge;
 import org.hiero.metrics.core.MetricKey;
@@ -51,6 +56,21 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
     /** Metric key for the number of subscriber errors */
     public static final MetricKey<LongCounter> METRIC_SUBSCRIBER_ERRORS =
             MetricKey.of("subscriber_errors", LongCounter.class).addCategory(METRICS_CATEGORY);
+    /** Metric key for the time live batches wait between reaching a session and being sent */
+    public static final MetricKey<LongCounter> METRIC_SUBSCRIBER_LIVE_SEND_LATENCY_NS =
+            MetricKey.of("subscriber_live_send_latency_ns", LongCounter.class).addCategory(METRICS_CATEGORY);
+    /** Metric key for the number of live batches the send latency was measured over */
+    public static final MetricKey<LongCounter> METRIC_SUBSCRIBER_LIVE_BATCHES_SENT =
+            MetricKey.of("subscriber_live_batches_sent", LongCounter.class).addCategory(METRICS_CATEGORY);
+    /** Dynamic label name identifying one subscriber session */
+    private static final String LABEL_SUBSCRIBER = "subscriber";
+    /**
+     * Number of subscriber sessions that get a metric label of their own. Sessions beyond this share a single
+     * overflow label, so the series count stays bounded no matter how many subscribers connect at once.
+     */
+    private static final int MAX_METRICS_SLOTS = 64;
+    /** Label value shared by every session that connects while all {@value #MAX_METRICS_SLOTS} slots are taken */
+    private static final String LABEL_VALUE_OVERFLOW = "overflow";
 
     /** The logger for this class. */
     private final Logger LOGGER = System.getLogger(getClass().getName());
@@ -126,6 +146,81 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
     }
 
     /**
+     * Holder for the metrics of the subscriber service, registered once and shared by all sessions.
+     *
+     * @param numberOfSubscribers gauge of currently connected subscribers
+     * @param subscriberErrors counter of errors while streaming to subscribers
+     * @param sendLatencyNs counter accumulating, per subscriber, the time live batches waited between reaching a
+     *     session and being sent
+     * @param batchesSent counter of measured live batches per subscriber, the denominator for
+     *     {@code sendLatencyNs}
+     */
+    public record MetricsHolder(
+            LongGauge.Measurement numberOfSubscribers,
+            LongCounter.Measurement subscriberErrors,
+            LongCounter sendLatencyNs,
+            LongCounter batchesSent) {
+        /**
+         * Initialize and return a new {@link MetricsHolder} instance.
+         *
+         * @param metricRegistry used to create and initialize metrics
+         * @return a new {@link MetricsHolder} instance fully initialized
+         */
+        public static MetricsHolder createMetrics(@NonNull final MetricRegistry metricRegistry) {
+            final LongGauge.Measurement numberOfSubscribers = metricRegistry
+                    .register(LongGauge.builder(METRIC_SUBSCRIBER_OPEN_CONNECTIONS)
+                            .setDescription("Connected subscribers"))
+                    .getOrCreateNotLabeled();
+            final LongCounter.Measurement subscriberErrors = metricRegistry
+                    .register(LongCounter.builder(METRIC_SUBSCRIBER_ERRORS)
+                            .setDescription("Errors while streaming to subscribers"))
+                    .getOrCreateNotLabeled();
+            final LongCounter sendLatencyNs =
+                    metricRegistry.register(LongCounter.builder(METRIC_SUBSCRIBER_LIVE_SEND_LATENCY_NS)
+                            .setDescription(
+                                    "Time (ns) live batches waited between reaching a subscriber session and being sent")
+                            .addDynamicLabelNames(LABEL_SUBSCRIBER));
+            final LongCounter batchesSent =
+                    metricRegistry.register(LongCounter.builder(METRIC_SUBSCRIBER_LIVE_BATCHES_SENT)
+                            .setDescription("Live batches sent to subscribers, the denominator for the send latency")
+                            .addDynamicLabelNames(LABEL_SUBSCRIBER));
+            return new MetricsHolder(numberOfSubscribers, subscriberErrors, sendLatencyNs, batchesSent);
+        }
+
+        /**
+         * Resolve the send measurements for one session, labeled with the given slot.
+         *
+         * @param slot the slot index to use as the {@code subscriber} label value, or {@value #MAX_METRICS_SLOTS} for
+         *     a session that connected while all slots were taken
+         * @return the measurements that session records its sends to
+         */
+        public SessionMetrics forSlot(final int slot) {
+            final String labelValue = slot < MAX_METRICS_SLOTS ? Integer.toString(slot) : LABEL_VALUE_OVERFLOW;
+            return new SessionMetrics(
+                    sendLatencyNs.getOrCreateLabeled(LABEL_SUBSCRIBER, labelValue),
+                    batchesSent.getOrCreateLabeled(LABEL_SUBSCRIBER, labelValue));
+        }
+
+        /**
+         * The send measurements of one subscriber session.
+         *
+         * @param latencyNs accumulated send latency, in nanoseconds, for this session
+         * @param batches count of live batches measured for this session
+         */
+        public record SessionMetrics(LongCounter.Measurement latencyNs, LongCounter.Measurement batches) {
+            /**
+             * Record that one live batch was sent to the client.
+             *
+             * @param latencyNanos time the batch waited between reaching the session and being sent
+             */
+            public void recordBatchSent(final long latencyNanos) {
+                latencyNs.increment(latencyNanos);
+                batches.increment();
+            }
+        }
+    }
+
+    /**
      * Handler for block stream subscription requests from clients. Handles creation of session, assigning a clientId and managing futures.
      */
     static class SubscribeBlockStreamHandler
@@ -139,11 +234,16 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
         private final BlockNodeContext context;
         /** Set of open client sessions */
         private volatile Map<Long, BlockStreamSubscriberSession> openSessions;
-        // Metrics
-        /** Counter for errors while streaming to subscribers */
-        private final LongCounter.Measurement subscriberErrorsCounter;
-        /** Gauge for number of subscribers */
-        private final LongGauge.Measurement numberOfSubscribers;
+        /** The metrics of the subscriber service */
+        private final MetricsHolder metrics;
+        /**
+         * Metric label slots released by ended sessions, available for reuse. Reusing them bounds the number of
+         * per-subscriber metric series by the peak count of concurrent subscribers, which matters because the metrics
+         * API has no way to unregister a labeled measurement once created.
+         */
+        private final Queue<Integer> freeMetricsSlots = new ConcurrentLinkedQueue<>();
+        /** The next metric label slot to use when no released slot is available */
+        private final AtomicInteger nextMetricsSlot = new AtomicInteger(0);
 
         private final ExecutorService virtualThreadExecutor;
         private volatile CompletionService<BlockStreamSubscriberSession> streamSessions;
@@ -154,15 +254,32 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
             virtualThreadExecutor = context.threadPoolManager().getVirtualThreadExecutor();
             streamSessions = new ExecutorCompletionService<>(virtualThreadExecutor);
             // create the metrics
-            final MetricRegistry metricRegistry = context.metricRegistry();
-            numberOfSubscribers = metricRegistry
-                    .register(LongGauge.builder(METRIC_SUBSCRIBER_OPEN_CONNECTIONS)
-                            .setDescription("Connected subscribers"))
-                    .getOrCreateNotLabeled();
-            subscriberErrorsCounter = metricRegistry
-                    .register(LongCounter.builder(METRIC_SUBSCRIBER_ERRORS)
-                            .setDescription("Errors while streaming to subscribers"))
-                    .getOrCreateNotLabeled();
+            metrics = MetricsHolder.createMetrics(context.metricRegistry());
+        }
+
+        /**
+         * Take a metric label slot for a new session, reusing one released by an ended session when available.
+         * Once all {@value #MAX_METRICS_SLOTS} slots are in use, every further session gets the shared overflow slot.
+         *
+         * @return the slot index to label the new session's measurements with
+         */
+        private int acquireMetricsSlot() {
+            final Integer reused = freeMetricsSlots.poll();
+            return reused == null
+                    ? nextMetricsSlot.getAndUpdate(next -> Math.min(next + 1, MAX_METRICS_SLOTS))
+                    : reused;
+        }
+
+        /**
+         * Release a slot taken by {@link #acquireMetricsSlot()} so a later session can reuse its label value. The
+         * overflow slot is shared by any number of concurrent sessions, so it is never pooled.
+         *
+         * @param slot the slot the ended session was labeled with
+         */
+        private void releaseMetricsSlot(final int slot) {
+            if (slot < MAX_METRICS_SLOTS) {
+                freeMetricsSlots.add(slot);
+            }
         }
 
         private void stop() {
@@ -208,14 +325,29 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
             final Map<Long, BlockStreamSubscriberSession> sessions = openSessions;
             if (streams != null && sessions != null) {
                 final SessionContext sessionContext = SessionContext.create(clientId, request, context);
-                final BlockStreamSubscriberSession blockStreamSession =
-                        new BlockStreamSubscriberSession(sessionContext, responsePipeline, context, sessionReadyLatch);
-                streams.submit(blockStreamSession);
+                final int metricsSlot = acquireMetricsSlot();
+                // Slots are recycled, so this is the only record of which client a `subscriber` label value refers to.
+                LOGGER.log(
+                        Level.DEBUG, "Subscriber session {0} is measured by metrics slot {1}.", clientId, metricsSlot);
+                final BlockStreamSubscriberSession blockStreamSession = new BlockStreamSubscriberSession(
+                        sessionContext,
+                        responsePipeline,
+                        context,
+                        sessionReadyLatch,
+                        metrics.forSlot(metricsSlot),
+                        () -> releaseMetricsSlot(metricsSlot));
+                try {
+                    streams.submit(blockStreamSession);
+                } catch (final RejectedExecutionException e) {
+                    // The session never runs, so it never releases its slot; release it here instead.
+                    releaseMetricsSlot(metricsSlot);
+                    throw e;
+                }
                 // Wait for the session to start
                 sessionReadyLatch.await();
                 // add the session to the set of open sessions
                 sessions.put(clientId, blockStreamSession);
-                numberOfSubscribers.set(sessionCount.incrementAndGet());
+                metrics.numberOfSubscribers().set(sessionCount.incrementAndGet());
                 Future<BlockStreamSubscriberSession> completedSessionFuture;
                 // Get any available completed sessions and log success/failure.
                 while ((completedSessionFuture = streams.poll()) != null) {
@@ -260,7 +392,7 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
                     // Subscribers can reconnect or retry, so this is only an informational log.
                     final String message = "Subscriber session %(,d failed due to {0}.".formatted(clientId);
                     LOGGER.log(Level.INFO, message, failureCause);
-                    subscriberErrorsCounter.increment();
+                    metrics.subscriberErrors().increment();
                 } else {
                     // Otherwise, log that the session completed successfully.
                     LOGGER.log(Level.TRACE, "Subscriber session %(,d completed successfully.".formatted(clientId));
@@ -270,10 +402,10 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
                 // the session to fail, so the error is significant.
                 final String message = "Subscriber session failed due to unhandled %s:%n{0}.".formatted(e.getCause());
                 LOGGER.log(Level.ERROR, message, e);
-                subscriberErrorsCounter.increment();
+                metrics.subscriberErrors().increment();
             }
             // Decrement the session count and update the metric.
-            numberOfSubscribers.set(sessionCount.decrementAndGet());
+            metrics.numberOfSubscribers().set(sessionCount.decrementAndGet());
         }
 
         /*==================== Testing Access Methods ====================*/

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSessionTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSessionTest.java
@@ -20,6 +20,7 @@ import org.hiero.block.api.SubscribeStreamResponse.Code;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.SubscribeStreamResponseUnparsed;
 import org.hiero.block.internal.SubscribeStreamResponseUnparsed.ResponseOneOfType;
+import org.hiero.block.node.app.fixtures.TestMetricsExporter;
 import org.hiero.block.node.app.fixtures.pipeline.TestResponsePipeline;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleBlockRangeSet;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
@@ -28,6 +29,9 @@ import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.historicalblocks.BlockRangeSet;
 import org.hiero.block.node.stream.subscriber.BlockStreamSubscriberSession.SessionContext;
+import org.hiero.block.node.stream.subscriber.SubscriberServicePlugin.MetricsHolder;
+import org.hiero.block.node.stream.subscriber.SubscriberServicePlugin.MetricsHolder.SessionMetrics;
+import org.hiero.metrics.core.MetricRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -60,6 +64,14 @@ class BlockStreamSubscriberSessionTest {
     private BlockNodeContext blockNodeContext;
     /** Session ready latch for the session. */
     private CountDownLatch sessionReadyLatch;
+    /** Exporter used to read current metric values. */
+    private TestMetricsExporter metricsExporter;
+    /** Metric registry backing the block node context. */
+    private MetricRegistry metricRegistry;
+    /** The subscriber service metrics the sessions under test record to. */
+    private MetricsHolder subscriberMetrics;
+    /** The metrics slot handed to the session under test. */
+    private SessionMetrics sessionMetrics;
 
     /**
      * Environment setup before each test.
@@ -74,6 +86,11 @@ class BlockStreamSubscriberSessionTest {
                 .build();
         defaultSubscriberConfig = configuration.getConfigData(SubscriberConfig.class);
         final TestBlockMessagingFacility messagingFacility = new TestBlockMessagingFacility();
+        metricsExporter = new TestMetricsExporter();
+        metricRegistry =
+                MetricRegistry.builder().setMetricsExporter(metricsExporter).build();
+        subscriberMetrics = MetricsHolder.createMetrics(metricRegistry);
+        sessionMetrics = subscriberMetrics.forSlot(0);
         blockNodeContext = generateContext(configuration, messagingFacility, historicalBlockFacility);
         sessionReadyLatch = new CountDownLatch(1);
     }
@@ -109,7 +126,12 @@ class BlockStreamSubscriberSessionTest {
         void testValidParameters() {
             assertThatNoException()
                     .isThrownBy(() -> new BlockStreamSubscriberSession(
-                            sessionContext, responsePipeline, blockNodeContext, sessionReadyLatch));
+                            sessionContext,
+                            responsePipeline,
+                            blockNodeContext,
+                            sessionReadyLatch,
+                            sessionMetrics,
+                            () -> {}));
         }
 
         /**
@@ -122,7 +144,7 @@ class BlockStreamSubscriberSessionTest {
         void testNullRequest() {
             assertThatNullPointerException()
                     .isThrownBy(() -> new BlockStreamSubscriberSession(
-                            null, responsePipeline, blockNodeContext, sessionReadyLatch));
+                            null, responsePipeline, blockNodeContext, sessionReadyLatch, sessionMetrics, () -> {}));
         }
 
         /**
@@ -135,7 +157,7 @@ class BlockStreamSubscriberSessionTest {
         void testNullResponsePipeline() {
             assertThatNullPointerException()
                     .isThrownBy(() -> new BlockStreamSubscriberSession(
-                            sessionContext, null, blockNodeContext, sessionReadyLatch));
+                            sessionContext, null, blockNodeContext, sessionReadyLatch, sessionMetrics, () -> {}));
         }
 
         /**
@@ -148,7 +170,7 @@ class BlockStreamSubscriberSessionTest {
         void testNullBlockNodeContext() {
             assertThatNullPointerException()
                     .isThrownBy(() -> new BlockStreamSubscriberSession(
-                            sessionContext, responsePipeline, null, sessionReadyLatch));
+                            sessionContext, responsePipeline, null, sessionReadyLatch, sessionMetrics, () -> {}));
         }
 
         /**
@@ -160,8 +182,8 @@ class BlockStreamSubscriberSessionTest {
         @DisplayName("Test Constructor with Null Session Ready Latch")
         void testNullSessionReadyLatch() {
             assertThatNullPointerException()
-                    .isThrownBy(() ->
-                            new BlockStreamSubscriberSession(sessionContext, responsePipeline, blockNodeContext, null));
+                    .isThrownBy(() -> new BlockStreamSubscriberSession(
+                            sessionContext, responsePipeline, blockNodeContext, null, sessionMetrics, () -> {}));
         }
     }
 
@@ -1250,7 +1272,9 @@ class BlockStreamSubscriberSessionTest {
                     SessionContext.create(clientId, request, chunkingContext),
                     chunkingPipeline,
                     chunkingContext,
-                    sessionReadyLatch);
+                    sessionReadyLatch,
+                    sessionMetrics,
+                    () -> {});
 
             // Call the chunking method directly
             session.sendBlockItemsChunked(smallBlock);
@@ -1295,7 +1319,9 @@ class BlockStreamSubscriberSessionTest {
                     SessionContext.create(clientId, request, chunkingContext),
                     chunkingPipeline,
                     chunkingContext,
-                    sessionReadyLatch);
+                    sessionReadyLatch,
+                    sessionMetrics,
+                    () -> {});
 
             // Call the chunking method directly
             session.sendBlockItemsChunked(largeBlock);
@@ -1350,7 +1376,9 @@ class BlockStreamSubscriberSessionTest {
                     SessionContext.create(clientId, request, chunkingContext),
                     chunkingPipeline,
                     chunkingContext,
-                    sessionReadyLatch);
+                    sessionReadyLatch,
+                    sessionMetrics,
+                    () -> {});
 
             // Call the chunking method directly
             session.sendBlockItemsChunked(mixedBlock);
@@ -1398,7 +1426,9 @@ class BlockStreamSubscriberSessionTest {
                     SessionContext.create(clientId, request, chunkingContext),
                     chunkingPipeline,
                     chunkingContext,
-                    sessionReadyLatch);
+                    sessionReadyLatch,
+                    sessionMetrics,
+                    () -> {});
 
             // Call the chunking method directly
             session.sendBlockItemsChunked(emptyBlock);
@@ -1429,7 +1459,7 @@ class BlockStreamSubscriberSessionTest {
             final SimpleInMemoryHistoricalBlockFacility historicalBlockFacility) {
         return new BlockNodeContext(
                 configuration,
-                null,
+                metricRegistry,
                 null,
                 messagingFacility,
                 historicalBlockFacility,
@@ -1452,6 +1482,8 @@ class BlockStreamSubscriberSessionTest {
                 SessionContext.create(clientId, request, blockNodeContext),
                 responsePipeline,
                 blockNodeContext,
-                sessionReadyLatch);
+                sessionReadyLatch,
+                sessionMetrics,
+                () -> {});
     }
 }

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberServicePluginTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberServicePluginTest.java
@@ -195,6 +195,34 @@ class SubscriberServicePluginTest {
                     }
 
                     /**
+                     * This test aims to assert that a session served entirely
+                     * from history does not touch the send metrics, which
+                     * only measure batches taken from the live stream.
+                     */
+                    @Test
+                    @DisplayName("Test Subscriber: Historical Only Request Does Not Record Send Metrics")
+                    void testHistoricalOnlyRequestRecordsNoSends() {
+                        // First we create the block and supply it to history only
+                        final TestBlock blockZero = TestBlockBuilder.generateBlockWithNumber(0);
+                        historicalBlockFacility.handleBlockItemsReceived(blockZero.asBlockItems());
+                        // Then, we create the request for block 0
+                        final SubscribeStreamRequest request = SubscribeStreamRequest.newBuilder()
+                                .startBlockNumber(0L)
+                                .endBlockNumber(0L)
+                                .build();
+                        // Send the request
+                        toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(request));
+                        // Wait for responses
+                        awaitResponse(fromPluginBytes, 3); // one with items, end of block, one with success status
+                        // Nothing came from live, so neither send metric may have moved.
+                        // Note getMetricValue ignores labels; the single session here produces only one series.
+                        assertThat(getMetricValue(SubscriberServicePlugin.METRIC_SUBSCRIBER_LIVE_BATCHES_SENT))
+                                .isZero();
+                        assertThat(getMetricValue(SubscriberServicePlugin.METRIC_SUBSCRIBER_LIVE_SEND_LATENCY_NS))
+                                .isZero();
+                    }
+
+                    /**
                      * This test aims to assert that when a valid request for a
                      * single block is sent to the plugin, a response with the
                      * block items is returned, followed by a success status
@@ -838,6 +866,42 @@ class SubscriberServicePluginTest {
                     }
 
                     /**
+                     * This test aims to assert that every live batch sent to a
+                     * subscriber is counted by the send metrics, and that the
+                     * accumulated latency is non-zero.
+                     */
+                    @Test
+                    @DisplayName("Test Subscriber: Live Batches Are Measured By The Send Metrics")
+                    void testLiveBatchesRecordSendLatency() {
+                        // First we create the blocks
+                        final List<TestBlock> blocksZeroToTwo = TestBlockBuilder.generateBlocksInRange(0, 2);
+                        // Then, we create the request for live stream
+                        final SubscribeStreamRequest request = SubscribeStreamRequest.newBuilder()
+                                .startBlockNumber(-1L)
+                                .endBlockNumber(-1L)
+                                .build();
+                        // Send the request
+                        toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(request));
+                        // Disable history to listen to live data so we ensure
+                        // blocks will be supplied from live
+                        historicalBlockFacility.setDisablePlugin();
+                        // Now supply the requested blocks to live ring buffer, one batch each
+                        for (final TestBlock block : blocksZeroToTwo) {
+                            blockMessaging.sendBlockItems(block.asBlockItems());
+                        }
+                        // Wait for responses for block items
+                        awaitResponse(fromPluginBytes, 2 * blocksZeroToTwo.size());
+                        plugin.stop();
+                        // Every live batch sent must have been measured, with a non-zero total latency.
+                        // Note getMetricValue ignores labels, so this only reads one series; it is correct here
+                        // because the single session in this test produces exactly one.
+                        assertThat(getMetricValue(SubscriberServicePlugin.METRIC_SUBSCRIBER_LIVE_BATCHES_SENT))
+                                .isEqualTo(blocksZeroToTwo.size());
+                        assertThat(getMetricValue(SubscriberServicePlugin.METRIC_SUBSCRIBER_LIVE_SEND_LATENCY_NS))
+                                .isPositive();
+                    }
+
+                    /**
                      * This test aims to assert that when a valid request for
                      * live stream is sent to the plugin, a response(s) with the
                      * block items is returned, and items keep streaming
@@ -1224,6 +1288,96 @@ class SubscriberServicePluginTest {
                 fail("Unexpected response type %s."
                         .formatted(subscribeResponse.response().kind()));
             }
+        }
+    }
+
+    /**
+     * Tests for the metric label slots that keep the number of per-subscriber send series bounded.
+     * <p>
+     * This runs on its own fixture because a released slot is only observable across two sessions that run one after
+     * another, which needs the single threaded executor below.
+     */
+    @Nested
+    @DisplayName("Metrics Slot Reuse Tests")
+    class MetricsSlotReuseTests
+            extends GrpcPluginTestBase<SubscriberServicePlugin, ExecutorService, ScheduledBlockingExecutor> {
+        private final SimpleInMemoryHistoricalBlockFacility historicalBlockFacility;
+
+        MetricsSlotReuseTests() {
+            // A single thread, so that a probe task submitted to the executor can only run once the first session's
+            // thread has finished, which is the point at which it has released its slot.
+            super(Executors.newSingleThreadExecutor(), new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+            final SubscriberServicePlugin toTest = new SubscriberServicePlugin();
+            historicalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
+            start(toTest, toTest.methods().getFirst(), historicalBlockFacility);
+        }
+
+        /**
+         * This test aims to assert that a session which has ended releases its metric label slot, so the next session
+         * to connect is labeled with the same slot rather than a fresh one.
+         */
+        @Test
+        @DisplayName("Test Metrics Slot: Sequential Sessions Reuse The Same Slot")
+        void testSequentialSessionsReuseSlot() throws Exception {
+            // A request for a single block that history already has, so the session ends on its own
+            final TestBlock blockZero = TestBlockBuilder.generateBlockWithNumber(0);
+            historicalBlockFacility.handleBlockItemsReceived(blockZero.asBlockItems());
+            final SubscribeStreamRequest request = SubscribeStreamRequest.newBuilder()
+                    .startBlockNumber(0L)
+                    .endBlockNumber(0L)
+                    .build();
+            toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(request));
+            awaitResponse(fromPluginBytes, 3); // one with items, end of block, one with success status
+            // The slot is released as the last thing the session thread does, so wait for that thread to finish
+            testThreadPoolManager.getVirtualThreadExecutor().submit(() -> {}).get();
+            // A second session now has a released slot to take, so it must not create a second series
+            final TestPipeline secondSubscriber = createNewPipeline();
+            secondSubscriber.toPluginPipe().onNext(SubscribeStreamRequest.PROTOBUF.toBytes(request));
+            awaitResponse(secondSubscriber.fromPluginBytes(), 3);
+            assertThat(getMetricValuesByLabel(SubscriberServicePlugin.METRIC_SUBSCRIBER_LIVE_BATCHES_SENT))
+                    .containsOnlyKeys("0");
+        }
+    }
+
+    /**
+     * Tests that concurrently open sessions are measured separately.
+     * <p>
+     * This runs on its own fixture because both sessions must be able to start, which the single threaded executor
+     * the other cases use does not allow.
+     */
+    @Nested
+    @DisplayName("Metrics Slot Concurrency Tests")
+    class MetricsSlotConcurrencyTests
+            extends GrpcPluginTestBase<SubscriberServicePlugin, ExecutorService, ScheduledBlockingExecutor> {
+        MetricsSlotConcurrencyTests() {
+            super(Executors.newCachedThreadPool(), new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+            final SubscriberServicePlugin toTest = new SubscriberServicePlugin();
+            start(toTest, toTest.methods().getFirst(), new SimpleInMemoryHistoricalBlockFacility());
+        }
+
+        /**
+         * This test aims to assert that sessions open at the same time are labeled with different slots, so that one
+         * lagging subscriber is measured separately from a healthy one.
+         */
+        @Test
+        @DisplayName("Test Metrics Slot: Concurrent Sessions Get Different Slots")
+        void testConcurrentSessionsGetDifferentSlots() {
+            final SubscribeStreamRequest liveRequest = SubscribeStreamRequest.newBuilder()
+                    .startBlockNumber(-1L)
+                    .endBlockNumber(-1L)
+                    .build();
+            toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(liveRequest));
+            final TestPipeline secondSubscriber = createNewPipeline();
+            secondSubscriber.toPluginPipe().onNext(SubscribeStreamRequest.PROTOBUF.toBytes(liveRequest));
+            // Neither session has ended, so the second one cannot have taken the first one's slot
+            assertThat(getMetricValuesByLabel(SubscriberServicePlugin.METRIC_SUBSCRIBER_LIVE_BATCHES_SENT))
+                    .containsOnlyKeys("0", "1");
+            // A live session that has never seen a block cannot be stopped, so supply one before closing down
+            blockMessaging.sendBlockItems(
+                    TestBlockBuilder.generateBlockWithNumber(0).asBlockItems());
+            awaitResponse(fromPluginBytes, 2); // one with items, one end of block
+            awaitResponse(secondSubscriber.fromPluginBytes(), 2);
+            plugin.stop();
         }
     }
 

--- a/charts/block-node-server/dashboards/performance-metrics.json
+++ b/charts/block-node-server/dashboards/performance-metrics.json
@@ -1616,6 +1616,178 @@
       },
       "fieldConfig": {
         "defaults": {
+          "decimals": 2,
+          "noValue": "No live traffic",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 20000000
+              },
+              {
+                "color": "yellow",
+                "value": 50000000
+              },
+              {
+                "color": "red",
+                "value": 60000000
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 0,
+        "y": 43
+      },
+      "id": 42,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(increase(blocknode_subscriber_live_send_latency_ns_total[$__range]) / increase(blocknode_subscriber_live_batches_sent_total[$__range]))",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Send Latency Avg (range, worst subscriber)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 20000000
+              },
+              {
+                "color": "yellow",
+                "value": 50000000
+              },
+              {
+                "color": "red",
+                "value": 60000000
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 19,
+        "x": 5,
+        "y": 43
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(blocknode_subscriber_live_send_latency_ns_total[$__rate_interval]) / rate(blocknode_subscriber_live_batches_sent_total[$__rate_interval])",
+          "interval": "15s",
+          "range": true,
+          "refId": "A",
+          "legendFormat": "{{subscriber}}"
+        }
+      ],
+      "title": "Send Latency Avg Rate over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -1634,7 +1806,7 @@
         "h": 6,
         "w": 5,
         "x": 0,
-        "y": 43
+        "y": 49
       },
       "id": 25,
       "options": {
@@ -1692,7 +1864,7 @@
         "h": 6,
         "w": 6,
         "x": 5,
-        "y": 43
+        "y": 49
       },
       "id": 26,
       "options": {
@@ -1786,7 +1958,7 @@
         "h": 6,
         "w": 13,
         "x": 11,
-        "y": 43
+        "y": 49
       },
       "id": 28,
       "options": {
@@ -1822,7 +1994,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 55
       },
       "id": 13,
       "panels": [],
@@ -1860,7 +2032,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 50
+        "y": 56
       },
       "id": 14,
       "options": {
@@ -1978,7 +2150,7 @@
         "h": 9,
         "w": 16,
         "x": 8,
-        "y": 50
+        "y": 56
       },
       "id": 7,
       "options": {

--- a/docs/block-node/metrics.md
+++ b/docs/block-node/metrics.md
@@ -134,10 +134,31 @@ Observes inbound streams from publishers.
 **Plugin:** `stream-subscriber [block-node-stream-subscriber]`
 Observes outbound streams served to subscribers.
 
-|  Type   |             Name              |              Description              |
-|---------|-------------------------------|---------------------------------------|
-| Gauge   | `subscriber_open_connections` | Connected subscribers                 |
-| Counter | `subscriber_errors`           | Errors while streaming to subscribers |
+|  Type   |               Name                |                                    Description                                     |
+|---------|-----------------------------------|------------------------------------------------------------------------------------|
+| Gauge   | `subscriber_open_connections`     | Connected subscribers                                                              |
+| Counter | `subscriber_errors`               | Errors while streaming to subscribers                                              |
+| Counter | `subscriber_live_send_latency_ns` | Time (ns) live batches waited between reaching a subscriber session and being sent |
+| Counter | `subscriber_live_batches_sent`    | Live batches sent to subscribers, the denominator for the send latency             |
+
+The two send metrics carry a `subscriber` label, one series per concurrent subscriber, so a lagging consumer shows
+up on its own series rather than being averaged into the others. The label value is a slot index, not a client
+identity: it is reused once a session ends, so one series can cover different clients over time. At most 64 sessions
+get a slot of their own; while those are all in use, every further session is labeled `overflow` and shares one
+series, which caps the label at 65 values however many subscribers connect. The plugin logs the client id it hands
+each slot to at `DEBUG` level, which is the only mapping from a slot value back to a client.
+
+Only batches taken from the live stream are measured, timed from the point the messaging facility hands the batch to
+the session, which is before it is put on the session's queue. Time spent blocked on a full queue therefore counts
+towards the latency, so a spike can mean the session is falling behind rather than the client being slow to read.
+Blocks served from history are not measured, because the ingest time of a block read back from storage says nothing
+about send latency.
+
+This bounds how bad the latency can look. Once a session's live queue is nearly full, it drops whole blocks from the
+queue and catches those blocks up from history instead. Dropped batches are never sent, so they are never measured,
+and the blocks that replace them are historical and also unmeasured. A subscriber lagging that hard therefore shows a
+latency that stops climbing rather than one that keeps rising; a session repeatedly falling back to history is
+visible in the logs, not in these metrics.
 
 ---
 
@@ -339,6 +360,7 @@ is a block-count cap, not a disk-size cap (see [Host / Volume](#host--volume-ext
 | M        | `hashing_block_time`                       | If value exceeds 2s, otherwise, configure as needed  |
 | M        | `verification_block_time`                  | If value exceeds 20s, otherwise, configure as needed |
 | M        | `files_recent_persistence_time_latency_ns` | If value exceeds 20s, otherwise, configure as needed |
+| M        | `subscriber_live_send_latency_ns`          | If a subscriber's average batch wait exceeds 60ms    |
 
 **Cloud Expanded**: Alerts for metrics regarding expanded cloud storage (single-block S3 uploads)
 


### PR DESCRIPTION
## Reviewer Notes
  
* Adds a per-subscriber metric for how long a live batch waits before being sent
* Recycles a fixed set of metric label slots, so series count follows peak concurrent subscribers

## Related Issue(s)

Closes #1567