### PR TITLE
fix: K6 Tests - set CN_VERSION=latest

### DIFF
--- a/tools-and-tests/k6/run-k6-tests.sh
+++ b/tools-and-tests/k6/run-k6-tests.sh
@@ -100,6 +100,7 @@ start_solo() {
     (
     pushd "../scripts/solo-e2e-test" || return
     echo "TOPOLOGY=minimal" > .env
+    echo "CN_VERSION=latest" > .env
     task up
     if [[ $? -ne 0 ]]; then
         echo "FAILED TO START SOLO"


### PR DESCRIPTION
## Reviewer Notes
Overrides the default CN_VERSION="main" with CN_VERSION-latest

## Related Issue(s)
Closes: #3566