### PR TITLE
fix(solo-e2e): stop wrap output from tripping EAGAIN and stabilize peer-fed block node assertions

### DIFF
--- a/tools-and-tests/scripts/network-topology-tool/README.md
+++ b/tools-and-tests/scripts/network-topology-tool/README.md
@@ -60,6 +60,7 @@ block_nodes:
     address: block-node-1
     port: 40840
     greedy: false  # Enable greedy backfill mode (defaults to false)
+    backfill_scan_interval: 15000  # Backfill scan interval in ms (defaults to 15000)
 
 consensus_nodes:
   node1:
@@ -126,6 +127,7 @@ blockNode:
   config:
     BACKFILL_BLOCK_NODE_SOURCES_PATH: "/opt/hiero/block-node/backfill/block-node-sources.json"
     BACKFILL_GREEDY: "false"  # Value from topology's greedy field
+    BACKFILL_SCAN_INTERVAL: "15000"  # Value from topology's backfill_scan_interval field
   backfill:
     path: "/opt/hiero/block-node/backfill"
     filename: "block-node-sources.json"

--- a/tools-and-tests/scripts/network-topology-tool/generate-chart-values-config-overlays.sh
+++ b/tools-and-tests/scripts/network-topology-tool/generate-chart-values-config-overlays.sh
@@ -44,6 +44,12 @@ NAMESPACE="solo-network"
 OUTPUT_DIR=""  # Set after parsing topology file if not specified
 VERIFICATION_MODE="tss"  # "tss" (default) or "rsa-wrb" (WRB cutover Mirror Node config)
 
+# Backfill scan interval in ms for peered Block Nodes. The Block Node default is 60000, which is
+# longer than the window most test assertions allow for a peer-fed node to advance, so a node with
+# no publisher of its own looks stalled purely because the next scan has not fired yet. Override
+# per node with `block_nodes.<name>.backfill_scan_interval`.
+DEFAULT_BACKFILL_SCAN_INTERVAL=15000
+
 function fail {
     printf '%s\n' "$1" >&2
     exit "${2-1}"
@@ -190,6 +196,7 @@ function generate_bn_overlay {
   # Build backfill sources array (only when peers are configured)
   local sources=""
   local greedy_mode="false"
+  local scan_interval="${DEFAULT_BACKFILL_SCAN_INTERVAL}"
 
   if [[ "${peer_count}" -gt 0 ]]; then
     local peer_names
@@ -245,6 +252,7 @@ function generate_bn_overlay {
       done <<< "${peer_names}"
 
       greedy_mode=$(yq ".block_nodes[\"${bn_name}\"].greedy // false" "${TOPOLOGY_FILE}" 2>/dev/null)
+      scan_interval=$(yq ".block_nodes[\"${bn_name}\"].backfill_scan_interval // ${DEFAULT_BACKFILL_SCAN_INTERVAL}" "${TOPOLOGY_FILE}" 2>/dev/null)
     fi
   fi
 
@@ -269,6 +277,7 @@ function generate_bn_overlay {
       echo "  config:"
       echo "    BACKFILL_BLOCK_NODE_SOURCES_PATH: \"/opt/hiero/block-node/backfill/block-node-sources.json\""
       echo "    BACKFILL_GREEDY: \"${greedy_mode}\""
+      echo "    BACKFILL_SCAN_INTERVAL: \"${scan_interval}\""
       echo "  backfill:"
       echo "    path: \"/opt/hiero/block-node/backfill\""
       echo "    filename: \"block-node-sources.json\""

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-cli-wrap-and-compare.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-cli-wrap-and-compare.sh
@@ -44,6 +44,7 @@ LOCAL_CN_BLOCKS_DIR="${LOCAL_WORK_DIR}/cn-blocks"
 
 MIN_RECORD_FILES=5
 MAX_FILES_TO_EXTRACT=200  # Limit for testing - set to 0 for no limit
+WRAP_OUTPUT_EXCERPT_LINES=200
 
 function kctl {
     kubectl --context "${CONTEXT}" "$@"
@@ -703,6 +704,23 @@ function extract_from_cn {
     return 0
 }
 
+# Echo a bounded excerpt of a captured `blocks wrap` run.
+#
+# The wrap command emits one `[SIGNATURE DEBUG]` line per signature plus carriage-return
+# progress frames, so a full run is hundreds of KB. GitHub Actions gives the runner a
+# non-blocking stdout pipe: writing that much in one go returns EAGAIN part-way through,
+# which under `set -e` aborts the test with a truncated log and no real error. Keep the
+# full output on disk and print only the lines that carry signal.
+function print_wrap_output {
+    local wrap_log="$1"
+
+    log "Wrap output excerpt (full log: ${wrap_log}):"
+    tr '\r' '\n' < "${wrap_log}" \
+        | awk '{ gsub(/\033\[[0-9;]*[A-Za-z]/, ""); print }' \
+        | grep -vE '^\[SIGNATURE DEBUG\]|^\[[= ]*\] +[0-9]+\.[0-9]+%|^$' \
+        | tail -n "${WRAP_OUTPUT_EXCERPT_LINES}" || true
+}
+
 function do_wrap {
     log "Wrapping record files with WRB CLI..."
 
@@ -786,23 +804,23 @@ EOF
     # Using --skip-block-number-validation for Solo test network where blocks don't start from 0
     log "Running blocks wrap command on day archives..."
     local rc=0
-    local wrap_output
-    wrap_output=$(HIERO_NETWORK_CONFIG="${network_config_file}" java -jar "${jar}" blocks wrap \
+    local wrap_log="${LOCAL_WORK_DIR}/wrap-output.log"
+    HIERO_NETWORK_CONFIG="${network_config_file}" java -jar "${jar}" blocks wrap \
         --input-dir "${day_archives_dir}" \
         --output-dir "${LOCAL_WRAPPED_DIR}" \
         --blocktimes-file "${block_times_file}" \
         --day-blocks "${day_blocks_file}" \
         --network other \
-        --skip-block-number-validation 2>&1) || rc=$?
+        --skip-block-number-validation > "${wrap_log}" 2>&1 || rc=$?
 
-    echo "$wrap_output"
+    print_wrap_output "${wrap_log}"
 
     if [[ ${rc} -ne 0 ]]; then
         # Check if this is a block number mismatch error
-        if echo "$wrap_output" | grep -q "Block number mismatch.*computed blockNum 0 != record file block number"; then
+        if grep -q "Block number mismatch.*computed blockNum 0 != record file block number" "${wrap_log}"; then
             # Extract the actual starting block number from the error
             local actual_block_num
-            actual_block_num=$(echo "$wrap_output" | grep -oP "record file block number \K[0-9]+" | head -1)
+            actual_block_num=$(grep -oP "record file block number \K[0-9]+" "${wrap_log}" | head -1)
 
             if [[ -n "$actual_block_num" ]]; then
                 log "Block number mismatch detected. Actual starting block: ${actual_block_num}"
@@ -831,15 +849,16 @@ EOF
 
                 # Retry wrapping with corrected and padded metadata
                 log "Retrying wrap with padded metadata (blocks 0-$((actual_block_num-1)) padded, $((actual_block_num))-$((actual_block_num+199)) actual)..."
-                wrap_output=$(HIERO_NETWORK_CONFIG="${network_config_file}" java -jar "${jar}" blocks wrap \
+                rc=0
+                HIERO_NETWORK_CONFIG="${network_config_file}" java -jar "${jar}" blocks wrap \
                     --input-dir "${day_archives_dir}" \
                     --output-dir "${LOCAL_WRAPPED_DIR}" \
                     --blocktimes-file "${block_times_file}" \
                     --day-blocks "${day_blocks_file}" \
                     --network other \
-                    --skip-block-number-validation 2>&1) || rc=$?
+                    --skip-block-number-validation > "${wrap_log}" 2>&1 || rc=$?
 
-                echo "$wrap_output"
+                print_wrap_output "${wrap_log}"
 
                 if [[ ${rc} -ne 0 ]]; then
                     log "ERROR: Wrapping failed again after metadata correction with exit code ${rc}"

--- a/tools-and-tests/scripts/solo-e2e-test/tests/smoke-test.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/smoke-test.yaml
@@ -46,10 +46,13 @@ assertions:
     args:
       min_block: 0
 
+  # Topologies where a Block Node has no publisher of its own (fan-out-3cn-2bn) feed that node
+  # by peer backfill, which advances on a scan interval rather than continuously. The window has
+  # to outlast one interval or the node reads as stalled between scans.
   - id: all-blocks-increasing
     type: blocks-increasing
     description: "All Block Nodes are receiving new blocks"
     target: all
     args:
-      wait_seconds: 15
-      max_attempts: 2
+      wait_seconds: 20
+      max_attempts: 3


### PR DESCRIPTION
wrb-cli-wrap-and-compare.sh:
- Redirect `blocks wrap` output to ${LOCAL_WORK_DIR}/wrap-output.log instead of capturing it in a shell variable
- Add print_wrap_output to emit a bounded excerpt: strip ANSI escapes, drop [SIGNATURE DEBUG] lines and progress frames, tail the last 200 lines
- Read the block-number-mismatch retry trigger and the starting block number from the log file
- Reset rc to 0 before the retry wrap so a successful retry is no longer reported as a failure

generate-chart-values-config-overlays.sh:
- Emit BACKFILL_SCAN_INTERVAL in the Block Node overlay for every node with peers
- Default to 15000 ms via DEFAULT_BACKFILL_SCAN_INTERVAL, overridable per node with block_nodes.<name>.backfill_scan_interval

tests/smoke-test.yaml:
- Widen the all-blocks-increasing window from 15s x 2 to 20s x 3

network-topology-tool/README.md:
- Document backfill_scan_interval and the generated BACKFILL_SCAN_INTERVAL key

## Reviewer Notes

## Related Issue(s)
 Use keywords `Fix, Fixes, Fixed, Close, Closes, Closed, Resolve, Resolves, Resolved`
to connect an issue to be closed by this pull request.
