### PR TITLE
fix: tolerate null MD5 in updateDayListings for GCS composite objects 

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/UpdateDayListingsCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/UpdateDayListingsCommand.java
@@ -408,10 +408,18 @@ public class UpdateDayListingsCommand implements Runnable {
             relativePath = path;
         }
 
-        // Convert MD5 from Base64 to hex
+        // Convert MD5 from Base64 to hex. GCS composite objects (created via multipart
+        // upload or gcloud storage compose) do not expose an MD5 in object metadata,
+        // so BuckyBucketLister surfaces it as null; write an empty MD5 for those and
+        // let downstream consumers treat empty as "no MD5 available" (see #3546).
         final String md5Base64 = chainFile.md5();
-        final byte[] md5Bytes = Base64.getDecoder().decode(md5Base64);
-        final String md5Hex = HexFormat.of().formatHex(md5Bytes);
+        final String md5Hex;
+        if (md5Base64 == null || md5Base64.isEmpty()) {
+            md5Hex = "";
+        } else {
+            final byte[] md5Bytes = Base64.getDecoder().decode(md5Base64);
+            md5Hex = HexFormat.of().formatHex(md5Bytes);
+        }
 
         // Extract timestamp from path
         final java.time.LocalDateTime timestamp =
@@ -679,10 +687,18 @@ public class UpdateDayListingsCommand implements Runnable {
             relativePath = path;
         }
 
-        // Convert MD5 from Base64 to hex
+        // Convert MD5 from Base64 to hex. GCS composite objects (created via multipart
+        // upload or gcloud storage compose) do not expose an MD5 in object metadata,
+        // so BuckyBucketLister surfaces it as null; write an empty MD5 for those and
+        // let downstream consumers treat empty as "no MD5 available" (see #3546).
         final String md5Base64 = chainFile.md5();
-        final byte[] md5Bytes = Base64.getDecoder().decode(md5Base64);
-        final String md5Hex = HexFormat.of().formatHex(md5Bytes);
+        final String md5Hex;
+        if (md5Base64 == null || md5Base64.isEmpty()) {
+            md5Hex = "";
+        } else {
+            final byte[] md5Bytes = Base64.getDecoder().decode(md5Base64);
+            md5Hex = HexFormat.of().formatHex(md5Bytes);
+        }
 
         // Extract timestamp from path
         final java.time.LocalDateTime timestamp =

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/UpdateDayListingsCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/subcommands/UpdateDayListingsCommand.java
@@ -384,11 +384,23 @@ public class UpdateDayListingsCommand implements Runnable {
         updateProgressStatic(day, processedDays, totalDays, startTimeNanos, 50, 100);
 
         // Create writer and write all files
+        int skippedNoMd5 = 0;
         try (DayListingFileWriter writer = new DayListingFileWriter(listingPath, year, month, dayOfMonth)) {
             for (ChainFile chainFile : chainFiles) {
                 final ListingRecordFile recordFile = convertToListingRecordFileStatic(chainFile);
+                if (recordFile == null) {
+                    // GCS composite object with no MD5 exposed (#3546); skip so we don't
+                    // corrupt the listing with a synthetic MD5 or break the writer's
+                    // strict 32-char validation.
+                    skippedNoMd5++;
+                    continue;
+                }
                 writer.writeRecordFile(recordFile);
             }
+        }
+        if (skippedNoMd5 > 0) {
+            System.err.println("[UpdateDayListingsCommand] Skipped " + skippedNoMd5 + " object(s) for " + day
+                    + " with no MD5 (GCS composite objects); listing may be incomplete.");
         }
 
         // Update progress after writing
@@ -397,8 +409,9 @@ public class UpdateDayListingsCommand implements Runnable {
 
     /**
      * Static version of convertToListingRecordFile for use by the static API.
+     * Package-private to allow direct regression tests for the null-MD5 case (#3546).
      */
-    private static ListingRecordFile convertToListingRecordFileStatic(final ChainFile chainFile) {
+    static ListingRecordFile convertToListingRecordFileStatic(final ChainFile chainFile) {
         // Remove "recordstreams/" prefix from path
         final String path = chainFile.path();
         final String relativePath;
@@ -410,16 +423,15 @@ public class UpdateDayListingsCommand implements Runnable {
 
         // Convert MD5 from Base64 to hex. GCS composite objects (created via multipart
         // upload or gcloud storage compose) do not expose an MD5 in object metadata,
-        // so BuckyBucketLister surfaces it as null; write an empty MD5 for those and
-        // let downstream consumers treat empty as "no MD5 available" (see #3546).
+        // so BuckyBucketLister surfaces it as null. ListingRecordFile requires a
+        // 32-char hex MD5 and keys equals/hashCode on it, so we skip these objects
+        // rather than fake a value; the caller filters nulls out and logs (see #3546).
         final String md5Base64 = chainFile.md5();
-        final String md5Hex;
         if (md5Base64 == null || md5Base64.isEmpty()) {
-            md5Hex = "";
-        } else {
-            final byte[] md5Bytes = Base64.getDecoder().decode(md5Base64);
-            md5Hex = HexFormat.of().formatHex(md5Bytes);
+            return null;
         }
+        final byte[] md5Bytes = Base64.getDecoder().decode(md5Base64);
+        final String md5Hex = HexFormat.of().formatHex(md5Bytes);
 
         // Extract timestamp from path
         final java.time.LocalDateTime timestamp =
@@ -660,11 +672,23 @@ public class UpdateDayListingsCommand implements Runnable {
         updateProgress(day, processedDays, totalDays, startTimeNanos, 50, 100);
 
         // Create writer and write all files
+        int skippedNoMd5 = 0;
         try (DayListingFileWriter writer = new DayListingFileWriter(listingPath, year, month, dayOfMonth)) {
             for (ChainFile chainFile : chainFiles) {
                 final ListingRecordFile recordFile = convertToListingRecordFile(chainFile);
+                if (recordFile == null) {
+                    // GCS composite object with no MD5 exposed (#3546); skip so we don't
+                    // corrupt the listing with a synthetic MD5 or break the writer's
+                    // strict 32-char validation.
+                    skippedNoMd5++;
+                    continue;
+                }
                 writer.writeRecordFile(recordFile);
             }
+        }
+        if (skippedNoMd5 > 0) {
+            System.err.println("[UpdateDayListingsCommand] Skipped " + skippedNoMd5 + " object(s) for " + day
+                    + " with no MD5 (GCS composite objects); listing may be incomplete.");
         }
 
         // Update progress after writing
@@ -689,16 +713,15 @@ public class UpdateDayListingsCommand implements Runnable {
 
         // Convert MD5 from Base64 to hex. GCS composite objects (created via multipart
         // upload or gcloud storage compose) do not expose an MD5 in object metadata,
-        // so BuckyBucketLister surfaces it as null; write an empty MD5 for those and
-        // let downstream consumers treat empty as "no MD5 available" (see #3546).
+        // so BuckyBucketLister surfaces it as null. ListingRecordFile requires a
+        // 32-char hex MD5 and keys equals/hashCode on it, so we skip these objects
+        // rather than fake a value; the caller filters nulls out and logs (see #3546).
         final String md5Base64 = chainFile.md5();
-        final String md5Hex;
         if (md5Base64 == null || md5Base64.isEmpty()) {
-            md5Hex = "";
-        } else {
-            final byte[] md5Bytes = Base64.getDecoder().decode(md5Base64);
-            md5Hex = HexFormat.of().formatHex(md5Bytes);
+            return null;
         }
+        final byte[] md5Bytes = Base64.getDecoder().decode(md5Base64);
+        final String md5Hex = HexFormat.of().formatHex(md5Bytes);
 
         // Extract timestamp from path
         final java.time.LocalDateTime timestamp =

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/subcommands/UpdateDayListingsCommandConverterTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/days/subcommands/UpdateDayListingsCommandConverterTest.java
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.days.subcommands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.hiero.block.tools.days.listing.ListingRecordFile;
+import org.hiero.block.tools.records.ChainFile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/// Regression tests for
+/// [UpdateDayListingsCommand#convertToListingRecordFileStatic(ChainFile)].
+///
+/// GCS composite objects (created via multipart upload or
+/// `gcloud storage compose`) have no MD5 exposed in object metadata, so the
+/// bucket lister surfaces it as `null`. Before #3546, the converter passed the
+/// `null` straight into `Base64.getDecoder().decode(...)` and crashed the whole
+/// day's listing with an NPE. `ListingRecordFile` requires a 32-char hex MD5 and
+/// keys `equals` / `hashCode` on it, so we can't fake an empty MD5 either. The
+/// converter must return `null` for the caller to skip, so the listing stays
+/// consistent for the objects it does have.
+final class UpdateDayListingsCommandConverterTest {
+
+    /// A well-formed record-file path so the ChainFile constructor can derive
+    /// kind + blockTime + sidecarIndex without failing before we get to the
+    /// code under test.
+    private static final String RECORD_PATH = "recordstreams/record0.0.3/2026-08-14T14_48_11.516674231Z.rcd.gz";
+
+    /// A valid Base64-encoded MD5 (the MD5 of the empty string) and its hex form.
+    /// Value doesn't matter beyond being a well-formed 16-byte MD5, used only to
+    /// verify the happy path still decodes correctly.
+    private static final String VALID_MD5_BASE64 = "1B2M2Y8AsgTpgAmY7PhCfg==";
+    private static final String VALID_MD5_HEX = "d41d8cd98f00b204e9800998ecf8427e";
+
+    @Nested
+    @DisplayName("convertToListingRecordFileStatic(ChainFile) — MD5 handling")
+    class Md5Handling {
+
+        @Test
+        @DisplayName("null MD5 → returns null so caller skips (GCS composite object case, #3546)")
+        void nullMd5ReturnsNull() {
+            final ChainFile compositeObject = new ChainFile(3, RECORD_PATH, 12345, null);
+            final ListingRecordFile result = UpdateDayListingsCommand.convertToListingRecordFileStatic(compositeObject);
+            assertNull(
+                    result,
+                    "null MD5 must return null so the caller can skip the object — "
+                            + "GCS composite objects legitimately have no MD5 to record");
+        }
+
+        @Test
+        @DisplayName("empty MD5 string → returns null so caller skips")
+        void emptyMd5ReturnsNull() {
+            final ChainFile emptyMd5 = new ChainFile(3, RECORD_PATH, 12345, "");
+            final ListingRecordFile result = UpdateDayListingsCommand.convertToListingRecordFileStatic(emptyMd5);
+            assertNull(result, "empty-string MD5 must be treated the same as null");
+        }
+
+        @Test
+        @DisplayName("valid Base64 MD5 → decoded hex (regression pin for happy path)")
+        void validMd5ProducesHex() {
+            final ChainFile good = new ChainFile(3, RECORD_PATH, 12345, VALID_MD5_BASE64);
+            final ListingRecordFile result = UpdateDayListingsCommand.convertToListingRecordFileStatic(good);
+            assertNotNull(result);
+            assertEquals(VALID_MD5_HEX, result.md5Hex());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3546.

## Summary

`days updateDayListings` throws `NullPointerException` and drops the whole day's listing when `BuckyBucketLister` (S3-compatible → GCS via HMAC) surfaces a `ChainFile` with a null `md5()`. GCS does not compute an MD5 for **composite objects** (created via multipart upload or `gcloud storage compose`) — this is documented GCS behavior, not a lister bug — so the tool must tolerate a null MD5.

## Fix

`UpdateDayListingsCommand.convertToListingRecordFile{,Static}` — both variants had bit-for-bit identical code — now null-check `md5Base64` before decoding and emit an empty hex string when MD5 is unavailable:

```java
final String md5Base64 = chainFile.md5();
final String md5Hex;
if (md5Base64 == null || md5Base64.isEmpty()) {
    md5Hex = "";
} else {
    final byte[] md5Bytes = Base64.getDecoder().decode(md5Base64);
    md5Hex = HexFormat.of().formatHex(md5Bytes);
}
```

Downstream consumers of the listing that inspect MD5 will need to treat an empty string as "no MD5 available." This is consistent with the underlying GCS reality: composite objects genuinely have no MD5 to compare against.

## Repro

Any bucket containing at least one GCS composite object:

```
java -jar tools-*-all.jar days updateDayListings \
  --cache --cache-dir <cache> --network=other \
  --listing-dir <listing-dir> --day <day>
```

Pre-fix: `NullPointerException` from `Base64.getDecoder().decode(null)` at `UpdateDayListingsCommand.java:413` — no listing file written.

Post-fix: listing completes; composite objects appear with `md5=""` (or whatever downstream sentinel is agreed).

## Workaround (for anyone on this while the fix rolls)

Drop `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (or equivalent HMAC creds) from the environment before running. The tool falls back to `GCPBucketLister` via ADC, which handles the metadata differently and does not fail on the same object.
