### PR TITLE
feat: Add Application State notifications for the Application State Facility

### DIFF
--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
@@ -10,15 +10,20 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.RejectedExecutionException;
+import org.hiero.block.node.spi.blockmessaging.AddressBookHistoryNotification;
+import org.hiero.block.node.spi.blockmessaging.AvailableBlocksNotification;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
+import org.hiero.block.node.spi.blockmessaging.ContextNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.NoBackPressureBlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification;
+import org.hiero.block.node.spi.blockmessaging.StoredBlocksNotification;
+import org.hiero.block.node.spi.blockmessaging.TssDataNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 
 /**
@@ -42,6 +47,18 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
     /** set of block notification handlers */
     private final Set<BlockNotificationHandler> blockNotificationHandlers =
             new ConcurrentSkipListSet<>(Comparator.comparingInt(Object::hashCode));
+    /** set of context notification handlers */
+    private final Set<ContextNotificationHandler> contextNotificationHandlers =
+            new ConcurrentSkipListSet<>(Comparator.comparingInt(Object::hashCode));
+    /** list of all sent TSS data update notifications */
+    private final List<TssDataNotification> sentTssDataNotifications = new CopyOnWriteArrayList<>();
+    /** list of all sent address book history update notifications */
+    private final List<AddressBookHistoryNotification> sentAddressBookHistoryNotifications =
+            new CopyOnWriteArrayList<>();
+    /** list of all sent stored blocks update notifications */
+    private final List<StoredBlocksNotification> sentStoredBlocksNotifications = new CopyOnWriteArrayList<>();
+    /** list of all sent available blocks update notifications */
+    private final List<AvailableBlocksNotification> sentAvailableBlocksNotifications = new CopyOnWriteArrayList<>();
     /** list of all sent block items */
     private final List<BlockItems> sentBlockBlockItems = new CopyOnWriteArrayList<>();
     /** list of all sent block verification notifications */
@@ -133,6 +150,51 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
      */
     public int getBlockNotificationHandlerCount() {
         return blockNotificationHandlers.size();
+    }
+
+    /**
+     * Get the number of context notification handlers registered.
+     *
+     * @return the number of context notification handlers
+     */
+    public int getContextNotificationHandlerCount() {
+        return contextNotificationHandlers.size();
+    }
+
+    /**
+     * Get all TSS data update notifications sent to the block messaging facility.
+     *
+     * @return the list of sent TSS data update notifications
+     */
+    public List<TssDataNotification> getSentTssDataNotifications() {
+        return sentTssDataNotifications;
+    }
+
+    /**
+     * Get all address book history update notifications sent to the block messaging facility.
+     *
+     * @return the list of sent address book history update notifications
+     */
+    public List<AddressBookHistoryNotification> getSentAddressBookHistoryNotifications() {
+        return sentAddressBookHistoryNotifications;
+    }
+
+    /**
+     * Get all stored blocks update notifications sent to the block messaging facility.
+     *
+     * @return the list of sent stored blocks update notifications
+     */
+    public List<StoredBlocksNotification> getSentStoredBlocksNotifications() {
+        return sentStoredBlocksNotifications;
+    }
+
+    /**
+     * Get all available blocks update notifications sent to the block messaging facility.
+     *
+     * @return the list of sent available blocks update notifications
+     */
+    public List<AvailableBlocksNotification> getSentAvailableBlocksNotifications() {
+        return sentAvailableBlocksNotifications;
     }
 
     /**
@@ -301,6 +363,67 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
     @Override
     public void unregisterBlockNotificationHandler(final BlockNotificationHandler handler) {
         blockNotificationHandlers.remove(handler);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendTssDataUpdate(final TssDataNotification notification) {
+        sentTssDataNotifications.add(notification);
+        for (final ContextNotificationHandler handler : contextNotificationHandlers) {
+            handler.handleTssDataUpdate(notification);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendAddressBookHistoryUpdate(final AddressBookHistoryNotification notification) {
+        sentAddressBookHistoryNotifications.add(notification);
+        for (final ContextNotificationHandler handler : contextNotificationHandlers) {
+            handler.handleAddressBookHistoryUpdate(notification);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendStoredBlocksUpdate(final StoredBlocksNotification notification) {
+        sentStoredBlocksNotifications.add(notification);
+        for (final ContextNotificationHandler handler : contextNotificationHandlers) {
+            handler.handleStoredBlocksUpdate(notification);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendAvailableBlocksUpdate(final AvailableBlocksNotification notification) {
+        sentAvailableBlocksNotifications.add(notification);
+        for (final ContextNotificationHandler handler : contextNotificationHandlers) {
+            handler.handleAvailableBlocksUpdate(notification);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void registerContextNotificationHandler(
+            final ContextNotificationHandler handler, final boolean cpuIntensiveHandler, final String handlerName) {
+        contextNotificationHandlers.add(handler);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void unregisterContextNotificationHandler(final ContextNotificationHandler handler) {
+        contextNotificationHandlers.remove(handler);
     }
 
     private void logNotification(final Record notification) {

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java
@@ -11,13 +11,13 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.RejectedExecutionException;
 import org.hiero.block.node.spi.blockmessaging.AddressBookHistoryNotification;
+import org.hiero.block.node.spi.blockmessaging.ApplicationStateNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.AvailableBlocksNotification;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
-import org.hiero.block.node.spi.blockmessaging.ContextNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.NoBackPressureBlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
@@ -47,8 +47,8 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
     /** set of block notification handlers */
     private final Set<BlockNotificationHandler> blockNotificationHandlers =
             new ConcurrentSkipListSet<>(Comparator.comparingInt(Object::hashCode));
-    /** set of context notification handlers */
-    private final Set<ContextNotificationHandler> contextNotificationHandlers =
+    /** set of application state notification handlers */
+    private final Set<ApplicationStateNotificationHandler> applicationStateNotificationHandlers =
             new ConcurrentSkipListSet<>(Comparator.comparingInt(Object::hashCode));
     /** list of all sent TSS data update notifications */
     private final List<TssDataNotification> sentTssDataNotifications = new CopyOnWriteArrayList<>();
@@ -153,12 +153,12 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
     }
 
     /**
-     * Get the number of context notification handlers registered.
+     * Get the number of application state notification handlers registered.
      *
-     * @return the number of context notification handlers
+     * @return the number of application state notification handlers
      */
-    public int getContextNotificationHandlerCount() {
-        return contextNotificationHandlers.size();
+    public int getApplicationStateNotificationHandlerCount() {
+        return applicationStateNotificationHandlers.size();
     }
 
     /**
@@ -371,7 +371,7 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
     @Override
     public void sendTssDataUpdate(final TssDataNotification notification) {
         sentTssDataNotifications.add(notification);
-        for (final ContextNotificationHandler handler : contextNotificationHandlers) {
+        for (final ApplicationStateNotificationHandler handler : applicationStateNotificationHandlers) {
             handler.handleTssDataUpdate(notification);
         }
     }
@@ -382,7 +382,7 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
     @Override
     public void sendAddressBookHistoryUpdate(final AddressBookHistoryNotification notification) {
         sentAddressBookHistoryNotifications.add(notification);
-        for (final ContextNotificationHandler handler : contextNotificationHandlers) {
+        for (final ApplicationStateNotificationHandler handler : applicationStateNotificationHandlers) {
             handler.handleAddressBookHistoryUpdate(notification);
         }
     }
@@ -393,7 +393,7 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
     @Override
     public void sendStoredBlocksUpdate(final StoredBlocksNotification notification) {
         sentStoredBlocksNotifications.add(notification);
-        for (final ContextNotificationHandler handler : contextNotificationHandlers) {
+        for (final ApplicationStateNotificationHandler handler : applicationStateNotificationHandlers) {
             handler.handleStoredBlocksUpdate(notification);
         }
     }
@@ -404,7 +404,7 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
     @Override
     public void sendAvailableBlocksUpdate(final AvailableBlocksNotification notification) {
         sentAvailableBlocksNotifications.add(notification);
-        for (final ContextNotificationHandler handler : contextNotificationHandlers) {
+        for (final ApplicationStateNotificationHandler handler : applicationStateNotificationHandlers) {
             handler.handleAvailableBlocksUpdate(notification);
         }
     }
@@ -413,17 +413,19 @@ public class TestBlockMessagingFacility implements BlockMessagingFacility {
      * {@inheritDoc}
      */
     @Override
-    public void registerContextNotificationHandler(
-            final ContextNotificationHandler handler, final boolean cpuIntensiveHandler, final String handlerName) {
-        contextNotificationHandlers.add(handler);
+    public void registerApplicationStateNotificationHandler(
+            final ApplicationStateNotificationHandler handler,
+            final boolean cpuIntensiveHandler,
+            final String handlerName) {
+        applicationStateNotificationHandlers.add(handler);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void unregisterContextNotificationHandler(final ContextNotificationHandler handler) {
-        contextNotificationHandlers.remove(handler);
+    public void unregisterApplicationStateNotificationHandler(final ApplicationStateNotificationHandler handler) {
+        applicationStateNotificationHandlers.remove(handler);
     }
 
     private void logNotification(final Record notification) {

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -22,16 +22,21 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.blockmessaging.AddressBookHistoryNotification;
+import org.hiero.block.node.spi.blockmessaging.AvailableBlocksNotification;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
+import org.hiero.block.node.spi.blockmessaging.ContextNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.GatingHandler;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.NoBackPressureBlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification;
+import org.hiero.block.node.spi.blockmessaging.StoredBlocksNotification;
+import org.hiero.block.node.spi.blockmessaging.TssDataNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.hiero.metrics.LongCounter;
 import org.hiero.metrics.ObservableGauge;
@@ -70,6 +75,22 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
     public static final MetricKey<LongCounter> METRIC_MESSAGING_PUBLISHER_STATUS_UPDATE_NOTIFICATIONS = MetricKey.of(
                     "messaging_publisher_status_update_notifications", LongCounter.class)
             .addCategory(METRICS_CATEGORY);
+    /** Metric key for TSS data update notifications sent */
+    public static final MetricKey<LongCounter> METRIC_MESSAGING_TSS_DATA_UPDATE_NOTIFICATIONS = MetricKey.of(
+                    "messaging_tss_data_update_notifications", LongCounter.class)
+            .addCategory(METRICS_CATEGORY);
+    /** Metric key for address book history update notifications sent */
+    public static final MetricKey<LongCounter> METRIC_MESSAGING_ADDRESS_BOOK_HISTORY_UPDATE_NOTIFICATIONS =
+            MetricKey.of("messaging_address_book_history_update_notifications", LongCounter.class)
+                    .addCategory(METRICS_CATEGORY);
+    /** Metric key for stored blocks update notifications sent */
+    public static final MetricKey<LongCounter> METRIC_MESSAGING_STORED_BLOCKS_UPDATE_NOTIFICATIONS = MetricKey.of(
+                    "messaging_stored_blocks_update_notifications", LongCounter.class)
+            .addCategory(METRICS_CATEGORY);
+    /** Metric key for available blocks update notifications sent */
+    public static final MetricKey<LongCounter> METRIC_MESSAGING_AVAILABLE_BLOCKS_UPDATE_NOTIFICATIONS = MetricKey.of(
+                    "messaging_available_blocks_update_notifications", LongCounter.class)
+            .addCategory(METRICS_CATEGORY);
     /** Metric key for the number of active item listeners */
     public static final MetricKey<ObservableGauge> METRIC_MESSAGING_NO_OF_ITEM_LISTENERS = MetricKey.of(
                     "messaging_no_of_item_listeners", ObservableGauge.class)
@@ -100,6 +121,14 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
     private LongCounter.Measurement newestBlockKnownToNetworkNotificationsCounter;
     /** Counter for publisher status update notifications sent */
     private LongCounter.Measurement publisherStatusUpdateNotificationsCounter;
+    /** Counter for TSS data update notifications sent */
+    private LongCounter.Measurement tssDataUpdateNotificationsCounter;
+    /** Counter for address book history update notifications sent */
+    private LongCounter.Measurement addressBookHistoryUpdateNotificationsCounter;
+    /** Counter for stored blocks update notifications sent */
+    private LongCounter.Measurement storedBlocksUpdateNotificationsCounter;
+    /** Counter for available blocks update notifications sent */
+    private LongCounter.Measurement availableBlocksUpdateNotificationsCounter;
 
     /**
      * The thread factory used to create the virtual threads for the disruptor. Virtual threads are daemon threads by
@@ -199,6 +228,13 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
     private final Map<BlockNotificationHandler, BatchEventProcessor<BlockNotificationRingEvent>>
             blockNotificationHandlerToEventProcessor = new HashMap<>();
 
+    /** Map of context notification handlers to their threads. So that we can stop them */
+    private final Map<ContextNotificationHandler, Thread> contextNotificationHandlerToThread = new HashMap<>();
+
+    /** Map of context notification handlers to their event processors. So that we can stop them */
+    private final Map<ContextNotificationHandler, BatchEventProcessor<BlockNotificationRingEvent>>
+            contextNotificationHandlerToEventProcessor = new HashMap<>();
+
     /**
      * List of pre-registered block item handlers, that were registered before the service started. These will be added
      * when the service is started and the list cleared
@@ -210,6 +246,13 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
      * be added when the service is started and the list cleared
      */
     private final List<PreRegisteredBlockNotificationHandler> preRegisteredBlockNotificationHandlers =
+            new ArrayList<>();
+
+    /**
+     * List of pre-registered context notification handlers, that were registered before the service started. These
+     * will be added when the service is started and the list cleared
+     */
+    private final List<PreRegisteredContextNotificationHandler> preRegisteredContextNotificationHandlers =
             new ArrayList<>();
 
     private ExecutorService messageForwarder;
@@ -286,6 +329,26 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                         .setDescription("Notifications issued for publisher status updates"))
                 .getOrCreateNotLabeled();
 
+        tssDataUpdateNotificationsCounter = metricRegistry
+                .register(LongCounter.builder(METRIC_MESSAGING_TSS_DATA_UPDATE_NOTIFICATIONS)
+                        .setDescription("TSS data update notifications sent"))
+                .getOrCreateNotLabeled();
+
+        addressBookHistoryUpdateNotificationsCounter = metricRegistry
+                .register(LongCounter.builder(METRIC_MESSAGING_ADDRESS_BOOK_HISTORY_UPDATE_NOTIFICATIONS)
+                        .setDescription("Address book history update notifications sent"))
+                .getOrCreateNotLabeled();
+
+        storedBlocksUpdateNotificationsCounter = metricRegistry
+                .register(LongCounter.builder(METRIC_MESSAGING_STORED_BLOCKS_UPDATE_NOTIFICATIONS)
+                        .setDescription("Stored blocks update notifications sent"))
+                .getOrCreateNotLabeled();
+
+        availableBlocksUpdateNotificationsCounter = metricRegistry
+                .register(LongCounter.builder(METRIC_MESSAGING_AVAILABLE_BLOCKS_UPDATE_NOTIFICATIONS)
+                        .setDescription("Available blocks update notifications sent"))
+                .getOrCreateNotLabeled();
+
         // Initialize gauges
         metricRegistry
                 .register(ObservableGauge.builder(METRIC_MESSAGING_NO_OF_ITEM_LISTENERS)
@@ -295,7 +358,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
         metricRegistry
                 .register(ObservableGauge.builder(METRIC_MESSAGING_NO_OF_NOTIFICATION_LISTENERS)
                         .setDescription("Active notification listeners"))
-                .observe(blockNotificationHandlerToThread::size);
+                .observe(() -> blockNotificationHandlerToThread.size() + contextNotificationHandlerToThread.size());
 
         metricRegistry
                 .register(ObservableGauge.builder(METRIC_MESSAGING_ITEM_QUEUE_PERCENT_USED)
@@ -502,6 +565,106 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
      * {@inheritDoc}
      */
     @Override
+    public void sendTssDataUpdate(final TssDataNotification notification) {
+        messageForwarder.submit(() -> {
+            LOGGER.log(DEBUG, "Sending TSS data update notification");
+            blockNotificationDisruptor.getRingBuffer().publishEvent((event, sequence) -> event.set(notification));
+            tssDataUpdateNotificationsCounter.increment();
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendAddressBookHistoryUpdate(final AddressBookHistoryNotification notification) {
+        messageForwarder.submit(() -> {
+            LOGGER.log(DEBUG, "Sending address book history update notification");
+            blockNotificationDisruptor.getRingBuffer().publishEvent((event, sequence) -> event.set(notification));
+            addressBookHistoryUpdateNotificationsCounter.increment();
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendStoredBlocksUpdate(final StoredBlocksNotification notification) {
+        messageForwarder.submit(() -> {
+            LOGGER.log(DEBUG, "Sending stored blocks update notification");
+            blockNotificationDisruptor.getRingBuffer().publishEvent((event, sequence) -> event.set(notification));
+            storedBlocksUpdateNotificationsCounter.increment();
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendAvailableBlocksUpdate(final AvailableBlocksNotification notification) {
+        messageForwarder.submit(() -> {
+            LOGGER.log(DEBUG, "Sending available blocks update notification");
+            blockNotificationDisruptor.getRingBuffer().publishEvent((event, sequence) -> event.set(notification));
+            availableBlocksUpdateNotificationsCounter.increment();
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized void registerContextNotificationHandler(
+            final ContextNotificationHandler handler, final boolean cpuIntensiveHandler, final String handlerName) {
+        final InformedEventHandler<BlockNotificationRingEvent> informedEventHandler =
+                (event, sequence, endOfBatch, percentageBehindRingHead) -> {
+                    if (event.getTssDataNotification() != null) {
+                        handler.handleTssDataUpdate(event.getTssDataNotification());
+                    } else if (event.getAddressBookHistoryNotification() != null) {
+                        handler.handleAddressBookHistoryUpdate(event.getAddressBookHistoryNotification());
+                    } else if (event.getStoredBlocksNotification() != null) {
+                        handler.handleStoredBlocksUpdate(event.getStoredBlocksNotification());
+                    } else if (event.getAvailableBlocksNotification() != null) {
+                        handler.handleAvailableBlocksUpdate(event.getAvailableBlocksNotification());
+                    }
+                    // Block-stream notification types on the same ring buffer are silently ignored.
+                };
+        if (blockNotificationDisruptor.hasStarted()) {
+            registerHandler(
+                    handler,
+                    cpuIntensiveHandler,
+                    handlerName,
+                    blockNotificationDisruptor.getRingBuffer(),
+                    informedEventHandler,
+                    contextNotificationHandlerToEventProcessor,
+                    contextNotificationHandlerToThread);
+        } else {
+            preRegisteredContextNotificationHandlers.add(new PreRegisteredContextNotificationHandler(
+                    handler, informedEventHandler, cpuIntensiveHandler, handlerName));
+        }
+        LOGGER.log(
+                DEBUG,
+                "Registering context notification handler: {0}, cpuIntensive: {1}, handlerName: {2}",
+                handler.getClass().getSimpleName(),
+                cpuIntensiveHandler,
+                handlerName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized void unregisterContextNotificationHandler(final ContextNotificationHandler handler) {
+        unregisterHandler(
+                handler,
+                blockNotificationDisruptor.getRingBuffer(),
+                contextNotificationHandlerToEventProcessor,
+                contextNotificationHandlerToThread);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public synchronized void registerBlockNotificationHandler(
             final BlockNotificationHandler handler, final boolean cpuIntensiveHandler, final String handlerName) {
         final InformedEventHandler<BlockNotificationRingEvent> informedEventHandler =
@@ -517,7 +680,11 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                         handler.handleNewestBlockKnownToNetwork(event.getNewestBlockKnownToNetworkNotification());
                     } else if (event.getPublisherStatusUpdateNotification() != null) {
                         handler.handlePublisherStatusUpdate(event.getPublisherStatusUpdateNotification());
-                    } else {
+                    } else if (event.getTssDataNotification() == null
+                            && event.getAddressBookHistoryNotification() == null
+                            && event.getStoredBlocksNotification() == null
+                            && event.getAvailableBlocksNotification() == null) {
+                        // Context notification types are silently ignored; only log when truly empty.
                         LOGGER.log(Level.INFO, "Received an event with no notification set");
                     }
                 };
@@ -588,6 +755,17 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                     blockNotificationHandlerToEventProcessor,
                     blockNotificationHandlerToThread);
         }
+        // register all the pre-registered context notification handlers
+        for (var preRegisteredHandler : preRegisteredContextNotificationHandlers) {
+            registerHandler(
+                    preRegisteredHandler.handler(),
+                    preRegisteredHandler.cpuIntensiveHandler(),
+                    preRegisteredHandler.handlerName(),
+                    blockNotificationDisruptor.getRingBuffer(),
+                    preRegisteredHandler.informedHandler(),
+                    contextNotificationHandlerToEventProcessor,
+                    contextNotificationHandlerToThread);
+        }
 
         // log successful start
         if (LOGGER.isLoggable(DEBUG)) {
@@ -620,6 +798,11 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
             blockNotificationDisruptor.getRingBuffer().removeGatingSequence(eventHandler.getSequence());
             eventHandler.halt();
         }
+        // Stop all the context notification event handlers
+        for (var eventHandler : contextNotificationHandlerToEventProcessor.values()) {
+            blockNotificationDisruptor.getRingBuffer().removeGatingSequence(eventHandler.getSequence());
+            eventHandler.halt();
+        }
         // Shuts down all the threads handling events.
         blockItemDisruptor.shutdown();
         blockNotificationDisruptor.shutdown();
@@ -628,6 +811,11 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
             thread.interrupt();
             // log the stopping of the thread
             LOGGER.log(DEBUG, "Stopped block notification handler thread: {0}", thread.getName());
+        }
+        // Stop all the context notification handler threads
+        for (Thread thread : contextNotificationHandlerToThread.values()) {
+            thread.interrupt();
+            LOGGER.log(DEBUG, "Stopped context notification handler thread: {0}", thread.getName());
         }
         messageForwarder.shutdown();
     }
@@ -769,6 +957,20 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
      */
     private record PreRegisteredBlockNotificationHandler(
             BlockNotificationHandler handler,
+            InformedEventHandler<BlockNotificationRingEvent> informedHandler,
+            boolean cpuIntensiveHandler,
+            String handlerName) {}
+
+    /**
+     * Record for pre-registered context notification handlers.
+     *
+     * @param handler the context notification handler
+     * @param informedHandler the informed event handler
+     * @param cpuIntensiveHandler hint to the service that this handler is CPU intensive vs IO intensive
+     * @param handlerName the name of the handler, used for thread name and logging
+     */
+    private record PreRegisteredContextNotificationHandler(
+            ContextNotificationHandler handler,
             InformedEventHandler<BlockNotificationRingEvent> informedHandler,
             boolean cpuIntensiveHandler,
             String handlerName) {}

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -23,13 +23,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.blockmessaging.AddressBookHistoryNotification;
+import org.hiero.block.node.spi.blockmessaging.ApplicationStateNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.AvailableBlocksNotification;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockItemHandler;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
-import org.hiero.block.node.spi.blockmessaging.ContextNotificationHandler;
 import org.hiero.block.node.spi.blockmessaging.GatingHandler;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.NoBackPressureBlockItemHandler;
@@ -228,12 +228,13 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
     private final Map<BlockNotificationHandler, BatchEventProcessor<BlockNotificationRingEvent>>
             blockNotificationHandlerToEventProcessor = new HashMap<>();
 
-    /** Map of context notification handlers to their threads. So that we can stop them */
-    private final Map<ContextNotificationHandler, Thread> contextNotificationHandlerToThread = new HashMap<>();
+    /** Map of application state notification handlers to their threads. So that we can stop them */
+    private final Map<ApplicationStateNotificationHandler, Thread> applicationStateNotificationHandlerToThread =
+            new HashMap<>();
 
-    /** Map of context notification handlers to their event processors. So that we can stop them */
-    private final Map<ContextNotificationHandler, BatchEventProcessor<BlockNotificationRingEvent>>
-            contextNotificationHandlerToEventProcessor = new HashMap<>();
+    /** Map of application state notification handlers to their event processors. So that we can stop them */
+    private final Map<ApplicationStateNotificationHandler, BatchEventProcessor<BlockNotificationRingEvent>>
+            applicationStateNotificationHandlerToEventProcessor = new HashMap<>();
 
     /**
      * List of pre-registered block item handlers, that were registered before the service started. These will be added
@@ -249,11 +250,11 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
             new ArrayList<>();
 
     /**
-     * List of pre-registered context notification handlers, that were registered before the service started. These
+     * List of pre-registered application state notification handlers, that were registered before the service started. These
      * will be added when the service is started and the list cleared
      */
-    private final List<PreRegisteredContextNotificationHandler> preRegisteredContextNotificationHandlers =
-            new ArrayList<>();
+    private final List<PreRegisteredApplicationStateNotificationHandler>
+            preRegisteredApplicationStateNotificationHandlers = new ArrayList<>();
 
     private ExecutorService messageForwarder;
 
@@ -358,7 +359,8 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
         metricRegistry
                 .register(ObservableGauge.builder(METRIC_MESSAGING_NO_OF_NOTIFICATION_LISTENERS)
                         .setDescription("Active notification listeners"))
-                .observe(() -> blockNotificationHandlerToThread.size() + contextNotificationHandlerToThread.size());
+                .observe(() ->
+                        blockNotificationHandlerToThread.size() + applicationStateNotificationHandlerToThread.size());
 
         metricRegistry
                 .register(ObservableGauge.builder(METRIC_MESSAGING_ITEM_QUEUE_PERCENT_USED)
@@ -613,8 +615,10 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
      * {@inheritDoc}
      */
     @Override
-    public synchronized void registerContextNotificationHandler(
-            final ContextNotificationHandler handler, final boolean cpuIntensiveHandler, final String handlerName) {
+    public synchronized void registerApplicationStateNotificationHandler(
+            final ApplicationStateNotificationHandler handler,
+            final boolean cpuIntensiveHandler,
+            final String handlerName) {
         final InformedEventHandler<BlockNotificationRingEvent> informedEventHandler =
                 (event, sequence, endOfBatch, percentageBehindRingHead) -> {
                     if (event.getTssDataNotification() != null) {
@@ -635,15 +639,15 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                     handlerName,
                     blockNotificationDisruptor.getRingBuffer(),
                     informedEventHandler,
-                    contextNotificationHandlerToEventProcessor,
-                    contextNotificationHandlerToThread);
+                    applicationStateNotificationHandlerToEventProcessor,
+                    applicationStateNotificationHandlerToThread);
         } else {
-            preRegisteredContextNotificationHandlers.add(new PreRegisteredContextNotificationHandler(
+            preRegisteredApplicationStateNotificationHandlers.add(new PreRegisteredApplicationStateNotificationHandler(
                     handler, informedEventHandler, cpuIntensiveHandler, handlerName));
         }
         LOGGER.log(
                 DEBUG,
-                "Registering context notification handler: {0}, cpuIntensive: {1}, handlerName: {2}",
+                "Registering application state notification handler: {0}, cpuIntensive: {1}, handlerName: {2}",
                 handler.getClass().getSimpleName(),
                 cpuIntensiveHandler,
                 handlerName);
@@ -653,12 +657,13 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
      * {@inheritDoc}
      */
     @Override
-    public synchronized void unregisterContextNotificationHandler(final ContextNotificationHandler handler) {
+    public synchronized void unregisterApplicationStateNotificationHandler(
+            final ApplicationStateNotificationHandler handler) {
         unregisterHandler(
                 handler,
                 blockNotificationDisruptor.getRingBuffer(),
-                contextNotificationHandlerToEventProcessor,
-                contextNotificationHandlerToThread);
+                applicationStateNotificationHandlerToEventProcessor,
+                applicationStateNotificationHandlerToThread);
     }
 
     /**
@@ -755,16 +760,16 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                     blockNotificationHandlerToEventProcessor,
                     blockNotificationHandlerToThread);
         }
-        // register all the pre-registered context notification handlers
-        for (var preRegisteredHandler : preRegisteredContextNotificationHandlers) {
+        // register all the pre-registered application state notification handlers
+        for (var preRegisteredHandler : preRegisteredApplicationStateNotificationHandlers) {
             registerHandler(
                     preRegisteredHandler.handler(),
                     preRegisteredHandler.cpuIntensiveHandler(),
                     preRegisteredHandler.handlerName(),
                     blockNotificationDisruptor.getRingBuffer(),
                     preRegisteredHandler.informedHandler(),
-                    contextNotificationHandlerToEventProcessor,
-                    contextNotificationHandlerToThread);
+                    applicationStateNotificationHandlerToEventProcessor,
+                    applicationStateNotificationHandlerToThread);
         }
 
         // log successful start
@@ -799,7 +804,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
             eventHandler.halt();
         }
         // Stop all the context notification event handlers
-        for (var eventHandler : contextNotificationHandlerToEventProcessor.values()) {
+        for (var eventHandler : applicationStateNotificationHandlerToEventProcessor.values()) {
             blockNotificationDisruptor.getRingBuffer().removeGatingSequence(eventHandler.getSequence());
             eventHandler.halt();
         }
@@ -812,10 +817,10 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
             // log the stopping of the thread
             LOGGER.log(DEBUG, "Stopped block notification handler thread: {0}", thread.getName());
         }
-        // Stop all the context notification handler threads
-        for (Thread thread : contextNotificationHandlerToThread.values()) {
+        // Stop all the application state notification handler threads
+        for (Thread thread : applicationStateNotificationHandlerToThread.values()) {
             thread.interrupt();
-            LOGGER.log(DEBUG, "Stopped context notification handler thread: {0}", thread.getName());
+            LOGGER.log(DEBUG, "Stopped application state notification handler thread: {0}", thread.getName());
         }
         messageForwarder.shutdown();
     }
@@ -962,15 +967,15 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
             String handlerName) {}
 
     /**
-     * Record for pre-registered context notification handlers.
+     * Record for pre-registered application state notification handlers.
      *
-     * @param handler the context notification handler
+     * @param handler the application state notification handler
      * @param informedHandler the informed event handler
      * @param cpuIntensiveHandler hint to the service that this handler is CPU intensive vs IO intensive
      * @param handlerName the name of the handler, used for thread name and logging
      */
-    private record PreRegisteredContextNotificationHandler(
-            ContextNotificationHandler handler,
+    private record PreRegisteredApplicationStateNotificationHandler(
+            ApplicationStateNotificationHandler handler,
             InformedEventHandler<BlockNotificationRingEvent> informedHandler,
             boolean cpuIntensiveHandler,
             String handlerName) {}

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java
@@ -749,6 +749,8 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                     blockItemHandlerToEventProcessor,
                     blockItemHandlerToThread);
         }
+        preRegisteredBlockItemHandlers.clear();
+
         // register all the pre-registered block notification handlers
         for (var preRegisteredHandler : preRegisteredBlockNotificationHandlers) {
             registerHandler(
@@ -760,6 +762,8 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                     blockNotificationHandlerToEventProcessor,
                     blockNotificationHandlerToThread);
         }
+        preRegisteredBlockNotificationHandlers.clear();
+
         // register all the pre-registered application state notification handlers
         for (var preRegisteredHandler : preRegisteredApplicationStateNotificationHandlers) {
             registerHandler(
@@ -771,6 +775,7 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
                     applicationStateNotificationHandlerToEventProcessor,
                     applicationStateNotificationHandlerToThread);
         }
+        preRegisteredApplicationStateNotificationHandlers.clear();
 
         // log successful start
         if (LOGGER.isLoggable(DEBUG)) {
@@ -792,22 +797,26 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
             blockItemDisruptor.getRingBuffer().removeGatingSequence(eventHandler.getSequence());
             eventHandler.halt();
         }
+        blockItemHandlerToEventProcessor.clear();
         // Stop all the block item handler threads
         for (Thread thread : blockItemHandlerToThread.values()) {
             thread.interrupt();
             // log the stopping of the thread
             LOGGER.log(DEBUG, "Stopped block item handler thread: {0}", thread.getName());
         }
+        blockItemHandlerToThread.clear();
         // Stop all the block notification event handlers
         for (var eventHandler : blockNotificationHandlerToEventProcessor.values()) {
             blockNotificationDisruptor.getRingBuffer().removeGatingSequence(eventHandler.getSequence());
             eventHandler.halt();
         }
+        blockNotificationHandlerToEventProcessor.clear();
         // Stop all the context notification event handlers
         for (var eventHandler : applicationStateNotificationHandlerToEventProcessor.values()) {
             blockNotificationDisruptor.getRingBuffer().removeGatingSequence(eventHandler.getSequence());
             eventHandler.halt();
         }
+        applicationStateNotificationHandlerToEventProcessor.clear();
         // Shuts down all the threads handling events.
         blockItemDisruptor.shutdown();
         blockNotificationDisruptor.shutdown();
@@ -817,11 +826,13 @@ public class BlockMessagingFacilityImpl implements BlockMessagingFacility {
             // log the stopping of the thread
             LOGGER.log(DEBUG, "Stopped block notification handler thread: {0}", thread.getName());
         }
+        blockNotificationHandlerToThread.clear();
         // Stop all the application state notification handler threads
         for (Thread thread : applicationStateNotificationHandlerToThread.values()) {
             thread.interrupt();
             LOGGER.log(DEBUG, "Stopped application state notification handler thread: {0}", thread.getName());
         }
+        applicationStateNotificationHandlerToThread.clear();
         messageForwarder.shutdown();
     }
 

--- a/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockNotificationRingEvent.java
+++ b/block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockNotificationRingEvent.java
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.messaging;
 
+import org.hiero.block.node.spi.blockmessaging.AddressBookHistoryNotification;
+import org.hiero.block.node.spi.blockmessaging.AvailableBlocksNotification;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification;
+import org.hiero.block.node.spi.blockmessaging.StoredBlocksNotification;
+import org.hiero.block.node.spi.blockmessaging.TssDataNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 
 /**
@@ -24,6 +28,14 @@ public final class BlockNotificationRingEvent {
     private NewestBlockKnownToNetworkNotification newestBlockKnownToNetworkNotification;
     /** The publisher status update notification to be published to downstream subscribers through the LMAX Disruptor. */
     private PublisherStatusUpdateNotification publisherStatusUpdateNotification;
+    /** The TSS data update notification to be published to downstream subscribers through the LMAX Disruptor. */
+    private TssDataNotification tssDataNotification;
+    /** The address book history update notification to be published to downstream subscribers through the LMAX Disruptor. */
+    private AddressBookHistoryNotification addressBookHistoryNotification;
+    /** The stored blocks update notification to be published to downstream subscribers through the LMAX Disruptor. */
+    private StoredBlocksNotification storedBlocksNotification;
+    /** The available blocks update notification to be published to downstream subscribers through the LMAX Disruptor. */
+    private AvailableBlocksNotification availableBlocksNotification;
 
     /**
      * Sets the given notification to be published to downstream subscribers
@@ -37,6 +49,10 @@ public final class BlockNotificationRingEvent {
         this.backfilledBlockNotification = null;
         this.newestBlockKnownToNetworkNotification = null;
         this.publisherStatusUpdateNotification = null;
+        this.tssDataNotification = null;
+        this.addressBookHistoryNotification = null;
+        this.storedBlocksNotification = null;
+        this.availableBlocksNotification = null;
     }
 
     /**
@@ -51,6 +67,10 @@ public final class BlockNotificationRingEvent {
         this.backfilledBlockNotification = null;
         this.newestBlockKnownToNetworkNotification = null;
         this.publisherStatusUpdateNotification = null;
+        this.tssDataNotification = null;
+        this.addressBookHistoryNotification = null;
+        this.storedBlocksNotification = null;
+        this.availableBlocksNotification = null;
     }
 
     /**
@@ -65,6 +85,10 @@ public final class BlockNotificationRingEvent {
         this.persistedNotification = null;
         this.newestBlockKnownToNetworkNotification = null;
         this.publisherStatusUpdateNotification = null;
+        this.tssDataNotification = null;
+        this.addressBookHistoryNotification = null;
+        this.storedBlocksNotification = null;
+        this.availableBlocksNotification = null;
     }
 
     /**
@@ -79,7 +103,12 @@ public final class BlockNotificationRingEvent {
         this.verificationNotification = null;
         this.persistedNotification = null;
         this.publisherStatusUpdateNotification = null;
+        this.tssDataNotification = null;
+        this.addressBookHistoryNotification = null;
+        this.storedBlocksNotification = null;
+        this.availableBlocksNotification = null;
     }
+
     /**
      * Sets the given notification to be published to downstream subscribers
      * through the LMAX Disruptor.
@@ -92,6 +121,82 @@ public final class BlockNotificationRingEvent {
         this.backfilledBlockNotification = null;
         this.verificationNotification = null;
         this.persistedNotification = null;
+        this.tssDataNotification = null;
+        this.addressBookHistoryNotification = null;
+        this.storedBlocksNotification = null;
+        this.availableBlocksNotification = null;
+    }
+
+    /**
+     * Sets the given notification to be published to downstream subscribers
+     * through the LMAX Disruptor.
+     *
+     * @param notification to set
+     */
+    public void set(final TssDataNotification notification) {
+        this.tssDataNotification = notification;
+        this.verificationNotification = null;
+        this.persistedNotification = null;
+        this.backfilledBlockNotification = null;
+        this.newestBlockKnownToNetworkNotification = null;
+        this.publisherStatusUpdateNotification = null;
+        this.addressBookHistoryNotification = null;
+        this.storedBlocksNotification = null;
+        this.availableBlocksNotification = null;
+    }
+
+    /**
+     * Sets the given notification to be published to downstream subscribers
+     * through the LMAX Disruptor.
+     *
+     * @param notification to set
+     */
+    public void set(final AddressBookHistoryNotification notification) {
+        this.addressBookHistoryNotification = notification;
+        this.verificationNotification = null;
+        this.persistedNotification = null;
+        this.backfilledBlockNotification = null;
+        this.newestBlockKnownToNetworkNotification = null;
+        this.publisherStatusUpdateNotification = null;
+        this.tssDataNotification = null;
+        this.storedBlocksNotification = null;
+        this.availableBlocksNotification = null;
+    }
+
+    /**
+     * Sets the given notification to be published to downstream subscribers
+     * through the LMAX Disruptor.
+     *
+     * @param notification to set
+     */
+    public void set(final StoredBlocksNotification notification) {
+        this.storedBlocksNotification = notification;
+        this.verificationNotification = null;
+        this.persistedNotification = null;
+        this.backfilledBlockNotification = null;
+        this.newestBlockKnownToNetworkNotification = null;
+        this.publisherStatusUpdateNotification = null;
+        this.tssDataNotification = null;
+        this.addressBookHistoryNotification = null;
+        this.availableBlocksNotification = null;
+    }
+
+    /**
+     * Sets the given notification to be published to downstream subscribers
+     * through the LMAX Disruptor.
+     *
+     * @param notification to set
+     */
+    public void set(final AvailableBlocksNotification notification) {
+        this.availableBlocksNotification = notification;
+        this.verificationNotification = null;
+        this.persistedNotification = null;
+        this.backfilledBlockNotification = null;
+        this.newestBlockKnownToNetworkNotification = null;
+        this.publisherStatusUpdateNotification = null;
+        this.tssDataNotification = null;
+        this.addressBookHistoryNotification = null;
+        this.storedBlocksNotification = null;
     }
 
     /**
@@ -152,5 +257,49 @@ public final class BlockNotificationRingEvent {
      */
     public PublisherStatusUpdateNotification getPublisherStatusUpdateNotification() {
         return publisherStatusUpdateNotification;
+    }
+
+    /**
+     * Gets the TSS data update notification of the event from the LMAX Disruptor
+     * on the consumer side.
+     * If the event is not a {@link TssDataNotification}, this will return null.
+     *
+     * @return the value of the event
+     */
+    public TssDataNotification getTssDataNotification() {
+        return tssDataNotification;
+    }
+
+    /**
+     * Gets the address book history update notification of the event from the LMAX Disruptor
+     * on the consumer side.
+     * If the event is not a {@link AddressBookHistoryNotification}, this will return null.
+     *
+     * @return the value of the event
+     */
+    public AddressBookHistoryNotification getAddressBookHistoryNotification() {
+        return addressBookHistoryNotification;
+    }
+
+    /**
+     * Gets the stored blocks update notification of the event from the LMAX Disruptor
+     * on the consumer side.
+     * If the event is not a {@link StoredBlocksNotification}, this will return null.
+     *
+     * @return the value of the event
+     */
+    public StoredBlocksNotification getStoredBlocksNotification() {
+        return storedBlocksNotification;
+    }
+
+    /**
+     * Gets the available blocks update notification of the event from the LMAX Disruptor
+     * on the consumer side.
+     * If the event is not a {@link AvailableBlocksNotification}, this will return null.
+     *
+     * @return the value of the event
+     */
+    public AvailableBlocksNotification getAvailableBlocksNotification() {
+        return availableBlocksNotification;
     }
 }

--- a/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/ApplicationStateNotificationTest.java
+++ b/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/ApplicationStateNotificationTest.java
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.server.messaging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.locks.LockSupport;
+import org.hiero.block.node.app.fixtures.async.BlockingExecutor;
+import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
+import org.hiero.block.node.app.fixtures.async.TestThreadPoolManager;
+import org.hiero.block.node.messaging.BlockMessagingFacilityImpl;
+import org.hiero.block.node.spi.BlockNodeContext;
+import org.hiero.block.node.spi.blockmessaging.AddressBookHistoryNotification;
+import org.hiero.block.node.spi.blockmessaging.ApplicationStateNotificationHandler;
+import org.hiero.block.node.spi.blockmessaging.AvailableBlocksNotification;
+import org.hiero.block.node.spi.blockmessaging.BlockMessagingFacility;
+import org.hiero.block.node.spi.blockmessaging.BlockNotificationHandler;
+import org.hiero.block.node.spi.blockmessaging.BlockSource;
+import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
+import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification;
+import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification.UpdateType;
+import org.hiero.block.node.spi.blockmessaging.StoredBlocksNotification;
+import org.hiero.block.node.spi.blockmessaging.TssDataNotification;
+import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for application state notification delivery through {@link BlockMessagingFacilityImpl}.
+ * Covers registration, delivery of all four application state notification types, isolation from
+ * block-stream events, unregistration, and multi-handler fan-out.
+ */
+public class ApplicationStateNotificationTest {
+
+    private TestThreadPoolManager<BlockingExecutor, ScheduledBlockingExecutor> threadPoolManager;
+    private BlockNodeContext context;
+
+    @BeforeEach
+    void setup() {
+        threadPoolManager = new TestThreadPoolManager<>(
+                new BlockingExecutor(new LinkedBlockingQueue<>()),
+                new ScheduledBlockingExecutor(new LinkedBlockingQueue<>()));
+        context = TestConfig.generateContext(threadPoolManager);
+    }
+
+    /**
+     * Default method implementations on {@link ApplicationStateNotificationHandler} must be no-ops
+     * that do not throw.
+     */
+    @Test
+    void defaultMethodsAreNoOps() {
+        final ApplicationStateNotificationHandler handler = new ApplicationStateNotificationHandler() {};
+        handler.handleTssDataUpdate(new TssDataNotification(null));
+        handler.handleAddressBookHistoryUpdate(new AddressBookHistoryNotification(null));
+        handler.handleStoredBlocksUpdate(new StoredBlocksNotification(List.of()));
+        handler.handleAvailableBlocksUpdate(new AvailableBlocksNotification(List.of()));
+    }
+
+    /**
+     * A handler pre-registered before {@code start()} must receive all four application state
+     * notification types after the service starts.
+     */
+    @Test
+    void preRegisteredHandlerReceivesAllFourTypes() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(4);
+        final AtomicIntegerArray counters = new AtomicIntegerArray(4);
+        final ApplicationStateNotificationHandler handler = new ApplicationStateNotificationHandler() {
+            @Override
+            public void handleTssDataUpdate(final TssDataNotification n) {
+                counters.incrementAndGet(0);
+                latch.countDown();
+            }
+
+            @Override
+            public void handleAddressBookHistoryUpdate(final AddressBookHistoryNotification n) {
+                counters.incrementAndGet(1);
+                latch.countDown();
+            }
+
+            @Override
+            public void handleStoredBlocksUpdate(final StoredBlocksNotification n) {
+                counters.incrementAndGet(2);
+                latch.countDown();
+            }
+
+            @Override
+            public void handleAvailableBlocksUpdate(final AvailableBlocksNotification n) {
+                counters.incrementAndGet(3);
+                latch.countDown();
+            }
+        };
+
+        final BlockMessagingFacility service = new BlockMessagingFacilityImpl();
+        service.init(context, null);
+        service.registerApplicationStateNotificationHandler(handler, false, "pre-reg");
+        service.start();
+
+        sendAllApplicationStateNotifications(service);
+        threadPoolManager
+                .executor()
+                .executeAsync(false, 10_000L, true, true, () -> Executors.newSingleThreadExecutor());
+
+        assertTrue(latch.await(20, TimeUnit.SECONDS), "Handler did not receive all four notification types");
+        assertEquals(1, counters.get(0), "TSS data count");
+        assertEquals(1, counters.get(1), "Address book history count");
+        assertEquals(1, counters.get(2), "Stored blocks count");
+        assertEquals(1, counters.get(3), "Available blocks count");
+        service.stop();
+    }
+
+    /**
+     * A handler registered dynamically after {@code start()} must also receive all four
+     * application state notification types.
+     */
+    @Test
+    void dynamicallyRegisteredHandlerReceivesAllFourTypes() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(4);
+        final AtomicIntegerArray counters = new AtomicIntegerArray(4);
+        final ApplicationStateNotificationHandler handler = new ApplicationStateNotificationHandler() {
+            @Override
+            public void handleTssDataUpdate(final TssDataNotification n) {
+                counters.incrementAndGet(0);
+                latch.countDown();
+            }
+
+            @Override
+            public void handleAddressBookHistoryUpdate(final AddressBookHistoryNotification n) {
+                counters.incrementAndGet(1);
+                latch.countDown();
+            }
+
+            @Override
+            public void handleStoredBlocksUpdate(final StoredBlocksNotification n) {
+                counters.incrementAndGet(2);
+                latch.countDown();
+            }
+
+            @Override
+            public void handleAvailableBlocksUpdate(final AvailableBlocksNotification n) {
+                counters.incrementAndGet(3);
+                latch.countDown();
+            }
+        };
+
+        final BlockMessagingFacility service = new BlockMessagingFacilityImpl();
+        service.init(context, null);
+        service.start();
+        // register AFTER start
+        service.registerApplicationStateNotificationHandler(handler, false, "dynamic");
+
+        sendAllApplicationStateNotifications(service);
+        threadPoolManager
+                .executor()
+                .executeAsync(false, 10_000L, true, true, () -> Executors.newSingleThreadExecutor());
+
+        assertTrue(latch.await(20, TimeUnit.SECONDS), "Dynamically registered handler did not receive all types");
+        assertEquals(1, counters.get(0));
+        assertEquals(1, counters.get(1));
+        assertEquals(1, counters.get(2));
+        assertEquals(1, counters.get(3));
+        service.stop();
+    }
+
+    /**
+     * A CPU-intensive application state handler (platform thread) must receive notifications just
+     * like a virtual-thread handler.
+     */
+    @Test
+    void cpuIntensiveHandlerReceivesNotifications() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final ApplicationStateNotificationHandler handler = new ApplicationStateNotificationHandler() {
+            @Override
+            public void handleTssDataUpdate(final TssDataNotification n) {
+                latch.countDown();
+            }
+        };
+
+        final BlockMessagingFacility service = new BlockMessagingFacilityImpl();
+        service.init(context, null);
+        service.registerApplicationStateNotificationHandler(handler, true, "cpu-intensive"); // platform thread
+        service.start();
+
+        service.sendTssDataUpdate(new TssDataNotification(null));
+        threadPoolManager
+                .executor()
+                .executeAsync(false, 10_000L, true, true, () -> Executors.newSingleThreadExecutor());
+
+        assertTrue(latch.await(20, TimeUnit.SECONDS), "CPU-intensive handler did not receive notification");
+        service.stop();
+    }
+
+    /**
+     * Multiple handlers must all receive the same application state notifications (fan-out).
+     */
+    @Test
+    void multipleHandlersAllReceiveNotifications() throws InterruptedException {
+        final int handlerCount = 3;
+        final CountDownLatch latch = new CountDownLatch(handlerCount);
+        final AtomicIntegerArray counters = new AtomicIntegerArray(handlerCount);
+
+        final BlockMessagingFacility service = new BlockMessagingFacilityImpl();
+        service.init(context, null);
+        for (int i = 0; i < handlerCount; i++) {
+            final int idx = i;
+            service.registerApplicationStateNotificationHandler(
+                    new ApplicationStateNotificationHandler() {
+                        @Override
+                        public void handleTssDataUpdate(final TssDataNotification n) {
+                            counters.incrementAndGet(idx);
+                            latch.countDown();
+                        }
+                    },
+                    false,
+                    "handler-" + i);
+        }
+        service.start();
+
+        service.sendTssDataUpdate(new TssDataNotification(null));
+        threadPoolManager
+                .executor()
+                .executeAsync(false, 10_000L, true, true, () -> Executors.newSingleThreadExecutor());
+
+        assertTrue(latch.await(20, TimeUnit.SECONDS), "Not all handlers received the notification");
+        for (int i = 0; i < handlerCount; i++) {
+            assertEquals(1, counters.get(i), "Handler " + i + " count");
+        }
+        service.stop();
+    }
+
+    /**
+     * Unregistering a handler must stop further delivery to it while not affecting other handlers.
+     */
+    @Test
+    void unregisteredHandlerStopsReceivingNotifications() throws InterruptedException {
+        final CountDownLatch firstBatchLatch = new CountDownLatch(1);
+        final AtomicIntegerArray counters = new AtomicIntegerArray(1);
+        final ApplicationStateNotificationHandler handler = new ApplicationStateNotificationHandler() {
+            @Override
+            public void handleTssDataUpdate(final TssDataNotification n) {
+                counters.incrementAndGet(0);
+                firstBatchLatch.countDown();
+            }
+        };
+
+        final BlockMessagingFacility service = new BlockMessagingFacilityImpl();
+        service.init(context, null);
+        service.registerApplicationStateNotificationHandler(handler, false, "to-unregister");
+        service.start();
+
+        // First batch — handler should receive it.
+        service.sendTssDataUpdate(new TssDataNotification(null));
+        threadPoolManager
+                .executor()
+                .executeAsync(false, 10_000L, true, true, () -> Executors.newSingleThreadExecutor());
+        assertTrue(firstBatchLatch.await(20, TimeUnit.SECONDS));
+        assertEquals(1, counters.get(0));
+
+        // Unregister, then send more.
+        service.unregisterApplicationStateNotificationHandler(handler);
+        LockSupport.parkNanos(10_000_000L); // 10 ms for unregister to propagate
+
+        service.sendTssDataUpdate(new TssDataNotification(null));
+        threadPoolManager
+                .executor()
+                .executeAsync(false, 10_000L, true, true, () -> Executors.newSingleThreadExecutor());
+        LockSupport.parkNanos(100_000_000L); // 100 ms — unregistered, no latch to gate on
+
+        assertEquals(1, counters.get(0), "Handler should not receive events after unregistration");
+        service.stop();
+    }
+
+    /**
+     * An {@link ApplicationStateNotificationHandler} must silently ignore block-stream notification
+     * events; only the application state notification used as a sentinel must be delivered.
+     */
+    @Test
+    void applicationStateHandlerIgnoresBlockStreamEvents() throws InterruptedException {
+        final CountDownLatch sentinelLatch = new CountDownLatch(1);
+        final AtomicIntegerArray counters = new AtomicIntegerArray(1);
+        final ApplicationStateNotificationHandler handler = new ApplicationStateNotificationHandler() {
+            @Override
+            public void handleTssDataUpdate(final TssDataNotification n) {
+                // Sentinel: only this should arrive.
+                counters.incrementAndGet(0);
+                sentinelLatch.countDown();
+            }
+        };
+
+        final BlockMessagingFacility service = new BlockMessagingFacilityImpl();
+        service.init(context, null);
+        service.registerApplicationStateNotificationHandler(handler, false, "app-state-handler");
+        service.start();
+
+        // Send three block-stream notifications, then one TSS as sentinel.
+        service.sendBlockVerification(new VerificationNotification(true, null, 1L, null, null, BlockSource.PUBLISHER));
+        service.sendBlockPersisted(new PersistedNotification(1L, true, 0, BlockSource.PUBLISHER));
+        service.sendPublisherStatusUpdate(new PublisherStatusUpdateNotification(UpdateType.PUBLISHER_CONNECTED, 1));
+        service.sendTssDataUpdate(new TssDataNotification(null));
+        threadPoolManager
+                .executor()
+                .executeAsync(false, 10_000L, true, true, () -> Executors.newSingleThreadExecutor());
+
+        // Wait for sentinel; only 1 application state notification should have been delivered.
+        assertTrue(sentinelLatch.await(20, TimeUnit.SECONDS));
+        assertEquals(
+                1,
+                counters.get(0),
+                "Application state handler should only receive TSS sentinel, not block-stream events");
+        service.stop();
+    }
+
+    /**
+     * A {@link BlockNotificationHandler} must silently ignore application state notification
+     * events; only the verification notification used as a sentinel must trigger the block handler.
+     */
+    @Test
+    void blockHandlerIgnoresApplicationStateEvents() throws InterruptedException {
+        final CountDownLatch verificationLatch = new CountDownLatch(1);
+        final AtomicIntegerArray counters = new AtomicIntegerArray(1);
+        final BlockNotificationHandler blockHandler = new BlockNotificationHandler() {
+            @Override
+            public void handleVerification(final VerificationNotification n) {
+                counters.incrementAndGet(0);
+                verificationLatch.countDown();
+            }
+        };
+
+        final BlockMessagingFacility service = new BlockMessagingFacilityImpl();
+        service.init(context, null);
+        service.registerBlockNotificationHandler(blockHandler, false, "block-handler");
+        service.start();
+
+        // Send all four application state notifications, then one verification as sentinel.
+        sendAllApplicationStateNotifications(service);
+        service.sendBlockVerification(new VerificationNotification(true, null, 1L, null, null, BlockSource.PUBLISHER));
+        threadPoolManager
+                .executor()
+                .executeAsync(false, 10_000L, true, true, () -> Executors.newSingleThreadExecutor());
+
+        // Wait for sentinel; block handler should only have fired once (the verification).
+        assertTrue(verificationLatch.await(20, TimeUnit.SECONDS));
+        assertEquals(
+                1,
+                counters.get(0),
+                "Block handler should only receive verification sentinel, not application state events");
+        service.stop();
+    }
+
+    // ---- helpers ----
+
+    private static void sendAllApplicationStateNotifications(final BlockMessagingFacility service) {
+        service.sendTssDataUpdate(new TssDataNotification(null));
+        service.sendAddressBookHistoryUpdate(new AddressBookHistoryNotification(null));
+        service.sendStoredBlocksUpdate(new StoredBlocksNotification(List.of()));
+        service.sendAvailableBlocksUpdate(new AvailableBlocksNotification(List.of()));
+    }
+}

--- a/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationRingEventTest.java
+++ b/block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationRingEventTest.java
@@ -4,14 +4,20 @@ package org.hiero.block.server.messaging;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.List;
+import org.hiero.block.api.BlockRange;
 import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.messaging.BlockNotificationRingEvent;
+import org.hiero.block.node.spi.blockmessaging.AddressBookHistoryNotification;
+import org.hiero.block.node.spi.blockmessaging.AvailableBlocksNotification;
 import org.hiero.block.node.spi.blockmessaging.BackfilledBlockNotification;
 import org.hiero.block.node.spi.blockmessaging.BlockSource;
 import org.hiero.block.node.spi.blockmessaging.NewestBlockKnownToNetworkNotification;
 import org.hiero.block.node.spi.blockmessaging.PersistedNotification;
 import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification;
 import org.hiero.block.node.spi.blockmessaging.PublisherStatusUpdateNotification.UpdateType;
+import org.hiero.block.node.spi.blockmessaging.StoredBlocksNotification;
+import org.hiero.block.node.spi.blockmessaging.TssDataNotification;
 import org.hiero.block.node.spi.blockmessaging.VerificationNotification;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,6 +38,10 @@ class BlockNotificationRingEventTest {
         assertNull(event.getBackfilledBlockNotification());
         assertNull(event.getNewestBlockKnownToNetworkNotification());
         assertNull(event.getPublisherStatusUpdateNotification());
+        assertNull(event.getTssDataNotification());
+        assertNull(event.getAddressBookHistoryNotification());
+        assertNull(event.getStoredBlocksNotification());
+        assertNull(event.getAvailableBlocksNotification());
     }
 
     /**
@@ -209,5 +219,102 @@ class BlockNotificationRingEventTest {
         event.set(notification2);
         assertEquals(notification2, event.getPersistedNotification());
         assertNull(event.getVerificationNotification());
+    }
+
+    /**
+     * Tests setting and getting a TSS data update notification.
+     */
+    @Test
+    @DisplayName("Should set and get TssDataNotification correctly")
+    void shouldSetAndGetTssDataNotification() {
+        final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
+        final TssDataNotification notification = new TssDataNotification(null);
+        event.set(notification);
+        assertEquals(notification, event.getTssDataNotification());
+        assertNull(event.getVerificationNotification(), "Verification notification should be null");
+        assertNull(event.getPersistedNotification(), "Persisted notification should be null");
+        assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
+        assertNull(event.getNewestBlockKnownToNetworkNotification(), "Newest block notification should be null");
+        assertNull(event.getPublisherStatusUpdateNotification(), "Publisher status notification should be null");
+        assertNull(event.getAddressBookHistoryNotification(), "Address book history notification should be null");
+        assertNull(event.getStoredBlocksNotification(), "Stored blocks notification should be null");
+        assertNull(event.getAvailableBlocksNotification(), "Available blocks notification should be null");
+    }
+
+    /**
+     * Tests setting and getting an address book history update notification.
+     */
+    @Test
+    @DisplayName("Should set and get AddressBookHistoryNotification correctly")
+    void shouldSetAndGetAddressBookHistoryNotification() {
+        final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
+        final AddressBookHistoryNotification notification = new AddressBookHistoryNotification(null);
+        event.set(notification);
+        assertEquals(notification, event.getAddressBookHistoryNotification());
+        assertNull(event.getVerificationNotification(), "Verification notification should be null");
+        assertNull(event.getPersistedNotification(), "Persisted notification should be null");
+        assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
+        assertNull(event.getNewestBlockKnownToNetworkNotification(), "Newest block notification should be null");
+        assertNull(event.getPublisherStatusUpdateNotification(), "Publisher status notification should be null");
+        assertNull(event.getTssDataNotification(), "TSS data notification should be null");
+        assertNull(event.getStoredBlocksNotification(), "Stored blocks notification should be null");
+        assertNull(event.getAvailableBlocksNotification(), "Available blocks notification should be null");
+    }
+
+    /**
+     * Tests setting and getting a stored blocks update notification.
+     */
+    @Test
+    @DisplayName("Should set and get StoredBlocksNotification correctly")
+    void shouldSetAndGetStoredBlocksNotification() {
+        final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
+        final StoredBlocksNotification notification = new StoredBlocksNotification(List.of());
+        event.set(notification);
+        assertEquals(notification, event.getStoredBlocksNotification());
+        assertNull(event.getVerificationNotification(), "Verification notification should be null");
+        assertNull(event.getPersistedNotification(), "Persisted notification should be null");
+        assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
+        assertNull(event.getNewestBlockKnownToNetworkNotification(), "Newest block notification should be null");
+        assertNull(event.getPublisherStatusUpdateNotification(), "Publisher status notification should be null");
+        assertNull(event.getTssDataNotification(), "TSS data notification should be null");
+        assertNull(event.getAddressBookHistoryNotification(), "Address book history notification should be null");
+        assertNull(event.getAvailableBlocksNotification(), "Available blocks notification should be null");
+    }
+
+    /**
+     * Tests setting and getting an available blocks update notification.
+     */
+    @Test
+    @DisplayName("Should set and get AvailableBlocksNotification correctly")
+    void shouldSetAndGetAvailableBlocksNotification() {
+        final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
+        final List<BlockRange> ranges =
+                List.of(BlockRange.newBuilder().rangeStart(1L).rangeEnd(100L).build());
+        final AvailableBlocksNotification notification = new AvailableBlocksNotification(ranges);
+        event.set(notification);
+        assertEquals(notification, event.getAvailableBlocksNotification());
+        assertNull(event.getVerificationNotification(), "Verification notification should be null");
+        assertNull(event.getPersistedNotification(), "Persisted notification should be null");
+        assertNull(event.getBackfilledBlockNotification(), "Backfilled notification should be null");
+        assertNull(event.getNewestBlockKnownToNetworkNotification(), "Newest block notification should be null");
+        assertNull(event.getPublisherStatusUpdateNotification(), "Publisher status notification should be null");
+        assertNull(event.getTssDataNotification(), "TSS data notification should be null");
+        assertNull(event.getAddressBookHistoryNotification(), "Address book history notification should be null");
+        assertNull(event.getStoredBlocksNotification(), "Stored blocks notification should be null");
+    }
+
+    /**
+     * Tests that setting a TSS data notification clears a previously set block-stream notification.
+     */
+    @Test
+    @DisplayName("Setting TssDataNotification should clear block-stream notifications")
+    void settingTssDataNotificationShouldClearBlockStreamNotifications() {
+        final BlockNotificationRingEvent event = new BlockNotificationRingEvent();
+        event.set(new PersistedNotification(1, true, 0, BlockSource.PUBLISHER));
+        assertEquals(1L, event.getPersistedNotification().blockNumber());
+
+        event.set(new TssDataNotification(null));
+        assertNull(event.getPersistedNotification(), "Persisted notification should be cleared");
+        assertNull(event.getVerificationNotification(), "Verification notification should be cleared");
     }
 }

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/AddressBookHistoryNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/AddressBookHistoryNotification.java
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.blockmessaging;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.hiero.block.api.RangedAddressBookHistory;
+
+/**
+ * Notification sent when the node's ranged address book history is updated.
+ *
+ * @param rangedAddressBookHistory the updated address book history; {@code null} when no history
+ *     has been loaded
+ */
+public record AddressBookHistoryNotification(@Nullable RangedAddressBookHistory rangedAddressBookHistory) {}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/AddressBookHistoryNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/AddressBookHistoryNotification.java
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.spi.blockmessaging;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
 import org.hiero.block.api.RangedAddressBookHistory;
 
 /**
  * Notification sent when the node's ranged address book history is updated.
  *
- * @param rangedAddressBookHistory the updated address book history; {@code null} when no history
- *     has been loaded
+ * @param rangedAddressBookHistory the updated address book history
  */
-public record AddressBookHistoryNotification(@Nullable RangedAddressBookHistory rangedAddressBookHistory) {}
+public record AddressBookHistoryNotification(RangedAddressBookHistory rangedAddressBookHistory) {}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/ApplicationStateNotificationHandler.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/ApplicationStateNotificationHandler.java
@@ -2,15 +2,15 @@
 package org.hiero.block.node.spi.blockmessaging;
 
 /**
- * Interface for handling context update notifications. Plugins that need to react to changes in
- * node-level state (TSS data, address book history, stored blocks, or available blocks) implement
- * this interface and register via
- * {@link BlockMessagingFacility#registerContextNotificationHandler}.
+ * Interface for handling application state update notifications. Plugins that need to react to
+ * changes in node-level state (TSS data, address book history, stored blocks, or available blocks)
+ * implement this interface and register via
+ * {@link BlockMessagingFacility#registerApplicationStateNotificationHandler}.
  *
  * <p>Each registered handler runs on its own dedicated thread. All handler methods have no-op
  * default implementations so that implementors only override the notifications they care about.
  */
-public interface ContextNotificationHandler extends GatingHandler {
+public interface ApplicationStateNotificationHandler extends GatingHandler {
 
     /**
      * Handle a TSS data update notification. Always called on the handler's own messaging thread.

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/ApplicationStateNotificationHandler.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/ApplicationStateNotificationHandler.java
@@ -42,4 +42,12 @@ public interface ApplicationStateNotificationHandler extends GatingHandler {
      * @param notification the available blocks update notification to handle
      */
     default void handleAvailableBlocksUpdate(final AvailableBlocksNotification notification) {}
+
+    /**
+     * These notifications are non-gating
+     */
+    @Override
+    default boolean isGating() {
+        return false;
+    }
 }

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/AvailableBlocksNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/AvailableBlocksNotification.java
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.blockmessaging;
+
+import java.util.List;
+import org.hiero.block.api.BlockRange;
+
+/**
+ * Notification sent when the set of blocks available for client retrieval changes.
+ *
+ * @param availableBlocks the current available block ranges
+ */
+public record AvailableBlocksNotification(List<BlockRange> availableBlocks) {}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
@@ -124,7 +124,7 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
      *
      * @param notification the TSS data update notification to send
      */
-    void sendTssDataUpdate(TssDataNotification notification);
+    void sendTssDataUpdate(final TssDataNotification notification);
 
     /**
      * Use this method to send an address book history update notification to all registered context notification
@@ -132,21 +132,21 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
      *
      * @param notification the address book history update notification to send
      */
-    void sendAddressBookHistoryUpdate(AddressBookHistoryNotification notification);
+    void sendAddressBookHistoryUpdate(final AddressBookHistoryNotification notification);
 
     /**
      * Use this method to send a stored blocks update notification to all registered context notification handlers.
      *
      * @param notification the stored blocks update notification to send
      */
-    void sendStoredBlocksUpdate(StoredBlocksNotification notification);
+    void sendStoredBlocksUpdate(final StoredBlocksNotification notification);
 
     /**
      * Use this method to send an available blocks update notification to all registered context notification handlers.
      *
      * @param notification the available blocks update notification to send
      */
-    void sendAvailableBlocksUpdate(AvailableBlocksNotification notification);
+    void sendAvailableBlocksUpdate(final AvailableBlocksNotification notification);
 
     /**
      * Use this method to register a context notification handler. The handler will be called when node-level state

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
@@ -157,8 +157,8 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
      * @param cpuIntensiveHandler hint to the service that this handler is CPU intensive vs IO intensive
      * @param handlerName         the name of the handler, used for thread name and logging
      */
-    void registerContextNotificationHandler(
-            ContextNotificationHandler handler, boolean cpuIntensiveHandler, String handlerName);
+    void registerApplicationStateNotificationHandler(
+            ApplicationStateNotificationHandler handler, boolean cpuIntensiveHandler, String handlerName);
 
     /**
      * Use this method to dynamically unregister a context notification handler. The handler will no longer be called
@@ -167,5 +167,5 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
      *
      * @param handler the context notification handler to unregister
      */
-    void unregisterContextNotificationHandler(ContextNotificationHandler handler);
+    void unregisterApplicationStateNotificationHandler(ApplicationStateNotificationHandler handler);
 }

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
@@ -118,4 +118,54 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
      * @param handler the block notification handler to unregister
      */
     void unregisterBlockNotificationHandler(BlockNotificationHandler handler);
+
+    /**
+     * Use this method to send a TSS data update notification to all registered context notification handlers.
+     *
+     * @param notification the TSS data update notification to send
+     */
+    void sendTssDataUpdate(TssDataNotification notification);
+
+    /**
+     * Use this method to send an address book history update notification to all registered context notification
+     * handlers.
+     *
+     * @param notification the address book history update notification to send
+     */
+    void sendAddressBookHistoryUpdate(AddressBookHistoryNotification notification);
+
+    /**
+     * Use this method to send a stored blocks update notification to all registered context notification handlers.
+     *
+     * @param notification the stored blocks update notification to send
+     */
+    void sendStoredBlocksUpdate(StoredBlocksNotification notification);
+
+    /**
+     * Use this method to send an available blocks update notification to all registered context notification handlers.
+     *
+     * @param notification the available blocks update notification to send
+     */
+    void sendAvailableBlocksUpdate(AvailableBlocksNotification notification);
+
+    /**
+     * Use this method to register a context notification handler. The handler will be called when node-level state
+     * changes (TSS data, address book history, stored blocks, or available blocks). Each registered handler runs on
+     * its own dedicated thread.
+     *
+     * @param handler             the context notification handler to register
+     * @param cpuIntensiveHandler hint to the service that this handler is CPU intensive vs IO intensive
+     * @param handlerName         the name of the handler, used for thread name and logging
+     */
+    void registerContextNotificationHandler(
+            ContextNotificationHandler handler, boolean cpuIntensiveHandler, String handlerName);
+
+    /**
+     * Use this method to dynamically unregister a context notification handler. The handler will no longer be called
+     * when context notifications arrive. You only need to unregister handlers if they need to be unregistered before
+     * the service is shutdown. Shutting down the service will unregister all handlers.
+     *
+     * @param handler the context notification handler to unregister
+     */
+    void unregisterContextNotificationHandler(ContextNotificationHandler handler);
 }

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java
@@ -120,14 +120,14 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
     void unregisterBlockNotificationHandler(BlockNotificationHandler handler);
 
     /**
-     * Use this method to send a TSS data update notification to all registered context notification handlers.
+     * Use this method to send a TSS data update notification to all registered application notification handlers.
      *
      * @param notification the TSS data update notification to send
      */
     void sendTssDataUpdate(final TssDataNotification notification);
 
     /**
-     * Use this method to send an address book history update notification to all registered context notification
+     * Use this method to send an address book history update notification to all registered application notification
      * handlers.
      *
      * @param notification the address book history update notification to send
@@ -135,25 +135,25 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
     void sendAddressBookHistoryUpdate(final AddressBookHistoryNotification notification);
 
     /**
-     * Use this method to send a stored blocks update notification to all registered context notification handlers.
+     * Use this method to send a stored blocks update notification to all registered application notification handlers.
      *
      * @param notification the stored blocks update notification to send
      */
     void sendStoredBlocksUpdate(final StoredBlocksNotification notification);
 
     /**
-     * Use this method to send an available blocks update notification to all registered context notification handlers.
+     * Use this method to send an available blocks update notification to all registered application notification handlers.
      *
      * @param notification the available blocks update notification to send
      */
     void sendAvailableBlocksUpdate(final AvailableBlocksNotification notification);
 
     /**
-     * Use this method to register a context notification handler. The handler will be called when node-level state
+     * Use this method to register a application notification handler. The handler will be called when node-level state
      * changes (TSS data, address book history, stored blocks, or available blocks). Each registered handler runs on
      * its own dedicated thread.
      *
-     * @param handler             the context notification handler to register
+     * @param handler             the application notification handler to register
      * @param cpuIntensiveHandler hint to the service that this handler is CPU intensive vs IO intensive
      * @param handlerName         the name of the handler, used for thread name and logging
      */
@@ -161,11 +161,11 @@ public interface BlockMessagingFacility extends BlockNodePlugin {
             ApplicationStateNotificationHandler handler, boolean cpuIntensiveHandler, String handlerName);
 
     /**
-     * Use this method to dynamically unregister a context notification handler. The handler will no longer be called
-     * when context notifications arrive. You only need to unregister handlers if they need to be unregistered before
+     * Use this method to dynamically unregister a application notification handler. The handler will no longer be called
+     * when application notifications arrive. You only need to unregister handlers if they need to be unregistered before
      * the service is shutdown. Shutting down the service will unregister all handlers.
      *
-     * @param handler the context notification handler to unregister
+     * @param handler the application notification handler to unregister
      */
     void unregisterApplicationStateNotificationHandler(ApplicationStateNotificationHandler handler);
 }

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/ContextNotificationHandler.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/ContextNotificationHandler.java
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.blockmessaging;
+
+/**
+ * Interface for handling context update notifications. Plugins that need to react to changes in
+ * node-level state (TSS data, address book history, stored blocks, or available blocks) implement
+ * this interface and register via
+ * {@link BlockMessagingFacility#registerContextNotificationHandler}.
+ *
+ * <p>Each registered handler runs on its own dedicated thread. All handler methods have no-op
+ * default implementations so that implementors only override the notifications they care about.
+ */
+public interface ContextNotificationHandler extends GatingHandler {
+
+    /**
+     * Handle a TSS data update notification. Always called on the handler's own messaging thread.
+     *
+     * @param notification the TSS data update notification to handle
+     */
+    default void handleTssDataUpdate(final TssDataNotification notification) {}
+
+    /**
+     * Handle an address book history update notification. Always called on the handler's own
+     * messaging thread.
+     *
+     * @param notification the address book history update notification to handle
+     */
+    default void handleAddressBookHistoryUpdate(final AddressBookHistoryNotification notification) {}
+
+    /**
+     * Handle a stored blocks update notification. Always called on the handler's own messaging
+     * thread.
+     *
+     * @param notification the stored blocks update notification to handle
+     */
+    default void handleStoredBlocksUpdate(final StoredBlocksNotification notification) {}
+
+    /**
+     * Handle an available blocks update notification. Always called on the handler's own messaging
+     * thread.
+     *
+     * @param notification the available blocks update notification to handle
+     */
+    default void handleAvailableBlocksUpdate(final AvailableBlocksNotification notification) {}
+}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/StoredBlocksNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/StoredBlocksNotification.java
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.blockmessaging;
+
+import java.util.List;
+import org.hiero.block.api.BlockRange;
+
+/**
+ * Notification sent when the set of stored blocks changes. The list represents the merged view of
+ * cloud-archived stored blocks and locally available blocks.
+ *
+ * @param storedBlocks the current merged stored block ranges
+ */
+public record StoredBlocksNotification(List<BlockRange> storedBlocks) {}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/StoredBlocksNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/StoredBlocksNotification.java
@@ -10,4 +10,8 @@ import org.hiero.block.api.BlockRange;
  *
  * @param storedBlocks the current merged stored block ranges
  */
-public record StoredBlocksNotification(List<BlockRange> storedBlocks) {}
+public record StoredBlocksNotification(List<BlockRange> storedBlocks) {
+    public StoredBlocksNotification {
+        storedBlocks = List.copyOf(storedBlocks);
+    }
+}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/TssDataNotification.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/TssDataNotification.java
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.blockmessaging;
+
+import org.hiero.block.api.TssData;
+
+/**
+ * Notification sent when the node's TSS data is updated.
+ *
+ * @param tssData the updated TSS data
+ */
+public record TssDataNotification(TssData tssData) {}


### PR DESCRIPTION
## Reviewer Notes

Add the ApplicationStateNotifications in to BlockMessaging.

**Step 1 — 4 new notification records** (all in `spi-plugins`, `blockmessaging` package):
- [`TssDataNotification.java`](block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/TssDataNotification.java)
- [`AddressBookHistoryNotification.java`](block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/AddressBookHistoryNotification.java)
- [`StoredBlocksNotification.java`](block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/StoredBlocksNotification.java)
- [`AvailableBlocksNotification.java`](block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/AvailableBlocksNotification.java)

**Step 2 — `ApplicationStatetNotificationHandler` interface** ([`ApplicationStateNotificationHandler.java`](block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/ApplicationStateNotificationHandler.java)): extends `GatingHandler`, four default no-op methods.

**Step 3 — Disruptor wiring**:
- [`BlockNotificationRingEvent`](block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockNotificationRingEvent.java) — 4 new nullable fields, 4 new `set()`/`get()` pairs; every `set` nulls all 9 fields.
- [`BlockMessagingFacility`](block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/blockmessaging/BlockMessagingFacility.java) — 6 new methods: 4 sends + register/unregister.
- [`BlockMessagingFacilityImpl`](block-node/facility-messaging/src/main/java/org/hiero/block/node/messaging/BlockMessagingFacilityImpl.java) — full implementation: 4 metrics, 2 handler maps, pre-registration list, 4 send methods (via `messageForwarder` → existing ring), `register`/`unregister`, `start`/`stop` updates, fixed spurious "no notification set" log for app state events.
- [`TestBlockMessagingFacility`](block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/TestBlockMessagingFacility.java) — synchronous stub implementation of all 6 new methods.
- [`BlockNotificationRingEventTest`](block-node/facility-messaging/src/test/java/org/hiero/block/server/messaging/BlockNotificationRingEventTest.java) — 5 new tests covering all 4 application state notification types and the cross-type clear behaviour.

## Related Issue(s)
Closes: #3606
