### PR TITLE
docs: add zero-downtime Block Node upgrade procedure (#3460)

### DIFF
--- a/docs/block-node/operations/resetting-and-upgrading-the-block-node.md
+++ b/docs/block-node/operations/resetting-and-upgrading-the-block-node.md
@@ -9,11 +9,11 @@ It assumes the Block Node was installed using the standard Helm chart, either vi
 Reset and upgrade are two distinct day-two operations that are often confused:
 
 - **Upgrade** changes the running Block Node version (image tag and Helm chart version) without discarding the local block storage or state. Pre-existing live and historic blocks remain on disk; the new version resumes from where the previous one left off.
-- **Reset** wipes the Block Node's local block data (both live blocks and historic blocks), clears the node application state details (e.g. rosters), and starts the node fresh. A reset is destructive: Consensus Nodes only keep a minimal recent buffer and cannot serve the wiped history, so the lost data must be backfilled from another Block Node that holds the relevant range (typically a Tier 1 archive node). For a mature network — Hedera mainnet, for example — that [backfill](../glossary.md#backfill) can take a very long time (potentially weeks), proportional to the total block history.
+- **Reset** wipes the Block Node's local block data (both live blocks and historic blocks), clears the node application state details (e.g. rosters), and starts the node fresh. A reset is destructive: Consensus Nodes only keep a minimal recent buffer and cannot serve the wiped history, so the lost data must be backfilled from another Block Node that holds the relevant range (typically a Tier 1 archive node). For a mature network - Hedera mainnet, for example - that [backfill](../glossary.md#backfill) can take a very long time (potentially weeks), proportional to the total block history.
 
 The two operations can be chained. **[Solo Provisioner](../glossary.md#solo-provisioner) is the recommended path**: `sudo solo-provisioner block node upgrade --with-reset` performs the reset and the upgrade in a single managed transaction (the `--with-reset` flag wipes the block node data directories; PVs and PVCs are preserved). For manual Taskfile-managed deployments, `task reset-upgrade` is the equivalent. Use the chained operation when you need to discard data and move forward; use a plain upgrade (`sudo solo-provisioner block node upgrade` or `task helm-upgrade`) for a clean version bump.
 
-> **Production Block Nodes should rarely, if ever, be reset under normal circumstances.** Treat reset as a recovery procedure for corruption, version-incompatibility, or network changes — not as routine maintenance. For high-value Block Nodes, maintain an offline backup of the live and archive PVC contents (updated daily where possible) so a corrupted node can be restored from snapshot instead of resyncing from another Block Node.
+> **Production Block Nodes should rarely, if ever, be reset under normal circumstances.** Treat reset as a recovery procedure for corruption, version-incompatibility, or network changes - not as routine maintenance. For high-value Block Nodes, maintain an offline backup of the live and archive PVC contents (updated daily where possible) so a corrupted node can be restored from snapshot instead of resyncing from another Block Node.
 
 ## Prerequisites
 
@@ -50,9 +50,21 @@ Reset the Block Node only when there is a concrete reason to discard local data.
 - **Recovery from a bad version in dev or test environments** - rolling back from a development build that wrote incompatible data to disk. In `testnet` or `mainnet`, encountering this would represent a major process failure upstream and should not occur under normal release management.
 - **Cleaning a dev or test deployment** before reusing the cluster for a fresh integration run.
 
-**Why it matters:** Reset is destructive. The Block Node wipes its live and historic block stores on disk and restarts; the pod will report an empty range (`firstAvailableBlock = lastAvailableBlock = uint64_max`) and must be backfilled from another Block Node that holds the relevant history (Consensus Nodes cannot supply it — they only retain a minimal recent buffer). Mirror Nodes pointed at the reset Block Node will see `NOT_AVAILABLE` until enough blocks have been backfilled to satisfy their `start_block_number`. On a mature network, full backfill can take days or weeks.
+**Why it matters:** Reset is destructive. The Block Node wipes its live and historic block stores on disk and restarts; the pod will report an empty range (`firstAvailableBlock = lastAvailableBlock = uint64_max`) and must be backfilled from another Block Node that holds the relevant history (Consensus Nodes cannot supply it - they only retain a minimal recent buffer). Mirror Nodes pointed at the reset Block Node will see `NOT_AVAILABLE` until enough blocks have been backfilled to satisfy their `start_block_number`. On a mature network, full backfill can take days or weeks.
 
 > **Caution:** Reset cannot be undone from inside the Block Node. If you need a recoverable snapshot of the data before resetting, copy the contents of the live and archive PVCs to off-cluster storage first.
+
+## Zero-downtime upgrade
+
+If a secondary Block Node is available and the CN's `block-nodes.json` lists it as a lower-priority
+fallback, the CN fails over to it automatically during the pod restart - no blocks are lost and no
+manual re-pointing is needed. See [Zero-Downtime Block Node Upgrade](./zero-downtime-upgrade.md)
+for the full procedure.
+
+Without a secondary, the standard upgrade below causes a brief ingestion gap (typically 1-2 minutes).
+Schedule it during a low-traffic period.
+
+---
 
 ## Upgrading the Block Node
 
@@ -144,7 +156,7 @@ curl -s "http://$BLOCK_NODE_HOST:16007/metrics" | grep blocknode_subscriber
 
 The auto-recovery behaviour for a failed mid-upgrade transaction depends on how the upgrade was invoked:
 
-- **Solo Provisioner-managed upgrades** are invoked with Helm's `--atomic` flag, so Helm itself reverts a failed transaction in place. The Provisioner additionally exposes `--rollback-on-error`, which unwinds any completed workflow steps in reverse — including downgrading the chart back to the previously installed version and removing PV/PVCs that the failed migration just created. No manual intervention is required.
+- **Solo Provisioner-managed upgrades** are invoked with Helm's `--atomic` flag, so Helm itself reverts a failed transaction in place. The Provisioner additionally exposes `--rollback-on-error`, which unwinds any completed workflow steps in reverse - including downgrading the chart back to the previously installed version and removing PV/PVCs that the failed migration just created. No manual intervention is required.
 - **`task helm-upgrade` does not pass `--atomic`.** If `helm upgrade` fails partway, the release can be left in a partially applied state. Investigate with `helm status "$RELEASE" -n "$NAMESPACE"`, then either run `helm rollback` to the previous revision (subject to the Path B caveats below) or re-run `task helm-upgrade` after correcting the underlying issue.
 
 If the upgrade returned cleanly but the new version turned out to be unhealthy in steady state, follow the path below that matches your deployment.
@@ -177,7 +189,7 @@ helm rollback "$RELEASE" <previous-revision> -n "$NAMESPACE"
 
 The Helm release manifest reverts to the named revision. The PVCs are untouched, so existing block data remains available to the rolled-back pod.
 
-> **Caveat - migrations are forward-only.** `helm rollback` reverts the Helm release manifest only. Side effects that the higher version introduced — new PVCs, modified StatefulSet shape, ConfigMap changes — are not reversed. If the upgrade between the two revisions crossed a migration boundary, the rolled-back deployment may end up inconsistent (chart says version N, the disk and resource layout say version N+1). In that case, treat the situation as a full reset: `task clear-release` followed by `task helm-release` with `VERSION` set to the previous chart version. This drops block data, so confirm that's acceptable before proceeding.
+> **Caveat - migrations are forward-only.** `helm rollback` reverts the Helm release manifest only. Side effects that the higher version introduced - new PVCs, modified StatefulSet shape, ConfigMap changes - are not reversed. If the upgrade between the two revisions crossed a migration boundary, the rolled-back deployment may end up inconsistent (chart says version N, the disk and resource layout say version N+1). In that case, treat the situation as a full reset: `task clear-release` followed by `task helm-release` with `VERSION` set to the previous chart version. This drops block data, so confirm that's acceptable before proceeding.
 
 ## Resetting the Block Node
 
@@ -238,7 +250,7 @@ grpcurl -plaintext -emit-defaults \
 
 ### Path A: Solo Provisioner-managed deployments
 
-`sudo solo-provisioner block node uninstall` removes the StatefulSet but leaves PVs and PVCs intact — block data is preserved on disk. Note that `reconfigure --with-reset` is an exception to this rule: it wipes data inside volumes and also deletes the PVs and PVCs. If you need to remove PVs and PVCs without a reconfigure, the only supported path is a full cluster teardown:
+`sudo solo-provisioner block node uninstall` removes the StatefulSet but leaves PVs and PVCs intact - block data is preserved on disk. Note that `reconfigure --with-reset` is an exception to this rule: it wipes data inside volumes and also deletes the PVs and PVCs. If you need to remove PVs and PVCs without a reconfigure, the only supported path is a full cluster teardown:
 
 ```bash
 sudo solo-provisioner kube cluster uninstall
@@ -248,7 +260,7 @@ sudo solo-provisioner kube cluster uninstall
 
 ### Path B: Manual Taskfile-managed deployments
 
-If you need to remove the Block Node entirely — PVCs, PVs, namespace, the lot - use:
+If you need to remove the Block Node entirely - PVCs, PVs, namespace, the lot - use:
 
 ```bash
 task clear-release
@@ -268,8 +280,8 @@ This runs `helm uninstall $RELEASE -n $NAMESPACE`, deletes the live, logging, an
 | `kubectl exec` inside `reset-file-store` fails with `error: unable to upgrade connection`                                                                                                          | The pod is restarting or not ready when the task runs.                                            | Wait until the pod is `Running` and ready, then re-run `task reset-file-store`.                                                                                                                                               |
 | `task reset-upgrade` succeeded but Mirror Nodes still see `NOT_AVAILABLE`                                                                                                                          | Expected - the reset Block Node has no blocks yet.                                                | Wait for ingestion or backfill to populate the block range. Mirror Nodes will reconnect automatically once `start_block_number` is within the available range.                                                                |
 | `helm rollback` fails with `release: not found`                                                                                                                                                    | Helm history was pruned, or the rollback target revision does not exist.                          | List available revisions with `helm history "$RELEASE" -n "$NAMESPACE"`. If no eligible target remains, redeploy by setting `VERSION` to the previous chart version and running `task helm-upgrade`.                          |
-| `solo-provisioner block node upgrade --chart-version <lower>` returns `block node chart version cannot be downgraded from X to Y`                                                                  | Expected — the Provisioner rejects in-place downgrades.                                           | Use the supported uninstall + reinstall path from [Step 5 Path A](#path-a-solo-provisioner-managed-deployments).                                                                                                              |
-| After a direct `helm rollback` on a Solo Provisioner-managed release, the next `solo-provisioner` command refuses a legitimate upgrade, skips a migration, or renders values for the wrong version | Provisioner state file is out of sync with the cluster — direct `helm` calls do not update it.    | Reconcile manually: re-align the Provisioner's recorded chart version with the actual cluster state, or follow the uninstall + reinstall path from [Step 5 Path A](#path-a-solo-provisioner-managed-deployments).             |
+| `solo-provisioner block node upgrade --chart-version <lower>` returns `block node chart version cannot be downgraded from X to Y`                                                                  | Expected - the Provisioner rejects in-place downgrades.                                           | Use the supported uninstall + reinstall path from [Step 5 Path A](#path-a-solo-provisioner-managed-deployments).                                                                                                              |
+| After a direct `helm rollback` on a Solo Provisioner-managed release, the next `solo-provisioner` command refuses a legitimate upgrade, skips a migration, or renders values for the wrong version | Provisioner state file is out of sync with the cluster - direct `helm` calls do not update it.    | Reconcile manually: re-align the Provisioner's recorded chart version with the actual cluster state, or follow the uninstall + reinstall path from [Step 5 Path A](#path-a-solo-provisioner-managed-deployments).             |
 | After `helm rollback` on a manual deployment, the pod fails to start or the StatefulSet appears to have extra/missing PVCs compared to the rolled-back chart                                       | Forward-only migrations were applied during the upgrade and were not reversed by `helm rollback`. | Treat as a full reset: `task clear-release` then `task helm-release` with the previous `VERSION`. Confirm block data loss is acceptable first.                                                                                |
 | Pod is `Running` but `serverStatus` returns `connection refused` from outside the cluster                                                                                                          | Service or LoadBalancer was recreated with a different external address.                          | `kubectl get svc -n "$NAMESPACE"` - confirm the external IP / port mapping; update downstream consumers if it changed.                                                                                                        |
 | After a cross-network reset, the Block Node refuses publisher connections from the new network's Consensus Nodes                                                                                   | Stale address-book or network configuration in the new chart values.                              | Confirm the Helm values for the new network are applied (`--values values-override/<new-network>.yaml`). Run a `task helm-upgrade` after correcting the values.                                                               |

--- a/docs/block-node/operations/zero-downtime-upgrade.md
+++ b/docs/block-node/operations/zero-downtime-upgrade.md
@@ -1,0 +1,193 @@
+# Zero-Downtime Block Node Upgrade
+
+A standard upgrade restarts the Block Node pod, which briefly interrupts block ingestion and
+subscriber streams for the duration of the pod restart (typically 1-2 minutes). If a secondary
+Block Node is available and the Consensus Node is configured to fail over to it, blocks continue
+flowing during the upgrade window - no blocks are missed and the Block Node's block range has no gap.
+
+Zero-downtime upgrade does not use a different upgrade command. The difference is entirely in the
+CN configuration: `block-nodes.json` lists the secondary as a lower-priority fallback, and the CN
+switches to it automatically when the primary pod goes down. No manual re-pointing is needed.
+
+## Prerequisite - secondary Block Node and priority failover
+
+You need two things in place before starting:
+
+1. A secondary Block Node that is running and reachable by the CN on its streaming (publish) port.
+2. The CN's `block-nodes.json` must include both Block Nodes with distinct `priority` values:
+
+```json
+{
+  "nodes": [
+    {
+      "address": "bn-primary.example.com",
+      "streamingPort": 40984,
+      "servicePort": 40982,
+      "priority": 0
+    },
+    {
+      "address": "bn-secondary.example.com",
+      "streamingPort": 40984,
+      "servicePort": 40982,
+      "priority": 1
+    }
+  ]
+}
+```
+
+`priority: 0` is highest priority - the CN streams to this node by default. `priority: 1` is the
+fallback. When the primary pod goes down, the CN detects the connection drop and switches to the
+secondary automatically. When the primary returns, the CN switches back.
+
+> **Port note:** `streamingPort` and `servicePort` depend on your deployment profile. LFH-profile:
+> `streamingPort 40984`, `servicePort 40982`. Base-chart: both `40840`. Confirm your values in your
+> Block Node's Helm values before adding the entry.
+
+`block-nodes.json` supports live reload - no CN restart is needed to add or change entries.
+
+See [Configuring a Consensus Node to Stream Blocks to a Block Node](./consensus-node-to-block-node-configuration.md)
+for the full `block-nodes.json` schema and live-reload details.
+
+## Step 1 - Record baseline on both Block Nodes
+
+Set these shell variables to your deployment values before running any commands in this procedure:
+
+```bash
+export PRIMARY_BN_HOST="<primary-BN-address>"     # e.g. bn-primary.example.com
+export SECONDARY_BN_HOST="<secondary-BN-address>" # e.g. bn-secondary.example.com
+export NAMESPACE="block-node"                      # your deployment namespace
+export SERVICEPORT=40982                           # servicePort from block-nodes.json (LFH: 40982, base-chart: 40840)
+```
+
+Capture `firstAvailableBlock` and `lastAvailableBlock` on both the primary and the secondary.
+These commands require `grpcurl` and the Block Node protobuf bundle extracted to `~/bn-proto` -
+see [Block Node gRPC API Quickstart](../api-quickstart.md) for download instructions.
+
+```bash
+grpcurl -plaintext -emit-defaults \
+  -import-path ~/bn-proto \
+  -proto block-node/api/node_service.proto \
+  -d '{}' \
+  "$PRIMARY_BN_HOST:$SERVICEPORT" \
+  org.hiero.block.api.BlockNodeService/serverStatus
+
+grpcurl -plaintext -emit-defaults \
+  -import-path ~/bn-proto \
+  -proto block-node/api/node_service.proto \
+  -d '{}' \
+  "$SECONDARY_BN_HOST:$SERVICEPORT" \
+  org.hiero.block.api.BlockNodeService/serverStatus
+```
+
+Record `lastAvailableBlock` on the primary - call this **N**. After the upgrade the primary must
+backfill from N+1 up to the block where the CN resumed streaming to it.
+
+Also verify the secondary is actively ingesting before proceeding. Run this command twice, 10
+seconds apart, and confirm the value increases:
+
+```bash
+curl -s "http://$SECONDARY_BN_HOST:16007/metrics" | grep blocknode_publisher_block_items_received_total
+```
+
+If the value is zero or not increasing, the CN is not streaming to the secondary - do not proceed
+until the failover path is confirmed working.
+
+## Step 2 - Upgrade the primary
+
+Run the standard upgrade on the primary. The CN switches to the secondary automatically when the
+primary pod terminates.
+
+**Solo Provisioner (mainnet / production):**
+
+```bash
+sudo solo-provisioner block node upgrade \
+  --profile=mainnet \
+  --values=<UPDATED_VALUES_FILE> \
+  --no-reuse-values \
+  --chart-version=<X.Y.Z>
+```
+
+**Taskfile (manual deployment):**
+
+```bash
+task helm-upgrade
+```
+
+Monitor the pod restart:
+
+```bash
+kubectl get pods -n "$NAMESPACE" -w
+```
+
+While the primary pod is terminating and restarting, the secondary receives all CN-published blocks.
+
+## Step 3 - Verify recovery
+
+**Confirm the primary is ingesting blocks again:**
+
+Run this command twice, 10 seconds apart, and confirm the value increases:
+
+```bash
+curl -s "http://$PRIMARY_BN_HOST:16007/metrics" | grep blocknode_publisher_block_items_received_total
+```
+
+If the value is not increasing after the pod reaches Running, the CN has
+not yet reconnected to the primary. The CN reconnects automatically: after the primary's connection
+cooldown expires, the CN's connection monitor (which runs every 200 ms) detects the primary as
+available and switches back. This typically resolves within seconds to a minute of the pod becoming
+Ready. If the metric is still not incrementing after a few minutes, temporarily remove the secondary
+entry from `block-nodes.json` to force the CN to connect to the primary, confirm
+`blocknode_publisher_block_items_received_total` on the primary starts incrementing, then restore
+the secondary entry.
+
+**Monitor backfill of the upgrade-window gap:**
+
+During the upgrade window the primary missed blocks N+1 through M (the blocks the secondary
+received while the primary was restarting). The backfill plugin closes this gap automatically - but
+only if `backfill.blockNodeSourcesPath` (`BACKFILL_BLOCK_NODE_SOURCES_PATH` env var) is set to a
+file listing the secondary (or another peer that holds the upgrade-window blocks). The default value
+is empty, which means backfill is disabled unless explicitly configured.
+
+```bash
+curl -s "http://$PRIMARY_BN_HOST:16007/metrics" | grep -E "backfill_pending_blocks|backfill_blocks_backfilled"
+```
+
+- `blocknode_backfill_pending_blocks` declining to `0` and `blocknode_backfill_blocks_backfilled_total` increasing confirms the gap is closing.
+- If both remain at `0` with no movement, the backfill source is not configured. Add the secondary as a source entry under `blockNode.backfill.sources` in the primary's Helm values and redeploy - the chart creates the sources file and sets `BACKFILL_BLOCK_NODE_SOURCES_PATH` automatically. If backfill is not configured, the upgrade-window gap will not be automatically filled.
+
+**Re-run `serverStatus` on the primary:**
+
+```bash
+grpcurl -plaintext -emit-defaults \
+  -import-path ~/bn-proto \
+  -proto block-node/api/node_service.proto \
+  -d '{}' \
+  "$PRIMARY_BN_HOST:$SERVICEPORT" \
+  org.hiero.block.api.BlockNodeService/serverStatus
+```
+
+- `firstAvailableBlock` must equal the pre-upgrade value - no older blocks were lost.
+- `lastAvailableBlock` must equal or exceed N and must continue advancing.
+
+**Verify subscriber reconnection:**
+
+```bash
+curl -s "http://$PRIMARY_BN_HOST:16007/metrics" | grep blocknode_subscriber_open_connections
+```
+
+`blocknode_subscriber_open_connections` should return to its pre-upgrade level as Mirror Nodes
+re-establish their subscribe streams.
+
+## If there is no secondary Block Node
+
+Without a secondary, there is no failover path. Blocks produced by the network while the primary
+pod is restarting are not captured, leaving a gap in the primary's block range. Schedule the
+upgrade during a low-traffic period and use the standard upgrade procedure in
+[Resetting and Upgrading the Block Node](./resetting-and-upgrading-the-block-node.md#upgrading-the-block-node).
+
+## Related
+
+- [Resetting and Upgrading the Block Node](./resetting-and-upgrading-the-block-node.md)
+- [Configuring a Consensus Node to Stream Blocks to a Block Node](./consensus-node-to-block-node-configuration.md)
+- [Block Node gRPC API Quickstart](../api-quickstart.md)
+- [Metrics Reference](../metrics.md)


### PR DESCRIPTION
## Reviewer Notes

Adds a standalone zero-downtime-upgrade.md covering the CN priority-based failover mechanism, pre-upgrade baseline capture, upgrade execution, and post-upgrade verification. 

## Related Issue(s)
Closes #3460