### PR TITLE
docs(block-node): add Kubernetes resource sizing guidance for Block Node

### DIFF
--- a/docs/block-node/operations/block-node-hardware-specifications.md
+++ b/docs/block-node/operations/block-node-hardware-specifications.md
@@ -11,8 +11,8 @@ deployments.
 
 |                       Node type                        |        Network        |                                  See section                                  |
 |--------------------------------------------------------|-----------------------|-------------------------------------------------------------------------------|
-| Tier 1 — receives stream directly from Consensus Nodes | Mainnet               | [Tier 1 Mainnet Server Specifications](#tier-1-mainnet-server-specifications) |
-| Tier 2 — receives stream from another Block Node       | Mainnet               | [Tier 2 Server Specifications](#tier-2-server-specifications)                 |
+| Tier 1 - receives stream directly from Consensus Nodes | Mainnet               | [Tier 1 Mainnet Server Specifications](#tier-1-mainnet-server-specifications) |
+| Tier 2 - receives stream from another Block Node       | Mainnet               | [Tier 2 Server Specifications](#tier-2-server-specifications)                 |
 | Any tier                                               | Testnet or Previewnet | [Testnet and Previewnet Sizing](#testnet-and-previewnet-sizing)               |
 
 ---
@@ -100,7 +100,7 @@ No state services are offered and most if not all services are expected to be pr
 ### Rolling-History (Partial History) Tier 2
 
 A Rolling-History Tier 2 node does not store full blockchain history. CPU and
-RAM requirements match Tier 1 — the primary driver is the State Management task
+RAM requirements match Tier 1 - the primary driver is the State Management task
 (which handles live state and serves downstream subscribers), not verification
 or persistence alone. Exact minimums for nodes that do not manage live state
 have not yet been formally benchmarked. The `stream-publisher` plugin is not
@@ -111,7 +111,7 @@ is sized to the retention window rather than the full block history.
 |-------------------|-----------------------------------------------------------------------------------|
 | CPU               | 24 cores / 48 threads, single socket, ≥ 2.0 GHz base clock                        |
 | RAM               | 256 GB                                                                            |
-| Fast NVMe Disk    | 7.5 TB NVMe SSD (recent blocks + live state; partially optional — see note below) |
+| Fast NVMe Disk    | 7.5 TB NVMe SSD (recent blocks + live state; partially optional - see note below) |
 | Bulk Storage Disk | Size to retention window (see table below)                                        |
 | Network           | 10 Gbps NIC minimum (see [Network Requirements](#network-requirements))           |
 | OS                | Linux host OS (Ubuntu 24.04 LTS or Debian 13.x LTS recommended)                   |
@@ -169,6 +169,49 @@ Applying the block size model at lower TPS:
 Actual testnet block sizes vary with transaction mix; these figures serve as
 planning estimates. Storage requirements are significantly smaller than mainnet.
 
+### Kubernetes resource sizing
+
+When deploying the Block Node in Kubernetes, container resource requests and limits must be set
+consistently and must account for JVM heap overhead inside the container.
+
+The [Helm chart](https://github.com/hiero-ledger/hiero-block-node/blob/main/charts/block-node-server/values.yaml)
+ships with default values that **require adjustment before use**:
+
+| Helm value | Default |
+|------------|---------|
+| `resources.requests.cpu` | `4` |
+| `resources.requests.memory` | `12Gi` |
+| `resources.limits.cpu` | `4` |
+| `resources.limits.memory` | `15Gi` |
+| `blockNode.config.JAVA_OPTS` (heap flags) | `-Xms16G -Xmx16G` |
+
+> **Warning:** The default `JAVA_OPTS` sets a 16 GiB heap (`-Xms16G -Xmx16G`), which exceeds
+> the default 15 GiB memory limit. A pod using these defaults will be OOM-killed at startup.
+> Always override both `resources.limits.memory` and `JAVA_OPTS` together before deploying.
+
+Set the JVM heap (`-Xmx`) to between 75-90% of the container memory limit, leaving the
+remainder for JVM non-heap overhead (metaspace, code cache, native threads). For testnet
+workloads, a memory limit matching the [recommended VM sizing](#recommended-vm-sizing) above
+(32 GB) is a reasonable starting point:
+
+```yaml
+resources:
+  requests:
+    memory: "32Gi"
+  limits:
+    memory: "32Gi"
+blockNode:
+  config:
+    JAVA_OPTS: '-Xms24G -Xmx24G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
+```
+
+To diagnose OOM-killed pods:
+
+```bash
+kubectl -n block-node describe pod <pod-name> | grep -A 3 "Last State"
+kubectl -n block-node logs <pod-name> --previous
+```
+
 ---
 
 ## Storage Benchmark Targets
@@ -183,7 +226,7 @@ across all drives in the configuration, not per-drive requirements.
 | Disk Type | Sustained Write | Sustained Read |  Write IOPS   |   Read IOPS   | Random Read AIO IOPS | P99 Write Latency | P99 Read Latency |
 |-----------|-----------------|----------------|---------------|---------------|----------------------|-------------------|------------------|
 | Fast NVMe | 4 GBps          | 6 GBps         | 350k (random) | 900k (random) | 1M                   | < 300 µs          | < 200 µs         |
-| Bulk Disk | 300 MBps        | 1 GBps         | 1200          | 4000          | n/a                  | —                 | —                |
+| Bulk Disk | 300 MBps        | 1 GBps         | 1200          | 4000          | n/a                  | -                 | -                |
 
 #### Notes
 
@@ -242,7 +285,7 @@ T = transactions per block = TPS × block_interval
 
 #### Assumptions used in the tables below
 
-- Block interval: 1 second (1 block/sec — conservative; mainnet in early 2026
+- Block interval: 1 second (1 block/sec - conservative; mainnet in early 2026
   runs at 0.5 blocks/sec)
 - Compression ratio: 2.39× (zstd, from v3 mixed-workload model)
 - Worst-case egress subscribers: 33 (13 Block Nodes backfilling +
@@ -307,7 +350,7 @@ uncompressed stream. All figures use the raw (uncompressed) wire size.
 |  2,000 |               156 GB |                 4.6 TB |               5.1 TB |                 154 TB |
 | 20,000 |               1.5 TB |                  45 TB |                50 TB |                 1.5 PB |
 
-**Worst-case peak bandwidth (burst — 4 in-flight blocks per subscriber):**
+**Worst-case peak bandwidth (burst - 4 in-flight blocks per subscriber):**
 
 |    TPS | Steady-state egress (33 sub) | Burst egress (33 sub, 4× in-flight) |
 |-------:|-----------------------------:|------------------------------------:|


### PR DESCRIPTION
## Reviewer Notes

Documents the default Helm chart resource/JVM mismatch that OOM-kills pods at startup (15Gi container limit vs -Xms16G/-Xmx16G heap) and provides correct override values with the blockNode.config.JAVA_OPTS key path, a 75-90% heap-to-limit sizing rule, and kubectl commands for diagnosing OOM-killed pods.

Verified against values.yaml, configmap.yaml template, helm template dry-run, and all values-overrides profiles (mini, mid-size, LFH).

## Related Issue(s)
Closes #3620
