### PR TITLE
feat(throttle): add per-client admission control for serverStatus

### DIFF
--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/AppConfigExtension.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/AppConfigExtension.java
@@ -18,6 +18,11 @@ public class AppConfigExtension implements ConfigurationExtension {
     @NonNull
     @Override
     public Set<Class<? extends Record>> getConfigDataTypes() {
-        return Set.of(ServerConfig.class, WebServerHttp2Config.class, NodeConfig.class, ApplicationStateConfig.class);
+        return Set.of(
+                ServerConfig.class,
+                WebServerHttp2Config.class,
+                NodeConfig.class,
+                ApplicationStateConfig.class,
+                GlobalThrottleConfig.class);
     }
 }

--- a/block-node/app-config/src/main/java/org/hiero/block/node/app/config/GlobalThrottleConfig.java
+++ b/block-node/app-config/src/main/java/org/hiero/block/node/app/config/GlobalThrottleConfig.java
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.app.config;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import com.swirlds.config.api.validation.annotation.Min;
+import org.hiero.block.node.base.Loggable;
+
+/**
+ * Node-wide concurrency ceilings for throttled gRPC methods, one field per method.
+ *
+ * <p>A ceiling here represents an allocation of the node's total shared capacity (connections,
+ * heap, disk I/O) across every throttled API, which is inherently a node-level view rather than
+ * something any single plugin can reason about on its own — unlike a method's per-client rate and
+ * concurrency settings, which are owned by the plugin that implements that method. See
+ * {@code docs/design/apis/api-throttling.md} ("Configuration ownership") for the full rationale.
+ *
+ * @param serverStatusMaxConcurrent maximum concurrent in-flight {@code serverStatus} /
+ *     {@code serverStatusDetail} calls across all clients
+ * @param clientStateTtlMinutes how long a throttled service keeps a client's rate/concurrency
+ *     state after that client's last call before the entry becomes eligible for eviction; bounds
+ *     the throttle's own memory use as new clients are seen over time (see
+ *     {@code docs/design/apis/api-throttling.md} §5)
+ * @param clientStateSweepIntervalMinutes how often the backstop sweep for stale, never-looked-up-again
+ *     client entries runs
+ */
+@ConfigData("throttle.global")
+public record GlobalThrottleConfig(
+        @Loggable @ConfigProperty(defaultValue = "1000") @Min(1)
+        int serverStatusMaxConcurrent,
+
+        @Loggable @ConfigProperty(defaultValue = "30") @Min(1)
+        int clientStateTtlMinutes,
+
+        @Loggable @ConfigProperty(defaultValue = "5") @Min(1)
+        int clientStateSweepIntervalMinutes) {}

--- a/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/BlockNodeApp.java
@@ -57,6 +57,7 @@ import org.hiero.block.api.RangedNodeAddressBook;
 import org.hiero.block.api.TssData;
 import org.hiero.block.internal.BlockRangesState;
 import org.hiero.block.node.app.config.AutomaticEnvironmentVariableConfigSource;
+import org.hiero.block.node.app.config.GlobalThrottleConfig;
 import org.hiero.block.node.app.config.ServerConfig;
 import org.hiero.block.node.app.config.WebServerHttp2Config;
 import org.hiero.block.node.app.config.state.ApplicationStateConfig;
@@ -293,7 +294,9 @@ public class BlockNodeApp implements HealthFacility, ApplicationStateFacility {
                 .build();
 
         // Create HTTP & GRPC routing builders; null port in plugin registrations resolves to server.port
-        serviceBuilder = new ServiceBuilderImpl(serverConfig, http2Config, socketOptions);
+        final GlobalThrottleConfig globalThrottleConfig = configuration.getConfigData(GlobalThrottleConfig.class);
+        serviceBuilder = new ServiceBuilderImpl(
+                serverConfig, http2Config, socketOptions, globalThrottleConfig, metricRegistry, threadPoolManager);
         // ==== INITIALIZE PLUGINS =====================================================================================
         // Initialize all the facilities & plugins, adding routing for each plugin
         for (BlockNodePlugin plugin : loadedPlugins) {

--- a/block-node/app/src/main/java/org/hiero/block/node/app/ServiceBuilderImpl.java
+++ b/block-node/app/src/main/java/org/hiero/block/node/app/ServiceBuilderImpl.java
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.block.node.app;
 
+import static java.lang.System.Logger.Level.INFO;
+import static java.lang.System.Logger.Level.WARNING;
+
 import com.hedera.pbj.grpc.helidon.PbjRouting;
 import com.hedera.pbj.grpc.helidon.config.PbjConfig;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
@@ -13,15 +16,28 @@ import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http2.Http2Config;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.hiero.block.node.app.config.GlobalThrottleConfig;
 import org.hiero.block.node.app.config.ServerConfig;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.threading.ThreadPoolManager;
+import org.hiero.block.node.spi.throttle.RemoteAddressKeyExtractor;
+import org.hiero.block.node.spi.throttle.StaleClientSweepable;
+import org.hiero.block.node.spi.throttle.ThrottleExempt;
+import org.hiero.block.node.spi.throttle.ThrottlePolicy;
+import org.hiero.block.node.spi.throttle.ThrottleSpec;
+import org.hiero.block.node.spi.throttle.ThrottledServiceInterface;
+import org.hiero.metrics.core.MetricRegistry;
 
 /// Default implementation of [ServiceBuilder]. That builds HTTP and PBJ GRPC services.
 ///
@@ -32,6 +48,8 @@ import org.hiero.block.node.spi.ServiceBuilder;
 /// A `null` port in any registration call resolves to the default port supplied at
 /// construction time (typically `server.port`).
 public class ServiceBuilderImpl implements ServiceBuilder {
+    private static final System.Logger LOGGER = System.getLogger(ServiceBuilderImpl.class.getName());
+
     /** Per-port HTTP routing builders. */
     private final Map<Integer, HttpRouting.Builder> httpBuilders = new HashMap<>();
     /** Per-port PBJ gRPC routing builders. */
@@ -40,14 +58,30 @@ public class ServiceBuilderImpl implements ServiceBuilder {
     private final ServerConfig serverConfig;
     private final Http2Config http2Config;
     private final SocketOptions socketOptions;
+    private final GlobalThrottleConfig globalThrottleConfig;
+    private final MetricRegistry metricRegistry;
+    private final ThreadPoolManager threadPoolManager;
     private WebServerResult generalWebserver;
     private final LinkedHashSet<WebServerResult> additionalWebservers;
 
+    /** Every throttled service this instance has created, for the periodic stale-client sweep. */
+    private final List<StaleClientSweepable> throttledServices = new ArrayList<>();
+    /** Lazily created on the first throttled registration; runs the stale-client-state sweep. */
+    private ScheduledExecutorService clientStateSweepExecutor;
+
     public ServiceBuilderImpl(
-            final ServerConfig serverConfig, final Http2Config http2Config, final SocketOptions socketOptions) {
+            final ServerConfig serverConfig,
+            final Http2Config http2Config,
+            final SocketOptions socketOptions,
+            final GlobalThrottleConfig globalThrottleConfig,
+            final MetricRegistry metricRegistry,
+            final ThreadPoolManager threadPoolManager) {
         this.serverConfig = serverConfig;
         this.http2Config = http2Config;
         this.socketOptions = socketOptions;
+        this.globalThrottleConfig = globalThrottleConfig;
+        this.metricRegistry = metricRegistry;
+        this.threadPoolManager = threadPoolManager;
         additionalWebservers = new LinkedHashSet<>();
     }
 
@@ -58,9 +92,73 @@ public class ServiceBuilderImpl implements ServiceBuilder {
     }
 
     /// {@inheritDoc}
+    ///
+    /// Every registration is logged once, at startup, as one of throttled ([ThrottleSpec]), exempt
+    /// ([ThrottleExempt]), or neither — the last case logs a warning, since an admission-control
+    /// gap is far more likely to be an oversight than a deliberate choice, and nothing else here
+    /// would otherwise make that omission visible.
+    ///
+    /// If `service` also implements [ThrottleSpec], merges its per-client settings with its own
+    /// reported [ThrottleSpec#globalConcurrencyCeiling], and registers the resulting
+    /// [ThrottledServiceInterface] in place of the raw service.
     @Override
     public void registerGrpcService(@Nullable Integer port, @NonNull ServiceInterface service) {
-        grpcBuilders.computeIfAbsent(resolve(port), k -> PbjRouting.builder()).service(service);
+        if (service instanceof ThrottleSpec spec) {
+            LOGGER.log(INFO, "Registered gRPC service {0}: throttled", service.serviceName());
+            registerThrottledGrpcService(port, service, spec);
+        } else {
+            if (service instanceof ThrottleExempt) {
+                LOGGER.log(
+                        INFO,
+                        "Registered gRPC service {0}: exempt (deliberately not throttled)",
+                        service.serviceName());
+            } else {
+                LOGGER.log(
+                        WARNING,
+                        "Registered gRPC service {0}: NOT throttled, and not marked exempt via ThrottleExempt — "
+                                + "confirm this is intentional",
+                        service.serviceName());
+            }
+            grpcBuilders
+                    .computeIfAbsent(resolve(port), k -> PbjRouting.builder())
+                    .service(service);
+        }
+    }
+
+    private void registerThrottledGrpcService(
+            @Nullable final Integer port, @NonNull final ServiceInterface service, @NonNull final ThrottleSpec spec) {
+        final ThrottlePolicy policy = ThrottlePolicy.merge(spec.perClientSettings(), spec.globalConcurrencyCeiling());
+        final ThrottledServiceInterface throttled = new ThrottledServiceInterface(
+                service,
+                policy,
+                new RemoteAddressKeyExtractor(),
+                metricRegistry,
+                Duration.ofMinutes(globalThrottleConfig.clientStateTtlMinutes()));
+        throttledServices.add(throttled);
+        ensureClientStateSweepStarted();
+        grpcBuilders.computeIfAbsent(resolve(port), k -> PbjRouting.builder()).service(throttled);
+    }
+
+    /// Starts the periodic stale-client-state sweep the first time it's needed (i.e. the first
+    /// throttled service registration), rather than unconditionally in the constructor — a node
+    /// with no throttled services registers nothing and spawns no sweep thread.
+    private void ensureClientStateSweepStarted() {
+        if (clientStateSweepExecutor != null) {
+            return;
+        }
+        clientStateSweepExecutor = threadPoolManager.createVirtualThreadScheduledExecutor(
+                1, "throttle-client-state-sweep", (thread, throwable) -> {});
+        final long intervalMinutes = globalThrottleConfig.clientStateSweepIntervalMinutes();
+        clientStateSweepExecutor.scheduleAtFixedRate(
+                () -> {
+                    final long now = System.nanoTime();
+                    for (final StaleClientSweepable throttled : throttledServices) {
+                        throttled.sweepStaleClients(now);
+                    }
+                },
+                intervalMinutes,
+                intervalMinutes,
+                TimeUnit.MINUTES);
     }
 
     /// Returns all HTTP routing builders keyed by port.
@@ -126,6 +224,9 @@ public class ServiceBuilderImpl implements ServiceBuilder {
         additionalWebservers.parallelStream()
                 .forEach(server -> server.serverCreated().stop());
         generalWebserver.serverCreated().stop();
+        if (clientStateSweepExecutor != null) {
+            clientStateSweepExecutor.shutdownNow();
+        }
     }
 
     @Override

--- a/block-node/app/src/test/java/org/hiero/block/node/app/ServiceBuilderImplTest.java
+++ b/block-node/app/src/test/java/org/hiero/block/node/app/ServiceBuilderImplTest.java
@@ -2,6 +2,7 @@
 package org.hiero.block.node.app;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.hedera.pbj.grpc.helidon.PbjRouting;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
@@ -19,11 +21,21 @@ import io.helidon.common.socket.SocketOptions;
 import io.helidon.webserver.http.HttpRouting;
 import io.helidon.webserver.http.HttpService;
 import io.helidon.webserver.http2.Http2Config;
+import java.util.List;
 import java.util.Map;
+import org.hiero.block.node.app.config.GlobalThrottleConfig;
 import org.hiero.block.node.app.config.ServerConfig;
+import org.hiero.block.node.app.fixtures.TestMetricsExporter;
+import org.hiero.block.node.spi.threading.ThreadPoolManager;
+import org.hiero.block.node.spi.throttle.PerClientThrottleSettings;
+import org.hiero.block.node.spi.throttle.ThrottleExempt;
+import org.hiero.block.node.spi.throttle.ThrottleSpec;
+import org.hiero.block.node.spi.throttle.ThrottledServiceInterface;
+import org.hiero.metrics.core.MetricRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Tests for {@link ServiceBuilderImpl} class which implements the {@link org.hiero.block.node.spi.ServiceBuilder}
@@ -42,7 +54,132 @@ class ServiceBuilderImplTest {
         final Http2Config http2Config = Http2Config.builder().build();
         final SocketOptions socketOptions = SocketOptions.builder().build();
         ServerConfig testConfig = new ServerConfig(0, 0, 0, PUBLISHER_PORT, 0, 0, 0, 0, false, 0, 0);
-        serviceBuilder = new ServiceBuilderImpl(testConfig, http2Config, socketOptions);
+        final GlobalThrottleConfig globalThrottleConfig = new GlobalThrottleConfig(1000, 30, 5);
+        final MetricRegistry metricRegistry = MetricRegistry.builder()
+                .setMetricsExporter(new TestMetricsExporter())
+                .build();
+        final ThreadPoolManager threadPoolManager = mock(ThreadPoolManager.class);
+        // Only exercised by throttled-registration tests, which trigger the lazily-started
+        // stale-client sweep; a mock executor is enough since these tests don't assert on sweeps.
+        when(threadPoolManager.createVirtualThreadScheduledExecutor(
+                        org.mockito.ArgumentMatchers.anyInt(),
+                        org.mockito.ArgumentMatchers.any(),
+                        org.mockito.ArgumentMatchers.any()))
+                .thenReturn(mock(java.util.concurrent.ScheduledExecutorService.class));
+        serviceBuilder = new ServiceBuilderImpl(
+                testConfig, http2Config, socketOptions, globalThrottleConfig, metricRegistry, threadPoolManager);
+    }
+
+    @Test
+    @DisplayName("registerGrpcService wraps a ThrottleSpec service using its own reported settings")
+    void registerGrpcService_throttleSpec_wrapsService() {
+        final ServiceInterface testService =
+                new TestThrottledService("TestService", new PerClientThrottleSettings(10, 5, 3), 100);
+        final PbjRouting.Builder spyBuilder = injectGrpcBuilderSpy(CONSUMER_PORT);
+
+        serviceBuilder.registerGrpcService(CONSUMER_PORT, testService);
+
+        final ArgumentCaptor<ServiceInterface> registered = ArgumentCaptor.forClass(ServiceInterface.class);
+        verify(spyBuilder).service(registered.capture());
+        assertInstanceOf(ThrottledServiceInterface.class, registered.getValue());
+        assertNotSame(testService, registered.getValue(), "the raw service must be wrapped, not registered as-is");
+    }
+
+    @Test
+    @DisplayName("registerGrpcService registers a ThrottleExempt service as-is, without wrapping")
+    void registerGrpcService_throttleExempt_registersRawServiceWithoutWrapping() {
+        final ServiceInterface testService = new TestExemptService("TestExemptService");
+        final PbjRouting.Builder spyBuilder = injectGrpcBuilderSpy(CONSUMER_PORT);
+
+        serviceBuilder.registerGrpcService(CONSUMER_PORT, testService);
+
+        verify(spyBuilder).service(eq(testService));
+    }
+
+    /// A minimal, hand-written [ServiceInterface] + [ThrottleSpec] test double. Deliberately not a
+    /// Mockito mock with `extraInterfaces`: the generated mock class would live in
+    /// `ServiceInterface`'s own module (`com.hedera.pbj.runtime`), which does not read
+    /// `org.hiero.block.node.spi` — so Mockito cannot make it implement `ThrottleSpec` across that
+    /// module boundary. A real class compiled into this module has no such restriction.
+    private static final class TestThrottledService implements ServiceInterface, ThrottleSpec {
+        private final String serviceName;
+        private final PerClientThrottleSettings perClientSettings;
+        private final int globalConcurrencyCeiling;
+
+        TestThrottledService(
+                final String serviceName,
+                final PerClientThrottleSettings perClientSettings,
+                final int globalConcurrencyCeiling) {
+            this.serviceName = serviceName;
+            this.perClientSettings = perClientSettings;
+            this.globalConcurrencyCeiling = globalConcurrencyCeiling;
+        }
+
+        @Override
+        public String serviceName() {
+            return serviceName;
+        }
+
+        @Override
+        public String fullName() {
+            return serviceName;
+        }
+
+        @Override
+        public List<Method> methods() {
+            return List.of();
+        }
+
+        @Override
+        public com.hedera.pbj.runtime.grpc.Pipeline<? super com.hedera.pbj.runtime.io.buffer.Bytes> open(
+                final Method method,
+                final RequestOptions opts,
+                final com.hedera.pbj.runtime.grpc.Pipeline<? super com.hedera.pbj.runtime.io.buffer.Bytes> responses) {
+            throw new UnsupportedOperationException("not exercised by these registration-only tests");
+        }
+
+        @Override
+        public PerClientThrottleSettings perClientSettings() {
+            return perClientSettings;
+        }
+
+        @Override
+        public int globalConcurrencyCeiling() {
+            return globalConcurrencyCeiling;
+        }
+    }
+
+    /// A minimal, hand-written [ServiceInterface] + [ThrottleExempt] test double; see
+    /// [TestThrottledService] for why this isn't a Mockito `extraInterfaces` mock.
+    private static final class TestExemptService implements ServiceInterface, ThrottleExempt {
+        private final String serviceName;
+
+        TestExemptService(final String serviceName) {
+            this.serviceName = serviceName;
+        }
+
+        @Override
+        public String serviceName() {
+            return serviceName;
+        }
+
+        @Override
+        public String fullName() {
+            return serviceName;
+        }
+
+        @Override
+        public List<Method> methods() {
+            return List.of();
+        }
+
+        @Override
+        public com.hedera.pbj.runtime.grpc.Pipeline<? super com.hedera.pbj.runtime.io.buffer.Bytes> open(
+                final Method method,
+                final RequestOptions opts,
+                final com.hedera.pbj.runtime.grpc.Pipeline<? super com.hedera.pbj.runtime.io.buffer.Bytes> responses) {
+            throw new UnsupportedOperationException("not exercised by these registration-only tests");
+        }
     }
 
     @Test

--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusConfigExtension.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusConfigExtension.java
@@ -16,6 +16,6 @@ public class ServerStatusConfigExtension implements ConfigurationExtension {
     @NonNull
     @Override
     public Set<Class<? extends Record>> getConfigDataTypes() {
-        return Set.of(ServerStatusConfig.class);
+        return Set.of(ServerStatusConfig.class, ServerStatusThrottleConfig.class);
     }
 }

--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusServicePlugin.java
@@ -17,6 +17,7 @@ import org.hiero.block.api.BlockRange;
 import org.hiero.block.api.ServerStatusDetailResponse;
 import org.hiero.block.api.ServerStatusRequest;
 import org.hiero.block.api.ServerStatusResponse;
+import org.hiero.block.node.app.config.GlobalThrottleConfig;
 import org.hiero.block.node.app.config.node.NodeConfig;
 import org.hiero.block.node.spi.ApplicationStateFacility;
 import org.hiero.block.node.spi.BlockNodeContext;
@@ -24,6 +25,8 @@ import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
 import org.hiero.block.node.spi.historicalblocks.BlockRangeSet;
 import org.hiero.block.node.spi.historicalblocks.HistoricalBlockFacility;
+import org.hiero.block.node.spi.throttle.PerClientThrottleSettings;
+import org.hiero.block.node.spi.throttle.ThrottleSpec;
 import org.hiero.metrics.LongCounter;
 import org.hiero.metrics.core.MetricKey;
 import org.hiero.metrics.core.MetricRegistry;
@@ -31,7 +34,7 @@ import org.hiero.metrics.core.MetricRegistry;
 /**
  * Plugin that implements the BlockNodeService and provides the 'serverStatus' RPC.
  */
-public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServiceInterface {
+public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServiceInterface, ThrottleSpec {
     /** Metric key for the number of server status requests */
     public static final MetricKey<LongCounter> METRIC_SERVER_STATUS_REQUESTS =
             MetricKey.of("server_status_requests", LongCounter.class).addCategory(METRICS_CATEGORY);
@@ -53,6 +56,10 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
     private LongCounter.Measurement requestDetailCounter;
     /** Scheduler for the periodic status heartbeat; null when the heartbeat is disabled. */
     private ScheduledExecutorService heartbeatExecutor;
+    /** This service's per-client throttle settings, computed once in {@link #init}; see {@link ThrottleSpec}. */
+    private volatile PerClientThrottleSettings throttleSettings;
+    /** This service's node-wide concurrency ceiling, computed once in {@link #init}; see {@link ThrottleSpec}. */
+    private volatile int globalConcurrencyCeiling;
 
     /**
      * Handle a request for server status
@@ -185,10 +192,33 @@ public class ServerStatusServicePlugin implements BlockNodePlugin, BlockNodeServ
                         .setDescription("Number of server status details requests"))
                 .getOrCreateNotLabeled();
 
+        final ServerStatusThrottleConfig throttleConfig =
+                context.configuration().getConfigData(ServerStatusThrottleConfig.class);
+        this.throttleSettings = new PerClientThrottleSettings(
+                throttleConfig.ratePerSecond(),
+                throttleConfig.burstTolerance(),
+                throttleConfig.maxConcurrentPerClient());
+        this.globalConcurrencyCeiling = context.configuration()
+                .getConfigData(GlobalThrottleConfig.class)
+                .serverStatusMaxConcurrent();
+
         // Register this service; a null port (the default) shares server.port
         final Integer port =
                 context.configuration().getConfigData(ServerStatusConfig.class).port();
         serviceBuilder.registerGrpcService(port, this);
+    }
+
+    /// {@inheritDoc}
+    @NonNull
+    @Override
+    public PerClientThrottleSettings perClientSettings() {
+        return throttleSettings;
+    }
+
+    /// {@inheritDoc}
+    @Override
+    public int globalConcurrencyCeiling() {
+        return globalConcurrencyCeiling;
     }
 
     @Override

--- a/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusThrottleConfig.java
+++ b/block-node/server-status/src/main/java/org/hiero/block/node/server/status/ServerStatusThrottleConfig.java
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.server.status;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import com.swirlds.config.api.validation.annotation.Min;
+import org.hiero.block.node.base.Loggable;
+
+/**
+ * Per-client throttle settings for {@code BlockNodeService.serverStatus} / {@code serverStatusDetail}.
+ * The node-wide concurrency ceiling for this method lives separately, in the shared
+ * {@code GlobalThrottleConfig} (app-config) — see {@code docs/design/apis/api-throttling.md}
+ * ("Configuration ownership") for why.
+ *
+ * @param ratePerSecond sustained requests per second allowed for one client
+ * @param burstTolerance how many pacing intervals early a client's request may arrive and still
+ *     be admitted
+ * @param maxConcurrentPerClient maximum concurrent in-flight calls for one client
+ */
+@ConfigData("throttle.serverStatus")
+public record ServerStatusThrottleConfig(
+        @Loggable @ConfigProperty(defaultValue = "50") @Min(1)
+        int ratePerSecond,
+
+        @Loggable @ConfigProperty(defaultValue = "20") @Min(0)
+        int burstTolerance,
+
+        @Loggable @ConfigProperty(defaultValue = "5") @Min(1)
+        int maxConcurrentPerClient) {}

--- a/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java
+++ b/block-node/server-status/src/test/java/org/hiero/block/node/server/status/ServerStatusServicePluginTest.java
@@ -22,6 +22,7 @@ import org.hiero.block.node.app.fixtures.blocks.TestBlockBuilder;
 import org.hiero.block.node.app.fixtures.logging.TestLogHandler;
 import org.hiero.block.node.app.fixtures.plugintest.GrpcPluginTestBase;
 import org.hiero.block.node.app.fixtures.plugintest.SimpleInMemoryHistoricalBlockFacility;
+import org.hiero.block.node.spi.throttle.PerClientThrottleSettings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -314,6 +315,24 @@ public class ServerStatusServicePluginTest
             julLogger.removeHandler(logHandler);
         }
         assertEquals(1, logHandler.countContaining("Server status heartbeat disabled"));
+    }
+
+    @Test
+    @DisplayName("ThrottleSpec reports the configured per-client settings and global ceiling")
+    void perClientSettingsAndGlobalCeilingReflectConfig() {
+        final ServerStatusServicePlugin localPlugin = new ServerStatusServicePlugin();
+        start(
+                localPlugin,
+                localPlugin.methods().getFirst(),
+                new SimpleInMemoryHistoricalBlockFacility(),
+                Map.of(
+                        "throttle.serverStatus.ratePerSecond", "42",
+                        "throttle.serverStatus.burstTolerance", "7",
+                        "throttle.serverStatus.maxConcurrentPerClient", "3",
+                        "throttle.global.serverStatusMaxConcurrent", "99"));
+
+        assertEquals(new PerClientThrottleSettings(42, 7, 3), localPlugin.perClientSettings());
+        assertEquals(99, localPlugin.globalConcurrencyCeiling());
     }
 
     /**

--- a/block-node/spi-plugins/src/main/java/module-info.java
+++ b/block-node/spi-plugins/src/main/java/module-info.java
@@ -5,6 +5,7 @@ module org.hiero.block.node.spi {
     exports org.hiero.block.node.spi.historicalblocks;
     exports org.hiero.block.node.spi.module;
     exports org.hiero.block.node.spi.threading;
+    exports org.hiero.block.node.spi.throttle;
     exports org.hiero.block.node.spi;
 
     requires transitive com.hedera.pbj.runtime;

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/AdmissionResult.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/AdmissionResult.java
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.throttle;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/// The outcome of one [ClientThrottle#tryAdmit] call: either admitted, with the action to run
+/// exactly once to release the concurrency permit it acquired, or rejected, with the reason.
+record AdmissionResult(
+        boolean admitted,
+        @Nullable String rejectionReason,
+        @Nullable Runnable releasePermit) {
+    static AdmissionResult admitted(final Runnable releasePermit) {
+        return new AdmissionResult(true, null, releasePermit);
+    }
+
+    static AdmissionResult rejected(final String reason) {
+        return new AdmissionResult(false, reason, null);
+    }
+}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/ClientKeyExtractor.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/ClientKeyExtractor.java
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.throttle;
+
+import com.hedera.pbj.runtime.grpc.ServiceInterface.RequestOptions;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/// Derives the key used to group a caller's requests for per-client rate/concurrency limiting.
+///
+/// The default implementation ([RemoteAddressKeyExtractor]) keys by network address. This
+/// interface exists specifically so that an authenticated-identity-based implementation (an mTLS
+/// client certificate, or an API key) can replace it later without any change to
+/// [ThrottledServiceInterface], [ThrottlePolicy], or any plugin configuration.
+/// [RequestOptions#remoteCertificateChain()] already exists today, unused, as exactly what a
+/// future certificate-based extractor would read.
+public interface ClientKeyExtractor {
+    /// Derives a stable key identifying the caller of this request.
+    ///
+    /// @param options the request options for the call
+    /// @return a non-null key grouping this caller's requests
+    @NonNull
+    String extractKey(@NonNull RequestOptions options);
+}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/ClientThrottle.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/ClientThrottle.java
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.throttle;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.hiero.block.node.spi.BlockNodePlugin;
+import org.hiero.metrics.LongCounter;
+import org.hiero.metrics.ObservableGauge;
+import org.hiero.metrics.core.MetricKey;
+import org.hiero.metrics.core.MetricRegistry;
+
+/// The admission decision and per-client bookkeeping for one throttled gRPC method: a
+/// GCRA-rate-limited, concurrency-capped, TTL-evicted pool of client state, shared by
+/// [ThrottledServiceInterface].
+///
+/// On every [#tryAdmit] call, in order — the first check that rejects wins, and no later check
+/// runs: (1) the node-wide concurrency ceiling, (2) the per-client concurrency ceiling, (3) the
+/// GCRA rate check, which is the only state-mutating check and therefore runs last (see
+/// `docs/design/apis/api-throttling.md` for why).
+final class ClientThrottle implements StaleClientSweepable {
+    private final ThrottlePolicy policy;
+    private final String description;
+    private final long clientStateTtlNanos;
+    private final ConcurrentHashMap<String, ClientState> clientStates = new ConcurrentHashMap<>();
+    private final AtomicInteger globalInFlight = new AtomicInteger();
+
+    private final LongCounter.Measurement admittedCounter;
+    private final LongCounter.Measurement rejectedGlobalConcurrencyCounter;
+    private final LongCounter.Measurement rejectedClientConcurrencyCounter;
+    private final LongCounter.Measurement rejectedRateCounter;
+
+    /// @param policy the resolved per-client + node-wide policy this instance enforces
+    /// @param metricRegistry the registry to register this instance's metrics with
+    /// @param metricPrefix a unique-per-instance prefix for this instance's metric names
+    /// @param description a human-readable label for this instance, used in rejection reasons and
+    ///     metric descriptions (e.g. {@code "BlockNodeService.serverStatus"})
+    /// @param clientStateTtl how long a client's state is kept after its last-seen call before it
+    ///     becomes eligible for eviction (lazily on next lookup, or via [#sweepStaleClients])
+    ClientThrottle(
+            @NonNull final ThrottlePolicy policy,
+            @NonNull final MetricRegistry metricRegistry,
+            @NonNull final String metricPrefix,
+            @NonNull final String description,
+            @NonNull final Duration clientStateTtl) {
+        this.policy = policy;
+        this.description = description;
+        this.clientStateTtlNanos = clientStateTtl.toNanos();
+
+        admittedCounter = metricRegistry
+                .register(LongCounter.builder(MetricKey.of(metricPrefix + "_admitted_total", LongCounter.class)
+                                .addCategory(BlockNodePlugin.METRICS_CATEGORY))
+                        .setDescription("Calls admitted by the throttle for " + description))
+                .getOrCreateNotLabeled();
+        rejectedGlobalConcurrencyCounter = metricRegistry
+                .register(LongCounter.builder(
+                                MetricKey.of(metricPrefix + "_rejected_global_concurrency_total", LongCounter.class)
+                                        .addCategory(BlockNodePlugin.METRICS_CATEGORY))
+                        .setDescription("Calls rejected by the node-wide concurrency ceiling for " + description))
+                .getOrCreateNotLabeled();
+        rejectedClientConcurrencyCounter = metricRegistry
+                .register(LongCounter.builder(
+                                MetricKey.of(metricPrefix + "_rejected_client_concurrency_total", LongCounter.class)
+                                        .addCategory(BlockNodePlugin.METRICS_CATEGORY))
+                        .setDescription("Calls rejected by the per-client concurrency ceiling for " + description))
+                .getOrCreateNotLabeled();
+        rejectedRateCounter = metricRegistry
+                .register(LongCounter.builder(MetricKey.of(metricPrefix + "_rejected_rate_total", LongCounter.class)
+                                .addCategory(BlockNodePlugin.METRICS_CATEGORY))
+                        .setDescription("Calls rejected by the per-client rate limit for " + description))
+                .getOrCreateNotLabeled();
+        metricRegistry
+                .register(ObservableGauge.builder(
+                                MetricKey.of(metricPrefix + "_client_state_count", ObservableGauge.class)
+                                        .addCategory(BlockNodePlugin.METRICS_CATEGORY))
+                        .setDescription(
+                                "Number of distinct clients currently tracked by the throttle for " + description))
+                .observe(clientStates::mappingCount);
+    }
+
+    /// Attempts to admit a call from `clientKey`, applying the decision order described in the
+    /// class-level documentation.
+    ///
+    /// @param clientKey the caller's key, from a [ClientKeyExtractor]
+    /// @param nowNanos the current time from a monotonic clock (e.g. [System#nanoTime()])
+    /// @return the admission result — see [AdmissionResult]
+    @NonNull
+    AdmissionResult tryAdmit(@NonNull final String clientKey, final long nowNanos) {
+        // Atomic per-key compute: either reuse a live/still-fresh entry, or replace a stale,
+        // currently-unused one with a fresh limiter. A client that hasn't been seen in a while
+        // deserves a clean rate-limit history, not one artificially constrained by ancient calls.
+        final ClientState state = clientStates.compute(clientKey, (ignoredKey, existing) -> {
+            if (existing != null && !(isStale(existing, nowNanos) && existing.inFlight.get() == 0)) {
+                return existing;
+            }
+            return new ClientState(new GcraLimiter(policy.ratePerSecond(), policy.burstTolerance()));
+        });
+        state.lastSeenNanos = nowNanos;
+
+        if (globalInFlight.get() >= policy.maxConcurrentGlobal()) {
+            rejectedGlobalConcurrencyCounter.increment();
+            return AdmissionResult.rejected("node-wide concurrency limit reached for " + description);
+        }
+        if (state.inFlight.get() >= policy.maxConcurrentPerClient()) {
+            rejectedClientConcurrencyCounter.increment();
+            return AdmissionResult.rejected("per-client concurrency limit reached for " + description);
+        }
+        if (!state.limiter.tryAcquire(nowNanos)) {
+            rejectedRateCounter.increment();
+            return AdmissionResult.rejected("rate limit exceeded for " + description);
+        }
+
+        globalInFlight.incrementAndGet();
+        state.inFlight.incrementAndGet();
+        admittedCounter.increment();
+
+        final AtomicBoolean released = new AtomicBoolean(false);
+        final Runnable releasePermit = () -> {
+            if (released.compareAndSet(false, true)) {
+                globalInFlight.decrementAndGet();
+                state.inFlight.decrementAndGet();
+            }
+        };
+        return AdmissionResult.admitted(releasePermit);
+    }
+
+    /// {@inheritDoc}
+    @Override
+    public int sweepStaleClients(final long nowNanos) {
+        final AtomicInteger evictedCount = new AtomicInteger();
+        clientStates.entrySet().removeIf(entry -> {
+            final ClientState state = entry.getValue();
+            final boolean evict = isStale(state, nowNanos) && state.inFlight.get() == 0;
+            if (evict) {
+                evictedCount.incrementAndGet();
+            }
+            return evict;
+        });
+        return evictedCount.get();
+    }
+
+    private boolean isStale(@NonNull final ClientState state, final long nowNanos) {
+        return nowNanos - state.lastSeenNanos >= clientStateTtlNanos;
+    }
+
+    /// Per-client state: the client's own rate limiter, its current in-flight call count, and
+    /// when it was last seen (for eviction, see [#sweepStaleClients]).
+    private static final class ClientState {
+        private final GcraLimiter limiter;
+        private final AtomicInteger inFlight = new AtomicInteger();
+        private volatile long lastSeenNanos;
+
+        private ClientState(final GcraLimiter limiter) {
+            this.limiter = limiter;
+        }
+    }
+}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/GcraLimiter.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/GcraLimiter.java
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.throttle;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/// A lock-free rate limiter for one client implementing the Generic Cell Rate Algorithm (GCRA),
+/// the leaky-bucket-equivalent algorithm described in `docs/design/apis/api-throttling.md`.
+///
+/// GCRA tracks a single value, the "theoretical arrival time" (TAT): the earliest instant the
+/// next request would be allowed if traffic were perfectly evenly spaced. A request is admitted
+/// if it does not arrive more than `burstTolerance` pacing intervals ahead of that schedule.
+///
+/// This class holds state for exactly one client's rate limit on exactly one method — it is not
+/// shared across clients. [ThrottledServiceInterface] holds one instance per (client key, method).
+///
+/// The clock is deliberately a caller-supplied monotonic nanosecond value (e.g.
+/// [System#nanoTime()]), not wall-clock time: wall-clock time can jump backwards or forwards on
+/// an NTP adjustment, which would corrupt the TAT comparison and cause false bursts or false
+/// rejections.
+public final class GcraLimiter {
+    /// Spacing interval between admitted requests, in nanoseconds. Zero only if the configured
+    /// rate is non-positive, which should be prevented by config validation.
+    private final long intervalNanos;
+
+    /// How far ahead of the pacing schedule a request may arrive and still be admitted, in
+    /// nanoseconds.
+    private final long toleranceNanos;
+
+    /// The theoretical arrival time, in the same units as the caller's monotonic clock. Starts at
+    /// zero; the first call on a fresh limiter is always admitted regardless of the clock's actual
+    /// origin, since only differences between calls within this limiter's lifetime are compared.
+    private final AtomicLong theoreticalArrivalTimeNanos = new AtomicLong(0L);
+
+    /// Creates a new limiter for one client's rate on one method.
+    ///
+    /// @param ratePerSecond the sustained rate to allow, in requests per second; must be positive
+    /// @param burstTolerance how many pacing intervals early a request may arrive and still be
+    ///     admitted; zero means no burst tolerance beyond exact pacing
+    public GcraLimiter(final int ratePerSecond, final int burstTolerance) {
+        if (ratePerSecond <= 0) {
+            throw new IllegalArgumentException("ratePerSecond must be positive, was " + ratePerSecond);
+        }
+        this.intervalNanos = Math.max(1L, 1_000_000_000L / ratePerSecond);
+        this.toleranceNanos = Math.max(0, burstTolerance) * intervalNanos;
+    }
+
+    /// Attempts to admit a request arriving at the given monotonic time.
+    ///
+    /// @param nowNanos the current time from a monotonic clock (e.g. [System#nanoTime()])
+    /// @return {@code true} if the request conforms to the rate and should be admitted;
+    ///     {@code false} if it arrives too far ahead of the pacing schedule and should be rejected
+    public boolean tryAcquire(final long nowNanos) {
+        while (true) {
+            final long tat = theoreticalArrivalTimeNanos.get();
+            final long earliestAllowed = tat - toleranceNanos;
+            if (nowNanos < earliestAllowed) {
+                return false;
+            }
+            final long newTat = Math.max(nowNanos, tat) + intervalNanos;
+            if (theoreticalArrivalTimeNanos.compareAndSet(tat, newTat)) {
+                return true;
+            }
+            // Another thread advanced the TAT concurrently; retry with the new value.
+        }
+    }
+}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/PerClientThrottleSettings.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/PerClientThrottleSettings.java
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.throttle;
+
+/// The per-client throttle settings a plugin declares for one gRPC method, in that plugin's own
+/// configuration. Does **not** include the node-wide concurrency ceiling: that is a node-level
+/// capacity-allocation concern, resolved separately and merged in by the service-registration
+/// point into a full [ThrottlePolicy]. See `docs/design/apis/api-throttling.md` ("Configuration
+/// ownership") for the rationale behind this split.
+///
+/// @param ratePerSecond sustained requests (or, for streaming APIs, new session opens) per second
+///     allowed for one client
+/// @param burstTolerance how far ahead of the even-pacing schedule a client's request may arrive
+///     and still be admitted, expressed as a multiple of the pacing interval
+/// @param maxConcurrentPerClient maximum concurrent in-flight calls/sessions for one client on
+///     this method
+public record PerClientThrottleSettings(int ratePerSecond, int burstTolerance, int maxConcurrentPerClient) {}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/ReleasingPipeline.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/ReleasingPipeline.java
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.throttle;
+
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.Flow;
+
+/// Wraps the outgoing `responses` pipeline so a call's concurrency permit is released exactly
+/// once, whichever of [#onComplete] or [#onError] fires first — both are reliable, single-fire
+/// completion signals for every RPC shape, unlike the pipeline `open()` returns (see
+/// [ThrottledServiceInterface] for the full reasoning).
+final class ReleasingPipeline implements Pipeline<Bytes> {
+    private final Pipeline<? super Bytes> delegate;
+    private final Runnable releasePermit;
+
+    ReleasingPipeline(@NonNull final Pipeline<? super Bytes> delegate, @NonNull final Runnable releasePermit) {
+        this.delegate = delegate;
+        this.releasePermit = releasePermit;
+    }
+
+    @Override
+    public void onSubscribe(final Flow.Subscription subscription) {
+        delegate.onSubscribe(subscription);
+    }
+
+    @Override
+    public void onNext(final Bytes item) {
+        delegate.onNext(item);
+    }
+
+    @Override
+    public void onError(final Throwable throwable) {
+        releasePermit.run();
+        delegate.onError(throwable);
+    }
+
+    @Override
+    public void onComplete() {
+        releasePermit.run();
+        delegate.onComplete();
+    }
+
+    @Override
+    public void clientEndStreamReceived() {
+        delegate.clientEndStreamReceived();
+    }
+
+    @Override
+    public void closeConnection() {
+        delegate.closeConnection();
+    }
+}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/RemoteAddressKeyExtractor.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/RemoteAddressKeyExtractor.java
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.throttle;
+
+import com.hedera.pbj.runtime.grpc.ServiceInterface.RequestOptions;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+/// Default [ClientKeyExtractor] that keys by the caller's remote network address, ignoring the
+/// port so that multiple connections from the same client share one bucket.
+///
+/// Known, accepted limitation: clients behind a shared NAT/corporate gateway, or behind a
+/// reverse proxy/load balancer that does not forward the original client address, will share a
+/// bucket. See `docs/design/apis/api-throttling.md` for the rationale.
+public final class RemoteAddressKeyExtractor implements ClientKeyExtractor {
+    private static final String UNKNOWN_KEY = "unknown";
+
+    @NonNull
+    @Override
+    public String extractKey(@NonNull final RequestOptions options) {
+        final SocketAddress address = options.remoteAddress();
+        // The interface's default remoteAddress() can return null (e.g. an unusual transport or
+        // test harness that does not override it); fall back to a shared bucket rather than
+        // producing a null client key.
+        if (address == null) {
+            return UNKNOWN_KEY;
+        }
+        if (address instanceof InetSocketAddress inetSocketAddress) {
+            return inetSocketAddress.getAddress().getHostAddress();
+        }
+        return address.toString();
+    }
+}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/StaleClientSweepable.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/StaleClientSweepable.java
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.throttle;
+
+/// Implemented by a throttled-service wrapper so a caller (see `ServiceBuilderImpl`) can run the
+/// periodic stale-client-state sweep uniformly across every throttled service.
+public interface StaleClientSweepable {
+    /// Removes idle, not-in-flight client-state entries — see the implementing class for the
+    /// precise eviction rule.
+    ///
+    /// @param nowNanos the current time from a monotonic clock (e.g. [System#nanoTime()])
+    /// @return the number of entries evicted
+    int sweepStaleClients(long nowNanos);
+}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/ThrottleExempt.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/ThrottleExempt.java
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.throttle;
+
+/// Implemented by a plugin's `ServiceInterface`, alongside it, to declare that this gRPC service is
+/// deliberately not admission-controlled — as opposed to a service that simply forgot to implement
+/// [ThrottleSpec]. Registration logs every gRPC service as throttled, exempt, or neither; a service
+/// that is neither logs a warning, since an untagged, unthrottled service is far more likely to be
+/// an oversight than an intentional choice. A service should implement this only when there's a
+/// real reason not to admission-control it (e.g. an ingest path protected by a different mechanism
+/// than the per-client rate/concurrency model this package implements).
+public interface ThrottleExempt {}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/ThrottlePolicy.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/ThrottlePolicy.java
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.throttle;
+
+/// The fully-resolved runtime admission-control policy for one gRPC method: a plugin's own
+/// [PerClientThrottleSettings] merged with the node-wide concurrency ceiling for that method.
+///
+/// @param ratePerSecond sustained requests (or new session opens, for streaming APIs) per second
+///     allowed for one client
+/// @param burstTolerance how far ahead of the even-pacing schedule a client's request may arrive
+///     and still be admitted, expressed as a multiple of the pacing interval
+/// @param maxConcurrentPerClient maximum concurrent in-flight calls/sessions for one client on
+///     this method
+/// @param maxConcurrentGlobal maximum concurrent in-flight calls/sessions across all clients on
+///     this method
+public record ThrottlePolicy(
+        int ratePerSecond, int burstTolerance, int maxConcurrentPerClient, int maxConcurrentGlobal) {
+
+    /// Merges a plugin's own per-client settings with the node-wide ceiling for the same method.
+    ///
+    /// @param settings the plugin-owned per-client settings
+    /// @param maxConcurrentGlobal the node-wide concurrency ceiling for this method
+    /// @return the merged runtime policy
+    public static ThrottlePolicy merge(final PerClientThrottleSettings settings, final int maxConcurrentGlobal) {
+        return new ThrottlePolicy(
+                settings.ratePerSecond(),
+                settings.burstTolerance(),
+                settings.maxConcurrentPerClient(),
+                maxConcurrentGlobal);
+    }
+}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/ThrottleSpec.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/ThrottleSpec.java
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.throttle;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/// Implemented by a plugin's `ServiceInterface`, alongside it, to opt that service into per-client
+/// admission control without a separate registration call. `ServiceBuilder.registerGrpcService(port,
+/// service)` is the only registration method a plugin ever calls; the registration point checks
+/// `instanceof ThrottleSpec` on the service it's given and wraps it automatically when present,
+/// resolving settings from this interface rather than from extra call-site arguments.
+public interface ThrottleSpec {
+    /// This service's per-client rate/concurrency settings, read from the plugin's own
+    /// configuration.
+    ///
+    /// @return the per-client settings
+    @NonNull
+    PerClientThrottleSettings perClientSettings();
+
+    /// This service's node-wide concurrency ceiling. A ceiling here represents an allocation of
+    /// the node's total shared capacity across every throttled API — the plugin doesn't choose
+    /// this number itself, it reads it from the centrally-owned, node-level config
+    /// (`GlobalThrottleConfig` in the `app-config` module) and reports it here, the same way it
+    /// already reads its own per-client settings from its own config record. See
+    /// `docs/design/apis/api-throttling.md` ("Configuration ownership") for the full rationale on
+    /// why this stays centrally owned rather than becoming a per-plugin config value.
+    ///
+    /// @return the node-wide concurrency ceiling for this service
+    int globalConcurrencyCeiling();
+}

--- a/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/ThrottledServiceInterface.java
+++ b/block-node/spi-plugins/src/main/java/org/hiero/block/node/spi/throttle/ThrottledServiceInterface.java
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.throttle;
+
+import com.hedera.pbj.runtime.grpc.GrpcException;
+import com.hedera.pbj.runtime.grpc.GrpcStatus;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.grpc.Pipelines;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Duration;
+import java.util.List;
+import org.hiero.metrics.core.MetricRegistry;
+
+/// Wraps a plugin's [ServiceInterface] with a per-client rate/concurrency admission policy, as
+/// described in `docs/design/apis/api-throttling.md`. Attaches at `open()` — the one method every
+/// gRPC call, unary or streaming, passes through — so the mechanism doesn't depend on which web
+/// server hosts the service.
+///
+/// The concurrency permit is released via the *outgoing* `responses` pipeline passed into
+/// `open()`, not the pipeline `open()` returns: for a server-streaming call, the returned pipeline
+/// can complete (e.g. the client half-closing its request side) long before the call itself is
+/// actually done, so releasing on it would free the permit while the call is still in flight. The
+/// outgoing pipeline's `onComplete`/`onError` are the only signals reliable for every call shape.
+///
+/// This class is deliberately the *only* place in the throttle mechanism that references PBJ's
+/// `ServiceInterface`/`Pipeline` types — [ClientThrottle] (and everything it uses: [GcraLimiter],
+/// client-state eviction) takes only a client key and a clock reading, with no knowledge of gRPC
+/// or how it's attached to a call.
+public final class ThrottledServiceInterface implements ServiceInterface, StaleClientSweepable {
+    private final ServiceInterface delegate;
+    private final ClientKeyExtractor keyExtractor;
+    private final ClientThrottle throttle;
+
+    /// Wraps {@code delegate} with admission control, registering metrics under names derived
+    /// from the delegate's own service name so multiple throttled services don't collide.
+    ///
+    /// @param delegate the real plugin service implementation to protect
+    /// @param policy the resolved per-client + node-wide policy for this service's methods
+    /// @param keyExtractor derives the per-client key from each call's request options
+    /// @param metricRegistry the registry to register this instance's metrics with
+    /// @param clientStateTtl how long a client's state is kept after its last-seen call before it
+    ///     becomes eligible for eviction (lazily on next lookup, or via [#sweepStaleClients])
+    public ThrottledServiceInterface(
+            @NonNull final ServiceInterface delegate,
+            @NonNull final ThrottlePolicy policy,
+            @NonNull final ClientKeyExtractor keyExtractor,
+            @NonNull final MetricRegistry metricRegistry,
+            @NonNull final Duration clientStateTtl) {
+        this.delegate = delegate;
+        this.keyExtractor = keyExtractor;
+        this.throttle = new ClientThrottle(
+                policy, metricRegistry, "throttle_" + delegate.serviceName(), delegate.serviceName(), clientStateTtl);
+    }
+
+    @NonNull
+    @Override
+    public String serviceName() {
+        return delegate.serviceName();
+    }
+
+    @NonNull
+    @Override
+    public String fullName() {
+        return delegate.fullName();
+    }
+
+    @NonNull
+    @Override
+    public List<Method> methods() {
+        return delegate.methods();
+    }
+
+    @NonNull
+    @Override
+    public Pipeline<? super Bytes> open(
+            @NonNull final Method method,
+            @NonNull final RequestOptions options,
+            @NonNull final Pipeline<? super Bytes> replies) {
+        final String clientKey = keyExtractor.extractKey(options);
+        final AdmissionResult result = throttle.tryAdmit(clientKey, System.nanoTime());
+        if (!result.admitted()) {
+            replies.onError(new GrpcException(GrpcStatus.RESOURCE_EXHAUSTED, result.rejectionReason()));
+            return Pipelines.noop();
+        }
+        return delegate.open(method, options, new ReleasingPipeline(replies, result.releasePermit()));
+    }
+
+    /// {@inheritDoc}
+    @Override
+    public int sweepStaleClients(final long nowNanos) {
+        return throttle.sweepStaleClients(nowNanos);
+    }
+}

--- a/block-node/spi-plugins/src/test/java/org/hiero/block/node/spi/throttle/GcraLimiterTest.java
+++ b/block-node/spi-plugins/src/test/java/org/hiero/block/node/spi/throttle/GcraLimiterTest.java
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.throttle;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GcraLimiterTest {
+
+    @Test
+    @DisplayName("First call on a fresh limiter is always admitted")
+    void firstCallAdmitted() {
+        final GcraLimiter limiter = new GcraLimiter(10, 0);
+        assertTrue(limiter.tryAcquire(System.nanoTime()));
+    }
+
+    @Test
+    @DisplayName("Calls faster than the configured rate, beyond burst tolerance, are rejected")
+    void tooFastRejected() {
+        // 1 request/second, no burst tolerance: the second call 1ms later must be rejected.
+        final GcraLimiter limiter = new GcraLimiter(1, 0);
+        final long now = System.nanoTime();
+        assertTrue(limiter.tryAcquire(now));
+        assertFalse(limiter.tryAcquire(now + 1_000_000L)); // +1ms, far short of the 1s interval
+    }
+
+    @Test
+    @DisplayName("A call spaced out beyond the pacing interval is admitted")
+    void spacedOutCallAdmitted() {
+        final GcraLimiter limiter = new GcraLimiter(10, 0); // 100ms interval
+        final long now = System.nanoTime();
+        assertTrue(limiter.tryAcquire(now));
+        assertTrue(limiter.tryAcquire(now + 200_000_000L)); // +200ms, beyond the 100ms interval
+    }
+
+    @Test
+    @DisplayName("Burst tolerance allows a bounded number of early arrivals")
+    void burstToleranceAllowsEarlyArrivals() {
+        // 10/s => 100ms interval; burst tolerance of 2 intervals.
+        final GcraLimiter limiter = new GcraLimiter(10, 2);
+        final long now = System.nanoTime();
+        assertTrue(limiter.tryAcquire(now)); // TAT -> now + 100ms
+        // Arriving immediately after (0ms later) is within the 200ms tolerance window.
+        assertTrue(limiter.tryAcquire(now)); // TAT -> now + 200ms
+        assertTrue(limiter.tryAcquire(now)); // TAT -> now + 300ms; earliest allowed = now + 100ms
+        // A fourth immediate arrival is now outside the tolerance window (earliest allowed = now + 200ms).
+        assertFalse(limiter.tryAcquire(now));
+    }
+
+    @Test
+    @DisplayName("Rejects non-positive rates at construction")
+    void rejectsNonPositiveRate() {
+        assertThrows(IllegalArgumentException.class, () -> new GcraLimiter(0, 0));
+        assertThrows(IllegalArgumentException.class, () -> new GcraLimiter(-5, 0));
+    }
+}

--- a/block-node/spi-plugins/src/test/java/org/hiero/block/node/spi/throttle/ThrottledServiceInterfaceTest.java
+++ b/block-node/spi-plugins/src/test/java/org/hiero/block/node/spi/throttle/ThrottledServiceInterfaceTest.java
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.node.spi.throttle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.pbj.runtime.grpc.GrpcException;
+import com.hedera.pbj.runtime.grpc.GrpcStatus;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Flow;
+import org.hiero.metrics.core.MetricRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/// Verifies the admission decision order and, most importantly, that the concurrency permit is
+/// released via the *outgoing* `responses` pipeline passed into [ServiceInterface#open] rather
+/// than the pipeline `open()` returns — the correctness detail called out in
+/// `docs/design/apis/api-throttling.md`. A fake delegate returns a pipeline whose completion is
+/// deliberately never wired to anything, exactly mimicking how a real server-streaming call's
+/// returned pipeline behaves in production; the tests below prove the decorator does not depend
+/// on it.
+class ThrottledServiceInterfaceTest {
+
+    private static final ServiceInterface.Method ONLY_METHOD = () -> "onlyMethod";
+
+    private RecordingService recordingService;
+    private MetricRegistry metricRegistry;
+
+    @BeforeEach
+    void setUp() {
+        recordingService = new RecordingService();
+        metricRegistry = MetricRegistry.builder()
+                .setMetricsExporter(new NoOpMetricsExporter())
+                .build();
+    }
+
+    @Test
+    @DisplayName("An admitted call is passed through to the delegate")
+    void admittedCallReachesDelegate() {
+        final ThrottledServiceInterface throttled = throttledWith(new ThrottlePolicy(100, 10, 5, 5));
+        final CapturingPipeline replies = new CapturingPipeline();
+
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), replies);
+
+        assertEquals(1, recordingService.openCalls);
+        assertTrue(replies.errors.isEmpty());
+    }
+
+    @Test
+    @DisplayName("The per-client concurrency ceiling rejects a second concurrent call from the same client")
+    void perClientConcurrencyCeilingRejectsSecondCall() {
+        final ThrottledServiceInterface throttled = throttledWith(new ThrottlePolicy(100, 10, 1, 5));
+        final CapturingPipeline firstCallReplies = new CapturingPipeline();
+        final CapturingPipeline secondCallReplies = new CapturingPipeline();
+
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), firstCallReplies); // holds the one permit
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), secondCallReplies); // should be rejected
+
+        assertEquals(1, recordingService.openCalls, "the rejected call must never reach the delegate");
+        assertTrue(firstCallReplies.errors.isEmpty());
+        assertEquals(1, secondCallReplies.errors.size());
+        assertInstanceOf(GrpcException.class, secondCallReplies.errors.getFirst());
+        assertEquals(GrpcStatus.RESOURCE_EXHAUSTED, ((GrpcException) secondCallReplies.errors.getFirst()).status());
+    }
+
+    @Test
+    @DisplayName("A different client is not affected by another client's concurrency ceiling")
+    void differentClientsHaveIndependentCeilings() {
+        final ThrottledServiceInterface throttled = throttledWith(new ThrottlePolicy(100, 10, 1, 5));
+        final CapturingPipeline clientAReplies = new CapturingPipeline();
+        final CapturingPipeline clientBReplies = new CapturingPipeline();
+
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), clientAReplies);
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.2"), clientBReplies);
+
+        assertEquals(2, recordingService.openCalls);
+        assertTrue(clientAReplies.errors.isEmpty());
+        assertTrue(clientBReplies.errors.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Completing the outgoing responses pipeline releases the permit; completing the delegate's "
+            + "unrelated returned pipeline does not")
+    void permitReleaseAttachesToOutgoingPipelineNotTheReturnValue() {
+        final ThrottledServiceInterface throttled = throttledWith(new ThrottlePolicy(100, 10, 1, 5));
+        final CapturingPipeline firstCallReplies = new CapturingPipeline();
+
+        final Pipeline<? super Bytes> returnedFromOpen =
+                throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), firstCallReplies);
+
+        // Simulate a server-streaming call: the delegate's returned pipeline completes (as if the
+        // client had merely half-closed its request side) while the real call is still in flight.
+        // This must NOT release the permit.
+        returnedFromOpen.onComplete();
+        final CapturingPipeline stillBlockedReplies = new CapturingPipeline();
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), stillBlockedReplies);
+        assertEquals(
+                1, stillBlockedReplies.errors.size(), "the returned pipeline completing must not release the permit");
+
+        // Now complete the actual outgoing responses pipeline the decorator wrapped — this is the
+        // correct, reliable completion signal, and must release the permit.
+        recordingService.capturedReplies.onComplete();
+        final CapturingPipeline nowAdmittedReplies = new CapturingPipeline();
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), nowAdmittedReplies);
+        assertTrue(nowAdmittedReplies.errors.isEmpty(), "completing the outgoing pipeline must release the permit");
+        assertEquals(2, recordingService.openCalls, "only the two admitted calls should reach the delegate");
+    }
+
+    @Test
+    @DisplayName("An error on the outgoing responses pipeline also releases the permit exactly once")
+    void errorOnOutgoingPipelineReleasesPermitOnce() {
+        final ThrottledServiceInterface throttled = throttledWith(new ThrottlePolicy(100, 10, 1, 5));
+        final CapturingPipeline firstCallReplies = new CapturingPipeline();
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), firstCallReplies);
+
+        // Simulate the call failing/being cancelled, then simulate a duplicate completion signal
+        // (e.g. cancel immediately followed by a business-logic error) to prove the release is
+        // idempotent, not just eventually-consistent.
+        recordingService.capturedReplies.onError(new RuntimeException("simulated cancellation"));
+        recordingService.capturedReplies.onComplete(); // must be a no-op the second time
+
+        final CapturingPipeline secondCallReplies = new CapturingPipeline();
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), secondCallReplies);
+        assertTrue(secondCallReplies.errors.isEmpty(), "the permit must be released after the error");
+    }
+
+    @Test
+    @DisplayName("The node-wide concurrency ceiling rejects calls once reached, regardless of client")
+    void globalConcurrencyCeilingRejectsAcrossClients() {
+        final ThrottledServiceInterface throttled = throttledWith(new ThrottlePolicy(100, 10, 5, 1));
+        final CapturingPipeline clientAReplies = new CapturingPipeline();
+        final CapturingPipeline clientBReplies = new CapturingPipeline();
+
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), clientAReplies); // consumes the one global permit
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.2"), clientBReplies); // different client, still rejected
+
+        assertTrue(clientAReplies.errors.isEmpty());
+        assertEquals(1, clientBReplies.errors.size());
+    }
+
+    @Test
+    @DisplayName("A client calling faster than its rate limit is rejected without reaching the delegate")
+    void rateLimitRejectsFastCalls() {
+        // Rate of 1/s with no burst tolerance and a generous concurrency ceiling isolates the rate check.
+        final ThrottledServiceInterface throttled = throttledWith(new ThrottlePolicy(1, 0, 100, 100));
+        final CapturingPipeline firstCallReplies = new CapturingPipeline();
+        final CapturingPipeline secondCallReplies = new CapturingPipeline();
+
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), firstCallReplies);
+        recordingService.capturedReplies.onComplete(); // free up the concurrency slot immediately
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), secondCallReplies); // arrives well within 1s
+
+        assertTrue(firstCallReplies.errors.isEmpty());
+        assertEquals(1, secondCallReplies.errors.size());
+    }
+
+    @Test
+    @DisplayName("A client idle longer than the TTL gets a fresh rate-limit history on its next call")
+    void lazyEvictionReplacesStaleClientState() throws InterruptedException {
+        // Rate of 1/s with no burst tolerance: an immediate second call from the same client would
+        // normally be rejected by the rate limiter, unless its state was reset by TTL-based eviction.
+        final ThrottledServiceInterface throttled =
+                throttledWith(new ThrottlePolicy(1, 0, 100, 100), Duration.ofMillis(20));
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), new CapturingPipeline());
+        recordingService.capturedReplies.onComplete(); // free the concurrency slot
+
+        Thread.sleep(50); // exceed the 20ms TTL
+
+        final CapturingPipeline secondCallReplies = new CapturingPipeline();
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), secondCallReplies);
+
+        assertTrue(
+                secondCallReplies.errors.isEmpty(),
+                "a fresh rate limiter after TTL-based eviction should admit this call despite the 1/s rate");
+    }
+
+    @Test
+    @DisplayName("sweepStaleClients evicts idle entries but never one with a call still in flight")
+    void sweepStaleClientsRespectsInFlightCalls() {
+        final ThrottledServiceInterface throttled =
+                throttledWith(new ThrottlePolicy(100, 10, 5, 5), Duration.ofMillis(10));
+
+        // Client A: opens and completes immediately, so it is idle with nothing in flight.
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.1"), new CapturingPipeline());
+        recordingService.capturedReplies.onComplete();
+
+        // Client B: opens and is deliberately left in flight (never completed).
+        throttled.open(ONLY_METHOD, optionsFor("10.0.0.2"), new CapturingPipeline());
+
+        final long farFuture = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+        final int evicted = throttled.sweepStaleClients(farFuture);
+
+        assertEquals(1, evicted, "only the idle client should be evicted; the in-flight client must be kept");
+    }
+
+    private ThrottledServiceInterface throttledWith(final ThrottlePolicy policy) {
+        // A TTL far longer than any test could run keeps eviction (covered separately below) out of
+        // the way of every test that isn't specifically exercising it.
+        return throttledWith(policy, Duration.ofDays(1));
+    }
+
+    private ThrottledServiceInterface throttledWith(final ThrottlePolicy policy, final Duration clientStateTtl) {
+        return new ThrottledServiceInterface(
+                recordingService, policy, new RemoteAddressKeyExtractor(), metricRegistry, clientStateTtl);
+    }
+
+    private static ServiceInterface.RequestOptions optionsFor(final String ipAddress) {
+        final InetSocketAddress address = new InetSocketAddress(loopbackLike(ipAddress), 40840);
+        return new ServiceInterface.RequestOptions() {
+            @Override
+            public Optional<String> authority() {
+                return Optional.empty();
+            }
+
+            @Override
+            public String contentType() {
+                return ServiceInterface.RequestOptions.APPLICATION_GRPC_PROTO;
+            }
+
+            @Override
+            public java.net.SocketAddress remoteAddress() {
+                return address;
+            }
+        };
+    }
+
+    private static InetAddress loopbackLike(final String ipAddress) {
+        try {
+            return InetAddress.getByName(ipAddress);
+        } catch (final java.net.UnknownHostException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /// A fake delegate service that records every call to `open()` and, on each call, returns a
+    /// fresh pipeline whose completion is never wired to anything else — mirroring how a real
+    /// server-streaming call's returned pipeline behaves in production (see the class-level
+    /// documentation on [ThrottledServiceInterface]).
+    private static final class RecordingService implements ServiceInterface {
+        private int openCalls;
+        private Pipeline<? super Bytes> capturedReplies;
+
+        @Override
+        public String serviceName() {
+            return "RecordingService";
+        }
+
+        @Override
+        public String fullName() {
+            return "test.RecordingService";
+        }
+
+        @Override
+        public List<Method> methods() {
+            return List.of(ONLY_METHOD);
+        }
+
+        @Override
+        public Pipeline<? super Bytes> open(
+                final Method method, final RequestOptions options, final Pipeline<? super Bytes> replies) {
+            openCalls++;
+            this.capturedReplies = replies;
+            return new InertPipeline();
+        }
+    }
+
+    /// A pipeline that does nothing and whose completion is deliberately never observed by
+    /// anything, standing in for the return value of a real server-streaming call's `open()`.
+    private static final class InertPipeline implements Pipeline<Bytes> {
+        @Override
+        public void onSubscribe(final Flow.Subscription subscription) {}
+
+        @Override
+        public void onNext(final Bytes item) {}
+
+        @Override
+        public void onError(final Throwable throwable) {}
+
+        @Override
+        public void onComplete() {}
+    }
+
+    /// Captures every error signaled to this pipeline, for assertions.
+    private static final class CapturingPipeline implements Pipeline<Bytes> {
+        private final List<Throwable> errors = new ArrayList<>();
+
+        @Override
+        public void onSubscribe(final Flow.Subscription subscription) {}
+
+        @Override
+        public void onNext(final Bytes item) {}
+
+        @Override
+        public void onError(final Throwable throwable) {
+            errors.add(throwable);
+        }
+
+        @Override
+        public void onComplete() {}
+    }
+
+    /// A no-op metrics exporter so tests don't need a real metrics backend.
+    private static final class NoOpMetricsExporter implements org.hiero.metrics.core.MetricsExporter {
+        @Override
+        public void setSnapshotSupplier(
+                final java.util.function.Supplier<org.hiero.metrics.core.MetricRegistrySnapshot> supplier) {}
+
+        @Override
+        public void close() {}
+    }
+}

--- a/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
+++ b/block-node/stream-publisher/src/main/java/org/hiero/block/node/stream/publisher/StreamPublisherPlugin.java
@@ -18,6 +18,7 @@ import org.hiero.block.node.app.config.ServerConfig;
 import org.hiero.block.node.spi.BlockNodeContext;
 import org.hiero.block.node.spi.BlockNodePlugin;
 import org.hiero.block.node.spi.ServiceBuilder;
+import org.hiero.block.node.spi.throttle.ThrottleExempt;
 import org.hiero.metrics.LongCounter;
 import org.hiero.metrics.LongGauge;
 import org.hiero.metrics.core.MetricKey;
@@ -41,7 +42,13 @@ import org.hiero.metrics.core.MetricRegistry;
 /// in advance by other publishers, and also manages notification handling so
 /// that messaging sends one notification and, if needed, all handlers can send
 /// appropriate responses to their publishers.
-public final class StreamPublisherPlugin implements BlockNodePlugin, BlockStreamPublishServiceInterface {
+///
+/// Deliberately implements [ThrottleExempt], not [org.hiero.block.node.spi.throttle.ThrottleSpec]:
+/// the ingest path has its own size/compatibility validation rather than the per-client
+/// rate/concurrency admission model that interface implements — this marker exists so
+/// registration logs that omission as an intentional choice rather than a silent gap.
+public final class StreamPublisherPlugin
+        implements BlockNodePlugin, BlockStreamPublishServiceInterface, ThrottleExempt {
 
     /// Maximum length for the correlation ID header value.
     /// Chosen to accommodate current formats (e.g. `N#-STR#`, `N#-STR#-BLK#-REQ#`) and

--- a/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeThrottleTests.java
+++ b/tools-and-tests/suites/src/main/java/org/hiero/block/suites/e2e/BlockNodeThrottleTests.java
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.block.suites.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClient;
+import com.hedera.pbj.grpc.client.helidon.PbjGrpcClientConfig;
+import com.hedera.pbj.runtime.grpc.GrpcException;
+import com.hedera.pbj.runtime.grpc.GrpcStatus;
+import com.hedera.pbj.runtime.grpc.ServiceInterface;
+import io.helidon.common.tls.Tls;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webclient.grpc.GrpcClientProtocolConfig;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.hiero.block.api.BlockNodeServiceInterface;
+import org.hiero.block.api.ServerStatusRequest;
+import org.hiero.block.api.ServerStatusResponse;
+import org.hiero.block.node.app.BlockNodeApp;
+import org.hiero.block.node.spi.ServiceLoaderFunction;
+import org.hiero.block.node.spi.health.HealthFacility.State;
+import org.hiero.block.suites.utils.BlockItemBuilderUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * E2E tests validating the admission-control / throttling mechanism (see
+ * {@code docs/design/apis/api-throttling.md}) actually rejects and admits calls against a real,
+ * fully-wired {@link BlockNodeApp} — not mocks. Each test overrides the relevant throttle
+ * configuration to small, easy-to-exceed values via system properties (the same override mechanism
+ * every plugin's config already supports) before starting the app, so tests can be short and
+ * deterministic instead of racing real-world rate limits.
+ */
+@Tag("api")
+public class BlockNodeThrottleTests {
+    private static final String BLOCKS_DATA_DIR_PATH = "build/tmp/data";
+    private static final ServerStatusRequest SIMPLE_SERVER_STATUS_REQUEST =
+            ServerStatusRequest.newBuilder().build();
+    private static final Options OPTIONS =
+            new Options(Optional.empty(), ServiceInterface.RequestOptions.APPLICATION_GRPC);
+
+    private final String serverPort = System.getenv("SERVER_PORT") == null ? "40840" : System.getenv("SERVER_PORT");
+
+    private record Options(Optional<String> authority, String contentType) implements ServiceInterface.RequestOptions {}
+
+    private BlockNodeApp app;
+    /** Every system property key this test set, so {@link #afterEach()} can clear exactly those. */
+    private final Set<String> overriddenPropertyKeys = new HashSet<>();
+
+    @BeforeEach
+    void beforeEach() throws IOException {
+        final Path dataDir = Paths.get(BLOCKS_DATA_DIR_PATH).toAbsolutePath();
+        if (Files.exists(dataDir)) {
+            Files.walk(dataDir)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(java.io.File::delete);
+        }
+        BlockItemBuilderUtils.provisionTssBootstrap();
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (app != null && app.blockNodeState() != State.SHUTTING_DOWN) {
+            app.shutdown("BlockNodeThrottleTests", "test teardown");
+        }
+        overriddenPropertyKeys.forEach(System::clearProperty);
+        overriddenPropertyKeys.clear();
+    }
+
+    /** Sets the given config overrides as system properties, then constructs and starts the app. */
+    private void startApp(final Map<String, String> throttleOverrides) throws InterruptedException, IOException {
+        throttleOverrides.forEach((key, value) -> {
+            System.setProperty(key, value);
+            overriddenPropertyKeys.add(key);
+        });
+        app = new BlockNodeApp(new ServiceLoaderFunction(), false);
+        app.start();
+        Thread.sleep(200); // short pause to allow async startup tasks to complete
+        assertEquals(State.RUNNING, app.blockNodeState());
+    }
+
+    private PbjGrpcClient createGrpcClient() {
+        final Duration timeoutDuration = Duration.ofSeconds(30);
+        final Tls tls = Tls.builder().enabled(false).build();
+        final WebClient webClient = WebClient.builder()
+                .baseUri("http://localhost:" + serverPort)
+                .tls(tls)
+                .protocolConfigs(List.of(GrpcClientProtocolConfig.builder()
+                        .abortPollTimeExpired(false)
+                        .pollWaitTime(timeoutDuration)
+                        .build()))
+                .connectTimeout(timeoutDuration)
+                .keepAlive(true)
+                .build();
+        final PbjGrpcClientConfig grpcConfig =
+                new PbjGrpcClientConfig(timeoutDuration, tls, OPTIONS.authority(), OPTIONS.contentType());
+        return new PbjGrpcClient(webClient, grpcConfig);
+    }
+
+    /**
+     * Repeats {@code call} until it throws a {@code RESOURCE_EXHAUSTED} rejection, or fails after
+     * {@code attempts} tries. A GCRA rate limit configured at its tightest possible setting
+     * (1/second, no burst) still only guarantees rejection of a call arriving within the same
+     * ~1-second window as the previous one — a single pair of back-to-back calls can, on a loaded
+     * test machine, legitimately land more than a second apart. Repeating the attempt makes the
+     * assertion robust to that scheduling jitter without weakening what it actually proves: the
+     * throttle does reject calls, it isn't just always admitting everything.
+     */
+    private static void assertEventuallyRejectedByThrottle(final int attempts, final ThrowingRunnable call) {
+        for (int attempt = 0; attempt < attempts; attempt++) {
+            try {
+                call.run();
+            } catch (final RuntimeException e) {
+                assertThat(e.getCause()).isInstanceOf(GrpcException.class);
+                assertThat(((GrpcException) e.getCause()).status()).isEqualTo(GrpcStatus.RESOURCE_EXHAUSTED);
+                return;
+            }
+        }
+        fail("Expected at least one of " + attempts + " rapid back-to-back calls to be rejected by the throttle");
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run();
+    }
+
+    @Test
+    @DisplayName("serverStatus: a second call faster than the configured rate is rejected")
+    void serverStatusRateLimitRejectsSecondCallWithinWindow() throws InterruptedException, IOException {
+        final Map<String, String> overrides = new HashMap<>();
+        overrides.put("throttle.serverStatus.ratePerSecond", "1");
+        overrides.put("throttle.serverStatus.burstTolerance", "0");
+        overrides.put("throttle.serverStatus.maxConcurrentPerClient", "1000");
+        startApp(overrides);
+
+        final BlockNodeServiceInterface.BlockNodeServiceClient client =
+                new BlockNodeServiceInterface.BlockNodeServiceClient(createGrpcClient(), OPTIONS);
+        try {
+            final ServerStatusResponse first = client.serverStatus(SIMPLE_SERVER_STATUS_REQUEST);
+            assertNotNull(first);
+
+            assertEventuallyRejectedByThrottle(10, () -> client.serverStatus(SIMPLE_SERVER_STATUS_REQUEST));
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    @DisplayName("serverStatus: burst tolerance admits a bounded number of rapid calls before rejecting")
+    void serverStatusBurstToleranceAdmitsBoundedNumberOfRapidCalls() throws InterruptedException, IOException {
+        final int burstTolerance = 3;
+        final Map<String, String> overrides = new HashMap<>();
+        overrides.put("throttle.serverStatus.ratePerSecond", "1");
+        overrides.put("throttle.serverStatus.burstTolerance", String.valueOf(burstTolerance));
+        overrides.put("throttle.serverStatus.maxConcurrentPerClient", "1000");
+        startApp(overrides);
+
+        final BlockNodeServiceInterface.BlockNodeServiceClient client =
+                new BlockNodeServiceInterface.BlockNodeServiceClient(createGrpcClient(), OPTIONS);
+        try {
+            // burstTolerance pacing intervals of slack means burstTolerance + 1 rapid calls must
+            // all be admitted before the throttle catches up.
+            for (int i = 0; i < burstTolerance + 1; i++) {
+                assertNotNull(client.serverStatus(SIMPLE_SERVER_STATUS_REQUEST));
+            }
+
+            // The burst allowance is now exhausted; further rapid calls must eventually be rejected.
+            assertEventuallyRejectedByThrottle(10, () -> client.serverStatus(SIMPLE_SERVER_STATUS_REQUEST));
+        } finally {
+            client.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the shared, reusable per-client admission-control mechanism from `docs/design/apis/api-throttling.md`, and wires it end-to-end for the lowest-risk method first: `BlockNodeService.serverStatus` / `serverStatusDetail`. Later phases extend the same mechanism to the other gRPC APIs unchanged.

- A GCRA rate limiter (lock-free, one `AtomicLong` per client per method) plus per-client and node-wide concurrency ceilings, applied in a fixed decision order: global concurrency → per-client concurrency → rate (the only state-mutating check, so it runs last).
- A `ServiceInterface` admission decorator, attached at `open()` — the one method every gRPC call (unary or streaming) passes through — so the mechanism doesn't depend on which web server hosts the service.
- The concurrency permit is released via the *outgoing* `responses` pipeline, not the pipeline `open()` returns — verified directly against a real `Pipeline`, not a mock.
- A plugin opts into admission control (or explicitly opts out) purely by implementing a marker interface (`ThrottleSpec` / `ThrottleExempt`) alongside its `ServiceInterface`; registration stays a single `ServiceBuilder.registerGrpcService(port, service)` call for every plugin. Every registration is logged as throttled, exempt, or neither, so an unmarked, unthrottled service is a visible warning rather than a silent gap.

## Test plan

- [x] Unit tests for the GCRA math, the admission decision order, permit release semantics (including idempotent release under overlapping completion signals), and TTL-based client-state eviction.
- [x] `ServiceBuilderImpl` registration tests for both the `ThrottleSpec` and `ThrottleExempt` paths.
- [x] `ServerStatusServicePlugin` reports its configured per-client settings and global ceiling correctly.
- [x] Two e2e tests against a real, fully-wired node confirming the rate limit and burst tolerance actually reject/admit `serverStatus` calls.
- [x] Full existing test suites for every touched module pass.

Closes #3530.
