### PR TITLE
fix: tss-signature-transition runs after tests that deliberately kill block-node-1

### DIFF
--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -159,7 +159,7 @@ jobs:
               # Quick validation - single topology smoke test + backfill test
               MATRIX='[
                 {"topology":"single","tests":"smoke-test,tss-signature-transition,wrb-cli-hash-validation,wrb-cli-wrapping-validation"},
-                {"topology":"2cn-2bn-backfill","tests":"full-history-backfill,tss-signature-transition"},
+                {"topology":"2cn-2bn-backfill","tests":"tss-signature-transition,full-history-backfill"},
                 {"topology":"single-wrb-rsa","tests":"smoke-test,rsa-roster-verification"},
                 {"topology":"wrb-differential-test","tests":"wrb-differential-test"}
               ]'
@@ -171,8 +171,8 @@ jobs:
                 {"topology":"paired-3","tests":"smoke-test,basic-load,tss-signature-transition"},
                 {"topology":"3cn-1bn","tests":"smoke-test,tss-signature-transition"},
                 {"topology":"fan-out-3cn-2bn","tests":"smoke-test,tss-signature-transition"},
-                {"topology":"2cn-2bn-backfill","tests":"full-history-backfill,tss-signature-transition"},
-                {"topology":"2cn-2bn-archive","tests":"archive-backfill,tss-signature-transition"},
+                {"topology":"2cn-2bn-backfill","tests":"tss-signature-transition,full-history-backfill"},
+                {"topology":"2cn-2bn-archive","tests":"tss-signature-transition,archive-backfill"},
                 {"topology":"7cn-3bn-distributed","tests":"smoke-test,tss-signature-transition"},
                 {"topology":"single-wrb-rsa","tests":"smoke-test,rsa-roster-verification"},
                 {"topology":"3cn-2bn-wrb-rsa","tests":"smoke-test,rsa-roster-verification"},

--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -172,7 +172,7 @@ jobs:
                 {"topology":"3cn-1bn","tests":"smoke-test,tss-signature-transition"},
                 {"topology":"fan-out-3cn-2bn","tests":"smoke-test,tss-signature-transition"},
                 {"topology":"2cn-2bn-backfill","tests":"tss-signature-transition,full-history-backfill"},
-                {"topology":"2cn-2bn-archive","tests":"tss-signature-transition,archive-backfill"},
+                {"topology":"2cn-2bn-archive","tests":"archive-backfill"},
                 {"topology":"7cn-3bn-distributed","tests":"smoke-test,tss-signature-transition"},
                 {"topology":"single-wrb-rsa","tests":"smoke-test,rsa-roster-verification"},
                 {"topology":"3cn-2bn-wrb-rsa","tests":"smoke-test,rsa-roster-verification"},

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -440,6 +440,7 @@ jobs:
 
       # Deploy network using shared script
       - name: Deploy network
+        timeout-minutes: 20
         env:
           # Empty unless the Consensus Node was built from source above, in which case Solo
           # is pointed at those jars instead of downloading a (nonexistent) SNAPSHOT zip.
@@ -596,6 +597,7 @@ jobs:
       # Run each test definition sequentially on the same deployment
       - name: Run Test Definitions
         id: tests_end
+        timeout-minutes: 75
         if: ${{ inputs.test-definition != 'none' && inputs.test-definition != '' }}
         run: |
           TESTS_DIR="${{ github.workspace }}/tools-and-tests/scripts/solo-e2e-test/tests"

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -597,7 +597,7 @@ jobs:
       # Run each test definition sequentially on the same deployment
       - name: Run Test Definitions
         id: tests_end
-        timeout-minutes: 75
+        timeout-minutes: 90
         if: ${{ inputs.test-definition != 'none' && inputs.test-definition != '' }}
         run: |
           TESTS_DIR="${{ github.workspace }}/tools-and-tests/scripts/solo-e2e-test/tests"

--- a/tools-and-tests/scripts/solo-e2e-test/README.md
+++ b/tools-and-tests/scripts/solo-e2e-test/README.md
@@ -97,6 +97,7 @@ task down
 | Task               | [taskfile.dev](https://taskfile.dev/installation/)                                      |
 | yq                 | [github.com/mikefarah/yq](https://github.com/mikefarah/yq#install)                      |
 | grpcurl (optional) | [github.com/fullstorydev/grpcurl](https://github.com/fullstorydev/grpcurl#installation) |
+| timeout (optional) | GNU coreutils; on macOS `brew install coreutils` provides `gtimeout`                    |
 
 ```bash
 task check  # Verify all installed

--- a/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
+++ b/tools-and-tests/scripts/solo-e2e-test/Taskfile.yml
@@ -114,6 +114,9 @@ tasks:
         echo "  Solo: $(solo --version)"
         echo "  yq: $(yq --version)"
         command -v pnpm >/dev/null 2>&1 && echo "  pnpm: $(pnpm --version)" || echo "  pnpm: not installed (needed for TCK tests)"
+        command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1 \
+          && echo "  timeout: $(command -v timeout || command -v gtimeout)" \
+          || echo "  timeout: not installed (some 'task test:unit' scenarios skip; macOS: brew install coreutils)"
     silent: true
 
   solo:install:

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/monitor-block-proofs.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/monitor-block-proofs.sh
@@ -43,6 +43,40 @@ STEP=50
 # before the data flood kills the port-forward. Rejected blocks are treated as
 # NOT_AVAILABLE, which the binary search handles correctly.
 MAX_MSG_SIZE=10000000
+# Per-call wall-clock ceiling for grpcurl. A Service whose pods are gone still
+# accepts a kubectl port-forward connection and then stalls forever, so without
+# this a single call can block the whole script past the max_block*2
+# deadline before check_hard_timeout gets a chance to run. 60s is well clear of a legitimate
+# fetch: observed blocks are ~40KB, the largest seen 983.9KB, and MAX_MSG_SIZE
+# caps a download at 10MB. On expiry grpcurl reports "context deadline
+# exceeded", which the CONNECTION_ERROR pattern below already handles.
+MAX_CALL_SECONDS=60
+
+# Hard timeout: max_block * 2s (block production interval).
+# If max_block=1000, timeout=2000s (~33 min). 0 means no timeout.
+if [[ "$MAX_BLOCK" -gt 0 ]]; then
+  HARD_TIMEOUT=$(( MAX_BLOCK * 2 ))
+else
+  HARD_TIMEOUT=0
+fi
+START_TIME=$(date +%s)
+
+# Checked from get_sig_type_safe (every gRPC call site: scan loop, binary
+# search, lower-bound search, print_result) rather than only between scan
+# iterations, so post-detection work can't run unbounded past the deadline.
+function check_hard_timeout {
+  [[ "$HARD_TIMEOUT" -gt 0 ]] || return 0
+  local elapsed=$(( $(date +%s) - START_TIME ))
+  if [[ "$elapsed" -ge "$HARD_TIMEOUT" ]]; then
+    echo "" >&2
+    echo "=== Signature Transition ===" >&2
+    echo "  Status: WRAPS NOT DETECTED" >&2
+    echo "  Hard timeout: ${HARD_TIMEOUT}s elapsed (max_block=${MAX_BLOCK} * 2s)" >&2
+    # set -e doesn't reliably cross nested $(...) layers; signal the top-level script.
+    kill -TERM "$$"
+    exit 1
+  fi
+}
 
 if ! command -v grpcurl &>/dev/null; then
   echo "ERROR: grpcurl not found" >&2
@@ -62,6 +96,7 @@ function get_sig_type {
   raw=$(cd "${PROTO_DIR}" && grpcurl -plaintext -import-path . \
     -proto "block-node/api/block_access_service.proto" \
     -max-msg-sz "${MAX_MSG_SIZE}" \
+    -max-time "${MAX_CALL_SECONDS}" \
     -d "{\"block_number\": ${block_number}}" \
     "${BN_ENDPOINT}" org.hiero.block.api.BlockAccessService/getBlock 2>&1) || true
 
@@ -138,6 +173,7 @@ print(f'{sig_bytes} {binary_size}')
 #   3. If retry also fails (oversized block crashing port-forward), returns NOT_AVAILABLE
 # Without PORT_FORWARD_CMD, CONNECTION_ERROR is returned as-is for the caller to handle.
 function get_sig_type_safe {
+  check_hard_timeout
   local block_number="$1"
   local result
   result=$(get_sig_type "${block_number}")
@@ -243,15 +279,6 @@ function print_result {
   format_block_line "$((transition_block + 1))" "$next_result"
 }
 
-# Hard timeout: max_block * 2s (block production interval).
-# If max_block=1000, timeout=2000s (~33 min). 0 means no timeout.
-if [[ "$MAX_BLOCK" -gt 0 ]]; then
-  HARD_TIMEOUT=$(( MAX_BLOCK * 2 ))
-else
-  HARD_TIMEOUT=0
-fi
-START_TIME=$(date +%s)
-
 # Main: scan every STEP blocks
 echo "Scanning for WRAPS signature (every ${STEP} blocks)..."
 block=0
@@ -265,18 +292,6 @@ while true; do
     echo "  Status: WRAPS NOT DETECTED"
     echo "  Max block limit: ${MAX_BLOCK}"
     exit 1
-  fi
-
-  # Enforce hard wall-clock timeout
-  if [[ "$HARD_TIMEOUT" -gt 0 ]]; then
-    local_elapsed=$(( $(date +%s) - START_TIME ))
-    if [[ "$local_elapsed" -ge "$HARD_TIMEOUT" ]]; then
-      echo ""
-      echo "=== Signature Transition ==="
-      echo "  Status: WRAPS NOT DETECTED"
-      echo "  Hard timeout: ${HARD_TIMEOUT}s elapsed (max_block=${MAX_BLOCK} * 2s)"
-      exit 1
-    fi
   fi
 
   result=$(get_sig_type_safe "$block")
@@ -302,7 +317,7 @@ while true; do
     printf "."
     sleep 5
     # Block production is every ~2s. Wait patiently — the block will be produced.
-    # Only max_block (checked at top of loop) limits how long we wait.
+    # max_block and the hard wall-clock timeout are what bound the wait.
     block=$(( block - STEP ))
     continue
   fi

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/monitor-block-proofs.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/monitor-block-proofs.sh
@@ -25,9 +25,11 @@
 #                     instead of failing immediately (max 3 restarts).
 #
 # Exit codes:
-#   0  WRAPS transition found
+#   0  WRAPS transition found (including a hard-timeout hit after WRAPS was observed:
+#      the transition is real, only its exact block number went unnarrowed)
 #   1  max-block reached without WRAPS, or error
 #   2  connection error with no port-forward-cmd provided
+#   3  hard wall-clock timeout (max_block*2) hit before WRAPS was ever observed
 
 set -euo pipefail
 
@@ -36,7 +38,9 @@ BN_ENDPOINT="${2:-localhost:40840}"
 MAX_BLOCK="${3:-0}"
 PORT_FORWARD_CMD="${4:-}"
 
-STEP=50
+# Scan stride. Env-overridable so the unit suite can pair a tiny max_block with a
+# stride small enough to enter the scan loop at all; production always uses 50.
+STEP="${MONITOR_BLOCK_STEP:-50}"
 # Max gRPC message size to accept. Normal blocks are ~40KB; the TSS genesis
 # block can be ~100MB. Downloading 100MB through kubectl port-forward crashes
 # the SPDY tunnel. A 10MB limit rejects oversized blocks early (via RST_STREAM)
@@ -61,6 +65,20 @@ else
 fi
 START_TIME=$(date +%s)
 
+# Set once WRAPS is observed. Everything after that only sharpens the reported
+# block number, so a deadline hit with this set is imprecision, not a failure.
+WRAPS_SEEN_BLOCK=""
+
+# Without a trap the TERM from check_hard_timeout exits 143, indistinguishable
+# from any other abnormal death. 3 names the self-imposed deadline.
+function on_hard_timeout {
+  if [[ -n "${WRAPS_SEEN_BLOCK}" ]]; then
+    exit 0
+  fi
+  exit 3
+}
+trap on_hard_timeout TERM
+
 # Checked from get_sig_type_safe (every gRPC call site: scan loop, binary
 # search, lower-bound search, print_result) rather than only between scan
 # iterations, so post-detection work can't run unbounded past the deadline.
@@ -70,9 +88,15 @@ function check_hard_timeout {
   if [[ "$elapsed" -ge "$HARD_TIMEOUT" ]]; then
     echo "" >&2
     echo "=== Signature Transition ===" >&2
-    echo "  Status: WRAPS NOT DETECTED" >&2
-    echo "  Hard timeout: ${HARD_TIMEOUT}s elapsed (max_block=${MAX_BLOCK} * 2s)" >&2
+    if [[ -n "${WRAPS_SEEN_BLOCK}" ]]; then
+      echo "  First WRAPS block: ${WRAPS_SEEN_BLOCK}" >&2
+      echo "  (upper bound only: exact transition block not narrowed, ${HARD_TIMEOUT}s deadline hit during binary search)" >&2
+    else
+      echo "  Status: WRAPS NOT DETECTED" >&2
+      echo "  Hard timeout: ${HARD_TIMEOUT}s elapsed (max_block=${MAX_BLOCK} * 2s)" >&2
+    fi
     # set -e doesn't reliably cross nested $(...) layers; signal the top-level script.
+    # The exit below lets the enclosing $(...) finish so the parent can run its trap.
     kill -TERM "$$"
     exit 1
   fi
@@ -331,6 +355,8 @@ while true; do
   echo "  Block ${block}: ${sig_type} (sig: ${sig_bytes} bytes, block: $(format_size "$block_size"))"
 
   if [[ "$sig_type" == "WRAPS" ]]; then
+    # Record it before narrowing: from here on the assertion is already satisfied.
+    WRAPS_SEEN_BLOCK=$block
     echo "  WRAPS detected, binary searching for exact transition..."
     low=$(find_schnorr_lower_bound "$block")
     transition=$(binary_search_transition "$low" "$block")

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-port-forward.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-port-forward.sh
@@ -132,7 +132,7 @@ pf() {
         [[ -f "${PF_KEEPALIVE_FILE}" ]] || break
         sleep 2
       done
-    done ) 2>/dev/null &
+    done ) >/dev/null 2>&1 &
 }
 
 # Stop any previous generation of forwards and their supervisors before starting

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-test-runner.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-test-runner.sh
@@ -39,6 +39,15 @@ OUTPUT_MODE="console"
 VALIDATE_ONLY=false
 DEPLOYMENT="${DEPLOYMENT:-deployment-solo}"
 
+# Slack added on top of monitor-block-proofs.sh's own max_block*2 deadline when
+# assert_signature_transition wraps it in `timeout`. monitor-block-proofs.sh
+# checks its own deadline before every gRPC call, so the worst-case overshoot
+# before its deadline fires is one call plus its port-forward retry chain
+# (2x MAX_CALL_SECONDS + 2x3s sleep, ~126s); 180s covers that with room to
+# spare, so the script's own deadline normally fires first, keeping its more
+# informative output. Env-overridable so the unit suite can bound it tightly.
+SIGNATURE_TRANSITION_GRACE_SECONDS="${SIGNATURE_TRANSITION_GRACE_SECONDS:-180}"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -1380,8 +1389,12 @@ function assert_signature_transition {
     fi
 
     local pf_cmd="${SCRIPT_DIR}/solo-port-forward.sh --namespace ${NAMESPACE}"
-    local output
-    if output=$("$script" "${PROTO_PATH}" "localhost:${port}" "$max_block" "${pf_cmd}" 2>&1); then
+    local output status
+    local hard_timeout=0
+    if [[ "$max_block" -gt 0 ]]; then
+        hard_timeout=$(( max_block * 2 + SIGNATURE_TRANSITION_GRACE_SECONDS ))
+    fi
+    if output=$(timeout --foreground "${hard_timeout}" "$script" "${PROTO_PATH}" "localhost:${port}" "$max_block" "${pf_cmd}" 2>&1); then
         local transition_block transition_summary
         transition_summary=$(echo "${output}" | grep -A 10 "=== Signature Transition ===")
         transition_block=$(echo "${transition_summary}" | grep "First WRAPS block:" | awk '{print $NF}')
@@ -1389,8 +1402,13 @@ function assert_signature_transition {
         echo "${transition_summary}"
         return 0
     else
+        status=$?
         echo "${output}" >&2
-        echo "${target}: WRAPS not detected within ${max_block} blocks"
+        if [[ "${status}" -eq 124 ]]; then
+            echo "${target}: monitor-block-proofs.sh exceeded ${hard_timeout}s and was killed"
+        else
+            echo "${target}: WRAPS not detected within ${max_block} blocks (exit ${status})"
+        fi
         return 1
     fi
 }

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/solo-test-runner.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/solo-test-runner.sh
@@ -48,6 +48,11 @@ DEPLOYMENT="${DEPLOYMENT:-deployment-solo}"
 # informative output. Env-overridable so the unit suite can bound it tightly.
 SIGNATURE_TRANSITION_GRACE_SECONDS="${SIGNATURE_TRANSITION_GRACE_SECONDS:-180}"
 
+# Stock macOS ships neither `timeout` nor `gtimeout`. It is only a backstop here --
+# the monitor enforces its own max_block*2 deadline -- so wrap only when present.
+# Set it empty (not unset) to exercise the unwrapped path on a machine that has it.
+TIMEOUT_BIN="${TIMEOUT_BIN-$(command -v timeout || command -v gtimeout || true)}"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -284,17 +289,8 @@ function execute_snapshot_block_heights {
     : > "${snapshot_file}"
 
     for bn in $(get_all_block_nodes); do
-        local port
-        port=$(get_bn_grpc_port "$bn")
-        local import_args="-import-path ${PROTO_PATH}"
-        local status_json last_block
-        # shellcheck disable=SC2086
-        status_json=$(grpcurl -plaintext -emit-defaults \
-            ${import_args} \
-            -proto block-node/api/node_service.proto \
-            -d '{}' "localhost:${port}" \
-            org.hiero.block.api.BlockNodeService/serverStatus 2>/dev/null)
-        last_block=$(echo "$status_json" | jq -r '.lastAvailableBlock // "0"' 2>/dev/null)
+        local last_block
+        last_block=$(bn_server_status "$bn" | jq -r '.lastAvailableBlock // "0"' 2>/dev/null)
         last_block=${last_block:-0}
         echo "${bn}=${last_block}" >> "${snapshot_file}"
         echo "  ${bn}: lastBlock=${last_block}"
@@ -928,27 +924,36 @@ function get_bn_grpc_port {
     echo $((40839 + node_num))
 }
 
+# Fetch a Block Node's serverStatus as JSON. Prints nothing if the call fails; callers
+# supply their own jq default and decide what an absent field means.
+#
+# -max-time for the same reason monitor-block-proofs.sh sets it: a Service whose pods are
+# gone still accepts a kubectl port-forward connection and then stalls forever, so an
+# unbounded call here hangs the caller indefinitely.
+function bn_server_status {
+    local target="$1"
+    local port
+    port=$(get_bn_grpc_port "$target")
+
+    grpcurl -plaintext -emit-defaults -max-time 30 \
+        -import-path "${PROTO_PATH}" \
+        -proto block-node/api/node_service.proto \
+        -d '{}' "localhost:${port}" \
+        org.hiero.block.api.BlockNodeService/serverStatus 2>/dev/null
+}
+
 # Single node block availability check
 function assert_block_available_single {
     local target="$1"
     local min_block="${2:-0}"
     local max_block_gte="${3:-0}"
-    local port
-    port=$(get_bn_grpc_port "$target")
 
     if ! validate_proto_path "${target}"; then
         return 1
     fi
 
-    local import_args="-import-path ${PROTO_PATH}"
-
     local status_json
-    # shellcheck disable=SC2086  # Intentional word splitting for import path argument
-    status_json=$(grpcurl -plaintext -emit-defaults \
-        ${import_args} \
-        -proto block-node/api/node_service.proto \
-        -d '{}' "localhost:${port}" \
-        org.hiero.block.api.BlockNodeService/serverStatus 2>/dev/null)
+    status_json=$(bn_server_status "$target")
 
     local first_block last_block
     first_block=$(echo "$status_json" | jq -r '.firstAvailableBlock // "null"')
@@ -1171,24 +1176,14 @@ function assert_rsa_roster_verification {
 # Helper to get block count from a node with error handling
 function get_block_count {
     local target="$1"
-    local port
-    port=$(get_bn_grpc_port "$target")
 
     if ! validate_proto_path >/dev/null 2>&1; then
         echo ""
         return 1
     fi
 
-    local import_args="-import-path ${PROTO_PATH}"
-    local json block_count
-
-    json=$(grpcurl -plaintext -emit-defaults \
-        ${import_args} \
-        -proto block-node/api/node_service.proto \
-        -d '{}' "localhost:${port}" \
-        org.hiero.block.api.BlockNodeService/serverStatus 2>/dev/null)
-
-    block_count=$(echo "$json" | jq -r '.lastAvailableBlock // ""' 2>/dev/null)
+    local block_count
+    block_count=$(bn_server_status "$target" | jq -r '.lastAvailableBlock // ""' 2>/dev/null)
 
     # Return empty if we got nothing valid. An empty store reports the UINT64_MAX
     # sentinel here, which compares equal to itself — without this guard
@@ -1306,17 +1301,8 @@ function assert_blocks_converged {
     local failed=0
 
     for bn in $(get_all_block_nodes); do
-        local port
-        port=$(get_bn_grpc_port "$bn")
-        local import_args="-import-path ${PROTO_PATH}"
-        local status_json last_block
-        # shellcheck disable=SC2086
-        status_json=$(grpcurl -plaintext -emit-defaults \
-            ${import_args} \
-            -proto block-node/api/node_service.proto \
-            -d '{}' "localhost:${port}" \
-            org.hiero.block.api.BlockNodeService/serverStatus 2>/dev/null)
-        last_block=$(echo "$status_json" | jq -r '.lastAvailableBlock // "0"' 2>/dev/null)
+        local last_block
+        last_block=$(bn_server_status "$bn" | jq -r '.lastAvailableBlock // "0"' 2>/dev/null)
         last_block=${last_block:-0}
         results="${results}${bn}: lastBlock=${last_block}\n"
         [[ "${last_block}" -lt "${min_last}" ]] && min_last="${last_block}"
@@ -1382,6 +1368,15 @@ function assert_signature_transition {
         return 1
     fi
 
+    # A node that holds no blocks -- scaled down, or one that never receives a live stream --
+    # cannot satisfy this assertion, and the monitor would wait out its whole max_block * 2
+    # deadline discovering that. Ask serverStatus first and fail in seconds instead.
+    local availability
+    if ! availability=$(assert_block_available_single "$target"); then
+        echo "${availability}"
+        return 1
+    fi
+
     local script="${SCRIPT_DIR}/monitor-block-proofs.sh"
     if [[ ! -x "$script" ]]; then
         echo "${target}: monitor-block-proofs.sh not found at ${script}"
@@ -1389,12 +1384,31 @@ function assert_signature_transition {
     fi
 
     local pf_cmd="${SCRIPT_DIR}/solo-port-forward.sh --namespace ${NAMESPACE}"
-    local output status
+    local output
+    local status=0
+    local monitor_deadline=0
     local hard_timeout=0
     if [[ "$max_block" -gt 0 ]]; then
-        hard_timeout=$(( max_block * 2 + SIGNATURE_TRANSITION_GRACE_SECONDS ))
+        monitor_deadline=$(( max_block * 2 ))
+        hard_timeout=$(( monitor_deadline + SIGNATURE_TRANSITION_GRACE_SECONDS ))
     fi
-    if output=$(timeout --foreground "${hard_timeout}" "$script" "${PROTO_PATH}" "localhost:${port}" "$max_block" "${pf_cmd}" 2>&1); then
+
+    # Output goes to a file, not a command substitution: a leaked descendant holding
+    # stdout would keep the substitution open long after `timeout` killed the monitor.
+    local out_file
+    out_file=$(mktemp)
+    if [[ -n "${TIMEOUT_BIN}" ]]; then
+        "${TIMEOUT_BIN}" --foreground "${hard_timeout}" \
+            "$script" "${PROTO_PATH}" "localhost:${port}" "$max_block" "${pf_cmd}" \
+            >"${out_file}" 2>&1 || status=$?
+    else
+        "$script" "${PROTO_PATH}" "localhost:${port}" "$max_block" "${pf_cmd}" \
+            >"${out_file}" 2>&1 || status=$?
+    fi
+    output=$(cat "${out_file}")
+    rm -f "${out_file}"
+
+    if [[ "${status}" -eq 0 ]]; then
         local transition_block transition_summary
         transition_summary=$(echo "${output}" | grep -A 10 "=== Signature Transition ===")
         transition_block=$(echo "${transition_summary}" | grep "First WRAPS block:" | awk '{print $NF}')
@@ -1402,10 +1416,11 @@ function assert_signature_transition {
         echo "${transition_summary}"
         return 0
     else
-        status=$?
         echo "${output}" >&2
-        if [[ "${status}" -eq 124 ]]; then
-            echo "${target}: monitor-block-proofs.sh exceeded ${hard_timeout}s and was killed"
+        if [[ "${status}" -eq 3 ]]; then
+            echo "${target}: monitor-block-proofs.sh hit its own ${monitor_deadline}s deadline (max_block * 2)"
+        elif [[ "${status}" -eq 124 ]]; then
+            echo "${target}: monitor-block-proofs.sh exceeded ${hard_timeout}s and was killed by the wrapper"
         else
             echo "${target}: WRAPS not detected within ${max_block} blocks (exit ${status})"
         fi

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/monitor-hard-timeout/grpcurl
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/monitor-hard-timeout/grpcurl
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fake grpcurl for the real monitor-block-proofs.sh: every block is NOT_AVAILABLE,
+# so the scan loop waits forever and only the max_block*2 deadline can end it.
+echo '{ "status": "NOT_AVAILABLE" }'

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/signature-transition-failure/monitor-block-proofs.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/signature-transition-failure/monitor-block-proofs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stand-in for the real monitor-block-proofs.sh: fails immediately without
+# hanging, so the non-timeout branch of assert_signature_transition's status
+# handling gets exercised.
+exit 1

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/signature-transition-leaked-descendant/monitor-block-proofs.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/signature-transition-leaked-descendant/monitor-block-proofs.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# `timeout --foreground` signals only this script, never the helper. If the caller reads
+# this output through a command substitution it then waits on the helper's copy of the
+# pipe -- the killed monitor still wedges the caller until the helper exits. The caller
+# must collect the output some other way; that is what the test asserts.
+
+# The leak: deliberately never killed, and holds whatever stdout it was given.
+sleep 300 &
+
+# Bash defers a trap until the foreground command finishes, so the hang is backgrounded
+# and waited on -- otherwise TERM would not be handled for the full 300s and every caller
+# would look wedged, leak or no leak.
+trap 'kill "${child}" 2>/dev/null; exit 143' TERM
+sleep 300 &
+child=$!
+wait "${child}"

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/signature-transition-wraps-imprecise/monitor-block-proofs.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/signature-transition-wraps-imprecise/monitor-block-proofs.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stand-in for the real monitor-block-proofs.sh: reproduces what check_hard_timeout
+# prints when its deadline lapses after WRAPS was already observed -- the transition is
+# real, only the exact block went unnarrowed, so it exits 0 rather than 3.
+#
+# Pins the contract the runner depends on: that `First WRAPS block:` is still the last
+# field on its own line once the caveat is added, so the summary reports a block number.
+echo ""
+echo "=== Signature Transition ==="
+echo "  First WRAPS block: 1"
+echo "  (upper bound only: exact transition block not narrowed, 4s deadline hit during binary search)"

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/signature-transition/monitor-block-proofs.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/test/fixtures/signature-transition/monitor-block-proofs.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stand-in for the real monitor-block-proofs.sh: hangs the way a port-forward to a
+# Service with no endpoints does, so assert_signature_transition's `timeout` wrapper
+# is the only thing that can end it. `timeout --foreground` only signals this direct
+# child, not its descendants, so the sleep is backgrounded and explicitly killed on
+# TERM here, the same way real grpcurl self-bounds via -max-time.
+
+trap 'kill "$child" 2>/dev/null; exit 143' TERM
+sleep 300 &
+child=$!
+wait "$child"

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/test/test-signature-transition.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/test/test-signature-transition.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fixture-based unit test for assert_signature_transition in solo-test-runner.sh:
+# a monitor-block-proofs.sh that never returns must be killed by the `timeout`
+# wrapper and reported as a timeout, not as "WRAPS not detected"; one that fails
+# immediately must still be reported as "WRAPS not detected", not a timeout.
+#
+# Runs without a cluster: SCRIPT_DIR is pointed at fixture directories whose
+# monitor-block-proofs.sh either sleeps or exits 1.
+# Exit 0 on all-pass, 1 on any failure.
+
+set -u -o pipefail
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The runner parses its options at source time, so hand it a real test file; main()
+# itself stays unrun (it is guarded on BASH_SOURCE). Sourcing overwrites SCRIPT_DIR
+# with the runner's own directory, so the fixture override has to come after.
+# shellcheck disable=SC1091
+source "${TEST_DIR}/../solo-test-runner.sh" --test "${TEST_DIR}/../../tests/tss-signature-transition.yaml"
+
+SCRIPT_DIR="${TEST_DIR}/fixtures/signature-transition"
+# Any existing directory satisfies validate_proto_path; the fake monitor ignores it.
+# shellcheck disable=SC2034 # consumed by the sourced runner
+PROTO_PATH="${SCRIPT_DIR}"
+# max_block 1 plus 1s of grace gives a 3s ceiling.
+# shellcheck disable=SC2034 # consumed by the sourced runner
+SIGNATURE_TRANSITION_GRACE_SECONDS=1
+
+passed=0
+failed=0
+function record {
+    local name="$1" ok="$2"
+    if [[ "${ok}" == "true" ]]; then
+        echo "  PASS  ${name}"
+        passed=$((passed + 1))
+    else
+        echo "  FAIL  ${name}"
+        failed=$((failed + 1))
+    fi
+}
+
+echo "assert_signature_transition with a hung monitor-block-proofs.sh"
+
+started=${SECONDS}
+status=0
+output=$(assert_signature_transition block-node-1 1 2>/dev/null) || status=$?
+elapsed=$((SECONDS - started))
+
+[[ "${status}" -ne 0 ]] && ok=true || ok=false
+record "fails instead of reporting a transition (rc=${status})" "${ok}"
+
+# The 3s ceiling plus process teardown; anything near the fixture's 300s sleep means
+# the wrapper did not fire.
+[[ "${elapsed}" -lt 10 ]] && ok=true || ok=false
+record "returns in ${elapsed}s rather than hanging" "${ok}"
+
+[[ "${output}" == *"exceeded 3s and was killed"* ]] && ok=true || ok=false
+record "names the timeout rather than 'WRAPS not detected'" "${ok}"
+
+echo ""
+echo "assert_signature_transition with a monitor-block-proofs.sh that fails immediately"
+
+SCRIPT_DIR="${TEST_DIR}/fixtures/signature-transition-failure"
+# shellcheck disable=SC2034 # consumed by the sourced runner
+PROTO_PATH="${SCRIPT_DIR}"
+status=0
+output=$(assert_signature_transition block-node-1 1 2>/dev/null) || status=$?
+
+[[ "${status}" -ne 0 ]] && ok=true || ok=false
+record "fails instead of reporting a transition (rc=${status})" "${ok}"
+
+[[ "${output}" == *"WRAPS not detected within 1 blocks (exit 1)"* ]] && ok=true || ok=false
+record "reports 'WRAPS not detected' with the exit status, not a timeout" "${ok}"
+
+echo ""
+echo "Passed: ${passed}, Failed: ${failed}"
+[[ ${failed} -eq 0 ]]

--- a/tools-and-tests/scripts/solo-e2e-test/scripts/test/test-signature-transition.sh
+++ b/tools-and-tests/scripts/solo-e2e-test/scripts/test/test-signature-transition.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# Fixture-based unit test for assert_signature_transition in solo-test-runner.sh:
-# a monitor-block-proofs.sh that never returns must be killed by the `timeout`
-# wrapper and reported as a timeout, not as "WRAPS not detected"; one that fails
-# immediately must still be reported as "WRAPS not detected", not a timeout.
+# Fixture-based unit test for the signature-transition assertion:
 #
-# Runs without a cluster: SCRIPT_DIR is pointed at fixture directories whose
-# monitor-block-proofs.sh either sleeps or exits 1.
-# Exit 0 on all-pass, 1 on any failure.
+#   - assert_signature_transition in solo-test-runner.sh, against stand-in monitors that
+#     hang, leak a descendant, or fail immediately. These need GNU `timeout`; they skip
+#     when it is absent (stock macOS) rather than hanging for 300s.
+#   - monitor-block-proofs.sh's own max_block*2 deadline, against a fake grpcurl. These
+#     need no `timeout`: the monitor bounds itself.
+#
+# Runs without a cluster. Exit 0 on all-pass, 1 on any failure.
 
 set -u -o pipefail
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REAL_PATH="${PATH}"
 
 # The runner parses its options at source time, so hand it a real test file; main()
 # itself stays unrun (it is guarded on BASH_SOURCE). Sourcing overwrites SCRIPT_DIR
@@ -19,44 +21,100 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "${TEST_DIR}/../solo-test-runner.sh" --test "${TEST_DIR}/../../tests/tss-signature-transition.yaml"
 
-SCRIPT_DIR="${TEST_DIR}/fixtures/signature-transition"
-# Any existing directory satisfies validate_proto_path; the fake monitor ignores it.
-# shellcheck disable=SC2034 # consumed by the sourced runner
-PROTO_PATH="${SCRIPT_DIR}"
-# max_block 1 plus 1s of grace gives a 3s ceiling.
-# shellcheck disable=SC2034 # consumed by the sourced runner
-SIGNATURE_TRANSITION_GRACE_SECONDS=1
+# assert_signature_transition pre-flights its target with assert_block_available_single,
+# which needs a live Block Node. These tests are about what happens once the monitor is
+# running, so stand the pre-flight down rather than mocking serverStatus.
+function assert_block_available_single {
+    echo "$1: Blocks 0-1"
+}
 
 passed=0
 failed=0
+skipped=0
+
+# Same signature as test-archive-assertions.sh's record: the real value is printed on
+# failure so a reader does not have to reconstruct the output by hand.
 function record {
-    local name="$1" ok="$2"
-    if [[ "${ok}" == "true" ]]; then
+    local name="$1" expected="$2" actual="$3"
+    if [[ "${actual}" == "${expected}" ]]; then
         echo "  PASS  ${name}"
         passed=$((passed + 1))
     else
-        echo "  FAIL  ${name}"
+        echo "  FAIL  ${name} (expected ${expected}, got ${actual})"
         failed=$((failed + 1))
     fi
 }
 
-echo "assert_signature_transition with a hung monitor-block-proofs.sh"
+# record_contains <name> <substring> <output> — on mismatch reports the last output line,
+# which is the summary assert_signature_transition ends with.
+function record_contains {
+    local name="$1" needle="$2" haystack="$3" actual
+    if [[ "${haystack}" == *"${needle}"* ]]; then
+        actual="${needle}"
+    else
+        actual="$(echo "${haystack}" | tail -1)"
+    fi
+    record "${name}" "${needle}" "${actual}"
+}
 
-started=${SECONDS}
-status=0
-output=$(assert_signature_transition block-node-1 1 2>/dev/null) || status=$?
-elapsed=$((SECONDS - started))
+function skip {
+    echo "  SKIP  $1"
+    skipped=$((skipped + 1))
+}
 
-[[ "${status}" -ne 0 ]] && ok=true || ok=false
-record "fails instead of reporting a transition (rc=${status})" "${ok}"
+# under <seconds> <ceiling> — an "elapsed" value record can compare for equality.
+function under {
+    if [[ "$1" -lt "$2" ]]; then echo "under $2s"; else echo "$1s"; fi
+}
 
-# The 3s ceiling plus process teardown; anything near the fixture's 300s sleep means
-# the wrapper did not fire.
-[[ "${elapsed}" -lt 10 ]] && ok=true || ok=false
-record "returns in ${elapsed}s rather than hanging" "${ok}"
+# ============================================================================
+# assert_signature_transition's `timeout` wrapper
+# ============================================================================
 
-[[ "${output}" == *"exceeded 3s and was killed"* ]] && ok=true || ok=false
-record "names the timeout rather than 'WRAPS not detected'" "${ok}"
+# Any existing directory satisfies validate_proto_path; the fake monitors ignore it.
+# max_block 1 plus 1s of grace gives a 3s ceiling.
+# shellcheck disable=SC2034 # consumed by the sourced runner
+SIGNATURE_TRANSITION_GRACE_SECONDS=1
+
+if [[ -z "${TIMEOUT_BIN}" ]]; then
+    echo "assert_signature_transition's timeout wrapper"
+    skip "hung monitor / leaked descendant scenarios (no timeout or gtimeout on PATH)"
+else
+    echo "assert_signature_transition with a hung monitor-block-proofs.sh"
+
+    SCRIPT_DIR="${TEST_DIR}/fixtures/signature-transition"
+    # shellcheck disable=SC2034 # consumed by the sourced runner
+    PROTO_PATH="${SCRIPT_DIR}"
+    started=${SECONDS}
+    status=0
+    output=$(assert_signature_transition block-node-1 1 2>/dev/null) || status=$?
+    elapsed=$((SECONDS - started))
+
+    record "fails instead of reporting a transition" "rc=1" "rc=${status}"
+    # The 3s ceiling plus process teardown; anything near the fixture's 300s sleep means
+    # the wrapper did not fire.
+    record "returns rather than hanging" "under 10s" "$(under "${elapsed}" 10)"
+    record_contains "names the timeout rather than 'WRAPS not detected'" \
+        "exceeded 3s and was killed by the wrapper" "${output}"
+
+    echo ""
+    echo "assert_signature_transition with a monitor-block-proofs.sh that leaks a descendant"
+
+    SCRIPT_DIR="${TEST_DIR}/fixtures/signature-transition-leaked-descendant"
+    # shellcheck disable=SC2034 # consumed by the sourced runner
+    PROTO_PATH="${SCRIPT_DIR}"
+    started=${SECONDS}
+    status=0
+    output=$(assert_signature_transition block-node-1 1 2>/dev/null) || status=$?
+    elapsed=$((SECONDS - started))
+
+    record "fails instead of reporting a transition" "rc=1" "rc=${status}"
+    # The leaked helper sleeps 300s. Anything near that means the runner waited on the
+    # descendant's copy of a pipe rather than on the child `timeout` actually killed.
+    record "returns despite the leaked descendant" "under 10s" "$(under "${elapsed}" 10)"
+    record_contains "names the timeout rather than 'WRAPS not detected'" \
+        "exceeded 3s and was killed by the wrapper" "${output}"
+fi
 
 echo ""
 echo "assert_signature_transition with a monitor-block-proofs.sh that fails immediately"
@@ -67,12 +125,58 @@ PROTO_PATH="${SCRIPT_DIR}"
 status=0
 output=$(assert_signature_transition block-node-1 1 2>/dev/null) || status=$?
 
-[[ "${status}" -ne 0 ]] && ok=true || ok=false
-record "fails instead of reporting a transition (rc=${status})" "${ok}"
-
-[[ "${output}" == *"WRAPS not detected within 1 blocks (exit 1)"* ]] && ok=true || ok=false
-record "reports 'WRAPS not detected' with the exit status, not a timeout" "${ok}"
+record "fails instead of reporting a transition" "rc=1" "rc=${status}"
+record_contains "reports 'WRAPS not detected' with the exit status, not a timeout" \
+    "WRAPS not detected within 1 blocks (exit 1)" "${output}"
 
 echo ""
-echo "Passed: ${passed}, Failed: ${failed}"
+echo "assert_signature_transition with a monitor-block-proofs.sh that found WRAPS imprecisely"
+
+SCRIPT_DIR="${TEST_DIR}/fixtures/signature-transition-wraps-imprecise"
+# shellcheck disable=SC2034 # consumed by the sourced runner
+PROTO_PATH="${SCRIPT_DIR}"
+status=0
+output=$(assert_signature_transition block-node-1 1 2>/dev/null) || status=$?
+
+# Observing WRAPS satisfies the assertion; the deadline only cost the exact block number.
+record "treats an unnarrowed transition as a pass" "rc=0" "rc=${status}"
+record_contains "reports the block WRAPS was seen at, not the caveat line" \
+    "Schnorr -> WRAPS at block 1" "${output}"
+
+# ============================================================================
+# monitor-block-proofs.sh's own max_block*2 deadline (real monitor, fake grpcurl)
+# ============================================================================
+# max_block 2 puts the monitor's deadline at 4s; the grace keeps the wrapper, when
+# present, well clear of it so the monitor's own deadline is what fires. A stride of 1
+# is needed to enter the scan loop at all with a max_block that small.
+SCRIPT_DIR="${TEST_DIR}/.."
+# shellcheck disable=SC2034 # consumed by the sourced runner
+SIGNATURE_TRANSITION_GRACE_SECONDS=30
+export MONITOR_BLOCK_STEP=1
+
+# A fixture missing from the checkout otherwise surfaces only as "PROTO_PATH invalid".
+for fixture in "${TEST_DIR}"/fixtures/monitor-*/grpcurl; do
+    [[ -x "${fixture}" ]] || { echo "  FAIL  fixture missing: ${fixture}"; failed=$((failed + 1)); }
+done
+
+echo ""
+echo "monitor-block-proofs.sh hitting its own deadline with no WRAPS seen"
+
+PROTO_PATH="${TEST_DIR}/fixtures/monitor-hard-timeout"
+PATH="${PROTO_PATH}:${REAL_PATH}"
+started=${SECONDS}
+status=0
+output=$(assert_signature_transition block-node-1 2 2>/dev/null) || status=$?
+elapsed=$((SECONDS - started))
+PATH="${REAL_PATH}"
+
+record "fails instead of reporting a transition" "rc=1" "rc=${status}"
+record "returns rather than waiting for blocks forever" "under 20s" "$(under "${elapsed}" 20)"
+# Exit 3, not the 143 a bare SIGTERM death produces and not the wrapper's 124.
+record_contains "names the monitor's own deadline" \
+    "hit its own 4s deadline (max_block * 2)" "${output}"
+
+
+echo ""
+echo "Passed: ${passed}, Failed: ${failed}, Skipped: ${skipped}"
 [[ ${failed} -eq 0 ]]

--- a/tools-and-tests/scripts/solo-e2e-test/tests/basic-load.yaml
+++ b/tools-and-tests/scripts/solo-e2e-test/tests/basic-load.yaml
@@ -37,14 +37,14 @@ events:
   - id: stop-load
     type: load-stop
     description: "Stop load generation (cleanup)"
-    delay: 220  # ~30s buffer after load ends naturally
+    delay: 300
     args:
       test_class: CryptoTransferLoadTest
 
   - id: final-metrics
     type: print-metrics
     description: "Print final metrics"
-    delay: 240  # 4 minutes total
+    delay: 320
     args:
       target: all
 


### PR DESCRIPTION
## Reviewer Notes

* Runs the `tss-signature-transition` test before the backfill tests in topologies where a Block Node is killed, so it no longer waits on a node that is already gone
* Bounds the block proof monitor with a per-call gRPC deadline
* Adds step timeouts to the deploy and test steps of the Solo E2E workflow

## Related Issue(s)

Closes #3603