### PR TITLE
chore: Ensure inbound statusz request returns empty if known publishers is empty.

### DIFF
--- a/block-node/health/src/main/java/org/hiero/block/node/health/InboundStatusHandler.java
+++ b/block-node/health/src/main/java/org/hiero/block/node/health/InboundStatusHandler.java
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.health;
 
-import static org.hiero.block.node.health.HttpConnectionSupport.closeAfterHttp1;
-
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.helidon.http.HeaderNames;
 import io.helidon.webserver.http.ServerRequest;
@@ -44,9 +42,11 @@ final class InboundStatusHandler {
         endpoints.addAll(appState.knownPublishers().activeEndpoints());
         endpoints.addAll(appState.inboundPartners().activeEndpoints());
         endpoints.addAll(appState.backfillSources().activeEndpoints());
-        final NetworkData data =
-                NetworkData.newBuilder().activeEndpoints(endpoints).build();
-        closeAfterHttp1(request, response.status(200).header(HeaderNames.CONTENT_TYPE, "application/json"))
+        final NetworkData data = appState.knownPublishers().activeEndpoints().isEmpty()
+                ? NetworkData.newBuilder().build()
+                : NetworkData.newBuilder().activeEndpoints(endpoints).build();
+        HttpConnectionSupport.closeAfterHttp1(
+                        request, response.status(200).header(HeaderNames.CONTENT_TYPE, "application/json"))
                 .send(NetworkData.JSON.toJSON(data));
     }
 }

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
 import org.hiero.block.api.BlockEnd;
 import org.hiero.block.api.SubscribeStreamRequest;
 import org.hiero.block.api.SubscribeStreamResponse;
@@ -85,6 +86,7 @@ import org.hiero.block.node.spi.historicalblocks.BlockRangeSet;
  * </ul>
  */
 public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscriberSession> {
+    private static final long FUTURE_BLOCK_WAIT_TIME = 50_000L; // 50 microsesonds
     /** The logger for this class. */
     private final Logger LOGGER = System.getLogger(getClass().getName());
 
@@ -576,8 +578,9 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
             } else if (blockItems.isStartOfNewBlock() && blockItems.blockNumber() > nextBlockToSend.get()) {
                 // This block is _future_, so we need to wait, and try to get the next block from history
                 // first, then come back to this block.
-                LOGGER.log(
-                        Level.TRACE, "Retaining future block {0} for client {1}", blockItems.blockNumber(), clientId);
+                // Do nothing here, even a log can result in excessive log output.
+                // Pause very briefly (microseconds) to avoid CPU overload.
+                LockSupport.parkNanos(FUTURE_BLOCK_WAIT_TIME);
             } else {
                 // This is a past or future _partial_ block, so we need to trim the queue.
                 liveBlockQueue.poll(); // discard _this batch only_.


### PR DESCRIPTION
## Reviewer Notes
* Adjusted inbound status handler to return empty `NetworkData` if known publishers is empty.
* Removed one high-frequency, and unnecessary, trace log.

## Related Issue(s)
 Resolves #3540 
