### PR TITLE
fix: Backfill counts a verification-failed block as persisted, so it is never re-fetched

### DIFF
--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillConfiguration.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillConfiguration.java
@@ -19,7 +19,8 @@ import org.hiero.block.node.base.Loggable;
  * @param endBlock For some historical-purpose–specific BNs, there could be a maximum number of blocks, -1 means no limit.
  * @param blockNodeSourcesPath File path for a yaml configuration for the BN sources.
  * @param scanInterval Interval in milliseconds to scan for missing gaps (skips if the previous task is running)
- * @param maxRetries Maximum number of retries to fetch a missing block (with exponential back-off)
+ * @param maxRetries Maximum number of attempts to fetch a missing block (with exponential back-off); the fetch and
+ *                   persistence-wait loops both run for this many attempts, so it must be at least 1
  * @param initialRetryDelay Initial cooldown time between retries in milliseconds, will be multiplied by number of retry on each attempt
  * @param fetchBatchSize Number of blocks to fetch in a single gRPC call
  * @param delayBetweenBatches Cool downtime in milliseconds between batches of blocks to fetch
@@ -38,7 +39,7 @@ public record BackfillConfiguration(
         @Loggable @ConfigProperty(defaultValue = "-1") @Min(-1) long endBlock,
         @Loggable @ConfigProperty(defaultValue = "") String blockNodeSourcesPath,
         @Loggable @ConfigProperty(defaultValue = "60000") @Min(100) int scanInterval,
-        @Loggable @ConfigProperty(defaultValue = "3") @Min(0) @Max(10) int maxRetries,
+        @Loggable @ConfigProperty(defaultValue = "3") @Min(1) @Max(10) int maxRetries,
         @Loggable @ConfigProperty(defaultValue = "5000") @Min(500) int initialRetryDelay,
         @Loggable @ConfigProperty(defaultValue = "10") @Min(1) @Max(1024) int fetchBatchSize,
         @Loggable @ConfigProperty(defaultValue = "1000") @Min(100) int delayBetweenBatches,

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPersistenceAwaiter.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPersistenceAwaiter.java
@@ -9,7 +9,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
@@ -41,11 +40,36 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
      * The flag is last-write-wins - several persistence plugins can report on the same block, so a
      * late failure can overwrite an earlier success. The worst case is one extra fetch of a block
      * that is idempotent to re-persist, which is cheaper than sticky-success bookkeeping.
-     *
-     * @param latch released once the block's fate is known
-     * @param succeeded whether the block was reported as successfully persisted
      */
-    private record Pending(CountDownLatch latch, AtomicBoolean succeeded) {}
+    private static final class Pending {
+        private final CountDownLatch latch = new CountDownLatch(1);
+        private volatile boolean succeeded = false;
+
+        /**
+         * Records the outcome and releases the latch. The outcome is written first, so a waiter woken
+         * by the latch always sees it.
+         *
+         * @param successful whether the block was reported as successfully persisted
+         */
+        void complete(final boolean successful) {
+            succeeded = successful;
+            latch.countDown();
+        }
+
+        /**
+         * @return whether the block was reported as successfully persisted
+         */
+        boolean succeeded() {
+            return succeeded;
+        }
+
+        /**
+         * @return the latch released once the block's fate is known
+         */
+        CountDownLatch latch() {
+            return latch;
+        }
+    }
 
     /**
      * Map of block numbers to the latch/outcome pair released when the block's fate is known.
@@ -65,7 +89,7 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
         pendingBlocks.computeIfAbsent(blockNumber, k -> {
             final String trackingBlockMsg = "Tracking block [{0}] for persistence";
             LOGGER.log(TRACE, trackingBlockMsg, blockNumber);
-            return new Pending(new CountDownLatch(1), new AtomicBoolean(false));
+            return new Pending();
         });
     }
 
@@ -95,16 +119,12 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
             boolean completed = pending.latch().await(timeoutMs, TimeUnit.MILLISECONDS);
             if (completed) {
                 final String persistenceConfirmedMsg = "Block [{0}] persistence resolved, succeeded=[{1}]";
-                LOGGER.log(
-                        TRACE,
-                        persistenceConfirmedMsg,
-                        blockNumber,
-                        pending.succeeded().get());
+                LOGGER.log(TRACE, persistenceConfirmedMsg, blockNumber, pending.succeeded());
             } else {
                 final String persistenceTimedOutMsg = "Block [{0}] persistence timed out after [{1}]ms";
                 LOGGER.log(DEBUG, persistenceTimedOutMsg, blockNumber, timeoutMs);
             }
-            return completed && pending.succeeded().get();
+            return completed && pending.succeeded();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             final String waitInterruptedMsg = "Block [%s] persistence wait interrupted".formatted(blockNumber);
@@ -139,9 +159,7 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
                 final String persistenceFailedMsg = "Block [{0}] persistence failed";
                 LOGGER.log(INFO, persistenceFailedMsg, blockNumber);
             }
-            // Record the outcome before releasing, so a waiter woken by the latch always sees it.
-            pending.succeeded().set(notification.succeeded());
-            pending.latch().countDown();
+            pending.complete(notification.succeeded());
         }
     }
 
@@ -167,9 +185,7 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
             if (pending != null) {
                 final String verificationFailedMsg = "Block [{0}] verification failed, marking block as not persisted";
                 LOGGER.log(INFO, verificationFailedMsg, blockNumber);
-                // Record the outcome before releasing, so a waiter woken by the latch always sees it.
-                pending.succeeded().set(false);
-                pending.latch().countDown();
+                pending.complete(false);
             }
         }
     }
@@ -179,10 +195,10 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
      * resetting state.
      */
     public void clear() {
-        // Release all waiting threads before clearing. The outcome flag is left as-is (false unless
-        // something already reported success), so a block abandoned by a shutdown reads as not persisted.
+        // Release all waiting threads before clearing. A block abandoned by a shutdown is reported as
+        // not persisted, so it is re-detected and re-fetched on the next run.
         for (Pending pending : pendingBlocks.values()) {
-            pending.latch().countDown();
+            pending.complete(false);
         }
         pendingBlocks.clear();
     }

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPersistenceAwaiter.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPersistenceAwaiter.java
@@ -9,6 +9,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
@@ -26,16 +27,32 @@ import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
  *   <li>Send the block via the messaging facility</li>
  *   <li>Call {@link #awaitPersistence(long, long)} to block until persistence is confirmed</li>
  * </ol>
+ *
+ * <p>A released latch is <b>not</b> equivalent to a successfully persisted block: latches are also
+ * released on persistence failure and on verification failure so the waiter can fail fast. The
+ * outcome is therefore tracked alongside the latch, and {@link #awaitPersistence(long, long)}
+ * reports it.
  */
 public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
     private static final System.Logger LOGGER = System.getLogger(BackfillPersistenceAwaiter.class.getName());
 
     /**
-     * Map of block numbers to latches that are released when persistence is confirmed.
-     * The latch is created when a block is tracked and counted down when persistence
-     * notification is received.
+     * A tracked block: the latch released once its fate is known, plus whether that fate was success.
+     * The flag is last-write-wins - several persistence plugins can report on the same block, so a
+     * late failure can overwrite an earlier success. The worst case is one extra fetch of a block
+     * that is idempotent to re-persist, which is cheaper than sticky-success bookkeeping.
+     *
+     * @param latch released once the block's fate is known
+     * @param succeeded whether the block was reported as successfully persisted
      */
-    private final ConcurrentHashMap<Long, CountDownLatch> pendingBlocks = new ConcurrentHashMap<>();
+    private record Pending(CountDownLatch latch, AtomicBoolean succeeded) {}
+
+    /**
+     * Map of block numbers to the latch/outcome pair released when the block's fate is known.
+     * The entry is created when a block is tracked and counted down when a persistence or
+     * verification notification is received.
+     */
+    private final ConcurrentHashMap<Long, Pending> pendingBlocks = new ConcurrentHashMap<>();
 
     /**
      * Tracks a block that will be sent for persistence. Must be called before
@@ -48,20 +65,25 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
         pendingBlocks.computeIfAbsent(blockNumber, k -> {
             final String trackingBlockMsg = "Tracking block [{0}] for persistence";
             LOGGER.log(TRACE, trackingBlockMsg, blockNumber);
-            return new CountDownLatch(1);
+            return new Pending(new CountDownLatch(1), new AtomicBoolean(false));
         });
     }
 
     /**
      * Waits for persistence confirmation for a specific block.
+     * <p>
+     * A {@code false} result means "not persisted", covering a timeout, an interrupt, and a reported
+     * persistence or verification failure alike. All of those leave the block still missing, which is
+     * the only distinction the caller acts on.
      *
      * @param blockNumber the block number to wait for
      * @param timeoutMs maximum time to wait in milliseconds
-     * @return true if persistence was confirmed or block was not being tracked, false if timed out or interrupted
+     * @return true if persistence was confirmed or block was not being tracked, false if the block
+     *         failed to persist, timed out, or the wait was interrupted
      */
     public boolean awaitPersistence(long blockNumber, long timeoutMs) {
-        CountDownLatch latch = pendingBlocks.get(blockNumber);
-        if (latch == null) {
+        Pending pending = pendingBlocks.get(blockNumber);
+        if (pending == null) {
             final String alreadyPersistedMsg = "Block [{0}] already persisted or not tracked";
             LOGGER.log(DEBUG, alreadyPersistedMsg, blockNumber);
             return true;
@@ -70,15 +92,19 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
         final String waitingForBlockMsg = "Waiting for block [{0}] persistence (timeout=[{1}]ms)";
         LOGGER.log(TRACE, waitingForBlockMsg, blockNumber, timeoutMs);
         try {
-            boolean completed = latch.await(timeoutMs, TimeUnit.MILLISECONDS);
+            boolean completed = pending.latch().await(timeoutMs, TimeUnit.MILLISECONDS);
             if (completed) {
-                final String persistenceConfirmedMsg = "Block [{0}] persistence confirmed";
-                LOGGER.log(TRACE, persistenceConfirmedMsg, blockNumber);
+                final String persistenceConfirmedMsg = "Block [{0}] persistence resolved, succeeded=[{1}]";
+                LOGGER.log(
+                        TRACE,
+                        persistenceConfirmedMsg,
+                        blockNumber,
+                        pending.succeeded().get());
             } else {
                 final String persistenceTimedOutMsg = "Block [{0}] persistence timed out after [{1}]ms";
                 LOGGER.log(DEBUG, persistenceTimedOutMsg, blockNumber, timeoutMs);
             }
-            return completed;
+            return completed && pending.succeeded().get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             final String waitInterruptedMsg = "Block [%s] persistence wait interrupted".formatted(blockNumber);
@@ -91,7 +117,8 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
 
     /**
      * Handles persistence notifications from the messaging facility. When a block
-     * from the BACKFILL source is persisted, the corresponding latch is released.
+     * from the BACKFILL source is reported on, its outcome is recorded and the
+     * corresponding latch is released.
      *
      * @param notification the persistence notification
      */
@@ -103,8 +130,8 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
         }
 
         long blockNumber = notification.blockNumber();
-        CountDownLatch latch = pendingBlocks.get(blockNumber);
-        if (latch != null) {
+        Pending pending = pendingBlocks.get(blockNumber);
+        if (pending != null) {
             if (notification.succeeded()) {
                 final String receivedConfirmationMsg = "Received persistence confirmation for block [{0}]";
                 LOGGER.log(TRACE, receivedConfirmationMsg, blockNumber);
@@ -112,14 +139,17 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
                 final String persistenceFailedMsg = "Block [{0}] persistence failed";
                 LOGGER.log(INFO, persistenceFailedMsg, blockNumber);
             }
-            latch.countDown();
+            // Record the outcome before releasing, so a waiter woken by the latch always sees it.
+            pending.succeeded().set(notification.succeeded());
+            pending.latch().countDown();
         }
     }
 
     /**
      * Handles verification notifications from the messaging facility. If verification
-     * fails for a backfill block, the latch is released immediately to fail fast
-     * rather than waiting for a persistence notification that will never arrive.
+     * fails for a backfill block, the block is marked as not persisted and the latch is
+     * released immediately to fail fast rather than waiting for a persistence notification
+     * that will never arrive.
      *
      * @param notification the verification notification
      */
@@ -133,11 +163,13 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
         // Only release latch on verification failure - success means we still wait for persistence
         if (!notification.success()) {
             long blockNumber = notification.blockNumber();
-            CountDownLatch latch = pendingBlocks.get(blockNumber);
-            if (latch != null) {
-                final String verificationFailedMsg = "Block [{0}] verification failed, releasing latch";
+            Pending pending = pendingBlocks.get(blockNumber);
+            if (pending != null) {
+                final String verificationFailedMsg = "Block [{0}] verification failed, marking block as not persisted";
                 LOGGER.log(INFO, verificationFailedMsg, blockNumber);
-                latch.countDown();
+                // Record the outcome before releasing, so a waiter woken by the latch always sees it.
+                pending.succeeded().set(false);
+                pending.latch().countDown();
             }
         }
     }
@@ -147,9 +179,10 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
      * resetting state.
      */
     public void clear() {
-        // Release all waiting threads before clearing
-        for (CountDownLatch latch : pendingBlocks.values()) {
-            latch.countDown();
+        // Release all waiting threads before clearing. The outcome flag is left as-is (false unless
+        // something already reported success), so a block abandoned by a shutdown reads as not persisted.
+        for (Pending pending : pendingBlocks.values()) {
+            pending.latch().countDown();
         }
         pendingBlocks.clear();
     }

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPersistenceAwaiter.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillPersistenceAwaiter.java
@@ -64,10 +64,14 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
         }
 
         /**
-         * @return the latch released once the block's fate is known
+         * Waits until the block's fate is known, or the timeout elapses.
+         *
+         * @param timeoutMs maximum time to wait in milliseconds
+         * @return true if the fate became known before the timeout elapsed
+         * @throws InterruptedException if the wait is interrupted
          */
-        CountDownLatch latch() {
-            return latch;
+        boolean await(final long timeoutMs) throws InterruptedException {
+            return latch.await(timeoutMs, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -116,7 +120,7 @@ public class BackfillPersistenceAwaiter implements BlockNotificationHandler {
         final String waitingForBlockMsg = "Waiting for block [{0}] persistence (timeout=[{1}]ms)";
         LOGGER.log(TRACE, waitingForBlockMsg, blockNumber, timeoutMs);
         try {
-            boolean completed = pending.latch().await(timeoutMs, TimeUnit.MILLISECONDS);
+            boolean completed = pending.await(timeoutMs);
             if (completed) {
                 final String persistenceConfirmedMsg = "Block [{0}] persistence resolved, succeeded=[{1}]";
                 LOGGER.log(TRACE, persistenceConfirmedMsg, blockNumber, pending.succeeded());

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillRunner.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillRunner.java
@@ -282,22 +282,21 @@ final class BackfillRunner {
         List<Long> stillPending = blockNumbers;
         for (int attempt = 1; attempt <= config.maxRetries() && !stillPending.isEmpty(); attempt++) {
             stillPending = awaitBlocksPersistence(stillPending, chunk);
-            if (stillPending.isEmpty()) {
-                return true;
-            }
-            if (attempt < config.maxRetries()) {
+            if (!stillPending.isEmpty() && attempt < config.maxRetries()) {
                 final String retryingChunkMsg =
                         "Chunk [{0}] persistence attempt [{1}/{2}] incomplete for [{3}] block(s), continuing to "
                                 + "wait on the same in-flight session(s)";
                 logger.log(DEBUG, retryingChunkMsg, chunk, attempt, config.maxRetries(), stillPending.size());
-                Thread.sleep(Math.max(0, (long) config.initialRetryDelay() * attempt));
                 // awaitPersistence always clears its own bookkeeping entry once it returns (success,
-                // timeout, or interrupt alike), so without re-tracking here the next await call would
-                // immediately report "already persisted or not tracked" for a block that may still
-                // actually be in flight.
+                // failure, timeout, or interrupt alike), so without re-tracking here the next await call
+                // would immediately report "already persisted or not tracked" for a block that may still
+                // actually be in flight. A block that definitively failed is re-tracked too and burns
+                // another perBlockProcessingTimeout on a latch nothing will release; that is accepted,
+                // since giving it its own outcome state costs more than the rare extra wait.
                 for (long blockNumber : stillPending) {
                     persistenceAwaiter.trackBlock(blockNumber);
                 }
+                Thread.sleep(Math.max(0, (long) config.initialRetryDelay() * attempt));
             }
         }
         return stillPending.isEmpty();
@@ -344,7 +343,7 @@ final class BackfillRunner {
         for (long blockNumber : blockNumbers) {
             boolean persisted = persistenceAwaiter.awaitPersistence(blockNumber, config.perBlockProcessingTimeout());
             if (!persisted) {
-                final String persistenceTimedOutMsg = "Block [{0}] persistence timed out, will be re-detected";
+                final String persistenceTimedOutMsg = "Block [{0}] did not persist, will be re-detected";
                 logger.log(INFO, persistenceTimedOutMsg, blockNumber);
                 stillPending.add(blockNumber);
             }
@@ -408,7 +407,11 @@ final class BackfillRunner {
             return null;
         }
 
-        long chunkEnd = Math.min(Math.min(start + batchSize - 1, coveringRange.end()), gapEnd);
+        // The genesis block is the only source of TSS verification data on a node that has none yet, and
+        // it publishes that data during its own hashing stage. Sending it in a chunk of its own means
+        // blocks 1..N are not fetched until it has persisted, so they cannot race the bootstrap and fail
+        // with MISSING_VERIFICATION_DATA. Costs one extra single-block fetch, once per node lifetime.
+        long chunkEnd = start == 0 ? 0 : Math.min(Math.min(start + batchSize - 1, coveringRange.end()), gapEnd);
         return new LongRange(start, chunkEnd);
     }
 

--- a/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillRunner.java
+++ b/block-node/backfill/src/main/java/org/hiero/block/node/backfill/BackfillRunner.java
@@ -13,7 +13,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
 import org.hiero.block.internal.BlockNodeSourceConfig;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
@@ -277,7 +279,7 @@ final class BackfillRunner {
      * @return {@code true} if every block in the chunk was confirmed persisted within the retry budget
      */
     private boolean sendChunkAndAwaitPersistenceWithRetries(
-            List<BlockUnparsed> blocks, List<Long> blockNumbers, LongRange chunk) throws InterruptedException {
+            List<BlockUnparsed> blocks, List<Long> blockNumbers, LongRange chunk) {
         sendBlocksForPersistence(blocks, blockNumbers, chunk);
         List<Long> stillPending = blockNumbers;
         for (int attempt = 1; attempt <= config.maxRetries() && !stillPending.isEmpty(); attempt++) {
@@ -296,7 +298,8 @@ final class BackfillRunner {
                 for (long blockNumber : stillPending) {
                     persistenceAwaiter.trackBlock(blockNumber);
                 }
-                Thread.sleep(Math.max(0, (long) config.initialRetryDelay() * attempt));
+                LockSupport.parkNanos(
+                        TimeUnit.MILLISECONDS.toNanos(Math.max(0, (long) config.initialRetryDelay() * attempt)));
             }
         }
         return stillPending.isEmpty();
@@ -338,7 +341,7 @@ final class BackfillRunner {
      * @param chunk the range being processed (for logging)
      * @return the subset of {@code blockNumbers} that did not confirm persistence within the timeout
      */
-    private List<Long> awaitBlocksPersistence(List<Long> blockNumbers, LongRange chunk) throws InterruptedException {
+    private List<Long> awaitBlocksPersistence(List<Long> blockNumbers, LongRange chunk) {
         List<Long> stillPending = new ArrayList<>();
         for (long blockNumber : blockNumbers) {
             boolean persisted = persistenceAwaiter.awaitPersistence(blockNumber, config.perBlockProcessingTimeout());

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPersistenceAwaiterTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPersistenceAwaiterTest.java
@@ -2,8 +2,10 @@
 package org.hiero.block.node.backfill;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -188,8 +190,8 @@ class BackfillPersistenceAwaiterTest {
         }
 
         @Test
-        @DisplayName("should release latch on failed persistence notification")
-        void shouldReleaseLatchOnFailedPersistence() {
+        @DisplayName("should report failure promptly on failed persistence notification")
+        void shouldReportFailureOnFailedPersistence() {
             // given
             long blockNumber = 100L;
             subject.trackBlock(blockNumber);
@@ -197,9 +199,9 @@ class BackfillPersistenceAwaiterTest {
             // when - persistence failed
             subject.handlePersisted(new PersistedNotification(blockNumber, false, 1, BlockSource.BACKFILL));
 
-            // then - await should still return (latch released)
-            boolean result = subject.awaitPersistence(blockNumber, 100);
-            assertTrue(result);
+            // then - await returns without consuming the timeout, and reports the block as not persisted
+            assertTimeoutPreemptively(
+                    Duration.ofMillis(200), () -> assertFalse(subject.awaitPersistence(blockNumber, 5000)));
         }
 
         @Test
@@ -238,8 +240,8 @@ class BackfillPersistenceAwaiterTest {
     class HandleVerificationTests {
 
         @Test
-        @DisplayName("should release latch on verification failure for fail-fast behavior")
-        void shouldReleaseLatchOnVerificationFailure() {
+        @DisplayName("should report failure promptly on verification failure for fail-fast behavior")
+        void shouldReportFailureOnVerificationFailure() {
             // given
             long blockNumber = 100L;
             subject.trackBlock(blockNumber);
@@ -253,9 +255,9 @@ class BackfillPersistenceAwaiterTest {
                     null,
                     BlockSource.BACKFILL));
 
-            // then - await should return immediately
-            boolean result = subject.awaitPersistence(blockNumber, 100);
-            assertTrue(result);
+            // then - await returns without consuming the timeout, and reports the block as not persisted
+            assertTimeoutPreemptively(
+                    Duration.ofMillis(200), () -> assertFalse(subject.awaitPersistence(blockNumber, 5000)));
         }
 
         @Test
@@ -272,6 +274,29 @@ class BackfillPersistenceAwaiterTest {
             // then - block should still be pending (waiting for persistence), await times out
             boolean result = subject.awaitPersistence(blockNumber, 50);
             assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("should report success after re-tracking a block that previously failed")
+        void shouldReportSuccessAfterReTrackFollowingFailure() {
+            // given - a block that failed verification and was awaited (which clears its entry)
+            long blockNumber = 100L;
+            subject.trackBlock(blockNumber);
+            subject.handleVerification(new VerificationNotification(
+                    false,
+                    FailureInfo.standard(FailureType.BAD_BLOCK_PROOF),
+                    blockNumber,
+                    null,
+                    null,
+                    BlockSource.BACKFILL));
+            assertFalse(subject.awaitPersistence(blockNumber, 100));
+
+            // when - the runner re-tracks it for another attempt and it persists this time
+            subject.trackBlock(blockNumber);
+            subject.handlePersisted(new PersistedNotification(blockNumber, true, 1, BlockSource.BACKFILL));
+
+            // then - the stale failure must not leak into the new attempt
+            assertTrue(subject.awaitPersistence(blockNumber, 100));
         }
 
         @Test
@@ -337,6 +362,34 @@ class BackfillPersistenceAwaiterTest {
             assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS), "Threads should be released");
             assertTrue(thread1Released.get());
             assertTrue(thread2Released.get());
+        }
+
+        @Test
+        @DisplayName("should report failure to a thread released by clear")
+        void shouldReportFailureAfterClear() throws InterruptedException {
+            // given
+            long blockNumber = 100L;
+            subject.trackBlock(blockNumber);
+
+            AtomicBoolean awaitResult = new AtomicBoolean(true);
+            CountDownLatch threadStarted = new CountDownLatch(1);
+            CountDownLatch threadDone = new CountDownLatch(1);
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            executor.submit(() -> {
+                threadStarted.countDown();
+                awaitResult.set(subject.awaitPersistence(blockNumber, 5000));
+                threadDone.countDown();
+            });
+            assertTrue(threadStarted.await(1, TimeUnit.SECONDS), "Thread should start");
+            Thread.sleep(50); // Give the thread time to enter await
+
+            // when - shutdown abandons the block
+            subject.clear();
+
+            // then - the waiter is released, and a block abandoned mid-flight is not persisted
+            assertTrue(threadDone.await(1, TimeUnit.SECONDS), "Thread should be released");
+            assertFalse(awaitResult.get());
+            executor.shutdown();
         }
 
         @Test

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillPluginTest.java
@@ -3,6 +3,7 @@ package org.hiero.block.node.backfill;
 
 import static java.util.concurrent.locks.LockSupport.parkNanos;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.pbj.runtime.ParseException;
@@ -688,7 +689,10 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         // start block-node with blocks from 0 to 30; on-demand backfill will cover 31 to 50
         start(new BackfillPlugin(), historicalBlockFacility, configOverride);
 
-        final long targetBlock = 40L;
+        // The last block of the gap, and of its chunk: a failed block now also stops its chunk, so
+        // failing an earlier one would strand the rest of the gap until the next autonomous scan.
+        // Failing the last one costs nothing, and BackfillPlugin.handlePersisted re-queues it directly.
+        final long targetBlock = 50L;
         final AtomicBoolean failedOnce = new AtomicBoolean();
         // 20 blocks (31..50) must eventually succeed, including the one that fails its first attempt
         CountDownLatch countDownLatch = new CountDownLatch(20);
@@ -1709,13 +1713,16 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
         final String backfillSourcePath = testTempDir + "/backfill-source-mass-failure.json";
         createTestBlockNodeSourcesFile(backfillSource, backfillSourcePath);
 
-        // Fast scan so several cycles happen quickly.
+        // Fast scan so several cycles happen quickly. A single await attempt per block keeps the
+        // chunk's failure cheap: none of these blocks is ever confirmed persisted, so a larger retry
+        // budget would only spend perBlockProcessingTimeout per block per extra attempt.
         Map<String, String> configOverride = BackfillConfigBuilder.NewBuilder()
                 .backfillSourcePath(backfillSourcePath)
                 .greedy(true)
                 .fetchBatchSize(100)
                 .initialDelay(50)
                 .scanInterval(300)
+                .maxRetries(1)
                 .build();
         // Live-tail queue capacity well below blockCount, so the per-block retries handlePersisted()
         // issues below overflow it for most of them - mirroring a real mass MISSING_VERIFICATION_DATA burst.
@@ -1763,10 +1770,186 @@ class BackfillPluginTest extends PluginTestBase<BackfillPlugin, ExecutorService,
 
         // The range is still genuinely missing from the store, so a later scan must re-detect and
         // resubmit it (triggering a second fetch of at least one block) rather than treating it as
-        // already handled because of a stale high-water mark.
+        // already handled because of a stale high-water mark. Two independent mechanisms now get it
+        // re-detected: the chunk itself never reports as persisted, so the runner returns
+        // gap.start() - 1 and the GapProcessor pulls the high-water mark back; and, for whichever of
+        // these failures did make it into the tiny live-tail queue, the per-block requeue.
         assertTrue(
                 resubmitFetchLatch.await(10, TimeUnit.SECONDS),
                 "A subsequent scan should re-fetch the still-missing live-tail range after the mass failure");
+    }
+
+    @Test
+    @DisplayName("A block that fails verification is re-fetched by a later gap scan")
+    void testVerificationFailureIsReFetchedByALaterScan() throws InterruptedException {
+        // Peer serves a small range that lands entirely as LIVE_TAIL on an empty store.
+        final int blockCount = 5;
+        final long targetBlock = 2L;
+        final TestBlockNodeServer server = new TestBlockNodeServer(0, getHistoricalBlockFacility(0, blockCount - 1));
+        testBlockNodeServers.add(server);
+        BlockNodeSource backfillSource = BlockNodeSource.newBuilder()
+                .nodes(BlockNodeSourceConfig.newBuilder()
+                        .address("localhost")
+                        .port(server.port())
+                        .priority(1)
+                        .build())
+                .build();
+        final String backfillSourcePath = testTempDir + "/backfill-source-verification-failure.json";
+        createTestBlockNodeSourcesFile(backfillSource, backfillSourcePath);
+
+        // Fast scan so several cycles happen quickly; a single short await keeps the failing block cheap.
+        final Map<String, String> configOverride = BackfillConfigBuilder.NewBuilder()
+                .backfillSourcePath(backfillSourcePath)
+                .greedy(true)
+                .initialDelay(50)
+                .scanInterval(300)
+                .maxRetries(1)
+                .perBlockProcessingTimeout(500)
+                .build();
+
+        // Counts how many times each block has been fetched from the peer. A second fetch of the target
+        // block can only happen if a later scan re-detected it - the exact behavior under test.
+        final Map<Long, AtomicInteger> fetchCountsByBlock = new ConcurrentHashMap<>();
+        final CountDownLatch firstFetchLatch = new CountDownLatch(1);
+        final CountDownLatch resubmitFetchLatch = new CountDownLatch(1);
+        // The target block fails verification only on its first fetch, mirroring a node whose TSS data
+        // is not loaded yet; every other block (and the target's later attempts) verifies and persists.
+        final AtomicBoolean targetFailedOnce = new AtomicBoolean();
+        blockMessaging.registerBlockNotificationHandler(
+                new BlockNotificationHandler() {
+                    @Override
+                    public void handleBackfilled(BackfilledBlockNotification notification) {
+                        final long blockNumber = notification.blockNumber();
+                        int fetchCount = fetchCountsByBlock
+                                .computeIfAbsent(blockNumber, b -> new AtomicInteger())
+                                .incrementAndGet();
+                        if (blockNumber == targetBlock) {
+                            if (fetchCount == 1) {
+                                firstFetchLatch.countDown();
+                            } else if (fetchCount == 2) {
+                                resubmitFetchLatch.countDown();
+                            }
+                        }
+                        boolean induceFailure =
+                                blockNumber == targetBlock && targetFailedOnce.compareAndSet(false, true);
+                        blockNodeContext
+                                .blockMessaging()
+                                .sendBlockVerification(new VerificationNotification(
+                                        !induceFailure,
+                                        induceFailure
+                                                ? VerificationNotification.FailureInfo.standard(
+                                                        VerificationNotification.FailureType.MISSING_VERIFICATION_DATA)
+                                                : null,
+                                        blockNumber,
+                                        Bytes.wrap("123"),
+                                        notification.block(),
+                                        BlockSource.BACKFILL));
+                        if (!induceFailure) {
+                            blockNodeContext
+                                    .blockMessaging()
+                                    .sendBlockPersisted(
+                                            new PersistedNotification(blockNumber, true, 10, BlockSource.BACKFILL));
+                        }
+                    }
+                },
+                false,
+                "test-verification-failure-fetch-handler");
+
+        // Empty store: the whole peer range is classified LIVE_TAIL, and nothing is ever added to it,
+        // so the range stays genuinely missing and re-detection is unambiguous.
+        start(new BackfillPlugin(), new SimpleInMemoryHistoricalBlockFacility(), configOverride);
+
+        assertTrue(firstFetchLatch.await(10, TimeUnit.SECONDS), "First scan should fetch the target block");
+
+        // A verification failure means the block never persisted, so a later scan must re-fetch it
+        // rather than treating the gap as completed.
+        assertTrue(
+                resubmitFetchLatch.await(10, TimeUnit.SECONDS),
+                "A subsequent scan should re-fetch the block that failed verification");
+    }
+
+    @Test
+    @DisplayName("The genesis block is backfilled and persisted before any of its successors is fetched")
+    void testGenesisBlockIsBackfilledBeforeItsSuccessors() throws InterruptedException {
+        // Peer serves a range larger than one chunk would be if block 0 were not special-cased.
+        final int blockCount = 12;
+        final TestBlockNodeServer server = new TestBlockNodeServer(0, getHistoricalBlockFacility(0, blockCount - 1));
+        testBlockNodeServers.add(server);
+        BlockNodeSource backfillSource = BlockNodeSource.newBuilder()
+                .nodes(BlockNodeSourceConfig.newBuilder()
+                        .address("localhost")
+                        .port(server.port())
+                        .priority(1)
+                        .build())
+                .build();
+        final String backfillSourcePath = testTempDir + "/backfill-source-genesis-first.json";
+        createTestBlockNodeSourcesFile(backfillSource, backfillSourcePath);
+
+        final Map<String, String> configOverride = BackfillConfigBuilder.NewBuilder()
+                .backfillSourcePath(backfillSourcePath)
+                .greedy(true)
+                .initialDelay(50)
+                .fetchBatchSize(10)
+                .build();
+
+        // Block 0's persistence is deliberately delayed. On a real node, block 0's own hashing stage is
+        // what publishes the TSS data its successors need to verify, so anything fetched alongside it
+        // fails with MISSING_VERIFICATION_DATA. Nothing else may be fetched until block 0 has persisted.
+        final AtomicBoolean genesisPersisted = new AtomicBoolean();
+        final AtomicBoolean successorFetchedTooEarly = new AtomicBoolean();
+        final CountDownLatch successorFetchedLatch = new CountDownLatch(1);
+        blockMessaging.registerBlockNotificationHandler(
+                new BlockNotificationHandler() {
+                    @Override
+                    public void handleBackfilled(BackfilledBlockNotification notification) {
+                        final long blockNumber = notification.blockNumber();
+                        if (blockNumber > 0) {
+                            if (!genesisPersisted.get()) {
+                                successorFetchedTooEarly.set(true);
+                            }
+                            successorFetchedLatch.countDown();
+                        }
+                        blockNodeContext
+                                .blockMessaging()
+                                .sendBlockVerification(new VerificationNotification(
+                                        true,
+                                        null,
+                                        blockNumber,
+                                        Bytes.wrap("123"),
+                                        notification.block(),
+                                        BlockSource.BACKFILL));
+                        if (blockNumber == 0) {
+                            // Confirm block 0 only after a delay, so a successor dispatched in the same
+                            // chunk would be observed before the confirmation rather than after it.
+                            Thread.ofVirtual().start(() -> {
+                                try {
+                                    Thread.sleep(300);
+                                } catch (InterruptedException ignored) {
+                                    Thread.currentThread().interrupt();
+                                }
+                                // Flag before the send it enables, or the runner can win the race.
+                                genesisPersisted.set(true);
+                                blockNodeContext
+                                        .blockMessaging()
+                                        .sendBlockPersisted(
+                                                new PersistedNotification(0L, true, 10, BlockSource.BACKFILL));
+                            });
+                        } else {
+                            blockNodeContext
+                                    .blockMessaging()
+                                    .sendBlockPersisted(
+                                            new PersistedNotification(blockNumber, true, 10, BlockSource.BACKFILL));
+                        }
+                    }
+                },
+                false,
+                "test-genesis-ordering-handler");
+
+        start(new BackfillPlugin(), new SimpleInMemoryHistoricalBlockFacility(), configOverride);
+
+        assertTrue(
+                successorFetchedLatch.await(15, TimeUnit.SECONDS), "Blocks after the genesis block should be fetched");
+        assertFalse(successorFetchedTooEarly.get(), "No block should be fetched before block 0 has persisted");
     }
 
     private void createTestBlockNodeSourcesFile(BlockNodeSource backfillSource, String configPath) {

--- a/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillRunnerTest.java
+++ b/block-node/backfill/src/test/java/org/hiero/block/node/backfill/BackfillRunnerTest.java
@@ -21,12 +21,16 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import org.hiero.block.internal.BlockNodeSourceConfig;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
 import org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility;
+import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
+import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.hiero.block.node.spi.historicalblocks.LongRange;
 import org.hiero.metrics.LongCounter;
 import org.junit.jupiter.api.BeforeEach;
@@ -210,6 +214,32 @@ class BackfillRunnerTest {
             assertEquals(150L, result.start());
             assertEquals(159L, result.end());
         }
+
+        @Test
+        @DisplayName("should give the genesis block a chunk of its own")
+        void shouldGiveGenesisBlockItsOwnChunk() {
+            // given
+            BlockNodeSourceConfig nodeConfig = mock(BlockNodeSourceConfig.class);
+            Map<BlockNodeSourceConfig, List<LongRange>> availability = new HashMap<>();
+            availability.put(nodeConfig, List.of(new LongRange(0, 500)));
+            long batchSize = 10;
+
+            // when - a gap that starts at the genesis block
+            LongRange genesisChunk = BackfillRunner.computeChunk(
+                    new NodeSelectionStrategy.NodeSelection(nodeConfig, 0L), availability, 500L, batchSize);
+
+            // then - block 0 is fetched alone, so its TSS data lands before anything that needs it
+            assertNotNull(genesisChunk);
+            assertEquals(0L, genesisChunk.start());
+            assertEquals(0L, genesisChunk.end());
+
+            // and - the chunk after it spans the full batch size again
+            LongRange nextChunk = BackfillRunner.computeChunk(
+                    new NodeSelectionStrategy.NodeSelection(nodeConfig, 1L), availability, 500L, batchSize);
+            assertNotNull(nextChunk);
+            assertEquals(1L, nextChunk.start());
+            assertEquals(10L, nextChunk.end()); // 1 + 10 - 1
+        }
     }
 
     @Nested
@@ -309,10 +339,9 @@ class BackfillRunnerTest {
 
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
-                    new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
+                    new BlockNotificationHandler() {
                         @Override
-                        public void handleBackfilled(
-                                org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
+                        public void handleBackfilled(BackfilledBlockNotification notification) {
                             messaging.sendBlockPersisted(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
                         }
@@ -355,10 +384,9 @@ class BackfillRunnerTest {
 
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
-                    new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
+                    new BlockNotificationHandler() {
                         @Override
-                        public void handleBackfilled(
-                                org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
+                        public void handleBackfilled(BackfilledBlockNotification notification) {
                             messaging.sendBlockPersisted(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
                         }
@@ -402,10 +430,9 @@ class BackfillRunnerTest {
 
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
-                    new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
+                    new BlockNotificationHandler() {
                         @Override
-                        public void handleBackfilled(
-                                org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
+                        public void handleBackfilled(BackfilledBlockNotification notification) {
                             messaging.sendBlockPersisted(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
                         }
@@ -470,10 +497,9 @@ class BackfillRunnerTest {
 
             // Register a handler that simulates immediate persistence (verification + persist flow)
             messaging.registerBlockNotificationHandler(
-                    new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
+                    new BlockNotificationHandler() {
                         @Override
-                        public void handleBackfilled(
-                                org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
+                        public void handleBackfilled(BackfilledBlockNotification notification) {
                             // Simulate immediate persistence
                             messaging.sendBlockPersisted(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
@@ -510,10 +536,9 @@ class BackfillRunnerTest {
             // Register persistence awaiter and simulate persistence
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
-                    new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
+                    new BlockNotificationHandler() {
                         @Override
-                        public void handleBackfilled(
-                                org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
+                        public void handleBackfilled(BackfilledBlockNotification notification) {
                             messaging.sendBlockPersisted(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
                         }
@@ -614,10 +639,9 @@ class BackfillRunnerTest {
 
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
-                    new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
+                    new BlockNotificationHandler() {
                         @Override
-                        public void handleBackfilled(
-                                org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
+                        public void handleBackfilled(BackfilledBlockNotification notification) {
                             // Deliver the persisted notification only after the first await's
                             // 100ms timeout has already elapsed, so only a retried (re-tracked)
                             // await can pick it up. 175ms lands comfortably inside the second
@@ -644,6 +668,71 @@ class BackfillRunnerTest {
             // then - eventually persisted via retry, and the block was fetched only once (no
             // duplicate dispatch of a second, independent verification session for it)
             assertEquals(0L, lastSuccessful, "Should succeed once the delayed persistence notification lands");
+            verify(mockFetcher, times(1)).fetchBlocksFromNode(eq(nodeConfig), any());
+        }
+
+        @Test
+        @DisplayName("should not lose a persisted notification that arrives during the retry backoff")
+        void shouldNotLosePersistenceArrivingDuringRetryBackoff() throws Exception {
+            // given - a backoff far longer than the per-block timeout, so the notification lands
+            // while the runner is sleeping between attempts rather than while it is awaiting.
+            // Nothing is listening during that sleep unless the block was re-tracked before it,
+            // and a dropped notification leaves every later attempt waiting on a latch that will
+            // never be released, failing a chunk whose block is actually on disk.
+            BackfillConfiguration retryConfig = BackfillPluginTest.BackfillConfigBuilder.NewBuilder()
+                    .delayBetweenBatches(0)
+                    .perBlockProcessingTimeout(50)
+                    .initialRetryDelay(400)
+                    .maxRetries(3)
+                    .buildRecord();
+            BackfillRunner retrySubject = new BackfillRunner(
+                    mockFetcher,
+                    retryConfig,
+                    messaging,
+                    logger,
+                    mockMetricsHolder,
+                    pendingBackfillBlocks,
+                    persistenceAwaiter);
+
+            GapDetector.Gap gap = new GapDetector.Gap(new LongRange(0, 0), GapDetector.Type.HISTORICAL);
+            BlockNodeSourceConfig nodeConfig = mock(BlockNodeSourceConfig.class);
+            Map<BlockNodeSourceConfig, List<LongRange>> availability = new HashMap<>();
+            availability.put(nodeConfig, List.of(new LongRange(0, 0)));
+            BlockUnparsed testBlock = createTestBlock(0L);
+
+            when(mockFetcher.getAvailabilityForRange(any())).thenReturn(availability);
+            when(mockFetcher.selectNextChunk(anyLong(), anyLong(), any()))
+                    .thenReturn(Optional.of(new NodeSelectionStrategy.NodeSelection(nodeConfig, 0L)));
+            when(mockFetcher.fetchBlocksFromNode(eq(nodeConfig), any())).thenReturn(List.of(testBlock));
+
+            messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
+            messaging.registerBlockNotificationHandler(
+                    new BlockNotificationHandler() {
+                        @Override
+                        public void handleBackfilled(BackfilledBlockNotification notification) {
+                            // 200ms is past the first attempt's 50ms timeout and well inside the
+                            // 400ms backoff that follows it, so only a block re-tracked before the
+                            // sleep can still receive this.
+                            new Thread(() -> {
+                                        try {
+                                            Thread.sleep(200);
+                                        } catch (InterruptedException ignored) {
+                                            Thread.currentThread().interrupt();
+                                        }
+                                        messaging.sendBlockPersisted(new PersistedNotification(
+                                                notification.blockNumber(), true, 1, BlockSource.BACKFILL));
+                                    })
+                                    .start();
+                        }
+                    },
+                    false,
+                    "backoff-window-persistence-handler");
+
+            // when
+            long lastSuccessful = retrySubject.run(gap);
+
+            // then
+            assertEquals(0L, lastSuccessful, "Notification delivered during the backoff should still be seen");
             verify(mockFetcher, times(1)).fetchBlocksFromNode(eq(nodeConfig), any());
         }
 
@@ -692,6 +781,86 @@ class BackfillRunnerTest {
             assertEquals(-1L, lastSuccessful, "Should never succeed since block 0 never persists");
             verify(mockFetcher, times(1)).fetchBlocksFromNode(eq(nodeConfig), any());
         }
+
+        @Test
+        @DisplayName("should not advance when a block fails verification")
+        void shouldNotAdvanceWhenVerificationFails() throws Exception {
+            // given - block 10 fails verification, so no persisted notification will ever follow.
+            // A released latch is not the same as a persisted block: the gap must not advance.
+            long lastSuccessful = runSingleBlockGapWithOutcome(
+                    10L,
+                    notification -> messaging.sendBlockVerification(new VerificationNotification(
+                            false,
+                            VerificationNotification.FailureInfo.standard(
+                                    VerificationNotification.FailureType.MISSING_VERIFICATION_DATA),
+                            notification.blockNumber(),
+                            null,
+                            null,
+                            BlockSource.BACKFILL)));
+
+            // then
+            assertEquals(9L, lastSuccessful, "Should return start - 1 when the block failed verification");
+        }
+
+        @Test
+        @DisplayName("should not advance when persistence reports failure")
+        void shouldNotAdvanceWhenPersistenceReportsFailure() throws Exception {
+            // given - block 10's persistence is reported as failed
+            long lastSuccessful = runSingleBlockGapWithOutcome(
+                    10L,
+                    notification -> messaging.sendBlockPersisted(
+                            new PersistedNotification(notification.blockNumber(), false, 1, BlockSource.BACKFILL)));
+
+            // then
+            assertEquals(9L, lastSuccessful, "Should return start - 1 when the block failed to persist");
+        }
+
+        /**
+         * Runs a single-block gap whose only block gets the given outcome published for it as soon as it
+         * is dispatched. TestBlockMessagingFacility dispatches synchronously on the caller's thread, so
+         * the outcome always lands before the runner starts awaiting.
+         */
+        private long runSingleBlockGapWithOutcome(
+                long blockNumber, Consumer<BackfilledBlockNotification> outcomePublisher) throws Exception {
+            BackfillConfiguration singleAttemptConfig = BackfillPluginTest.BackfillConfigBuilder.NewBuilder()
+                    .delayBetweenBatches(0)
+                    .perBlockProcessingTimeout(500)
+                    .maxRetries(1)
+                    .buildRecord();
+            BackfillRunner failureSubject = new BackfillRunner(
+                    mockFetcher,
+                    singleAttemptConfig,
+                    messaging,
+                    logger,
+                    mockMetricsHolder,
+                    pendingBackfillBlocks,
+                    persistenceAwaiter);
+
+            GapDetector.Gap gap =
+                    new GapDetector.Gap(new LongRange(blockNumber, blockNumber), GapDetector.Type.HISTORICAL);
+            BlockNodeSourceConfig nodeConfig = mock(BlockNodeSourceConfig.class);
+            Map<BlockNodeSourceConfig, List<LongRange>> availability = new HashMap<>();
+            availability.put(nodeConfig, List.of(new LongRange(blockNumber, blockNumber)));
+
+            when(mockFetcher.getAvailabilityForRange(any())).thenReturn(availability);
+            when(mockFetcher.selectNextChunk(anyLong(), anyLong(), any()))
+                    .thenReturn(Optional.of(new NodeSelectionStrategy.NodeSelection(nodeConfig, blockNumber)));
+            when(mockFetcher.fetchBlocksFromNode(eq(nodeConfig), any()))
+                    .thenReturn(List.of(createTestBlock(blockNumber)));
+
+            messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
+            messaging.registerBlockNotificationHandler(
+                    new BlockNotificationHandler() {
+                        @Override
+                        public void handleBackfilled(BackfilledBlockNotification notification) {
+                            outcomePublisher.accept(notification);
+                        }
+                    },
+                    false,
+                    "test-failure-handler");
+
+            return failureSubject.run(gap);
+        }
     }
 
     @Nested
@@ -701,28 +870,27 @@ class BackfillRunnerTest {
         @Test
         @DisplayName("should return gap end when all blocks successfully backfilled")
         void shouldReturnGapEndOnFullCompletion() throws Exception {
-            // given
-            GapDetector.Gap gap = new GapDetector.Gap(new LongRange(0, 2), GapDetector.Type.HISTORICAL);
+            // given - a gap clear of block 0, which computeChunk deliberately fetches on its own
+            GapDetector.Gap gap = new GapDetector.Gap(new LongRange(10, 12), GapDetector.Type.HISTORICAL);
             BlockNodeSourceConfig nodeConfig = mock(BlockNodeSourceConfig.class);
             Map<BlockNodeSourceConfig, List<LongRange>> availability = new HashMap<>();
-            availability.put(nodeConfig, List.of(new LongRange(0, 2)));
+            availability.put(nodeConfig, List.of(new LongRange(10, 12)));
 
-            BlockUnparsed block0 = createTestBlock(0L);
-            BlockUnparsed block1 = createTestBlock(1L);
-            BlockUnparsed block2 = createTestBlock(2L);
+            BlockUnparsed block10 = createTestBlock(10L);
+            BlockUnparsed block11 = createTestBlock(11L);
+            BlockUnparsed block12 = createTestBlock(12L);
 
             when(mockFetcher.getAvailabilityForRange(any())).thenReturn(availability);
             when(mockFetcher.selectNextChunk(anyLong(), anyLong(), any()))
-                    .thenReturn(Optional.of(new NodeSelectionStrategy.NodeSelection(nodeConfig, 0L)));
-            when(mockFetcher.fetchBlocksFromNode(eq(nodeConfig), any())).thenReturn(List.of(block0, block1, block2));
+                    .thenReturn(Optional.of(new NodeSelectionStrategy.NodeSelection(nodeConfig, 10L)));
+            when(mockFetcher.fetchBlocksFromNode(eq(nodeConfig), any())).thenReturn(List.of(block10, block11, block12));
 
             // Register handlers for persistence flow
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
-                    new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
+                    new BlockNotificationHandler() {
                         @Override
-                        public void handleBackfilled(
-                                org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
+                        public void handleBackfilled(BackfilledBlockNotification notification) {
                             messaging.sendBlockPersisted(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
                         }
@@ -734,13 +902,15 @@ class BackfillRunnerTest {
             long lastSuccessful = subject.run(gap);
 
             // then
-            assertEquals(2L, lastSuccessful, "Should return gap end (2) on full completion");
+            assertEquals(12L, lastSuccessful, "Should return gap end (12) on full completion");
         }
 
         @Test
         @DisplayName("should return last successful block when gap partially completed")
         void shouldReturnLastSuccessfulBlockOnPartialCompletion() throws Exception {
-            // given - gap 0-9 with batch size 5, first batch (0-4) succeeds, second batch fails
+            // given - gap 10-19 with batch size 5, first batch (10-14) succeeds, second batch fails.
+            // The gap deliberately starts clear of block 0, which computeChunk chunks on its own -
+            // that special case has its own test in ComputeChunkTests.
             // Use custom config with fetchBatchSize=5 so we need two chunks
             BackfillConfiguration smallBatchConfig = BackfillPluginTest.BackfillConfigBuilder.NewBuilder()
                     .delayBetweenBatches(0)
@@ -755,28 +925,28 @@ class BackfillRunnerTest {
                     pendingBackfillBlocks,
                     persistenceAwaiter);
 
-            GapDetector.Gap gap = new GapDetector.Gap(new LongRange(0, 9), GapDetector.Type.HISTORICAL);
+            GapDetector.Gap gap = new GapDetector.Gap(new LongRange(10, 19), GapDetector.Type.HISTORICAL);
             BlockNodeSourceConfig nodeConfig = mock(BlockNodeSourceConfig.class);
 
             Map<BlockNodeSourceConfig, List<LongRange>> initialAvailability = new HashMap<>();
-            initialAvailability.put(nodeConfig, List.of(new LongRange(0, 9)));
+            initialAvailability.put(nodeConfig, List.of(new LongRange(10, 19)));
 
             List<BlockUnparsed> firstBatch = List.of(
-                    createTestBlock(0L),
-                    createTestBlock(1L),
-                    createTestBlock(2L),
-                    createTestBlock(3L),
-                    createTestBlock(4L));
+                    createTestBlock(10L),
+                    createTestBlock(11L),
+                    createTestBlock(12L),
+                    createTestBlock(13L),
+                    createTestBlock(14L));
 
             // First getAvailabilityForRange returns initial, second (replan) returns empty
             when(mockFetcher.getAvailabilityForRange(any()))
                     .thenReturn(initialAvailability)
                     .thenReturn(Collections.emptyMap());
-            // First select returns node for block 0, second for block 5
+            // First select returns node for block 10, second for block 15
             when(mockFetcher.selectNextChunk(anyLong(), anyLong(), any()))
-                    .thenReturn(Optional.of(new NodeSelectionStrategy.NodeSelection(nodeConfig, 0L)))
-                    .thenReturn(Optional.of(new NodeSelectionStrategy.NodeSelection(nodeConfig, 5L)));
-            // First fetch succeeds with 5 blocks (0-4), second returns empty (simulating failure)
+                    .thenReturn(Optional.of(new NodeSelectionStrategy.NodeSelection(nodeConfig, 10L)))
+                    .thenReturn(Optional.of(new NodeSelectionStrategy.NodeSelection(nodeConfig, 15L)));
+            // First fetch succeeds with 5 blocks (10-14), second returns empty (simulating failure)
             when(mockFetcher.fetchBlocksFromNode(eq(nodeConfig), any()))
                     .thenReturn(firstBatch)
                     .thenReturn(Collections.emptyList());
@@ -784,10 +954,9 @@ class BackfillRunnerTest {
             // Register handlers for persistence flow
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
-                    new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
+                    new BlockNotificationHandler() {
                         @Override
-                        public void handleBackfilled(
-                                org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
+                        public void handleBackfilled(BackfilledBlockNotification notification) {
                             messaging.sendBlockPersisted(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
                         }
@@ -798,8 +967,8 @@ class BackfillRunnerTest {
             // when
             long lastSuccessful = smallBatchSubject.run(gap);
 
-            // then - chunk 0-4 succeeded, so lastSuccessfulBlock is 4
-            assertEquals(4L, lastSuccessful, "Should return 4 as last successful block (partial completion)");
+            // then - chunk 10-14 succeeded, so lastSuccessfulBlock is 14
+            assertEquals(14L, lastSuccessful, "Should return 14 as last successful block (partial completion)");
         }
 
         @Test
@@ -841,10 +1010,9 @@ class BackfillRunnerTest {
             // Register handlers for persistence flow
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
-                    new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
+                    new BlockNotificationHandler() {
                         @Override
-                        public void handleBackfilled(
-                                org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
+                        public void handleBackfilled(BackfilledBlockNotification notification) {
                             messaging.sendBlockPersisted(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
                         }
@@ -878,10 +1046,9 @@ class BackfillRunnerTest {
             // Register handlers for persistence flow
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
-                    new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
+                    new BlockNotificationHandler() {
                         @Override
-                        public void handleBackfilled(
-                                org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
+                        public void handleBackfilled(BackfilledBlockNotification notification) {
                             messaging.sendBlockPersisted(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
                         }
@@ -899,29 +1066,29 @@ class BackfillRunnerTest {
         @Test
         @DisplayName("should report multiple blocks fetched and dispatched")
         void shouldReportMultipleBlocks() throws Exception {
-            // given
-            GapDetector.Gap gap = new GapDetector.Gap(new LongRange(0, 2), GapDetector.Type.HISTORICAL);
+            // given - a gap clear of block 0: the mock replays all three blocks for any chunk, so a
+            // gap that started at 0 would be split into two chunks and count each block twice
+            GapDetector.Gap gap = new GapDetector.Gap(new LongRange(10, 12), GapDetector.Type.HISTORICAL);
             BlockNodeSourceConfig nodeConfig = mock(BlockNodeSourceConfig.class);
             Map<BlockNodeSourceConfig, List<LongRange>> availability = new HashMap<>();
-            availability.put(nodeConfig, List.of(new LongRange(0, 2)));
+            availability.put(nodeConfig, List.of(new LongRange(10, 12)));
 
-            BlockUnparsed testBlock0 = createTestBlock(0L);
-            BlockUnparsed testBlock1 = createTestBlock(1L);
-            BlockUnparsed testBlock2 = createTestBlock(2L);
+            BlockUnparsed testBlock10 = createTestBlock(10L);
+            BlockUnparsed testBlock11 = createTestBlock(11L);
+            BlockUnparsed testBlock12 = createTestBlock(12L);
 
             when(mockFetcher.getAvailabilityForRange(any())).thenReturn(availability);
             when(mockFetcher.selectNextChunk(anyLong(), anyLong(), any()))
-                    .thenReturn(Optional.of(new NodeSelectionStrategy.NodeSelection(nodeConfig, 0L)));
+                    .thenReturn(Optional.of(new NodeSelectionStrategy.NodeSelection(nodeConfig, 10L)));
             when(mockFetcher.fetchBlocksFromNode(eq(nodeConfig), any()))
-                    .thenReturn(List.of(testBlock0, testBlock1, testBlock2));
+                    .thenReturn(List.of(testBlock10, testBlock11, testBlock12));
 
             // Register handlers for persistence flow
             messaging.registerBlockNotificationHandler(persistenceAwaiter, false, "persistence-awaiter");
             messaging.registerBlockNotificationHandler(
-                    new org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler() {
+                    new BlockNotificationHandler() {
                         @Override
-                        public void handleBackfilled(
-                                org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification notification) {
+                        public void handleBackfilled(BackfilledBlockNotification notification) {
                             messaging.sendBlockPersisted(new PersistedNotification(
                                     notification.blockNumber(), true, 1, BlockSource.BACKFILL));
                         }

--- a/docs/block-node/configuration.md
+++ b/docs/block-node/configuration.md
@@ -163,7 +163,7 @@ A more robust pattern for fully operator-managed plugins is to mount a pre-popul
 | BACKFILL_END_BLOCK                       | Max block number, -1 means no limit.                                                                                   |        -1 |
 | BACKFILL_BLOCK_NODE_SOURCES_PATH         | File path for BN sources (PBJ JSON `block-nodes.json`).                                                                |        "" |
 | BACKFILL_SCAN_INTERVAL                   | Scan interval for gap detection (ms).                                                                                  |     60000 |
-| BACKFILL_MAX_RETRIES                     | Max retries to fetch a block.                                                                                          |         3 |
+| BACKFILL_MAX_RETRIES                     | Max attempts to fetch a block, minimum 1.                                                                              |         3 |
 | BACKFILL_INITIAL_RETRY_DELAY             | Initial retry delay (ms), grows linearly.                                                                              |      5000 |
 | BACKFILL_FETCH_BATCH_SIZE                | Number of blocks per gRPC call.                                                                                        |        10 |
 | BACKFILL_DELAY_BETWEEN_BATCHES           | Delay (ms) between block batches.                                                                                      |      1000 |

--- a/docs/design/backfill-plugin.md
+++ b/docs/design/backfill-plugin.md
@@ -43,7 +43,9 @@ Detect missing gaps in the stored block sequence and autonomously fetch missing 
 
   <dt>Chunk</dt>
   <dd>A contiguous range of blocks fetched in a single operation, bounded by the peer's available range,
-    the configured fetchBatchSize, and the gap end.</dd>
+    the configured fetchBatchSize, and the gap end. Block 0 is the exception: it is always fetched in a
+    chunk of its own, so the TSS verification data it bootstraps is persisted before any later block
+    that needs it is fetched.</dd>
 
   <dt>Dual Schedulers</dt>
   <dd>Two independent schedulers (Historical and Live-Tail) that process gaps concurrently,
@@ -253,7 +255,7 @@ Properties are set via the Block Node configuration system (prefix: `backfill.`)
 | `endBlock`                  | long    | -1      | Last block (-1 = unlimited)                 |
 | `blockNodeSourcesPath`      | String  | ""      | Path to peer nodes JSON file                |
 | `scanInterval`              | int     | 60000   | Gap detection interval in ms                |
-| `maxRetries`                | int     | 3       | Max retry attempts per fetch                |
+| `maxRetries`                | int     | 3       | Max attempts per fetch (min 1)              |
 | `initialRetryDelay`         | int     | 5000    | Initial retry delay in ms                   |
 | `fetchBatchSize`            | int     | 10      | Blocks per gRPC request                     |
 | `delayBetweenBatches`       | int     | 1000    | Delay between batches in ms                 |

--- a/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
+++ b/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
@@ -244,14 +244,7 @@ tasks:
   port-forward:stop:
     desc: Stop all port forwards
     cmds:
-      - |
-        echo "Stopping port forwards..."
-        if pkill -f "kubectl port-forward" 2>/dev/null; then
-          echo "  Port forward processes terminated"
-        else
-          echo "  No port forward processes found"
-        fi
-        echo "Port forwards stopped."
+      - '"{{.SCRIPTS_DIR}}/solo-port-forward.sh" --namespace "{{.NAMESPACE}}" --stop'
 
   # ============================================================================
   # Verification

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/backfill/common.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/backfill/common.sh
@@ -20,12 +20,29 @@ bn_grpc_port() { echo $((40839 + $1)); }
 # Read one Prometheus metric from a BN over its port-forward and round it to an
 # integer -- gauges are exported in floating-point form ("612.0"), which bash
 # arithmetic rejects. Prints nothing and returns 1 when the metric is absent.
+# A single read is retried: a port-forward can drop mid-run, and its supervisor
+# needs a moment to bring it back. Without this, one dropped connection aborts a
+# 25-minute test from a one-shot caller.
 read_bn_metric_int() {
-    local bn_index="$1" metric="$2" raw
-    raw=$(curl -s --max-time 5 "http://localhost:$(bn_metrics_port "${bn_index}")/metrics" 2>/dev/null |
-        awk -v m="${metric}" '$1 == m { print $2; exit }')
-    [[ -n "${raw}" ]] || return 1
-    printf "%.0f" "${raw}" 2>/dev/null || return 1
+    local bn_index="$1" metric="$2" body raw attempt max_attempts=3
+    for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+        body=$(curl -s --max-time 5 "http://localhost:$(bn_metrics_port "${bn_index}")/metrics" 2>/dev/null)
+        # Only an unreachable endpoint is worth retrying. One that answers without
+        # the metric is the ordinary "not exported yet" case, which polling callers
+        # handle themselves, so it returns at once instead of costing them 19s.
+        if [[ -n "${body}" ]]; then
+            raw=$(awk -v m="${metric}" '$1 == m { print $2; exit }' <<<"${body}")
+            if [[ -z "${raw}" ]]; then
+                return 1
+            fi
+            printf "%.0f" "${raw}" 2>/dev/null || return 1
+            return 0
+        fi
+        if [[ "${attempt}" -lt "${max_attempts}" ]]; then
+            sleep 2
+        fi
+    done
+    return 1
 }
 
 # Highest block number the given BN has seen on its inbound publisher stream.

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-port-forward.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-port-forward.sh
@@ -6,9 +6,11 @@
 #
 # Usage:
 #   ./solo-port-forward.sh --namespace <namespace>
+#   ./solo-port-forward.sh --namespace <namespace> --stop
 #
 # Options:
 #   --namespace NAMESPACE    Kubernetes namespace (required)
+#   --stop                   Tear down this namespace's port forwards and exit
 #   --help                   Show this help message
 #
 # Port Mappings:
@@ -25,15 +27,18 @@
 set -o pipefail
 
 NAMESPACE=""
+STOP_ONLY="false"
 
 function show_help {
   cat << 'EOF'
 Usage: solo-port-forward.sh --namespace <namespace>
+       solo-port-forward.sh --namespace <namespace> --stop
 
 Discovers and forwards ports for some deployed Solo services of interest.
 
 Options:
   --namespace NAMESPACE    Kubernetes namespace (required)
+  --stop                   Tear down this namespace's port forwards and exit
   --help                   Show this help message
 
 Port Mappings:
@@ -57,6 +62,10 @@ while [[ $# -gt 0 ]]; do
       NAMESPACE="$2"
       shift 2
       ;;
+    --stop)
+      STOP_ONLY="true"
+      shift
+      ;;
     --help|-h)
       show_help
       ;;
@@ -69,10 +78,73 @@ done
 
 [[ -z "${NAMESPACE}" ]] && { echo "ERROR: --namespace is required"; exit 1; }
 
+# Both the sentinel and the pkill pattern are namespace-scoped, so forwards a
+# developer holds open against another namespace survive this script. The pattern
+# is anchored on the "-n ${NAMESPACE} " that pf() below emits, so a namespace that
+# happens to be a substring of a service name cannot match on the service instead.
+# The long-lived forwards wrb-distribution's scripts spawn pass their namespace as
+# "--namespace NS" before the verb, so they are left alone, as they always were.
+: "${PF_KEEPALIVE_FILE:=/tmp/solo-port-forward-${NAMESPACE}.keepalive}"
+PF_PATTERN="kubectl.*port-forward.*-n ${NAMESPACE} "
+
+# Stop every forward and its supervisor. Remove the sentinel first so a
+# supervisor whose kubectl is killed below exits instead of restarting it; the
+# sleep outlasts the supervisor's own retry sleep, so every one of them has
+# woken up and seen the sentinel gone by the time it returns. The second pkill
+# reaps a forward started in the window between the rm and the first pkill,
+# whose supervisor then exited without ever killing it.
+stop_forwards() {
+  rm -f "${PF_KEEPALIVE_FILE}"
+  pkill -f "${PF_PATTERN}" 2>/dev/null || true
+  sleep 3
+  pkill -f "${PF_PATTERN}" 2>/dev/null || true
+}
+
+if [[ "${STOP_ONLY}" == "true" ]]; then
+  echo "Stopping port forwards for namespace: ${NAMESPACE}"
+  stop_forwards
+  echo "Port forwards stopped."
+  exit 0
+fi
+
 echo "Discovering deployed services in namespace: ${NAMESPACE}"
 
-# Kill existing port-forwards
-pkill -f "kubectl port-forward" 2>/dev/null || true
+# Supervise a port-forward: kubectl exits whenever its connection drops, which
+# silently leaves a test talking to a dead local port. Restart it until the
+# keepalive sentinel is removed.
+#   $1 = svc/<name>, $2 = <local>:<remote>
+pf() {
+  ( delay=2
+    while [[ -f "${PF_KEEPALIVE_FILE}" ]]; do
+      started=${SECONDS}
+      kubectl port-forward "$1" -n "${NAMESPACE}" "$2" >/dev/null 2>&1
+      # A forward that ran for a while dropped its connection: retry promptly. One that
+      # exits instantly is a service that is gone, so back off up to 30s rather than
+      # respawning every 2s for the rest of a 25-minute run.
+      if (( SECONDS - started >= 10 )); then
+        delay=2
+      else
+        delay=$(( delay * 2 > 30 ? 30 : delay * 2 ))
+      fi
+      # Slept in 2s slices so a removed sentinel is still noticed within the window
+      # stop_forwards waits out, however long the backoff has grown.
+      for (( slept = 0; slept < delay; slept += 2 )); do
+        [[ -f "${PF_KEEPALIVE_FILE}" ]] || break
+        sleep 2
+      done
+    done ) 2>/dev/null &
+}
+
+# Stop any previous generation of forwards and their supervisors before starting
+# a new one, so they neither restart nor hold on to the local ports.
+stop_forwards
+
+# An interrupted run (Ctrl-C, CI cancel) would otherwise leave the sentinel and
+# a half-built generation of forwards behind, restarting themselves forever.
+# Not on EXIT: a successful run is *meant* to leave its forwards running.
+trap 'stop_forwards' INT TERM
+
+touch "${PF_KEEPALIVE_FILE}"
 
 # Arrays to collect endpoints for summary
 declare -a CN_ENDPOINTS=()
@@ -87,7 +159,7 @@ echo "Setting up port forwards..."
 
 # Consensus node (single)
 if kubectl get svc haproxy-node1-svc -n "${NAMESPACE}" >/dev/null 2>&1; then
-  kubectl port-forward svc/haproxy-node1-svc -n "${NAMESPACE}" 50211:50211 >/dev/null 2>&1 &
+  pf "svc/haproxy-node1-svc" "50211:50211"
   CN_ENDPOINTS+=("localhost:50211")
 fi
 
@@ -95,7 +167,7 @@ fi
 BN_PORT=40840
 for svc in $(kubectl get svc -n "${NAMESPACE}" -o name 2>/dev/null | grep -E "block-node-[0-9]+$" | sort); do
   svc_name=$(basename "$svc")
-  kubectl port-forward "svc/${svc_name}" -n "${NAMESPACE}" ${BN_PORT}:40840 >/dev/null 2>&1 &
+  pf "svc/${svc_name}" "${BN_PORT}:40840"
   BN_ENDPOINTS+=("localhost:${BN_PORT} (${svc_name})")
   BN_PORT=$((BN_PORT + 1))
 done
@@ -104,7 +176,7 @@ done
 BN_METRICS_PORT=16007
 for svc in $(kubectl get svc -n "${NAMESPACE}" -o name 2>/dev/null | grep -E "block-node-[0-9]+$" | sort); do
   svc_name=$(basename "$svc")
-  kubectl port-forward "svc/${svc_name}" -n "${NAMESPACE}" ${BN_METRICS_PORT}:16007 >/dev/null 2>&1 &
+  pf "svc/${svc_name}" "${BN_METRICS_PORT}:16007"
   BN_METRICS_ENDPOINTS+=("http://localhost:${BN_METRICS_PORT}/metrics (${svc_name})")
   BN_METRICS_PORT=$((BN_METRICS_PORT + 1))
 done
@@ -113,7 +185,7 @@ done
 MN_PORT=5551
 for svc in $(kubectl get svc -n "${NAMESPACE}" -o name 2>/dev/null | grep "mirror-.*-rest$" | sort); do
   svc_name=$(basename "$svc")
-  kubectl port-forward "svc/${svc_name}" -n "${NAMESPACE}" ${MN_PORT}:80 >/dev/null 2>&1 &
+  pf "svc/${svc_name}" "${MN_PORT}:80"
   MN_ENDPOINTS+=("http://localhost:${MN_PORT} (${svc_name})")
   MN_PORT=$((MN_PORT + 1))
 done
@@ -124,10 +196,10 @@ RELAY_WS_PORT=8546
 for svc in $(kubectl get svc -n "${NAMESPACE}" -o name 2>/dev/null | grep -E "relay-[0-9]+" | grep -v "\-ws" | sort); do
   svc_name=$(basename "$svc")
   ws_svc="${svc_name}-ws"
-  kubectl port-forward "svc/${svc_name}" -n "${NAMESPACE}" ${RELAY_PORT}:7546 >/dev/null 2>&1 &
+  pf "svc/${svc_name}" "${RELAY_PORT}:7546"
   RELAY_ENDPOINTS+=("http://localhost:${RELAY_PORT} JSON-RPC (${svc_name})")
   if kubectl get svc "${ws_svc}" -n "${NAMESPACE}" >/dev/null 2>&1; then
-    kubectl port-forward "svc/${ws_svc}" -n "${NAMESPACE}" ${RELAY_WS_PORT}:8546 >/dev/null 2>&1 &
+    pf "svc/${ws_svc}" "${RELAY_WS_PORT}:8546"
     RELAY_ENDPOINTS+=("ws://localhost:${RELAY_WS_PORT} WebSocket (${ws_svc})")
   fi
   RELAY_PORT=$((RELAY_PORT + 1))
@@ -138,7 +210,7 @@ done
 EXPLORER_PORT=8080
 for svc in $(kubectl get svc -n "${NAMESPACE}" -o name 2>/dev/null | grep "explorer" | sort); do
   svc_name=$(basename "$svc")
-  kubectl port-forward "svc/${svc_name}" -n "${NAMESPACE}" ${EXPLORER_PORT}:80 >/dev/null 2>&1 &
+  pf "svc/${svc_name}" "${EXPLORER_PORT}:80"
   EXPLORER_ENDPOINTS+=("http://localhost:${EXPLORER_PORT} (${svc_name})")
   EXPLORER_PORT=$((EXPLORER_PORT + 1))
 done
@@ -147,7 +219,7 @@ done
 GRAFANA_SVC=$(kubectl get svc -n "${NAMESPACE}" -o name 2>/dev/null | grep grafana | head -1)
 if [[ -n "$GRAFANA_SVC" ]]; then
   svc_name=$(basename "$GRAFANA_SVC")
-  kubectl port-forward "svc/${svc_name}" -n "${NAMESPACE}" 3000:80 >/dev/null 2>&1 &
+  pf "svc/${svc_name}" "3000:80"
   METRICS_ENDPOINTS+=("http://localhost:3000 Grafana (admin/admin)")
 fi
 
@@ -155,7 +227,7 @@ fi
 PROM_SVC=$(kubectl get svc -n "${NAMESPACE}" -o name 2>/dev/null | grep "kubepromstack-prometheus" | head -1)
 if [[ -n "$PROM_SVC" ]]; then
   svc_name=$(basename "$PROM_SVC")
-  kubectl port-forward "svc/${svc_name}" -n "${NAMESPACE}" 9090:9090 >/dev/null 2>&1 &
+  pf "svc/${svc_name}" "9090:9090"
   METRICS_ENDPOINTS+=("http://localhost:9090 Prometheus")
 fi
 

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-test-runner.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-test-runner.sh
@@ -335,9 +335,8 @@ function execute_node_up {
 
 function execute_port_forward {
     echo "Refreshing port forwards..."
-    # Kill existing port-forwards
-    pkill -f "kubectl.*port-forward.*${NAMESPACE}" 2>/dev/null || true
-    sleep 2
+    # Killing the existing forwards is solo-port-forward.sh's job: it also has to
+    # retire their supervisors, and doing half of that here just races it.
     # Restart port forwards (script only takes --namespace)
     "${SCRIPT_DIR}/solo-port-forward.sh" --namespace "${NAMESPACE}" &
     sleep 10

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-cli-validate-blocks.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/wrb-cli-validate-blocks.sh
@@ -110,7 +110,10 @@ function do_validate {
         --no-resume \
         "${LOCAL_BLOCKS_DIR}/live" 2>&1) || rc=$?
 
-    echo "$output"
+    # A large write hitting EAGAIN on a slow CI stdout pipe must not fail the test:
+    # the status that matters is in rc, and the VALIDATION FAILED check below reads
+    # the variable, not the terminal. printf is for not mangling backslashes.
+    printf '%s\n' "$output" || true
 
     # Clean up extracted blocks
     log "Cleaning up extracted blocks..."

--- a/tools-and-tests/scripts/solo-e2e-test/tests/full-history-backfill.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/full-history-backfill.yaml
@@ -171,5 +171,8 @@ assertions:
     description: "All Block Nodes receiving live blocks after recovery"
     target: all
     args:
+      # 30s x 2 was exactly backfill.scanInterval (default 60000ms), so a node catching up
+      # via backfill rather than a live stream could exhaust the window inside a single
+      # quiet interval. Give it two full sweeps of headroom.
       wait_seconds: 30
-      max_attempts: 2
+      max_attempts: 4

--- a/tools-and-tests/scripts/solo-e2e-test/tests/smoke-test.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/smoke-test.yaml
@@ -54,5 +54,5 @@ assertions:
     description: "All Block Nodes are receiving new blocks"
     target: all
     args:
-      wait_seconds: 20
-      max_attempts: 3
+      wait_seconds: 15
+      max_attempts: 6


### PR DESCRIPTION
## Reviewer Notes

* Backfill no longer counts a verification-failed block as persisted
* Fetches the genesis block in a chunk of its own, so later blocks cannot race the TSS bootstrap
* Makes the Solo E2E harness survive a dropped port forward
* Prints captured CLI output in the WRB test scripts so a failed write on a slow CI pipe cannot fail the step

## Related Issue(s)

Closes #3541
Closes #3542