### PR TITLE
docs: remove Hashgraph PoC and cohort references from operator docs

### DIFF
--- a/docs/block-node/faq/integration-faq.md
+++ b/docs/block-node/faq/integration-faq.md
@@ -41,20 +41,20 @@ The BN can send five response types during an active stream:
 | `BlockAcknowledgement` | After block proof received and verified           | Mark block secured and continue streaming the next block |
 | `SkipBlock`            | Another publisher is currently sending this block | Skip the current block and continue with the next        |
 | `ResendBlock`          | BN needs the CN to resend from a specific block   | Resend from the block number specified                   |
-| `BehindPublisher`      | BN is behind — CN is too far ahead                | Start a new stream from the block number specified       |
-| `EndOfStream`          | Terminal — stream is closed                       | See the status code and take the appropriate action      |
+| `BehindPublisher`      | BN is behind - CN is too far ahead                | Start a new stream from the block number specified       |
+| `EndOfStream`          | Terminal - stream is closed                       | See the status code and take the appropriate action      |
 
 ### What does `DUPLICATE_BLOCK` mean and what should the CN do?
 
 `DUPLICATE_BLOCK` means the block header the CN sent
 corresponds to a block that is already stored and verified by the BN. The CN closes the
-stream and resumes streaming — to this BN or a different available Block Node — beginning
+stream and resumes streaming - to this BN or a different available Block Node - beginning
 with the block after the last persisted and verified block.
 
 ### What does `PERSISTENCE_FAILED` mean and is the block lost?
 
 `PERSISTENCE_FAILED` (code 7 in `EndOfStream`) means the BN failed to durably store
-the block. **The block is not necessarily lost** — the CN still has it. The CN must:
+the block. **The block is not necessarily lost** - the CN still has it. The CN must:
 
 1. Start a new stream and resend the block to this BN or a different reliable BN.
 2. **Not discard the block** until it has been acknowledged as persisted and verified by
@@ -63,15 +63,15 @@ the block. **The block is not necessarily lost** — the CN still has it. The CN
 ### What does `BAD_BLOCK_PROOF` mean?
 
 `BAD_BLOCK_PROOF` (code 6 in `EndOfStream`) means a `BlockProof` item could not be
-validated. The CN closes the stream and resumes streaming — to this BN or a different
-available Block Node — from before the failed block.
+validated. The CN closes the stream and resumes streaming - to this BN or a different
+available Block Node - from before the failed block.
 
 ### When does the Block Node send `TIMEOUT` to the Consensus Node?
 
 `TIMEOUT` (code 4 in `EndOfStream`) is sent when the delay between stream items
-exceeds the BN's configured timeout — the CN did not deliver the next item within the
-allowed window. The CN closes the stream and resumes streaming — to this BN or a
-different available Block Node — from the timed-out block.
+exceeds the BN's configured timeout - the CN did not deliver the next item within the
+allowed window. The CN closes the stream and resumes streaming - to this BN or a
+different available Block Node - from the timed-out block.
 
 ### Does the Block Node reconnect to the Consensus Node if the stream drops?
 
@@ -105,7 +105,7 @@ closes.
 
 |               Code               |                                                      Meaning                                                      |                              What to do                               |
 |----------------------------------|-------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
-| `INVALID_START_BLOCK_NUMBER` (4) | `start_block_number` is structurally invalid — below `first_available_block`, or beyond the future-request window | Fix the request parameters; do not retry with the same value          |
+| `INVALID_START_BLOCK_NUMBER` (4) | `start_block_number` is structurally invalid - below `first_available_block`, or beyond the future-request window | Fix the request parameters; do not retry with the same value          |
 | `NOT_AVAILABLE` (6)              | The block is not available on this BN at this time (e.g. pruned, or node is still backfilling)                    | Retry later with exponential backoff, or query a different Block Node |
 
 ### What should a subscriber do on `NOT_AVAILABLE`?
@@ -129,7 +129,7 @@ reasonable time.
 
 The BN **silently switches a slow subscriber session back to history** and streams from
 the historical block store until the subscriber catches up to the live stream. Gaps are
-never introduced by the BN — they can only come from the upstream unverified CN→BN
+never introduced by the BN - they can only come from the upstream unverified CN→BN
 stream.
 
 Blocks delivered from the live queue are unverified and may contain errors, be
@@ -146,8 +146,8 @@ its `BlockProof`.
 
 |        Code         |                                                           Meaning                                                            |
 |---------------------|------------------------------------------------------------------------------------------------------------------------------|
-| `NOT_FOUND` (4)     | The block **should** be available on this BN (within its managed range) but was not found — may be a transient storage issue |
-| `NOT_AVAILABLE` (5) | The block is **outside** this BN's managed range — the BN has never held it or it has been pruned                            |
+| `NOT_FOUND` (4)     | The block **should** be available on this BN (within its managed range) but was not found - may be a transient storage issue |
+| `NOT_AVAILABLE` (5) | The block is **outside** this BN's managed range - the BN has never held it or it has been pruned                            |
 
 For `NOT_AVAILABLE`, call `serverStatusDetail` to determine the BN's `available_ranges`,
 then query a BN that covers the needed range.
@@ -225,7 +225,7 @@ Use `FILE_AND_GRPC` before "cutover" to send blocks while still directly uploadi
 ### Does `block-nodes.json` require a CN restart to take effect?
 
 **No.** The CN watches `block-nodes.json` for create, modify, and delete events and
-reloads it live. Changes take effect immediately — existing connections are shut down
+reloads it live. Changes take effect immediately - existing connections are shut down
 cleanly and new connections are established with the updated configuration. If the file
 is missing or fails to parse, the CN logs a warning and stops establishing new
 connections until a valid file is present.
@@ -244,7 +244,7 @@ solo block node add-external \
 ```
 
 Run this command after the network is initialised but **before** starting the Consensus
-Nodes — this ensures the BN receives every block from block 0 onwards.
+Nodes - this ensures the BN receives every block from block 0 onwards.
 
 > See [Load Testing with Solo and NLG](../operations/load-testing-a-deployed-block-node-using-solo-and-nlg.md) for more details.
 
@@ -254,7 +254,7 @@ Nodes — this ensures the BN receives every block from block 0 onwards.
 
 ### How do I generate an `admin_key` for Block Node registration?
 
-The `admin_key` is a **Hiero network key — not a generic EVM key or Hedera wallet key**.
+The `admin_key` is a **Hiero network key - not a generic EVM key or Hedera wallet key**.
 
 **Key type:** Ed25519 (standard recommendation). Generated via `PrivateKey.generateED25519()` in any of the seven official Hiero SDKs (Java, JavaScript, Go, Rust, Swift, C++, Python). Use an HSM or KMS if your operational policy requires hardware-backed key custody.
 
@@ -267,7 +267,7 @@ The `admin_key` is a **Hiero network key — not a generic EVM key or Hedera wal
 
 ```javascript
 const adminKey = PrivateKey.generateED25519();
-// Store the private key securely — loss is unrecoverable
+// Store the private key securely - loss is unrecoverable
 ```
 
 > See [Block Node On-Chain Registration](../block-node-on-chain-registration.md) for the
@@ -296,7 +296,7 @@ to a long-lived gRPC stream from a Block Node**:
 
 1. Run all common pre-upgrade checks (health, storage, provisioner version, artifact
    backup).
-2. **Clear the block store** — reset removes preview blocks incompatible with the WRB
+2. **Clear the block store** - reset removes preview blocks incompatible with the WRB
    format.
 3. Enable the `roster-bootstrap-rsa` plugin.
 4. Configure the RSA bootstrap roster (via Mirror Node auto-fetch, peer BN query, or
@@ -314,13 +314,13 @@ to a long-lived gRPC stream from a Block Node**:
 
 ### Which Block Node version supports which Consensus Node version?
 
-The Block Node is designed with long-term forward compatibility as a core goal — a given BN version is intended to remain
+The Block Node is designed with long-term forward compatibility as a core goal - a given BN version is intended to remain
 compatible with future CN versions for as long as practical. In practice this means the
 minimum compatible BN version for a given CN release is expected to change very slowly
 (for example, BN 1.0.0 might remain the minimum compatible version across many CN
 releases).
 
-That said, **always run the latest available Block Node release** — the minimum
+That said, **always run the latest available Block Node release** - the minimum
 compatible version is a floor, not a recommendation to stay pinned.
 
 The current BN release is built and tested against the CN version pinned in
@@ -334,6 +334,7 @@ grep "hederaVersion" hiero-dependency-versions/build.gradle.kts
 
 The E2E test suite (`solo-e2e-test.yml`) runs against the latest available version of
 each component dynamically rather than pinned pairs. For production compatibility
-guidance, consult your Hashgraph PoC.
+guidance, consult the release notes or open an issue in the
+[hiero-block-node repository](https://github.com/hiero-ledger/hiero-block-node).
 
 ---

--- a/docs/block-node/faq/operator-faq.md
+++ b/docs/block-node/faq/operator-faq.md
@@ -17,8 +17,8 @@ Requirements depend on your deployment tier and network:
 |             Deployment              |                      CPU                      |  RAM   | Fast NVMe |          Bulk storage           |
 |-------------------------------------|-----------------------------------------------|--------|-----------|---------------------------------|
 | Tier 1 mainnet (Local Full History) | 24 cores / 48 threads, single-socket ≥2.0 GHz | 256 GB | 7.5 TB    | 100 TB HDD (500 TB recommended) |
-| Tier 2 Remote Full History          | 16 cores / 32 threads                         | 128 GB | —         | 100 GB+                         |
-| Testnet / previewnet                | 16 vCPU                                       | 32 GB  | —         | Sized to retention window       |
+| Tier 2 Remote Full History          | 16 cores / 32 threads                         | 128 GB | -         | 100 GB+                         |
+| Testnet / previewnet                | 16 vCPU                                       | 32 GB  | -         | Sized to retention window       |
 
 Network: minimum 2 × 10 Gbps NICs for Tier 1 mainnet.
 
@@ -55,7 +55,7 @@ immediately available to relieve pressure while more storage is provisioned or d
 is migrated.
 - Drive performance generally degrades slightly above 80% utilisation.
 
-The 80% figure is a recommendation, not a hard requirement — operators may choose a
+The 80% figure is a recommendation, not a hard requirement - operators may choose a
 different value based on their own retention and capacity policies.
 
 ---
@@ -66,9 +66,9 @@ different value based on their own retention and capacity policies.
 
 |        Port         |                                   Purpose                                    |                    Direction                    |                                 Production exposure                                 |
 |---------------------|------------------------------------------------------------------------------|-------------------------------------------------|-------------------------------------------------------------------------------------|
-| **40840** (default) | gRPC — Publish, Subscribe, Status, Block Access APIs                         | Inbound from CNs, MNs, peer BNs; kubelet probes | Public (Tier 1: CNs + authorised subscribers; Tier 2: upstream BNs + subscribers)   |
+| **40840** (default) | gRPC - Publish, Subscribe, Status, Block Access APIs                         | Inbound from CNs, MNs, peer BNs; kubelet probes | Public (Tier 1: CNs + authorised subscribers; Tier 2: upstream BNs + subscribers)   |
 | **16007**           | Prometheus / OpenMetrics scrape                                              | Inbound from monitoring                         | Internal cluster only                                                               |
-| **5005**            | JVM remote debug (JDWP)                                                      | Inbound from debugger                           | **Must be denied in production** — enabling JDWP significantly degrades performance |
+| **5005**            | JVM remote debug (JDWP)                                                      | Inbound from debugger                           | **Must be denied in production** - enabling JDWP significantly degrades performance |
 | Outbound (dynamic)  | Backfill plugin dials peer Block Node subscribe API (destination port 40840) | Outbound to peer BNs                            | Required if backfill plugin is enabled                                              |
 | Outbound (dynamic)  | RSA Bootstrap Plugin fetches RSA address book from Mirror Node               | Outbound to Mirror Node                         | Required if roster-bootstrap-rsa plugin is enabled                                  |
 
@@ -80,7 +80,7 @@ Ingress or load balancer.
 ### What are the expected inbound and outbound traffic flows?
 
 **Inbound (port 40840):**
-- Consensus Nodes push block streams (Tier 1 only — requires `stream-publisher` plugin)
+- Consensus Nodes push block streams (Tier 1 only - requires `stream-publisher` plugin)
 - Mirror Nodes and downstream Block Nodes subscribe to block streams
 - All clients call `serverStatus` to discover available block ranges
 - Kubernetes kubelet issues HTTP GET liveness and readiness probes
@@ -107,8 +107,9 @@ Estimates from the hardware specifications at 2,000 TPS sustained load:
 At 20,000 TPS the egress estimate reaches ~580 MB/s steady-state, requiring 10+ Gbps
 NICs. These are well-informed estimates based on block-size modelling, confirmed by the
 block node team as current targets. The 33-subscriber figure may change as the network
-topology evolves — verify the expected subscriber count with your Hashgraph PoC before
-finalising hardware procurement.
+topology evolves - verify the expected subscriber count in the release notes or by opening
+an issue in the [hiero-block-node repository](https://github.com/hiero-ledger/hiero-block-node)
+before finalising hardware procurement.
 
 > See [Block Node Hardware Specifications](../operations/block-node-hardware-specifications.md) for full details.
 
@@ -123,7 +124,7 @@ by port:
 | **Publisher (CN → BN, 40840)**  | **Not currently supported.** The Consensus Node PBJ client disables TLS globally; enabling TLS upstream on this port will break CN streaming. Expected to become configurable in a future CN release (~0.78/0.79). |
 | **Subscriber (MN → BN, 40840)** | Permitted if the operator desires it for privacy or compliance.                                                                                                                                                    |
 | **Status (40840)**              | Not supported until a qualified CN release is available.                                                                                                                                                           |
-| **Metrics (16007)**             | Internal only — do not expose publicly. TLS is not relevant.                                                                                                                                                       |
+| **Metrics (16007)**             | Internal only - do not expose publicly. TLS is not relevant.                                                                                                                                                       |
 
 **Authentication:** There is no built-in authentication mechanism, and there are no
 plans to add any. Security is enforced at the network and transport layer.
@@ -135,16 +136,16 @@ plans to add any. Security is enforced at the network and transport layer.
 The Block Node has no authentication and there are no plans to add any. This is by
 design: **trust is in the data, not in the node.** Every block carries a
 [Block Proof](../glossary.md#block-proof) that cryptographically verifies the block's
-authenticity — subscribers verify the data themselves rather than trusting the node
+authenticity - subscribers verify the data themselves rather than trusting the node
 delivering it.
 
 **TLS** is advisory for subscriber-facing ports only. Do **not** enable TLS on the
-Publisher port (CN → BN) until CN support is qualified (targeted ~0.78/0.79) — doing
+Publisher port (CN → BN) until CN support is qualified (targeted ~0.78/0.79) - doing
 so will break all Consensus Node ingest.
 
 **Practical network controls:**
-- Restrict port 16007 (metrics) to internal cluster access only — never expose it publicly.
-- Deny port 5005 (JDWP) in all production firewall rules — enabling JDWP significantly
+- Restrict port 16007 (metrics) to internal cluster access only - never expose it publicly.
+- Deny port 5005 (JDWP) in all production firewall rules - enabling JDWP significantly
 degrades performance.
 - Use Kubernetes `NetworkPolicy` to limit which pods can reach port 40840 if your
 deployment environment requires it.
@@ -158,9 +159,9 @@ deployment environment requires it.
 |                           |                Tier 1                |                         Tier 2                         |
 |---------------------------|--------------------------------------|--------------------------------------------------------|
 | Block stream source       | Directly from Consensus Nodes        | From an upstream Block Node (Tier 1 or another Tier 2) |
-| Who runs it               | Governing Council / trusted entities | Community operators, enterprises — permissionless      |
+| Who runs it               | Governing Council / trusted entities | Community operators, enterprises - permissionless      |
 | `stream-publisher` plugin | **Required**                         | **Must be removed** from `plugins.names`               |
-| Hardware                  | Mainnet bare-metal specs             | Lower — sized to retention window                      |
+| Hardware                  | Mainnet bare-metal specs             | Lower - sized to retention window                      |
 
 > See [Block Node Types and Tiers](../../Block-Node-Types.md) and [Configuration Reference](../configuration.md) for full details.
 
@@ -168,10 +169,10 @@ deployment environment requires it.
 
 |        Type         |                     History retained                      |                          Typical use                          |
 |---------------------|-----------------------------------------------------------|---------------------------------------------------------------|
-| **Full Node**       | All history from genesis on local storage                 | Tier 1 mainnet — `plugin-profile-lfh` or `plugin-profile-all` |
-| **Rolling-History** | Recent history only (configurable window, e.g. 7–90 days) | Tier 2 — low-cost redistribution                              |
-| **Light Node**      | Minimal — health and status only                          | Development, testing, testnet                                 |
-| **Archive Server**  | Cold storage — no live streaming                          | Offline archival                                              |
+| **Full Node**       | All history from genesis on local storage                 | Tier 1 mainnet - `plugin-profile-lfh` or `plugin-profile-all` |
+| **Rolling-History** | Recent history only (configurable window, e.g. 7–90 days) | Tier 2 - low-cost redistribution                              |
+| **Light Node**      | Minimal - health and status only                          | Development, testing, testnet                                 |
+| **Archive Server**  | Cold storage - no live streaming                          | Offline archival                                              |
 
 > See [Block Node Types and Tiers](../../Block-Node-Types.md) for full details.
 
@@ -199,10 +200,10 @@ Select a pre-built Helm values override from
 
 |         Profile          |                                                   Use                                                    |
 |--------------------------|----------------------------------------------------------------------------------------------------------|
-| `plugin-profile-lfh`     | Tier 1 — full history on local NVMe + HDD                                                                |
-| `plugin-profile-rfh`     | Remote archival — cloud storage backend                                                                  |
-| `plugin-profile-all`     | Full history local + cloud backup *(testing only — plugins may conflict and produce unexpected results)* |
-| `plugin-profile-minimal` | Development / testnet — health and status only                                                           |
+| `plugin-profile-lfh`     | Tier 1 - full history on local NVMe + HDD                                                                |
+| `plugin-profile-rfh`     | Remote archival - cloud storage backend                                                                  |
+| `plugin-profile-all`     | Full history local + cloud backup *(testing only - plugins may conflict and produce unexpected results)* |
+| `plugin-profile-minimal` | Development / testnet - health and status only                                                           |
 
 For **Tier 2**, start from `plugin-profile-lfh` and remove `stream-publisher` from
 `plugins.names`. The presence of `stream-publisher` is the key difference between
@@ -228,7 +229,7 @@ blockNode:
     serverStatus: 40982  # SERVER_STATUS_PORT
 ```
 
-When set in Helm, do not also set these in `blockNode.config` — they are injected
+When set in Helm, do not also set these in `blockNode.config` - they are injected
 automatically as environment variables.
 
 > See [Configuration Reference](../configuration.md) for full details.
@@ -315,7 +316,7 @@ Both paths are configurable via `blockNode.health.liveness.endpoint` and
 
 ### What metrics should I alert on?
 
-**Medium severity — page on call:**
+**Medium severity - page on call:**
 
 |                        Metric                        |     Threshold     |
 |------------------------------------------------------|-------------------|
@@ -326,7 +327,7 @@ Both paths are configurable via `blockNode.health.liveness.endpoint` and
 | `blocknode_publisher_stream_errors`                  | > 5 in 60 s       |
 | `blocknode_files_recent_persistence_time_latency_ns` | > 20 milliseconds |
 
-**Low severity — investigate next business day:**
+**Low severity - investigate next business day:**
 
 |                    Metric                     |  Threshold  |
 |-----------------------------------------------|-------------|
@@ -339,7 +340,7 @@ Both paths are configurable via `blockNode.health.liveness.endpoint` and
 ### What log level should I run in production?
 
 Set `org.hiero.block.level = INFO` in production. Use `FINE` only when actively
-debugging — it generates significant volume.
+debugging - it generates significant volume.
 
 > **Note:** The current chart default in `values.yaml` is `FINE` with a comment
 > "temporarily while testing is ongoing." Override this to `INFO` in your production
@@ -378,7 +379,7 @@ subscribe activity.
 
 ### Does the Block Node reconnect to the Consensus Node automatically?
 
-**No.** The Block Node is the server — it does not initiate connections. The Consensus
+**No.** The Block Node is the server - it does not initiate connections. The Consensus
 Node is the client and opens the publish stream to the Block Node. If the stream closes
 (for any reason), the Block Node sends an `EndOfStream` response and waits passively.
 The Consensus Node is responsible for reconnecting.
@@ -426,7 +427,7 @@ Provisioner or run `task reset-upgrade`.
 ### How do I reset the Block Node state?
 
 > ⚠️ **Destructive operation.** A reset permanently deletes all locally stored block data.
-> After a reset, the node must backfill from a peer Block Node — on mainnet this can
+> After a reset, the node must backfill from a peer Block Node - on mainnet this can
 > take days or weeks. Back up PVC contents before proceeding.
 
 **Reset only (same version):**
@@ -454,7 +455,7 @@ Edit `plugins.names` in your Helm values (comma-separated plugin identifiers), t
 ```yaml
 blockNode:
   config:
-    # Example: Tier 2 — stream-publisher removed
+    # Example: Tier 2 - stream-publisher removed
     PLUGINS_NAMES: "backfill,block-access-service,blocks-file-recent,blocks-file-historic,facility-messaging,health,roster-bootstrap-rsa,roster-bootstrap-tss,server-status,stream-subscriber,block-verification"
 ```
 
@@ -476,8 +477,8 @@ scanning every `BACKFILL_SCAN_INTERVAL` (default 60 s) for gaps in local block s
 and fetching from configured peer sources.
 
 Backfill triggers in two scenarios:
-1. **Startup gaps** — blocks missing from storage when the pod starts.
-2. **Live-tail gaps** — gaps detected during normal operation (e.g. after a reset or
+1. **Startup gaps** - blocks missing from storage when the pod starts.
+2. **Live-tail gaps** - gaps detected during normal operation (e.g. after a reset or
 network interruption).
 
 ### How do I tune backfill retry behavior?
@@ -511,7 +512,7 @@ Nodes:
 ```
 
 All Tier 1 Block Nodes should have at least one source configured. More than one is
-recommended for redundancy — the backfill plugin selects by earliest available block,
+recommended for redundancy - the backfill plugin selects by earliest available block,
 then priority, then health score.
 
 > See [Preparing for WRB Cutover](../operations/preparing-your-block-node-for-wrb-cutover.md) for full details.
@@ -522,7 +523,7 @@ then priority, then health score.
 
 ### Who pays for ingress and egress costs?
 
-**Operators pay infrastructure costs directly** — their cloud provider credit card is on
+**Operators pay infrastructure costs directly** - their cloud provider credit card is on
 file and billed for all ingress, egress, and compute.
 
 **Hedera provides daily rewards** intended to offset operational expenses including
@@ -569,13 +570,13 @@ The Block Node public API protos live in `protobuf-sources/src/main/proto/block-
 
 |               Proto file               |                                           Services / messages defined                                           |
 |----------------------------------------|-----------------------------------------------------------------------------------------------------------------|
-| `block_stream_publish_service.proto`   | `BlockStreamPublishService.publishBlockStream` — CN → BN ingestion                                              |
-| `block_stream_subscribe_service.proto` | `BlockStreamSubscribeService.subscribeBlockStream` — MN / Tier 2 consumption                                    |
-| `block_access_service.proto`           | `BlockAccessService.getBlock` — random-access single-block retrieval                                            |
-| `node_service.proto`                   | `BlockNodeService.serverStatus` / `serverStatusDetail` — metadata and health                                    |
-| `state_service.proto`                  | `StateService.stateSnapshot` — *(defined; not yet implemented)*                                                 |
-| `proof_service.proto`                  | `ProofService` — block content and state proofs *(not yet implemented)*                                         |
-| `reconnect_service.proto`              | `ReconnectService.reconnect()` — provides state + block data to lagging Consensus Nodes *(not yet implemented)* |
+| `block_stream_publish_service.proto`   | `BlockStreamPublishService.publishBlockStream` - CN → BN ingestion                                              |
+| `block_stream_subscribe_service.proto` | `BlockStreamSubscribeService.subscribeBlockStream` - MN / Tier 2 consumption                                    |
+| `block_access_service.proto`           | `BlockAccessService.getBlock` - random-access single-block retrieval                                            |
+| `node_service.proto`                   | `BlockNodeService.serverStatus` / `serverStatusDetail` - metadata and health                                    |
+| `state_service.proto`                  | `StateService.stateSnapshot` - *(defined; not yet implemented)*                                                 |
+| `proof_service.proto`                  | `ProofService` - block content and state proofs *(not yet implemented)*                                         |
+| `reconnect_service.proto`              | `ReconnectService.reconnect()` - provides state + block data to lagging Consensus Nodes *(not yet implemented)* |
 | `network-data.proto`                   | Shared network endpoint message types: `NetworkData`, `NetworkConnection`                                       |
 | `shared_message_types.proto`           | Shared message types: `BlockItemSet`, `BlockProof`, `EndOfStream`, etc.                                         |
 
@@ -605,10 +606,10 @@ Each plugin is identified by its `plugins.names` key (used in Helm configuration
 
 |       Plugin name        |                                       Feature provided                                       |             Tier required             |
 |--------------------------|----------------------------------------------------------------------------------------------|---------------------------------------|
-| `stream-publisher`       | Accepts block streams from Consensus Nodes (`publishBlockStream` RPC)                        | Tier 1 only — **remove for Tier 2**   |
+| `stream-publisher`       | Accepts block streams from Consensus Nodes (`publishBlockStream` RPC)                        | Tier 1 only - **remove for Tier 2**   |
 | `stream-subscriber`      | Serves block streams to Mirror Nodes and downstream Block Nodes (`subscribeBlockStream` RPC) | Tier 1 and Tier 2                     |
 | `block-access-service`   | Single-block random-access retrieval (`getBlock` RPC)                                        | Tier 1 and Tier 2                     |
-| `server-status`          | `serverStatus` and `serverStatusDetail` RPCs — block range, version, plugin list             | All deployments                       |
+| `server-status`          | `serverStatus` and `serverStatusDetail` RPCs - block range, version, plugin list             | All deployments                       |
 | `health`                 | Kubernetes liveness (`/healthz/livez`) and readiness (`/healthz/readyz`) probes              | All deployments                       |
 | `block-verification`     | Verifies block proofs before persistence (TSS and RSA/WRB)                                   | All deployments                       |
 | `blocks-file-recent`     | Short-term block persistence on local NVMe with configurable retention policy                | LFH and RFH profiles                  |
@@ -618,7 +619,7 @@ Each plugin is identified by its `plugins.names` key (used in Helm configuration
 | `backfill`               | Fetches missing historical blocks from peer Block Nodes                                      | All production deployments            |
 | `roster-bootstrap-rsa`   | Loads the RSA node address book at startup for WRB block proof verification                  | Required for WRB cutover              |
 | `roster-bootstrap-tss`   | Loads TSS roster data for post-cutover block proof verification                              | Required post-cutover                 |
-| `facility-messaging`     | Internal LMAX Disruptor event bus — distributes block items to all plugins                   | All deployments (core infrastructure) |
+| `facility-messaging`     | Internal LMAX Disruptor event bus - distributes block items to all plugins                   | All deployments (core infrastructure) |
 
 > See [Configuration Reference](../configuration.md) for `plugins.names` syntax and profile examples.
 
@@ -633,8 +634,8 @@ directly.
 
 **For on-chain registration (HIP-1137):**
 Each `service_endpoint` requires either:
-- `domain_name` — an FQDN of up to 250 ASCII characters, OR
-- `ip_address` — an IPv4 or IPv6 address in big-endian byte order.
+- `domain_name` - an FQDN of up to 250 ASCII characters, OR
+- `ip_address` - an IPv4 or IPv6 address in big-endian byte order.
 
 The two are mutually exclusive per endpoint. For production deployments a stable hostname
 is recommended so that IP address changes do not require a registration update.

--- a/docs/block-node/operations/block-node-hardware-specifications.md
+++ b/docs/block-node/operations/block-node-hardware-specifications.md
@@ -11,8 +11,8 @@ deployments.
 
 |                       Node type                        |        Network        |                                  See section                                  |
 |--------------------------------------------------------|-----------------------|-------------------------------------------------------------------------------|
-| Tier 1 — receives stream directly from Consensus Nodes | Mainnet               | [Tier 1 Mainnet Server Specifications](#tier-1-mainnet-server-specifications) |
-| Tier 2 — receives stream from another Block Node       | Mainnet               | [Tier 2 Server Specifications](#tier-2-server-specifications)                 |
+| Tier 1 - receives stream directly from Consensus Nodes | Mainnet               | [Tier 1 Mainnet Server Specifications](#tier-1-mainnet-server-specifications) |
+| Tier 2 - receives stream from another Block Node       | Mainnet               | [Tier 2 Server Specifications](#tier-2-server-specifications)                 |
 | Any tier                                               | Testnet or Previewnet | [Testnet and Previewnet Sizing](#testnet-and-previewnet-sizing)               |
 
 ---
@@ -100,7 +100,7 @@ No state services are offered and most if not all services are expected to be pr
 ### Rolling-History (Partial History) Tier 2
 
 A Rolling-History Tier 2 node does not store full blockchain history. CPU and
-RAM requirements match Tier 1 — the primary driver is the State Management task
+RAM requirements match Tier 1 - the primary driver is the State Management task
 (which handles live state and serves downstream subscribers), not verification
 or persistence alone. Exact minimums for nodes that do not manage live state
 have not yet been formally benchmarked. The `stream-publisher` plugin is not
@@ -111,14 +111,16 @@ is sized to the retention window rather than the full block history.
 |-------------------|-----------------------------------------------------------------------------------|
 | CPU               | 24 cores / 48 threads, single socket, ≥ 2.0 GHz base clock                        |
 | RAM               | 256 GB                                                                            |
-| Fast NVMe Disk    | 7.5 TB NVMe SSD (recent blocks + live state; partially optional — see note below) |
+| Fast NVMe Disk    | 7.5 TB NVMe SSD (recent blocks + live state; partially optional - see note below) |
 | Bulk Storage Disk | Size to retention window (see table below)                                        |
 | Network           | 10 Gbps NIC minimum (see [Network Requirements](#network-requirements))           |
 | OS                | Linux host OS (Ubuntu 24.04 LTS or Debian 13.x LTS recommended)                   |
 
 > **Note:** The Fast NVMe Disk is at least partially optional for Rolling-History Tier 2 nodes. Its
-> necessity depends on whether the node manages live state and serves downstream subscribers. Consult
-> your Hashgraph PoC for the current recommended configuration if you are not managing live state.
+> necessity depends on whether the node manages live state and serves downstream subscribers. If you
+> are not managing live state, open an issue in the
+> [hiero-block-node repository](https://github.com/hiero-ledger/hiero-block-node) for guidance on
+> the current recommended configuration.
 
 **Bulk storage by retention window (at 10K TPS mainnet, 20% headroom):**
 
@@ -183,7 +185,7 @@ across all drives in the configuration, not per-drive requirements.
 | Disk Type | Sustained Write | Sustained Read |  Write IOPS   |   Read IOPS   | Random Read AIO IOPS | P99 Write Latency | P99 Read Latency |
 |-----------|-----------------|----------------|---------------|---------------|----------------------|-------------------|------------------|
 | Fast NVMe | 4 GBps          | 6 GBps         | 350k (random) | 900k (random) | 1M                   | < 300 µs          | < 200 µs         |
-| Bulk Disk | 300 MBps        | 1 GBps         | 1200          | 4000          | n/a                  | —                 | —                |
+| Bulk Disk | 300 MBps        | 1 GBps         | 1200          | 4000          | n/a                  | -                 | -                |
 
 #### Notes
 
@@ -242,7 +244,7 @@ T = transactions per block = TPS × block_interval
 
 #### Assumptions used in the tables below
 
-- Block interval: 1 second (1 block/sec — conservative; mainnet in early 2026
+- Block interval: 1 second (1 block/sec - conservative; mainnet in early 2026
   runs at 0.5 blocks/sec)
 - Compression ratio: 2.39× (zstd, from v3 mixed-workload model)
 - Worst-case egress subscribers: 33 (13 Block Nodes backfilling +
@@ -307,7 +309,7 @@ uncompressed stream. All figures use the raw (uncompressed) wire size.
 |  2,000 |               156 GB |                 4.6 TB |               5.1 TB |                 154 TB |
 | 20,000 |               1.5 TB |                  45 TB |                50 TB |                 1.5 PB |
 
-**Worst-case peak bandwidth (burst — 4 in-flight blocks per subscriber):**
+**Worst-case peak bandwidth (burst - 4 in-flight blocks per subscriber):**
 
 |    TPS | Steady-state egress (33 sub) | Burst egress (33 sub, 4× in-flight) |
 |-------:|-----------------------------:|------------------------------------:|

--- a/docs/block-node/operations/preparing-your-block-node-for-wrb-cutover.md
+++ b/docs/block-node/operations/preparing-your-block-node-for-wrb-cutover.md
@@ -14,7 +14,7 @@ Complete all steps in this section before every upgrade, regardless of release.
 
 ### Confirm Block Node health
 
-Before upgrading, confirm the Block Node is healthy. Do not upgrade an unhealthy node — an in-progress failure becomes a stuck rollout.
+Before upgrading, confirm the Block Node is healthy. Do not upgrade an unhealthy node - an in-progress failure becomes a stuck rollout.
 
 1. List all pods and confirm the Block Node pod is `Running` with all containers ready:
 
@@ -44,7 +44,7 @@ Before upgrading, confirm the Block Node is healthy. Do not upgrade an unhealthy
      org.hiero.block.api.BlockNodeService/serverStatus
    ```
 
-   Record `firstAvailableBlock` and `lastAvailableBlock`. Both should be sensible block numbers — not `18446744073709551615` (the sentinel for "no blocks yet") — if the Block Node has been ingesting. For instructions on downloading the protobuf bundle into `~/bn-proto`, see [Connecting a Mirror Node to a Block Node](./connecting-a-mirror-node-to-a-block-node.md).
+   Record `firstAvailableBlock` and `lastAvailableBlock`. Both should be sensible block numbers - not `18446744073709551615` (the sentinel for "no blocks yet") - if the Block Node has been ingesting. For instructions on downloading the protobuf bundle into `~/bn-proto`, see [Connecting a Mirror Node to a Block Node](./connecting-a-mirror-node-to-a-block-node.md).
 
 3. Confirm Alloy telemetry is shipping (if configured):
 
@@ -77,7 +77,7 @@ The Block Node uses five persistent volumes. Confirm each is mounted and has ade
 | `archive`      | `blockNode.persistence.archive.mountPath` (default `/opt/hiero/block-node/data/historic`)     | 90 TB              | Compressed historic block archive                                                       |
 | `verification` | `blockNode.persistence.verification.mountPath` (default `/opt/hiero/block-node/verification`) | 50 GB              | Block hash state and verification data                                                  |
 | `logging`      | `blockNode.persistence.logging.mountPath` (default `/opt/hiero/block-node/logs`)              | 100 GB             | Application logs                                                                        |
-| `plugins`      | `blockNode.persistence.plugins`                                                               | —                  | Plugin JARs; always mounted but may contain no JARs until plugins are explicitly loaded |
+| `plugins`      | `blockNode.persistence.plugins`                                                               | -                  | Plugin JARs; always mounted but may contain no JARs until plugins are explicitly loaded |
 
 > Note: The exact mount paths depend on your Helm values. Run `helm -n block-node get values <release-name>` to inspect your installation's overrides.
 >
@@ -98,7 +98,7 @@ kubectl -n block-node exec $BN_POD -c block-node-server -- df -h \
 
 ### Confirm provisioner version
 
-Upgrade Solo Provisioner to the latest release before upgrading the Block Node. Your Hashgraph PoC will confirm the supported provisioner version for the cohort.
+Upgrade Solo Provisioner to the latest release before upgrading the Block Node. Check the [Solo Provisioner releases page](https://github.com/hashgraph/solo-weaver/releases) for the latest supported version.
 
 1. Check the installed version:
 
@@ -126,7 +126,7 @@ Before the upgrade, confirm you have current copies of the following files store
 
 |          Artifact           |                                                         Location on host                                                         |                                              Why it is irreplaceable                                               |
 |-----------------------------|----------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
-| `block-node-values.yaml`    | `/etc/solo-provisioner/block-node-values.yaml`                                                                                   | Cohort-specific Helm overlay generated once at handoff                                                             |
+| `block-node-values.yaml`    | `/etc/solo-provisioner/block-node-values.yaml`                                                                                   | Operator-specific Helm values overlay for this deployment                                                          |
 | `rsa-bootstrap-roster.json` | Default: `/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json` (configurable via `app.state.rsaBootstrapFilePath`) | RSA public-key roster for WRB proof verification; only needed when not using Mirror Node auto-fetch for the roster |
 
 ---
@@ -139,9 +139,9 @@ Complete the subsection below that matches the upgrade you are preparing for. Fu
 
 ### WRB streaming cutover prep
 
-**Applies to:** the Consensus Node release that activates Wrapped Record Block (WRB) streaming — currently scheduled for CN release 0.75.0. The exact release may change if release testing surfaces a blocker; your Hashgraph PoC will confirm the target release before the maintenance window.
+**Applies to:** the Consensus Node release that activates Wrapped Record Block (WRB) streaming - currently scheduled for CN release 0.75.0. The exact release may change if release testing surfaces a blocker; monitor the [hiero-consensus-node releases](https://github.com/hiero-ledger/hiero-consensus-node/releases) and network announcements for the confirmed target release.
 
-For the full network cutover timeline — phases, CN-side WRB catch-up, [TSS](../glossary.md#tss-hintsts) ceremony, and [Jumpstart Data](../glossary.md#jumpstart-data) — see [Cutover Process and Timeline](../Cutover-Process.md).
+For the full network cutover timeline - phases, CN-side WRB catch-up, [TSS](../glossary.md#tss-hintsts) ceremony, and [Jumpstart Data](../glossary.md#jumpstart-data) - see [Cutover Process and Timeline](../Cutover-Process.md).
 
 **What is changing:** from the cutover release onwards, Consensus Nodes begin producing Wrapped Recordfile Blocks with aggregated RSA signature Block Proofs. The production of Record files uploaded to S3 storage will continue until the cutover to TSS and Block Streams in a later release. Any preview blocks stored by the Block Node before the cutover are invalid and must be discarded before the BN can receive and store authoritative WRB history. Do not skip the reset step even if the BN appears to be functioning normally.
 
@@ -151,7 +151,7 @@ Complete the [common pre-upgrade checks](#common-pre-upgrade-checks) first, then
 
 #### Clear the block store (preview-blocks reset)
 
-> **Caution:** This operation is destructive and cannot be undone. It scales the StatefulSet to 0, clears all files from the `live`, `archive`, `verification`, and `logging` storage directories, then scales back up to 1. All block data on this node is lost. Do not run this step until your Hashgraph PoC has confirmed the maintenance window is open and your off-host artifact backups are current.
+> **Caution:** This operation is destructive and cannot be undone. It scales the StatefulSet to 0, clears all files from the `live`, `archive`, `verification`, and `logging` storage directories, then scales back up to 1. All block data on this node is lost. Do not run this step until the maintenance window is confirmed open and your off-host artifact backups are current.
 
 ```bash
 sudo solo-provisioner block node reset --profile=mainnet
@@ -193,7 +193,7 @@ grpcurl -plaintext -emit-defaults \
 
   Both values at `18446744073709551615` confirm the store is empty and the Block Node is ready to backfill.
 
-If the reset fails, run the following to diagnose the issue and share the output with your Hashgraph PoC:
+If the reset fails, run the following to diagnose the issue. Attach this output when opening a support ticket:
 
 ```bash
 sudo head /opt/solo/weaver/logs/solo-provisioner.log
@@ -207,16 +207,16 @@ The `roster-bootstrap-rsa` plugin must be included in your Block Node's plugin l
 
 **Enable the plugin**
 
-Add `roster-bootstrap-rsa` to your plugin list in `block-node-values.yaml`. Append it to your existing `plugins.names` value — the example below shows the full plugin list used for [LFH](../glossary.md#local-full-history-lfh) nodes on previewnet, provided for reference:
+Add `roster-bootstrap-rsa` to your plugin list in `block-node-values.yaml`. Append it to your existing `plugins.names` value - the example below shows the full plugin list used for [LFH](../glossary.md#local-full-history-lfh) nodes on previewnet, provided for reference:
 
 ```yaml
 plugins:
   names: facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-historic,blocks-file-recent,backfill,roster-bootstrap-rsa,roster-bootstrap-tss
 ```
 
-**Mirror Node auto-fetch (mainnet cohort default)**
+**Mirror Node auto-fetch**
 
-When `ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL` is set in your `block-node-values.yaml`, the plugin fetches the roster from the Mirror Node REST API at startup and caches it locally. After `block node reset`, the cached copy is cleared along with the rest of the storage directories and is automatically re-fetched on the next pod start — no manual intervention is needed. Before the cutover window, confirm outbound connectivity to the Mirror Node is available from the BN host.
+When `ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL` is set in your `block-node-values.yaml`, the plugin fetches the roster from the Mirror Node REST API at startup and caches it locally. After `block node reset`, the cached copy is cleared along with the rest of the storage directories and is automatically re-fetched on the next pod start - no manual intervention is needed. Before the cutover window, confirm outbound connectivity to the Mirror Node is available from the BN host.
 
 Set the URL in your Helm values overlay:
 
@@ -233,13 +233,13 @@ Mirror Node base URLs by network:
 | Testnet    | `https://testnet.mirrornode.hedera.com`        |
 | Previewnet | `https://previewnet.mirrornode.hedera.com`     |
 
-> Note: If the Mirror Node is unreachable, the plugin polls indefinitely — every 5 seconds until the first roster is fetched, then every 60 seconds for periodic refresh. Both intervals are configurable. WRB proof verification is non-functional until the roster is available.
+> Note: If the Mirror Node is unreachable, the plugin polls indefinitely - every 5 seconds until the first roster is fetched, then every 60 seconds for periodic refresh. Both intervals are configurable. WRB proof verification is non-functional until the roster is available.
 
 **Peer Block Node query**
 
 All Tier 1 Block Nodes should have at least one peer Block Node source configured; more than one is recommended for redundancy. When `roster.bootstrap.rsa.blockNodeSourcesPath` is set, the plugin queries configured peer Block Nodes via gRPC to retrieve the roster. This runs concurrently with the Mirror Node query; whichever responds first provides the initial roster. The peer BN query follows the same two-phase polling schedule (5-second initial interval, 60-second subsequent interval, both configurable).
 
-This is the **same file** referenced by `BACKFILL_BLOCK_NODE_SOURCES_PATH` — configuring it once serves both the roster-bootstrap-rsa plugin and the backfill plugin. Set the path in your Helm values overlay:
+This is the **same file** referenced by `BACKFILL_BLOCK_NODE_SOURCES_PATH` - configuring it once serves both the roster-bootstrap-rsa plugin and the backfill plugin. Set the path in your Helm values overlay:
 
 ```yaml
 config:
@@ -257,20 +257,22 @@ The file format is a JSON object with a `nodes` array:
 }
 ```
 
-Configure this file via your Helm chart's ConfigMap or values override mechanism. Use the endpoints provided by your Hashgraph PoC.
+Configure this file via your Helm chart's ConfigMap or values override mechanism. Use the endpoints for your peer Block Nodes.
 
 **Manual file (alternative)**
 
-If `ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL` is not configured, the plugin reads the roster from `app.state.rsaBootstrapFilePath` (default: `/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json`). The file is delivered as part of the cohort package by your Hashgraph PoC. After `block node reset`, confirm the file is still present and non-empty:
+If `ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL` is not configured, the plugin reads the roster from `app.state.rsaBootstrapFilePath` (default: `/opt/hiero/block-node/application-state/rsa-bootstrap-roster.json`). After `block node reset`, confirm the file is still present and non-empty:
+
+> Note: For production networks with a running Mirror Node, the roster file is fetched automatically - no manual file delivery is needed. For test environments without a Mirror Node, obtain a `genesis-network.json` file from the Consensus Node and convert it using the script at `tools-and-tests/scripts/node-operations/genesis-network-to-bn-rsa-roster.sh`.
 
 ```bash
 kubectl -n block-node exec $BN_POD -c block-node-server -- \
-  ls -lh /opt/hiero/block-node/node/rsa-bootstrap-roster.json
+  ls -lh /opt/hiero/block-node/application-state/rsa-bootstrap-roster.json
 ```
 
-- **If the file is missing after reset:** re-deliver it from your off-host backup using the mechanism in your cohort's `block-node-values.yaml`.
+- **If the file is missing after reset:** re-deliver it from your off-host backup using the mechanism defined in your Helm values overlay.
 
-In either case, confirm the roster loaded cleanly after the pod starts by querying `serverStatusDetail` — the response should contain a non-empty `rosterHash` field:
+In either case, confirm the roster loaded cleanly after the pod starts by querying `serverStatusDetail` - the response should contain a non-empty `nodeAddressBook` field:
 
 ```bash
 grpcurl -plaintext -emit-defaults \
@@ -281,15 +283,15 @@ grpcurl -plaintext -emit-defaults \
   org.hiero.block.api.BlockNodeService/serverStatusDetail
 ```
 
-- **Expected:** the response includes a non-empty `rosterHash` field, confirming the RSA roster is loaded and active.
+- **Expected:** the response includes a non-empty `nodeAddressBook` field, confirming the RSA roster is loaded and active.
 
 #### Configure backfill sources (if required)
 
-After the block store reset, the BN backfills WRB history automatically as long as other Block Nodes on the network already hold the relevant block range. All Tier 1 operators should have at least one Block Node source configured for both backfill and peer roster queries. **Most operators do not need to manually configure a specific backfill source** — once peer Block Nodes are advertising history on the network, the backfill plugin discovers them through the normal backfill path.
+After the block store reset, the BN backfills WRB history automatically as long as other Block Nodes on the network already hold the relevant block range. All Tier 1 operators should have at least one Block Node source configured for both backfill and peer roster queries. **Most operators do not need to manually configure a specific backfill source** - once peer Block Nodes are advertising history on the network, the backfill plugin discovers them through the normal backfill path.
 
 **Enable greedy backfill**
 
-Hashgraph recommends enabling greedy backfill on all Tier 1 Block Nodes for the WRB cutover. With greedy [backfill](../glossary.md#backfill) enabled, the BN proactively retrieves blocks beyond the latest acknowledged block, preventing the node from falling too far behind during the initial catch-up period.
+For the WRB cutover, enable greedy backfill on all Tier 1 Block Nodes. With greedy [backfill](../glossary.md#backfill) enabled, the BN proactively retrieves blocks beyond the latest acknowledged block, preventing the node from falling too far behind during the initial catch-up period.
 
 In your Helm values overlay, set `BACKFILL_GREEDY` to `"true"`, apply the change, and confirm:
 
@@ -300,11 +302,11 @@ helm -n block-node get values <release-name> | grep BACKFILL_GREEDY
 
 - **Expected:** `BACKFILL_GREEDY: "true"`
 
-**Edge case — bootstrapping from genesis when no public BN holds the history yet:**
+**Edge case - bootstrapping from genesis when no public BN holds the history yet:**
 
-During the initial mainnet WRB cutover, the wrapped record block history may not yet be available from public Block Nodes. In this case, a special-purpose Block Node holding the offline-wrapped WRBs serves as a temporary backfill source. Operators who need access to this node will receive the endpoint and connection details through a separate operator communication channel — it is not published in this document.
+During the initial mainnet WRB cutover, the wrapped record block history may not yet be available from public Block Nodes. In this case, a special-purpose Block Node holding the offline-wrapped WRBs serves as a temporary backfill source. Operators who need access to this node will receive the endpoint and connection details through a separate operator communication channel - it is not published in this document.
 
-If you are directed by your Hashgraph PoC to configure a specific backfill source:
+If you need to configure a specific backfill source:
 
 1. Update your Helm values overlay with the backfill source path, `BLOCK_NODE_EARLIEST_MANAGED_BLOCK` set to `"0"` (so the BN manages from genesis), a `startBlock` of `"0"`, and a `fetchBatchSize` of `"100"` for faster throughput. Apply the change:
 
@@ -320,13 +322,13 @@ If you are directed by your Hashgraph PoC to configure a specific backfill sourc
    helm -n block-node upgrade <release-name> <chart> -f block-node-values.yaml
    helm -n block-node get values <release-name> | grep -i backfill
    ```
-2. The `block-node-sources.json` file format is a JSON object with a `nodes` array. Configure the file via your Helm chart's ConfigMap or values override mechanism. Use the hostname and port provided by your Hashgraph PoC:
+2. The `block-node-sources.json` file format is a JSON object with a `nodes` array. Configure the file via your Helm chart's ConfigMap or values override mechanism:
 
    ```json
    {
      "nodes": [
        {
-         "address": "<host-provided-by-hashgraph-poc>",
+         "address": "<peer-block-node-host>",
          "port": 40980,
          "priority": 1
        }
@@ -336,7 +338,7 @@ If you are directed by your Hashgraph PoC to configure a specific backfill sourc
 
    > Note: Even when backfilling from a special-purpose BN, all blocks are cryptographically verified by the BN's verification plugin before they are stored. Block legitimacy is confirmed regardless of the backfill source.
 
-3. Monitor backfill progress by querying `serverStatus` — `lastAvailableBlock` should increase steadily as blocks are fetched and verified:
+3. Monitor backfill progress by querying `serverStatus` - `lastAvailableBlock` should increase steadily as blocks are fetched and verified:
 
    ```bash
    grpcurl -plaintext -emit-defaults \
@@ -351,13 +353,13 @@ If you are directed by your Hashgraph PoC to configure a specific backfill sourc
 
 #### Configure TSS bootstrap (if TSS is enabled)
 
-If your network has TSS enabled, the Block Node needs TSS data to verify blocks. On a fresh genesis network, block 0 carries all TSS data and the Block Node ingests it automatically — no bootstrap file is needed. On a non-genesis network (for example, a node joining an already-running network or being restored after a reset post-cutover), you must supply the TSS data before startup.
+If your network has TSS enabled, the Block Node needs TSS data to verify blocks. On a fresh genesis network, block 0 carries all TSS data and the Block Node ingests it automatically - no bootstrap file is needed. On a non-genesis network (for example, a node joining an already-running network or being restored after a reset post-cutover), you must supply the TSS data before startup.
 
 Two options are supported in parallel; whichever resolves first takes effect:
 
 **Bootstrap file**
 
-Set `app.state.tssBootstrapFilePath` (default: `/opt/hiero/block-node/application-state/tss-bootstrap-roster.json`) to the path of a JSON file containing the TSS data. The file is generated by the WRB CLI during cutover. Deliver it using the same mechanism as the RSA bootstrap file — your Hashgraph PoC will provide it for the mainnet cohort.
+Set `app.state.tssBootstrapFilePath` (default: `/opt/hiero/block-node/application-state/tss-bootstrap-roster.json`) to the path of a JSON file containing the TSS data. The file is generated by the WRB CLI during the cutover process and must be present on the Block Node host before startup.
 
 The file format:
 
@@ -376,7 +378,7 @@ The file format:
 }
 ```
 
-> Note: The values above are placeholders. Your Hashgraph PoC provides the actual base64-encoded values for your network.
+> Note: The values above are placeholders. Obtain the actual base64-encoded values from the WRB CLI output for your network.
 
 **Peer Block Node query**
 
@@ -410,7 +412,7 @@ Set `roster.bootstrap.tss.blockNodeSourcesPath` (default: `""`) to the path of a
 }
 ```
 
-After the Block Node starts, confirm TSS data loaded by querying `serverStatusDetail` — the response should include a non-empty `tssData` field:
+After the Block Node starts, confirm TSS data loaded by querying `serverStatusDetail` - the response should include a non-empty `tssData` field:
 
 ```bash
 grpcurl -plaintext -emit-defaults \
@@ -440,7 +442,7 @@ After completing all applicable checks, confirm the BN is ready before the maint
 | Backfill active (WRB only, if configured) | `kubectl -n block-node logs $BN_POD -c block-node-server \| grep -i backfill` | Fetching or completed (if `BACKFILL_BLOCK_NODE_SOURCES_PATH` is set) |
 | Alloy shipping                            | `kubectl -n grafana-alloy get pods`                                           | `1/1 Running`                                                        |
 
-If any check fails, resolve the issue and confirm readiness with your Hashgraph PoC before the maintenance window opens.
+If any check fails, resolve the issue before the maintenance window opens.
 
 ---
 
@@ -452,7 +454,7 @@ If any check fails, resolve the issue and confirm readiness with your Hashgraph 
 | `solo-provisioner block node check` fails with "profile flag is required"              | `--profile` flag missing                                             | Always pass `--profile=mainnet`.                                                                                                                                                                                                                                                          |
 | `block node reset` exits with "permission denied"                                      | Command run without `sudo`                                           | Prefix with `sudo`.                                                                                                                                                                                                                                                                       |
 | Pod stuck in `0/1` or init containers running after reset                              | Init containers setting up storage and resolving plugins             | Allow 2-5 minutes. Run `kubectl -n block-node describe pod $BN_POD` to see init-container status.                                                                                                                                                                                         |
-| RSA roster missing or not loaded after reset                                           | Mirror Node unreachable, or file missing (file-based delivery)       | If using Mirror Node auto-fetch, confirm `ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL` is set and the Mirror Node is reachable — the roster is re-fetched automatically on pod start. If using file-based delivery, re-deliver from off-host backup.                                        |
+| RSA roster missing or not loaded after reset                                           | Mirror Node unreachable, or file missing (file-based delivery)       | If using Mirror Node auto-fetch, confirm `ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL` is set and the Mirror Node is reachable - the roster is re-fetched automatically on pod start. If using file-based delivery, re-deliver from off-host backup.                                        |
 | Backfill not starting                                                                  | `backfill.blockNodeSourcesPath` is blank or points to a missing file | Confirm `BACKFILL_BLOCK_NODE_SOURCES_PATH` is set and the referenced JSON file exists in the pod.                                                                                                                                                                                         |
 | `firstAvailableBlock` still shows old block numbers after reset                        | Reset did not complete successfully                                  | Check `sudo head /opt/solo/weaver/logs/solo-provisioner.log` for the step that failed.                                                                                                                                                                                                    |
 | `grpcurl` returns `connection refused` on port 40982 (or configured serverStatus port) | Block Node is not yet listening                                      | Wait for the pod to reach `1/1 Running`; confirm `SERVER_STATUS_PORT` in the Block Node configuration.                                                                                                                                                                                    |

--- a/docs/block-node/operations/production-guide/steady-state-operations.md
+++ b/docs/block-node/operations/production-guide/steady-state-operations.md
@@ -30,7 +30,7 @@ export BN=$(kubectl -n block-node get pod \
 
 ## Key metrics
 
-Dashboard links are provided by Hashgraph DevOps at handoff. The most important metrics to
+Dashboard links are configured as part of the Grafana Alloy setup included with the Block Node deployment. The most important metrics to
 watch:
 
 |         Category         |                                                          Metrics                                                          |               What to watch for                |
@@ -81,10 +81,11 @@ Replace `<RELEASE_NAME>` with the name shown in the `NAME` column of `helm -n bl
 
 ## Upgrades **[OPERATOR]**
 
-Upgrade obligations and timing are governed by the Operating Agreement. Hashgraph publishes
-chart versions and release notes; operators schedule upgrades against their own
-change-management process. Coordinate cohort-wide staggering on the shared channel to avoid
-simultaneous restarts. Security-critical upgrades are flagged by Hashgraph DevOps.
+Chart versions and release notes are published on the
+[hiero-block-node releases page](https://github.com/hiero-ledger/hiero-block-node/releases).
+Operators schedule upgrades against their own change-management process. Coordinate
+staggered restarts across your operator group to avoid simultaneous downtime.
+Security-critical upgrades are flagged in release notes.
 
 ```bash
 sudo solo-provisioner block node upgrade \
@@ -95,10 +96,10 @@ sudo solo-provisioner block node upgrade \
 ```
 
 Notes:
-- `<UPDATED_VALUES_FILE>` is the values overlay Hashgraph provides for the new release
+- `<UPDATED_VALUES_FILE>` is the values overlay for the new release
 - `--no-reuse-values` discards any previously applied values and uses only the specified
 file - always pass this flag to avoid inheriting stale chart defaults from a previous install
-- Use `--with-reset` only when explicitly instructed by Hashgraph DevOps - this clears all
+- Use `--with-reset` only when explicitly required by the upgrade release notes - this clears all
 block data and triggers a full re-backfill
 
 ---
@@ -115,17 +116,19 @@ kubectl -n block-node logs $BN --tail=2000
 uname -a && uptime && free -h && df -h
 ```
 
-Escalate through the agreed shared channel with Hashgraph DevOps. For P0 incidents, use the
-on-call contact provided at handoff.
+For escalation, open an issue in the
+[hiero-block-node repository](https://github.com/hiero-ledger/hiero-block-node) or use your
+network's operator communication channel.
 
 ---
 
 ## Backups and pre-incident hygiene
 
-- Hashgraph does **not** back up `live`, `archive`, or `application-state` volumes - block
-  data is reproducible from upstream by design
-- Hashgraph retains telemetry shipped via Alloy, subject to platform retention windows
-- Keep operator-side copies of `<HASHGRAPH_PROVIDED_VALUES_FILE>`, the RSA bootstrap roster
+- The `live`, `archive`, and `application-state` volumes are operator-managed and not backed
+  up centrally - block data is reproducible from upstream by design
+- Telemetry shipped via Alloy is retained by the monitoring platform, subject to its
+  retention windows
+- Keep operator-side copies of your values overlay file, the RSA bootstrap roster
   file (if using the pre-generated delivery path), and the TLS bundle
 - Document the `admin_key` recovery path - losing the key means the registration cannot be
   updated


### PR DESCRIPTION
## Reviewer Notes

Replace all references to "Hashgraph PoC", "cohort", and Hashgraph-as-intermediary with open-source-neutral alternatives (release notes, GitHub issues, peer operator coordination) across five docs. Also fix two pre-existing bugs in the WRB cutover guide: wrong RSA bootstrap roster path in kubectl exec command, and incorrect `rosterHash` field name (does not exist in ServerStatusDetailResponse; correct field is `nodeAddressBook`).

