### PR TITLE
chore(3552): send acknowledgement after skip when skip sent instead of duplicate

### DIFF
--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManager.java
@@ -67,7 +67,6 @@ import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification
 import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification.UpdateType;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureInfo;
-import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureType;
 import org.hiero.block.node.spi.threading.ThreadPoolManager;
 import org.hiero.metrics.LongCounter;
 import org.hiero.metrics.LongGauge;
@@ -261,7 +260,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
                 case END_ERROR, END_DUPLICATE ->
                     // This should not happen because the Handler should have shut down.
                     BlockAction.END_ERROR;
-                case SKIP, RESEND, SEND_BEHIND ->
+                case SKIP, SKIP_AND_ACK, RESEND, SEND_BEHIND ->
                     // This should not happen because the Handler should have reset the previous action.
                     BlockAction.END_ERROR;
             };
@@ -995,7 +994,7 @@ public final class LiveStreamPublisherManager implements StreamPublisherManager 
             // ending the stream so a slightly-behind publisher can fast-forward without
             // reconnecting.
             if ((lastPersisted - blockNumber) <= duplicateBlockSkipWindow) {
-                return BlockAction.SKIP;
+                return BlockAction.SKIP_AND_ACK;
             }
             return BlockAction.END_DUPLICATE;
         } else if (blockNumber < nextUnstreamed) {

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/PublisherHandler.java
@@ -281,26 +281,36 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
         // if there are several blocks "behind" that acknowledgement.
         // The publishers expect that acknowledgement for block N implicitly
         // acknowledges all blocks up to and including N.
+        if (baseSendBlockAcknowledgement(blockToAcknowledge)) {
+            // if response was sent successfully, we can remove
+            // all unacknowledged blocks that are less than or equal to the
+            // new last acknowledged block number.
+            unacknowledgedStreamedBlocks.headSet(blockToAcknowledge, true).clear();
+        }
+    }
+
+    private boolean baseSendBlockAcknowledgement(final long blockToAcknowledge) {
         final BlockAcknowledgement ack = BlockAcknowledgement.newBuilder()
                 .blockNumber(blockToAcknowledge)
                 .build();
         final PublishStreamResponse response =
                 PublishStreamResponse.newBuilder().acknowledgement(ack).build();
-        if (sendResponse(response)) {
-            // if response was sent successfully, we can remove
-            // all unacknowledged blocks that are less than or equal to the
-            // new last acknowledged block number.
-            unacknowledgedStreamedBlocks.headSet(blockToAcknowledge, true).clear();
+        final boolean success = sendResponse(response);
+        if (success) {
             metrics.blockAcknowledgementsSent.increment(); // @todo(1415) add label
-            final long ackTime = System.nanoTime();
-            LOGGER.log(TRACE, LATENCY_END_METRIC_MESSAGE, blockToAcknowledge, ackTime, handlerId, correlationIdPrefix);
-            final String ackTraceEndMessage = "[{2}] Sent acknowledgement for block {0,number,#} from handler {1}";
-            LOGGER.log(TRACE, ackTraceEndMessage, blockToAcknowledge, handlerId, correlationIdPrefix);
+            if (LOGGER.isLoggable(TRACE)) {
+                final long ackTime = System.nanoTime();
+                LOGGER.log(
+                        TRACE, LATENCY_END_METRIC_MESSAGE, blockToAcknowledge, ackTime, handlerId, correlationIdPrefix);
+                final String ackTraceEndMessage = "[{2}] Sent acknowledgement for block {0,number,#} from handler {1}";
+                LOGGER.log(TRACE, ackTraceEndMessage, blockToAcknowledge, handlerId, correlationIdPrefix);
+            }
         } else {
             // Here, we must end immediately, because if we failed to send, then
             // we will never get another `onNext`.
             checkMidBlockAndShutdown(currentStreamingBlockNumber.get(), false);
         }
+        return success;
     }
 
     /// This method must be called when a verification fails for a given block.
@@ -478,6 +488,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
         return switch (actionFromPublisher) {
             case ACCEPT -> handleAccept(blockNumber, requestContainsHeader, itemSetUnparsed);
             case SKIP -> handleSkip(blockNumber);
+            case SKIP_AND_ACK -> handleSkipAndAck(blockNumber);
             case RESEND -> {
                 final String errorMessage =
                         "[{0}] Handler {1} unexpectedly received the block action {2} as an action for new header/block in progress";
@@ -564,7 +575,7 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
                 // If we get a resend, we must handle it
                 case RESEND -> handleResend(actionForBlock.blockNumber());
                 // These cases are not expected to be returned
-                case SKIP, SEND_BEHIND, END_DUPLICATE, END_ERROR ->
+                case SKIP, SKIP_AND_ACK, SEND_BEHIND, END_DUPLICATE, END_ERROR ->
                     unexpectedActionForEndOfBlock(actionForBlock, currentStreamingNumber);
             };
         }
@@ -718,9 +729,16 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
                 DEBUG, "[{0}] Handler {1} is sending SKIP for block {2}", correlationIdPrefix, handlerId, blockNumber);
         // If the action is SKIP, we need to send a skip response
         // to the publisher and not propagate the items.
-        final SkipBlock skipBlock =
-                SkipBlock.newBuilder().blockNumber(blockNumber).build();
-        return new SkipBlockResult(this, skipBlock, currentStreamingBlockNumber.get());
+        return new SkipBlockResult(this, blockNumber, currentStreamingBlockNumber.get());
+    }
+
+    /// Handle the SKIP_AND_ACK action for a block.
+    private PublisherRequestResult handleSkipAndAck(final long blockNumber) {
+        LOGGER.log(
+                DEBUG, "[{0}] Handler {1} is sending SKIP for block {2}", correlationIdPrefix, handlerId, blockNumber);
+        // If the action is SKIP, we need to send a skip response
+        // to the publisher and not propagate the items.
+        return new SkipAckBlockResult(this, blockNumber, currentStreamingBlockNumber.get());
     }
 
     /// Handle the RESEND action for a block.
@@ -955,29 +973,67 @@ public final class PublisherHandler implements Pipeline<PublishStreamRequestUnpa
     /// not successful.
     private static final class SkipBlockResult extends PublisherRequestResultBase {
         private final SkipBlock skipBlockResponse;
-        private final long currentStreamingNumber;
+        private final long currentWhenSkipped;
 
         private SkipBlockResult(
                 @NonNull final PublisherHandler handler,
-                @NonNull final SkipBlock skipBlockResponse,
+                @NonNull final long skipBlock,
                 final long currentStreamingNumber) {
             super(handler);
-            this.skipBlockResponse = Objects.requireNonNull(skipBlockResponse);
-            this.currentStreamingNumber = currentStreamingNumber;
+            skipBlockResponse = SkipBlock.newBuilder().blockNumber(skipBlock).build();
+            currentWhenSkipped = currentStreamingNumber;
         }
 
         @Override
         public void handle() {
-            final PublishStreamResponse response = PublishStreamResponse.newBuilder()
-                    .skipBlock(skipBlockResponse)
-                    .build();
-            if (handler.sendResponse(response)) {
-                handler.metrics.blockSkipsSent.increment(); // @todo(1415) add label
-                handler.resetState();
-            } else {
-                // Connection is broken, and we failed to send a message.
-                // Close the connection and let the client reconnect.
-                handler.checkMidBlockAndShutdown(currentStreamingNumber, false);
+            handler.sendSkipForBlock(skipBlockResponse, currentWhenSkipped);
+        }
+    }
+
+    /// Send a skip block response, returning success or failure.
+    /// @param skipBlockResponse a Skip Block response object to send
+    /// @param currentWhenSkipped the current stream _when the skip was
+    ///     detected_, the current value _may_ have subsequently changed,
+    ///     though it is very unlikely.
+    /// @return true if the send succeeds, false if the call failed and shutdown
+    ///     was requested instead.
+    private boolean sendSkipForBlock(final SkipBlock skipBlockResponse, final long currentWhenSkipped) {
+        final PublishStreamResponse response =
+                PublishStreamResponse.newBuilder().skipBlock(skipBlockResponse).build();
+        boolean success = sendResponse(response);
+        if (success) {
+            metrics.blockSkipsSent.increment(); // @todo(1415) add label
+            resetState();
+        } else {
+            // Connection is broken, and we failed to send a message.
+            // Close the connection and let the client reconnect.
+            checkMidBlockAndShutdown(currentWhenSkipped, false);
+        }
+        return success;
+    }
+
+    /// This type of result aims to send a [SkipBlock] to the publisher, sends
+    /// an ACKNOWLEDGEMENT for the latest _persisted_ block and then
+    /// reset the state. The handler will be closed if sending the response is
+    /// not successful.
+    private static final class SkipAckBlockResult extends PublisherRequestResultBase {
+        private final SkipBlock skipBlockResponse;
+        private final long currentWhenSkipped;
+        private final StreamPublisherManager publisherManager;
+
+        private SkipAckBlockResult(
+                @NonNull final PublisherHandler handler, @NonNull final long skipBlock, final long currentStreamBlock) {
+            super(handler);
+            publisherManager = handler.publisherManager;
+            skipBlockResponse = SkipBlock.newBuilder().blockNumber(skipBlock).build();
+            currentWhenSkipped = currentStreamBlock;
+        }
+
+        @Override
+        public void handle() {
+            if (handler.sendSkipForBlock(skipBlockResponse, currentWhenSkipped)) {
+                // send acknowledgement, but don't clear queues
+                handler.baseSendBlockAcknowledgement(publisherManager.getLatestBlockNumber());
             }
         }
     }

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherManager.java
@@ -107,6 +107,9 @@ public interface StreamPublisherManager extends BlockNotificationHandler {
         ACCEPT,
         /// todo(1420) add documentation
         SKIP,
+        /// Send a SKIP followed by an ACKNOWLEDGE for a block that is already
+        /// persisted, but recent enough to be within the "soft duplicate" window.
+        SKIP_AND_ACK,
         /// todo(1420) add documentation
         RESEND,
         /// todo(1420) add documentation

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/LiveStreamPublisherManagerTest.java
@@ -265,7 +265,7 @@ class LiveStreamPublisherManagerTest {
                         100L, 99L, 97L, 96L, 95L,
                     })
             @DisplayName(
-                    "getActionForBlock() returns SKIP when the provided block number is a duplicate within the skip window and previous action is NULL")
+                    "getActionForBlock() returns SKIP_AND_ACK when the provided block number is a duplicate within the skip window and previous action is NULL")
             void testGetActionNullPreviousActionDuplicateWithinSkipWindow(final long blockNumber) {
                 // lastPersistedBlock = 100, default duplicateBlockSkipWindow = 5.
                 // Block numbers 95..100 all sit at distance <= 5 and must return SKIP.
@@ -275,7 +275,7 @@ class LiveStreamPublisherManagerTest {
                 historicalBlockFacility.setTemporaryAvailableBlocks(availableBlocks);
                 toTest.handlePersisted(new PersistedNotification(lastPersistedBlock, true, 0, BlockSource.PUBLISHER));
                 final BlockAction actual = toTest.getActionForBlock(blockNumber, null, publisherHandlerId);
-                assertThat(actual).isEqualTo(BlockAction.SKIP);
+                assertThat(actual).isEqualTo(BlockAction.SKIP_AND_ACK);
             }
 
             /// This test aims to assert that the
@@ -2753,11 +2753,12 @@ class LiveStreamPublisherManagerTest {
             /// > In order for a handler to start streaming a block, it must pass through the manager.
             /// The manager does not allow two or more publishers to stream the same block simultaneously.
             /// When the duplicate falls within the default `producer.duplicateBlockSkipWindow`,
-            /// the manager answers with [PublishStreamResponse.SkipBlock] instead of closing the
+            /// the manager answers with [PublishStreamResponse.SkipBlock] followed by
+            /// [PublishStreamResponse.BlockAcknowledgement] instead of closing the
             /// stream so the publisher can fast-forward.
             @Test
             @DisplayName(
-                    "Test blockIsEnding() when receiving premature header for same publisher, skip if block is already being acknowledged within the skip window")
+                    "Test blockIsEnding() when receiving premature header for same publisher, skip-and-ack if block is already being acknowledged within the skip window")
             void testBlockIsEndingWhenReceivingPrematureHeaderSamePublisherDifferentBlockDuplicate() {
                 // First, we need to build and stream the next block in line
                 final TestBlock block0 = TestBlockBuilder.generateBlockWithNumber(0L);
@@ -2820,11 +2821,14 @@ class LiveStreamPublisherManagerTest {
                 // Block 0 is a duplicate (already persisted) and sits at distance 0 from the
                 // last persisted block, which is well within the default duplicateBlockSkipWindow,
                 // so the manager answers with SkipBlock rather than closing the stream.
+                assertThat(responsePipeline.getOnNextCalls()).hasSize(2);
                 assertThat(responsePipeline.getOnNextCalls())
-                        .hasSize(1)
                         .first()
                         .returns(ResponseOneOfType.SKIP_BLOCK, responseKindExtractor)
                         .returns(block0.number(), skipBlockNumberExtractor);
+                assertThat(responsePipeline.getOnNextCalls())
+                        .last()
+                        .returns(ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor);
             }
 
             /// Verifies that [LiveStreamPublisherManager#blockIsEnding(long, long)]

--- a/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
+++ b/block-node/stream-publisher/src/test/java/org/hiero/block/node/stream/publisher/StreamPublisherPluginTest.java
@@ -658,13 +658,18 @@ class StreamPublisherPluginTest {
             toPluginPipe.onNext(PublishStreamRequestUnparsed.PROTOBUF.toBytes(firstRequest));
             // Distance-zero duplicates fall inside the configured duplicateBlockSkipWindow, so
             // the publisher is told to skip the block rather than having its stream closed.
+            assertThat(fromPluginBytes).hasSize(2);
             assertThat(fromPluginBytes)
-                    .hasSize(1)
                     .first()
                     .extracting(bytesToPublishStreamResponseMapper)
                     .isNotNull()
                     .returns(ResponseOneOfType.SKIP_BLOCK, responseKindExtractor)
                     .returns(0L, skipBlockNumberExtractor);
+            assertThat(fromPluginBytes)
+                    .last()
+                    .extracting(bytesToPublishStreamResponseMapper)
+                    .isNotNull()
+                    .returns(ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor);
         }
 
         /// This test aims to verify that once a block has been streamed to the
@@ -710,17 +715,19 @@ class StreamPublisherPluginTest {
             awaitPluginResponses(1);
             // Distance-zero duplicates fall inside the configured duplicateBlockSkipWindow, so
             // the publisher is told to skip the block rather than having its stream closed.
+            assertThat(fromPluginBytes).hasSize(2);
             assertThat(fromPluginBytes)
-                    .hasSize(1)
                     .first()
                     .extracting(bytesToPublishStreamResponseMapper)
                     .isNotNull()
                     .returns(ResponseOneOfType.SKIP_BLOCK, responseKindExtractor)
                     .returns(0L, skipBlockNumberExtractor);
+            assertThat(fromPluginBytes)
+                    .last()
+                    .extracting(bytesToPublishStreamResponseMapper)
+                    .isNotNull()
+                    .returns(ResponseOneOfType.ACKNOWLEDGEMENT, responseKindExtractor);
         }
-
-        // @todo(1693) add tests:
-        //    - add e2e test cases to test plan
     }
 
     /// Tests for failed block verification


### PR DESCRIPTION
## Reviewer Notes
* Added an action for skip-and-ack
* Added a handler block result for skip-and-ack
* Extracted base logic for sending skip and acknowledgement
   * Made both skip and skip-and-ack call the skip method
   * The base acknowledgement doesn't clear queues, so we can minimize impact when acknowledging a duplicate.
* Added a check for trace is-loggable around a costly trace logging block.

## Related Issue(s)
 Resolves #3554.
