### PR TITLE
docs(block-node): add CN stream mode troubleshooting and section-wise cross-links

### DIFF
--- a/docs/block-node/operations/block-node-hardware-specifications.md
+++ b/docs/block-node/operations/block-node-hardware-specifications.md
@@ -11,8 +11,8 @@ deployments.
 
 |                       Node type                        |        Network        |                                  See section                                  |
 |--------------------------------------------------------|-----------------------|-------------------------------------------------------------------------------|
-| Tier 1 — receives stream directly from Consensus Nodes | Mainnet               | [Tier 1 Mainnet Server Specifications](#tier-1-mainnet-server-specifications) |
-| Tier 2 — receives stream from another Block Node       | Mainnet               | [Tier 2 Server Specifications](#tier-2-server-specifications)                 |
+| Tier 1 - receives stream directly from Consensus Nodes | Mainnet               | [Tier 1 Mainnet Server Specifications](#tier-1-mainnet-server-specifications) |
+| Tier 2 - receives stream from another Block Node       | Mainnet               | [Tier 2 Server Specifications](#tier-2-server-specifications)                 |
 | Any tier                                               | Testnet or Previewnet | [Testnet and Previewnet Sizing](#testnet-and-previewnet-sizing)               |
 
 ---
@@ -100,7 +100,7 @@ No state services are offered and most if not all services are expected to be pr
 ### Rolling-History (Partial History) Tier 2
 
 A Rolling-History Tier 2 node does not store full blockchain history. CPU and
-RAM requirements match Tier 1 — the primary driver is the State Management task
+RAM requirements match Tier 1 - the primary driver is the State Management task
 (which handles live state and serves downstream subscribers), not verification
 or persistence alone. Exact minimums for nodes that do not manage live state
 have not yet been formally benchmarked. The `stream-publisher` plugin is not
@@ -111,7 +111,7 @@ is sized to the retention window rather than the full block history.
 |-------------------|-----------------------------------------------------------------------------------|
 | CPU               | 24 cores / 48 threads, single socket, ≥ 2.0 GHz base clock                        |
 | RAM               | 256 GB                                                                            |
-| Fast NVMe Disk    | 7.5 TB NVMe SSD (recent blocks + live state; partially optional — see note below) |
+| Fast NVMe Disk    | 7.5 TB NVMe SSD (recent blocks + live state; partially optional - see note below) |
 | Bulk Storage Disk | Size to retention window (see table below)                                        |
 | Network           | 10 Gbps NIC minimum (see [Network Requirements](#network-requirements))           |
 | OS                | Linux host OS (Ubuntu 24.04 LTS or Debian 13.x LTS recommended)                   |
@@ -183,7 +183,7 @@ across all drives in the configuration, not per-drive requirements.
 | Disk Type | Sustained Write | Sustained Read |  Write IOPS   |   Read IOPS   | Random Read AIO IOPS | P99 Write Latency | P99 Read Latency |
 |-----------|-----------------|----------------|---------------|---------------|----------------------|-------------------|------------------|
 | Fast NVMe | 4 GBps          | 6 GBps         | 350k (random) | 900k (random) | 1M                   | < 300 µs          | < 200 µs         |
-| Bulk Disk | 300 MBps        | 1 GBps         | 1200          | 4000          | n/a                  | —                 | —                |
+| Bulk Disk | 300 MBps        | 1 GBps         | 1200          | 4000          | n/a                  | -                 | -                |
 
 #### Notes
 
@@ -242,7 +242,7 @@ T = transactions per block = TPS × block_interval
 
 #### Assumptions used in the tables below
 
-- Block interval: 1 second (1 block/sec — conservative; mainnet in early 2026
+- Block interval: 1 second (1 block/sec - conservative; mainnet in early 2026
   runs at 0.5 blocks/sec)
 - Compression ratio: 2.39× (zstd, from v3 mixed-workload model)
 - Worst-case egress subscribers: 33 (13 Block Nodes backfilling +
@@ -307,7 +307,7 @@ uncompressed stream. All figures use the raw (uncompressed) wire size.
 |  2,000 |               156 GB |                 4.6 TB |               5.1 TB |                 154 TB |
 | 20,000 |               1.5 TB |                  45 TB |                50 TB |                 1.5 PB |
 
-**Worst-case peak bandwidth (burst — 4 in-flight blocks per subscriber):**
+**Worst-case peak bandwidth (burst - 4 in-flight blocks per subscriber):**
 
 |    TPS | Steady-state egress (33 sub) | Burst egress (33 sub, 4× in-flight) |
 |-------:|-----------------------------:|------------------------------------:|
@@ -350,3 +350,4 @@ uncompressed stream. All figures use the raw (uncompressed) wire size.
   shares the Fast NVMe disk, ensure sufficient capacity remains reserved for the
   application, reclaim ephemeral data aggressively, and avoid scheduling
   maintenance tasks at UTC midnight. Allow at least 10 GB for OCI image storage.
+- **Disk space exhaustion**: If a running Block Node reports disk-full errors or stops writing blocks, see [Disk full / out of space](../troubleshooting.md#disk-full--out-of-space) for immediate triage steps and longer-term remediation.

--- a/docs/block-node/operations/connecting-a-mirror-node-to-a-block-node.md
+++ b/docs/block-node/operations/connecting-a-mirror-node-to-a-block-node.md
@@ -43,7 +43,7 @@ The table below summarises the Mirror-Node-side technical requirements. For Bloc
 |    Requirement    |                                                                                                                                                                                                                                                              Details                                                                                                                                                                                                                                                              |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Network access    | TCP connectivity from the Mirror Node host to each Block Node host on its Subscribe API port (`40980` in LFH profile; `40840` in base-chart default).                                                                                                                                                                                                                                                                                                                                                                             |
-| Proto definitions | `block_stream_subscribe_service.proto`, `node_service.proto`, and `shared_message_types.proto` from [`protobuf-sources/src/main/proto/block-node/api/`](https://github.com/hiero-ledger/hiero-block-node/tree/main/protobuf-sources/src/main/proto/block-node/api). For ad-hoc `grpcurl` use, the matching versioned bundle from the [Block Node releases](https://github.com/hiero-ledger/hiero-block-node/releases) page is the easiest source — see [Step 1](#step-1-confirm-each-block-node-is-reachable-and-serving-blocks). |
+| Proto definitions | `block_stream_subscribe_service.proto`, `node_service.proto`, and `shared_message_types.proto` from [`protobuf-sources/src/main/proto/block-node/api/`](https://github.com/hiero-ledger/hiero-block-node/tree/main/protobuf-sources/src/main/proto/block-node/api). For ad-hoc `grpcurl` use, the matching versioned bundle from the [Block Node releases](https://github.com/hiero-ledger/hiero-block-node/releases) page is the easiest source - see [Step 1](#step-1-confirm-each-block-node-is-reachable-and-serving-blocks). |
 | gRPC reflection   | The Block Node does **not** enable gRPC server reflection on the public port. Clients must supply protobuf descriptors explicitly.                                                                                                                                                                                                                                                                                                                                                                                                |
 
 ## Configuration
@@ -58,7 +58,7 @@ Configure the Mirror Node via `application.yml` (or equivalent Spring property s
 
 |                 Property                 | Default |                                                             Set to                                                              |
 |------------------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------|
-| `hiero.mirror.importer.block.enabled`    | `false` | `true` — master switch for the block-stream source.                                                                             |
+| `hiero.mirror.importer.block.enabled`    | `false` | `true` - master switch for the block-stream source.                                                                             |
 | `hiero.mirror.importer.block.sourceType` | `AUTO`  | `BLOCK_NODE` to subscribe exclusively, or `AUTO` to try Block Node first and fall back to record-file ingestion if unavailable. |
 
 #### Block Node endpoints
@@ -67,7 +67,7 @@ Declare one entry under `hiero.mirror.importer.block.nodes[]` per target Block N
 
 |                     Property                      | Default |                                                Effect                                                 |
 |---------------------------------------------------|---------|-------------------------------------------------------------------------------------------------------|
-| `hiero.mirror.importer.block.nodes[].host`        | —       | Host or IP of the Block Node gRPC service. **Required.**                                              |
+| `hiero.mirror.importer.block.nodes[].host`        | -       | Host or IP of the Block Node gRPC service. **Required.**                                              |
 | `hiero.mirror.importer.block.nodes[].port`        | `40980` | Subscribe API port of the Block Node. LFH profile default: `40980`; base-chart default: `40840`.      |
 | `hiero.mirror.importer.block.nodes[].priority`    | `0`     | Selection priority. **Lower value is higher priority.** Highest-priority reachable node is preferred. |
 | `hiero.mirror.importer.block.nodes[].requiresTls` | `false` | Set to `true` if the Block Node endpoint is fronted by TLS termination.                               |
@@ -153,7 +153,7 @@ grpcurl -plaintext -emit-defaults \
   org.hiero.block.api.BlockNodeService/serverStatus
 ```
 
-> **Note:** The download uses `curl -LO` rather than `wget` because `wget` is not installed on macOS by default. On Linux either tool works. The extracted tarball lays out `block/`, `block-node/`, `platform/`, `services/`, and `streams/` directly in the current directory — there is no version-prefixed top-level folder.
+> **Note:** The download uses `curl -LO` rather than `wget` because `wget` is not installed on macOS by default. On Linux either tool works. The extracted tarball lays out `block/`, `block-node/`, `platform/`, `services/`, and `streams/` directly in the current directory - there is no version-prefixed top-level folder.
 
 - **Expected output** (active node with blocks ingested):
 
@@ -302,4 +302,4 @@ grpcurl -plaintext -d '{}' \
 - [Block Node Overview](../block-node-overview.md)
 - [Block Node Configuration](../configuration.md)
 - [Block Node Metrics](../metrics.md)
-- [Block Node Troubleshooting](../troubleshooting.md)
+- [Mirror Node cannot connect to Block Node](../troubleshooting.md#mirror-node-operator-mirror-node-cannot-connect-to-block-node)

--- a/docs/block-node/operations/consensus-node-to-block-node-configuration.md
+++ b/docs/block-node/operations/consensus-node-to-block-node-configuration.md
@@ -200,7 +200,7 @@ curl -s http://<BN_HOST>:16007/metrics | grep blocknode_publisher_block_items_re
 A steadily increasing value confirms the Block Node is receiving blocks from the CN.
 A value of `0` or no metric present means the CN has not yet established a streaming connection.
 
-See [Block Node Metrics](../metrics.md) for the full metrics reference and [Block Node Troubleshooting](../troubleshooting.md) if the connection does not establish.
+See [Block Node Metrics](../metrics.md) for the full metrics reference and [Block Node not receiving new blocks](../troubleshooting.md#block-node-not-receiving-new-blocks) if the connection does not establish.
 
 ## Optional - Tune connection behaviour
 

--- a/docs/block-node/operations/network-ports-and-protocols.md
+++ b/docs/block-node/operations/network-ports-and-protocols.md
@@ -58,11 +58,11 @@ Operators familiar with the Hedera consensus network may reach for the wrong por
 
 ### gRPC Block Stream APIs
 
-The Block Node exposes gRPC APIs that form its primary network surface. In the LFH production profile each API runs on its own dedicated port; the API name is the stable identifier — port numbers are configurable defaults.
+The Block Node exposes gRPC APIs that form its primary network surface. In the LFH production profile each API runs on its own dedicated port; the API name is the stable identifier - port numbers are configurable defaults.
 
-- **Publish API** — Consensus Nodes stream finalized blocks into the Block Node via `BlockStreamPublishService`. Initiator: Consensus Node.
-- **Subscribe API** — Mirror Nodes and downstream Block Nodes consume the block stream via `BlockStreamSubscribeService.subscribeBlockStream`. Initiator: subscriber.
-- **Status API** — clients query block-range availability, available services, and response latency via `BlockNodeService.serverStatus`. Initiator: any Block Node client.
+- **Publish API** - Consensus Nodes stream finalized blocks into the Block Node via `BlockStreamPublishService`. Initiator: Consensus Node.
+- **Subscribe API** - Mirror Nodes and downstream Block Nodes consume the block stream via `BlockStreamSubscribeService.subscribeBlockStream`. Initiator: subscriber.
+- **Status API** - clients query block-range availability, available services, and response latency via `BlockNodeService.serverStatus`. Initiator: any Block Node client.
 
 Health probes run on their own dedicated HTTP port (see [Health and readiness probes](#health-and-readiness-probes)).
 
@@ -100,7 +100,8 @@ The Block Node exposes OpenMetrics-format counters and gauges via Helidon's metr
 
 - The metrics endpoint is typically reachable only from within the cluster. Most deployments scrape it via a sidecar or a `ServiceMonitor`; exposing it externally is rarely needed and increases attack surface.
 - The Prometheus convention of suffixing counter names with `_total` is applied at scrape time; the underlying metric name in the Block Node is registered without the suffix.
-- Port `16007` is dedicated exclusively to metrics and is independent of all Block Node gRPC services and web servers. It does not share a port with any other service in any deployment profile — including base-chart deployments where all gRPC services share `service.port`.
+- Port `16007` is dedicated exclusively to metrics and is independent of all Block Node gRPC services and web servers. It does not share a port with any other service in any deployment profile - including base-chart deployments where all gRPC services share `service.port`.
+- If the metrics endpoint is unreachable despite the port being open, see [Metrics endpoint not accessible](../troubleshooting.md#metrics-endpoint-not-accessible) for step-by-step triage.
 
 ### 5005 - JVM remote debug (dev/test only)
 
@@ -141,6 +142,7 @@ When the `backfill` plugin is enabled, the Block Node acts as a gRPC client to a
 
 - A Block Node with no `BACKFILL_BLOCK_NODE_SOURCES_PATH` file mounted makes no outbound gRPC connections of this kind. The plugin, if present, loads but stays idle.
 - The list of peer Block Nodes is operator-supplied via a JSON file mounted into the pod. Firewalls and security groups must permit egress to every listed peer's Subscribe API port (`40980` in LFH; `40840` in base-chart default).
+- If backfill is configured but blocks are not being pulled, see [Blocks are not being backfilled](../troubleshooting.md#blocks-are-not-being-backfilled) for step-by-step triage.
 
 ### Health and readiness probes
 
@@ -238,7 +240,7 @@ The Block Node Helm chart does not ship a `NetworkPolicy` template or any other 
 
 ### Must allow (LFH production profile)
 
-- **Inbound TCP `40984`** from Consensus Node source IPs only — restrict this port to known publisher IPs; deny all other inbound.
+- **Inbound TCP `40984`** from Consensus Node source IPs only - restrict this port to known publisher IPs; deny all other inbound.
 - **Inbound TCP `40980`** from Mirror Nodes and peer Block Nodes that subscribe to this Block Node.
 - **Inbound TCP `40981`** from authorized block-access clients.
 - **Inbound TCP `40982`** from monitoring and operator tooling (server-status API).
@@ -248,7 +250,7 @@ The Block Node Helm chart does not ship a `NetworkPolicy` template or any other 
 
 > **Additional outbound connections.** The backfill egress rule above covers the most common explicitly-configured outbound flow. Depending on profile and enabled plugins, a Block Node may also make outbound connections for Mirror Node integration, RSA and TSS bootstrap, and (for the Remote Full History profile) S3-compatible object storage. Solo Provisioner will manage inbound and outbound firewall rules automatically in a future release when traffic shaping support is enabled.
 >
-> **Base-chart default (non-LFH deployments).** When per-service ports are not set, replace the per-port rules above with a single **Inbound TCP `40840`** rule covering all services, and **Outbound TCP `40840`** for backfill egress. The kubelet health probe still uses **Inbound TCP `40983`** and Prometheus metrics still uses **Inbound TCP `16007`** — both ports are set explicitly in the base `values.yaml` regardless of whether the LFH profile is active.
+> **Base-chart default (non-LFH deployments).** When per-service ports are not set, replace the per-port rules above with a single **Inbound TCP `40840`** rule covering all services, and **Outbound TCP `40840`** for backfill egress. The kubelet health probe still uses **Inbound TCP `40983`** and Prometheus metrics still uses **Inbound TCP `16007`** - both ports are set explicitly in the base `values.yaml` regardless of whether the LFH profile is active.
 
 ### Must deny
 
@@ -259,3 +261,5 @@ The Block Node Helm chart does not ship a `NetworkPolicy` template or any other 
 - On Kubernetes, a `NetworkPolicy` scoped to the Block Node pod (typically by `app.kubernetes.io/name: block-node-server` label) expresses the above. Restrict `from:` and `to:` to specific namespace or pod selectors rather than `{}` open-to-all.
 - On bare-metal or cloud-VM deployments, a host firewall or cloud security group enforces the same rules. Cloud security groups vary in stateful vs stateless semantics; consult the provider's documentation.
 - DNS egress to a resolver is required if `BACKFILL_BLOCK_NODE_SOURCES_PATH` lists peer Block Nodes by hostname (the JSON file accepts either hostnames or IPs).
+
+If subscribers fail to connect despite correct firewall rules, see [Block Node operator: subscribers cannot connect](../troubleshooting.md#block-node-operator-subscribers-cannot-connect) for step-by-step triage.

--- a/docs/block-node/operations/preparing-your-block-node-for-wrb-cutover.md
+++ b/docs/block-node/operations/preparing-your-block-node-for-wrb-cutover.md
@@ -14,7 +14,7 @@ Complete all steps in this section before every upgrade, regardless of release.
 
 ### Confirm Block Node health
 
-Before upgrading, confirm the Block Node is healthy. Do not upgrade an unhealthy node — an in-progress failure becomes a stuck rollout.
+Before upgrading, confirm the Block Node is healthy. Do not upgrade an unhealthy node - an in-progress failure becomes a stuck rollout.
 
 1. List all pods and confirm the Block Node pod is `Running` with all containers ready:
 
@@ -44,7 +44,7 @@ Before upgrading, confirm the Block Node is healthy. Do not upgrade an unhealthy
      org.hiero.block.api.BlockNodeService/serverStatus
    ```
 
-   Record `firstAvailableBlock` and `lastAvailableBlock`. Both should be sensible block numbers — not `18446744073709551615` (the sentinel for "no blocks yet") — if the Block Node has been ingesting. For instructions on downloading the protobuf bundle into `~/bn-proto`, see [Connecting a Mirror Node to a Block Node](./connecting-a-mirror-node-to-a-block-node.md).
+   Record `firstAvailableBlock` and `lastAvailableBlock`. Both should be sensible block numbers - not `18446744073709551615` (the sentinel for "no blocks yet") - if the Block Node has been ingesting. For instructions on downloading the protobuf bundle into `~/bn-proto`, see [Connecting a Mirror Node to a Block Node](./connecting-a-mirror-node-to-a-block-node.md).
 
 3. Confirm Alloy telemetry is shipping (if configured):
 
@@ -77,7 +77,7 @@ The Block Node uses five persistent volumes. Confirm each is mounted and has ade
 | `archive`      | `blockNode.persistence.archive.mountPath` (default `/opt/hiero/block-node/data/historic`)     | 90 TB              | Compressed historic block archive                                                       |
 | `verification` | `blockNode.persistence.verification.mountPath` (default `/opt/hiero/block-node/verification`) | 50 GB              | Block hash state and verification data                                                  |
 | `logging`      | `blockNode.persistence.logging.mountPath` (default `/opt/hiero/block-node/logs`)              | 100 GB             | Application logs                                                                        |
-| `plugins`      | `blockNode.persistence.plugins`                                                               | —                  | Plugin JARs; always mounted but may contain no JARs until plugins are explicitly loaded |
+| `plugins`      | `blockNode.persistence.plugins`                                                               | -                  | Plugin JARs; always mounted but may contain no JARs until plugins are explicitly loaded |
 
 > Note: The exact mount paths depend on your Helm values. Run `helm -n block-node get values <release-name>` to inspect your installation's overrides.
 >
@@ -139,9 +139,9 @@ Complete the subsection below that matches the upgrade you are preparing for. Fu
 
 ### WRB streaming cutover prep
 
-**Applies to:** the Consensus Node release that activates Wrapped Record Block (WRB) streaming — currently scheduled for CN release 0.75.0. The exact release may change if release testing surfaces a blocker; your Hashgraph PoC will confirm the target release before the maintenance window.
+**Applies to:** the Consensus Node release that activates Wrapped Record Block (WRB) streaming - currently scheduled for CN release 0.75.0. The exact release may change if release testing surfaces a blocker; your Hashgraph PoC will confirm the target release before the maintenance window.
 
-For the full network cutover timeline — phases, CN-side WRB catch-up, [TSS](../glossary.md#tss-hintsts) ceremony, and [Jumpstart Data](../glossary.md#jumpstart-data) — see [Cutover Process and Timeline](../Cutover-Process.md).
+For the full network cutover timeline - phases, CN-side WRB catch-up, [TSS](../glossary.md#tss-hintsts) ceremony, and [Jumpstart Data](../glossary.md#jumpstart-data) - see [Cutover Process and Timeline](../Cutover-Process.md).
 
 **What is changing:** from the cutover release onwards, Consensus Nodes begin producing Wrapped Recordfile Blocks with aggregated RSA signature Block Proofs. The production of Record files uploaded to S3 storage will continue until the cutover to TSS and Block Streams in a later release. Any preview blocks stored by the Block Node before the cutover are invalid and must be discarded before the BN can receive and store authoritative WRB history. Do not skip the reset step even if the BN appears to be functioning normally.
 
@@ -207,7 +207,7 @@ The `roster-bootstrap-rsa` plugin must be included in your Block Node's plugin l
 
 **Enable the plugin**
 
-Add `roster-bootstrap-rsa` to your plugin list in `block-node-values.yaml`. Append it to your existing `plugins.names` value — the example below shows the full plugin list used for [LFH](../glossary.md#local-full-history-lfh) nodes on previewnet, provided for reference:
+Add `roster-bootstrap-rsa` to your plugin list in `block-node-values.yaml`. Append it to your existing `plugins.names` value - the example below shows the full plugin list used for [LFH](../glossary.md#local-full-history-lfh) nodes on previewnet, provided for reference:
 
 ```yaml
 plugins:
@@ -216,7 +216,7 @@ plugins:
 
 **Mirror Node auto-fetch (mainnet cohort default)**
 
-When `ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL` is set in your `block-node-values.yaml`, the plugin fetches the roster from the Mirror Node REST API at startup and caches it locally. After `block node reset`, the cached copy is cleared along with the rest of the storage directories and is automatically re-fetched on the next pod start — no manual intervention is needed. Before the cutover window, confirm outbound connectivity to the Mirror Node is available from the BN host.
+When `ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL` is set in your `block-node-values.yaml`, the plugin fetches the roster from the Mirror Node REST API at startup and caches it locally. After `block node reset`, the cached copy is cleared along with the rest of the storage directories and is automatically re-fetched on the next pod start - no manual intervention is needed. Before the cutover window, confirm outbound connectivity to the Mirror Node is available from the BN host.
 
 Set the URL in your Helm values overlay:
 
@@ -233,13 +233,13 @@ Mirror Node base URLs by network:
 | Testnet    | `https://testnet.mirrornode.hedera.com`        |
 | Previewnet | `https://previewnet.mirrornode.hedera.com`     |
 
-> Note: If the Mirror Node is unreachable, the plugin polls indefinitely — every 5 seconds until the first roster is fetched, then every 60 seconds for periodic refresh. Both intervals are configurable. WRB proof verification is non-functional until the roster is available.
+> Note: If the Mirror Node is unreachable, the plugin polls indefinitely - every 5 seconds until the first roster is fetched, then every 60 seconds for periodic refresh. Both intervals are configurable. WRB proof verification is non-functional until the roster is available.
 
 **Peer Block Node query**
 
 All Tier 1 Block Nodes should have at least one peer Block Node source configured; more than one is recommended for redundancy. When `roster.bootstrap.rsa.blockNodeSourcesPath` is set, the plugin queries configured peer Block Nodes via gRPC to retrieve the roster. This runs concurrently with the Mirror Node query; whichever responds first provides the initial roster. The peer BN query follows the same two-phase polling schedule (5-second initial interval, 60-second subsequent interval, both configurable).
 
-This is the **same file** referenced by `BACKFILL_BLOCK_NODE_SOURCES_PATH` — configuring it once serves both the roster-bootstrap-rsa plugin and the backfill plugin. Set the path in your Helm values overlay:
+This is the **same file** referenced by `BACKFILL_BLOCK_NODE_SOURCES_PATH` - configuring it once serves both the roster-bootstrap-rsa plugin and the backfill plugin. Set the path in your Helm values overlay:
 
 ```yaml
 config:
@@ -270,7 +270,7 @@ kubectl -n block-node exec $BN_POD -c block-node-server -- \
 
 - **If the file is missing after reset:** re-deliver it from your off-host backup using the mechanism in your cohort's `block-node-values.yaml`.
 
-In either case, confirm the roster loaded cleanly after the pod starts by querying `serverStatusDetail` — the response should contain a non-empty `rosterHash` field:
+In either case, confirm the roster loaded cleanly after the pod starts by querying `serverStatusDetail` - the response should contain a non-empty `rosterHash` field:
 
 ```bash
 grpcurl -plaintext -emit-defaults \
@@ -285,7 +285,7 @@ grpcurl -plaintext -emit-defaults \
 
 #### Configure backfill sources (if required)
 
-After the block store reset, the BN backfills WRB history automatically as long as other Block Nodes on the network already hold the relevant block range. All Tier 1 operators should have at least one Block Node source configured for both backfill and peer roster queries. **Most operators do not need to manually configure a specific backfill source** — once peer Block Nodes are advertising history on the network, the backfill plugin discovers them through the normal backfill path.
+After the block store reset, the BN backfills WRB history automatically as long as other Block Nodes on the network already hold the relevant block range. All Tier 1 operators should have at least one Block Node source configured for both backfill and peer roster queries. **Most operators do not need to manually configure a specific backfill source** - once peer Block Nodes are advertising history on the network, the backfill plugin discovers them through the normal backfill path.
 
 **Enable greedy backfill**
 
@@ -300,9 +300,9 @@ helm -n block-node get values <release-name> | grep BACKFILL_GREEDY
 
 - **Expected:** `BACKFILL_GREEDY: "true"`
 
-**Edge case — bootstrapping from genesis when no public BN holds the history yet:**
+**Edge case - bootstrapping from genesis when no public BN holds the history yet:**
 
-During the initial mainnet WRB cutover, the wrapped record block history may not yet be available from public Block Nodes. In this case, a special-purpose Block Node holding the offline-wrapped WRBs serves as a temporary backfill source. Operators who need access to this node will receive the endpoint and connection details through a separate operator communication channel — it is not published in this document.
+During the initial mainnet WRB cutover, the wrapped record block history may not yet be available from public Block Nodes. In this case, a special-purpose Block Node holding the offline-wrapped WRBs serves as a temporary backfill source. Operators who need access to this node will receive the endpoint and connection details through a separate operator communication channel - it is not published in this document.
 
 If you are directed by your Hashgraph PoC to configure a specific backfill source:
 
@@ -336,7 +336,7 @@ If you are directed by your Hashgraph PoC to configure a specific backfill sourc
 
    > Note: Even when backfilling from a special-purpose BN, all blocks are cryptographically verified by the BN's verification plugin before they are stored. Block legitimacy is confirmed regardless of the backfill source.
 
-3. Monitor backfill progress by querying `serverStatus` — `lastAvailableBlock` should increase steadily as blocks are fetched and verified:
+3. Monitor backfill progress by querying `serverStatus` - `lastAvailableBlock` should increase steadily as blocks are fetched and verified:
 
    ```bash
    grpcurl -plaintext -emit-defaults \
@@ -351,13 +351,13 @@ If you are directed by your Hashgraph PoC to configure a specific backfill sourc
 
 #### Configure TSS bootstrap (if TSS is enabled)
 
-If your network has TSS enabled, the Block Node needs TSS data to verify blocks. On a fresh genesis network, block 0 carries all TSS data and the Block Node ingests it automatically — no bootstrap file is needed. On a non-genesis network (for example, a node joining an already-running network or being restored after a reset post-cutover), you must supply the TSS data before startup.
+If your network has TSS enabled, the Block Node needs TSS data to verify blocks. On a fresh genesis network, block 0 carries all TSS data and the Block Node ingests it automatically - no bootstrap file is needed. On a non-genesis network (for example, a node joining an already-running network or being restored after a reset post-cutover), you must supply the TSS data before startup.
 
 Two options are supported in parallel; whichever resolves first takes effect:
 
 **Bootstrap file**
 
-Set `app.state.tssBootstrapFilePath` (default: `/opt/hiero/block-node/application-state/tss-bootstrap-roster.json`) to the path of a JSON file containing the TSS data. The file is generated by the WRB CLI during cutover. Deliver it using the same mechanism as the RSA bootstrap file — your Hashgraph PoC will provide it for the mainnet cohort.
+Set `app.state.tssBootstrapFilePath` (default: `/opt/hiero/block-node/application-state/tss-bootstrap-roster.json`) to the path of a JSON file containing the TSS data. The file is generated by the WRB CLI during cutover. Deliver it using the same mechanism as the RSA bootstrap file - your Hashgraph PoC will provide it for the mainnet cohort.
 
 The file format:
 
@@ -410,7 +410,7 @@ Set `roster.bootstrap.tss.blockNodeSourcesPath` (default: `""`) to the path of a
 }
 ```
 
-After the Block Node starts, confirm TSS data loaded by querying `serverStatusDetail` — the response should include a non-empty `tssData` field:
+After the Block Node starts, confirm TSS data loaded by querying `serverStatusDetail` - the response should include a non-empty `tssData` field:
 
 ```bash
 grpcurl -plaintext -emit-defaults \
@@ -452,13 +452,13 @@ If any check fails, resolve the issue and confirm readiness with your Hashgraph 
 | `solo-provisioner block node check` fails with "profile flag is required"              | `--profile` flag missing                                             | Always pass `--profile=mainnet`.                                                                                                                                                                                                                                                          |
 | `block node reset` exits with "permission denied"                                      | Command run without `sudo`                                           | Prefix with `sudo`.                                                                                                                                                                                                                                                                       |
 | Pod stuck in `0/1` or init containers running after reset                              | Init containers setting up storage and resolving plugins             | Allow 2-5 minutes. Run `kubectl -n block-node describe pod $BN_POD` to see init-container status.                                                                                                                                                                                         |
-| RSA roster missing or not loaded after reset                                           | Mirror Node unreachable, or file missing (file-based delivery)       | If using Mirror Node auto-fetch, confirm `ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL` is set and the Mirror Node is reachable — the roster is re-fetched automatically on pod start. If using file-based delivery, re-deliver from off-host backup.                                        |
+| RSA roster missing or not loaded after reset                                           | Mirror Node unreachable, or file missing (file-based delivery)       | If using Mirror Node auto-fetch, confirm `ROSTER_BOOTSTRAP_RSA_MIRROR_NODE_BASE_URL` is set and the Mirror Node is reachable - the roster is re-fetched automatically on pod start. If using file-based delivery, re-deliver from off-host backup.                                        |
 | Backfill not starting                                                                  | `backfill.blockNodeSourcesPath` is blank or points to a missing file | Confirm `BACKFILL_BLOCK_NODE_SOURCES_PATH` is set and the referenced JSON file exists in the pod.                                                                                                                                                                                         |
 | `firstAvailableBlock` still shows old block numbers after reset                        | Reset did not complete successfully                                  | Check `sudo head /opt/solo/weaver/logs/solo-provisioner.log` for the step that failed.                                                                                                                                                                                                    |
 | `grpcurl` returns `connection refused` on port 40982 (or configured serverStatus port) | Block Node is not yet listening                                      | Wait for the pod to reach `1/1 Running`; confirm `SERVER_STATUS_PORT` in the Block Node configuration.                                                                                                                                                                                    |
 | `MISSING_VERIFICATION_DATA` in verification logs at block 0                            | TSS bootstrap data not configured or file not accessible to the pod  | Confirm `app.state.tssBootstrapFilePath` exists inside the pod (not just on the host). Alternatively, configure `roster.bootstrap.tss.blockNodeSourcesPath` to point to a peer Block Node that holds TSS data. See [Configure TSS bootstrap](#configure-tss-bootstrap-if-tss-is-enabled). |
 
-For issues not covered here, see [Block Node Troubleshooting](../troubleshooting.md). When opening a support ticket, attach:
+For `BAD_BLOCK_PROOF` or `MISSING_VERIFICATION_DATA` errors not resolved by the table above, see [Block verification fails](../troubleshooting.md#block-verification-fails-bad_block_proof-or-missing_verification_data). For all other issues not covered here, see [Block Node Troubleshooting](../troubleshooting.md). When opening a support ticket, attach:
 
 ```bash
 sudo solo-provisioner -v --output=json

--- a/docs/block-node/troubleshooting.md
+++ b/docs/block-node/troubleshooting.md
@@ -44,21 +44,21 @@ lines, and (c) get more detail when you need it.
 ##### A healthy node's INFO signature
 
 On a healthy node you should see the startup sequence once, then only the periodic status
-heartbeat at INFO (block-by-block progress is intentionally **not** at INFO — watch it via
+heartbeat at INFO (block-by-block progress is intentionally **not** at INFO - watch it via
 [metrics](#12-prometheus-metrics--monitoring) instead):
 
 |     When     |                                                                   Log tag / message                                                                    |                             Meaning                             |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
-| Startup      | `BlockNodeApp` — `Loaded Hiero Java modules:` then a `====` banner + config dump                                                                       | Process booted; effective configuration logged (secrets masked) |
-| Startup      | `BlockNodeApp` — `BlockNode Primary Server configured on port(s): …`                                                                                   | Server bound its listen port(s)                                 |
-| Startup      | `BlockNodeApp` — `Started BlockNode Server : State=RUNNING HistoricBlockRange=[…]`                                                                     | Node is up and serving; note the state and block range          |
-| Steady state | `ServerStatusServicePlugin` — `Status heartbeat: oldestBlock=… newestBlock=… nextExpected=…` (periodic)                                                | Node is alive and its block range is advancing                  |
-| Shutdown     | `Main` — `Shutdown requested by JVM shutting down` … `Shutdown finished` (SIGTERM); internal stops also log `BlockNodeApp` — `Shutting down, reason=…` | Orderly shutdown; the `reason` explains why                     |
+| Startup      | `BlockNodeApp` - `Loaded Hiero Java modules:` then a `====` banner + config dump                                                                       | Process booted; effective configuration logged (secrets masked) |
+| Startup      | `BlockNodeApp` - `BlockNode Primary Server configured on port(s): …`                                                                                   | Server bound its listen port(s)                                 |
+| Startup      | `BlockNodeApp` - `Started BlockNode Server : State=RUNNING HistoricBlockRange=[…]`                                                                     | Node is up and serving; note the state and block range          |
+| Steady state | `ServerStatusServicePlugin` - `Status heartbeat: oldestBlock=… newestBlock=… nextExpected=…` (periodic)                                                | Node is alive and its block range is advancing                  |
+| Shutdown     | `Main` - `Shutdown requested by JVM shutting down` … `Shutdown finished` (SIGTERM); internal stops also log `BlockNodeApp` - `Shutting down, reason=…` | Orderly shutdown; the `reason` explains why                     |
 
 If the heartbeat's `newestBlock` stops advancing while consensus nodes are producing blocks,
-ingest is stalled — go to [Block Node not receiving new blocks](#block-node-not-receiving-new-blocks).
+ingest is stalled - go to [Block Node not receiving new blocks](#block-node-not-receiving-new-blocks).
 
-Example — INFO from a healthy run, then a stall (captured from a real run; per-block
+Example - INFO from a healthy run, then a stall (captured from a real run; per-block
 verify/persist/ack are DEBUG-only and not shown here):
 
 ```text
@@ -75,9 +75,9 @@ INFO ServerStatusServicePlugin  Status heartbeat: oldestBlock=0 newestBlock=896 
 |-----------------------------------------------------------------------|--------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
 | `VerificationServicePlugin` (WARNING)                                 | A block failed signature / proof verification          | Check `blocknode_verification_blocks_failed`; a spike may signal upstream or key issues                               |
 | `BackfillPlugin` (WARNING)                                            | Backfill could not persist / verify / re-queue a block | Check storage & verification health; watch `blocknode_backfill*` metrics (transient "cannot reach upstream" is DEBUG) |
-| `BlockFileRecentPlugin` / `BlockFileHistoricPlugin` (WARNING/SEVERE)  | Storage read/write or archive failure                  | Check disk space and I/O — see [Disk full](#disk-full--out-of-space)                                                  |
+| `BlockFileRecentPlugin` / `BlockFileHistoricPlugin` (WARNING/SEVERE)  | Storage read/write or archive failure                  | Check disk space and I/O - see [Disk full](#disk-full--out-of-space)                                                  |
 | `Failed to upload` (BlockUploadTask / TempArchiveUploadTask, WARNING) | Cloud archive upload failed                            | Check bucket credentials/connectivity; watch `cloud_storage_archive_failed_tasks`                                     |
-| Any `SEVERE`                                                          | System entering a failure state                        | Investigate immediately — see the matching runbook below                                                              |
+| Any `SEVERE`                                                          | System entering a failure state                        | Investigate immediately - see the matching runbook below                                                              |
 
 ##### Reading and tailing logs (Kubernetes)
 
@@ -91,7 +91,7 @@ kubectl -n block-node logs <pod> | grep -E "SEVERE|WARNING"   # problems only
 ##### Getting more detail on demand
 
 When INFO is not enough, raise **only the relevant package** to `FINE` (DEBUG), reproduce, then
-revert — do not run DEBUG globally in production. Example: for a verification problem set
+revert - do not run DEBUG globally in production. Example: for a verification problem set
 `org.hiero.block.node.block.verification.level = FINE`; for backfill set
 `org.hiero.block.node.backfill.level = FINE`. See
 [Enabling DEBUG on demand](./logging.md#enabling-debug-on-demand-log-only-troubleshooting).
@@ -129,13 +129,17 @@ Use the runbooks below during incidents. Each follows a consistent pattern:
 
 ### Block Node not receiving new blocks
 
-> **Tip:** Use this runbook when ingest appears stalled — publisher metrics are flat and the status heartbeat's `newestBlock` is not advancing.
+> **Tip:** Use this runbook when ingest appears stalled - publisher metrics are flat and the status heartbeat's `newestBlock` is not advancing.
 
 1. **Triage**
    - Confirm symptoms:
      - `publisher_block_items_received` flat or near-zero.
      - `publisher_open_connections` dropping toward zero.
      - The status heartbeat's `newestBlock` is not advancing (per-block ingest is tracked by metrics and the heartbeat, not INFO logs).
+   - **Check CN block stream configuration before assuming a network or node issue.** Either property below can prevent blocks from reaching the Block Node regardless of network connectivity:
+     - `blockStream.streamMode` must be `BOTH` or `BLOCKS`. If set to `RECORDS`, the CN streams records only and sends no blocks - even if a gRPC connection to the Block Node is established.
+     - `blockStream.writerMode` must be `FILE_AND_GRPC` or `GRPC`. If set to `FILE`, the CN writes blocks to the local filesystem only and the gRPC connection manager never starts.
+     - See [Consensus Node to Block Node Configuration](./operations/consensus-node-to-block-node-configuration.md) for how to check and update these properties.
    - Check node health:
      - Verify process is running and not crashlooping.
      - Confirm CPU / memory are not obviously saturated.
@@ -148,9 +152,12 @@ Use the runbooks below during incidents. Each follows a consistent pattern:
      - Check any intermediate firewalls / load balancers for drops.
      - Confirm the correct IP and port for the CN endpoint.
 2. **Logs**
-   - Search for:
-     - Connection-related errors to consensus nodes.
+   - Search for on the **Consensus Node** (not the Block Node):
+     - `Streaming is not enabled; block node connection manager will not be started` - this WARNING in `BlockNodeConnectionManager` means `blockStream.writerMode` is `FILE`. The CN never attempts to connect.
+     - Connection-related errors to Block Nodes.
      - Repeated reconnect attempts or backoff warnings.
+   - Search for on the **Block Node**:
+     - Any SEVERE or WARNING from `StreamPublisherPlugin`.
 3. **Metrics**
    - Confirm:
      - `publisher_block_items_received` has stalled.
@@ -196,6 +203,7 @@ Use the runbooks below during incidents. Each follows a consistent pattern:
            '{"start_block_number": <BLOCK>, "end_block_number": <BLOCK>}'
        ```
    - Verify the correct advertised hostname / IP and port in Block Node config, and that DNS or load balancer points to the active node.
+   - For the full list of BN ports, traffic directions, and expected firewall rules, see [Network Ports and Protocols](./operations/network-ports-and-protocols.md).
 3. **TLS (if TLS is enabled at your ingress or proxy)**
    - Check client logs for:
      - `x509: certificate has expired or is not yet valid`.
@@ -231,12 +239,12 @@ Use the runbooks below during incidents. Each follows a consistent pattern:
      nc -vz <BLOCK_NODE_HOST> 40980
      ```
 
-     - **Success**: `Connection to <BLOCK_NODE_HOST> port 40980 succeeded!` — proceed to the next step.
+     - **Success**: `Connection to <BLOCK_NODE_HOST> port 40980 succeeded!` - proceed to the next step.
      - **Failure**: TCP reachability is broken. Check firewall rules, security groups, and that the Block Node process is running. Confirm the port matches `hiero.mirror.importer.block.nodes[].port` in the Mirror Node configuration.
 3. **Block Node status**
    - Query `serverStatus` to confirm blocks are available and the gRPC endpoint is responding.
      See [Step 1 in Connecting a Mirror Node to a Block Node](./operations/connecting-a-mirror-node-to-a-block-node.md#step-1-confirm-each-block-node-is-reachable-and-serving-blocks) for the exact command.
-     - If both `firstAvailableBlock` and `lastAvailableBlock` equal `18446744073709551615`, the Block Node has not yet ingested any blocks — wait before subscribing.
+     - If both `firstAvailableBlock` and `lastAvailableBlock` equal `18446744073709551615`, the Block Node has not yet ingested any blocks - wait before subscribing.
      - If `serverStatus` itself fails to connect, the Block Node may be unreachable, the port may be wrong, or TLS is required but not configured on the client side.
 4. **Subscribe smoke test**
    - Attempt a manual `subscribeBlockStream` call from the Mirror Node host to confirm the Block Node will accept a subscription and identify the exact terminal status code.
@@ -287,6 +295,7 @@ Use the runbooks below during incidents. Each follows a consistent pattern:
    - For archival needs, migrate to a node with larger storage or externalize cold data.
    - Tune retention settings for blocks, snapshots, and logs.
    - Ensure monitoring alerts fire well before 100% usage (for example, at 75%, 85%, 95%).
+   - For storage capacity planning and expected daily growth rates, see [Block Node Hardware Specifications](./operations/block-node-hardware-specifications.md).
 5. **Verification**
    - Confirm `files_recent_total_bytes_stored` (and/or `files_historic_total_bytes_stored`) and host `df -h` fall below alert thresholds.
    - Block ingest resumes normally and no further I/O errors appear in logs.
@@ -366,8 +375,8 @@ Use the runbooks below during incidents. Each follows a consistent pattern:
 > **Applies to:** Block Nodes running with WRB streaming (Consensus Node `v0.75`) or TSS-enabled builds.
 
 1. **Triage**
-   - `BAD_BLOCK_PROOF` in the verification logs: the block proof failed validation — most often the block root hash does not match. This error has several possible explanations and is distinct from missing verification data.
-   - `MISSING_VERIFICATION_DATA` in the verification logs (`VerificationSessionFailedException`): the Block Node lacks the data needed to verify a block proof. Both missing RSA address book data (WRB/RSA proofs) and missing TSS data (TSS proofs) produce this error — which applies depends on the type of Block Proof being verified.
+   - `BAD_BLOCK_PROOF` in the verification logs: the block proof failed validation - most often the block root hash does not match. This error has several possible explanations and is distinct from missing verification data.
+   - `MISSING_VERIFICATION_DATA` in the verification logs (`VerificationSessionFailedException`): the Block Node lacks the data needed to verify a block proof. Both missing RSA address book data (WRB/RSA proofs) and missing TSS data (TSS proofs) produce this error - which applies depends on the type of Block Proof being verified.
 2. **Logs**
    - Search for the error keyword using the `VerificationServicePlugin` tag:
 
@@ -391,16 +400,17 @@ Use the runbooks below during incidents. Each follows a consistent pattern:
 
 The table below is a **summary-only quick reference**. Use the runbooks above for full diagnosis and remediation steps.
 
-|                         **Issue**                         |                                      **Symptoms**                                       |                                                       **Diagnosis**                                                       |                                                                                                                                 **Resolution**                                                                                                                                 |
-|-----------------------------------------------------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Node not receiving new blocks                             | Ingest stalled; publisher metrics flat, heartbeat `newestBlock` not advancing           | Check firewall on publish/ingest port (`40984` in LFH; `40840` base-chart default), Consensus Node logs                   | Open inbound port, ensure node is authorized / whitelisted by upstream CN; check ingress cert if using TLS termination                                                                                                                                                         |
-| Block Node operator: subscribers cannot connect           | gRPC connection failures; clients repeatedly reconnecting                               | Endpoint config; `stream-subscriber` plugin present; TLS cert check at ingress (if TLS is enabled)                        | Fix endpoint or firewall; renew ingress TLS certs (if TLS is enabled); add `stream-subscriber` to plugin configuration                                                                                                                                                         |
-| Mirror Node operator: Mirror Node cannot connect          | MN block height not advancing; repeated subscribe errors in importer logs               | `nc` reachability; `serverStatus` output; subscribe smoke test; MN `block.*` config                                       | Fix endpoint or firewall; correct `requiresTls`; see [connecting guide](./operations/connecting-a-mirror-node-to-a-block-node.md#troubleshooting)                                                                                                                              |
-| Disk full / out of space                                  | Node crashes or refuses new blocks                                                      | `df -h`, `files_recent_total_bytes_stored` nearing limit                                                                  | Prune old blocks (partial-history), expand volume, or migrate to archive node                                                                                                                                                                                                  |
-| Metrics endpoint not accessible                           | Grafana dashboards empty, Prometheus target `DOWN`                                      | Port `16007` blocked or metrics disabled via config                                                                       | Open port, enable metrics, fix Prometheus scrape job                                                                                                                                                                                                                           |
-| Blocks not being backfilled                               | Log entries show backfill warnings, missing historical ranges                           | Check `blocknode_backfill*` metrics, `BLOCK_NODE_EARLIEST_MANAGED_BLOCK` / `BACKFILL_START_BLOCK` config                  | Fix earliest-block config, restart node if required, ensure healthy upstream archival source                                                                                                                                                                                   |
-| Block verification fails with `BAD_BLOCK_PROOF`           | `BAD_BLOCK_PROOF` in verification logs                                                  | Block proof validation failure; block root hash does not match or proof is otherwise invalid                              | Examine log context around the error to identify the block and proof type; verify the upstream source is sending correct, uncorrupted block data                                                                                                                               |
-| Block verification fails with `MISSING_VERIFICATION_DATA` | `MISSING_VERIFICATION_DATA` / `VerificationSessionFailedException` in verification logs | RSA address book data missing (WRB/RSA proofs) or TSS data missing (TSS proofs); file not accessible inside the container | For RSA proofs: set `app.state.rsaBootstrapFilePath` and mount the file inside the container. For TSS proofs: set `app.state.tssBootstrapFilePath`; see [WRB cutover doc](./operations/preparing-your-block-node-for-wrb-cutover.md#configure-tss-bootstrap-if-tss-is-enabled) |
+|                         **Issue**                         |                                                                **Symptoms**                                                                |                                                                       **Diagnosis**                                                                        |                                                                                                                                 **Resolution**                                                                                                                                 |
+|-----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| CN not sending blocks (misconfigured stream mode)         | `publisher_block_items_received` stays at 0; no ingest despite BN running (`writerMode=FILE` also keeps `publisher_open_connections` at 0) | Check CN `blockStream.streamMode` (must be `BOTH` or `BLOCKS`, not `RECORDS`) and `blockStream.writerMode` (must be `FILE_AND_GRPC` or `GRPC`, not `FILE`) | Set the correct values in CN configuration and restart; see [CN to BN Configuration](./operations/consensus-node-to-block-node-configuration.md)                                                                                                                               |
+| Node not receiving new blocks                             | Ingest stalled; publisher metrics flat, heartbeat `newestBlock` not advancing                                                              | Check firewall on publish/ingest port (`40984` in LFH; `40840` base-chart default), Consensus Node logs                                                    | Open inbound port, ensure node is authorized / whitelisted by upstream CN; check ingress cert if using TLS termination                                                                                                                                                         |
+| Block Node operator: subscribers cannot connect           | gRPC connection failures; clients repeatedly reconnecting                                                                                  | Endpoint config; `stream-subscriber` plugin present; TLS cert check at ingress (if TLS is enabled)                                                         | Fix endpoint or firewall; renew ingress TLS certs (if TLS is enabled); add `stream-subscriber` to plugin configuration                                                                                                                                                         |
+| Mirror Node operator: Mirror Node cannot connect          | MN block height not advancing; repeated subscribe errors in importer logs                                                                  | `nc` reachability; `serverStatus` output; subscribe smoke test; MN `block.*` config                                                                        | Fix endpoint or firewall; correct `requiresTls`; see [connecting guide](./operations/connecting-a-mirror-node-to-a-block-node.md#troubleshooting)                                                                                                                              |
+| Disk full / out of space                                  | Node crashes or refuses new blocks                                                                                                         | `df -h`, `files_recent_total_bytes_stored` nearing limit                                                                                                   | Prune old blocks (partial-history), expand volume, or migrate to archive node                                                                                                                                                                                                  |
+| Metrics endpoint not accessible                           | Grafana dashboards empty, Prometheus target `DOWN`                                                                                         | Port `16007` blocked or metrics disabled via config                                                                                                        | Open port, enable metrics, fix Prometheus scrape job                                                                                                                                                                                                                           |
+| Blocks not being backfilled                               | Log entries show backfill warnings, missing historical ranges                                                                              | Check `blocknode_backfill*` metrics, `BLOCK_NODE_EARLIEST_MANAGED_BLOCK` / `BACKFILL_START_BLOCK` config                                                   | Fix earliest-block config, restart node if required, ensure healthy upstream archival source                                                                                                                                                                                   |
+| Block verification fails with `BAD_BLOCK_PROOF`           | `BAD_BLOCK_PROOF` in verification logs                                                                                                     | Block proof validation failure; block root hash does not match or proof is otherwise invalid                                                               | Examine log context around the error to identify the block and proof type; verify the upstream source is sending correct, uncorrupted block data                                                                                                                               |
+| Block verification fails with `MISSING_VERIFICATION_DATA` | `MISSING_VERIFICATION_DATA` / `VerificationSessionFailedException` in verification logs                                                    | RSA address book data missing (WRB/RSA proofs) or TSS data missing (TSS proofs); file not accessible inside the container                                  | For RSA proofs: set `app.state.rsaBootstrapFilePath` and mount the file inside the container. For TSS proofs: set `app.state.tssBootstrapFilePath`; see [WRB cutover doc](./operations/preparing-your-block-node-for-wrb-cutover.md#configure-tss-bootstrap-if-tss-is-enabled) |
 
 ---
 


### PR DESCRIPTION
## Reviewer Notes

As per the feedback received from Lindell Alderman, add a new troubleshooting entry for blocks not reaching the Block Node due to blockStream.streamMode or blockStream.writerMode misconfiguration, with verified symptom metrics and the exact CN log message to search for.

Wires bidirectional section-specific cross-links across six docs so readers can navigate directly from a reference doc to the relevant troubleshooting runbook section and back.


## Related Issue(s)
Closes #3621
