### PR TITLE
ci: harden workflow token permissions and pin container base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,10 @@ updates:
     open-pull-requests-limit: 10
 
   - package-ecosystem: docker
-    directory: /auth-layer-proxy
+    directories:
+      - /block-node/app/docker
+      - /tools-and-tests/simulator/docker
+      - /tools-and-tests/tools/docker
     assignees:
       - "swirlds-automation"
     labels:

--- a/.github/workflows/gradle-wrapper-validation.yaml
+++ b/.github/workflows/gradle-wrapper-validation.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "Gradle Wrapper Validation"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    timeout-minutes: 10
+    name: Validate Gradle Wrapper
+    runs-on: hl-bn-lin-md
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0

--- a/.github/workflows/milestone-rollover.yaml
+++ b/.github/workflows/milestone-rollover.yaml
@@ -31,7 +31,7 @@ on:
         default: "false"
 
 permissions:
-  issues: write
+  contents: read
 
 defaults:
   run:
@@ -42,6 +42,8 @@ jobs:
     timeout-minutes: 10
     name: Roll Over Milestone
     runs-on: hl-bn-lin-md
+    permissions:
+      issues: write
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -19,9 +19,7 @@ env:
   GRADLE_EXEC: "ionice -c 2 -n 2 nice -n 19 ./gradlew "
 
 permissions:
-  id-token: write
   contents: read
-  packages: write
 
 jobs:
   package-protobuf-source:

--- a/.github/workflows/pr-formatting.yaml
+++ b/.github/workflows/pr-formatting.yaml
@@ -23,13 +23,15 @@ defaults:
     shell: bash
 
 permissions:
-  statuses: write
+  contents: read
 
 jobs:
   pr-formatting-checks:
     timeout-minutes: 10
     name: PR Formatting Checks
     runs-on: hl-bn-lin-md
+    permissions:
+      statuses: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -28,9 +28,7 @@ on:
         required: false
 
 permissions:
-  contents: write
-  actions: write
-  issues: write
+  contents: read
 
 defaults:
   run:
@@ -41,6 +39,9 @@ jobs:
     timeout-minutes: 15
     name: Release
     runs-on: hl-bn-lin-md
+    permissions:
+      contents: write
+      actions: write
     outputs:
       create_pr: ${{ env.CREATE_PR }}
       is_prerelease: ${{ env.IS_PRERELEASE }}
@@ -307,6 +308,9 @@ jobs:
   generate_notes:
     name: Generate Release Notes
     needs: release
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/release-notes-generator.yaml
     with:
       release_branch: ${{ needs.release.outputs.release_branch }}
@@ -318,6 +322,8 @@ jobs:
     name: Roll Over Milestone
     needs: release
     if: ${{ needs.release.outputs.is_prerelease == 'false' }}
+    permissions:
+      issues: write
     uses: ./.github/workflows/milestone-rollover.yaml
     with:
       release_version: ${{ needs.release.outputs.release_version }}
@@ -328,6 +334,9 @@ jobs:
     timeout-minutes: 10
     name: Create GitHub Release
     runs-on: hl-bn-lin-md
+    permissions:
+      contents: write
+      actions: write
     needs: [release, generate_notes]
     continue-on-error: true
     if: ${{ always() && needs.release.result == 'success' }}
@@ -405,6 +414,8 @@ jobs:
     timeout-minutes: 10
     name: Create PR
     runs-on: hl-bn-lin-md
+    permissions:
+      contents: write
     needs: release
     if: ${{ needs.release.outputs.create_pr == 'true' }}
     env:

--- a/.github/workflows/release-notes-generator.yaml
+++ b/.github/workflows/release-notes-generator.yaml
@@ -37,7 +37,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 defaults:
   run:
@@ -48,6 +47,9 @@ jobs:
     timeout-minutes: 10
     name: Generate Release Notes
     runs-on: hl-bn-lin-md
+    permissions:
+      contents: read
+      actions: write
     env:
       # Single source of truth — bump to pick up a new git-cliff release.
       # Verify tarball structure: tar tzf git-cliff-<V>-x86_64-unknown-linux-musl.tar.gz | head

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -27,9 +27,7 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  contents: write
-  packages: write
+  contents: read
 
 env:
   OWNER: hashgraph
@@ -45,6 +43,10 @@ jobs:
   publish-app:
     timeout-minutes: 30
     runs-on: hl-bn-lin-md
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
     strategy:
       matrix:
         # Define the images you want to build
@@ -127,6 +129,9 @@ jobs:
   publish-jars:
     timeout-minutes: 30
     runs-on: hl-bn-lin-md
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Harden Runner
@@ -188,6 +193,10 @@ jobs:
   publish-simulator:
     timeout-minutes: 30
     runs-on: hl-bn-lin-md
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
 
     steps:
       - name: Harden Runner
@@ -258,6 +267,10 @@ jobs:
       - publish-app
       - publish-jars
     runs-on: hl-bn-lin-md
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
 
     steps:
       - name: Harden Runner
@@ -298,6 +311,10 @@ jobs:
     timeout-minutes: 15
     needs: publish-simulator
     runs-on: hl-bn-lin-md
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -46,7 +46,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
   contents: read
 
 env:
@@ -60,6 +59,9 @@ jobs:
     timeout-minutes: 15
     name: Generate Baseline
     runs-on: hl-bn-lin-md
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       sha: ${{ steps.commit.outputs.sha }}
       path: ${{ steps.baseline.outputs.path }}
@@ -139,6 +141,9 @@ jobs:
     timeout-minutes: 15
     name: "Verify Artifacts (${{ join(matrix.os, ', ') }})"
     runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write
+      contents: read
     needs:
       - generate-baseline
     strategy:

--- a/block-node/app/docker/Dockerfile
+++ b/block-node/app/docker/Dockerfile
@@ -10,7 +10,7 @@ ARG SOURCE_DATE_EPOCH="0"
 # Setup Builder Image
 #
 ########################################################################################################################
-FROM eclipse-temurin:25.0.2_10-jre-ubi10-minimal AS base-image
+FROM eclipse-temurin:25.0.2_10-jre-ubi10-minimal@sha256:c897ce903faf6736e4b5cbb2dd5e05e6b74909d71105f3cfe33840b3ce7b8b21 AS base-image
 # Define Build Arguments
 ARG SOURCE_DATE_EPOCH
 ARG UID=2000

--- a/tools-and-tests/simulator/docker/Dockerfile
+++ b/tools-and-tests/simulator/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25
+FROM eclipse-temurin:25@sha256:e787e08ef76f4c16866108cd7f9fcd96a68eef3ac6cc76866897d4d02d5a2262
 
 # Create a non-root user and group
 ARG UNAME=hedera

--- a/tools-and-tests/tools/docker/Dockerfile
+++ b/tools-and-tests/tools/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Use Eclipse Temurin with Java 25 as the base image
-FROM eclipse-temurin:25
+FROM eclipse-temurin:25@sha256:e787e08ef76f4c16866108cd7f9fcd96a68eef3ac6cc76866897d4d02d5a2262
 
 # Define version
 ARG VERSION


### PR DESCRIPTION
## Reviewer Notes

This PR raises the repository's OpenSSF Scorecard by tightening `GITHUB_TOKEN` permissions in the workflows, pinning the container base images by digest, and adding a Gradle wrapper validation workflow. No build, test, or release logic changes; every job keeps the scopes it actually exercises, just declared at the job level instead of for the whole workflow.

### Token-Permissions (published score 0 → 10)

Scorecard scores the whole repository 0 on this check when any workflow declares `contents: write`, `packages: write` or `actions: write` at the top level. Every workflow now declares a read-only top-level block (`contents: read`) and write scopes are declared on the jobs that use them:

| Workflow | Before (top level) | After |
|---|---|---|
| `pr-checks.yaml` | `id-token: write`, `contents: read`, `packages: write` | `contents: read` only. The `id-token`/`packages` scopes were added in #425 for the deterministic-build reusable workflow calls, which were removed in #887 and #1408; nothing in the remaining jobs uses them. |
| `pr-formatting.yaml` | `statuses: write` | `statuses: write` on the `pr-formatting-checks` job |
| `release-automation.yaml` | `contents: write`, `actions: write`, `issues: write` | `release` / `create_release`: `contents: write` + `actions: write`; `create_pr`: `contents: write`; `generate_notes` (reusable call): `contents: read` + `actions: write`; `milestone_rollover` (reusable call): `issues: write`. Caller jobs of reusable workflows must grant what the callee declares, so those two carry the callee's scopes. |
| `release-notes-generator.yaml` | `contents: read`, `actions: write` | `actions: write` moved to the `generate-notes` job |
| `release-push-image.yaml` | `id-token: write`, `contents: write`, `packages: write` | `packages: write` + `id-token: write` on the image and chart publishing jobs, `id-token: write` on `publish-jars`. `contents: write` is dropped: it was added in #1738 for the `release-action` step that has since moved to `release-automation.yaml`; the remaining steps only use `GITHUB_TOKEN` to log in to GHCR. |
| `milestone-rollover.yaml` | `issues: write` | moved to the `rollover` job (hygiene only, not scored) |
| `zxc-verify-gradle-build-determinism.yaml` | `id-token: write`, `contents: read` | `id-token: write` on both jobs (hygiene only, not scored; workflow is currently disabled) |

### Pinned-Dependencies (8 → 9)

- `block-node/app/docker/Dockerfile`: `eclipse-temurin:25.0.2_10-jre-ubi10-minimal` pinned to its multi-arch index digest.
- `tools-and-tests/simulator/docker/Dockerfile` and `tools-and-tests/tools/docker/Dockerfile`: `eclipse-temurin:25` pinned to its multi-arch index digest.
- Digests were resolved with `docker buildx imagetools inspect <image:tag>` (the OCI index digest, so both `linux/amd64` and `linux/arm64` builds keep working).
- `.github/dependabot.yml`: the `docker` ecosystem entry pointed at `/auth-layer-proxy`, which no longer exists in the tree. It now lists the three directories above so Dependabot keeps the digests current the same way it does for action SHAs.

### Binary-Artifacts (9 → 10 once the new workflow has run on `main`)

- New `.github/workflows/gradle-wrapper-validation.yaml` running `gradle/actions/wrapper-validation` on pushes to `main` and on pull requests. Scorecard only exempts `gradle/wrapper/gradle-wrapper.jar` when this specific action has a successful run on the latest `main` commit; the implicit validation done by `setup-gradle` does not count.

### Intentionally not changed

- **CodeQL / SAST**: the repository already uses GitHub's default CodeQL setup (`actions`, `java-kotlin`, `javascript-typescript`, `python` run on every PR and push). An advanced-configuration workflow cannot coexist with default setup, so none is added.
- `curl … | bash` installer for `solo-provisioner` in `e2e-node-operator.yaml` (already fetched from a version tag) and the `curl … | python3 -c` JSON probes in the solo e2e scripts (data piped into an inline parser, not code execution).
- Global `npm i -g` tool installs (`@hashgraph/solo`, `pnpm`) and the `npm install` in the TCK checkout; these have no lockfile to switch to `npm ci`.
- `FROM base-image AS solo-dev` in the app Dockerfile is a stage reference, not an image.

### Verification

- `actionlint` on every touched and added workflow: no new findings versus `main`.
- `scorecard --local . --checks Token-Permissions,Pinned-Dependencies,Binary-Artifacts,Dangerous-Workflow`:

| Check | Before | After |
|---|---|---|
| Token-Permissions | 0 | 10 |
| Pinned-Dependencies | 8 | 9 |
| Binary-Artifacts | 9 | 9 locally (exemption needs a successful run on `main`) |
| Dangerous-Workflow | 10 | 10 |

## Related Issue(s)

None.
