### PR TITLE
chore: Bump Solo CLI to 0.88.1 to pick up the block node message size fix

### DIFF
--- a/.github/workflows/solo-e2e-scheduler.yml
+++ b/.github/workflows/solo-e2e-scheduler.yml
@@ -233,7 +233,7 @@ jobs:
           if [[ -n "${{ inputs.solo-version }}" ]]; then
             SOLO_VERSION="${{ inputs.solo-version }}"
           else
-            SOLO_VERSION="0.84.1"
+            SOLO_VERSION="0.88.1"
           fi
 
           # Relay version: use input if provided, otherwise default to latest

--- a/.github/workflows/solo-e2e-test.yml
+++ b/.github/workflows/solo-e2e-test.yml
@@ -36,7 +36,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         type: string
-        default: "0.84.1"
+        default: "0.88.1"
       solo-source:
         description: "Solo install source: 'npm' or 'git' (build an approved fork/branch)"
         type: string
@@ -145,7 +145,7 @@ on:
       solo-version:
         description: "Solo CLI Version"
         required: false
-        default: "0.84.1"
+        default: "0.88.1"
       solo-source:
         description: "Solo install source"
         required: false


### PR DESCRIPTION
## Reviewer Notes

* Bumps the default Solo CLI version used by the E2E workflows to 0.88.1, which no longer overrides the Block Node's message size limit

## Related Issue(s)

Closes #3624