### PR TITLE
fix: reclaim stuck resend slots that never complete

### DIFF
--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -35,7 +35,6 @@ import java.util.Objects;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -142,8 +141,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     private final ConcurrentSkipListMap<Long, BlockItemUnparsed> blockProofs;
     private final ConcurrentSkipListSet<Long> endBlocksReceived;
     private final ConcurrentSkipListSet<Long> blocksToResend;
-    private final ConcurrentSkipListSet<Long> activeResendBlocks;
-    private final ConcurrentMap<Long, Long> resendStartReferenceByBlock;
+    private final ConcurrentSkipListMap<Long, Long> activeResendBlocks;
     /// Flow state per handler ID; created in addHandler, removed in removeHandler.
     private final ConcurrentSkipListMap<Long, HandlerFlowState> handlerFlowState;
     /// Maps block number to the ID of the handler that currently holds ACCEPT for that block.
@@ -181,8 +179,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         blockProofs = new ConcurrentSkipListMap<>();
         endBlocksReceived = new ConcurrentSkipListSet<>();
         blocksToResend = new ConcurrentSkipListSet<>();
-        activeResendBlocks = new ConcurrentSkipListSet<>();
-        resendStartReferenceByBlock = new ConcurrentHashMap<>();
+        activeResendBlocks = new ConcurrentSkipListMap<>();
         activeStreamHandlerByBlock = new ConcurrentSkipListMap<>();
         handlerFlowState = new ConcurrentSkipListMap<>();
         initializeBlockNumbers(serverContext);
@@ -305,7 +302,6 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         }
         // Remove from the active resend set, if it's present
         activeResendBlocks.remove(blockNumber);
-        resendStartReferenceByBlock.remove(blockNumber);
         // The completing block is no longer an ACCEPT candidate for stall detection.
         activeStreamHandlerByBlock.remove(blockNumber);
         // After removing the completing block, check whether any remaining
@@ -328,7 +324,6 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         final Deque<BlockItemSetUnparsed> deque = queueByBlockMap.remove(blockNumber);
         // Remove from the active resend set, if it's present (it should not be)
         activeResendBlocks.remove(blockNumber);
-        resendStartReferenceByBlock.remove(blockNumber);
         // Remove this block from the ACCEPT winner tracking in all cases;
         // if the handler dropped mid-block there is no stall to detect here.
         activeStreamHandlerByBlock.remove(blockNumber);
@@ -623,7 +618,6 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             // resent that was never sent.
             blocksToResend.clear();
             activeResendBlocks.clear();
-            resendStartReferenceByBlock.clear();
             blockProofs.clear();
             queueByBlockMap.clear();
             endBlocksReceived.clear();
@@ -655,7 +649,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         // Use block number + 1 as a default if something isn't set, because we'll reduce by one later.
         final long defaultValue = blockNumber + 1;
         final long earliestInFlight = queueByBlockMap.isEmpty() ? defaultValue : queueByBlockMap.firstKey();
-        final long activeResend = activeResendBlocks.isEmpty() ? defaultValue : activeResendBlocks.first();
+        final long activeResend = activeResendBlocks.isEmpty() ? defaultValue : activeResendBlocks.firstKey();
         final long scheduledResend = blocksToResend.isEmpty() ? defaultValue : blocksToResend.first();
         final long earliestResend = Math.min(activeResend, scheduledResend);
         final long earliestKnownGap = Math.min(earliestInFlight, earliestResend);
@@ -799,18 +793,10 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 endStalledBlock(completedBlockNumber, handlerId, candidateBlock, STALL_DETECTED_LOG_MESSAGE);
                 blocksToResend.add(candidateBlock);
             } else if (isResendingLive(candidateBlock)
-                    && completedBlockNumber
-                            > resendStartReferenceByBlock.getOrDefault(candidateBlock, Long.MAX_VALUE)
-                                    + maxBlocksBeforeStalled
+                    && activeResendBlocks.containsKey(candidateBlock)
+                    && completedBlockNumber > activeResendBlocks.get(candidateBlock) + maxBlocksBeforeStalled
                     && activeStreamHandlerByBlock.remove(candidateBlock, handlerId)) {
-                // Resend holder stopped streaming. Reclaim the slot so a different
-                // publisher can supply the block and the ack pipeline can advance
-                // (see #2934). Sibling of the normal-stall branch above, but the
-                // reference point is the live tip at the moment the resend slot was
-                // won instead of the candidate block itself, because during a resend
-                // the candidate is by definition far behind the live tip.
                 activeResendBlocks.remove(candidateBlock);
-                resendStartReferenceByBlock.remove(candidateBlock);
                 endStalledBlock(completedBlockNumber, handlerId, candidateBlock, RESEND_STALL_LOG_MESSAGE);
                 blocksToResend.add(candidateBlock);
             }
@@ -852,7 +838,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     ///     this block node.
     ///
     private boolean isResendingLive(final long candidateBlock) {
-        return activeResendBlocks.contains(candidateBlock) && candidateBlock > lastPersistedBlockNumber.get();
+        return activeResendBlocks.containsKey(candidateBlock) && candidateBlock > lastPersistedBlockNumber.get();
     }
 
     /// todo(1420) add documentation
@@ -1004,8 +990,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 // Track the block as actively resending so gap detection in correctForResendAndStreaming
                 // and stall detection in isResendingLive can see it. The set is cleared by endOfBlock /
                 // blockIsEnding on completion, and by handleVerification on failed re-verification.
-                activeResendBlocks.add(blockNumber);
-                resendStartReferenceByBlock.put(blockNumber, lastPersistedBlockNumber.get());
+                activeResendBlocks.put(blockNumber, lastPersistedBlockNumber.get());
                 return BlockAction.ACCEPT;
             } else {
                 return BlockAction.SKIP;

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -79,6 +80,8 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             "[{0}] Stall detected: handler {1} has not completed block {2}, another handler completed block {3}";
     private static final String BLOCK_ABANDONED_LOG_MESSAGE =
             "[{0}] Replacement persistence detected: handler {1} has not completed block {2}, but a different source persisted the same block {3}";
+    private static final String RESEND_STALL_LOG_MESSAGE =
+            "[{0}] Resend stall detected: handler {1} won RESEND slot for block {2} but the live tip advanced past the configured limit while streaming; last completion seen was block {3}. Reclaiming the slot.";
     /// Limit the maximum scheduled threads to 12, more than that is almost certainly excessive.
     private static final int MAX_SCHEDULE_THREADS = 12;
     /// Value assigned as a Handler message budget when that handler is being paused
@@ -140,6 +143,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     private final ConcurrentSkipListSet<Long> endBlocksReceived;
     private final ConcurrentSkipListSet<Long> blocksToResend;
     private final ConcurrentSkipListSet<Long> activeResendBlocks;
+    private final ConcurrentMap<Long, Long> resendStartReferenceByBlock;
     /// Flow state per handler ID; created in addHandler, removed in removeHandler.
     private final ConcurrentSkipListMap<Long, HandlerFlowState> handlerFlowState;
     /// Maps block number to the ID of the handler that currently holds ACCEPT for that block.
@@ -178,6 +182,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         endBlocksReceived = new ConcurrentSkipListSet<>();
         blocksToResend = new ConcurrentSkipListSet<>();
         activeResendBlocks = new ConcurrentSkipListSet<>();
+        resendStartReferenceByBlock = new ConcurrentHashMap<>();
         activeStreamHandlerByBlock = new ConcurrentSkipListMap<>();
         handlerFlowState = new ConcurrentSkipListMap<>();
         initializeBlockNumbers(serverContext);
@@ -300,6 +305,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         }
         // Remove from the active resend set, if it's present
         activeResendBlocks.remove(blockNumber);
+        resendStartReferenceByBlock.remove(blockNumber);
         // The completing block is no longer an ACCEPT candidate for stall detection.
         activeStreamHandlerByBlock.remove(blockNumber);
         // After removing the completing block, check whether any remaining
@@ -322,6 +328,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         final Deque<BlockItemSetUnparsed> deque = queueByBlockMap.remove(blockNumber);
         // Remove from the active resend set, if it's present (it should not be)
         activeResendBlocks.remove(blockNumber);
+        resendStartReferenceByBlock.remove(blockNumber);
         // Remove this block from the ACCEPT winner tracking in all cases;
         // if the handler dropped mid-block there is no stall to detect here.
         activeStreamHandlerByBlock.remove(blockNumber);
@@ -616,6 +623,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             // resent that was never sent.
             blocksToResend.clear();
             activeResendBlocks.clear();
+            resendStartReferenceByBlock.clear();
             blockProofs.clear();
             queueByBlockMap.clear();
             endBlocksReceived.clear();
@@ -789,6 +797,21 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                     && activeStreamHandlerByBlock.remove(candidateBlock, handlerId)) {
                 // This thread won the CAS — execute the stall action.
                 endStalledBlock(completedBlockNumber, handlerId, candidateBlock, STALL_DETECTED_LOG_MESSAGE);
+                blocksToResend.add(candidateBlock);
+            } else if (isResendingLive(candidateBlock)
+                    && completedBlockNumber
+                            > resendStartReferenceByBlock.getOrDefault(candidateBlock, Long.MAX_VALUE)
+                                    + maxBlocksBeforeStalled
+                    && activeStreamHandlerByBlock.remove(candidateBlock, handlerId)) {
+                // Resend holder stopped streaming. Reclaim the slot so a different
+                // publisher can supply the block and the ack pipeline can advance
+                // (see #2934). Sibling of the normal-stall branch above, but the
+                // reference point is the live tip at the moment the resend slot was
+                // won instead of the candidate block itself, because during a resend
+                // the candidate is by definition far behind the live tip.
+                activeResendBlocks.remove(candidateBlock);
+                resendStartReferenceByBlock.remove(candidateBlock);
+                endStalledBlock(completedBlockNumber, handlerId, candidateBlock, RESEND_STALL_LOG_MESSAGE);
                 blocksToResend.add(candidateBlock);
             }
         }
@@ -982,6 +1005,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 // and stall detection in isResendingLive can see it. The set is cleared by endOfBlock /
                 // blockIsEnding on completion, and by handleVerification on failed re-verification.
                 activeResendBlocks.add(blockNumber);
+                resendStartReferenceByBlock.put(blockNumber, lastPersistedBlockNumber.get());
                 return BlockAction.ACCEPT;
             } else {
                 return BlockAction.SKIP;

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -4,8 +4,8 @@ package org.hiero.block.node.stream.publisher;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.endThisBlock;
-import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.sendHeaderOnly;
+import static org.hiero.block.node.stream.publisher.PublishApiUtility.endThisBlock;
+import static org.hiero.block.node.stream.publisher.PublishApiUtility.sendHeaderOnly;
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
@@ -3669,13 +3669,13 @@ class LiveStreamPublisherManagerTest {
                     endThisBlock(publisherHandler2, block);
                 }
                 // Block 1 fails verification -> blocksToResend = {1}.
+                // CANCELLED is used deliberately: it schedules a resend with
+                // NO_STREAM_ACTION, so handler 2 (which supplied block 1) keeps
+                // its stream and can go on to advance the live tip. A supplier
+                // fault such as BAD_BLOCK_PROOF would end handler 2's stream
+                // and there would be nothing left to trigger the reclaim.
                 toTest.handleVerification(new VerificationNotification(
-                        false,
-                        FailureInfo.standard(FailureType.BAD_BLOCK_PROOF),
-                        1L,
-                        null,
-                        null,
-                        BlockSource.PUBLISHER));
+                        false, FailureInfo.standard(FailureType.CANCELLED), 1L, null, null, BlockSource.PUBLISHER));
                 // Handler 1 wins the RESEND(1) slot by sending only the header, then goes silent.
                 responsePipeline.clear();
                 sendHeaderOnly(publisherHandler, 1L);
@@ -3718,17 +3718,15 @@ class LiveStreamPublisherManagerTest {
                     publisherHandler2.onNext(req);
                     endThisBlock(publisherHandler2, block);
                 }
+                // CANCELLED schedules the resend without ending any stream, so
+                // handler 2 stays connected to advance the live tip; see
+                // testStuckResendHolderReceivesTimeout for the full reasoning.
                 toTest.handleVerification(new VerificationNotification(
-                        false,
-                        FailureInfo.standard(FailureType.BAD_BLOCK_PROOF),
-                        1L,
-                        null,
-                        null,
-                        BlockSource.PUBLISHER));
+                        false, FailureInfo.standard(FailureType.CANCELLED), 1L, null, null, BlockSource.PUBLISHER));
                 // Handler 1 wins RESEND(1), goes silent.
                 sendHeaderOnly(publisherHandler, 1L);
-                // Clear pipeline 2 noise from the SKIP responses issued while blocks 2, 3
-                // were streaming past handler 1's silent state.
+                // Start from a clean pipeline 2 so the only responses examined are
+                // the ones produced while blocks 2 and 3 stream.
                 responsePipeline2.clear();
                 // Handler 2 completes blocks 2 and 3. endOfBlock(3) fires the reclaim,
                 // then returns RESEND(1) to handler 2.
@@ -3768,13 +3766,11 @@ class LiveStreamPublisherManagerTest {
                     publisherHandler2.onNext(req);
                     endThisBlock(publisherHandler2, block);
                 }
+                // CANCELLED schedules the resend without ending any stream, so
+                // handler 2 stays connected to advance the live tip; see
+                // testStuckResendHolderReceivesTimeout for the full reasoning.
                 toTest.handleVerification(new VerificationNotification(
-                        false,
-                        FailureInfo.standard(FailureType.BAD_BLOCK_PROOF),
-                        1L,
-                        null,
-                        null,
-                        BlockSource.PUBLISHER));
+                        false, FailureInfo.standard(FailureType.CANCELLED), 1L, null, null, BlockSource.PUBLISHER));
                 // Handler 1 wins RESEND(1) and completes it fully and promptly.
                 responsePipeline.clear();
                 final PublishStreamRequestUnparsed resendBlock1Req = PublishStreamRequestUnparsed.newBuilder()

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -3646,6 +3646,161 @@ class LiveStreamPublisherManagerTest {
                             assertThat(r.resendBlock().blockNumber()).isEqualTo(0L);
                         });
             }
+
+            /// A handler that wins RESEND(N) via the header path and then stops
+            /// streaming must be reclaimed. Once the live tip advances past
+            /// (resendStartReference + K) via another handler's completions, the
+            /// resend-stall branch of `checkForStalledHandlers` must send
+            /// EndStream(TIMEOUT) to the stuck holder and shut it down. Without
+            /// the reclaim, `activeResendBlocks.first()` clamps every subsequent
+            /// acknowledgement through `correctForResendAndStreaming` and the
+            /// pipeline stops advancing (#2934).
+            @Test
+            @DisplayName("stuck resend holder receives EndStream(TIMEOUT) after live tip advances past K")
+            void testStuckResendHolderReceivesTimeout() {
+                // Handler 2 completes blocks 0 and 1 to advance nextUnstreamed past 1
+                // so handleVerification's failure branch fires for block 1.
+                for (long block = 0L; block <= 1L; block++) {
+                    final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
+                            .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
+                                    .asItemSetUnparsed())
+                            .build();
+                    publisherHandler2.onNext(req);
+                    endThisBlock(publisherHandler2, block);
+                }
+                // Block 1 fails verification -> blocksToResend = {1}.
+                toTest.handleVerification(new VerificationNotification(
+                        false,
+                        FailureInfo.standard(FailureType.BAD_BLOCK_PROOF),
+                        1L,
+                        null,
+                        null,
+                        BlockSource.PUBLISHER));
+                // Handler 1 wins the RESEND(1) slot by sending only the header, then goes silent.
+                responsePipeline.clear();
+                sendHeaderOnly(publisherHandler, 1L);
+                // Handler 2 completes blocks 2 and 3. endOfBlock(3) fires the resend-stall
+                // branch: completedBlockNumber(3) > resendStartReference(-1) + K(3) = 2.
+                for (long block = 2L; block <= 3L; block++) {
+                    final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
+                            .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
+                                    .asItemSetUnparsed())
+                            .build();
+                    publisherHandler2.onNext(req);
+                    endThisBlock(publisherHandler2, block);
+                }
+                threadPoolManager.scheduledExecutor().executeSerially();
+                assertThat(responsePipeline.getOnNextCalls())
+                        .as("handler 1 (stuck resend holder) must receive EndStream(TIMEOUT)")
+                        .anySatisfy(r -> {
+                            assertThat(r.response().kind())
+                                    .isEqualTo(PublishStreamResponse.ResponseOneOfType.END_STREAM);
+                            assertThat(r.endStream().status())
+                                    .isEqualTo(PublishStreamResponse.EndOfStream.Code.TIMEOUT);
+                        });
+                assertThat(responsePipeline.getOnCompleteCalls().get())
+                        .as("handler 1 must be shut down after resend-stall reclaim")
+                        .isEqualTo(1);
+            }
+
+            /// After a stuck resend slot is reclaimed, the block must be routed
+            /// to another publisher: the endOfBlock() that triggered the reclaim
+            /// must itself return ActionForBlock(RESEND, N) to the completing
+            /// handler so its pipeline receives ResendBlock(N).
+            @Test
+            @DisplayName("reclaimed resend block is offered to another publisher on next endOfBlock")
+            void testReclaimedBlockOfferedToNextPublisher() {
+                for (long block = 0L; block <= 1L; block++) {
+                    final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
+                            .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
+                                    .asItemSetUnparsed())
+                            .build();
+                    publisherHandler2.onNext(req);
+                    endThisBlock(publisherHandler2, block);
+                }
+                toTest.handleVerification(new VerificationNotification(
+                        false,
+                        FailureInfo.standard(FailureType.BAD_BLOCK_PROOF),
+                        1L,
+                        null,
+                        null,
+                        BlockSource.PUBLISHER));
+                // Handler 1 wins RESEND(1), goes silent.
+                sendHeaderOnly(publisherHandler, 1L);
+                // Clear pipeline 2 noise from the SKIP responses issued while blocks 2, 3
+                // were streaming past handler 1's silent state.
+                responsePipeline2.clear();
+                // Handler 2 completes blocks 2 and 3. endOfBlock(3) fires the reclaim,
+                // then returns RESEND(1) to handler 2.
+                for (long block = 2L; block <= 3L; block++) {
+                    final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
+                            .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
+                                    .asItemSetUnparsed())
+                            .build();
+                    publisherHandler2.onNext(req);
+                    endThisBlock(publisherHandler2, block);
+                }
+                threadPoolManager.scheduledExecutor().executeSerially();
+                assertThat(responsePipeline2.getOnNextCalls())
+                        .as("handler 2 must receive ResendBlock(1) after the reclaim")
+                        .anySatisfy(r -> {
+                            assertThat(r.response().kind())
+                                    .isEqualTo(PublishStreamResponse.ResponseOneOfType.RESEND_BLOCK);
+                            assertThat(r.resendBlock().blockNumber()).isEqualTo(1L);
+                        });
+            }
+
+            /// A resend holder that legitimately completes its block within the
+            /// window must NOT be reclaimed, even if the live tip subsequently
+            /// advances past (resendStartReference + K). The completion clears
+            /// `activeResendBlocks` so `isResendingLive` returns false and the
+            /// new stall branch does not fire. Guards against false-positive
+            /// reclaims that would regress the `isResendingLive` exemption
+            /// protection.
+            @Test
+            @DisplayName("legit resend that completes in time is not reclaimed")
+            void testLegitResendNotReclaimed() {
+                for (long block = 0L; block <= 1L; block++) {
+                    final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
+                            .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
+                                    .asItemSetUnparsed())
+                            .build();
+                    publisherHandler2.onNext(req);
+                    endThisBlock(publisherHandler2, block);
+                }
+                toTest.handleVerification(new VerificationNotification(
+                        false,
+                        FailureInfo.standard(FailureType.BAD_BLOCK_PROOF),
+                        1L,
+                        null,
+                        null,
+                        BlockSource.PUBLISHER));
+                // Handler 1 wins RESEND(1) and completes it fully and promptly.
+                responsePipeline.clear();
+                final PublishStreamRequestUnparsed resendBlock1Req = PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(TestBlockBuilder.generateBlockWithNumber(1L).asItemSetUnparsed())
+                        .build();
+                publisherHandler.onNext(resendBlock1Req);
+                endThisBlock(publisherHandler, 1L);
+                // Handler 2 then completes blocks 2, 3, 4, 5 — well past K blocks away
+                // from where the (now-completed) resend started. Nothing must fire.
+                for (long block = 2L; block <= 5L; block++) {
+                    final PublishStreamRequestUnparsed req = PublishStreamRequestUnparsed.newBuilder()
+                            .blockItems(TestBlockBuilder.generateBlockWithNumber(block)
+                                    .asItemSetUnparsed())
+                            .build();
+                    publisherHandler2.onNext(req);
+                    endThisBlock(publisherHandler2, block);
+                }
+                threadPoolManager.scheduledExecutor().executeSerially();
+                assertThat(responsePipeline.getOnNextCalls())
+                        .as("handler 1 that completed its resend in time must not receive TIMEOUT")
+                        .noneMatch(r -> r.response().kind() == PublishStreamResponse.ResponseOneOfType.END_STREAM
+                                && r.endStream().status() == PublishStreamResponse.EndOfStream.Code.TIMEOUT);
+                assertThat(responsePipeline.getOnCompleteCalls().get())
+                        .as("handler 1 must not be shut down after a legit, timely resend")
+                        .isZero();
+            }
         }
     }
 

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublishApiUtility.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublishApiUtility.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package org.hiero.block.node.stream.publisher.fixtures;
+package org.hiero.block.node.stream.publisher;
 
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -8,7 +8,6 @@ import org.hiero.block.api.BlockEnd;
 import org.hiero.block.internal.BlockItemSetUnparsed;
 import org.hiero.block.internal.PublishStreamRequestUnparsed;
 import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
-import org.hiero.block.node.stream.publisher.PublisherHandler;
 
 /// Utility class to assist with publish API testing.
 public final class PublishApiUtility {
@@ -17,28 +16,38 @@ public final class PublishApiUtility {
     private PublishApiUtility() {}
 
     /// Send an `EndOfBlock` message for a given block number.
-    /// @param publisherHandler A publisher handler to be tested.
+    /// @param handler A publisher handler to be tested.
     /// @param blockNumber A block number to close.
-    public static void endThisBlock(final PublisherHandler publisherHandler, final long blockNumber) {
+    public static void endThisBlock(final PublisherHandler handler, final long blockNumber) {
         final BlockEnd endOfBlock =
                 BlockEnd.newBuilder().blockNumber(blockNumber).build();
         final PublishStreamRequestUnparsed request =
                 PublishStreamRequestUnparsed.newBuilder().endOfBlock(endOfBlock).build();
-        publisherHandler.onNext(request);
+        // Avoid deadlock by ensuring there is a messaging budget to spend first.
+        final long currentBudget = handler.getMessageBudget();
+        if (currentBudget < 10) {
+            handler.setMessageBudget(currentBudget, 10);
+        }
+        handler.onNext(request);
     }
 
     /// Send only the block header for a given block number, simulating a
     /// publisher that goes silent mid-block.
-    /// @param publisherHandler A publisher handler to send the header to.
+    /// @param handler A publisher handler to send the header to.
     /// @param blockNumber A block number whose header to send.
-    public static void sendHeaderOnly(final PublisherHandler publisherHandler, final long blockNumber) {
+    public static void sendHeaderOnly(final PublisherHandler handler, final long blockNumber) {
         final BlockItemSetUnparsed headerOnly = BlockItemSetUnparsed.newBuilder()
                 .blockItems(List.of(
                         TestBlockBuilder.generateBlockWithNumber(blockNumber).getHeaderUnparsed()))
                 .build();
         final PublishStreamRequestUnparsed request =
                 PublishStreamRequestUnparsed.newBuilder().blockItems(headerOnly).build();
-        publisherHandler.onNext(request);
+        // Avoid deadlock by ensuring there is a messaging budget to spend first.
+        final long currentBudget = handler.getMessageBudget();
+        if (currentBudget < 10) {
+            handler.setMessageBudget(currentBudget, 10);
+        }
+        handler.onNext(request);
     }
 
     /// Send an `EndOfBlock` message for a given block number.

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherHandlerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherHandlerTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
-import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.endThisBlock;
+import static org.hiero.block.node.stream.publisher.PublishApiUtility.endThisBlock;
 
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.io.buffer.Bytes;

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherManagerRegressionTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherManagerRegressionTest.java
@@ -2,8 +2,8 @@
 package org.hiero.block.node.stream.publisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.endThisBlock;
-import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.sendHeaderOnly;
+import static org.hiero.block.node.stream.publisher.PublishApiUtility.endThisBlock;
+import static org.hiero.block.node.stream.publisher.PublishApiUtility.sendHeaderOnly;
 
 import com.swirlds.config.api.Configuration;
 import java.util.ArrayList;

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginRegressionTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginRegressionTest.java
@@ -4,7 +4,7 @@ package org.hiero.block.node.stream.publisher;
 import static java.util.concurrent.locks.LockSupport.parkNanos;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.block.node.base.ParseHelper.standardParse;
-import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.endThisBlock;
+import static org.hiero.block.node.stream.publisher.PublishApiUtility.endThisBlock;
 
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.UncheckedParseException;

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
@@ -5,7 +5,7 @@ import static java.util.concurrent.locks.LockSupport.parkNanos;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.block.node.app.fixtures.TestUtils.enableDebugLogging;
 import static org.hiero.block.node.base.ParseHelper.standardParse;
-import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.endThisBlock;
+import static org.hiero.block.node.stream.publisher.PublishApiUtility.endThisBlock;
 
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.pbj.runtime.ParseException;

--- a/tools-and-tests/tools/build.gradle.kts
+++ b/tools-and-tests/tools/build.gradle.kts
@@ -47,6 +47,7 @@ mainModuleInfo {
 
 testModuleInfo {
     requires("com.google.cloud.nio")
+    requires("org.assertj.core")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
 }

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/commands/days/model/TarZstdDayReaderUsingExecTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/commands/days/model/TarZstdDayReaderUsingExecTest.java
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.tools.commands.days.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -88,15 +90,14 @@ public class TarZstdDayReaderUsingExecTest {
     }
 
     /**
-     * A non-trailing record file missing its signature is wrapped with 0 signature files and a
-     * warning rather than throwing — .rcd_sig files may legitimately be absent when the record
-     * source (e.g. Solo's MinIO) does not store them, and TSS-signed blocks do not need RSA sigs.
-     * All records (including the sig-less one) must be returned so downstream callers can decide
-     * how to handle 0-sig blocks.
+     * A non-trailing record file missing its signature is _not_ wrapped with 0 signature files and a
+     * warning rather than throwing — .rcd_sig files must not be absent when the record
+     * source (e.g. Solo's MinIO) does not store them, WRBs are not TSS-signed blocks.
+     * All _valid_ records (excluding the sig-less one) must be returned.
      */
     @Test
-    public void streamTarZstd_middleRecordMissingSignature_includesRecordWithNoSigs(@TempDir Path tempDir)
-            throws Exception {
+    public void streamTarZstd_middleRecordMissingSignature_excludesRecordWithNoSigs(@TempDir Path tempDir)
+            throws IOException, InterruptedException {
         assumeTrue(isAvailable("tar"), "Skipping test: tar not available");
         assumeTrue(isAvailable("zstd"), "Skipping test: zstd not available");
 
@@ -112,14 +113,15 @@ public class TarZstdDayReaderUsingExecTest {
             }
         }
 
+        assertThat(Files.list(dayDir).count()).isGreaterThanOrEqualTo(recordCount);
         final Path archive = buildFlatTarZstd(dayDir, tempDir.resolve("2026-08-03.tar.zstd"));
 
         try (var stream = TarZstdDayReaderUsingExec.streamTarZstd(archive)) {
             final List<UnparsedRecordBlock> blocks = stream.toList();
             assertEquals(
-                    recordCount,
+                    recordCount - 1,
                     blocks.size(),
-                    "streamTarZstd should include all records even when a non-trailing one has no sig file");
+                    "streamTarZstd should include all records except when the record has no sig file");
         }
     }
 
@@ -128,7 +130,7 @@ public class TarZstdDayReaderUsingExecTest {
      * {@code tar -cf - *.rcd *.rcd_sig | zstd -T0 > archive}, run from within the day directory so
      * entries are flat (no subdirectory prefix).
      */
-    private static Path buildFlatTarZstd(Path dayDir, Path archive) throws Exception {
+    private static Path buildFlatTarZstd(Path dayDir, Path archive) throws IOException, InterruptedException {
         final ProcessBuilder pb = new ProcessBuilder(
                 "sh", "-c", "tar -cf - *.rcd *.rcd_sig | zstd -T0 > '" + archive.toAbsolutePath() + "'");
         pb.directory(dayDir.toFile());


### PR DESCRIPTION
Fixes #2934.

## Summary

When a publisher wins `RESEND(N)` via the header path and then goes silent, block `N` stays in `activeResendBlocks` indefinitely — it's only cleared by `endOfBlock` / `blockIsEnding` / `handleVerification`, none of which fire for a publisher that just stops streaming. Because `correctForResendAndStreaming` clamps every ack at `activeResendBlocks.first() - 1`, one stuck resend wedges acknowledgement and persistence of every block at or after `N`. The existing `isResendingLive` exemption keeps the normal stall detector from firing (to avoid false positives during legitimate concurrent resends), so nothing else reclaims the slot.

## Fix

Add a second stall branch in `checkForStalledHandlers` that only applies to resending handlers. It reclaims the slot when the live tip advances past `resendStartReference + K` blocks after the resend was accepted.

- Record `lastPersistedBlockNumber` at the moment the resend slot is won (in `getActionForHeader`, alongside `activeResendBlocks.add(N)`).
- In `checkForStalledHandlers`, if `isResendingLive(candidateBlock)` is true and `completedBlockNumber > resendStartReference + K`, remove from `activeResendBlocks`, clear the reference, end the handler with `EndStream(TIMEOUT)`, and re-add the block to `blocksToResend` so another publisher can supply it.

Design choices worth flagging for review:

- **Reuses the existing `MaxFutureBlocksBeforeStalled` config knob** (same concept, same unit) rather than introducing a parallel `MaxBlocksBeforeResendStalled` key — one dial for operators to tune.
- **Stored on the manager** (parallel `ConcurrentMap<Long, Long>` keyed by block number) instead of on `PublisherHandler` — matches the existing pattern for `blocksToResend`, `activeResendBlocks`, `activeStreamHandlerByBlock`, and avoids adding a getter/coupling to Handler state. Semantically identical to a per-Handler field.
- **Reference map cleared at every site that removes from `activeResendBlocks`** (`endOfBlock`, `blockIsEnding`, `endAllHandlersAndClearTracking`). One-liner per site.
- **`Long.MAX_VALUE` default** in the getOrDefault so a race between reference-recording and stall-check can never fire a spurious reclaim.

## Tests

Three new tests under `StallDetectionTests` in `LiveStreamPublisherManagerTest`, one per acceptance criterion from the ticket:

- `testStuckResendHolderReceivesTimeout` — win RESEND(1), go silent, complete blocks 2 + 3 elsewhere → asserts stuck holder receives `EndStream(TIMEOUT)` and is shut down.
- `testReclaimedBlockOfferedToNextPublisher` — after the reclaim fires, the completing handler receives `ResendBlock(1)` on its next `endOfBlock` (so another publisher can supply the block).
- `testLegitResendNotReclaimed` — resend holder completes its block in time; live tip subsequently advances well past `K` → no `EndStream(TIMEOUT)` fires. Guards against regression of the `isResendingLive` false-positive protection.
