### PR TITLE
chore: Live Active Session Buffer Size Metric and Evicted Sessions Log in Verification

### DIFF
--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/metrics/SessionHandlerMetrics.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/metrics/SessionHandlerMetrics.java
@@ -4,25 +4,34 @@ package org.hiero.block.node.block.verification.metrics;
 import static org.hiero.block.node.spi.BlockNodePlugin.METRICS_CATEGORY;
 
 import org.hiero.metrics.LongCounter;
-import org.hiero.metrics.LongCounter.Measurement;
+import org.hiero.metrics.LongGauge;
 import org.hiero.metrics.core.MetricKey;
 import org.hiero.metrics.core.MetricRegistry;
 
 /// Holder for metrics used by [org.hiero.block.node.block.verification.session.BlockSessionHandler].
 /// @param verificationBlocksReceived a [LongCounter.Measurement] of the number of blocks received for verification
-public record SessionHandlerMetrics(Measurement verificationBlocksReceived) {
+/// @param verificationActiveSessions a [LongGauge.Measurement] of the current size of the active sessions buffer
+public record SessionHandlerMetrics(
+        LongCounter.Measurement verificationBlocksReceived, LongGauge.Measurement verificationActiveSessions) {
     /// Metric key for the number of blocks received for verification.
     private static final MetricKey<LongCounter> METRIC_VERIFICATION_BLOCKS_RECEIVED =
             MetricKey.of("verification_blocks_received", LongCounter.class).addCategory(METRICS_CATEGORY);
+    /// Metric key for the current size of the active sessions buffer.
+    private static final MetricKey<LongGauge> METRIC_VERIFICATION_ACTIVE_SESSIONS =
+            MetricKey.of("verification_active_sessions", LongGauge.class).addCategory(METRICS_CATEGORY);
 
     /// Initialize and return a new [SessionHandlerMetrics] instance.
     /// @param metricRegistry used to create and initialize metrics
     /// @return a new [SessionHandlerMetrics] instance fully initialized
     public static SessionHandlerMetrics create(final MetricRegistry metricRegistry) {
-        final Measurement verificationBlocksReceived = metricRegistry
+        final LongCounter.Measurement verificationBlocksReceived = metricRegistry
                 .register(LongCounter.builder(METRIC_VERIFICATION_BLOCKS_RECEIVED)
                         .setDescription("Blocks received for verification"))
                 .getOrCreateNotLabeled();
-        return new SessionHandlerMetrics(verificationBlocksReceived);
+        final LongGauge.Measurement verificationActiveSessions = metricRegistry
+                .register(LongGauge.builder(METRIC_VERIFICATION_ACTIVE_SESSIONS)
+                        .setDescription("Currently active verification sessions"))
+                .getOrCreateNotLabeled();
+        return new SessionHandlerMetrics(verificationBlocksReceived, verificationActiveSessions);
     }
 }

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/BlockSessionHandler.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/BlockSessionHandler.java
@@ -123,6 +123,7 @@ public final class BlockSessionHandler {
                 }
             }
         }
+        updateActiveSessionsMetric();
     }
 
     /// Process the reception of live blocks from the publisher. Publisher supplied [BlockItems] can only
@@ -231,5 +232,11 @@ public final class BlockSessionHandler {
                 activePublisherSession.compareAndSet(removed, null);
             }
         }
+        updateActiveSessionsMetric();
+    }
+
+    /// Update the active sessions gauge with the current size of the active sessions buffer.
+    private void updateActiveSessionsMetric() {
+        sessionHandlerMetrics.verificationActiveSessions().set(activeSessions.size());
     }
 }

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/BlockSessionHandler.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/BlockSessionHandler.java
@@ -123,7 +123,7 @@ public final class BlockSessionHandler {
                 }
             }
         }
-        updateActiveSessionsMetric();
+        sessionHandlerMetrics.verificationActiveSessions().set(activeSessions.size());
     }
 
     /// Process the reception of live blocks from the publisher. Publisher supplied [BlockItems] can only
@@ -232,11 +232,6 @@ public final class BlockSessionHandler {
                 activePublisherSession.compareAndSet(removed, null);
             }
         }
-        updateActiveSessionsMetric();
-    }
-
-    /// Update the active sessions gauge with the current size of the active sessions buffer.
-    private void updateActiveSessionsMetric() {
         sessionHandlerMetrics.verificationActiveSessions().set(activeSessions.size());
     }
 }

--- a/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/SessionResultHandler.java
+++ b/block-node/block-verification/src/main/java/org/hiero/block/node/block/verification/session/SessionResultHandler.java
@@ -30,6 +30,13 @@ import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureT
 public final class SessionResultHandler implements BiConsumer<BlockVerificationResult, Throwable> {
     /// Logger for the handler.
     private static final Logger LOGGER = System.getLogger(SessionResultHandler.class.getName());
+    /// Message format for the informational log emitted for every cancelled session.
+    private static final String CANCELLED_SESSION_MESSAGE =
+            "Session for block {0} with source {1} was cancelled with type {2}";
+    /// Message format for the warning log emitted for every session that failed
+    /// with anything other than a cancellation.
+    private static final String EXCEPTIONAL_SESSION_COMPLETION_MESSAGE =
+            "Session for block %d with source %s completed exceptionally";
     /// The block node context, for access to messaging.
     private final BlockNodeContext context;
     /// The configuration for verification, source of the buffer sizes.
@@ -167,47 +174,30 @@ public final class SessionResultHandler implements BiConsumer<BlockVerificationR
     /// Handle a failed result. A failure notification carrying the appropriate
     /// failure type is sent, the failed metric is incremented, and a bad block
     /// dump is attempted when block items were captured at the failure site.
+    /// Cancellations, whether observed as a direct cancellation of the stage
+    /// chain or reported by a stage as a failure of a cancellation type, are
+    /// expected lifecycle events and are logged at INFO; every other failure is
+    /// logged at WARNING.
     ///
     /// @param throwable the failure to handle
     /// @return `true` if the reported failure type was [FailureType#UNKNOWN_ERROR]
     private boolean handleThrowable(final Throwable throwable) {
-        final String message =
-                "Session for block %d with source %s completed exceptionally".formatted(blockNumber, blockSource);
-        final SemanticVersion hapiVersion;
-        final List<BlockItemUnparsed> blockItems;
-        if (throwable instanceof CompletionException ce
-                && ce.getCause() instanceof VerificationSessionFailedException vfe) {
-            hapiVersion = vfe.getHapiVersion();
-            blockItems = vfe.getBlockItems();
-        } else {
-            hapiVersion = null;
-            blockItems = null;
-        }
+        SemanticVersion hapiVersion = null;
+        List<BlockItemUnparsed> blockItems = null;
         VerificationNotification notification = null;
         try {
             notification = switch (throwable) {
-                case CancellationException ignored ->
-                    new VerificationNotification(
-                            false,
-                            getFailureInfo(blockNumber, resolveCancellationType()),
-                            blockNumber,
-                            null,
-                            null,
-                            blockSource);
+                case CancellationException ignored -> processCancellation();
                 case CompletionException ce -> {
-                    LOGGER.log(Level.WARNING, message, ce.getCause() != null ? ce.getCause() : ce);
-                    yield processCompletionException(ce);
+                    if (ce.getCause() instanceof VerificationSessionFailedException vfe) {
+                        hapiVersion = vfe.getHapiVersion();
+                        blockItems = vfe.getBlockItems();
+                        yield processVerificationSessionFailedCompletion(vfe);
+                    } else {
+                        yield processUnknownExceptionalCompletion(ce);
+                    }
                 }
-                default -> {
-                    LOGGER.log(Level.WARNING, message, throwable);
-                    yield new VerificationNotification(
-                            false,
-                            getFailureInfo(blockNumber, SessionFailureType.UNKNOWN_ERROR),
-                            blockNumber,
-                            null,
-                            null,
-                            blockSource);
-                }
+                default -> processUnknownExceptionalCompletion(throwable);
             };
             safeSendNotification(notification);
             sessionResultMetrics.verificationBlocksFailed().increment();
@@ -219,38 +209,63 @@ public final class SessionResultHandler implements BiConsumer<BlockVerificationR
         return notification.failureInfo().failureType() == FailureType.UNKNOWN_ERROR;
     }
 
-    /// Process a completion exception case.
+    /// Process a session that was stopped before producing a result, regardless of
+    /// whether the stop was observed as a direct cancellation of the stage chain or
+    /// reported by a stage as a failure of a cancellation type. A reported type is
+    /// never trusted as is: only the owning session knows whether the batch ending
+    /// the block was received, so this handler always resolves the type itself (see
+    /// [#resolveCancellationType()]). A cancellation is an expected lifecycle event,
+    /// e.g. an eviction from a full active sessions buffer, so it is logged at INFO.
     ///
-    /// @param ce the completion exception wrapping the actual cause
-    /// @return a failure notification carrying the failure type of the cause, or
-    ///     [SessionFailureType#UNKNOWN_ERROR] when the cause is not a known failure
-    private VerificationNotification processCompletionException(final CompletionException ce) {
-        final Throwable cause = ce.getCause();
-        if (cause instanceof VerificationSessionFailedException vfe) {
-            // instanceof covers null also
-            // A stage reports a plain cancellation when it is stopped before
-            // producing a result. Only the session knows whether the full
-            // block was received, so the refinement happens here.
-            final SessionFailureType reportedFailureType = vfe.getFailureType();
-            final SessionFailureType actualFailureType = reportedFailureType == SessionFailureType.CANCELLED
-                    ? resolveCancellationType()
-                    : reportedFailureType;
+    /// @return a failure notification carrying the resolved cancellation type
+    private VerificationNotification processCancellation() {
+        final SessionFailureType cancellationType = resolveCancellationType();
+        LOGGER.log(Level.INFO, CANCELLED_SESSION_MESSAGE, blockNumber, blockSource, cancellationType);
+        return new VerificationNotification(
+                false, getFailureInfo(blockNumber, cancellationType), blockNumber, null, null, blockSource);
+    }
+
+    /// Process a session that failed with a known failure type, reported by one of
+    /// its stages. Failures of a cancellation type are routed to
+    /// [#processCancellation()]; any other known failure is logged at WARNING and
+    /// reported with the failure type exactly as the stage supplied it.
+    ///
+    /// @param vfe the failure reported by the stage
+    /// @return a failure notification carrying the resolved failure type
+    private VerificationNotification processVerificationSessionFailedCompletion(
+            final VerificationSessionFailedException vfe) {
+        if (vfe.getFailureType() == SessionFailureType.CANCELLED
+                || vfe.getFailureType() == SessionFailureType.CANCELLED_INCOMPLETE) {
+            return processCancellation();
+        } else {
+            final String message = EXCEPTIONAL_SESSION_COMPLETION_MESSAGE.formatted(blockNumber, blockSource);
+            LOGGER.log(Level.WARNING, message, vfe);
             return new VerificationNotification(
                     false,
-                    getFailureInfo(vfe.getBlockNumber(), actualFailureType),
+                    getFailureInfo(vfe.getBlockNumber(), vfe.getFailureType()),
                     vfe.getBlockNumber(),
                     null,
                     null,
                     vfe.getBlockSource());
-        } else {
-            return new VerificationNotification(
-                    false,
-                    getFailureInfo(blockNumber, SessionFailureType.UNKNOWN_ERROR),
-                    blockNumber,
-                    null,
-                    null,
-                    blockSource);
         }
+    }
+
+    /// Process a session that completed with an unexpected throwable carrying no
+    /// known failure type. The throwable is logged at WARNING and the failure is
+    /// reported as [SessionFailureType#UNKNOWN_ERROR].
+    ///
+    /// @param throwable the unexpected throwable the session completed with
+    /// @return a failure notification carrying the unknown error failure type
+    private VerificationNotification processUnknownExceptionalCompletion(final Throwable throwable) {
+        final String message = EXCEPTIONAL_SESSION_COMPLETION_MESSAGE.formatted(blockNumber, blockSource);
+        LOGGER.log(Level.WARNING, message, throwable);
+        return new VerificationNotification(
+                false,
+                getFailureInfo(blockNumber, SessionFailureType.UNKNOWN_ERROR),
+                blockNumber,
+                null,
+                null,
+                blockSource);
     }
 
     /// Handle a successful verification result. A success notification is sent,

--- a/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/session/BlockSessionHandlerTest.java
+++ b/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/session/BlockSessionHandlerTest.java
@@ -23,6 +23,7 @@ import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /// Tests for the [BlockSessionHandler].
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Test;
 class BlockSessionHandlerTest {
     private BlockingExecutor executor;
     private ConcurrentSkipListMap<SessionKey, BlockVerificationSession> activeSessions;
+    private MetricsHolder metrics;
     private BlockSessionHandler toTest;
 
     /// Setup before each test.
@@ -37,7 +39,7 @@ class BlockSessionHandlerTest {
     void setUp() {
         final BlockNodeContext context =
                 new BlockNodeContext(null, null, null, null, null, null, null, null, null, null, null, null, null);
-        final MetricsHolder metrics = MetricsHolder.create(TestUtils.createMetrics());
+        metrics = MetricsHolder.create(TestUtils.createMetrics());
         final TestConfigurationBuilder configBuilder = new TestConfigurationBuilder();
         final VerificationConfig verificationConfig = configBuilder
                 .withConfigDataType(VerificationConfig.class)
@@ -124,5 +126,64 @@ class BlockSessionHandlerTest {
         assertThat(activeSessions)
                 .hasSize(3)
                 .containsKeys(new SessionKey(2, 2), new SessionKey(3, 1), new SessionKey(4, 0));
+    }
+
+    /// Tests for the gauge that reflects the live size of the active sessions buffer.
+    @Nested
+    @DisplayName("Active Sessions Gauge Tests")
+    class ActiveSessionsGaugeTests {
+        /// This test aims to assert that the active sessions gauge grows together with
+        /// the active sessions buffer while new sessions are activated and the buffer
+        /// limit is not yet reached.
+        @Test
+        @DisplayName("gauge grows as new sessions are activated")
+        void testGaugeGrowsWithActivatedSessions() {
+            // Create two blocks, matching the buffer size configured in setup
+            final List<TestBlock> blocks = TestBlockBuilder.generateBlocksInRange(2, 3);
+            // Supply the first block and assert the gauge reflects one active session
+            toTest.processBlockItems(blocks.get(0).asBlockItems(), BlockSource.PUBLISHER);
+            assertThat(currentGaugeValue()).isEqualTo(1L);
+            // Supply the second block and assert the gauge reflects two active sessions
+            toTest.processBlockItems(blocks.get(1).asBlockItems(), BlockSource.PUBLISHER);
+            assertThat(currentGaugeValue()).isEqualTo(2L);
+        }
+
+        /// This test aims to assert that the active sessions gauge stays at the buffer
+        /// limit when the buffer is full and a new session evicts the lowest active
+        /// session, mirroring the actual size of the active sessions buffer.
+        @Test
+        @DisplayName("gauge stays at buffer size when a new session evicts the lowest active session")
+        void testGaugeStaysAtBufferSizeOnEviction() {
+            // Create three blocks, one more than the buffer size configured in setup
+            final List<TestBlock> blocks = TestBlockBuilder.generateBlocksInRange(2, 4);
+            // Supply blocks in order so the third activation evicts the lowest session
+            toTest.processBlockItems(blocks.get(0).asBlockItems(), BlockSource.PUBLISHER);
+            toTest.processBlockItems(blocks.get(1).asBlockItems(), BlockSource.PUBLISHER);
+            toTest.processBlockItems(blocks.get(2).asBlockItems(), BlockSource.PUBLISHER);
+            // Assert the gauge matches the buffer, capped at the configured size
+            assertThat(currentGaugeValue()).isEqualTo(2L).isEqualTo(activeSessions.size());
+        }
+
+        /// This test aims to assert that the active sessions gauge reflects a buffer
+        /// grown beyond the configured limit when the lowest active session is the one
+        /// that was just activated, since in that case no session is evicted.
+        @Test
+        @DisplayName("gauge reflects overfull buffer when the lowest active session is the last activated")
+        void testGaugeReflectsOverfullBufferWhenLowestIsLastActivated() {
+            // Create three blocks, one more than the buffer size configured in setup
+            final List<TestBlock> blocks = TestBlockBuilder.generateBlocksInRange(2, 4);
+            // Supply blocks in reverse order so the lowest session is always the last
+            // activated and no eviction happens
+            toTest.processBlockItems(blocks.get(2).asBlockItems(), BlockSource.PUBLISHER);
+            toTest.processBlockItems(blocks.get(1).asBlockItems(), BlockSource.PUBLISHER);
+            toTest.processBlockItems(blocks.get(0).asBlockItems(), BlockSource.PUBLISHER);
+            // Assert the gauge matches the overfull buffer
+            assertThat(currentGaugeValue()).isEqualTo(3L).isEqualTo(activeSessions.size());
+        }
+
+        /// Reads the current value of the active sessions gauge.
+        private long currentGaugeValue() {
+            return metrics.sessionHandlerMetrics().verificationActiveSessions().get();
+        }
     }
 }

--- a/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/session/SessionResultHandlerTest.java
+++ b/block-node/block-verification/src/test/java/org/hiero/block/node/block/verification/session/SessionResultHandlerTest.java
@@ -25,8 +25,8 @@ import org.hiero.block.node.spi.blockmessaging.VerificationNotification.FailureT
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 
 /// Tests for the [SessionResultHandler].
@@ -75,65 +75,62 @@ class SessionResultHandlerTest {
     @Nested
     @DisplayName("Cancellation Classification Tests")
     class CancellationClassificationTests {
-        /// This test aims to assert that when the session's stage chain is
-        /// cancelled directly (the handler receives a [CancellationException])
-        /// and the batch ending the block was never received, the handler
-        /// reports a failure of type [FailureType#CANCELLED_INCOMPLETE].
-        @Test
-        @DisplayName("accept() reports CANCELLED_INCOMPLETE on CancellationException when end of block not received")
-        void testCancellationExceptionIncompleteBlock() {
-            toTest.accept(null, new CancellationException());
-            assertSingleFailureOfType(FailureType.CANCELLED_INCOMPLETE);
-        }
-
-        /// This test aims to assert that when the session's stage chain is
-        /// cancelled directly (the handler receives a [CancellationException])
-        /// and the batch ending the block was received, the handler reports a
-        /// failure of type [FailureType#CANCELLED].
-        @Test
-        @DisplayName("accept() reports CANCELLED on CancellationException when end of block received")
-        void testCancellationExceptionCompleteBlock() {
-            endOfBlockReceived.set(true);
-            toTest.accept(null, new CancellationException());
-            assertSingleFailureOfType(FailureType.CANCELLED);
-        }
-
-        /// This test aims to assert that when a stage reports a plain
-        /// cancellation (a [VerificationSessionFailedException] of type
-        /// [SessionFailureType#CANCELLED], reachable when a stage is
-        /// interrupted without the chain itself being cancelled, e.g. on an
-        /// executor shutdown) and the batch ending the block was never
-        /// received, the handler refines the failure to
-        /// [FailureType#CANCELLED_INCOMPLETE].
-        @Test
-        @DisplayName(
-                "accept() refines a stage-reported CANCELLED to CANCELLED_INCOMPLETE when end of block not received")
-        void testStageCancellationIncompleteBlock() {
-            toTest.accept(null, stageCancellation());
-            assertSingleFailureOfType(FailureType.CANCELLED_INCOMPLETE);
-        }
-
-        /// This test aims to assert that when a stage reports a plain
-        /// cancellation (a [VerificationSessionFailedException] of type
-        /// [SessionFailureType#CANCELLED], reachable when a stage is
-        /// interrupted without the chain itself being cancelled, e.g. on an
-        /// executor shutdown) and the batch ending the block was received,
-        /// the handler keeps the failure as [FailureType#CANCELLED].
-        @Test
-        @DisplayName("accept() keeps a stage-reported CANCELLED when end of block received")
-        void testStageCancellationCompleteBlock() {
-            endOfBlockReceived.set(true);
-            toTest.accept(null, stageCancellation());
-            assertSingleFailureOfType(FailureType.CANCELLED);
-        }
-
-        /// This test aims to assert that the refinement applies only to
-        /// stage-reported cancellations: a stage failure of any other type is
-        /// reported as is, regardless of whether the batch ending the block
-        /// was received.
+        /// This test aims to assert that when the session's stage chain is cancelled
+        /// directly (the handler receives a [CancellationException]), the reported
+        /// failure type is resolved purely from whether the batch ending the block
+        /// was received: [FailureType#CANCELLED] when it was, so the supplier
+        /// considers the block delivered, and [FailureType#CANCELLED_INCOMPLETE]
+        /// when it was not, so the block was abandoned before it ever finished.
+        /// Both values of the end of block flag are exercised.
         @ParameterizedTest
-        @EnumSource(value = SessionFailureType.class, names = "CANCELLED", mode = EnumSource.Mode.EXCLUDE)
-        @DisplayName("accept() does not refine stage failures of other types")
+        @CsvSource({"true, CANCELLED", "false, CANCELLED_INCOMPLETE"})
+        @DisplayName("accept() resolves the type of a direct cancellation from the end of block flag")
+        void testDirectCancellationResolution(final boolean isEndOfBlockReceived, final FailureType expectedType) {
+            endOfBlockReceived.set(isEndOfBlockReceived);
+            toTest.accept(null, new CancellationException());
+            assertSingleFailureOfType(expectedType);
+        }
+
+        /// This test aims to assert that the handler is the sole authority on the
+        /// cancellation type. When a stage reports a cancellation (a
+        /// [VerificationSessionFailedException] of either cancellation type,
+        /// reachable when a stage is interrupted without the chain itself being
+        /// cancelled, e.g. on an executor shutdown), the reported type is never
+        /// trusted as is: for every combination of reported cancellation type and
+        /// end of block flag, the resulting type is resolved purely from whether the
+        /// batch ending the block was received, [FailureType#CANCELLED] when it was
+        /// and [FailureType#CANCELLED_INCOMPLETE] when it was not. All four
+        /// combinations are exercised.
+        @ParameterizedTest
+        @CsvSource({
+            "CANCELLED, true, CANCELLED",
+            "CANCELLED, false, CANCELLED_INCOMPLETE",
+            "CANCELLED_INCOMPLETE, true, CANCELLED",
+            "CANCELLED_INCOMPLETE, false, CANCELLED_INCOMPLETE"
+        })
+        @DisplayName("accept() resolves the type of a stage-reported cancellation from the end of block flag")
+        void testStageCancellationResolution(
+                final SessionFailureType reportedType,
+                final boolean isEndOfBlockReceived,
+                final FailureType expectedType) {
+            endOfBlockReceived.set(isEndOfBlockReceived);
+            toTest.accept(
+                    null,
+                    new CompletionException(
+                            new VerificationSessionFailedException(BLOCK_NUMBER, reportedType, BlockSource.PUBLISHER)));
+            assertSingleFailureOfType(expectedType);
+        }
+
+        /// This test aims to assert that the resolution applies only to
+        /// stage-reported cancellations: a stage failure of any non-cancellation
+        /// type is reported as is, regardless of whether the batch ending the
+        /// block was received.
+        @ParameterizedTest
+        @EnumSource(
+                value = SessionFailureType.class,
+                names = {"CANCELLED", "CANCELLED_INCOMPLETE"},
+                mode = EnumSource.Mode.EXCLUDE)
+        @DisplayName("accept() does not refine stage failures of non-cancellation types")
         void testOtherStageFailureNotRefined(final SessionFailureType failureType) {
             endOfBlockReceived.set(true);
             toTest.accept(
@@ -141,13 +138,6 @@ class SessionResultHandlerTest {
                     new CompletionException(
                             new VerificationSessionFailedException(BLOCK_NUMBER, failureType, BlockSource.PUBLISHER)));
             assertSingleFailureOfType(failureType.asFailureType());
-        }
-
-        /// Builds the throwable the handler receives when a stage reports a
-        /// plain cancellation.
-        private CompletionException stageCancellation() {
-            return new CompletionException(new VerificationSessionFailedException(
-                    BLOCK_NUMBER, SessionFailureType.CANCELLED, BlockSource.PUBLISHER));
         }
 
         /// Asserts that exactly one failure notification was sent, carrying

--- a/docs/block-node/metrics.md
+++ b/docs/block-node/metrics.md
@@ -151,6 +151,7 @@ Measures block‑verification throughput and success rate.
 |  Type   |               Name                |                                                          Description                                                           |
 |---------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
 | Counter | `verification_blocks_received`    | Blocks received for verification                                                                                               |
+| Gauge   | `verification_active_sessions`    | Currently active verification sessions (live size of the active sessions buffer)                                               |
 | Counter | `verification_blocks_verified`    | Blocks that passed verification                                                                                                |
 | Counter | `verification_blocks_failed`      | Blocks that failed verification                                                                                                |
 | Counter | `verification_blocks_error`       | Internal errors during verification                                                                                            |


### PR DESCRIPTION
* Add verification_active_sessions gauge tracking the live size of the active sessions buffer
* Add INFO log for cancelled verification notifications in the result handler
  * Demote the stage-reported cancellation log from WARNING to INFO, expected evictions must not page on-call
* Add tests
  * Gauge follows session activation, eviction, and overfull buffer
* Document the new gauge in metrics.md

Resolves #3590