### PR TITLE
feat(stream-publisher): Enforce cumulative block-byte ceiling per multi-message publish stream

### DIFF
--- a/block-node/stream-publisher/src/main/java/module-info.java
+++ b/block-node/stream-publisher/src/main/java/module-info.java
@@ -11,10 +11,10 @@ module org.hiero.block.node.stream.publisher {
 
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.config.api;
+    requires transitive org.hiero.block.node.app.config;
     requires transitive org.hiero.block.node.spi;
     requires transitive org.hiero.block.protobuf.pbj;
     requires transitive org.hiero.metrics;
-    requires org.hiero.block.node.app.config;
     requires org.hiero.block.node.base;
     requires com.github.spotbugs.annotations;
 

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -107,9 +107,8 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     private final int maxBlocksBeforeStalled;
     private final long staleResendPruneBuffer;
     private final int duplicateBlockSkipWindow;
-    /// Maximum cumulative serialized size in bytes accepted for a single
-    /// block across all messages of a publish stream.
-    private final int maxTotalBlockBytes;
+    /// The server configuration, exposed to the handlers.
+    private final ServerConfig serverConfig;
     private final ScheduledExecutorService scheduledExecutor;
     private volatile ScheduledFuture<Boolean> publisherUnavailabilityTimeoutFuture;
     /// nanoTime of the last penalty-count reset (tumbling window).
@@ -173,8 +172,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         maxBlocksBeforeStalled = publisherConfig.MaxFutureBlocksBeforeStalled();
         staleResendPruneBuffer = publisherConfig.staleResendPruneBuffer();
         duplicateBlockSkipWindow = publisherConfig.duplicateBlockSkipWindow();
-        maxTotalBlockBytes =
-                serverContext.configuration().getConfigData(ServerConfig.class).maxMessageSizeBytes();
+        serverConfig = serverContext.configuration().getConfigData(ServerConfig.class);
         publisherUnavailabilityTimeoutFuture = schedulePublisherUnavailabilityTimeout();
         blockProofs = new ConcurrentSkipListMap<>();
         endBlocksReceived = new ConcurrentSkipListSet<>();
@@ -404,8 +402,8 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     }
 
     @Override
-    public int maxTotalBlockBytes() {
-        return maxTotalBlockBytes;
+    public ServerConfig serverConfiguration() {
+        return serverConfig;
     }
 
     /// {@inheritDoc}

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -54,6 +54,7 @@ import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.api.PublishStreamResponse.EndOfStream.Code;
 import org.hiero.block.internal.BlockItemSetUnparsed;
 import org.hiero.block.internal.BlockItemUnparsed;
+import org.hiero.block.node.app.config.ServerConfig;
 import org.hiero.block.node.app.config.node.NodeConfig;
 import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
@@ -106,6 +107,9 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     private final int maxBlocksBeforeStalled;
     private final long staleResendPruneBuffer;
     private final int duplicateBlockSkipWindow;
+    /// Maximum cumulative serialized size in bytes accepted for a single
+    /// block across all messages of a publish stream.
+    private final int maxTotalBlockBytes;
     private final ScheduledExecutorService scheduledExecutor;
     private volatile ScheduledFuture<Boolean> publisherUnavailabilityTimeoutFuture;
     /// nanoTime of the last penalty-count reset (tumbling window).
@@ -169,6 +173,8 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
         maxBlocksBeforeStalled = publisherConfig.MaxFutureBlocksBeforeStalled();
         staleResendPruneBuffer = publisherConfig.staleResendPruneBuffer();
         duplicateBlockSkipWindow = publisherConfig.duplicateBlockSkipWindow();
+        maxTotalBlockBytes =
+                serverContext.configuration().getConfigData(ServerConfig.class).maxMessageSizeBytes();
         publisherUnavailabilityTimeoutFuture = schedulePublisherUnavailabilityTimeout();
         blockProofs = new ConcurrentSkipListMap<>();
         endBlocksReceived = new ConcurrentSkipListSet<>();
@@ -395,6 +401,11 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
     @Override
     public PublisherConfig configuration() {
         return publisherConfig;
+    }
+
+    @Override
+    public int maxTotalBlockBytes() {
+        return maxTotalBlockBytes;
     }
 
     /// {@inheritDoc}

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -15,6 +15,7 @@ import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC
 import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_ITEMS_RECEIVED;
 import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_NODE_BEHIND_SENT;
 import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_SEND_RESPONSE_FAILED;
+import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_DISCONNECTED_OVERSIZE;
 import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_FLOW_CONTROL_INDIVIDUAL_PAUSES;
 import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_RECEIVE_LATENCY_NS;
 import static org.hiero.block.node.stream.publisher.StreamPublisherPlugin.METRIC_PUBLISHER_STREAM_ERRORS;
@@ -120,6 +121,15 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
     private final AtomicLong messageBudget;
     /// The current configuration for the publisher.
     private final PublisherConfig configuration;
+    /// The maximum cumulative serialized size in bytes accepted for a single
+    /// block across all messages of this publish stream.
+    private final int maxTotalBlockBytes;
+    /// The cumulative serialized size in bytes of all item sets accepted so
+    /// far for the block currently streaming. Only ever incremented from the
+    /// `onNext` handling, which is always called from the same thread; reset
+    /// happens on each block header and in [#resetState()], which may run on
+    /// another thread during shutdown, hence volatile for visibility.
+    private volatile long currentBlockBytes;
     // @todo() remove this (and its usage) and use telemetry or metrics queries instead
     /// The start time in nanos of block being currently streamed
     private long currentStreamingBlockHeaderReceivedTime = System.nanoTime();
@@ -154,6 +164,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
         isActive = new AtomicBoolean(true);
         shutdownActive = new AtomicBoolean(false);
         configuration = publisherManager.configuration();
+        maxTotalBlockBytes = publisherManager.maxTotalBlockBytes();
         messageBudget = new AtomicLong(configuration.perHandlerMessageBudget());
     }
 
@@ -676,14 +687,36 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
     private PublisherRequestResult handleAccept(
             final long blockNumber, final boolean requestContainsHeader, final BlockItemSetUnparsed itemSetUnparsed) {
         if (requestContainsHeader) {
+            currentBlockBytes = 0L;
             final Deque<BlockItemSetUnparsed> newBlockQueue = new ConcurrentLinkedDeque<>();
             currentBlockQueue.set(newBlockQueue);
             publisherManager.registerQueueForBlock(handlerId, newBlockQueue, blockNumber);
         }
-        currentBlockQueue.get().offer(itemSetUnparsed);
-        publisherManager.signalDataReady();
-        metrics.liveBlockItemsReceived.increment(itemSetUnparsed.blockItems().size()); // @todo(1415) add label
-        return new ContinueResult(this);
+        final long newBlockTotalBytes =
+                currentBlockBytes + BlockItemSetUnparsed.PROTOBUF.measureRecord(itemSetUnparsed);
+        currentBlockBytes = newBlockTotalBytes;
+        final PublisherRequestResult result;
+        if (newBlockTotalBytes > maxTotalBlockBytes) {
+            final String message =
+                    "[{0}] Handler {1} disconnecting publisher, block {2} exceeds the cumulative byte ceiling: {3} > {4}";
+            LOGGER.log(
+                    DEBUG,
+                    message,
+                    correlationIdPrefix,
+                    handlerId,
+                    blockNumber,
+                    newBlockTotalBytes,
+                    maxTotalBlockBytes);
+            metrics.disconnectedOversize.increment();
+            result = new SendEndAndShutdownResult(this, Code.INVALID_REQUEST, blockNumber);
+        } else {
+            currentBlockQueue.get().offer(itemSetUnparsed);
+            publisherManager.signalDataReady();
+            metrics.liveBlockItemsReceived.increment(
+                    itemSetUnparsed.blockItems().size()); // @todo(1415) add label
+            result = new ContinueResult(this);
+        }
+        return result;
     }
 
     /// Handle the SKIP action for a block.
@@ -789,12 +822,14 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
     // ==== Private Methods ====================================================
 
     /// This method will reset the state of the handler. Block action will be
-    /// set to null, and the current streaming block number will be set to
-    /// {@value BlockNodePlugin#UNKNOWN_BLOCK_NUMBER}.
+    /// set to null, the current streaming block number will be set to
+    /// {@value BlockNodePlugin#UNKNOWN_BLOCK_NUMBER}, and the cumulative
+    /// byte count for the current block will be set to zero.
     private void resetState() {
         blockAction.set(null);
         currentStreamingBlockNumber.set(UNKNOWN_BLOCK_NUMBER);
         currentBlockQueue.set(null);
+        currentBlockBytes = 0L;
     }
 
     /// This method is called when we want to orderly shut down the handler.
@@ -1085,7 +1120,8 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
             LongCounter.Measurement sendResponseFailed,
             LongCounter.Measurement endStreamsReceived,
             LongCounter.Measurement receiveBlockTimeLatencyNs,
-            LongCounter.Measurement flowControlIndividualPauses) {
+            LongCounter.Measurement flowControlIndividualPauses,
+            LongCounter.Measurement disconnectedOversize) {
         /// Factory method.
         /// Creates a new instance of [MetricsHolder] using the provided
         /// [MetricRegistry] instance.
@@ -1141,6 +1177,12 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
                     .register(LongCounter.builder(METRIC_PUBLISHER_FLOW_CONTROL_INDIVIDUAL_PAUSES)
                             .setDescription("Publisher handler pauses due to per-handler message budget exhaustion"))
                     .getOrCreateNotLabeled();
+            final LongCounter.Measurement disconnectedOversize = metricRegistry
+                    .register(
+                            LongCounter.builder(METRIC_PUBLISHER_DISCONNECTED_OVERSIZE)
+                                    .setDescription(
+                                            "Publishers disconnected because a block exceeded the cumulative per-block byte ceiling"))
+                    .getOrCreateNotLabeled();
 
             return new MetricsHolder(
                     liveBlockItemsReceived,
@@ -1154,7 +1196,8 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
                     sendResponseFailed,
                     endStreamsReceived,
                     receiveBlockTimeLatencyNs,
-                    flowControlIndividualPauses);
+                    flowControlIndividualPauses,
+                    disconnectedOversize);
         }
     }
 }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -164,7 +164,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
         isActive = new AtomicBoolean(true);
         shutdownActive = new AtomicBoolean(false);
         configuration = publisherManager.configuration();
-        maxTotalBlockBytes = publisherManager.maxTotalBlockBytes();
+        maxTotalBlockBytes = publisherManager.serverConfiguration().maxMessageSizeBytes();
         messageBudget = new AtomicLong(configuration.perHandlerMessageBudget());
     }
 
@@ -692,21 +692,13 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
             currentBlockQueue.set(newBlockQueue);
             publisherManager.registerQueueForBlock(handlerId, newBlockQueue, blockNumber);
         }
-        final long newBlockTotalBytes =
-                currentBlockBytes + BlockItemSetUnparsed.PROTOBUF.measureRecord(itemSetUnparsed);
-        currentBlockBytes = newBlockTotalBytes;
+        currentBlockBytes += BlockItemSetUnparsed.PROTOBUF.measureRecord(itemSetUnparsed);
         final PublisherRequestResult result;
-        if (newBlockTotalBytes > maxTotalBlockBytes) {
+        if (currentBlockBytes > maxTotalBlockBytes) {
             final String message =
                     "[{0}] Handler {1} disconnecting publisher, block {2} exceeds the cumulative byte ceiling: {3} > {4}";
             LOGGER.log(
-                    DEBUG,
-                    message,
-                    correlationIdPrefix,
-                    handlerId,
-                    blockNumber,
-                    newBlockTotalBytes,
-                    maxTotalBlockBytes);
+                    DEBUG, message, correlationIdPrefix, handlerId, blockNumber, currentBlockBytes, maxTotalBlockBytes);
             metrics.disconnectedOversize.increment();
             result = new SendEndAndShutdownResult(this, Code.INVALID_REQUEST, blockNumber);
         } else {

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
@@ -8,6 +8,7 @@ import java.util.Deque;
 import java.util.concurrent.ScheduledFuture;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.internal.BlockItemSetUnparsed;
+import org.hiero.block.node.app.config.ServerConfig;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 
 /// todo(1420) add documentation
@@ -96,11 +97,9 @@ public interface StreamPublisherManager extends BlockNotificationHandler {
     /// @return The plugin configuration data.
     PublisherConfig configuration();
 
-    /// Get the maximum cumulative serialized size in bytes accepted for a
-    /// single block across all messages of a publish stream. Sourced from
-    /// the server configuration `maxMessageSizeBytes`.
-    /// @return the maximum total size in bytes accepted for a single block
-    int maxTotalBlockBytes();
+    /// Get the current configuration of the server.
+    /// @return The server configuration data.
+    ServerConfig serverConfiguration();
 
     /// The action to take within the PublisherHandler for a block.
     enum BlockAction {

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
@@ -96,6 +96,12 @@ public interface StreamPublisherManager extends BlockNotificationHandler {
     /// @return The plugin configuration data.
     PublisherConfig configuration();
 
+    /// Get the maximum cumulative serialized size in bytes accepted for a
+    /// single block across all messages of a publish stream. Sourced from
+    /// the server configuration `maxMessageSizeBytes`.
+    /// @return the maximum total size in bytes accepted for a single block
+    int maxTotalBlockBytes();
+
     /// The action to take within the PublisherHandler for a block.
     enum BlockAction {
         /// todo(1420) add documentation

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
@@ -101,6 +101,8 @@ public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStream
     public static final MetricKey<LongCounter> METRIC_PUBLISHER_FLOW_CONTROL_PENALTIES_APPLIED = MetricKey.of(
                     "publisher_flow_control_penalties_applied", LongCounter.class)
             .addCategory(METRICS_CATEGORY);
+    public static final MetricKey<LongCounter> METRIC_PUBLISHER_DISCONNECTED_OVERSIZE =
+            MetricKey.of("publisher_disconnected_oversize", LongCounter.class).addCategory(METRICS_CATEGORY);
 
     /// The logger for this class.
     private static final System.Logger LOGGER = System.getLogger(StreamPublisherPlugin.class.getName());

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.endThisBlock;
 import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.sendHeaderOnly;
 
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2470,6 +2471,170 @@ class LiveStreamPublisherManagerTest {
                 toTest.registerQueueForBlock(publisherHandlerId, new ConcurrentLinkedDeque<>(), blockNumber);
                 // blockIsEnding for an already-persisted block must not throw.
                 assertThatNoException().isThrownBy(() -> toTest.blockIsEnding(blockNumber, publisherHandlerId));
+            }
+        }
+
+        /// Tests asserting the interaction between the cumulative per-block
+        /// byte ceiling enforced by [PublisherHandler] and the resend
+        /// scheduling in [LiveStreamPublisherManager]. When a publisher is
+        /// disconnected with EndOfStream Code INVALID_REQUEST because a block
+        /// exceeded the ceiling, the block it was streaming must be scheduled
+        /// for resend and requested from another publisher on end of block.
+        @Nested
+        @DisplayName("Cumulative Block Byte Ceiling Resend Tests")
+        class CumulativeBlockByteCeilingResendTests {
+            /// The minimum value allowed for `server.maxMessageSizeBytes`,
+            /// used as a lowered ceiling so tests can breach it cheaply.
+            private static final int LOWERED_CEILING = 1_048_576;
+            /// A payload size such that two payloads breach the lowered
+            /// ceiling while a single one does not.
+            private static final int PAYLOAD_SIZE = 600_000;
+
+            /// Local setup for each test in this class. Here we override the
+            /// original setup that is present and reused from
+            /// [FunctionalityTests]. This is needed because these tests must
+            /// lower the cumulative per-block byte ceiling to the minimum
+            /// allowed value, which requires a fresh context, manager and
+            /// handlers built against the overridden configuration.
+            @BeforeEach
+            void localSetup() {
+                historicalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
+                threadPoolManager = new TestThreadPoolManager<>(
+                        new BlockingExecutor(new LinkedBlockingQueue<>()),
+                        new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+                messagingFacility = new TestBlockMessagingFacility();
+                final Configuration testConfiguration = TestStreamPublisherManager.createTestConfiguration(
+                        Map.of("server.maxMessageSizeBytes", String.valueOf(LOWERED_CEILING)));
+                final BlockNodeContext context = generateContext(
+                        historicalBlockFacility, threadPoolManager, messagingFacility, testConfiguration);
+                historicalBlockFacility.init(context, null);
+                final MetricRegistry registry = newRegistry();
+                managerMetrics = MetricsHolder.createMetrics(registry);
+                toTest = new LiveStreamPublisherManager(context, managerMetrics);
+                sharedHandlerMetrics = PublisherHandler.MetricsHolder.createMetrics(registry);
+                responsePipeline = new TestResponsePipeline();
+                publisherHandler = toTest.addHandler(responsePipeline, sharedHandlerMetrics, null);
+                responsePipeline2 = new TestResponsePipeline();
+                publisherHandler2 = toTest.addHandler(responsePipeline2, sharedHandlerMetrics, "");
+            }
+
+            /// This test aims to assert that when a publisher is disconnected
+            /// with EndOfStream Code INVALID_REQUEST because the block it was
+            /// streaming exceeded the cumulative per-block byte ceiling, the
+            /// offending block is scheduled for resend. Publisher 1 starts
+            /// block 0 with a header message under the ceiling, and publisher
+            /// 2 starts streaming block 1 (the next block in line) validly in
+            /// parallel. Publisher 1 then sends a second message that pushes
+            /// block 0 over the ceiling and must receive a single EndOfStream
+            /// with Code INVALID_REQUEST. When publisher 2 subsequently ends
+            /// block 1, the manager must answer the end of block with a
+            /// RESEND action for block 0, so publisher 2 must receive a
+            /// ResendBlock message for block 0. This is critical: without the
+            /// resend, the disconnected publisher's block would be lost until
+            /// backfill notices the gap.
+            @Test
+            @DisplayName(
+                    "Block ended by an oversize INVALID_REQUEST disconnect is requested for resend from another publisher on end of block")
+            void testOversizeDisconnectSchedulesResendForAnotherPublisher() {
+                // Publisher 1 starts streaming block 0, staying under the ceiling
+                publisherHandler.onNext(requestOf(headerItemSet(0L, PAYLOAD_SIZE)));
+                // Publisher 2 starts streaming block 1, the next block in line, validly
+                final TestBlock block1 = TestBlockBuilder.generateBlockWithNumber(1L);
+                publisherHandler2.onNext(block1.asPublishStreamRequestUnparsed());
+                // Publisher 1 pushes block 0 over the ceiling and is disconnected
+                publisherHandler.onNext(requestOf(fillerItemSet(PAYLOAD_SIZE)));
+                assertThat(responsePipeline.getOnNextCalls())
+                        .hasSize(1)
+                        .first()
+                        .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
+                        .returns(Code.INVALID_REQUEST, endStreamResponseCodeExtractor);
+                // Publisher 2 has received no responses yet
+                assertThat(responsePipeline2.getOnNextCalls()).isEmpty();
+                // Publisher 2 ends block 1 and must be asked to resend block 0
+                endThisBlock(publisherHandler2, block1.number());
+                assertThat(responsePipeline2.getOnNextCalls())
+                        .hasSize(1)
+                        .first()
+                        .returns(ResponseOneOfType.RESEND_BLOCK, responseKindExtractor)
+                        .returns(0L, resendBlockNumberExtractor);
+                // Assert the metrics reflect the disconnect and the resend
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_DISCONNECTED_OVERSIZE))
+                        .isEqualTo(1);
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCKS_RESEND_SENT))
+                        .isEqualTo(1);
+            }
+
+            /// This test aims to assert that a block scheduled for resend
+            /// after an oversize INVALID_REQUEST disconnect can actually be
+            /// re-published. The flow of the previous test runs first:
+            /// publisher 1 breaches the ceiling on block 0 and is
+            /// disconnected, publisher 2 ends block 1 and receives a
+            /// ResendBlock message for block 0. Publisher 2 then re-publishes
+            /// block 0 (header message under the ceiling) and ends it. Both
+            /// steps must be accepted silently, so the only response publisher
+            /// 2 ever receives is the single ResendBlock message: the resent
+            /// block header must win ACCEPT and the end of block must not
+            /// produce another action.
+            @Test
+            @DisplayName("Block scheduled for resend after an oversize disconnect is accepted when re-published")
+            void testResendBlockIsAcceptedWhenRepublished() {
+                // Publisher 1 breaches the ceiling on block 0 mid-stream while
+                // publisher 2 validly streams and ends block 1
+                publisherHandler.onNext(requestOf(headerItemSet(0L, PAYLOAD_SIZE)));
+                final TestBlock block1 = TestBlockBuilder.generateBlockWithNumber(1L);
+                publisherHandler2.onNext(block1.asPublishStreamRequestUnparsed());
+                publisherHandler.onNext(requestOf(fillerItemSet(PAYLOAD_SIZE)));
+                endThisBlock(publisherHandler2, block1.number());
+                // Publisher 2 has been asked to resend block 0
+                assertThat(responsePipeline2.getOnNextCalls())
+                        .hasSize(1)
+                        .first()
+                        .returns(ResponseOneOfType.RESEND_BLOCK, responseKindExtractor)
+                        .returns(0L, resendBlockNumberExtractor);
+                // Publisher 2 re-publishes block 0 and ends it
+                publisherHandler2.onNext(requestOf(headerItemSet(0L, PAYLOAD_SIZE)));
+                endThisBlock(publisherHandler2, 0L);
+                // Assert both steps were accepted silently: the ResendBlock
+                // message is still the only response publisher 2 has received
+                assertThat(responsePipeline2.getOnNextCalls())
+                        .hasSize(1)
+                        .first()
+                        .returns(ResponseOneOfType.RESEND_BLOCK, responseKindExtractor);
+                assertThat(responsePipeline2.getOnCompleteCalls().get()).isZero();
+                assertThat(responsePipeline2.getOnErrorCalls()).isEmpty();
+            }
+
+            /// Builds an item set whose first item is the block header for the
+            /// given block number, padded with a filler item of the given
+            /// payload size.
+            private BlockItemSetUnparsed headerItemSet(final long blockNumber, final int fillerPayloadSize) {
+                final BlockItemUnparsed header =
+                        TestBlockBuilder.generateBlockWithNumber(blockNumber).getHeaderUnparsed();
+                return BlockItemSetUnparsed.newBuilder()
+                        .blockItems(List.of(header, fillerItem(fillerPayloadSize)))
+                        .build();
+            }
+
+            /// Builds an item set holding a single filler item of the given
+            /// payload size.
+            private BlockItemSetUnparsed fillerItemSet(final int payloadSize) {
+                return BlockItemSetUnparsed.newBuilder()
+                        .blockItems(List.of(fillerItem(payloadSize)))
+                        .build();
+            }
+
+            /// Builds a filler item carrying an opaque payload of the given size.
+            private BlockItemUnparsed fillerItem(final int payloadSize) {
+                return BlockItemUnparsed.newBuilder()
+                        .signedTransaction(Bytes.wrap(new byte[payloadSize]))
+                        .build();
+            }
+
+            /// Wraps the given item set in a publish stream request.
+            private PublishStreamRequestUnparsed requestOf(final BlockItemSetUnparsed itemSet) {
+                return PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(itemSet)
+                        .build();
             }
         }
 

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherHandlerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherHandlerTest.java
@@ -8,10 +8,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.hiero.block.node.stream.publisher.fixtures.PublishApiUtility.endThisBlock;
 
 import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Flow.Subscription;
@@ -2899,6 +2901,234 @@ class PublisherHandlerTest {
                 endThisBlock(toTest, 0L);
                 assertThat(repliesPipeline.getOnNextCalls()).isEmpty();
                 assertThat(repliesPipeline.getOnCompleteCalls().get()).isZero();
+            }
+        }
+
+        /// Tests for the cumulative per-block byte ceiling enforced by
+        /// [PublisherHandler#onNext(PublishStreamRequestUnparsed)]. The
+        /// ceiling is sourced from the server configuration
+        /// `maxMessageSizeBytes` via
+        /// [StreamPublisherManager#maxTotalBlockBytes()].
+        @Nested
+        @DisplayName("Cumulative Block Byte Ceiling Tests")
+        class CumulativeBlockByteCeilingTest {
+            /// Thirty megabytes, the per-message payload size from the issue
+            /// acceptance criteria: five such messages exceed the default
+            /// ceiling of 131,072,000 bytes, while four do not.
+            private static final int THIRTY_MEGABYTES = 30 * 1024 * 1024;
+            /// The minimum value allowed for `server.maxMessageSizeBytes`,
+            /// used as a lowered ceiling so tests can breach it cheaply.
+            private static final int LOWERED_CEILING = 1_048_576;
+
+            /// This test aims to assert that the [PublisherHandler] enforces
+            /// the cumulative per-block byte ceiling. We feed five ~30 MB
+            /// messages for the same block (cumulative ~150 MB, above the
+            /// default ceiling of 131,072,000 bytes). The first four messages
+            /// (cumulative ~126 MB) must be accepted and offered to the
+            /// transfer queue with no responses sent. The fifth message pushes
+            /// the cumulative total over the ceiling, so the handler must
+            /// reply with a single EndOfStream with Code INVALID_REQUEST
+            /// carrying the latest known block number, must NOT offer the
+            /// fifth set to the queue, must end the block mid-stream, and must
+            /// close the connection (onComplete) once the delayed shutdown
+            /// runs.
+            @Test
+            @DisplayName(
+                    "Test onNext() ends stream with EndOfStream, Code INVALID_REQUEST when cumulative block bytes exceed the ceiling")
+            void testOversizedBlockEndsStreamWithInvalidRequest() {
+                // Train the manager to return ACCEPT for the block number
+                manager.setBlockActionForBlock(BlockAction.ACCEPT);
+                // Train the manager to return the expected latest block number
+                final long expectedLatestBlockNumber = 10L;
+                manager.setLatestBlockNumber(expectedLatestBlockNumber);
+                // The first message carries the block header, all five are ~30 MB
+                toTest.onNext(requestOf(headerItemSet(0L, THIRTY_MEGABYTES)));
+                for (int i = 0; i < 3; i++) {
+                    toTest.onNext(requestOf(fillerItemSet(THIRTY_MEGABYTES)));
+                }
+                // Assert no responses so far and all four sets offered to the queue
+                assertThat(repliesPipeline.getOnNextCalls()).isEmpty();
+                assertThat(manager.getQueueForBlock(0L)).hasSize(4);
+                // The fifth message pushes the cumulative total over the ceiling
+                toTest.onNext(requestOf(fillerItemSet(THIRTY_MEGABYTES)));
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
+                // Assert single response is INVALID_REQUEST with block number
+                // latest known and onComplete is called (shutdown)
+                assertThat(repliesPipeline.getOnNextCalls())
+                        .hasSize(1)
+                        .first()
+                        .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
+                        .returns(Code.INVALID_REQUEST, endStreamResponseCodeExtractor)
+                        .returns(expectedLatestBlockNumber, endStreamBlockNumberExtractor);
+                assertThat(repliesPipeline.getOnCompleteCalls().get()).isEqualTo(1);
+                // Assert the oversized set was not offered to the queue and the
+                // block ended mid-stream
+                assertThat(manager.getQueueForBlock(0L)).hasSize(4);
+                assertThat(manager.getBlocksEndedMidBlock()).contains(0L);
+                // Assert no other responses sent
+                assertThat(repliesPipeline.getOnErrorCalls()).isEmpty();
+                assertThat(repliesPipeline.getOnSubscriptionCalls()).isEmpty();
+                assertThat(repliesPipeline.getClientEndStreamCalls().get()).isEqualTo(0);
+            }
+
+            /// This test aims to assert that the [PublisherHandler] updates
+            /// the metrics properly when a publisher is disconnected for
+            /// exceeding the cumulative per-block byte ceiling. We feed five
+            /// ~30 MB messages for the same block (the fifth breaches the
+            /// default ceiling). We expect the oversize-disconnect counter and
+            /// the end-of-stream counter to be incremented exactly once, the
+            /// items-received counter to reflect only the accepted sets (five
+            /// items: header plus filler in the first set, one filler in each
+            /// of the next three sets), and the stream-errors counter to
+            /// remain unchanged.
+            @Test
+            @DisplayName(
+                    "Test onNext() metrics updated when cumulative block bytes exceed the ceiling - EndOfStream, Code INVALID_REQUEST")
+            void testOversizedBlockMetricsUpdated() {
+                // Train the manager to return ACCEPT for the block number
+                manager.setBlockActionForBlock(BlockAction.ACCEPT);
+                manager.setLatestBlockNumber(10L);
+                // The first message carries the block header, all five are ~30 MB
+                toTest.onNext(requestOf(headerItemSet(0L, THIRTY_MEGABYTES)));
+                for (int i = 0; i < 4; i++) {
+                    toTest.onNext(requestOf(fillerItemSet(THIRTY_MEGABYTES)));
+                }
+                // Assert metrics updated
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_DISCONNECTED_OVERSIZE))
+                        .isEqualTo(1);
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_ENDOFSTREAM_SENT))
+                        .isEqualTo(1);
+                // Assert only the four accepted sets counted (2 + 1 + 1 + 1 items)
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_ITEMS_RECEIVED))
+                        .isEqualTo(5);
+                // Assert other metrics unchanged
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_STREAM_ERRORS))
+                        .isEqualTo(0);
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCKS_ACK_SENT))
+                        .isEqualTo(0);
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCKS_SKIPS_SENT))
+                        .isEqualTo(0);
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_BLOCK_SEND_RESPONSE_FAILED))
+                        .isEqualTo(0);
+            }
+
+            /// This test aims to assert that the cumulative per-block byte
+            /// ceiling check is strictly greater-than: a block whose
+            /// cumulative serialized size lands exactly on the ceiling must
+            /// still be accepted, and only the next byte over the ceiling
+            /// triggers the disconnect. The handler is rebuilt with the
+            /// ceiling lowered to the minimum allowed value. We send a header
+            /// set and a second set sized so the cumulative total measures
+            /// exactly the ceiling, expecting both to be accepted with no
+            /// responses, then a third tiny set, expecting an EndOfStream with
+            /// Code INVALID_REQUEST.
+            @Test
+            @DisplayName("Test onNext() accepts cumulative block bytes exactly at the ceiling, rejects one byte over")
+            void testCumulativeBytesAtCeilingAccepted() {
+                recreateHandlerWithCeiling(LOWERED_CEILING);
+                // Train the manager to return ACCEPT for the block number
+                manager.setBlockActionForBlock(BlockAction.ACCEPT);
+                manager.setLatestBlockNumber(10L);
+                final BlockItemSetUnparsed headerSet = headerItemSet(0L, LOWERED_CEILING / 2);
+                final int headerSetSize = BlockItemSetUnparsed.PROTOBUF.measureRecord(headerSet);
+                // Size the second set so the cumulative total lands exactly on
+                // the ceiling: measure a rough guess, then correct the payload
+                // by the measured difference (framing grows linearly here)
+                final int remaining = LOWERED_CEILING - headerSetSize;
+                final int roughPayload = remaining - 64;
+                final int adjustment =
+                        remaining - BlockItemSetUnparsed.PROTOBUF.measureRecord(fillerItemSet(roughPayload));
+                final BlockItemSetUnparsed secondSet = fillerItemSet(roughPayload + adjustment);
+                assertThat(BlockItemSetUnparsed.PROTOBUF.measureRecord(secondSet))
+                        .isEqualTo(remaining);
+                // Call with both sets, cumulative total exactly at the ceiling
+                toTest.onNext(requestOf(headerSet));
+                toTest.onNext(requestOf(secondSet));
+                // Assert both sets accepted, no responses
+                assertThat(repliesPipeline.getOnNextCalls()).isEmpty();
+                assertThat(manager.getQueueForBlock(0L)).hasSize(2);
+                // Any further bytes breach the ceiling
+                toTest.onNext(requestOf(fillerItemSet(1)));
+                // Invoke the delayed shutdown so it actually runs
+                scheduledExecutor.executeSerially();
+                assertThat(repliesPipeline.getOnNextCalls())
+                        .hasSize(1)
+                        .first()
+                        .returns(ResponseOneOfType.END_STREAM, responseKindExtractor)
+                        .returns(Code.INVALID_REQUEST, endStreamResponseCodeExtractor);
+                assertThat(manager.getQueueForBlock(0L)).hasSize(2);
+            }
+
+            /// This test aims to assert that the cumulative per-block byte
+            /// counter resets when a new block header is received. The handler
+            /// is rebuilt with the ceiling lowered to the minimum allowed
+            /// value. We send a header set of roughly 700 KB for block 0, then
+            /// a header set of roughly 700 KB for block 1. If the counter did
+            /// not reset on the new header, the cumulative total (~1.4 MB)
+            /// would breach the ~1 MB ceiling; since it does reset, both sets
+            /// must be accepted and no responses sent.
+            @Test
+            @DisplayName("Test onNext() resets the cumulative byte counter on a new block header")
+            void testCumulativeCounterResetsOnNewBlockHeader() {
+                recreateHandlerWithCeiling(LOWERED_CEILING);
+                // Train the manager to return ACCEPT for the block numbers
+                manager.setBlockActionForBlock(BlockAction.ACCEPT);
+                manager.setLatestBlockNumber(10L);
+                // Two of these would breach the ceiling if the counter did not reset
+                final int payloadSize = 700_000;
+                toTest.onNext(requestOf(headerItemSet(0L, payloadSize)));
+                // A new header for the next block resets the cumulative counter
+                toTest.onNext(requestOf(headerItemSet(1L, payloadSize)));
+                // Assert both sets accepted, no responses
+                assertThat(repliesPipeline.getOnNextCalls()).isEmpty();
+                assertThat(manager.getQueueForBlock(1L)).hasSize(1);
+                assertThat(getMetricValue(StreamPublisherPlugin.METRIC_PUBLISHER_DISCONNECTED_OVERSIZE))
+                        .isEqualTo(0);
+            }
+
+            /// Rebuilds the manager and the handler under test with the
+            /// cumulative per-block byte ceiling overridden to the given value.
+            private void recreateHandlerWithCeiling(final int ceiling) {
+                manager = new TestStreamPublisherManager(
+                        new TestBlockMessagingFacility(),
+                        scheduledExecutor,
+                        Map.of("server.maxMessageSizeBytes", String.valueOf(ceiling)));
+                toTest = new PublisherHandler(handlerId, repliesPipeline, metrics, manager, null);
+                manager.addHandler(toTest);
+            }
+
+            /// Builds an item set whose first item is the block header for the
+            /// given block number, padded with a filler item of the given
+            /// payload size.
+            private BlockItemSetUnparsed headerItemSet(final long blockNumber, final int fillerPayloadSize) {
+                final BlockItemUnparsed header =
+                        TestBlockBuilder.generateBlockWithNumber(blockNumber).getHeaderUnparsed();
+                return BlockItemSetUnparsed.newBuilder()
+                        .blockItems(List.of(header, fillerItem(fillerPayloadSize)))
+                        .build();
+            }
+
+            /// Builds an item set holding a single filler item of the given
+            /// payload size.
+            private BlockItemSetUnparsed fillerItemSet(final int payloadSize) {
+                return BlockItemSetUnparsed.newBuilder()
+                        .blockItems(List.of(fillerItem(payloadSize)))
+                        .build();
+            }
+
+            /// Builds a filler item carrying an opaque payload of the given size.
+            private BlockItemUnparsed fillerItem(final int payloadSize) {
+                return BlockItemUnparsed.newBuilder()
+                        .signedTransaction(Bytes.wrap(new byte[payloadSize]))
+                        .build();
+            }
+
+            /// Wraps the given item set in a publish stream request.
+            private PublishStreamRequestUnparsed requestOf(final BlockItemSetUnparsed itemSet) {
+                return PublishStreamRequestUnparsed.newBuilder()
+                        .blockItems(itemSet)
+                        .build();
             }
         }
     }

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherHandlerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/PublisherHandlerTest.java
@@ -2908,7 +2908,7 @@ class PublisherHandlerTest {
         /// [PublisherHandler#onNext(PublishStreamRequestUnparsed)]. The
         /// ceiling is sourced from the server configuration
         /// `maxMessageSizeBytes` via
-        /// [StreamPublisherManager#maxTotalBlockBytes()].
+        /// [StreamPublisherManager#serverConfiguration()].
         @Nested
         @DisplayName("Cumulative Block Byte Ceiling Tests")
         class CumulativeBlockByteCeilingTest {

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestStreamPublisherManager.java
@@ -182,8 +182,8 @@ public class TestStreamPublisherManager implements StreamPublisherManager {
     }
 
     @Override
-    public int maxTotalBlockBytes() {
-        return testConfiguration.getConfigData(ServerConfig.class).maxMessageSizeBytes();
+    public ServerConfig serverConfiguration() {
+        return testConfiguration.getConfigData(ServerConfig.class);
     }
 
     @Override

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/fixtures/TestStreamPublisherManager.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.internal.BlockItemSetUnparsed;
+import org.hiero.block.node.app.config.ServerConfig;
 import org.hiero.block.node.app.fixtures.TestUtils;
 import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
 import org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility;
@@ -64,9 +65,16 @@ public class TestStreamPublisherManager implements StreamPublisherManager {
     public TestStreamPublisherManager(
             final TestBlockMessagingFacility testBlockMessagingFacility,
             final ScheduledBlockingExecutor scheduleExecutor) {
+        this(testBlockMessagingFacility, scheduleExecutor, Map.of());
+    }
+
+    public TestStreamPublisherManager(
+            final TestBlockMessagingFacility testBlockMessagingFacility,
+            final ScheduledBlockingExecutor scheduleExecutor,
+            final Map<String, String> configOverrides) {
         this.blockMessagingFacility = Objects.requireNonNull(testBlockMessagingFacility);
         scheduledExecutor = scheduleExecutor;
-        testConfiguration = createTestConfiguration();
+        testConfiguration = createTestConfiguration(configOverrides);
     }
 
     public static Configuration createTestConfiguration() {
@@ -171,6 +179,11 @@ public class TestStreamPublisherManager implements StreamPublisherManager {
     @Override
     public PublisherConfig configuration() {
         return testConfiguration.getConfigData(PublisherConfig.class);
+    }
+
+    @Override
+    public int maxTotalBlockBytes() {
+        return testConfiguration.getConfigData(ServerConfig.class).maxMessageSizeBytes();
     }
 
     @Override

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -16,7 +16,7 @@ Each plugin has its own properties, but this focuses on core options and core pl
 
 | ENV Variable                            | Description                                                                                                            | Default     |
 |:----------------------------------------|:-----------------------------------------------------------------------------------------------------------------------|:------------|
-| SERVER_MAX_MESSAGE_SIZE_BYTES           | Max message size (bytes) for HTTP/2.                                                                                   | 131,072,000 |
+| SERVER_MAX_MESSAGE_SIZE_BYTES           | Max message size (bytes) for HTTP/2. Also the cumulative byte ceiling for a single block on the publish stream.        | 131,072,000 |
 | SERVER_SOCKET_SEND_BUFFER_SIZE_BYTES    | Send buffer size (bytes).                                                                                              | 131,072     |
 | SERVER_SOCKET_RECEIVE_BUFFER_SIZE_BYTES | Receive buffer size (bytes). Override to 131072 for memory-constrained deployments (see `values-overrides/nano.yaml`). | 8,388,608   |
 | SERVER_PORT                             | Default port for all services. Individual plugins may bind to a different port via their own config.                   | 40840       |

--- a/docs/block-node/metrics.md
+++ b/docs/block-node/metrics.md
@@ -126,6 +126,7 @@ Observes inbound streams from publishers.
 | Counter | `publisher_flow_control_individual_pauses`   | Publisher handler pauses due to per-handler message budget exhaustion                                       |
 | Counter | `publisher_flow_control_aggregate_pauses`    | Intervals where aggregate message budget was exceeded and all handler budgets were withheld                 |
 | Counter | `publisher_flow_control_penalties_applied`   | Penalty pauses applied to handlers that repeatedly exhaust their budget                                     |
+| Counter | `publisher_disconnected_oversize`            | Publishers disconnected because a block exceeded the cumulative per-block byte ceiling                      |
 
 ---
 


### PR DESCRIPTION
* Track cumulative serialized bytes per block in PublisherHandler, reset on each block header
* End the stream with EndOfStream INVALID_REQUEST, clear the queue, and close the connection when a block exceeds the ceiling
  * The ended block is scheduled for resend and requested from another publisher on end of block
* Source the ceiling from ServerConfig maxMessageSizeBytes via new StreamPublisherManager.maxTotalBlockBytes()
* Add publisher_disconnected_oversize counter and document it in metrics.md and configuration.md
* Add tests
  * Oversized multi-message block ends stream with INVALID_REQUEST and increments the metric
  * Cumulative total at the cap is accepted; counter resets on new block header
  * Block ended by an oversize disconnect is resent via another publisher and accepted when re-published

Resolves #2931