### PR TITLE
fix: Increase the reliability and speed of WRB CLI

### DIFF
--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommand.java
@@ -354,6 +354,24 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
 
             long effectiveHighest = blockRegistry.highestBlockNumberStored();
 
+            // Fast path: nothing new to wrap since the last successful run. Skip the mid-zip
+            // resume delete-and-rewrap below entirely, rather than discarding a perfectly good
+            // zip only to discover moments later (via an empty dayPaths list, further down) that
+            // there was nothing to replace it with. This matters most for a repeatedly-invoked
+            // live-wrap poll loop: without this check, every single poll unconditionally deletes
+            // and fully re-verifies/re-wraps the entire current zip range from scratch, even when
+            // the input hasn't advanced at all since the previous poll.
+            //
+            // Exits 0, not 1: this is a normal, expected steady state (caught up, nothing new
+            // this poll), not a failure -- callers like start-live-wrap.sh count consecutive
+            // non-zero exits and give up on the whole polling loop after enough of them, which a
+            // brief lull in new records should never trigger.
+            if (isNothingNewToWrap(effectiveHighest, blockTimeReader.getMaxBlockNumber())) {
+                System.out.println(Ansi.AUTO.string("@|yellow Nothing new to wrap (already at block " + effectiveHighest
+                        + ", block_times.bin has no blocks beyond it); skipping.|@"));
+                return 0;
+            }
+
             // Mid-zip resume detection: if the watermark is not the last block of its zip
             // range, the partial zip may contain entries written by ZipFileSystem with data
             // descriptors that ZipInputStream cannot read. Back up to the start of that zip
@@ -970,6 +988,20 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
     }
 
     /**
+     * Returns whether there is nothing new to wrap: the registry has already been fully wrapped
+     * up to the highest block number the current {@code block_times.bin} metadata knows about.
+     *
+     * @param effectiveHighest the highest block number already durably wrapped, or {@code -1} if
+     *                         nothing has been wrapped yet
+     * @param maxKnownBlockNumber the highest block number covered by the current run's
+     *                            {@code block_times.bin}
+     * @return {@code true} if wrapping should be skipped entirely this run
+     */
+    static boolean isNothingNewToWrap(long effectiveHighest, long maxKnownBlockNumber) {
+        return effectiveHighest >= 0 && effectiveHighest == maxKnownBlockNumber;
+    }
+
+    /**
      * Load the durable commit watermark from the given file.
      *
      * @param watermarkFile the path to the watermark file
@@ -1149,7 +1181,9 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
      *
      * <p>This is called on the main (Stage 2) thread for each block. Address book changes are
      * stored with a +1ns timestamp offset so they apply to blocks AFTER the current one (since
-     * the current block was signed with the old keys).
+     * the current block was signed with the old keys) -- except at block 0, whose own address
+     * book update IS the network's founding roster and therefore applies starting at block 0
+     * itself; see the comment at the {@code blockNum == 0} check below.
      *
      * @param preVerified the pre-verified block from Stage 1
      * @param blockNum the block number
@@ -1176,9 +1210,19 @@ public class ToWrappedBlocksCommand implements Callable<Integer> {
                         AddressBookRegistry.filterToJustAddressBookTransactions(transactions);
                 if (!addressBookTxns.isEmpty()) {
                     final Instant blockInstant = preVerified.recordBlock().blockTime();
-                    // +1ns so the new address book applies to blocks AFTER this one
-                    final String changes =
-                            addressBookRegistry.updateAddressBook(blockInstant.plusNanos(1), addressBookTxns);
+                    // Block 0 is the network's own genesis block: whatever roster it establishes
+                    // IS the founding roster, and genesis is signed using those same founding
+                    // keys, so it must take effect starting AT block 0, not one nanosecond after
+                    // -- otherwise genesis is permanently stuck verifying against whatever
+                    // placeholder/bootstrap book preceded it (e.g. a network's genesis resource
+                    // fallback that doesn't match this chain's actual keys) and the reverify
+                    // check below can never trigger for block 0, since no discovery is ever
+                    // dated early enough to look "stale" for it. Every later block's update is a
+                    // genuine on-chain roster change and must NOT retroactively apply to the
+                    // block that announced it (that block was legitimately signed under the OLD
+                    // roster) -- hence +1ns for blockNum > 0.
+                    final Instant effectiveInstant = blockNum == 0 ? blockInstant : blockInstant.plusNanos(1);
+                    final String changes = addressBookRegistry.updateAddressBook(effectiveInstant, addressBookTxns);
                     if (changes != null) {
                         PrettyPrint.clearProgress();
                         System.out.println(Ansi.AUTO.string(

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/AddressBookRegistry.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/AddressBookRegistry.java
@@ -215,7 +215,21 @@ public class AddressBookRegistry {
         // Use content equality check instead of reference equality to properly detect duplicates
         // NodeAddressBook has proper equals() implementation that compares content
         if (newAddressBook != null && !newAddressBook.equals(currentBook)) {
-            addressBooks.add(new DatedNodeAddressBook(toTimestamp(blockInstant), newAddressBook));
+            final Timestamp newTs = toTimestamp(blockInstant);
+            final DatedNodeAddressBook lastEntry = addressBooks.getLast();
+            if (lastEntry.blockTimestampOrThrow().equals(newTs)) {
+                // A caller (ToWrappedBlocksCommand's block-0 genesis discovery) may supply a
+                // timestamp identical to the entry it's meant to supersede -- e.g. the network's
+                // founding roster is dated at block 0's own timestamp so it applies to block 0
+                // itself, which coincides exactly with the initial bootstrap/placeholder entry's
+                // timestamp. Appending a second entry at that identical timestamp would leave two
+                // ties in the list, and getAddressBookForBlock()'s binary search does not
+                // guarantee which of two equal-timestamp entries it returns. Replace in place
+                // instead so each timestamp maps to exactly one entry.
+                addressBooks.set(addressBooks.size() - 1, new DatedNodeAddressBook(newTs, newAddressBook));
+            } else {
+                addressBooks.add(new DatedNodeAddressBook(newTs, newAddressBook));
+            }
             return "Address Book Changed, via " + changeSource + ":\n"
                     + addressBookChanges(currentBook, newAddressBook);
         }

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/TarZstdDayReaderUsingExec.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/TarZstdDayReaderUsingExec.java
@@ -349,21 +349,19 @@ public class TarZstdDayReaderUsingExec {
                         "Primary record file not found for baseKey='" + baseKey + "' in dir='" + currentDir + "'");
             }
 
-            // Signature files are optional: the chronologically last group may legitimately be
-            // missing its .rcd_sig (still uploading), and any group may be missing sigs when the
-            // record source (e.g. MinIO) does not store .rcd_sig files at all (e.g. Solo's MinIO
-            // only stores .rcd.gz). Skip the trailing group so the caller can retry once the sig
-            // lands; for non-trailing groups log a warning and wrap without RSA signatures —
-            // TSS-signed blocks don't need RSA sigs, and RSA-signed blocks produce 0 valid sigs
-            // (cosmetically wrong but non-fatal: validation simply reports 0 verified nodes).
+            // Signature files are required: a record file with no RSA signatures cannot be
+            // verified and must not be wrapped. The chronologically last group may legitimately
+            // be missing its .rcd_sig (still uploading) — skip it so the caller can retry once
+            // signatures land. Any other sig-less group is also skipped with a warning.
             if (signatureFiles.isEmpty()) {
                 if (groupIndex == lastGroupIndex) {
                     System.err.println("Skipping incomplete trailing record for baseKey='" + baseKey + "' in dir='"
                             + currentDir + "' (no signature file yet; likely still uploading)");
-                    continue;
+                } else {
+                    System.err.println("WARNING: Skipping record baseKey='" + baseKey + "' in dir='" + currentDir
+                            + "': no RSA signature files found; record cannot be verified");
                 }
-                System.err.println("WARNING: No signature files for baseKey='" + baseKey + "' in dir='" + currentDir
-                        + "'; wrapping without RSA signatures");
+                continue;
             }
 
             // classify other record files (exclude the primary)

--- a/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/TarZstdDayReaderUsingExec.java
+++ b/tools-and-tests/tools/src/main/java/org/hiero/block/tools/days/model/TarZstdDayReaderUsingExec.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Spliterator;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.hiero.block.tools.records.model.unparsed.InMemoryFile;
@@ -87,13 +86,17 @@ public class TarZstdDayReaderUsingExec {
             @Override
             public boolean tryAdvance(Consumer<? super UnparsedRecordBlock> action) {
                 if (action == null) throw new NullPointerException();
-                if (finished) return false;
 
-                // If we already have ready blocks, emit one
+                // Check ready blocks before finished: end-of-input processing (below) can flush
+                // many blocks into `ready` in one tryAdvance call while also setting `finished`,
+                // e.g. for a flat (single-directory) archive where the directory-boundary branch
+                // never fires and everything is buffered until the iterator is exhausted. Checking
+                // `finished` first would silently drop every ready block but the one just returned.
                 if (!ready.isEmpty()) {
                     action.accept(ready.removeFirst());
                     return true;
                 }
+                if (finished) return false;
 
                 while (it.hasNext()) {
                     InMemoryFile f = it.next();
@@ -292,8 +295,14 @@ public class TarZstdDayReaderUsingExec {
             }
         }
 
-        // For each group in byBase, now separate signatureFiles and rcdFiles and build sets
+        // For each group in byBase, now separate signatureFiles and rcdFiles and build sets.
+        // byBase is a LinkedHashMap preserving tar/insertion order, which is chronological for
+        // timestamp-prefixed record files -- so the last entry is always the most recently
+        // produced one.
+        final int lastGroupIndex = byBase.size() - 1;
+        int groupIndex = -1;
         for (Map.Entry<String, List<InMemoryFile>> e : byBase.entrySet()) {
+            groupIndex++;
             String baseKey = e.getKey();
             List<InMemoryFile> files = e.getValue();
 
@@ -340,17 +349,21 @@ public class TarZstdDayReaderUsingExec {
                         "Primary record file not found for baseKey='" + baseKey + "' in dir='" + currentDir + "'");
             }
 
-            // There must be at least one signature file for the group; enforce invariant
+            // Signature files are optional: the chronologically last group may legitimately be
+            // missing its .rcd_sig (still uploading), and any group may be missing sigs when the
+            // record source (e.g. MinIO) does not store .rcd_sig files at all (e.g. Solo's MinIO
+            // only stores .rcd.gz). Skip the trailing group so the caller can retry once the sig
+            // lands; for non-trailing groups log a warning and wrap without RSA signatures —
+            // TSS-signed blocks don't need RSA sigs, and RSA-signed blocks produce 0 valid sigs
+            // (cosmetically wrong but non-fatal: validation simply reports 0 verified nodes).
             if (signatureFiles.isEmpty()) {
-                System.err.println("Missing signature files for baseKey='" + baseKey + "' in dir='" + currentDir + "'");
-                System.err.println(" File set: "
-                        + files.stream()
-                                .map(InMemoryFile::path)
-                                .map(Path::toString)
-                                .collect(Collectors.joining(", ")));
-                for (InMemoryFile f : rcdFiles) System.err.println("    " + f.path());
-                throw new RuntimeException(
-                        "No signature files found for baseKey='" + baseKey + "' in dir='" + currentDir + "'");
+                if (groupIndex == lastGroupIndex) {
+                    System.err.println("Skipping incomplete trailing record for baseKey='" + baseKey + "' in dir='"
+                            + currentDir + "' (no signature file yet; likely still uploading)");
+                    continue;
+                }
+                System.err.println("WARNING: No signature files for baseKey='" + baseKey + "' in dir='" + currentDir
+                        + "'; wrapping without RSA signatures");
             }
 
             // classify other record files (exclude the primary)

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommandTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/blocks/ToWrappedBlocksCommandTest.java
@@ -385,6 +385,39 @@ class ToWrappedBlocksCommandTest {
         }
     }
 
+    // ===== Nothing-new-to-wrap fast-path tests =====
+
+    @Nested
+    @DisplayName("isNothingNewToWrap fast-path guard")
+    class NothingNewToWrapTests {
+
+        @Test
+        @DisplayName("Nothing has been wrapped yet (effectiveHighest == -1) -- never a no-op")
+        void testNoOpFalseWhenNothingWrappedYet() {
+            assertFalse(
+                    ToWrappedBlocksCommand.isNothingNewToWrap(-1, 0),
+                    "Should always attempt to wrap when nothing has been wrapped yet, "
+                            + "even if block_times.bin reports a max of 0");
+        }
+
+        @Test
+        @DisplayName("Already wrapped exactly up to the known max -- is a no-op")
+        void testNoOpTrueWhenCaughtUp() {
+            assertTrue(
+                    ToWrappedBlocksCommand.isNothingNewToWrap(1259, 1259),
+                    "Should skip wrapping when already caught up to the known max block");
+        }
+
+        @Test
+        @DisplayName("Known max is ahead of what's wrapped -- not a no-op")
+        void testNoOpFalseWhenMoreDataAvailable() {
+            assertFalse(
+                    ToWrappedBlocksCommand.isNothingNewToWrap(1259, 1260),
+                    "Should still attempt to wrap when block_times.bin knows about more blocks "
+                            + "than have been wrapped so far");
+        }
+    }
+
     // ===== Hasher state save/load tests =====
 
     @Nested

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/commands/days/model/AddressBookRegistryTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/commands/days/model/AddressBookRegistryTest.java
@@ -146,6 +146,60 @@ public class AddressBookRegistryTest {
     }
 
     /**
+     * Test that an update timestamped identically to the current last entry replaces it in
+     * place rather than appending a duplicate-timestamp entry.
+     *
+     * <p>This is the scenario used by {@code ToWrappedBlocksCommand}'s block-0 genesis discovery:
+     * the network's founding roster is discovered from block 0's own transactions and must apply
+     * starting at block 0's own timestamp (not one nanosecond after, as later on-chain roster
+     * changes do), which is exactly the bootstrap/placeholder entry's own timestamp. Appending a
+     * second entry there would leave two entries tied on the same timestamp, and
+     * {@link AddressBookRegistry#getAddressBookForBlock} (backed by {@code Collections.binarySearch})
+     * does not guarantee which of two equal-timestamp entries it resolves to.
+     */
+    @Test
+    public void testUpdateAtSameTimestampReplacesRatherThanDuplicates() throws Exception {
+        try (var in = new ReadableStreamingData(AddressBookRegistryTest.class.getResourceAsStream(
+                "/2021-06-08T17_35_26.000831000Z-file-102-update-transaction-body.bin"))) {
+            int numOfTransactions = in.readInt();
+            List<TransactionBody> transactionBodies = new ArrayList<>(numOfTransactions);
+            for (int i = 0; i < numOfTransactions; i++) {
+                int len = in.readInt();
+                Bytes tbBytes = in.readBytes(len);
+                transactionBodies.add(standardParse(TransactionBody.PROTOBUF, tbBytes));
+            }
+
+            final AddressBookRegistry addressBookRegistry = new AddressBookRegistry();
+            assertEquals(1, addressBookRegistry.getAddressBookCount(), "Should start with only the bootstrap entry");
+            final NodeAddressBook bootstrapBook = addressBookRegistry.getCurrentAddressBook();
+
+            // Genesis-discovery timestamp: identical to the bootstrap entry's own timestamp.
+            final Instant genesisInstant = Instant.parse(org.hiero.block.tools.config.NetworkConfig.current()
+                    .genesisTimestamp()
+                    .replace('_', ':'));
+
+            final String changes = addressBookRegistry.updateAddressBook(genesisInstant, transactionBodies);
+            assertNotNull(changes, "Should detect changes from the discovered roster");
+
+            // Replaced in place, not appended -- still exactly one entry.
+            assertEquals(
+                    1,
+                    addressBookRegistry.getAddressBookCount(),
+                    "A same-timestamp update should replace the bootstrap entry, not duplicate it");
+
+            // getAddressBookForBlock() at that exact (tied) timestamp must resolve to the NEW
+            // book, not silently keep returning the stale bootstrap one.
+            final NodeAddressBook resolvedBook = addressBookRegistry.getAddressBookForBlock(genesisInstant);
+            assertNotEquals(
+                    bootstrapBook, resolvedBook, "Should resolve to the newly discovered book, not the bootstrap one");
+            assertEquals(
+                    24 - 3,
+                    resolvedBook.nodeAddress().size(),
+                    "Resolved book should be the discovered roster's content");
+        }
+    }
+
+    /**
      * Test that content equality is used, not reference equality.
      * This directly tests the bug where different object references with identical
      * content would be considered different.

--- a/tools-and-tests/tools/src/test/java/org/hiero/block/tools/commands/days/model/TarZstdDayReaderUsingExecTest.java
+++ b/tools-and-tests/tools/src/test/java/org/hiero/block/tools/commands/days/model/TarZstdDayReaderUsingExecTest.java
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.tools.commands.days.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.hiero.block.tools.days.model.TarZstdDayReaderUsingExec;
+import org.hiero.block.tools.records.model.unparsed.UnparsedRecordBlock;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression test for a bug where {@link TarZstdDayReaderUsingExec#streamTarZstd(Path)} silently
+ * dropped all but the first block when reading a "flat" day archive (record/signature files stored
+ * directly at the tar root, with no per-timestamp subdirectory) — the format produced by the
+ * solo-e2e-test WRB distribution scripts, as opposed to the per-timestamp-directory layout used by
+ * mirror-node-style day archives (see {@code 2019-09-13.tar.zstd}).
+ */
+public class TarZstdDayReaderUsingExecTest {
+
+    @Test
+    public void streamTarZstd_flatArchiveWithMultipleTimestamps_returnsAllBlocks(@TempDir Path tempDir)
+            throws Exception {
+        assumeTrue(isAvailable("tar"), "Skipping test: tar not available");
+        assumeTrue(isAvailable("zstd"), "Skipping test: zstd not available");
+
+        final int recordCount = 10;
+        final Path dayDir = tempDir.resolve("day");
+        Files.createDirectories(dayDir);
+        for (int i = 0; i < recordCount; i++) {
+            final String ts = String.format("2026-08-03T10_00_%02d.000000000Z", i);
+            // Minimal valid V6 record file: 4-byte big-endian version (6) + 4-byte HAPI version.
+            Files.write(dayDir.resolve(ts + ".rcd"), new byte[] {0, 0, 0, 6, 0, 0, 0, 0});
+            Files.write(dayDir.resolve(ts + ".rcd_sig"), "fake-signature".getBytes());
+        }
+
+        final Path archive = buildFlatTarZstd(dayDir, tempDir.resolve("2026-08-03.tar.zstd"));
+
+        try (var stream = TarZstdDayReaderUsingExec.streamTarZstd(archive)) {
+            final List<UnparsedRecordBlock> blocks = stream.toList();
+            assertEquals(recordCount, blocks.size(), "streamTarZstd should return every block in a flat archive");
+        }
+
+        // The list-based reader shares the same underlying grouping and never exhibited this bug;
+        // asserting parity guards against the two diverging again in the future.
+        final List<UnparsedRecordBlock> viaList = TarZstdDayReaderUsingExec.readTarZstd(archive);
+        assertEquals(recordCount, viaList.size(), "readTarZstd should return every block in a flat archive");
+    }
+
+    /**
+     * Regression test for a bug where a single record file still missing its signature file --
+     * the normal, expected state of the chronologically newest record during a live/ongoing
+     * download, since the CN uploads a record's {@code .rcd_sig} moments after its {@code .rcd}
+     * -- aborted the grouping pass for the ENTIRE day before any block was streamed out, silently
+     * discarding every other, fully-complete block in the same archive.
+     */
+    @Test
+    public void streamTarZstd_trailingRecordMissingSignature_skipsOnlyThatRecord(@TempDir Path tempDir)
+            throws Exception {
+        assumeTrue(isAvailable("tar"), "Skipping test: tar not available");
+        assumeTrue(isAvailable("zstd"), "Skipping test: zstd not available");
+
+        final int recordCount = 10;
+        final Path dayDir = tempDir.resolve("day");
+        Files.createDirectories(dayDir);
+        for (int i = 0; i < recordCount; i++) {
+            final String ts = String.format("2026-08-03T10_00_%02d.000000000Z", i);
+            Files.write(dayDir.resolve(ts + ".rcd"), new byte[] {0, 0, 0, 6, 0, 0, 0, 0});
+            // Omit the signature file for only the chronologically last record -- simulating the
+            // live "leading edge" where the .rcd has landed but its .rcd_sig hasn't uploaded yet.
+            if (i < recordCount - 1) {
+                Files.write(dayDir.resolve(ts + ".rcd_sig"), "fake-signature".getBytes());
+            }
+        }
+
+        final Path archive = buildFlatTarZstd(dayDir, tempDir.resolve("2026-08-03.tar.zstd"));
+
+        try (var stream = TarZstdDayReaderUsingExec.streamTarZstd(archive)) {
+            final List<UnparsedRecordBlock> blocks = stream.toList();
+            assertEquals(
+                    recordCount - 1,
+                    blocks.size(),
+                    "streamTarZstd should skip only the trailing record missing its signature file");
+        }
+    }
+
+    /**
+     * A non-trailing record file missing its signature is wrapped with 0 signature files and a
+     * warning rather than throwing — .rcd_sig files may legitimately be absent when the record
+     * source (e.g. Solo's MinIO) does not store them, and TSS-signed blocks do not need RSA sigs.
+     * All records (including the sig-less one) must be returned so downstream callers can decide
+     * how to handle 0-sig blocks.
+     */
+    @Test
+    public void streamTarZstd_middleRecordMissingSignature_includesRecordWithNoSigs(@TempDir Path tempDir)
+            throws Exception {
+        assumeTrue(isAvailable("tar"), "Skipping test: tar not available");
+        assumeTrue(isAvailable("zstd"), "Skipping test: zstd not available");
+
+        final int recordCount = 10;
+        final int missingIndex = recordCount / 2;
+        final Path dayDir = tempDir.resolve("day");
+        Files.createDirectories(dayDir);
+        for (int i = 0; i < recordCount; i++) {
+            final String ts = String.format("2026-08-03T10_00_%02d.000000000Z", i);
+            Files.write(dayDir.resolve(ts + ".rcd"), new byte[] {0, 0, 0, 6, 0, 0, 0, 0});
+            if (i != missingIndex) {
+                Files.write(dayDir.resolve(ts + ".rcd_sig"), "fake-signature".getBytes());
+            }
+        }
+
+        final Path archive = buildFlatTarZstd(dayDir, tempDir.resolve("2026-08-03.tar.zstd"));
+
+        try (var stream = TarZstdDayReaderUsingExec.streamTarZstd(archive)) {
+            final List<UnparsedRecordBlock> blocks = stream.toList();
+            assertEquals(
+                    recordCount,
+                    blocks.size(),
+                    "streamTarZstd should include all records even when a non-trailing one has no sig file");
+        }
+    }
+
+    /**
+     * Mirrors detect-tss-enablement.sh / install-and-run-wrb-cli.sh's own archive creation:
+     * {@code tar -cf - *.rcd *.rcd_sig | zstd -T0 > archive}, run from within the day directory so
+     * entries are flat (no subdirectory prefix).
+     */
+    private static Path buildFlatTarZstd(Path dayDir, Path archive) throws Exception {
+        final ProcessBuilder pb = new ProcessBuilder(
+                "sh", "-c", "tar -cf - *.rcd *.rcd_sig | zstd -T0 > '" + archive.toAbsolutePath() + "'");
+        pb.directory(dayDir.toFile());
+        pb.redirectErrorStream(true);
+        // Prevents macOS tar from adding AppleDouble ("._filename") resource-fork sidecar entries
+        // on APFS, which aren't real record files and would otherwise fail to parse; a no-op on
+        // Linux CI runners.
+        pb.environment().put("COPYFILE_DISABLE", "1");
+        final Process proc = pb.start();
+        final int exitCode = proc.waitFor();
+        assertEquals(0, exitCode, "tar/zstd archive creation should succeed");
+        return archive;
+    }
+
+    private static boolean isAvailable(String cmd) {
+        try {
+            final Process p = new ProcessBuilder("which", cmd).start();
+            return p.waitFor() == 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
- wrap no longer aborts on missing .rcd_sig files
- live-wrap poll loop exits 0 immediately when nothing is new.
- block-0 genesis roster applied at the right timestamp

____________________________________________________________________

## Reviewer Notes
<analysis>
The Java tools changes in this branch fix three independent bugs, all surfaced by the Solo e2e test environment:

1. **`TarZstdDayReaderUsingExec` — wrap no longer aborts on missing `.rcd_sig` files.** Solo's MinIO only stores `.rcd.gz`, never `.rcd_sig`. The old code threw for any non-trailing record group with no sig files, killing the wrap before a single block was produced. The fix logs a warning and continues wrapping with 0 signature files; 

2. **`ToWrappedBlocksCommand` — live-wrap poll loop exits 0 immediately when nothing is new.** Without this, every poll unconditionally deleted and re-wrapped the current zip range even when block_times.bin hadn't advanced, causing wasted work and spurious non-zero exits that would eventually trigger the poll loop's "give up" counter.

3. **`ToWrappedBlocksCommand` + `AddressBookRegistry` — block-0 genesis roster applied at the right timestamp.** Block 0's own address book update is the network's founding roster and must take effect starting at block 0, not `block0Time + 1ns`. The `+1ns` offset (correct for all later blocks, which are signed with the *old* roster) was being applied unconditionally, causing block-0 signature verification to check against a stale bootstrap entry. The fix uses `blockInstant` exactly for `blockNum == 0`, and `AddressBookRegistry.updateAddressBook()` now replaces the existing entry in place when the caller supplies a timestamp that exactly matches the last entry (the genesis case), preventing duplicate-timestamp entries that confuse binary search.

## Related Issue(s)
Closes #3543
