### PR TITLE
docs: address API throttling design doc review follow-ups (#3630)

### DIFF
--- a/docs/design/apis/api-throttling.md
+++ b/docs/design/apis/api-throttling.md
@@ -83,7 +83,8 @@ client or API triggered it.
 - **Leaky bucket (rate limiter)** — The rate-limiting model used per client per method: a request adds to a
   conceptual bucket, the bucket drains at a fixed rate, and a request is admitted only if the bucket isn't already
   full. Used strictly as a policer here (reject on arrival), not a shaper (delay and re-admit later); see
-  [Alternatives considered](#alternatives-considered).
+  [Alternatives considered](#alternatives-considered). The state representation used to implement this model is an
+  implementation choice, not part of the model itself — see [`GcraLimiter`](#gcralimiter).
 - **Bulkhead** — A bounded pool of permits that caps how many callers can concurrently use a shared resource,
   independent of who those callers are.
 - **Concurrency permit** — A slot representing one in-flight call or session against a limit; acquired on admission
@@ -98,9 +99,11 @@ per-client concurrency ceiling, and a node-wide concurrency ceiling.
 
 ### `GcraLimiter`
 
-A lock-free leaky-bucket rate limiter, keyed per client, implemented via GCRA. Holds one monotonic-clock timestamp
-(the theoretical arrival time) per key, advanced via compare-and-swap on each admitted request — deliberately not a
-token counter, since that would need the same timestamp anyway (to know when to refill) plus a second field.
+A lock-free leaky-bucket rate limiter, keyed per client, implemented via the
+[Generic Cell Rate Algorithm](https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm) (GCRA). Holds one
+monotonic-clock timestamp (the theoretical arrival time) per key, advanced via compare-and-swap on each admitted
+request — deliberately not a token counter, since that would need the same timestamp anyway (to know when to
+refill) plus a second field.
 
 ### `ClientKeyExtractor`
 

--- a/docs/design/apis/api-throttling.md
+++ b/docs/design/apis/api-throttling.md
@@ -224,10 +224,23 @@ immediately after a business-logic error).
 **Content-aware weighting for `getBlock` and `subscribeBlockStream`.** A single static weight per API cannot express
 that a historical block read is more expensive than a live one. Both APIs register a `ContentAwareWeigher` that
 inspects the requested block number (for `getBlock`) or the requested start block (for `subscribeBlockStream`)
-against the current recent/historical boundary, so a historical request is checked against a stricter policy than
-a live one. For `subscribeBlockStream`, this classification happens once, at admission time — a session that starts
-as a live subscription and later needs to catch up on history is protected by Component B below, not by
-re-evaluating its weight mid-session.
+against the recent/historical boundary described below, so a historical request is checked against a stricter
+policy than a live one. For `subscribeBlockStream`, this classification happens once, at admission time — a
+session that starts as a live subscription and later needs to catch up on history is protected by Component B
+below, not by re-evaluating its weight mid-session.
+
+**The recent/historical boundary** is distance from the tip: a request is historical if it targets a block more
+than a configurable `historicalThresholdBlocks` behind the current maximum available block, queried fresh on each
+call rather than cached — both `getBlock` and `subscribeBlockStream` already read that same value unconditionally
+elsewhere on their normal request path, so this doesn't add a new kind of cost, just one more read of a value
+already on the hot path. `getBlock`'s `retrieveLatest` (and a missing or negative block number) is always
+classified live, rather than resolving the actual latest block number just to weigh the call — the classification
+itself does not need to know what "latest" resolves to, only that the request isn't asking for something behind
+it. This threshold is a self-contained approximation, deliberately independent of the recent-storage-tier plugin's
+own retention boundary so the weigher doesn't require a specific storage-tier plugin to be present — the two are
+expected to be configured to match, but nothing enforces that if either is changed independently. Whether this
+approximation tracks the real recent/historical boundary closely enough in practice belongs in the acceptance
+tests for the implementation (see [Acceptance Tests](#acceptance-tests)).
 
 This changes where in the call the ordered checks above actually run, for these two APIs specifically: since
 classification needs the request bytes, and those aren't available until `onNext` (see `ContentAwareWeigher`), a
@@ -517,3 +530,6 @@ produced. `publishBlockStream` is not subject to any admission check and is unaf
 9. A benchmark measuring per-call latency and allocation rate, with admission control enabled versus disabled on the
    same hardware, shows no meaningful regression on throttled APIs and zero measurable overhead on
    `publishBlockStream`.
+10. The recent/historical boundary's default (`historicalThresholdBlocks`) tracks the recent-storage-tier plugin's
+    own retention boundary closely enough in practice that newly-ingested blocks are not misclassified as
+    historical under normal operation, despite the two values not being enforced to stay in sync.

--- a/docs/design/apis/api-throttling.md
+++ b/docs/design/apis/api-throttling.md
@@ -241,6 +241,13 @@ historical-`getBlock` ceiling and the bulkhead's permit count independently is a
 a guarantee that the bulkhead can never be contended by both sources at once. The bulkhead's own bounded behavior
 (reject or brief wait, never unbounded growth) is what keeps that scenario safe even so.
 
+The initial implementation uses one shared pool for all tiers, including recent/live reads — there is no per-tier
+bulkhead, and a `getBlock` call for a live block acquires and releases a permit the same as a historical one. This
+was a deliberate simplicity choice for the first delivery (see [Extensibility](#extensibility)) rather than a claim
+that a recent-block read is free of overhead: if warm-path latency sensitivity proves material, a separate,
+generously-sized bulkhead for recent reads — or skipping the bulkhead entirely for reads served from an
+in-memory/warm-file path — is the documented extension point to use.
+
 ### Configuration ownership
 
 Each gRPC method has exactly one plugin that implements it, so a client's rate and per-client concurrency limits for

--- a/docs/design/apis/api-throttling.md
+++ b/docs/design/apis/api-throttling.md
@@ -119,9 +119,16 @@ mechanism.
 
 ### `ContentAwareWeigher`
 
-An optional, per-API function that classifies a request into a weight class based on its content, evaluated once at
-admission time before any rate/concurrency check runs. Used by `getBlock` and `subscribeBlockStream` to distinguish
-live/recent requests from historical ones.
+An optional, per-API function that classifies a request into a weight class based on its content. Used by
+`getBlock` and `subscribeBlockStream` to distinguish live/recent requests from historical ones.
+
+A weigher cannot classify a call inside `open()` — for both unary and server-streaming calls, the request bytes
+are not available there; they arrive later, via `onNext` on the pipeline `open()` returns. Where a weigher is
+registered, admission is therefore deferred in full: `open()` only extracts the client key and constructs the
+delegate's pipeline (cheap — no business logic runs yet), and classification plus every Component A check (global
+concurrency, per-client concurrency, rate) run together, once, in a wrapping pipeline's own `onNext`, before the
+delegate's `onNext` — and therefore its business logic — ever runs. A rejected call never reaches the delegate at
+all, so nothing is admitted provisionally and no check is ever paid for twice.
 
 ### The admission decorator
 
@@ -193,7 +200,8 @@ For every call, in order — the first check that rejects wins, and no later che
 
 If every check passes, the call is admitted: both concurrency counters are incremented, and the real service's
 `open()` is invoked. If any check fails, the call is rejected immediately (see [Exceptions](#exceptions)) and the
-real service method is never invoked.
+real service method is never invoked. (For `getBlock` and `subscribeBlockStream` specifically, these checks run at
+a different point in the call than described above — see "Content-aware weighting" below for why.)
 
 **Overload prevention vs. single-consumer abuse are different guarantees.** The global concurrency check above,
 and `BlockReadBulkhead` (Component B), are identity-agnostic: they cap total in-flight work regardless of who's
@@ -216,10 +224,18 @@ immediately after a business-logic error).
 **Content-aware weighting for `getBlock` and `subscribeBlockStream`.** A single static weight per API cannot express
 that a historical block read is more expensive than a live one. Both APIs register a `ContentAwareWeigher` that
 inspects the requested block number (for `getBlock`) or the requested start block (for `subscribeBlockStream`)
-against the current recent/historical boundary, classifying the call *before* the admission checks above run, so a
-historical request is checked against a stricter policy than a live one. For `subscribeBlockStream`, this
-classification happens once, at admission time — a session that starts as a live subscription and later needs to
-catch up on history is protected by Component B below, not by re-evaluating its weight mid-session.
+against the current recent/historical boundary, so a historical request is checked against a stricter policy than
+a live one. For `subscribeBlockStream`, this classification happens once, at admission time — a session that starts
+as a live subscription and later needs to catch up on history is protected by Component B below, not by
+re-evaluating its weight mid-session.
+
+This changes where in the call the ordered checks above actually run, for these two APIs specifically: since
+classification needs the request bytes, and those aren't available until `onNext` (see `ContentAwareWeigher`), a
+weighted method's `open()` does not gate anything itself — it only extracts the client key and constructs the
+delegate's pipeline, cheaply. Classification and all three checks happen together, once, in the wrapping pipeline's
+own `onNext`, before the delegate's `onNext` is ever called. The end result is the same as the unweighted case (a
+rejected call's business logic never runs, and nothing is charged twice) — only the point in the call where that
+decision happens moves later, from `open()` to `onNext`.
 
 ### Component B — shared backend block-read bulkhead
 
@@ -352,6 +368,33 @@ Two extension points are designed in from the start, since both are anticipated 
 
 ## Diagram
 
+The flow below is the general case: a method with no `ContentAwareWeigher` (e.g. `serverStatus`) is admitted or
+rejected synchronously inside `open()`, before the delegate's `open()` is even called.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant D as Admission Decorator
+    participant P as Plugin Service
+
+    C->>D: open(method, options, responses)
+    D->>D: global concurrency check
+    D->>D: per-client concurrency check
+    D->>D: GCRA rate check
+    alt any check rejects
+        D-->>C: RESOURCE_EXHAUSTED
+    else admitted
+        D->>P: open(method, options, wrapped responses)
+        P-->>D: streams/returns response(s)
+        D->>D: release permit on responses.onComplete/onError
+        D-->>C: response(s)
+    end
+```
+
+A method with a `ContentAwareWeigher` (`getBlock`, `subscribeBlockStream`) cannot follow that flow, because
+classification needs request bytes that `open()` doesn't have yet. `open()` instead only builds pipelines — no
+admission decision happens there — and the decision moves to `onNext`, once request bytes actually arrive:
+
 ```mermaid
 sequenceDiagram
     participant C as Client
@@ -360,15 +403,22 @@ sequenceDiagram
     participant P as Plugin Service
 
     C->>D: open(method, options, responses)
-    D->>W: classify(method, request) [if registered]
+    D->>P: open(method, options, wrapped responses)
+    P-->>D: plugin's inbound pipeline
+    D-->>C: wrapping pipeline
+    Note over D,P: open() only constructs pipelines here — no admission decision yet
+
+    C->>D: onNext(requestBytes)
+    D->>W: classify(method, requestBytes)
     W-->>D: weight class
-    D->>D: global concurrency check
-    D->>D: per-client concurrency check
-    D->>D: GCRA rate check
+    D->>D: global concurrency check (weight class's policy)
+    D->>D: per-client concurrency check (weight class's policy)
+    D->>D: GCRA rate check (weight class's policy)
     alt any check rejects
-        D-->>C: RESOURCE_EXHAUSTED
+        D-->>C: onError(RESOURCE_EXHAUSTED)
+        Note over P: plugin's onNext is never called — its business logic never runs
     else admitted
-        D->>P: open(method, options, wrapped responses)
+        D->>P: onNext(requestBytes)
         P-->>D: streams/returns response(s)
         D->>D: release permit on responses.onComplete/onError
         D-->>C: response(s)

--- a/docs/design/apis/api-throttling.md
+++ b/docs/design/apis/api-throttling.md
@@ -71,26 +71,23 @@ client or API triggered it.
 
 ## Terms
 
-<dl>
-<dt>Admission control</dt><dd>Deciding, at the point a request or stream is opened, whether to accept it now or
-reject it immediately.</dd>
-<dt>Client key</dt><dd>An identifier used to group a caller's requests for the purpose of per-client limits. Derived
-from the caller's network address in this design.</dd>
-<dt>Weight class</dt><dd>A cost tier assigned to a request (e.g. LIGHT, MODERATE, HEAVY) that determines which
-rate/concurrency policy applies to it.</dd>
-<dt>Content-aware weigher</dt><dd>A per-API function that inspects a request's content (e.g. the requested block
-number) to classify it into a weight class before admission, rather than relying on a single static weight for the
-whole API.</dd>
-<dt>Leaky bucket (rate limiter)</dt><dd>The rate-limiting model used per client per method: a request adds to a
-conceptual bucket, the bucket drains at a fixed rate, and a request is admitted only if the bucket isn't already
-full. Used strictly as a policer here (reject on arrival), not a shaper (delay and re-admit later); see
-[Alternatives considered](#alternatives-considered). The state representation used to implement this model — GCRA,
-see [`GcraLimiter`](#gcralimiter) — is an implementation choice, not part of the model itself.</dd>
-<dt>Bulkhead</dt><dd>A bounded pool of permits that caps how many callers can concurrently use a shared resource,
-independent of who those callers are.</dd>
-<dt>Concurrency permit</dt><dd>A slot representing one in-flight call or session against a limit; acquired on
-admission and released when the call/session ends.</dd>
-</dl>
+- **Admission control** — Deciding, at the point a request or stream is opened, whether to accept it now or reject
+  it immediately.
+- **Client key** — An identifier used to group a caller's requests for the purpose of per-client limits. Derived from
+  the caller's network address in this design.
+- **Weight class** — A cost tier assigned to a request (e.g. LIGHT, MODERATE, HEAVY) that determines which
+  rate/concurrency policy applies to it.
+- **Content-aware weigher** — A per-API function that inspects a request's content (e.g. the requested block number)
+  to classify it into a weight class before admission, rather than relying on a single static weight for the whole
+  API.
+- **Leaky bucket (rate limiter)** — The rate-limiting model used per client per method: a request adds to a
+  conceptual bucket, the bucket drains at a fixed rate, and a request is admitted only if the bucket isn't already
+  full. Used strictly as a policer here (reject on arrival), not a shaper (delay and re-admit later); see
+  [Alternatives considered](#alternatives-considered).
+- **Bulkhead** — A bounded pool of permits that caps how many callers can concurrently use a shared resource,
+  independent of who those callers are.
+- **Concurrency permit** — A slot representing one in-flight call or session against a limit; acquired on admission
+  and released when the call/session ends.
 
 ## Entities
 

--- a/docs/design/apis/api-throttling.md
+++ b/docs/design/apis/api-throttling.md
@@ -413,6 +413,11 @@ Each throttled API's own module declares its per-client settings:
 | `burstTolerance`         | How far ahead of the even-pacing schedule a client's request may arrive and still be admitted    |
 | `maxConcurrentPerClient` | Maximum concurrent in-flight calls/sessions for one client on this method                        |
 
+This triple is the only configuration surface a throttled method has — there is no separate configuration
+dimension for weight class. A `ContentAwareWeigher`, where registered, must therefore express differentiated
+treatment as a function applied on top of this one triple (e.g. a multiplier on the effective bucket cost for
+`HEAVY`-classified calls) rather than by selecting between multiple configured policies.
+
 A single shared, node-level configuration record holds one node-wide concurrency ceiling per throttled method
 (`maxConcurrentGlobal`-equivalent), since this represents an allocation of shared node capacity across APIs rather
 than a single plugin's own concern.

--- a/docs/design/apis/api-throttling.md
+++ b/docs/design/apis/api-throttling.md
@@ -230,12 +230,12 @@ Component B is a single, bounded, non-client-keyed pool of permits guarding ever
   This wait is purely internal scheduling for already-admitted work — it never affects the admission decision in
   Component A.
 
-The node-wide concurrency ceilings Component A applies to historical `getBlock` requests should be sized with this
+The node-wide concurrency ceiling Component A applies to historical `getBlock` requests should be sized with this
 bulkhead's capacity in mind, since both draw from the same underlying resource — but because the bulkhead is also
-shared with subscriber catch-up traffic, which Component A's `getBlock` ceiling has no visibility into, sizing the
-two independently is a reasonable approximation rather than a guarantee that the bulkhead can never be contended by
-both sources at once. The bulkhead's own bounded behavior (reject or brief wait, never unbounded growth) is what
-keeps that scenario safe even so.
+shared with subscriber catch-up traffic, which that `getBlock` ceiling has no visibility into, sizing Component A's
+historical-`getBlock` ceiling and the bulkhead's permit count independently is a reasonable approximation rather than
+a guarantee that the bulkhead can never be contended by both sources at once. The bulkhead's own bounded behavior
+(reject or brief wait, never unbounded growth) is what keeps that scenario safe even so.
 
 ### Configuration ownership
 

--- a/docs/design/apis/api-throttling.md
+++ b/docs/design/apis/api-throttling.md
@@ -68,6 +68,10 @@ client or API triggered it.
   exception to this if hardware heterogeneity across deployments makes one hand-tuned default impractical — see the
   adaptive-bulkhead-sizing follow-up under the throttling epic — but that applies narrowly to capacity sizing, not
   to per-client policy (rate, burst, per-client concurrency), which stays a static fairness choice by design.
+- **Priority-aware throttling.** Giving some connections/clients/requests precedence over others under high
+  concurrency is out of scope for this iteration. Meaningful prioritization needs a trustworthy client identity to
+  assign priority to, so this is plausibly gated on the authenticated-client-identity work above (a
+  `ClientKeyExtractor` successor) rather than being independent work.
 
 ## Terms
 

--- a/docs/design/apis/api-throttling.md
+++ b/docs/design/apis/api-throttling.md
@@ -149,6 +149,13 @@ can be introduced later as a new implementation of this one interface, without c
 `ThrottlePolicy`, or any configuration record. `RequestOptions.remoteCertificateChain()` already exists on the
 underlying request options today, unused — it is exactly what a future `TlsCertificateKeyExtractor` would read from.
 
+Selection of a `ClientKeyExtractor` implementation is wiring-driven, not configuration-driven: the registration
+point constructs the extractor directly, one instance per throttled service registration, rather than reading a
+choice from configuration. Changing the active implementation therefore requires a code change and a restart. Each
+throttled service owns its own isolated per-client state table, so two different extractor implementations
+producing the same key string for different callers can only collide within calls to the *same* service, not
+across services.
+
 ## Design
 
 ![Overall approach: Component A admits or rejects at the API boundary; Component B protects the shared block-storage read path independent of which API triggered the read; publishBlockStream bypasses both](../../assets/api/api-throttling-architecture.svg)

--- a/docs/design/apis/api-throttling.md
+++ b/docs/design/apis/api-throttling.md
@@ -333,7 +333,12 @@ small and bounded by construction:
   - **Content-aware weighing must not require a full protobuf deserialization.** A weigher only needs to read one or
     two fields (e.g. a block number) to classify a request. It should do a targeted read of that field directly from
     the wire format, not fully deserialize the request message before the real handler does its own full parse —
-    otherwise every classified call would pay for parsing the request twice.
+    otherwise every classified call would pay for parsing the request twice. This is a hand-written read via PBJ's
+    `ProtoParserTools` (read the tag, extract field number and wire type, decode the target field or skip any other
+    field), the same low-level parsing primitives PBJ's own generated parsers use — there is no separate framework
+    support for a partial-field read, but none is needed. Each weigher currently implements this loop itself rather
+    than sharing one utility; factoring it out is worth doing once a second or third weigher needs the same logic,
+    not before.
 - **Acceptance criterion.** This goal should be validated, not assumed: a benchmark comparing per-call latency and
   allocation with admission control enabled versus disabled on the same hardware belongs in the acceptance tests for
   the implementation, not just asserted here (see [Acceptance Tests](#acceptance-tests)).

--- a/docs/design/apis/api-throttling.md
+++ b/docs/design/apis/api-throttling.md
@@ -413,14 +413,16 @@ Each throttled API's own module declares its per-client settings:
 | `burstTolerance`         | How far ahead of the even-pacing schedule a client's request may arrive and still be admitted    |
 | `maxConcurrentPerClient` | Maximum concurrent in-flight calls/sessions for one client on this method                        |
 
-This triple is the only configuration surface a throttled method has — there is no separate configuration
-dimension for weight class. A `ContentAwareWeigher`, where registered, must therefore express differentiated
-treatment as a function applied on top of this one triple (e.g. a multiplier on the effective bucket cost for
-`HEAVY`-classified calls) rather than by selecting between multiple configured policies.
+Where a method's `ContentAwareWeigher` can classify more than one weight class, each class gets its own full triple
+rather than sharing one: e.g. `getBlock` has independent live and historical per-client configuration, each with
+its own rate, burst, and per-client concurrency ceiling. This is a heavier configuration surface than a single
+per-method triple, but keeps each weight class's tuning — including how strict the historical policy is relative
+to the live one — fully independent.
 
-A single shared, node-level configuration record holds one node-wide concurrency ceiling per throttled method
-(`maxConcurrentGlobal`-equivalent), since this represents an allocation of shared node capacity across APIs rather
-than a single plugin's own concern.
+A single shared, node-level configuration record holds one node-wide concurrency ceiling per (method, weight
+class) — e.g. `getBlock` has independent live and historical node-wide ceilings — since this represents an
+allocation of shared node capacity across APIs rather than a single plugin's own concern. A method with only one
+weight class has just one ceiling.
 
 The shared block-read bulkhead has its own single configuration value: the number of permits in the pool, informed
 by the target deployment's storage characteristics.

--- a/docs/design/apis/api-throttling.md
+++ b/docs/design/apis/api-throttling.md
@@ -70,8 +70,8 @@ client or API triggered it.
   to per-client policy (rate, burst, per-client concurrency), which stays a static fairness choice by design.
 - **Priority-aware throttling.** Giving some connections/clients/requests precedence over others under high
   concurrency is out of scope for this iteration. Meaningful prioritization needs a trustworthy client identity to
-  assign priority to, so this is plausibly gated on the authenticated-client-identity work above (a
-  `ClientKeyExtractor` successor) rather than being independent work.
+  assign priority to, so it's plausibly gated on the authenticated-client-identity work above rather than
+  independent work.
 
 ## Terms
 
@@ -120,15 +120,9 @@ mechanism.
 ### `ContentAwareWeigher`
 
 An optional, per-API function that classifies a request into a weight class based on its content. Used by
-`getBlock` and `subscribeBlockStream` to distinguish live/recent requests from historical ones.
-
-A weigher cannot classify a call inside `open()` — for both unary and server-streaming calls, the request bytes
-are not available there; they arrive later, via `onNext` on the pipeline `open()` returns. Where a weigher is
-registered, admission is therefore deferred in full: `open()` only extracts the client key and constructs the
-delegate's pipeline (cheap — no business logic runs yet), and classification plus every Component A check (global
-concurrency, per-client concurrency, rate) run together, once, in a wrapping pipeline's own `onNext`, before the
-delegate's `onNext` — and therefore its business logic — ever runs. A rejected call never reaches the delegate at
-all, so nothing is admitted provisionally and no check is ever paid for twice.
+`getBlock` and `subscribeBlockStream` to distinguish live/recent requests from historical ones. It cannot classify
+inside `open()` — request bytes aren't available there — so where one is registered, admission moves to `onNext`;
+see [Content-aware weighting](#component-a--per-client-admission-gate) for the full flow.
 
 ### The admission decorator
 
@@ -156,12 +150,10 @@ can be introduced later as a new implementation of this one interface, without c
 `ThrottlePolicy`, or any configuration record. `RequestOptions.remoteCertificateChain()` already exists on the
 underlying request options today, unused — it is exactly what a future `TlsCertificateKeyExtractor` would read from.
 
-Selection of a `ClientKeyExtractor` implementation is wiring-driven, not configuration-driven: the registration
-point constructs the extractor directly, one instance per throttled service registration, rather than reading a
-choice from configuration. Changing the active implementation therefore requires a code change and a restart. Each
-throttled service owns its own isolated per-client state table, so two different extractor implementations
-producing the same key string for different callers can only collide within calls to the *same* service, not
-across services.
+Selection is wiring-driven, not configuration-driven: the registration point constructs the extractor directly,
+one instance per throttled service, so switching implementations needs a code change and a restart, not a config
+change. Each throttled service also owns its own isolated per-client state table, so two extractors producing the
+same key for different callers can only collide within calls to the *same* service, never across services.
 
 ## Design
 
@@ -221,34 +213,27 @@ deadline being exceeded — for both unary and streaming calls alike. The releas
 guard, since more than one of those signals can arrive for the same call (for example, a cancellation arriving
 immediately after a business-logic error).
 
-**Content-aware weighting for `getBlock` and `subscribeBlockStream`.** A single static weight per API cannot express
+**Content-aware weighting for `getBlock` and `subscribeBlockStream`.** A single static weight per API can't express
 that a historical block read is more expensive than a live one. Both APIs register a `ContentAwareWeigher` that
-inspects the requested block number (for `getBlock`) or the requested start block (for `subscribeBlockStream`)
-against the recent/historical boundary described below, so a historical request is checked against a stricter
-policy than a live one. For `subscribeBlockStream`, this classification happens once, at admission time — a
-session that starts as a live subscription and later needs to catch up on history is protected by Component B
-below, not by re-evaluating its weight mid-session.
+classifies the requested block (`getBlock`) or start block (`subscribeBlockStream`) against the boundary below, so
+historical requests are checked against a stricter policy. For `subscribeBlockStream` this classification happens
+once, at admission — a session that later catches up on history is protected by Component B, not by re-weighing
+mid-session.
 
 **The recent/historical boundary** is distance from the tip: a request is historical if it targets a block more
-than a configurable `historicalThresholdBlocks` behind the current maximum available block, queried fresh on each
-call rather than cached — both `getBlock` and `subscribeBlockStream` already read that same value unconditionally
-elsewhere on their normal request path, so this doesn't add a new kind of cost, just one more read of a value
-already on the hot path. `getBlock`'s `retrieveLatest` (and a missing or negative block number) is always
-classified live, rather than resolving the actual latest block number just to weigh the call — the classification
-itself does not need to know what "latest" resolves to, only that the request isn't asking for something behind
-it. This threshold is a self-contained approximation, deliberately independent of the recent-storage-tier plugin's
-own retention boundary so the weigher doesn't require a specific storage-tier plugin to be present — the two are
-expected to be configured to match, but nothing enforces that if either is changed independently. Whether this
-approximation tracks the real recent/historical boundary closely enough in practice belongs in the acceptance
-tests for the implementation (see [Acceptance Tests](#acceptance-tests)).
+than a configurable `historicalThresholdBlocks` behind the current maximum available block. Queried fresh each
+call, not cached — the same accessor is already read unconditionally elsewhere on this path, so this adds no new
+cost. `retrieveLatest` and a missing/negative block number are always classified live, avoiding the cost of
+resolving "latest" just to weigh the call. The threshold is deliberately decoupled from the recent-storage-tier
+plugin's own retention boundary, so the weigher doesn't depend on a specific storage-tier plugin being present —
+the two are expected to match, but nothing enforces it; validating that in practice belongs in the acceptance
+tests (see [Acceptance Tests](#acceptance-tests)).
 
-This changes where in the call the ordered checks above actually run, for these two APIs specifically: since
-classification needs the request bytes, and those aren't available until `onNext` (see `ContentAwareWeigher`), a
-weighted method's `open()` does not gate anything itself — it only extracts the client key and constructs the
-delegate's pipeline, cheaply. Classification and all three checks happen together, once, in the wrapping pipeline's
-own `onNext`, before the delegate's `onNext` is ever called. The end result is the same as the unweighted case (a
-rejected call's business logic never runs, and nothing is charged twice) — only the point in the call where that
-decision happens moves later, from `open()` to `onNext`.
+Because classification needs the request bytes, which aren't available until `onNext`, a weighted method's
+`open()` doesn't gate anything — it only extracts the client key and builds the delegate's pipeline. Classification
+and all three checks then run together in the wrapping pipeline's `onNext`, before the delegate's `onNext` is
+called. The outcome matches the unweighted case (a rejected call's business logic never runs, nothing is charged
+twice); only the point where that decision happens moves, from `open()` to `onNext`.
 
 ### Component B — shared backend block-read bulkhead
 
@@ -277,12 +262,11 @@ historical-`getBlock` ceiling and the bulkhead's permit count independently is a
 a guarantee that the bulkhead can never be contended by both sources at once. The bulkhead's own bounded behavior
 (reject or brief wait, never unbounded growth) is what keeps that scenario safe even so.
 
-The initial implementation uses one shared pool for all tiers, including recent/live reads — there is no per-tier
-bulkhead, and a `getBlock` call for a live block acquires and releases a permit the same as a historical one. This
-was a deliberate simplicity choice for the first delivery (see [Extensibility](#extensibility)) rather than a claim
-that a recent-block read is free of overhead: if warm-path latency sensitivity proves material, a separate,
-generously-sized bulkhead for recent reads — or skipping the bulkhead entirely for reads served from an
-in-memory/warm-file path — is the documented extension point to use.
+The initial implementation uses one pool for all tiers, including recent/live reads — a `getBlock` call for a live
+block acquires and releases a permit the same as a historical one. This is a deliberate simplicity choice, not a
+claim that live reads are free of overhead: if warm-path latency sensitivity proves material, a separate bulkhead
+for recent reads — or skipping the bulkhead for reads served from an in-memory/warm-file path — is the documented
+[Extensibility](#extensibility) point to use.
 
 ### Configuration ownership
 
@@ -334,10 +318,8 @@ small and bounded by construction:
     two fields (e.g. a block number) to classify a request. It should do a targeted read of that field directly from
     the wire format, not fully deserialize the request message before the real handler does its own full parse —
     otherwise every classified call would pay for parsing the request twice. This is a hand-written read via PBJ's
-    `ProtoParserTools` (read the tag, extract field number and wire type, decode the target field or skip any other
-    field), the same low-level parsing primitives PBJ's own generated parsers use — there is no separate framework
-    support for a partial-field read, but none is needed. Each weigher currently implements this loop itself rather
-    than sharing one utility; factoring it out is worth doing once a second or third weigher needs the same logic,
+    `ProtoParserTools` — the same low-level primitives PBJ's generated parsers use, just called directly instead of
+    from generated code. Each weigher implements its own read loop today; worth sharing once a third one needs it,
     not before.
 - **Acceptance criterion.** This goal should be validated, not assumed: a benchmark comparing per-call latency and
   allocation with admission control enabled versus disabled on the same hardware belongs in the acceptance tests for
@@ -481,16 +463,14 @@ Each throttled API's own module declares its per-client settings:
 | `burstTolerance`         | How far ahead of the even-pacing schedule a client's request may arrive and still be admitted    |
 | `maxConcurrentPerClient` | Maximum concurrent in-flight calls/sessions for one client on this method                        |
 
-Where a method's `ContentAwareWeigher` can classify more than one weight class, each class gets its own full triple
-rather than sharing one: e.g. `getBlock` has independent live and historical per-client configuration, each with
-its own rate, burst, and per-client concurrency ceiling. This is a heavier configuration surface than a single
-per-method triple, but keeps each weight class's tuning — including how strict the historical policy is relative
-to the live one — fully independent.
+Where a method's `ContentAwareWeigher` produces more than one weight class, each class gets its own full triple
+rather than sharing one — e.g. `getBlock` has independent live and historical per-client configuration — so each
+tier's tuning, including how much stricter the historical policy is, stays fully independent.
 
 A single shared, node-level configuration record holds one node-wide concurrency ceiling per (method, weight
-class) — e.g. `getBlock` has independent live and historical node-wide ceilings — since this represents an
-allocation of shared node capacity across APIs rather than a single plugin's own concern. A method with only one
-weight class has just one ceiling.
+class) — e.g. `getBlock` has independent live and historical ceilings — since this represents an allocation of
+shared node capacity across APIs rather than a single plugin's own concern. A method with only one weight class
+has just one ceiling.
 
 The shared block-read bulkhead has its own single configuration value: the number of permits in the pool, informed
 by the target deployment's storage characteristics.


### PR DESCRIPTION
## Summary

Addresses the doc-fixable items from #3630 (post-merge review follow-ups on #3529, `docs/design/apis/api-throttling.md`). Doc-only change, no code touched.

**Group A (doc fixes, no design discussion needed):**
- A1: converted the `Terms` section from a raw HTML `<dl>` (broke link/code-span rendering) to a markdown list
- A2: scoped GCRA framing to the `GcraLimiter` entity only, added an in-depth reference link there
- A3: named both quantities in the Component B sizing note instead of "the two"

**Group D2 (non-goal, no design discussion needed):**
- Recorded priority-aware throttling as an explicit non-goal, gated on the `ClientKeyExtractor` successor

**Group B (design decisions), cross-checked against actual implementation code — not guessed:**
- B4, B8: recorded decisions already made in open PRs #3627 (shared block-read bulkhead) and #3628 (per-client admission mechanism for `serverStatus`)
- B1, B2, B3, B7: validated directly against the exploratory spike on `spike/3530-throttle-phase1-mechanism-serverstatus` (#3535) — read the actual `WeightedThrottledServiceInterface`, `GetBlockWeigher`, `SubscribeStreamWeigher` code and their unit/e2e tests, not just the PR description. B3 corrects an earlier commit on this branch that guessed wrong before that spike code was checked.

**Follow-up refinements after initial resolution:**
- Added an `Alternatives considered` entry explaining why the weighted admission decision (B1) isn't split between `open()` (global/per-client concurrency) and `onNext` (rate check only): there's no weight-agnostic version of the concurrency checks to split off, since those ceilings are fields on each weight class's own `ThrottlePolicy`; a provisional-admit-then-reconcile approach would also reopen a release/reacquire race window on top of the permit-release subtlety already documented elsewhere in the doc.
- Clarified "Where admission control attaches," which previously read as if the admission check always runs synchronously inside `open()` — true for most methods, but not for the two weighted ones (B1) — ahead of the fuller explanation later in the doc.
- A clarity/conciseness pass over the whole document: consistent terminology, a fixed comma splice, tightened sentences, aligned cross-reference wording between the `ContentAwareWeigher` entity and where it's explained in full.

## Caveat

B1/B2/B3/B7's resolutions are validated against an **exploratory spike** (#3535, not a merged/clean PR) — described in the doc as the current implementation's behavior, with the underlying code cited. Since this PR was opened, the actual production implementation has started landing as real (draft) PRs forward-ported from that spike onto current `main`: #3628 (Phase 1 — core mechanism + `serverStatus`) and #3627 (Phase 4 — shared block-read bulkhead). If either changes materially from what's described here before merging, these sections may need a follow-up.

Resolves #3630
