### PR TITLE
feat: add shared block-read bulkhead protecting block storage

### DIFF
--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/AppConfigExtension.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/AppConfigExtension.java
@@ -18,6 +18,11 @@ public class AppConfigExtension implements ConfigurationExtension {
     @NonNull
     @Override
     public Set<Class<? extends Record>> getConfigDataTypes() {
-        return Set.of(ServerConfig.class, WebServerHttp2Config.class, NodeConfig.class, ApplicationStateConfig.class);
+        return Set.of(
+                ServerConfig.class,
+                WebServerHttp2Config.class,
+                NodeConfig.class,
+                ApplicationStateConfig.class,
+                BlockReadBulkheadConfig.class);
     }
 }

--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/BlockReadBulkheadConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/BlockReadBulkheadConfig.java
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.app.config;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import com.swirlds.config.api.validation.annotation.Min;
+import org.hiero.block.node.base.Loggable;
+
+/**
+ * Configuration for the shared block-storage read bulkhead: a single, bounded, non-client-keyed
+ * permit pool protecting block storage from combined read load across every API that reads from
+ * it, shared across every call path that draws on it via {@code ServiceBuilder.blockReadBulkhead()}.
+ *
+ * @param permits the fixed size of the bulkhead's permit pool
+ */
+@ConfigData("blockReadBulkhead")
+public record BlockReadBulkheadConfig(
+        @Loggable @ConfigProperty(defaultValue = "50") @Min(1)
+        int permits) {}

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -57,6 +57,7 @@ import org.hiero.block.api.RangedNodeAddressBook;
 import org.hiero.block.api.TssData;
 import org.hiero.block.internal.BlockRangesState;
 import org.hiero.block.node.app.config.AutomaticEnvironmentVariableConfigSource;
+import org.hiero.block.node.app.config.BlockReadBulkheadConfig;
 import org.hiero.block.node.app.config.ServerConfig;
 import org.hiero.block.node.app.config.WebServerHttp2Config;
 import org.hiero.block.node.app.config.state.ApplicationStateConfig;
@@ -293,7 +294,10 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 .build();
 
         // Create HTTP & GRPC routing builders; null port in plugin registrations resolves to server.port
-        serviceBuilder = new ServiceBuilderImpl(serverConfig, http2Config, socketOptions);
+        final BlockReadBulkheadConfig blockReadBulkheadConfig =
+                configuration.getConfigData(BlockReadBulkheadConfig.class);
+        serviceBuilder = new ServiceBuilderImpl(
+                serverConfig, http2Config, socketOptions, blockReadBulkheadConfig, metricRegistry);
         // ==== INITIALIZE PLUGINS =====================================================================================
         // Initialize all the facilities & plugins, adding routing for each plugin
         for (BlockNodePlugin plugin : loadedPlugins) {

--- a/block-node/app/src/main/java/org/hiero/block/node/app/ServiceBuilderImpl.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/ServiceBuilderImpl.java
@@ -20,8 +20,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
+import org.hiero.block.node.app.config.BlockReadBulkheadConfig;
 import org.hiero.block.node.app.config.ServerConfig;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.bulkhead.BlockReadBulkhead;
+import org.hiero.metrics.core.MetricRegistry;
 
 /// Default implementation of [ServiceBuilder]. That builds HTTP and PBJ GRPC services.
 ///
@@ -42,13 +45,27 @@ public class ServiceBuilderImpl implements ServiceBuilder {
     private final SocketOptions socketOptions;
     private WebServerResult generalWebserver;
     private final LinkedHashSet<WebServerResult> additionalWebservers;
+    /** The single, shared block-read bulkhead every plugin's [#blockReadBulkhead] call returns. */
+    private final BlockReadBulkhead blockReadBulkhead;
 
     public ServiceBuilderImpl(
-            final ServerConfig serverConfig, final Http2Config http2Config, final SocketOptions socketOptions) {
+            final ServerConfig serverConfig,
+            final Http2Config http2Config,
+            final SocketOptions socketOptions,
+            final BlockReadBulkheadConfig blockReadBulkheadConfig,
+            final MetricRegistry metricRegistry) {
         this.serverConfig = serverConfig;
         this.http2Config = http2Config;
         this.socketOptions = socketOptions;
+        this.blockReadBulkhead = new BlockReadBulkhead(blockReadBulkheadConfig.permits(), metricRegistry);
         additionalWebservers = new LinkedHashSet<>();
+    }
+
+    /// {@inheritDoc}
+    @NonNull
+    @Override
+    public BlockReadBulkhead blockReadBulkhead() {
+        return blockReadBulkhead;
     }
 
     /// {@inheritDoc}

--- a/block-node/app/src/test/java/org/hiero/block/node/app/ServiceBuilderImplTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/ServiceBuilderImplTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.app;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -20,7 +21,10 @@ import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http2.Http2Config;
 import java.util.Map;
+import org.hiero.block.node.app.config.BlockReadBulkheadConfig;
 import org.hiero.block.node.app.config.ServerConfig;
+import org.hiero.block.node.app.fixtures.TestMetricsExporter;
+import org.hiero.metrics.core.MetricRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,7 +46,25 @@ class ServiceBuilderImplTest {
         final Http2Config http2Config = Http2Config.builder().build();
         final SocketOptions socketOptions = SocketOptions.builder().build();
         ServerConfig testConfig = new ServerConfig(0, 0, 0, PUBLISHER_PORT, 0, 0, 0, 0, false, 0, 0);
-        serviceBuilder = new ServiceBuilderImpl(testConfig, http2Config, socketOptions);
+        final BlockReadBulkheadConfig blockReadBulkheadConfig = new BlockReadBulkheadConfig(50);
+        final MetricRegistry metricRegistry = MetricRegistry.builder()
+                .setMetricsExporter(new TestMetricsExporter())
+                .build();
+        serviceBuilder =
+                new ServiceBuilderImpl(testConfig, http2Config, socketOptions, blockReadBulkheadConfig, metricRegistry);
+    }
+
+    @Test
+    @DisplayName("blockReadBulkhead should return a non-null, correctly-sized bulkhead")
+    void blockReadBulkhead_returnsConfiguredBulkhead() {
+        assertNotNull(serviceBuilder.blockReadBulkhead());
+        assertEquals(50, serviceBuilder.blockReadBulkhead().totalPermits());
+    }
+
+    @Test
+    @DisplayName("blockReadBulkhead should return the same shared instance on every call")
+    void blockReadBulkhead_returnsSameInstance() {
+        assertSame(serviceBuilder.blockReadBulkhead(), serviceBuilder.blockReadBulkhead());
     }
 
     @Test

--- a/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/RecordingServiceBuilder.java
+++ b/block-node/app/src/testFixtures/java/org/hiero/block/node/app/fixtures/plugintest/RecordingServiceBuilder.java
@@ -15,7 +15,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Stream;
+import org.hiero.block.node.app.fixtures.TestMetricsExporter;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.bulkhead.BlockReadBulkhead;
+import org.hiero.metrics.core.MetricRegistry;
 
 /// A [ServiceBuilder] test fixture that records every call and every input instead of creating
 /// real Helidon web servers. It never opens a socket; it simply captures what a plugin registered so
@@ -87,6 +90,13 @@ public final class RecordingServiceBuilder implements ServiceBuilder {
     /** The port a {@code null} port resolves to, and the general server's base port. */
     private final int defaultPort;
 
+    /// A generous default so a plugin test using this fixture isn't inadvertently throttled by the
+    /// bulkhead unless it explicitly drains permits to test that behavior.
+    private static final int DEFAULT_BLOCK_READ_BULKHEAD_PERMITS = 1_000;
+    /// Lazily created on first use; this fixture never opens a socket, so a self-contained,
+    /// no-op-exported [MetricRegistry] is enough — there is no shared "real" registry to reuse.
+    private BlockReadBulkhead blockReadBulkhead;
+
     /** Every {@link #registerHttpService} invocation, in call order. */
     private final List<HttpServiceRegistration> httpServiceRegistrations = new ArrayList<>();
     /** Every {@link #registerGrpcService} invocation, in call order. */
@@ -139,6 +149,23 @@ public final class RecordingServiceBuilder implements ServiceBuilder {
     @Override
     public void registerGrpcService(@Nullable final Integer port, @NonNull final ServiceInterface service) {
         grpcServiceRegistrations.add(new GrpcServiceRegistration(port, service));
+    }
+
+    /// {@inheritDoc}
+    /// Lazily creates a single shared [BlockReadBulkhead], sized generously (see
+    /// [#DEFAULT_BLOCK_READ_BULKHEAD_PERMITS]) so plugin tests aren't inadvertently throttled by it.
+    /// A test that wants to exercise bulkhead denial can call this accessor directly and drain
+    /// permits with {@link BlockReadBulkhead#tryAcquire()} before invoking the plugin under test.
+    @NonNull
+    @Override
+    public BlockReadBulkhead blockReadBulkhead() {
+        if (blockReadBulkhead == null) {
+            final MetricRegistry metricRegistry = MetricRegistry.builder()
+                    .setMetricsExporter(new TestMetricsExporter())
+                    .build();
+            blockReadBulkhead = new BlockReadBulkhead(DEFAULT_BLOCK_READ_BULKHEAD_PERMITS, metricRegistry);
+        }
+        return blockReadBulkhead;
     }
 
     /// {@inheritDoc}

--- a/block-node/block-access-service/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
+++ b/block-node/block-access-service/src/main/java/org/hiero/block/node/access/service/BlockAccessServicePlugin.java
@@ -5,6 +5,8 @@ import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 import static org.hiero.block.node.base.ParseHelper.standardParse;
 
+import com.hedera.pbj.runtime.grpc.GrpcException;
+import com.hedera.pbj.runtime.grpc.GrpcStatus;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.Pipelines;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -18,6 +20,7 @@ import org.hiero.block.internal.BlockUnparsed;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.bulkhead.BlockReadBulkhead;
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
 import org.hiero.metrics.LongCounter;
@@ -45,6 +48,8 @@ public class BlockAccessServicePlugin implements BlockNodePlugin, BlockAccessSer
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
     /** The block provider */
     private HistoricalBlockFacility blockProvider;
+    /** The shared block-storage read bulkhead; protects storage independent of client identity */
+    private BlockReadBulkhead blockReadBulkhead;
     /** Counter for the number of requests */
     private LongCounter.Measurement requestCounter;
     /** Counter for the number of responses Success */
@@ -119,19 +124,33 @@ public class BlockAccessServicePlugin implements BlockNodePlugin, BlockAccessSer
                 responseCounterNotAvailable.increment();
                 return new BlockResponseUnparsed(Code.NOT_AVAILABLE, null);
             }
-            // Retrieve the block
-            try (final BlockAccessor accessor = blockProvider.block(blockNumberToRetrieve)) {
-                if (accessor != null) {
-                    // Use blockUnparsed() to avoid full parsing of block items
-                    final BlockUnparsed block = accessor.blockUnparsed();
-                    if (block != null) {
-                        responseCounterSuccess.increment();
-                        return new BlockResponseUnparsed(Code.SUCCESS, block);
-                    }
-                }
-                responseCounterNotFound.increment();
-                return new BlockResponseUnparsed(Code.NOT_FOUND, null);
+            // A single, shared, non-client-keyed permit pool guarding every read against block
+            // storage. getBlock is a single request/response exchange, so it acquires without
+            // waiting and rejects immediately if the pool is exhausted, rather than queuing.
+            if (!blockReadBulkhead.tryAcquire()) {
+                throw new GrpcException(GrpcStatus.RESOURCE_EXHAUSTED, "block storage read capacity exhausted");
             }
+            try {
+                // Retrieve the block
+                try (final BlockAccessor accessor = blockProvider.block(blockNumberToRetrieve)) {
+                    if (accessor != null) {
+                        // Use blockUnparsed() to avoid full parsing of block items
+                        final BlockUnparsed block = accessor.blockUnparsed();
+                        if (block != null) {
+                            responseCounterSuccess.increment();
+                            return new BlockResponseUnparsed(Code.SUCCESS, block);
+                        }
+                    }
+                    responseCounterNotFound.increment();
+                    return new BlockResponseUnparsed(Code.NOT_FOUND, null);
+                }
+            } finally {
+                blockReadBulkhead.release();
+            }
+        } catch (final GrpcException e) {
+            // Not an internal failure — propagate so the caller sees RESOURCE_EXHAUSTED, rather
+            // than being folded into the generic RuntimeException handling below.
+            throw e;
         } catch (final RuntimeException e) {
             final String message = "Failed to retrieve block number %d.".formatted(request.blockNumber());
             LOGGER.log(ERROR, message, e);
@@ -182,6 +201,7 @@ public class BlockAccessServicePlugin implements BlockNodePlugin, BlockAccessSer
                 .getOrCreateNotLabeled();
         // Get the block provider
         this.blockProvider = context.historicalBlockProvider();
+        this.blockReadBulkhead = serviceBuilder.blockReadBulkhead();
         // Register this service; a null port (the default) shares server.port
         final Integer port =
                 context.configuration().getConfigData(BlockAccessConfig.class).port();

--- a/block-node/block-access-service/src/test/java/org/hiero/block/node/access/service/BlockAccessServicePluginTest.java
+++ b/block-node/block-access-service/src/test/java/org/hiero/block/node/access/service/BlockAccessServicePluginTest.java
@@ -3,13 +3,23 @@ package org.hiero.block.node.access.service;
 
 import static org.hiero.block.node.base.ParseHelper.standardParse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.grpc.GrpcException;
+import com.hedera.pbj.runtime.grpc.GrpcStatus;
+import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Flow;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import org.hiero.block.api.BlockRequest;
@@ -23,6 +33,7 @@ import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
 import org.hiero.block.node.app.fixtures.plugintest.GrpcPluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.bulkhead.BlockReadBulkhead;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -185,6 +196,62 @@ public class BlockAccessServicePluginTest
         assertEquals(
                 info.blockNumber(),
                 response.block().items().getFirst().blockHeader().number());
+    }
+
+    @Test
+    @DisplayName("getBlock is rejected with RESOURCE_EXHAUSTED once the shared block-read bulkhead is exhausted")
+    void getBlockRejectedWhenBulkheadExhausted() {
+        final BlockReadBulkhead bulkhead = webserviceBuilder.blockReadBulkhead();
+        for (int i = 0; i < bulkhead.totalPermits(); i++) {
+            assertTrue(bulkhead.tryAcquire(), "expected to drain every bulkhead permit");
+        }
+        try {
+            final List<Throwable> errors = new ArrayList<>();
+            final Pipeline<Bytes> replies = new Pipeline<>() {
+                @Override
+                public void onSubscribe(final Flow.Subscription subscription) {}
+
+                @Override
+                public void onNext(final Bytes item) {}
+
+                @Override
+                public void onError(final Throwable throwable) {
+                    errors.add(throwable);
+                }
+
+                @Override
+                public void onComplete() {}
+            };
+            final Pipeline<? super Bytes> inbound = serviceInterface.open(method, requestOptions(), replies);
+            final Bytes requestBytes = BlockRequest.PROTOBUF.toBytes(
+                    BlockRequest.newBuilder().blockNumber(1L).build());
+            // Pipelines.unary() both forwards the exception to replies.onError(...) and rethrows it
+            // to the onNext() caller (the real webserver dispatch layer handles that rethrow; here
+            // we just need to not let it fail the test, since onError() already recorded it below).
+            assertThrows(GrpcException.class, () -> inbound.onNext(requestBytes));
+
+            assertEquals(1, errors.size());
+            assertInstanceOf(GrpcException.class, errors.getFirst());
+            assertEquals(GrpcStatus.RESOURCE_EXHAUSTED, ((GrpcException) errors.getFirst()).status());
+        } finally {
+            for (int i = 0; i < bulkhead.totalPermits(); i++) {
+                bulkhead.release();
+            }
+        }
+    }
+
+    private static ServiceInterface.RequestOptions requestOptions() {
+        return new ServiceInterface.RequestOptions() {
+            @Override
+            public Optional<String> authority() {
+                return Optional.empty();
+            }
+
+            @Override
+            public String contentType() {
+                return ServiceInterface.RequestOptions.APPLICATION_GRPC_PROTO;
+            }
+        };
     }
 
     private void sendBlocks(int numberOfBlocks) {

--- a/block-node/health/src/test/java/org/hiero/block/node/health/HealthConnectionCloseTest.java
+++ b/block-node/health/src/test/java/org/hiero/block/node/health/HealthConnectionCloseTest.java
@@ -27,11 +27,14 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
+import org.hiero.block.node.app.fixtures.TestMetricsExporter;
 import org.hiero.block.node.app.fixtures.async.BlockingExecutor;
 import org.hiero.block.node.app.fixtures.async.ScheduledBlockingExecutor;
 import org.hiero.block.node.app.fixtures.plugintest.NoBlocksHistoricalBlockFacility;
 import org.hiero.block.node.app.fixtures.plugintest.PluginTestBase;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.bulkhead.BlockReadBulkhead;
+import org.hiero.metrics.core.MetricRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -207,6 +210,9 @@ class HealthConnectionCloseTest
         private final Map<String, HttpService> registeredServices = new HashMap<>();
 
         private WebServer webServer;
+        /// Lazily created; the health plugin never reads from block storage, so no test here
+        /// exercises this beyond satisfying the interface.
+        private BlockReadBulkhead blockReadBulkhead;
 
         @Override
         public void registerHttpService(final String path, @Nullable final Integer port, final HttpService... service) {
@@ -218,6 +224,17 @@ class HealthConnectionCloseTest
         @Override
         public void registerGrpcService(@Nullable final Integer port, final ServiceInterface service) {
             // the health plugin registers no gRPC services
+        }
+
+        @Override
+        public BlockReadBulkhead blockReadBulkhead() {
+            if (blockReadBulkhead == null) {
+                final MetricRegistry metricRegistry = MetricRegistry.builder()
+                        .setMetricsExporter(new TestMetricsExporter())
+                        .build();
+                blockReadBulkhead = new BlockReadBulkhead(1_000, metricRegistry);
+            }
+            return blockReadBulkhead;
         }
 
         @Override

--- a/block-node/spi-plugins/src/main/java/module-info.java
+++ b/block-node/spi-plugins/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module org.hiero.block.node.spi {
     exports org.hiero.block.node.spi.blockmessaging;
+    exports org.hiero.block.node.spi.bulkhead;
     exports org.hiero.block.node.spi.health;
     exports org.hiero.block.node.spi.historicalblocks;
     exports org.hiero.block.node.spi.module;

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/ServiceBuilder.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/ServiceBuilder.java
@@ -10,6 +10,7 @@ import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http2.Http2Config;
 import java.util.Set;
 import java.util.TreeMap;
+import org.hiero.block.node.spi.bulkhead.BlockReadBulkhead;
 
 /// ServiceBuilder is an interface that defines the contract for registering HTTP and gRPC services
 /// with the web server during initialization.
@@ -70,6 +71,14 @@ public interface ServiceBuilder {
     /// use the default port
     /// @param service the gRPC service to register
     void registerGrpcService(@Nullable Integer port, @NonNull ServiceInterface service);
+
+    /// The single, shared bulkhead protecting block storage from combined read load across every
+    /// call path that reads from it, independent of client identity. Every plugin that reads
+    /// directly from block storage shares this one instance rather than creating its own.
+    ///
+    /// @return the shared block-read bulkhead
+    @NonNull
+    BlockReadBulkhead blockReadBulkhead();
 
     /// Registers a new webserver configured with one or more HTTP services
     /// attached to a set of ports.

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/bulkhead/BlockReadBulkhead.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/bulkhead/BlockReadBulkhead.java
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.bulkhead;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Duration;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import org.hiero.block.node.spi.BlockNodePlugin;
+import org.hiero.metrics.ObservableGauge;
+import org.hiero.metrics.core.MetricKey;
+import org.hiero.metrics.core.MetricRegistry;
+
+/// A single, shared, bounded, non-client-keyed pool of permits protecting every read against block
+/// storage, regardless of which API or client triggered it. Unlike a per-client admission check,
+/// this does not know or care about client identity — it protects the resource itself against
+/// combined load from every call path that reads from it.
+///
+/// Two call paths are expected to share one instance: a single request/response exchange that
+/// either gets a permit now or is rejected immediately ([#tryAcquire()]), and a standing session
+/// that should retry rather than be disconnected over one momentary saturation instant
+/// ([#tryAcquire(Duration)], a brief bounded wait). Callers must call [#release()] exactly once for
+/// every successful acquire, typically in a `finally` block.
+public final class BlockReadBulkhead {
+    private final Semaphore permits;
+    private final int totalPermits;
+
+    /// @param totalPermits the fixed size of this bulkhead's permit pool; must be positive
+    /// @param metricRegistry the registry to register this instance's metrics with
+    public BlockReadBulkhead(final int totalPermits, @NonNull final MetricRegistry metricRegistry) {
+        if (totalPermits <= 0) {
+            throw new IllegalArgumentException("totalPermits must be positive, was " + totalPermits);
+        }
+        this.totalPermits = totalPermits;
+        this.permits = new Semaphore(totalPermits, false);
+
+        metricRegistry
+                .register(ObservableGauge.builder(MetricKey.of("block_read_bulkhead_in_use", ObservableGauge.class)
+                                .addCategory(BlockNodePlugin.METRICS_CATEGORY))
+                        .setDescription("Permits currently held from the shared block-storage read bulkhead"))
+                .observe(() -> (long) (totalPermits - permits.availablePermits()));
+        metricRegistry
+                .register(ObservableGauge.builder(MetricKey.of("block_read_bulkhead_available", ObservableGauge.class)
+                                .addCategory(BlockNodePlugin.METRICS_CATEGORY))
+                        .setDescription("Permits currently available in the shared block-storage read bulkhead"))
+                .observe(() -> (long) permits.availablePermits());
+    }
+
+    /// Attempts to acquire a permit without waiting.
+    ///
+    /// @return {@code true} if a permit was acquired (the caller must [#release()] it); {@code
+    ///     false} if none is currently available
+    public boolean tryAcquire() {
+        return permits.tryAcquire();
+    }
+
+    /// Attempts to acquire a permit, waiting up to {@code maxWait} if none is immediately
+    /// available. This wait is purely internal scheduling for already-admitted work — it never
+    /// affects any admission decision.
+    ///
+    /// @param maxWait the maximum time to wait for a permit to become available
+    /// @return {@code true} if a permit was acquired (the caller must [#release()] it); {@code
+    ///     false} if none became available within {@code maxWait}
+    public boolean tryAcquire(@NonNull final Duration maxWait) {
+        try {
+            return permits.tryAcquire(maxWait.toNanos(), TimeUnit.NANOSECONDS);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    /// Releases a permit previously acquired via [#tryAcquire()] or [#tryAcquire(Duration)].
+    public void release() {
+        permits.release();
+    }
+
+    /// The fixed size of this bulkhead's permit pool.
+    public int totalPermits() {
+        return totalPermits;
+    }
+}

--- a/block-node/spi-plugins/src/test/java/org/hiero/block/node/spi/bulkhead/BlockReadBulkheadTest.java
+++ b/block-node/spi-plugins/src/test/java/org/hiero/block/node/spi/bulkhead/BlockReadBulkheadTest.java
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.bulkhead;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+import org.hiero.metrics.core.MetricRegistry;
+import org.hiero.metrics.core.MetricRegistrySnapshot;
+import org.hiero.metrics.core.MetricsExporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BlockReadBulkheadTest {
+    private MetricRegistry metricRegistry;
+
+    @BeforeEach
+    void setUp() {
+        metricRegistry = MetricRegistry.builder()
+                .setMetricsExporter(new NoOpMetricsExporter())
+                .build();
+    }
+
+    @Test
+    @DisplayName("A permit is acquired when the pool has capacity")
+    void tryAcquireSucceedsWhenPermitsAvailable() {
+        final BlockReadBulkhead bulkhead = new BlockReadBulkhead(1, metricRegistry);
+        assertTrue(bulkhead.tryAcquire());
+    }
+
+    @Test
+    @DisplayName("A non-blocking acquire fails immediately once the pool is exhausted")
+    void tryAcquireFailsWhenExhausted() {
+        final BlockReadBulkhead bulkhead = new BlockReadBulkhead(1, metricRegistry);
+        assertTrue(bulkhead.tryAcquire());
+        assertFalse(bulkhead.tryAcquire());
+    }
+
+    @Test
+    @DisplayName("Releasing a permit makes it available to a later acquirer")
+    void releaseFreesThePermit() {
+        final BlockReadBulkhead bulkhead = new BlockReadBulkhead(1, metricRegistry);
+        assertTrue(bulkhead.tryAcquire());
+        assertFalse(bulkhead.tryAcquire());
+        bulkhead.release();
+        assertTrue(bulkhead.tryAcquire());
+    }
+
+    @Test
+    @DisplayName("A bounded-wait acquire succeeds if a permit is released within the wait window")
+    void boundedWaitAcquireSucceedsOncePermitIsReleased() throws InterruptedException {
+        final BlockReadBulkhead bulkhead = new BlockReadBulkhead(1, metricRegistry);
+        assertTrue(bulkhead.tryAcquire());
+
+        final Thread releaser = new Thread(() -> {
+            try {
+                Thread.sleep(50);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            bulkhead.release();
+        });
+        releaser.start();
+
+        assertTrue(bulkhead.tryAcquire(Duration.ofSeconds(2)));
+        releaser.join();
+    }
+
+    @Test
+    @DisplayName("A bounded-wait acquire fails once the wait elapses with no permit released")
+    void boundedWaitAcquireFailsWhenNoPermitBecomesAvailable() {
+        final BlockReadBulkhead bulkhead = new BlockReadBulkhead(1, metricRegistry);
+        assertTrue(bulkhead.tryAcquire());
+        assertFalse(bulkhead.tryAcquire(Duration.ofMillis(50)));
+    }
+
+    @Test
+    @DisplayName("A non-positive permit count is rejected at construction")
+    void nonPositivePermitCountIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> new BlockReadBulkhead(0, metricRegistry));
+        assertThrows(IllegalArgumentException.class, () -> new BlockReadBulkhead(-1, metricRegistry));
+    }
+
+    @Test
+    @DisplayName("totalPermits() reports the fixed pool size regardless of current usage")
+    void totalPermitsIsFixed() {
+        final BlockReadBulkhead bulkhead = new BlockReadBulkhead(3, metricRegistry);
+        assertTrue(bulkhead.tryAcquire());
+        assertEquals(3, bulkhead.totalPermits());
+    }
+
+    /// A no-op metrics exporter so tests don't need a real metrics backend.
+    private static final class NoOpMetricsExporter implements MetricsExporter {
+        @Override
+        public void setSnapshotSupplier(final Supplier<MetricRegistrySnapshot> supplier) {}
+
+        @Override
+        public void close() {}
+    }
+}

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSession.java
@@ -18,6 +18,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.UncheckedIOException;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -40,6 +41,7 @@ import org.hiero.block.internal.SubscribeStreamResponseUnparsed.ResponseOneOfTyp
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
 import org.hiero.block.node.spi.blockmessaging.NoBackPressureBlockItemHandler;
+import org.hiero.block.node.spi.bulkhead.BlockReadBulkhead;
 import org.hiero.block.node.spi.historicalblocks.BlockAccessor;
 import org.hiero.block.node.spi.historicalblocks.BlockRangeSet;
 
@@ -98,6 +100,11 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
     private static final TimeUnit LIVE_POLL_UNITS = TimeUnit.MILLISECONDS;
     /** The "resolution", in ns, to use for a polling delays. */
     private static final long PARK_DELAY_TIME = 100_000;
+    /**
+     * How long a historical catch-up read waits for a shared block-read bulkhead permit before
+     * giving up on this poll and retrying later, rather than disconnecting the session.
+     */
+    private static final Duration HISTORICAL_READ_PERMIT_WAIT = Duration.ofMillis(100);
 
     /** The pipeline to send responses to the client */
     private final Pipeline<? super SubscribeStreamResponseUnparsed> responsePipeline;
@@ -166,18 +173,21 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
             @NonNull String handlerName,
             long clientId,
             long firstRequestedBlock,
-            long lastRequestedBlock) {
+            long lastRequestedBlock,
+            @NonNull BlockReadBulkhead blockReadBulkhead) {
         SessionContext(
                 @NonNull final SubscriberConfig subscriberConfig,
                 @NonNull final String handlerName,
                 final long clientId,
                 final long firstRequestedBlock,
-                final long lastRequestedBlock) {
+                final long lastRequestedBlock,
+                @NonNull final BlockReadBulkhead blockReadBulkhead) {
             this.subscriberConfig = requireNonNull(subscriberConfig);
             this.handlerName = requireNonNull(handlerName);
             this.clientId = clientId;
             this.firstRequestedBlock = firstRequestedBlock;
             this.lastRequestedBlock = lastRequestedBlock;
+            this.blockReadBulkhead = requireNonNull(blockReadBulkhead);
         }
 
         /**
@@ -187,11 +197,17 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
         static SessionContext create(
                 final long clientId,
                 @NonNull final SubscribeStreamRequest request,
-                @NonNull final BlockNodeContext context) {
+                @NonNull final BlockNodeContext context,
+                @NonNull final BlockReadBulkhead blockReadBulkhead) {
             final String handlerName = "Live stream client " + clientId;
             final SubscriberConfig subscriberConfig = context.configuration().getConfigData(SubscriberConfig.class);
             return new SessionContext(
-                    subscriberConfig, handlerName, clientId, request.startBlockNumber(), request.endBlockNumber());
+                    subscriberConfig,
+                    handlerName,
+                    clientId,
+                    request.startBlockNumber(),
+                    request.endBlockNumber(),
+                    blockReadBulkhead);
         }
     }
 
@@ -449,39 +465,51 @@ public class BlockStreamSubscriberSession implements Callable<BlockStreamSubscri
         // Don't send anything from history if this stream is interrupted, has sent
         // every requested block, or we can send the next block from "live".
         while (isHistoryPermitted()) {
-            // We need to send historical blocks.
-            // We will only send one block at a time to keep things "smooth".
-            // Start by getting a block accessor for the next block to send from the historical provider.
-            try (final BlockAccessor nextBlockAccessor =
-                    blockNodeContext.historicalBlockProvider().block(nextBlockToSend.get())) {
-                if (nextBlockAccessor != null) {
-                    // Get raw bytes first - this gives us O(1) size check
-                    final Bytes blockBytes = nextBlockAccessor.blockBytes(BlockAccessor.Format.PROTOBUF);
-                    if (blockBytes == null) {
-                        final String message = "Unable to retrieve historical block {0} for client {1}.";
-                        throw new IllegalStateException(message);
-                    }
-                    final int blockByteSize = (int) blockBytes.length();
-                    final BlockUnparsed block =
-                            standardParse(BlockUnparsed.PROTOBUF, blockBytes, maxProtobufMessageSizeBytes);
-                    // We have retrieved the block to send, so send it.
-                    sendOneFullBlock(block, blockByteSize);
-                    // Trim the queue if necessary, also increment the next block to send.
-                    trimBlockItemQueue(nextBlockToSend.incrementAndGet());
-                } else {
-                    // Only give up if this is an historical block, otherwise just
-                    // go back up and see if live has the block.
-                    if (!(nextBlockToSend.get() < 0 || nextBlockToSend.get() >= getLatestHistoricalBlock())) {
-                        // We cannot get the block needed, something has failed.
-                        // close the stream with an "unavailable" response.
-                        final String message = "Unable to read historical block, nextBlockToSend={0}.";
-                        LOGGER.log(Level.INFO, message, nextBlockToSend);
-                        close(SubscribeStreamResponse.Code.NOT_AVAILABLE);
+            // A single, shared, non-client-keyed permit pool guarding every read against block
+            // storage. A subscriber session is a standing resource, so unlike getBlock's immediate
+            // rejection, this waits briefly for a permit and, if none becomes available in time,
+            // simply retries on the next poll rather than disconnecting the session.
+            if (!sessionContext.blockReadBulkhead.tryAcquire(HISTORICAL_READ_PERMIT_WAIT)) {
+                awaitNewLiveEntries();
+                break;
+            }
+            try {
+                // We need to send historical blocks.
+                // We will only send one block at a time to keep things "smooth".
+                // Start by getting a block accessor for the next block to send from the historical provider.
+                try (final BlockAccessor nextBlockAccessor =
+                        blockNodeContext.historicalBlockProvider().block(nextBlockToSend.get())) {
+                    if (nextBlockAccessor != null) {
+                        // Get raw bytes first - this gives us O(1) size check
+                        final Bytes blockBytes = nextBlockAccessor.blockBytes(BlockAccessor.Format.PROTOBUF);
+                        if (blockBytes == null) {
+                            final String message = "Unable to retrieve historical block {0} for client {1}.";
+                            throw new IllegalStateException(message);
+                        }
+                        final int blockByteSize = (int) blockBytes.length();
+                        final BlockUnparsed block =
+                                standardParse(BlockUnparsed.PROTOBUF, blockBytes, maxProtobufMessageSizeBytes);
+                        // We have retrieved the block to send, so send it.
+                        sendOneFullBlock(block, blockByteSize);
+                        // Trim the queue if necessary, also increment the next block to send.
+                        trimBlockItemQueue(nextBlockToSend.incrementAndGet());
                     } else {
-                        awaitNewLiveEntries();
+                        // Only give up if this is an historical block, otherwise just
+                        // go back up and see if live has the block.
+                        if (!(nextBlockToSend.get() < 0 || nextBlockToSend.get() >= getLatestHistoricalBlock())) {
+                            // We cannot get the block needed, something has failed.
+                            // close the stream with an "unavailable" response.
+                            final String message = "Unable to read historical block, nextBlockToSend={0}.";
+                            LOGGER.log(Level.INFO, message, nextBlockToSend);
+                            close(SubscribeStreamResponse.Code.NOT_AVAILABLE);
+                        } else {
+                            awaitNewLiveEntries();
+                        }
+                        break;
                     }
-                    break;
                 }
+            } finally {
+                sessionContext.blockReadBulkhead.release();
             }
         }
     }

--- a/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
+++ b/block-node/stream-subscriber/src/main/java/org/hiero/block/node/stream/subscriber/SubscriberServicePlugin.java
@@ -31,6 +31,7 @@ import org.hiero.block.internal.SubscribeStreamResponseUnparsed.Builder;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.bulkhead.BlockReadBulkhead;
 import org.hiero.block.node.stream.subscriber.BlockStreamSubscriberSession.SessionContext;
 import org.hiero.metrics.LongCounter;
 import org.hiero.metrics.LongGauge;
@@ -56,6 +57,8 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
     private final Logger LOGGER = System.getLogger(getClass().getName());
     /** The block node context, used to provide access to facilities */
     private BlockNodeContext context;
+    /** The shared block-storage read bulkhead; protects storage independent of client identity */
+    private BlockReadBulkhead blockReadBulkhead;
     /** A handler for client requests */
     private SubscribeBlockStreamHandler clientHandler;
 
@@ -67,6 +70,7 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
     @Override
     public void init(@NonNull final BlockNodeContext context, @NonNull final ServiceBuilder serviceBuilder) {
         this.context = requireNonNull(context);
+        this.blockReadBulkhead = serviceBuilder.blockReadBulkhead();
         // register us as a service; a null port (the default) shares server.port
         final Integer port =
                 context.configuration().getConfigData(SubscriberConfig.class).port();
@@ -76,7 +80,7 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
     @Override
     public void start() {
         // Create the client handler and wait for it to start and reach a ready state.
-        clientHandler = new SubscribeBlockStreamHandler(context);
+        clientHandler = new SubscribeBlockStreamHandler(context, blockReadBulkhead);
     }
 
     @Override
@@ -137,6 +141,8 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
         private final AtomicLong nextClientId = new AtomicLong(0);
         /** A context that applies to the pipeline this handler supports. */
         private final BlockNodeContext context;
+        /** The shared block-storage read bulkhead; protects storage independent of client identity */
+        private final BlockReadBulkhead blockReadBulkhead;
         /** Set of open client sessions */
         private volatile Map<Long, BlockStreamSubscriberSession> openSessions;
         // Metrics
@@ -148,8 +154,10 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
         private final ExecutorService virtualThreadExecutor;
         private volatile CompletionService<BlockStreamSubscriberSession> streamSessions;
 
-        private SubscribeBlockStreamHandler(@NonNull final BlockNodeContext context) {
+        private SubscribeBlockStreamHandler(
+                @NonNull final BlockNodeContext context, @NonNull final BlockReadBulkhead blockReadBulkhead) {
             this.context = requireNonNull(context);
+            this.blockReadBulkhead = requireNonNull(blockReadBulkhead);
             openSessions = new ConcurrentSkipListMap<>();
             virtualThreadExecutor = context.threadPoolManager().getVirtualThreadExecutor();
             streamSessions = new ExecutorCompletionService<>(virtualThreadExecutor);
@@ -207,7 +215,8 @@ public class SubscriberServicePlugin implements BlockNodePlugin, BlockStreamSubs
             final CompletionService<BlockStreamSubscriberSession> streams = streamSessions;
             final Map<Long, BlockStreamSubscriberSession> sessions = openSessions;
             if (streams != null && sessions != null) {
-                final SessionContext sessionContext = SessionContext.create(clientId, request, context);
+                final SessionContext sessionContext =
+                        SessionContext.create(clientId, request, context, blockReadBulkhead);
                 final BlockStreamSubscriberSession blockStreamSession =
                         new BlockStreamSubscriberSession(sessionContext, responsePipeline, context, sessionReadyLatch);
                 streams.submit(blockStreamSession);

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSessionTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/BlockStreamSubscriberSessionTest.java
@@ -20,14 +20,17 @@ import org.hiero.block.api.SubscribeStreamResponse.Code;
 import org.hiero.block.internal.BlockItemUnparsed;
 import org.hiero.block.internal.SubscribeStreamResponseUnparsed;
 import org.hiero.block.internal.SubscribeStreamResponseUnparsed.ResponseOneOfType;
+import org.hiero.block.node.app.fixtures.TestMetricsExporter;
 import org.hiero.block.node.app.fixtures.pipeline.TestResponsePipeline;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleBlockRangeSet;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
 import org.hiero.block.node.app.fixtures.plugintest.TestBlockMessagingFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
+import org.hiero.block.node.spi.bulkhead.BlockReadBulkhead;
 import org.hiero.block.node.spi.historicalblocks.BlockRangeSet;
 import org.hiero.block.node.stream.subscriber.BlockStreamSubscriberSession.SessionContext;
+import org.hiero.metrics.core.MetricRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -46,6 +49,13 @@ class BlockStreamSubscriberSessionTest {
             response -> response.response().kind();
     private static final Function<SubscribeStreamResponseUnparsed, Code> responseStatusExtractor =
             SubscribeStreamResponseUnparsed::status;
+
+    /** A generously-sized bulkhead shared by every {@link SessionContext#create} call in this file. */
+    private static final BlockReadBulkhead TEST_BLOCK_READ_BULKHEAD = new BlockReadBulkhead(
+            1_000,
+            MetricRegistry.builder()
+                    .setMetricsExporter(new TestMetricsExporter())
+                    .build());
 
     // SESSION FIELDS
     /** Client id of the session. */
@@ -97,7 +107,7 @@ class BlockStreamSubscriberSessionTest {
                     .startBlockNumber(-1L)
                     .endBlockNumber(-1L)
                     .build();
-            sessionContext = SessionContext.create(clientId, validRequest, blockNodeContext);
+            sessionContext = SessionContext.create(clientId, validRequest, blockNodeContext, TEST_BLOCK_READ_BULKHEAD);
         }
 
         /**
@@ -1247,7 +1257,7 @@ class BlockStreamSubscriberSessionTest {
                     .endBlockNumber(0L)
                     .build();
             final BlockStreamSubscriberSession session = new BlockStreamSubscriberSession(
-                    SessionContext.create(clientId, request, chunkingContext),
+                    SessionContext.create(clientId, request, chunkingContext, TEST_BLOCK_READ_BULKHEAD),
                     chunkingPipeline,
                     chunkingContext,
                     sessionReadyLatch);
@@ -1292,7 +1302,7 @@ class BlockStreamSubscriberSessionTest {
                     .endBlockNumber(0L)
                     .build();
             final BlockStreamSubscriberSession session = new BlockStreamSubscriberSession(
-                    SessionContext.create(clientId, request, chunkingContext),
+                    SessionContext.create(clientId, request, chunkingContext, TEST_BLOCK_READ_BULKHEAD),
                     chunkingPipeline,
                     chunkingContext,
                     sessionReadyLatch);
@@ -1347,7 +1357,7 @@ class BlockStreamSubscriberSessionTest {
                     .endBlockNumber(0L)
                     .build();
             final BlockStreamSubscriberSession session = new BlockStreamSubscriberSession(
-                    SessionContext.create(clientId, request, chunkingContext),
+                    SessionContext.create(clientId, request, chunkingContext, TEST_BLOCK_READ_BULKHEAD),
                     chunkingPipeline,
                     chunkingContext,
                     sessionReadyLatch);
@@ -1395,7 +1405,7 @@ class BlockStreamSubscriberSessionTest {
                     .endBlockNumber(0L)
                     .build();
             final BlockStreamSubscriberSession session = new BlockStreamSubscriberSession(
-                    SessionContext.create(clientId, request, chunkingContext),
+                    SessionContext.create(clientId, request, chunkingContext, TEST_BLOCK_READ_BULKHEAD),
                     chunkingPipeline,
                     chunkingContext,
                     sessionReadyLatch);
@@ -1449,7 +1459,7 @@ class BlockStreamSubscriberSessionTest {
      */
     private BlockStreamSubscriberSession generateSession(final SubscribeStreamRequest request) {
         return new BlockStreamSubscriberSession(
-                SessionContext.create(clientId, request, blockNodeContext),
+                SessionContext.create(clientId, request, blockNodeContext, TEST_BLOCK_READ_BULKHEAD),
                 responsePipeline,
                 blockNodeContext,
                 sessionReadyLatch);

--- a/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberServicePluginTest.java
+++ b/block-node/stream-subscriber/src/test/java/org/hiero/block/node/stream/subscriber/SubscriberServicePluginTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.hiero.block.api.SubscribeStreamRequest;
@@ -28,6 +29,7 @@ import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
 import org.hiero.block.node.app.fixtures.plugintest.GrpcPluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
 import org.hiero.block.node.spi.blockmessaging.BlockItems;
+import org.hiero.block.node.spi.bulkhead.BlockReadBulkhead;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -87,6 +89,44 @@ class SubscriberServicePluginTest {
             final SubscriberServicePlugin toTest = new SubscriberServicePlugin();
             historicalBlockFacility = new SimpleInMemoryHistoricalBlockFacility();
             start(toTest, toTest.methods().getFirst(), historicalBlockFacility);
+        }
+
+        /**
+         * This test aims to assert that a subscriber session catching up on historical blocks
+         * retries on the next poll rather than disconnecting when the shared block-read bulkhead
+         * has no permit available, and that it proceeds normally once one frees up.
+         */
+        @Test
+        @DisplayName(
+                "Test Subscriber: historical catch-up retries rather than disconnects when the bulkhead is exhausted")
+        void testHistoricalReadRetriesWhenBulkheadExhausted() {
+            final TestBlock blockZero = TestBlockBuilder.generateBlockWithNumber(0);
+            historicalBlockFacility.handleBlockItemsReceived(blockZero.asBlockItems());
+
+            final BlockReadBulkhead bulkhead = webserviceBuilder.blockReadBulkhead();
+            for (int i = 0; i < bulkhead.totalPermits(); i++) {
+                assertThat(bulkhead.tryAcquire()).isTrue();
+            }
+            try {
+                final SubscribeStreamRequest request = SubscribeStreamRequest.newBuilder()
+                        .startBlockNumber(0L)
+                        .endBlockNumber(0L)
+                        .build();
+                toPluginPipe.onNext(SubscribeStreamRequest.PROTOBUF.toBytes(request));
+
+                // A few retry cycles' worth of waiting: no response at all yet proves the session is
+                // polling for a permit, not disconnecting (which would produce an error/status response).
+                parkNanos(TimeUnit.MILLISECONDS.toNanos(350));
+                assertThat(fromPluginBytes).isEmpty();
+            } finally {
+                for (int i = 0; i < bulkhead.totalPermits(); i++) {
+                    bulkhead.release();
+                }
+            }
+
+            // Now that a permit is available, the session should complete normally on its next poll.
+            final int expectedResponses = 3; // block items, end of block, success status
+            awaitResponse(fromPluginBytes, expectedResponses);
         }
 
         /**


### PR DESCRIPTION
## Summary

Adds a shared block-read bulkhead: a single, bounded, non-client-keyed permit pool protecting
block storage reads from combined overload, independent of which API or client triggered the
read. See `docs/design/apis/api-throttling.md` for the full design.

- `BlockReadBulkhead` is exposed as one shared instance via `ServiceBuilder.blockReadBulkhead()`,
  so `BlockAccessServicePlugin` and the subscriber plugin protect the same resource with the same
  instance.
- `getBlock` acquires without waiting and rejects immediately (`RESOURCE_EXHAUSTED`) if no permit
  is available.
- A subscriber session catching up on historical blocks waits briefly for a permit and retries on
  its next poll rather than disconnecting, since killing a long-lived session over one transient
  saturation instant is a worse outcome than a short delay.
- Sized by a single configuration value (`blockReadBulkhead.permits`, default 50).

This is independent of per-client admission control - no rate limiting, no client identity
tracking, just a shared capacity ceiling on the resource itself.

## Test plan

- [x] `BlockReadBulkheadTest`: construction validation, acquire/release, non-blocking and
      bounded-wait acquire modes.
- [x] `BlockAccessServicePluginTest`: `getBlock` is rejected with `RESOURCE_EXHAUSTED` once the
      bulkhead is exhausted.
- [x] `SubscriberServicePluginTest`: a historical catch-up read retries rather than disconnects
      when the bulkhead is exhausted, and completes normally once a permit frees up.
- [x] `ServiceBuilderImplTest`: the accessor returns a correctly-sized, stable shared instance.
- [x] Full build, test, and spotless pass for every touched module.

Closes #3533.
